### PR TITLE
feat(mira-hud): HUD v0.6 — vision capture, NeonDB pgvector recall, document-kb

### DIFF
--- a/PRDS/Claude-peers prd.md
+++ b/PRDS/Claude-peers prd.md
@@ -1,0 +1,38 @@
+<img src="https://r2cdn.perplexity.ai/pplx-full-logo-primary-dark%402x.png" style="height:64px;margin-right:32px"/>
+
+# ok lets use charlienode setup a prd for claude code to setup this process i need to run something on each computer correct and how do we make the claude-peers open on startup?
+
+Here's your complete PRD — drop it into your project root and Claude Code can execute the entire setup from it.
+
+## What the PRD Covers
+
+The document is organized as a 9-step runbook that Claude Code can follow directly:
+
+### Roles per machine
+
+- **PC-1 (broker host):** Runs the persistent broker daemon via systemd + acts as dispatcher
+- **PC-2–5 (workers):** Each connects to PC-1's Tailscale IP, no daemon needed locally
+
+
+### What runs on each machine
+
+| Machine | Broker Daemon | Needs to Set | Auto-start Via |
+| :-- | :-- | :-- | :-- |
+| PC-1 | ✅ Yes | Nothing — is the broker | `systemd` service |
+| PC-2–5 | ❌ No | `CLAUDE_PEERS_BROKER_URL=http://<PC1-tailscale-ip>:7899` in `.env` | Shell alias / desktop autostart |
+
+### Startup automation
+
+- **Broker on PC-1:** systemd service with `After=tailscaled.service` so it waits for Tailscale before starting
+- **All machines:** `alias claudepeers='claude --dangerously-load-development-channels server:claude-peers'` in `.bashrc` — one command to launch a peer-connected session
+- **Desktop autostart:** Optional `.desktop` entry with a 10-second delay to let Tailscale connect first
+
+
+### Key things to do before handing to Claude Code
+
+1. Get PC-1's Tailscale IP with `tailscale ip -4` and drop it in your `.env` on PC-2–5
+2. Generate one shared secret: `openssl rand -hex 32` and put the same value in every machine's `.env`
+3. Replace `youruser` in the systemd unit file with your actual Linux username
+
+Hand Claude Code the PRD file and say: *"Follow this PRD step by step to set up claude-peers on this machine."* — it has all the commands inline.
+

--- a/docs/runbooks/factorylm-vps.md
+++ b/docs/runbooks/factorylm-vps.md
@@ -1,0 +1,136 @@
+# Runbook: factorylm-prod VPS
+
+DigitalOcean droplet hosting factorylm.com, OpenClaw, Atlas CMMS, Plane, and supporting services.
+
+## Connection
+
+```bash
+# SSH alias (Charlie ~/.ssh/config)
+ssh factorylm-prod
+
+# Direct (works from anywhere)
+ssh -i ~/.ssh/id_ed25519 root@165.245.138.91
+```
+
+| Item | Value |
+|------|-------|
+| Public IP | 165.245.138.91 |
+| Tailscale IP | 100.68.120.99 |
+| Region | DigitalOcean ATL1 |
+| OS | Ubuntu 24.04 LTS |
+| Specs | 8 GB RAM / 4 vCPU / 160 GB disk |
+| SSH user | root |
+| SSH key (Charlie) | `~/.ssh/id_ed25519` |
+
+---
+
+## Website — factorylm.com
+
+| Item | Value |
+|------|-------|
+| Site root | `/var/www/html/preview/` |
+| nginx config | `/etc/nginx/sites-enabled/factorylm-landing` |
+| HTTPS cert | Let's Encrypt, expires 2026-06-28 (auto-renews) |
+| Deploy | Push to `main` on `Mikecranesync/factorylm-landing` → GitHub Action rsync |
+| Local clone (Charlie) | `~/Documents/GitHub/factorylm-landing/` |
+
+**Manual deploy (bypass CI):**
+```bash
+rsync -az --delete \
+  --exclude='.git/' --exclude='CLAUDE.md' --exclude='SITE_AUDIT.md' --exclude='VPS_INVENTORY.md' \
+  -e "ssh -i ~/.ssh/id_ed25519" \
+  ~/Documents/GitHub/factorylm-landing/ \
+  root@165.245.138.91:/var/www/html/preview/
+```
+
+**Reload nginx:**
+```bash
+ssh factorylm-prod "nginx -t && nginx -s reload"
+```
+
+---
+
+## Running Services
+
+### Docker containers (19)
+| Container | Port (host) | Purpose |
+|-----------|-------------|---------|
+| cmms-frontend | 3003 | Atlas CMMS UI (cmms.factorylm.ai) |
+| cmms-backend | 8082 | Atlas CMMS API |
+| cmms_db | 5433 | CMMS PostgreSQL |
+| cmms_minio | 9002/9003 | CMMS file storage |
+| flowise | 3001 (internal) | LLM workflow builder |
+| plane-web-1 | 8070 (public) | Plane project management |
+| plane-* (7 containers) | internal | Plane workers, DB, Redis, MQ, MinIO |
+| n8n | 5678 | Workflow automation |
+| infra_postgres_1 | 5432 (internal) | Shared pgvector PostgreSQL |
+| infra_redis_1 | 6379 (internal) | Shared Redis |
+
+### Systemd services
+| Service | Purpose |
+|---------|---------|
+| openclaw.service | Industrial AI gateway on :3000 (MIRA predecessor) |
+| master-of-puppets.service | Celery task orchestration (alarm triage, content capture) |
+| master-of-puppets-beat.service | Celery beat scheduler |
+| flower.service | Celery monitor UI on :5555 |
+| jarvis-telegram.service | Jarvis Telegram bot on :8081 |
+| friday-telegram.service | Friday Telegram bot |
+| discord-adapter.service | Discord bot gateway |
+| conveyor-relay.service | Live conveyor demo relay on :8400 |
+| remoteme.service | AI remote computer control on :8100 |
+| mission-control.service | FactoryLM dashboard |
+
+### Firewall (UFW) — publicly open ports
+| Port | Service |
+|------|---------|
+| 22 | SSH |
+| 80 | HTTP (redirects to HTTPS) |
+| 443 | HTTPS |
+| 8070 | Plane web |
+| 8400 | Conveyor Relay demo |
+
+All other ports: Tailscale only or internal.
+
+---
+
+## Common Operations
+
+**Check what's running:**
+```bash
+ssh factorylm-prod "docker ps --format 'table {{.Names}}\t{{.Status}}' && systemctl list-units --state=running --type=service | grep -E 'openclaw|jarvis|master|flower|friday|discord|conveyor|remoteme|mission'"
+```
+
+**Check disk / memory:**
+```bash
+ssh factorylm-prod "df -h / && free -h"
+```
+
+**Restart a Docker service:**
+```bash
+ssh factorylm-prod "docker restart <container-name>"
+```
+
+**Apply security updates:**
+```bash
+ssh factorylm-prod "apt update && apt upgrade -y"
+# Then reboot (system restart has been pending since Feb 2026)
+ssh factorylm-prod "reboot"
+# Wait ~60s then reconnect
+```
+
+---
+
+## Secrets
+
+Managed via Doppler:
+- Project `factorylm` / config `dev` — Discord adapter, main services
+- Project `openclaw` / config `dev_bot` — OpenClaw bot
+
+---
+
+## Notes
+
+- **OpenClaw** (`:3000`) is the predecessor to MIRA — same mission, multi-LLM routing for industrial diagnostics. Consider whether to decommission or repurpose as a MIRA relay node.
+- **infra_postgres** uses `pgvector/pgvector:pg16` — same vector extension as NeonDB. Could be used as a local vector store for MIRA if NeonDB is unavailable.
+- **12 GB** of disk used by `/root/computer_use_ootb/` (Anthropic demo) — safe to archive/delete.
+- **38 apt updates pending** as of 2026-03-30 including 15 security patches.

