### PR TITLE
feat: Reddit→Telegram curation pipeline

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -125,3 +125,9 @@ EMBED_TEXT_MODEL=nomic-embed-text
 FLOWER_USER=admin
 FLOWER_PASSWORD=mira2026
 GRAFANA_PASSWORD=mira2026
+
+# Reddit → Telegram Pipeline (tools/reddit_tg_pipeline/)
+# TELEGRAM_TARGET=          # @channel or chat ID for Reddit curation posts
+# MIN_UPVOTES=              # (optional) min score threshold, default 10
+# MAX_ITEMS_PER_SUB=        # (optional) posts per subreddit, default 100
+# MESSAGE_DELAY_SECS=       # (optional) inter-message delay, default 3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ MIRA/
 ├── mira-web/           # PLG acquisition funnel — Hono/Bun, /cmms landing + Mira AI chat (1 container)
 ├── tests/              # 5-regime testing framework (76 offline tests, 39 golden cases)
 ├── docs/               # PRD, ADRs, architecture C4 diagrams, runbooks
-├── tools/              # Photo pipeline, Google Drive/Photos ingest scripts
+├── tools/              # Photo pipeline, Google Drive/Photos ingest, Reddit→TG curation
 ├── install/            # Setup scripts, smoke tests
 ├── deployment/         # Admin guide, customer agreement
 └── plc/                # PLC program files (deferred to Config 4)

--- a/tools/reddit_tg_pipeline/.gitignore
+++ b/tools/reddit_tg_pipeline/.gitignore
@@ -1,0 +1,2 @@
+*.csv
+*.session

