### PR TITLE
feat: set hnsw.ef_search=100 for recall query tuning

### DIFF
--- a/mira-bots/shared/neon_recall.py
+++ b/mira-bots/shared/neon_recall.py
@@ -283,6 +283,10 @@ def recall_knowledge(
             pool_pre_ping=True,
         )
         with engine.connect() as conn:
+            # HNSW query-time tuning — see docs/HNSW_MIGRATION.md.
+            # Overrides default ef_search=40 for this transaction only.
+            conn.execute(text("SET LOCAL hnsw.ef_search = 100"))
+
             # Stage 1: Dense vector search
             vector_rows = (
                 conn.execute(


### PR DESCRIPTION
## Summary

One-line tuning change to `mira-bots/shared/neon_recall.py` that overrides pgvector's default `hnsw.ef_search` (40) to **100** for every `recall_knowledge()` call. Scoped via `SET LOCAL` inside the existing connect() transaction, so it applies to the recall query only and doesn't leak to other sessions.

This is **step 10** of `REMEDIATION_CHECKLIST.md`, prescribed verbatim in `docs/HNSW_MIGRATION.md`:
> After the index is built, add `SET LOCAL hnsw.ef_search = 100` to the recall query in `mira-bots/shared/neon_recall.py`. This increases recall accuracy at query time without affecting other sessions.

Default `ef_search=40` is tuned for small corpora; for the ~25K-chunk knowledge base, 100 is the HNSW_MIGRATION.md recommended balance of recall accuracy vs latency.

## This PR is only the code half of the remediation

**Steps 1–9 and 11–12 of `REMEDIATION_CHECKLIST.md` still need to run on Bravo by an operator** with `doppler` + `NEON_DATABASE_URL` + `MIRA_TENANT_ID` + Ollama running. Specifically:

1. Pre-flight (git pull, `pytest mira-crawler/tests/test_chunker.py`, Docling importable, Ollama has `nomic-embed-text`)
2. `bash mira-core/scripts/backup_knowledge_base.sh` (not optional — Step 7 is destructive)
3. `bash mira-core/scripts/remediate_knowledge_base.sh` (purges + re-ingests with Docling + sentence-aware chunker)
4. `psql $NEON_DATABASE_URL -f mira-core/scripts/migrate_to_hnsw.sql`
5. Rebuild bot containers on Bravo: `docker compose up -d --build mira-bot-telegram mira-bot-slack`
6. Telegram smoke tests: `F4 on PowerFlex 40?` and `PF525 ambient temp rating?`

## Blind spots the operator should know before pulling the trigger

1. **This PR is a no-op until step 9 (HNSW index migration) runs.** Setting `ef_search=100` on a database still on the old IVFFlat index silently does nothing — `ef_search` is a knob that only exists once the HNSW index is built. **Order: migrate index first, then the code change helps.**
2. **This PR is also a no-op until Bravo's bot containers are rebuilt.** Code in git ≠ code in production. After merge, someone has to SSH to Bravo and `docker compose up -d --build` the bot adapters. There's no CD pipeline to Bravo (per `CLAUDE.md` → Known Broken / Incomplete).
3. **Requires pgvector ≥ 0.5.0.** If Bravo's Neon is on older pgvector, every recall will throw on the `SET LOCAL hnsw.ef_search` statement. The outer try/except in `recall_knowledge()` catches it and returns `[]` — symptom would be "bot stopped finding anything." Verify with `SELECT extversion FROM pg_extension WHERE extname='vector'` before rolling out.
4. **Step 7 is destructive.** It `DELETE`s all `knowledge_entries` for the tenant before re-ingesting. If anything fails mid-rebuild (Ollama OOM, corrupted PDF, Bravo disk full, network blip to NeonDB) the KB can end up empty. Step 5 (backup) is the only recovery path.
5. **The "<5% fallback_char_split" target assumes text-based PDFs.** Scanned image PDFs (common with older Allen-Bradley manuals) will force Docling to OCR, and those chunks may fall back. Don't blame the chunker without checking which source PDFs are driving a high fallback rate.
6. **Two smoke-test queries (steps 11–12) don't prove the remediation worked at scale.** The `kb-benchmark` skill in this repo runs a full technician MCQ evaluation — run it after smoke tests to get a real before/after score.
7. **The 36 chunker unit tests only cover chunking.** They don't touch Docling PDF parsing, Ollama embedding, or NeonDB writes. Green tests are necessary but not sufficient.
8. **`CREATE INDEX CONCURRENTLY` on NeonDB can be killed on throttled tiers** and leave a partial/invalid index. Check `pg_indexes` after migration.

## How to verify this PR is live (after Bravo rollout)

- `EXPLAIN ANALYZE` the recall SELECT against NeonDB — should show `Index Scan using knowledge_entries_embedding_hnsw_idx`.
- Compare per-query latency before/after the bot rebuild. `ef_search=100` should be slightly slower per query than the default 40. If latency is identical, the `SET LOCAL` isn't taking effect (usually means step 9 wasn't run first).
- Tail bot logs for the `NEON_RECALL tenant=...` line — should appear on every inbound query.

## Test plan

- [x] `ruff check mira-bots/shared/neon_recall.py` passes
- [x] `pytest mira-crawler/tests/test_chunker.py -q` — 36/36 pass (checklist step 2 gate)
- [x] Python AST parse of `neon_recall.py` clean
- [ ] Operator: run steps 1–9 + 11–12 on Bravo per `REMEDIATION_CHECKLIST.md`
- [ ] Operator: `docker compose up -d --build mira-bot-telegram mira-bot-slack` on Bravo
- [ ] Operator: confirm `pg_extension` has `vector` at ≥ 0.5.0
- [ ] Operator: run `kb-benchmark` skill for before/after quality score
- [ ] Operator: tick all 12 boxes in `REMEDIATION_CHECKLIST.md` in a follow-up commit

https://claude.ai/code/session_016AceA9WFkgpF2dqXBwFGJw