--- a/mira-bots/docker-compose.yml
+++ b/mira-bots/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: mira-bot-telegram
     environment:
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+      - INGEST_SERVICE_URL=${INGEST_SERVICE_URL:-http://mira-ingest:8001}
       - OPENWEBUI_BASE_URL=${OPENWEBUI_BASE_URL:-http://mira-core:8080}
       - OPENWEBUI_API_KEY=${OPENWEBUI_API_KEY:-}
       - MCP_BASE_URL=${MCP_BASE_URL:-http://mira-mcp:8001}
@@ -45,6 +46,7 @@ services:
     environment:
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
       - SLACK_APP_TOKEN=${SLACK_APP_TOKEN}
+      - INGEST_SERVICE_URL=${INGEST_SERVICE_URL:-http://mira-ingest:8001}
       - OPENWEBUI_BASE_URL=${OPENWEBUI_BASE_URL:-http://mira-core:8080}
       - OPENWEBUI_API_KEY=${OPENWEBUI_API_KEY:-}
       - MCP_BASE_URL=${MCP_BASE_URL:-http://mira-mcp:8001}
@@ -84,6 +86,7 @@ services:
     environment:
       - TEAMS_APP_ID=${TEAMS_APP_ID:-}
       - TEAMS_APP_PASSWORD=${TEAMS_APP_PASSWORD:-}
+      - INGEST_SERVICE_URL=${INGEST_SERVICE_URL:-http://mira-ingest:8001}
       - TEAMS_PORT=${TEAMS_PORT:-8030}
       - MIRA_TENANT_ID=${MIRA_TENANT_ID:-}
       - NEON_DATABASE_URL=${NEON_DATABASE_URL:-}
@@ -121,6 +124,7 @@ services:
     container_name: mira-bot-whatsapp
     environment:
       - TWILIO_ACCOUNT_SID=${TWILIO_ACCOUNT_SID:-}
+      - INGEST_SERVICE_URL=${INGEST_SERVICE_URL:-http://mira-ingest:8001}
       - TWILIO_AUTH_TOKEN=${TWILIO_AUTH_TOKEN:-}
       - TWILIO_WHATSAPP_FROM=${TWILIO_WHATSAPP_FROM:-}
       - MIRA_TENANT_ID=${MIRA_TENANT_ID:-}

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -140,8 +140,7 @@ async def _ingest_photo_background(photo_bytes: bytes, asset_tag: str) -> None:
 
 
 async def document_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Receive PDF documents, index them into the knowledge base via mira-mcp."""
-    chat_id = str(update.effective_chat.id)
+    """Receive PDF documents, index into Open WebUI KB via mira-ingest."""
     doc = update.message.document
     filename = doc.file_name or "upload.pdf"
     caption = update.message.caption or ""
@@ -155,8 +154,12 @@ async def document_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     MB = 1024 * 1024
     if doc.file_size and doc.file_size > 20 * MB:
         await update.message.reply_text(
-            f"{filename} is {doc.file_size // MB}MB — Telegram's bot limit is 20MB."
+            f"{filename} is {doc.file_size // MB}MB — limit is 20MB."
         )
+        return
+
+    if not INGEST_SERVICE_URL:
+        await update.message.reply_text("Ingest service not configured.")
         return
 
     equipment_type = _equipment_type_from_doc(filename, caption)
@@ -164,33 +167,48 @@ async def document_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     logger.info("PDF from %s: %s (type=%s)", update.effective_user.first_name,
                 filename, equipment_type)
 
-    async def _do_ingest():
+    async def _do_ingest_doc():
         try:
-            file = await context.bot.get_file(doc.file_id)
-            pdf_bytes = bytes(await file.download_as_bytearray())
-            headers = {}
-            if MCP_REST_API_KEY:
-                headers["Authorization"] = f"Bearer {MCP_REST_API_KEY}"
-            async with httpx.AsyncClient(timeout=180) as client:
+            tg_file = await context.bot.get_file(doc.file_id)
+            pdf_bytes = bytes(await tg_file.download_as_bytearray())
+            async with httpx.AsyncClient(timeout=360) as client:
                 resp = await client.post(
-                    f"{MCP_BASE_URL}/ingest/pdf",
-                    headers=headers,
-                    data={"equipment_type": equipment_type},
+                    f"{INGEST_SERVICE_URL}/ingest/document-kb",
+                    data={"filename": filename, "equipment_type": equipment_type or ""},
                     files={"file": (filename, pdf_bytes, "application/pdf")},
                 )
                 resp.raise_for_status()
                 data = resp.json()
-            chunks = data.get("chunks", 0)
-            await update.message.reply_text(
-                f"Indexed {chunks} pages from {filename}\n"
-                f"Type: {data.get('equipment_type', equipment_type)}\n"
-                "Ask me anything about it."
-            )
+            col = data.get("collection_name", "Knowledge Base")
+            proc = data.get("processing_status", "completed")
+            if proc == "completed":
+                reply = (
+                    f"Indexed *{filename}* into *{col}* collection.\n"
+                    "Ask me anything about it."
+                )
+            else:
+                reply = (
+                    f"*{filename}* uploaded to *{col}*.\n"
+                    "Extraction is still processing — RAG will be available shortly."
+                )
+            await update.message.reply_text(reply, parse_mode="Markdown")
+        except httpx.HTTPStatusError as e:
+            code = e.response.status_code
+            if code == 429:
+                msg = "Daily ingest limit reached. Try again tomorrow."
+            elif code == 413:
+                msg = f"{filename} is too large (limit 20MB)."
+            elif code == 422:
+                msg = f"Could not process {filename}: {e.response.text[:120]}"
+            else:
+                msg = f"Indexing failed ({code}). Try again later."
+            logger.error("doc ingest HTTP %s: %s", code, e.response.text[:200])
+            await update.message.reply_text(msg)
         except Exception as exc:
-            logger.error("PDF ingest error: %s", exc)
-            await update.message.reply_text(f"Failed to index {filename}: {exc}")
+            logger.error("doc ingest error: %s", exc)
+            await update.message.reply_text(f"Indexing {filename} failed. Please try again.")
 
-    asyncio.create_task(_do_ingest())
+    asyncio.create_task(_do_ingest_doc())
 
 
 def _get_voice_enabled(chat_id: str) -> bool:

--- a/mira-core/docker-compose.yml
+++ b/mira-core/docker-compose.yml
@@ -12,6 +12,12 @@ services:
       - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY:?WEBUI_SECRET_KEY must be set in .env}
       - WEBUI_ENABLE_TELEMETRY=false
       - WEBUI_CHECK_FOR_UPDATES=false
+      # RAG embedding: nomic-embed-text via Ollama (matches mira-ingest NeonDB embeddings)
+      # Default all-MiniLM-L6-v2 truncates at 256 tokens; nomic handles 8192
+      - RAG_EMBEDDING_ENGINE=ollama
+      - RAG_EMBEDDING_MODEL=nomic-embed-text:latest
+      - RAG_CHUNK_SIZE=1000
+      - RAG_CHUNK_OVERLAP=100
     volumes:
       - open-webui-data:/app/backend/data
     networks:

--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -1,10 +1,12 @@
-"""MIRA ingest service — photo ingestion, vector search, KB push."""
+"""MIRA ingest service — photo ingestion, vector search, KB push, document KB ingest."""
 
+import asyncio
 import base64
 import io
 import json
 import logging
 import os
+import re
 import sqlite3
 import sys
 from datetime import datetime
@@ -27,6 +29,11 @@ OPENWEBUI_URL = os.getenv("OPENWEBUI_BASE_URL", "http://mira-core:8080")
 OPENWEBUI_API_KEY = os.getenv("OPENWEBUI_API_KEY", "")
 KNOWLEDGE_COLLECTION_ID = os.getenv("KNOWLEDGE_COLLECTION_ID", "")
 MAX_PX = int(os.getenv("MAX_INGEST_PX", "1024"))
+MIRA_TENANT_ID = os.getenv("MIRA_TENANT_ID", "")
+
+# Collection routing patterns for document-kb endpoint
+_ELECTRICAL_RE = re.compile(r"wiring|schematic|diagram|electrical|one.?line|ladder", re.I)
+_MANUAL_RE = re.compile(r"manual|vfd|drive|plc|motor|pump|compressor|datasheet", re.I)
 
 DESCRIBE_SYSTEM = (
     "You are an industrial maintenance AI helping a technician at a machine. "
@@ -178,6 +185,94 @@ async def _push_to_kb(asset_tag: str, description: str) -> None:
                 )
     except Exception as e:
         logger.warning("KB push failed (non-fatal): %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Document KB helpers
+# ---------------------------------------------------------------------------
+
+def _route_collection(filename: str, hint: str | None) -> tuple[str, str]:
+    """Map a filename (or explicit hint) to an Open WebUI knowledge collection."""
+    if hint:
+        h = hint.lower()
+        if h == "electrical":
+            return ("Electrical Prints", "Wiring diagrams and schematics.")
+        if h == "manual":
+            return ("Equipment Manuals", "Equipment manuals and datasheets.")
+        return ("Facility Documents", "General facility documents.")
+    if _ELECTRICAL_RE.search(filename):
+        return ("Electrical Prints", "Wiring diagrams and schematics.")
+    if _MANUAL_RE.search(filename):
+        return ("Equipment Manuals", "Equipment manuals and datasheets.")
+    return ("Facility Documents", "General facility documents uploaded by technicians.")
+
+
+async def _get_or_create_kb_collection(name: str, desc: str) -> str:
+    """Return the Open WebUI collection_id for `name`, creating it if needed."""
+    headers: dict[str, str] = {}
+    if OPENWEBUI_API_KEY:
+        headers["Authorization"] = f"Bearer {OPENWEBUI_API_KEY}"
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(f"{OPENWEBUI_URL}/api/v1/knowledge/", headers=headers)
+        resp.raise_for_status()
+        body = resp.json()
+        # Handle both list shape and {items:[]} shape
+        items = body if isinstance(body, list) else (body.get("items") or [])
+        for col in items:
+            if col.get("name") == name:
+                logger.info("KB collection found: %s (%s)", name, col["id"])
+                return col["id"]
+        # Not found — create
+        resp = await client.post(
+            f"{OPENWEBUI_URL}/api/v1/knowledge/create",
+            headers={**headers, "Content-Type": "application/json"},
+            json={"name": name, "description": desc},
+        )
+        resp.raise_for_status()
+        col_id = resp.json()["id"]
+        logger.info("KB collection created: %s (%s)", name, col_id)
+        return col_id
+
+
+async def _poll_file_status(file_id: str, timeout_s: int = 300) -> str:
+    """Poll Open WebUI until file extraction is complete (or timeout/failed)."""
+    headers: dict[str, str] = {}
+    if OPENWEBUI_API_KEY:
+        headers["Authorization"] = f"Bearer {OPENWEBUI_API_KEY}"
+    max_polls = timeout_s // 3
+    for i in range(max_polls):
+        await asyncio.sleep(3)
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(
+                    f"{OPENWEBUI_URL}/api/v1/files/{file_id}/process/status",
+                    headers=headers,
+                )
+                if resp.status_code == 404:
+                    # Status endpoint not available in this Open WebUI version.
+                    # Wait a fixed period and return completed optimistically.
+                    logger.info(
+                        "Status endpoint not found (404) for file_id=%s; "
+                        "waiting 25s then proceeding optimistically",
+                        file_id,
+                    )
+                    await asyncio.sleep(25)
+                    return "completed"
+                resp.raise_for_status()
+                body = resp.json()
+                # Status may be top-level or nested under "data"
+                status = body.get("status") or body.get("data", {}).get("status", "")
+                status = (status or "").lower()
+                logger.debug("Poll %d/%d file=%s status=%s", i + 1, max_polls, file_id, status)
+                if status in ("completed", "processed", "done", "ready"):
+                    return "completed"
+                if status in ("failed", "error"):
+                    logger.warning("File processing failed: file_id=%s", file_id)
+                    return "failed"
+        except Exception as e:
+            logger.warning("Poll %d error (continuing): %s", i + 1, e)
+    logger.warning("File status poll timeout after %ds: file_id=%s", timeout_s, file_id)
+    return "timeout"
 
 
 # ---------------------------------------------------------------------------
@@ -355,6 +450,138 @@ async def search_photos(body: dict):
 
     results.sort(key=lambda x: x["score"], reverse=True)
     return {"results": results[:top_k]}
+
+
+# ---------------------------------------------------------------------------
+# Document KB ingest — upload original PDF to Open WebUI, let it chunk + embed
+# ---------------------------------------------------------------------------
+
+@app.post("/ingest/document-kb")
+async def ingest_document_kb(
+    file: UploadFile = File(...),
+    filename: str = Form(default=None),
+    collection_hint: str = Form(default=None),
+    equipment_type: str = Form(default=None),
+):
+    """Upload a PDF to Open WebUI Knowledge Base.
+
+    Open WebUI handles text extraction, chunking, and embedding via its
+    configured engine (pypdf default; Docling when DOCLING_SERVER_URL is set).
+    No local parsing is performed here.
+
+    Returns JSON: {status, filename, collection_id, collection_name, file_id, processing_status}
+    """
+    raw = await file.read()
+    if not raw:
+        raise HTTPException(status_code=422, detail="Empty file upload")
+
+    fname = filename or file.filename or "document.pdf"
+
+    # Validate file type — PDF only for MVP
+    ext = fname.rsplit(".", 1)[-1].lower() if "." in fname else ""
+    mime = (file.content_type or "").lower()
+    if mime != "application/pdf" and ext != "pdf":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Only PDF files are supported (got mime={mime or 'unknown'}, ext={ext or 'none'})",
+        )
+
+    # Validate size (20MB Telegram limit, enforced universally)
+    MB = 1024 * 1024
+    if len(raw) > 20 * MB:
+        raise HTTPException(
+            status_code=413,
+            detail=f"File exceeds 20MB limit ({len(raw) // MB}MB)",
+        )
+
+    # Tier limit check (fail open on DB errors — never block on infra failures)
+    tenant_id = MIRA_TENANT_ID
+    if tenant_id:
+        try:
+            from db.neon import check_tier_limit
+            allowed, reason = check_tier_limit(tenant_id)
+            if not allowed:
+                raise HTTPException(status_code=429, detail=reason)
+        except HTTPException:
+            raise
+        except Exception:
+            pass
+
+    # Route to the correct collection
+    col_name, col_desc = _route_collection(fname, collection_hint)
+    logger.info("Document KB ingest: %s → collection '%s'", fname, col_name)
+
+    # Get or create the Open WebUI collection
+    try:
+        collection_id = await _get_or_create_kb_collection(col_name, col_desc)
+    except Exception as e:
+        logger.error("Collection create/find failed: %s", e)
+        raise HTTPException(status_code=500, detail=f"KB collection unavailable: {e}")
+
+    # Upload the raw PDF to Open WebUI
+    headers: dict[str, str] = {}
+    if OPENWEBUI_API_KEY:
+        headers["Authorization"] = f"Bearer {OPENWEBUI_API_KEY}"
+
+    try:
+        async with httpx.AsyncClient(timeout=60) as client:
+            resp = await client.post(
+                f"{OPENWEBUI_URL}/api/v1/files/",
+                headers=headers,
+                files={"file": (fname, raw, "application/pdf")},
+            )
+            resp.raise_for_status()
+            file_id = resp.json().get("id")
+    except Exception as e:
+        logger.error("Open WebUI file upload failed: %s", e)
+        raise HTTPException(status_code=422, detail=f"File upload failed: {e}")
+
+    if not file_id:
+        raise HTTPException(status_code=422, detail="Open WebUI did not return a file_id")
+
+    logger.info("File uploaded to Open WebUI: file_id=%s, polling for extraction...", file_id)
+
+    # Poll until extraction + embedding complete
+    processing_status = await _poll_file_status(file_id, timeout_s=300)
+
+    if processing_status == "failed":
+        raise HTTPException(
+            status_code=422,
+            detail=f"Open WebUI extraction failed for {fname}. Try re-uploading.",
+        )
+
+    # Attach to knowledge collection (extraction complete or timed-out best-effort)
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.post(
+                f"{OPENWEBUI_URL}/api/v1/knowledge/{collection_id}/file/add",
+                headers={**headers, "Content-Type": "application/json"},
+                json={"file_id": file_id},
+            )
+            if resp.status_code == 400 and "duplicate" in resp.text.lower():
+                logger.info("File already in KB collection (idempotent): file_id=%s", file_id)
+            elif resp.status_code not in (200, 201):
+                logger.warning(
+                    "KB attach returned %s: %s (non-fatal)",
+                    resp.status_code, resp.text[:200],
+                )
+    except Exception as e:
+        logger.warning("KB attach failed (non-fatal, file is uploaded): %s", e)
+
+    logger.info(
+        "Document KB ingest complete: %s → collection='%s' processing_status=%s",
+        fname, col_name, processing_status,
+    )
+
+    return {
+        "status": "ok",
+        "filename": fname,
+        "collection_id": collection_id,
+        "collection_name": col_name,
+        "file_id": file_id,
+        "processing_status": processing_status,
+        "equipment_type": equipment_type or "",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/mira-hud/.gitignore
+++ b/mira-hud/.gitignore
@@ -3,3 +3,4 @@ mira/
 *.log
 .DS_Store
 .env
+vision_captures/

--- a/mira-hud/hud.html
+++ b/mira-hud/hud.html
@@ -94,31 +94,6 @@ body{background:#000;overflow:hidden;font-family:'Courier New',monospace;color:#
 #vision-observations{font-size:11px;letter-spacing:.3px;line-height:1.7;color:#00cc6a}
 #vision-alerts{font-size:10px;letter-spacing:1px;margin-top:5px;min-height:14px}
 
-/* ─── MIRA RESPONSE PANEL ─── */
-#mira-response-panel{}
-#mira-response-text{font-size:14px;letter-spacing:.4px;line-height:1.7;min-height:42px}
-#mira-sources{font-size:9px;letter-spacing:1px;color:#3a7755;margin-top:5px}
-
-/* ─── QUERY BAR ─── */
-#query-bar{
-  position:absolute;bottom:60px;left:50%;transform:translateX(-50%);
-  width:68%;display:flex;gap:8px;pointer-events:auto
-}
-#query-input{
-  flex:1;background:rgba(0,10,5,.88);border:1px solid rgba(0,255,136,.4);
-  color:#00ff88;font-family:'Courier New',monospace;font-size:11px;
-  letter-spacing:1px;padding:7px 12px;outline:none
-}
-#query-input:focus{border-color:#00ff88}
-#query-input::placeholder{color:#2a5a3a}
-#query-send{
-  background:rgba(0,255,136,.1);border:1px solid #00ff88;
-  color:#00ff88;font-family:'Courier New',monospace;font-size:9px;
-  letter-spacing:2px;padding:7px 14px;cursor:pointer;text-transform:uppercase;
-  transition:background .2s;white-space:nowrap
-}
-#query-send:hover{background:rgba(0,255,136,.28)}
-
 /* ─── CONFIRM PROMPT ─── */
 #confirm-prompt{display:none;margin-top:10px;padding-top:10px;border-top:1px solid rgba(0,255,136,.3);text-align:center}
 #confirm-question{font-size:11px;letter-spacing:2px;color:#ffaa00;margin-bottom:10px}
@@ -248,9 +223,6 @@ body{background:#000;overflow:hidden;font-family:'Courier New',monospace;color:#
   0%,100%{box-shadow:0 0 0 0 rgba(255,170,0,.6)}
   50%{box-shadow:0 0 8px 2px rgba(255,170,0,.25)}
 }
-#query-bar.listening #query-input{border-color:#ffaa00;color:#ffaa00;animation:pulse-border 1.2s infinite}
-#query-bar.locked    #query-input{border-color:#00ff88;color:#00ff88}
-#query-bar.sending   #query-input{border-color:#00ff88;color:#5a9977;animation:blink 1s infinite}
 #voice-indicator{
   font-size:8px;letter-spacing:2px;color:#5a9977;
   position:absolute;bottom:52px;left:50%;transform:translateX(-50%);
@@ -348,25 +320,11 @@ body{background:#000;overflow:hidden;font-family:'Courier New',monospace;color:#
         <div id="scanning-indicator"></div>
         <button id="scan-again" onclick="startScanning()">↺ SCAN AGAIN</button>
       </div>
-      <!-- MIRA RAG response -->
-      <div id="mira-response-panel">
-        <div class="hud-label">▸ MIRA RESPONSE</div>
-        <div id="mira-response-text">Ready. Look at equipment or ask a question.</div>
-        <div id="mira-sources"></div>
-      </div>
       <!-- Procedure step (hidden — manual override via PREV/NEXT) -->
       <div id="step-label" style="display:none"></div>
       <div id="step-text"></div>
       <div id="progress-bar"><div id="progress-fill" style="width:0%"></div></div>
     </div>
-
-    <!-- Query bar -->
-    <div id="query-bar">
-      <input id="query-input" type="text" placeholder="ASK MIRA... (SPACE = voice | type + Enter)" maxlength="400" autocomplete="off"/>
-      <button id="query-send">ASK ▶</button>
-    </div>
-
-    <div id="voice-indicator"></div>
 
     <!-- Nav -->
     <div id="nav">
@@ -527,7 +485,6 @@ socket.on('connect', () => {
 });
 
 socket.on('visionUpdate', (d) => {
-  _visionBusy = false;
   const isReal = d.equipment &&
     d.equipment !== 'General environment' &&
     d.equipment !== 'Vision error' &&
@@ -770,7 +727,6 @@ function confirmYes() {
   document.getElementById('confirm-prompt').style.display = 'none';
   document.getElementById('scan-again').style.display     = '';
   setScanStatus('');
-  document.getElementById('mira-response-text').textContent = 'Asking MIRA...';
   socket.emit('confirmEquipment', _lastVision);
   _confirmedEquipment = `${_lastVision.equipment} ${_lastVision.model}`.trim();
 }
@@ -792,8 +748,6 @@ function startScanning() {
   document.getElementById('vision-model').textContent          = '--';
   document.getElementById('vision-observations').textContent   = 'Point camera at equipment to begin identification.';
   document.getElementById('vision-alerts').textContent         = '';
-  document.getElementById('mira-response-text').textContent    = 'Ready.';
-  document.getElementById('mira-sources').textContent          = '';
   setScanStatus('');
 }
 

--- a/mira-hud/package-lock.json
+++ b/mira-hud/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.80.0",
         "express": "^4.18.2",
+        "pg": "^8.11.3",
         "socket.io": "^4.7.5"
       }
     },
@@ -729,6 +730,134 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1040,6 +1169,15 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1129,6 +1267,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/mira-hud/package.json
+++ b/mira-hud/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.80.0",
     "express": "^4.18.2",
+    "pg": "^8.11.3",
     "socket.io": "^4.7.5"
   }
 }

--- a/mira-hud/server.js
+++ b/mira-hud/server.js
@@ -18,7 +18,8 @@ function getLanIP() {
 const app    = express();
 const server = http.createServer(app);
 const io     = new Server(server);
-let pythonBackendActive = false;  // set when mira_core.py registers; gates server.js RAG
+let pythonBackendActive = false;
+let pythonSocketId      = null;  // set when mira_core.py registers; gates server.js RAG
 
 // ─── AI SETUP ────────────────────────────────────────────────────────────────
 const DOCS_DIR = path.join(__dirname, 'vision_backend', 'docs');
@@ -345,12 +346,9 @@ io.on('connection', (socket) => {
   // Python backend registration — disables server.js RAG to prevent duplicate responses
   socket.on('registerPythonBackend', () => {
     pythonBackendActive = true;
+    pythonSocketId = socket.id;
     console.log('[backend] Python mira_core connected — server.js RAG disabled');
   });
-
-  // Python backend push paths — re-broadcast to all clients
-  socket.on('visionUpdate', (data) => { io.emit('visionUpdate', data); });
-  socket.on('miraResponse', (data) => { io.emit('miraResponse', data); });
 
   // Browser sends a base64 JPEG frame for Claude Vision analysis
   socket.on('analyzeFrame', async (base64Jpeg) => {
@@ -428,11 +426,7 @@ io.on('connection', (socket) => {
     try {
       const equipContext = `${equipment} ${model || ''}`.trim();
       const { answer, usage } = await callRAG(equipContext, question);
-      io.emit('miraResponse', {
-        answer,
-        sources: DOC_CONTEXT ? ['docs'] : [],
-        equipment_context: equipContext,
-      });
+      io.emit('mira_insight', { text: answer, tags: [] });
       logSession('mira_response', {
         equipment, model,
         question,
@@ -445,7 +439,7 @@ io.on('connection', (socket) => {
     } catch (err) {
       console.error('[rag]', err.message);
       logSession('mira_error', { equipment, error: err.message, duration_ms: Date.now() - t0 });
-      io.emit('miraResponse', { answer: `Error: ${err.message}`, sources: [], equipment_context: '' });
+      io.emit('mira_insight', { text: `MIRA: ${err.message}`, tags: [] });
     }
   });
 
@@ -459,11 +453,7 @@ io.on('connection', (socket) => {
     try {
       const ctx = (data.equipment_context || '').trim();
       const { answer, usage } = await callRAG(ctx || 'Unknown', question);
-      io.emit('miraResponse', {
-        answer,
-        sources: DOC_CONTEXT ? ['docs'] : [],
-        equipment_context: ctx,
-      });
+      io.emit('mira_insight', { text: answer, tags: [] });
       logSession('tech_query', {
         query:             question,
         equipment_context: ctx,
@@ -486,8 +476,9 @@ io.on('connection', (socket) => {
   });
 
   socket.on('disconnect', (reason) => {
-    if (pythonBackendActive && io.engine.clientsCount === 0) {
+    if (socket.id === pythonSocketId) {
       pythonBackendActive = false;
+      pythonSocketId = null;
       console.log('[backend] Python mira_core disconnected — server.js RAG re-enabled');
     }
     console.log(`[HUD] client disconnected: ${socket.id}`);

--- a/mira-hud/server.js
+++ b/mira-hud/server.js
@@ -7,6 +7,17 @@ const path       = require('path');
 const os         = require('os');
 const fs         = require('fs');
 const Anthropic  = require('@anthropic-ai/sdk');
+const { Pool }   = require('pg');
+
+const OLLAMA_BASE_URL = process.env.OLLAMA_BASE_URL || 'http://localhost:11434';
+const EMBED_MODEL     = 'nomic-embed-text:v1.5';
+const NEON_URL        = process.env.NEON_DATABASE_URL || '';
+const MIRA_TENANT_ID  = process.env.MIRA_TENANT_ID   || '';
+
+const _neonPool = NEON_URL
+  ? new Pool({ connectionString: NEON_URL, ssl: { rejectUnauthorized: false }, max: 3 })
+  : null;
+if (!_neonPool) console.warn('[kb] NEON_DATABASE_URL not set — KB recall disabled');
 
 function getLanIP() {
   for (const iface of Object.values(os.networkInterfaces()).flat()) {
@@ -38,14 +49,61 @@ const VISION_PROMPT =
   '{"equipment":"type or \'Unknown\'","model":"brand and model if visible or \'Unknown\'","observations":"1-2 sentence description","alerts":["safety concerns — empty array if none"]}\n' +
   'If no industrial equipment is visible set equipment to "General environment".';
 
-function buildRAGPrompt(equipContext, question) {
+function buildRAGPrompt(equipContext, question, kbRows = []) {
   const equip = (equipContext || '').replace(/\s+/g, ' ').trim() || 'Unknown';
-  return `You are MIRA, an industrial maintenance assistant. Answer concisely.\nEquipment: ${equip}\nQuestion: ${question}${DOC_CONTEXT ? '\n\nDocumentation:\n' + DOC_CONTEXT : ''}\n\nAnswer in 2-4 sentences. Be specific. Include fault code reset steps if relevant.`;
+  let kbSection = '';
+  if (kbRows.length) {
+    kbSection = '\n\nKnowledge Base:\n' + kbRows.map((r, i) =>
+      `[${i + 1}] (${r.source_type}) ${r.content.slice(0, 400)}`
+    ).join('\n\n');
+  } else if (DOC_CONTEXT) {
+    kbSection = '\n\nDocumentation:\n' + DOC_CONTEXT;
+  }
+  return `You are MIRA, an industrial maintenance assistant. Answer concisely.\nEquipment: ${equip}\nQuestion: ${question}${kbSection}\n\nAnswer in 2-4 sentences. Be specific. Include fault code reset steps if relevant.`;
 }
 
 const CLAUDE_MODEL = process.env.CLAUDE_MODEL || 'claude-sonnet-4-6';
 const anthropic    = process.env.ANTHROPIC_API_KEY ? new Anthropic() : null;
 if (!anthropic) console.warn('[claude] ANTHROPIC_API_KEY not set — vision/RAG disabled');
+
+async function embedText(text) {
+  try {
+    const resp = await fetch(`${OLLAMA_BASE_URL}/api/embeddings`, {
+      method:  'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body:    JSON.stringify({ model: EMBED_MODEL, prompt: text }),
+      signal:  AbortSignal.timeout(10_000),
+    });
+    if (!resp.ok) throw new Error(`Ollama HTTP ${resp.status}`);
+    const data = await resp.json();
+    return data.embedding || null;
+  } catch (err) {
+    console.warn('[kb] embed failed:', err.message);
+    return null;
+  }
+}
+
+async function recallKB(queryText, limit = 5) {
+  if (!_neonPool || !MIRA_TENANT_ID) return [];
+  const embedding = await embedText(queryText);
+  if (!embedding) return [];
+  try {
+    const { rows } = await _neonPool.query(
+      `SELECT content, source_type, manufacturer, model_number, source_url,
+              1 - (embedding <=> $1::vector) AS score
+       FROM knowledge_entries
+       WHERE tenant_id = $2
+         AND embedding IS NOT NULL
+       ORDER BY embedding <=> $1::vector
+       LIMIT $3`,
+      [`[${embedding.join(',')}]`, MIRA_TENANT_ID, limit]
+    );
+    return rows;
+  } catch (err) {
+    console.warn('[kb] recall failed:', err.message);
+    return [];
+  }
+}
 
 function parseVisionJSON(text) {
   let clean = text.trim();
@@ -76,11 +134,13 @@ async function callVision(base64Jpeg) {
 }
 
 async function callRAG(equipContext, question) {
+  const kbRows = await recallKB(`${equipContext} ${question}`);
   const msg = await anthropic.messages.create({
     model: CLAUDE_MODEL,
     max_tokens: 400,
-    messages: [{ role: 'user', content: buildRAGPrompt(equipContext, question) }],
+    messages: [{ role: 'user', content: buildRAGPrompt(equipContext, question, kbRows) }],
   });
+  console.log(`[rag] kb=${kbRows.length} in=${msg.usage.input_tokens} out=${msg.usage.output_tokens}`);
   return { answer: msg.content[0].text.trim(), usage: msg.usage };
 }
 
@@ -117,14 +177,16 @@ async function queryClaude(query) {
     const ctxMatch = query.match(/\[context:([^\]]*)\]/);
     const equipCtx = ctxMatch ? ctxMatch[1] : '';
     const cleanQ   = query.replace(/\[context:[^\]]*\]/, '').trim();
-    const prompt   = buildRAGPrompt(equipCtx, cleanQ);
+    const searchText = equipCtx ? `${equipCtx} ${cleanQ}` : cleanQ;
+    const kbRows   = await recallKB(searchText);
+    const prompt   = buildRAGPrompt(equipCtx, cleanQ, kbRows);
     const msg = await anthropic.messages.create({
       model:      CLAUDE_MODEL,
       max_tokens: 512,
       messages:   [{ role: 'user', content: prompt }],
     });
     const text = msg.content[0]?.text || 'MIRA: No response';
-    console.log(`[claude] in=${msg.usage.input_tokens} out=${msg.usage.output_tokens}`);
+    console.log(`[claude] in=${msg.usage.input_tokens} out=${msg.usage.output_tokens} kb=${kbRows.length}`);
     return { text, tags: [] };
   } catch (err) {
     console.error('[claude] error:', err.message);

--- a/mira-hud/server.js
+++ b/mira-hud/server.js
@@ -141,8 +141,50 @@ function pushHistory(type, text) {
   if (history.length > 100) history.shift();
 }
 
-const LOG_DIR = path.join(__dirname, 'vision_backend', 'logs');
-fs.mkdirSync(LOG_DIR, { recursive: true });
+const LOG_DIR      = path.join(__dirname, 'vision_backend', 'logs');
+const CAPTURES_DIR = path.join(__dirname, 'vision_captures');
+fs.mkdirSync(LOG_DIR,      { recursive: true });
+fs.mkdirSync(CAPTURES_DIR, { recursive: true });
+
+// ─── VISION CAPTURE STATE ─────────────────────────────────────────────────────
+const CAPTURE_RATE_MS = 5 * 60 * 1000;   // min gap between saves for same equipment
+let _lastSavedEquip = '';
+const _lastSaveTime = new Map();          // slug → timestamp
+let _lastFrameB64   = null;              // most recent frame, for demand capture
+let _lastVisionRes  = null;              // most recent vision result
+
+function toSlug(str) {
+  return (str || '').toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '');
+}
+
+function saveCaptureFrame(base64Jpeg, result, significance) {
+  if (!base64Jpeg) return;
+  try {
+    const now  = new Date();
+    const date = now.toISOString().slice(0, 10);
+    const slug = toSlug(result.equipment);
+    const ts   = now.toISOString().replace(/:/g, '-').replace(/\..+/, '');
+    const dir  = path.join(CAPTURES_DIR, date, slug);
+    fs.mkdirSync(dir, { recursive: true });
+    const relPath = `vision_captures/${date}/${slug}/${ts}.jpg`;
+    fs.writeFileSync(path.join(dir, `${ts}.jpg`), Buffer.from(base64Jpeg, 'base64'));
+    fs.writeFileSync(path.join(dir, `${ts}.json`), JSON.stringify({
+      ts:           now.toISOString(),
+      session_date: date,
+      significance,
+      image_path:   relPath,
+      equipment:    result.equipment,
+      model:        result.model,
+      observations: result.observations,
+      alerts:       result.alerts || [],
+      input_tokens:  result.input_tokens  || 0,
+      output_tokens: result.output_tokens || 0,
+    }, null, 2));
+    console.log(`[capture] ${slug} — ${significance}`);
+  } catch (err) {
+    console.error('[capture] save error:', err.message);
+  }
+}
 
 function logSession(type, data) {
   const entry = { ts: new Date().toISOString(), type, ...data };
@@ -285,30 +327,6 @@ io.on('connection', (socket) => {
     io.emit('mira_insight', result);
   });
 
-  // Vision frame → Claude Vision → visionUpdate
-  socket.on('analyzeFrame', async (base64Jpeg) => {
-    if (!anthropic) {
-      socket.emit('visionUpdate', {
-        equipment: 'Vision offline', model: '--',
-        observations: 'ANTHROPIC_API_KEY not set.',
-        alerts: [], equipment_context: '',
-      });
-      return;
-    }
-    try {
-      const { result } = await callVision(base64Jpeg);
-      const ctx = `${result.equipment} ${result.model || ''}`.trim();
-      io.emit('visionUpdate', { ...result, equipment_context: ctx });
-    } catch (err) {
-      console.error('[vision]', err.message);
-      socket.emit('visionUpdate', {
-        equipment: 'Vision error', model: '--',
-        observations: err.message.slice(0, 120),
-        alerts: [], equipment_context: '',
-      });
-    }
-  });
-
   // VIM vision overlay relay — Python → all HUD clients
   socket.on('vim_overlay', (data) => {
     io.emit('vim_overlay', data);
@@ -361,6 +379,26 @@ io.on('connection', (socket) => {
         input_tokens:    usage.input_tokens,
         output_tokens:   usage.output_tokens,
       });
+
+      // ─── SIGNIFICANCE CAPTURE ─────────────────────────────────────────────
+      _lastFrameB64  = base64Jpeg;
+      _lastVisionRes = { ...result, input_tokens: usage.input_tokens, output_tokens: usage.output_tokens };
+
+      if (specific) {
+        const slug      = toSlug(result.equipment);
+        const hasAlert  = result.alerts && result.alerts.length > 0;
+        const newScene  = result.equipment !== _lastSavedEquip;
+        const rateClear = (Date.now() - (_lastSaveTime.get(slug) || 0)) > CAPTURE_RATE_MS;
+        const sig = hasAlert ? 'alert'
+                  : newScene  ? 'scene_transition'
+                  : rateClear ? 'rate_limit_cleared'
+                  : null;
+        if (sig) {
+          saveCaptureFrame(base64Jpeg, _lastVisionRes, sig);
+          _lastSavedEquip = result.equipment;
+          _lastSaveTime.set(slug, Date.now());
+        }
+      }
     } catch (err) {
       console.error('[vision]', err.message);
       logSession('vision_error', { error: err.message, duration_ms: Date.now() - t0 });
@@ -372,9 +410,19 @@ io.on('connection', (socket) => {
     }
   });
 
-  // Tech confirmed the identified equipment — run RAG
+  // Tech confirmed the identified equipment — demand capture + RAG
   socket.on('confirmEquipment', async ({ equipment, model }) => {
     if (!anthropic) return;
+    // Demand capture: user confirmed — always save, highest confidence
+    if (_lastFrameB64) {
+      saveCaptureFrame(_lastFrameB64, {
+        ..._lastVisionRes,
+        equipment: equipment || _lastVisionRes?.equipment || 'Unknown',
+        model:     model     || _lastVisionRes?.model     || 'Unknown',
+      }, 'user_confirmed');
+      _lastSavedEquip = equipment;
+      _lastSaveTime.set(toSlug(equipment), Date.now());
+    }
     const t0 = Date.now();
     const question = 'What should the technician check or know about this equipment right now?';
     try {

--- a/mira-hud/vim/requirements.txt
+++ b/mira-hud/vim/requirements.txt
@@ -15,3 +15,8 @@ numpy>=1.26.0
 
 # Phase 4 — HUD Integration
 python-socketio[asyncio_client]>=5.11.0
+
+# Phase 5 — Capture Ingest (vision_backend/capture_ingest.py)
+SQLAlchemy>=2.0
+psycopg2-binary>=2.9
+watchdog>=4.0

--- a/mira-hud/vision_backend/capture_ingest.py
+++ b/mira-hud/vision_backend/capture_ingest.py
@@ -1,0 +1,283 @@
+"""capture_ingest.py — Vision Capture → NeonDB KB Ingest
+
+Watches vision_captures/ for new sidecar JSON files and ingests them
+into the NeonDB knowledge_entries table as 'live_capture' source type.
+
+Usage:
+    # Daemon: watch for new captures alongside HUD server
+    doppler run --project factorylm --config prd -- python capture_ingest.py --watch
+
+    # Backfill: process all existing uningested captures
+    doppler run --project factorylm --config prd -- python capture_ingest.py --backfill ../vision_captures/
+
+Dependencies: uv pip install -r ../vim/requirements.txt
+
+Environment (via Doppler):
+    NEON_DATABASE_URL  — NeonDB connection string (required)
+    MIRA_TENANT_ID     — tenant scoping (required)
+    OLLAMA_BASE_URL    — Ollama host (default: http://localhost:11434)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import httpx
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[ingest] %(levelname)s %(message)s",
+)
+logger = logging.getLogger("capture-ingest")
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+OLLAMA_BASE_URL = os.environ.get("OLLAMA_BASE_URL", "http://localhost:11434")
+EMBED_MODEL     = "nomic-embed-text:v1.5"
+TENANT_ID       = os.environ.get("MIRA_TENANT_ID", "")
+NEON_URL        = os.environ.get("NEON_DATABASE_URL", "")
+
+if not TENANT_ID:
+    logger.warning("MIRA_TENANT_ID not set — entries will use empty tenant_id")
+if not NEON_URL:
+    logger.error("NEON_DATABASE_URL not set — cannot ingest")
+    sys.exit(1)
+
+
+# ── NeonDB ────────────────────────────────────────────────────────────────────
+
+def _engine():
+    return create_engine(
+        NEON_URL,
+        poolclass=NullPool,
+        connect_args={"sslmode": "require"},
+        pool_pre_ping=True,
+    )
+
+
+def entry_exists(image_path: str) -> bool:
+    """Check if this capture has already been ingested (dedup by image_path)."""
+    try:
+        with _engine().connect() as conn:
+            count = conn.execute(text(
+                "SELECT COUNT(*) FROM knowledge_entries "
+                "WHERE tenant_id = :tid AND source_url = :url AND source_type = 'live_capture'"
+            ), {"tid": TENANT_ID, "url": image_path}).scalar()
+        return (count or 0) > 0
+    except Exception as e:
+        logger.warning("Dedup check failed (will proceed): %s", e)
+        return False
+
+
+def insert_entry(sidecar: dict, embedding: list[float]) -> str:
+    """Insert one live_capture entry into knowledge_entries. Returns new row id."""
+    entry_id = str(uuid.uuid4())
+    equipment  = sidecar.get("equipment", "Unknown")
+    model_str  = sidecar.get("model", "Unknown")
+    image_path = sidecar.get("image_path", "")
+    alerts     = sidecar.get("alerts", [])
+    verified   = sidecar.get("significance") == "user_confirmed"
+
+    # Manufacturer: first word of model string if meaningful
+    manufacturer = None
+    if model_str and model_str not in ("Unknown", ""):
+        first_word = model_str.split()[0]
+        if len(first_word) > 2:
+            manufacturer = first_word
+
+    meta = json.dumps({
+        "captured_at":  sidecar.get("ts"),
+        "equipment":    equipment,
+        "alerts":       alerts,
+        "significance": sidecar.get("significance"),
+        "image_path":   image_path,
+        "session_date": sidecar.get("session_date"),
+    })
+
+    with _engine().connect() as conn:
+        conn.execute(text("""
+            INSERT INTO knowledge_entries
+                (id, tenant_id, source_type, manufacturer, model_number,
+                 content, embedding, source_url, source_page, metadata,
+                 is_private, verified)
+            VALUES
+                (:id, :tenant_id, 'live_capture', :manufacturer, :model_number,
+                 :content, cast(:embedding AS vector), :source_url, 0,
+                 cast(:metadata AS jsonb), false, :verified)
+        """), {
+            "id":           entry_id,
+            "tenant_id":    TENANT_ID,
+            "manufacturer": manufacturer,
+            "model_number": model_str,
+            "content":      _build_content(sidecar),
+            "embedding":    str(embedding),
+            "source_url":   image_path,
+            "metadata":     meta,
+            "verified":     verified,
+        })
+        conn.commit()
+    return entry_id
+
+
+# ── Embedding ─────────────────────────────────────────────────────────────────
+
+def embed_text(text_str: str, max_retries: int = 3) -> list[float] | None:
+    """Embed text via Ollama nomic-embed-text:v1.5. Returns vector or None."""
+    for attempt in range(max_retries):
+        try:
+            resp = httpx.post(
+                f"{OLLAMA_BASE_URL}/api/embeddings",
+                json={"model": EMBED_MODEL, "prompt": text_str},
+                timeout=30.0,
+            )
+            resp.raise_for_status()
+            return resp.json()["embedding"]
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait = 2 ** attempt
+                logger.warning("Embed attempt %d/%d failed: %s — retry in %ds",
+                               attempt + 1, max_retries, e, wait)
+                time.sleep(wait)
+            else:
+                logger.error("Embed failed after %d attempts: %s", max_retries, e)
+                return None
+    return None
+
+
+def _build_content(sidecar: dict) -> str:
+    alerts_str = ", ".join(sidecar.get("alerts", [])) or "None"
+    return (
+        f"Equipment: {sidecar.get('equipment', 'Unknown')}\n"
+        f"Model: {sidecar.get('model', 'Unknown')}\n"
+        f"Observations: {sidecar.get('observations', '')}\n"
+        f"Alerts: {alerts_str}\n"
+        f"Session date: {sidecar.get('session_date', '')}\n"
+        f"Significance: {sidecar.get('significance', '')}"
+    )
+
+
+# ── Core ingest ───────────────────────────────────────────────────────────────
+
+def ingest_sidecar(json_path: Path) -> bool:
+    """Ingest one sidecar JSON file. Returns True on success."""
+    sentinel = json_path.with_suffix(".ingested")
+    if sentinel.exists():
+        return True  # already ingested
+
+    try:
+        sidecar = json.loads(json_path.read_text())
+    except Exception as e:
+        logger.error("Cannot read %s: %s", json_path, e)
+        return False
+
+    equipment = sidecar.get("equipment", "Unknown")
+    image_path = sidecar.get("image_path", str(json_path))
+
+    if equipment in ("Unknown", "General environment", ""):
+        logger.debug("Skipping low-signal capture: %s", json_path.name)
+        sentinel.touch()
+        return True
+
+    if entry_exists(image_path):
+        logger.info("Already ingested: %s", json_path.name)
+        sentinel.touch()
+        return True
+
+    content = _build_content(sidecar)
+    embedding = embed_text(content)
+    if embedding is None:
+        logger.error("Embedding failed for %s — skipping", json_path.name)
+        return False
+
+    try:
+        entry_id = insert_entry(sidecar, embedding)
+        sentinel.touch()
+        sig = sidecar.get("significance", "?")
+        logger.info("Ingested %s [%s] → %s", equipment, sig, entry_id[:8])
+        return True
+    except Exception as e:
+        logger.error("NeonDB insert failed for %s: %s", json_path.name, e)
+        return False
+
+
+# ── Backfill mode ─────────────────────────────────────────────────────────────
+
+def backfill(captures_dir: Path) -> None:
+    """Walk captures_dir, ingest all unprocessed sidecars."""
+    sidecars = sorted(captures_dir.rglob("*.json"))
+    total = len(sidecars)
+    logger.info("Backfill: found %d sidecar files in %s", total, captures_dir)
+    ok = failed = skipped = 0
+    for path in sidecars:
+        if path.suffix == ".ingested":
+            continue
+        result = ingest_sidecar(path)
+        if result:
+            if path.with_suffix(".ingested").exists():
+                ok += 1
+            else:
+                skipped += 1
+        else:
+            failed += 1
+    logger.info("Backfill complete: %d ingested, %d skipped, %d failed", ok, skipped, failed)
+
+
+# ── Watch mode ────────────────────────────────────────────────────────────────
+
+def watch(captures_dir: Path) -> None:
+    """Watch captures_dir for new sidecar JSON files and ingest them."""
+    try:
+        from watchdog.observers import Observer
+        from watchdog.events import FileSystemEventHandler
+    except ImportError:
+        logger.error("watchdog not installed — run: uv pip install watchdog>=4.0")
+        sys.exit(1)
+
+    class Handler(FileSystemEventHandler):
+        def on_created(self, event):
+            if event.is_directory:
+                return
+            path = Path(event.src_path)
+            if path.suffix == ".json" and not path.stem.endswith(".ingested"):
+                time.sleep(0.2)  # brief wait for write to flush
+                ingest_sidecar(path)
+
+    captures_dir.mkdir(parents=True, exist_ok=True)
+    observer = Observer()
+    observer.schedule(Handler(), str(captures_dir), recursive=True)
+    observer.start()
+    logger.info("Watching %s for new captures... (Ctrl+C to stop)", captures_dir)
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        observer.stop()
+    observer.join()
+    logger.info("Watcher stopped")
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Ingest MIRA vision captures to NeonDB KB")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--watch",    action="store_true",
+                       help="Watch vision_captures/ directory for new files")
+    group.add_argument("--backfill", metavar="PATH",
+                       help="Backfill all existing captures from PATH")
+    args = parser.parse_args()
+
+    if args.backfill:
+        backfill(Path(args.backfill))
+    else:
+        default_dir = Path(__file__).parent.parent / "vision_captures"
+        watch(default_dir)


### PR DESCRIPTION
## What's in this PR

5 commits on top of main (after feature/paperclip merge):

- HUD v0.6.0: vision capture to disk + KB ingest pipeline
- document-kb endpoint + nomic-embed RAG + bot PDF rewire
- HUD v0.6.1: audit fixes, answer routing, duplicate handlers
- NeonDB pgvector KB recall wired into HUD queryClaude + callRAG
- VPS runbook

Touches: `mira-hud`, `mira-bots`, `mira-core/mira-ingest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)