--- a/tools/reddit_tg_pipeline/README.md
+++ b/tools/reddit_tg_pipeline/README.md
@@ -1,0 +1,165 @@
+# Reddit → Telegram Troubleshooting Pipeline
+
+Scrapes high-upvote troubleshooting questions from Reddit via **Apify**,
+filters them by keyword and upvote threshold, then forwards them to a
+Telegram channel or chat via **Telethon**.
+
+---
+
+## File layout
+
+```
+tools/reddit_tg_pipeline/
+├── main.py                  ← CLI orchestrator
+├── apify_reddit_scraper.py  ← Apify actor runner + CSV export
+├── telethon_forwarder.py    ← Telethon message sender
+├── run_charlie.sh           ← Shell wrapper for Charlie node (Doppler + uv)
+└── README.md
+```
+
+---
+
+## Setup
+
+### 1. Install dependencies
+
+```bash
+cd /path/to/mira
+uv sync
+# or: uv pip install -r tools/requirements.txt
+```
+
+### 2. Get credentials
+
+| Secret | Where |
+|--------|-------|
+| `APIFY_API_KEY` | [Apify Console → Integrations](https://console.apify.com/account/integrations) |
+| `TELEGRAM_API_ID` | [my.telegram.org/apps](https://my.telegram.org/apps) |
+| `TELEGRAM_API_HASH` | same as above |
+| `TELEGRAM_TARGET` | `@channelname`, numeric chat ID, or phone number |
+
+### 3. Store in Doppler
+
+```bash
+doppler secrets set APIFY_API_KEY apify_api_xxx
+doppler secrets set TELEGRAM_API_ID 12345678
+doppler secrets set TELEGRAM_API_HASH abcdef123...
+doppler secrets set TELEGRAM_TARGET @mira_questions
+doppler secrets set MIN_UPVOTES 10
+doppler secrets set MAX_ITEMS_PER_SUB 100
+```
+
+### 4. First run (Telethon auth)
+
+The first run will prompt you to authenticate with your Telegram account
+(enter phone number + OTP code). After that, a `.session` file is saved
+locally and future runs are non-interactive.
+
+```bash
+./run_charlie.sh --dry-run   # verify everything works first
+```
+
+---
+
+## Usage
+
+```bash
+# Normal run: scrape + forward to Telegram
+./run_charlie.sh
+
+# Dry run — prints messages, nothing sent
+./run_charlie.sh --dry-run
+
+# Scrape only, save CSV, skip Telegram
+./run_charlie.sh --scrape-only
+
+# Forward from an existing CSV (skip scraping)
+cd tools/reddit_tg_pipeline
+python main.py --from-csv reddit_questions_20260405_120000.csv
+
+# Top 20 posts only
+./run_charlie.sh --limit 20
+
+# Override upvote threshold for this run
+cd tools/reddit_tg_pipeline
+python main.py --min-upvotes 50
+```
+
+---
+
+## Subreddits scraped
+
+Defined in `apify_reddit_scraper.py → SUBREDDITS` list. Current defaults:
+
+- r/techsupport
+- r/fixit
+- r/AskElectricians
+- r/DIY
+- r/HomeImprovement
+- r/MechanicAdvice
+- r/electricians
+- r/PLC
+- r/HVAC
+- r/plumbing
+
+Edit the list freely to target any public subreddit.
+
+---
+
+## Filter logic
+
+A post passes if **both** conditions are true:
+
+1. `upvotes >= MIN_UPVOTES` (default 10)
+2. Title or body matches at least one of the [troubleshooting keyword regex patterns](apify_reddit_scraper.py)
+
+---
+
+## CSV output
+
+Each run writes a timestamped CSV with these columns:
+
+| Column | Description |
+|--------|-------------|
+| `subreddit` | r/name |
+| `post_id` | Reddit post ID |
+| `title` | Post title |
+| `body` | First 500 chars of self-text |
+| `upvotes` | Score at scrape time |
+| `upvote_ratio` | e.g. 0.95 |
+| `num_comments` | Comment count |
+| `author` | u/username |
+| `url` | Full Reddit URL |
+| `created_at` | Post creation timestamp |
+| `scraped_at` | UTC ISO timestamp of scrape |
+
+---
+
+## Telegram message format
+
+```
+🔧 r/techsupport · 3/47
+
+**Why does my PC keep restarting randomly?**
+
+It happens every few hours with no warning. No BSOD, just an instant reboot.
+
+👍 142 upvotes  |  💬 38 comments  |  👤 u/some_user
+🔗 View on Reddit
+```
+
+---
+
+## Scheduling on Charlie (cron)
+
+```cron
+# Every day at 8am Eastern (UTC-4 in summer)
+0 12 * * * /path/to/mira/tools/reddit_tg_pipeline/run_charlie.sh >> /var/log/reddit_tg.log 2>&1
+```
+
+---
+
+## Apify Actor used
+
+**`silentflow/reddit-scraper`** — no Reddit API key required, supports
+hot/new/top sort, NSFW filtering, full metadata including upvotes and comment counts.

--- a/tools/reddit_tg_pipeline/apify_reddit_scraper.py
+++ b/tools/reddit_tg_pipeline/apify_reddit_scraper.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+apify_reddit_scraper.py
+-----------------------
+Uses the Apify Reddit Scraper actor (silentflow/reddit-scraper) to pull posts
+from target subreddits, filter for high-upvote troubleshooting questions, and
+export the results to CSV.
+
+Doppler secrets expected:
+  APIFY_API_KEY           — your Apify API token
+  MIN_UPVOTES             — (optional) minimum score threshold, default 10
+  MAX_ITEMS_PER_SUB       — (optional) posts to fetch per subreddit, default 100
+
+Actor: silentflow/reddit-scraper  (https://apify.com/silentflow/reddit-scraper)
+"""
+
+import csv
+import logging
+import os
+import re
+from datetime import datetime, timezone
+
+from apify_client import ApifyClient
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+ACTOR_ID = "silentflow/reddit-scraper"
+
+SUBREDDITS = [
+    "techsupport",
+    "fixit",
+    "AskElectricians",
+    "DIY",
+    "HomeImprovement",
+    "MechanicAdvice",
+    "electricians",
+    "PLC",                   # industrial / MIRA-relevant
+    "HVAC",
+    "plumbing",
+]
+
+# Keywords that strongly indicate a troubleshooting question.
+# See also: mira-bots/reddit/post_filter.py DIAGNOSTIC_KEYWORDS
+# (different purpose — reply-gating with heavier industrial focus)
+QUESTION_KEYWORDS = [
+    r"\bhow (do|can|should|to)\b",
+    r"\bwhy (is|does|won't|did|isn't)\b",
+    r"\bwhat (is|causes|should|does)\b",
+    r"\bnot working\b",
+    r"\bkeeps? (failing|tripping|shutting|rebooting|resetting)\b",
+    r"\bkeeps? (throwing|giving|showing)\b",
+    r"\bfault\b",
+    r"\balarm\b",
+    r"\berror\b",
+    r"\btroubleshoot\b",
+    r"\bfix\b",
+    r"\bhelp\b",
+    r"\bissue\b",
+    r"\bproblem\b",
+    r"\bbroken\b",
+    r"\bno power\b",
+    r"\btripping\b",
+    r"\boverload\b",
+    r"\b(wont|won't|doesn't|does not|can't|cannot) (start|run|work|turn on|power)\b",
+    r"\?$",   # ends with a question mark
+]
+
+COMPILED_KEYWORDS = [re.compile(p, re.IGNORECASE) for p in QUESTION_KEYWORDS]
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def is_question(title: str, body: str = "") -> bool:
+    """Return True if the post looks like a troubleshooting question."""
+    text = f"{title} {body}"
+    return any(pat.search(text) for pat in COMPILED_KEYWORDS)
+
+
+def build_actor_input(subreddit: str, max_items: int, sort: str = "hot") -> dict:
+    return {
+        "startUrls": [{"url": f"https://www.reddit.com/r/{subreddit}/"}],
+        "maxItems": max_items,
+        "sort": sort,
+        "includeNSFW": False,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main scraping function
+# ---------------------------------------------------------------------------
+def scrape_reddit(
+    output_csv: str = "reddit_questions.csv",
+    min_upvotes: int | None = None,
+    max_items_per_sub: int | None = None,
+) -> list[dict]:
+    """
+    Run the Apify actor for each subreddit, filter results, and write to CSV.
+    Returns a list of filtered post dicts.
+    """
+    api_token = os.environ.get("APIFY_API_KEY")
+    if not api_token:
+        raise EnvironmentError(
+            "APIFY_API_KEY is not set. "
+            "Add it via Doppler: doppler secrets set APIFY_API_KEY <value>"
+        )
+
+    min_upvotes = int(os.environ.get("MIN_UPVOTES", 10) if min_upvotes is None else min_upvotes)
+    max_items = int(
+        os.environ.get("MAX_ITEMS_PER_SUB", 100) if max_items_per_sub is None else max_items_per_sub
+    )
+
+    client = ApifyClient(api_token)
+    all_filtered: list[dict] = []
+
+    for sub in SUBREDDITS:
+        log.info("Scraping r/%s (max %d items, min %d upvotes)...", sub, max_items, min_upvotes)
+        actor_input = build_actor_input(sub, max_items, sort="hot")
+
+        try:
+            run = client.actor(ACTOR_ID).call(run_input=actor_input)
+        except Exception as exc:
+            log.error("Actor run failed for r/%s: %s", sub, exc)
+            continue
+
+        dataset_id = run.get("defaultDatasetId")
+        if not dataset_id:
+            log.warning("No dataset returned for r/%s — skipping.", sub)
+            continue
+
+        log.info("  Dataset ID: %s", dataset_id)
+        count = 0
+        kept = 0
+
+        for item in client.dataset(dataset_id).iterate_items():
+            # The silentflow actor marks posts with dataType == "post"
+            if item.get("dataType") != "post":
+                continue
+
+            count += 1
+            title = item.get("title", "") or ""
+            body = item.get("body", "") or ""
+            upvotes = item.get("upVotes", 0) or 0
+
+            if upvotes < min_upvotes:
+                continue
+            if not is_question(title, body):
+                continue
+
+            post = {
+                "subreddit": item.get("communityName", sub),
+                "post_id": item.get("id", ""),
+                "title": title,
+                "body": (body[:500] + "...") if len(body) > 500 else body,
+                "upvotes": upvotes,
+                "upvote_ratio": item.get("upVoteRatio", ""),
+                "num_comments": item.get("numberOfComments", 0),
+                "author": item.get("username", "[deleted]"),
+                "url": item.get("url", ""),
+                "created_at": item.get("createdAt", ""),
+                "scraped_at": datetime.now(timezone.utc).isoformat(),
+            }
+            all_filtered.append(post)
+            kept += 1
+
+        log.info("  r/%s — %d posts fetched, %d passed filters.", sub, count, kept)
+
+    log.info("Total qualifying posts: %d", len(all_filtered))
+
+    # Sort by upvotes descending
+    all_filtered.sort(key=lambda x: x["upvotes"], reverse=True)
+
+    # Write CSV
+    if all_filtered:
+        fieldnames = list(all_filtered[0].keys())
+        with open(output_csv, "w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(all_filtered)
+        log.info("CSV saved → %s", output_csv)
+    else:
+        log.warning("No posts matched filters — CSV not written.")
+
+    return all_filtered
+
+
+# ---------------------------------------------------------------------------
+# Standalone test run
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    results = scrape_reddit()
+    print(f"\n{len(results)} posts exported.")
+    for p in results[:5]:
+        print(f"  [{p['upvotes']:>5}] r/{p['subreddit']}: {p['title'][:80]}")

--- a/tools/reddit_tg_pipeline/main.py
+++ b/tools/reddit_tg_pipeline/main.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+main.py
+-------
+Orchestrator for the Reddit → Telegram troubleshooting-question pipeline.
+
+Usage:
+  # Normal run (scrape + forward)
+  python main.py
+
+  # Dry run (no Telegram messages sent)
+  python main.py --dry-run
+
+  # Skip scraping, forward from an existing CSV
+  python main.py --from-csv reddit_questions.csv
+
+  # Only scrape, skip Telegram forwarding
+  python main.py --scrape-only
+
+  # Limit how many posts to forward
+  python main.py --limit 20
+
+Doppler secrets (run via doppler run or run_charlie.sh):
+  APIFY_API_KEY            — Apify API token
+  TELEGRAM_API_ID          — Telegram app ID (my.telegram.org)
+  TELEGRAM_API_HASH        — Telegram app hash
+  TELEGRAM_TARGET          — Target channel/chat (@username or numeric ID)
+  TELEGRAM_SESSION_NAME    — (optional) .session file name
+  TELEGRAM_BOT_TOKEN       — (optional) use bot mode instead of user mode
+  MIN_UPVOTES              — (optional) int, default 10
+  MAX_ITEMS_PER_SUB        — (optional) int, default 100
+  MESSAGE_DELAY_SECS       — (optional) float, default 3.0
+  DRY_RUN                  — (optional) "1" to skip sending
+"""
+
+import argparse
+import csv
+import logging
+import os
+import sys
+from datetime import datetime
+
+from apify_reddit_scraper import scrape_reddit
+from telethon_forwarder import forward_posts
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# CSV loader (for --from-csv mode)
+# ---------------------------------------------------------------------------
+def load_from_csv(path: str) -> list[dict]:
+    posts = []
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            # Coerce numeric fields back from strings
+            row["upvotes"] = int(row.get("upvotes", 0) or 0)
+            row["num_comments"] = int(row.get("num_comments", 0) or 0)
+            posts.append(row)
+    log.info("Loaded %d posts from %s", len(posts), path)
+    return posts
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="Scrape Reddit troubleshooting questions → forward to Telegram"
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=os.environ.get("DRY_RUN", "0").lower() in ("1", "true"),
+        help="Print messages to stdout instead of sending to Telegram",
+    )
+    p.add_argument(
+        "--scrape-only",
+        action="store_true",
+        help="Run the scraper and export CSV, skip Telegram forwarding",
+    )
+    p.add_argument(
+        "--from-csv",
+        metavar="FILE",
+        default=None,
+        help="Skip scraping and load posts from this CSV file instead",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of posts to forward (defaults to all)",
+    )
+    p.add_argument(
+        "--output-csv",
+        metavar="FILE",
+        default=None,
+        help="CSV output path (default: reddit_questions_YYYYMMDD_HHMMSS.csv)",
+    )
+    p.add_argument(
+        "--min-upvotes",
+        type=int,
+        default=None,
+        help="Override MIN_UPVOTES environment variable",
+    )
+    p.add_argument(
+        "--max-items",
+        type=int,
+        default=None,
+        help="Override MAX_ITEMS_PER_SUB environment variable",
+    )
+    return p.parse_args()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+def main():
+    args = parse_args()
+
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    csv_path = args.output_csv or f"reddit_questions_{timestamp}.csv"
+
+    # ── Step 1: Acquire posts ──────────────────────────────────────────────
+    if args.from_csv:
+        posts = load_from_csv(args.from_csv)
+    else:
+        log.info("Starting Apify Reddit scrape...")
+        posts = scrape_reddit(
+            output_csv=csv_path,
+            min_upvotes=args.min_upvotes,
+            max_items_per_sub=args.max_items,
+        )
+        log.info("Scrape complete. CSV → %s", csv_path)
+
+    if not posts:
+        log.warning("No qualifying posts found. Exiting.")
+        sys.exit(0)
+
+    # ── Step 2: Apply limit ────────────────────────────────────────────────
+    if args.limit and args.limit < len(posts):
+        log.info("Limiting to top %d posts (out of %d).", args.limit, len(posts))
+        posts = posts[: args.limit]
+
+    # ── Step 3: Optionally skip forwarding ─────────────────────────────────
+    if args.scrape_only:
+        log.info("--scrape-only set. Skipping Telegram forwarding.")
+        print(f"\n✓ Done. {len(posts)} posts saved to: {csv_path}")
+        return
+
+    # ── Step 4: Forward to Telegram ────────────────────────────────────────
+    log.info("Starting Telegram forwarding (%d posts)...", len(posts))
+    stats = forward_posts(posts, dry_run=args.dry_run)
+
+    # ── Summary ────────────────────────────────────────────────────────────
+    print("\n" + "=" * 50)
+    print(f"  Pipeline complete — {timestamp}")
+    print("=" * 50)
+    print(f"  Posts scraped / loaded : {len(posts)}")
+    print(f"  Messages sent          : {stats['sent']}")
+    print(f"  Messages skipped       : {stats['skipped']}")
+    print(f"  Errors                 : {stats['errors']}")
+    if not args.from_csv:
+        print(f"  CSV path               : {csv_path}")
+    print("=" * 50)
+
+    if stats["errors"] > 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/reddit_tg_pipeline/run_charlie.sh
+++ b/tools/reddit_tg_pipeline/run_charlie.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# run_charlie.sh
+# Run the Reddit → Telegram pipeline on Charlie node using Doppler for secrets.
+#
+# Usage:
+#   chmod +x run_charlie.sh
+#   ./run_charlie.sh                   # normal run
+#   ./run_charlie.sh --dry-run         # dry run, no Telegram send
+#   ./run_charlie.sh --scrape-only     # only scrape + export CSV
+#   ./run_charlie.sh --limit 25        # forward top 25 posts only
+# ─────────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+echo ""
+echo "═══════════════════════════════════════════════════"
+echo "  Reddit → Telegram Pipeline  |  $(date '+%Y-%m-%d %H:%M:%S')"
+echo "═══════════════════════════════════════════════════"
+
+# Doppler is required — no .env fallback
+if ! command -v doppler &>/dev/null; then
+    echo "  [error] Doppler CLI not found. Install: brew install dopplerhq/cli/doppler"
+    exit 1
+fi
+
+echo "  [doppler] Loading secrets..."
+echo "  [python]  Starting pipeline..."
+
+cd "$SCRIPT_DIR"
+doppler run --project factorylm --config prd -- \
+    uv run --project "$REPO_ROOT" python main.py "$@"
+
+echo ""
+echo "  Done at $(date '+%H:%M:%S')"
+echo "═══════════════════════════════════════════════════"

--- a/tools/reddit_tg_pipeline/telethon_forwarder.py
+++ b/tools/reddit_tg_pipeline/telethon_forwarder.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+telethon_forwarder.py
+---------------------
+Sends filtered Reddit troubleshooting posts to a Telegram channel or chat
+using Telethon (MTProto — not the Bot API, so it can post as your user account
+OR as a bot depending on which credentials you supply).
+
+Doppler secrets expected:
+  TELEGRAM_API_ID        — from https://my.telegram.org/apps
+  TELEGRAM_API_HASH      — from https://my.telegram.org/apps
+  TELEGRAM_SESSION_NAME  — local .session file name (default: reddit_forwarder)
+  TELEGRAM_TARGET        — channel username (@mychannel), chat ID (-100xxxxx),
+                           or phone number of DM recipient
+
+Optional:
+  TELEGRAM_BOT_TOKEN     — if set, uses bot mode instead of user-account mode
+  MESSAGE_DELAY_SECS     — seconds to sleep between messages (default: 3)
+  DRY_RUN                — if "1" or "true", prints messages without sending
+"""
+
+import asyncio
+import logging
+import os
+
+from telethon import TelegramClient, errors
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Message template
+# ---------------------------------------------------------------------------
+def format_post(post: dict, index: int, total: int) -> str:
+    """Build a clean Telegram message from a Reddit post dict."""
+    sub = post.get("subreddit", "?")
+    title = post.get("title", "")
+    body = post.get("body", "").strip()
+    upvotes = post.get("upvotes", 0)
+    comments = post.get("num_comments", 0)
+    url = post.get("url", "")
+    author = post.get("author", "unknown")
+
+    # Trim body for Telegram's 4096-char limit
+    max_body = 600
+    if body and len(body) > max_body:
+        body = body[:max_body] + "…"
+
+    lines = [
+        f"🔧 **r/{sub}** · {index}/{total}",
+        "",
+        f"**{title}**",
+    ]
+    if body:
+        lines += ["", body]
+
+    lines += [
+        "",
+        f"👍 {upvotes:,} upvotes  |  💬 {comments} comments  |  👤 u/{author}",
+        f"🔗 [View on Reddit]({url})",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Core forwarder
+# ---------------------------------------------------------------------------
+async def _send_posts(
+    posts: list[dict],
+    target: str,
+    api_id: int,
+    api_hash: str,
+    session_name: str,
+    bot_token: str | None,
+    delay_secs: float,
+    dry_run: bool,
+) -> dict:
+    """Internal async coroutine. Returns summary stats."""
+    stats = {"sent": 0, "skipped": 0, "errors": 0}
+
+    if dry_run:
+        log.info("[DRY RUN] Would send %d posts to %s", len(posts), target)
+        for i, post in enumerate(posts, 1):
+            msg = format_post(post, i, len(posts))
+            print(f"\n--- Message {i} ---\n{msg}\n")
+            stats["sent"] += 1
+        return stats
+
+    # Build the TelegramClient
+    if bot_token:
+        client = TelegramClient(session_name, api_id, api_hash)
+        await client.start(bot_token=bot_token)
+        log.info("Connected as bot.")
+    else:
+        client = TelegramClient(session_name, api_id, api_hash)
+        await client.start()
+        me = await client.get_me()
+        log.info("Connected as user: %s (@%s)", me.first_name, me.username)
+
+    async with client:
+        # Resolve the target entity once
+        try:
+            entity = await client.get_entity(target)
+            log.info("Target resolved: %s", entity)
+        except Exception as exc:
+            log.error("Could not resolve target '%s': %s", target, exc)
+            stats["errors"] = len(posts)
+            return stats
+
+        total = len(posts)
+        for i, post in enumerate(posts, 1):
+            msg = format_post(post, i, total)
+            try:
+                await client.send_message(entity, msg, link_preview=False)
+                log.info("[%d/%d] Sent: %s", i, total, post.get("title", "")[:60])
+                stats["sent"] += 1
+            except errors.FloodWaitError as fwe:
+                wait = fwe.seconds + 5
+                log.warning("FloodWait — sleeping %ds before retry...", wait)
+                await asyncio.sleep(wait)
+                # Retry once
+                try:
+                    await client.send_message(entity, msg, link_preview=False)
+                    stats["sent"] += 1
+                except Exception as retry_exc:
+                    log.error("Retry failed for post %d: %s", i, retry_exc)
+                    stats["errors"] += 1
+            except errors.ChatWriteForbiddenError:
+                log.error("Write access denied for target '%s' — aborting.", target)
+                stats["skipped"] = total - i
+                break
+            except Exception as exc:
+                log.error("Failed to send post %d: %s", i, exc)
+                stats["errors"] += 1
+
+            if i < total:
+                await asyncio.sleep(delay_secs)
+
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Public interface
+# ---------------------------------------------------------------------------
+def forward_posts(
+    posts: list[dict],
+    target: str | None = None,
+    dry_run: bool | None = None,
+) -> dict:
+    """
+    Forward a list of post dicts to Telegram.
+    Reads credentials from environment / Doppler.
+    Returns a summary dict: {sent, skipped, errors}.
+    """
+    api_id_raw = os.environ.get("TELEGRAM_API_ID")
+    api_hash = os.environ.get("TELEGRAM_API_HASH")
+    session_name = os.environ.get("TELEGRAM_SESSION_NAME", "reddit_forwarder")
+    bot_token = os.environ.get("TELEGRAM_BOT_TOKEN")  # optional
+    _target = target or os.environ.get("TELEGRAM_TARGET")
+    delay_secs = float(os.environ.get("MESSAGE_DELAY_SECS", 3))
+
+    _dry_run = dry_run
+    if _dry_run is None:
+        _dry_run = os.environ.get("DRY_RUN", "0").lower() in ("1", "true", "yes")
+
+    # Validate required vars
+    missing = []
+    if not api_id_raw:
+        missing.append("TELEGRAM_API_ID")
+    if not api_hash:
+        missing.append("TELEGRAM_API_HASH")
+    if not _target:
+        missing.append("TELEGRAM_TARGET")
+    if missing:
+        raise EnvironmentError(
+            f"Missing required Telegram env vars: {', '.join(missing)}\n"
+            "Set them via Doppler before running."
+        )
+
+    api_id = int(api_id_raw)  # type: ignore[arg-type]
+
+    if not posts:
+        log.info("No posts to forward.")
+        return {"sent": 0, "skipped": 0, "errors": 0}
+
+    log.info(
+        "Forwarding %d posts to '%s'%s",
+        len(posts),
+        _target,
+        " [DRY RUN]" if _dry_run else "",
+    )
+
+    return asyncio.run(
+        _send_posts(
+            posts=posts,
+            target=_target,
+            api_id=api_id,
+            api_hash=api_hash,
+            session_name=session_name,
+            bot_token=bot_token,
+            delay_secs=delay_secs,
+            dry_run=_dry_run,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Standalone test
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
+    sample = [
+        {
+            "subreddit": "techsupport",
+            "title": "Why does my PC keep restarting randomly?",
+            "body": "It happens every few hours with no warning. No BSOD, just an instant reboot.",
+            "upvotes": 142,
+            "num_comments": 38,
+            "url": "https://reddit.com/r/techsupport/comments/example",
+            "author": "test_user",
+        }
+    ]
+
+    # Enable dry-run for standalone test so no real messages are sent
+    os.environ.setdefault("DRY_RUN", "1")
+    os.environ.setdefault("TELEGRAM_TARGET", "@your_channel_here")
+
+    result = forward_posts(sample)
+    print(f"\nResult: {result}")

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -2,3 +2,5 @@ google-auth-oauthlib>=1.2
 google-api-python-client>=2.0
 anthropic>=0.40
 httpx>=0.27
+apify-client>=1.8.0
+telethon>=1.36.0


### PR DESCRIPTION
## Summary
- Adds `tools/reddit_tg_pipeline/` — a content curation tool that scrapes high-upvote troubleshooting questions from 10 subreddits via Apify and forwards them to a Telegram channel via Telethon
- Designed to run as a daily cron on the Charlie node via `doppler run + uv run`
- Complements (does not replace) the existing `mira-bots/reddit/` reply bot — different purpose (curation vs reply)

## What's in the pipeline
- `main.py` — CLI orchestrator (argparse: `--dry-run`, `--scrape-only`, `--from-csv`, `--limit`)
- `apify_reddit_scraper.py` — Apify actor runner (`silentflow/reddit-scraper`), keyword/upvote filtering, CSV export
- `telethon_forwarder.py` — Telethon MTProto sender with FloodWait handling
- `run_charlie.sh` — Shell wrapper using `doppler run --project factorylm --config prd -- uv run`
- `README.md`, `.gitignore` (excludes `*.csv` and `*.session`)

## Aligned with MIRA standards
- `APIFY_API_KEY` (matches existing `mira-core/scripts/discover_manuals.py` convention, not `APIFY_API_TOKEN`)
- Python 3.12 type hints (`X | None`, not `Optional[X]`)
- `uv` invocation, not `pip`/`venv`
- Doppler-only for secrets (no `.env` fallback)
- `ruff check` passes clean

## Meta changes
- `.env.template` — documents new Doppler vars (`TELEGRAM_TARGET`, `MIN_UPVOTES`, `MAX_ITEMS_PER_SUB`, `MESSAGE_DELAY_SECS`)
- `tools/requirements.txt` — adds `apify-client>=1.8.0`, `telethon>=1.36.0`
- `CLAUDE.md` — updates `tools/` description in repo map

## Keyword lists: deliberately kept separate
The pipeline's `QUESTION_KEYWORDS` (broad, 10 general subreddits) intentionally does **not** consolidate with `mira-bots/reddit/post_filter.py`'s `DIAGNOSTIC_KEYWORDS` (industrial-focused, reply-gating). Different purpose, different subreddit scope, different architecture. A cross-reference comment is noted at the keyword list.

## Test plan
- [ ] `uvx ruff check tools/reddit_tg_pipeline/` — must pass clean
- [ ] `doppler run --project factorylm --config prd -- uv run python tools/reddit_tg_pipeline/main.py --scrape-only --limit 5` (verifies Apify connection + CSV output)
- [ ] `doppler run --project factorylm --config prd -- uv run python tools/reddit_tg_pipeline/main.py --dry-run --limit 3` (verifies message formatting without sending)
- [ ] `tools/reddit_tg_pipeline/run_charlie.sh --dry-run --limit 2` (verifies shell wrapper integration)
- [ ] First live run requires interactive phone+OTP auth to create the Telethon `.session` file (one-time)
- [ ] `pytest tests/` — no regressions in the wider repo

## Notes
- Apify cost: 10 subreddits × 100 items = ~1,000 actor calls/day on default settings. Verify plan capacity before enabling cron.
- Telethon `.session` file is gitignored and must persist on Charlie between runs.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>