### PR TITLE
test: fix 4 stale tests exposed by CI lint cleanup (removes #116 skips)

### DIFF
--- a/mira-bots/tests/test_image_downscale.py
+++ b/mira-bots/tests/test_image_downscale.py
@@ -4,8 +4,6 @@ import io
 import os
 import sys
 
-import pytest
-
 # Set dummy env vars for bot.py import
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy-token-for-testing")
 os.environ.setdefault("OPENWEBUI_BASE_URL",
@@ -22,20 +20,19 @@ from bot import _resize_for_vision
 from PIL import Image
 
 
-@pytest.mark.skip(
-    reason="Stale — _resize_for_vision() was retuned to MAX_VISION_PX=1024 "
-    "(see mira-bots/telegram/bot.py:97). Assertion still pins the old 512 "
-    "cap. Skipped to unblock CI as part of the style cleanup; real fix "
-    "updates the assertion to match the current 1024 target."
-)
-def test_large_image_resized_to_512():
-    """1920x1080 image should be downscaled so max side <= 512."""
+def test_large_image_resized_to_vision_max_px():
+    """1920x1080 image should be downscaled so max side <= MAX_VISION_PX.
+
+    Value tracks the MAX_VISION_PX env var (default 1024, see
+    mira-bots/telegram/bot.py:_resize_for_vision).
+    """
+    max_px = int(os.environ.get("MAX_VISION_PX", "1024"))
     img = Image.new("RGB", (1920, 1080), (128, 128, 128))
     buf = io.BytesIO()
     img.save(buf, "JPEG")
     result = _resize_for_vision(buf.getvalue())
     out = Image.open(io.BytesIO(result))
-    assert max(out.size) <= 512
+    assert max(out.size) <= max_px
 
 
 def test_small_image_unchanged():

--- a/mira-bots/tests/test_reranking.py
+++ b/mira-bots/tests/test_reranking.py
@@ -140,16 +140,15 @@ class TestRerankingIntegration:
         query_arg = worker.nemotron.rerank.call_args[0][0]
         assert "F004" in query_arg
 
-    @pytest.mark.skip(
-        reason="Stale — RAGWorker.process() photo-query path was refactored "
-        "to call _visual_search() when self._ingest_url is set, bypassing the "
-        "text-embed + _neon_recall path this test mocks. Skipped to unblock "
-        "CI as part of the style cleanup; real fix sets worker._ingest_url = "
-        "None to force the text-embed branch."
-    )
     @pytest.mark.asyncio
     async def test_rerank_called_for_photo_query(self):
         worker = _make_rag_worker()
+        # Force the text-embed + _neon_recall branch. When self._ingest_url is
+        # set, RAGWorker.process() routes photo queries through _visual_search()
+        # (dual-modality retrieval via HTTP to mira-ingest/ingest/search-visual)
+        # which bypasses the mock below. Disabling the ingest URL forces the
+        # else branch so the test can verify the rerank path end-to-end.
+        worker._ingest_url = None
         worker._call_llm = AsyncMock(return_value='{"reply": "test", "next_state": "Q1"}')
         worker._embed_ollama = AsyncMock(return_value=[0.1] * 768)
 
@@ -166,16 +165,11 @@ class TestRerankingIntegration:
         query_arg = worker.nemotron.rerank.call_args[0][0]
         assert "PowerFlex 525" in query_arg
 
-    @pytest.mark.skip(
-        reason="Stale — RAGWorker.process() photo-query path was refactored "
-        "to call _visual_search() when self._ingest_url is set, so "
-        "_embed_ollama is never called and worker._embed_ollama.call_args is "
-        "None. Skipped to unblock CI as part of the style cleanup; real fix "
-        "sets worker._ingest_url = None to force the text-embed branch."
-    )
     @pytest.mark.asyncio
     async def test_photo_query_embeds_with_asset_context(self):
         worker = _make_rag_worker()
+        # Force the text-embed branch — see comment in the previous test.
+        worker._ingest_url = None
         worker._call_llm = AsyncMock(return_value='{"reply": "test", "next_state": "Q1"}')
         worker._embed_ollama = AsyncMock(return_value=[0.1] * 768)
 

--- a/mira-core/mira-ingest/tests/test_benchmark.py
+++ b/mira-core/mira-ingest/tests/test_benchmark.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -214,50 +214,42 @@ def test_benchmark_questions_endpoint(client, isolated_db):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skip(
-    reason="Stale mock — reddit_harvest.py was refactored to use "
-    "DIAGNOSTIC_KEYWORDS regex + /search.json endpoint via _fetch_search(). "
-    "This mock targets the old listing shape and silently falls through to "
-    "the live Reddit API. Skipped here to unblock CI as part of the style "
-    "cleanup; tracked for a real rewrite that mocks _fetch_search directly."
-)
 def test_harvest_parses_json_and_filters(isolated_db):
-    """Mock httpx.Client.get to return fake Reddit JSON, verify harvest logic."""
-    fake_response_data = {
-        "data": {
-            "children": [
-                {
-                    "data": {
-                        "id": "post1",
-                        "title": "How do I troubleshoot a VFD fault code?",
-                        "score": 25,
-                        "permalink": "/r/PLC/comments/post1/how_do_i/",
-                    }
-                },
-                {
-                    "data": {
-                        "id": "post2",
-                        "title": "Check out my new workshop",
-                        "score": 100,
-                        "permalink": "/r/PLC/comments/post2/check_out/",
-                    }
-                },
-                {
-                    "data": {
-                        "id": "post3",
-                        "title": "Motor keeps tripping on startup?",
-                        "score": 12,
-                        "permalink": "/r/PLC/comments/post3/motor_keeps/",
-                    }
-                },
-            ],
-            "after": None,
-        }
-    }
-
-    fake_resp = MagicMock()
-    fake_resp.status_code = 200
-    fake_resp.json.return_value = fake_response_data
+    """Mock reddit_harvest._fetch_search to return fake posts; verify filter + dedup."""
+    # Each dict mirrors the `children[i]` shape that _fetch_search() returns:
+    # the raw Reddit `/search.json` child (has a `data` subkey with the post).
+    fake_children = [
+        {
+            "data": {
+                "id": "post1",
+                "title": "How do I troubleshoot a VFD fault code?",
+                "selftext": "Getting F004 on startup, any ideas?",
+                "score": 25,
+                "permalink": "/r/PLC/comments/post1/how_do_i/",
+                "is_self": True,
+            }
+        },
+        {
+            "data": {
+                "id": "post2",
+                "title": "Check out my new workshop",
+                "selftext": "Finally finished the shop.",
+                "score": 100,
+                "permalink": "/r/PLC/comments/post2/check_out/",
+                "is_self": True,
+            }
+        },
+        {
+            "data": {
+                "id": "post3",
+                "title": "Motor keeps tripping on startup?",
+                "selftext": "3-phase motor, trips every time.",
+                "score": 12,
+                "permalink": "/r/PLC/comments/post3/motor_keeps/",
+                "is_self": True,
+            }
+        },
+    ]
 
     # Add scripts path so we can import reddit_harvest
     scripts_path = os.path.join(
@@ -269,9 +261,19 @@ def test_harvest_parses_json_and_filters(isolated_db):
 
     import reddit_harvest
 
-    with patch.object(reddit_harvest.httpx.Client, "get", return_value=fake_resp):
+    # Patch at the seam: _fetch_search() is the single function that talks to Reddit.
+    # Every (sub, query) pair gets the same 3 posts; seen_post_ids dedup guarantees
+    # each is only counted once across the 30 calls (5 subs × 6 queries).
+    # Also stub time.sleep so the 2s-per-call throttle doesn't add 60s to the test.
+    with (
+        patch.object(reddit_harvest, "_fetch_search", return_value=fake_children),
+        patch.object(reddit_harvest.time, "sleep", return_value=None),
+    ):
         result = reddit_harvest.harvest(db_path=isolated_db)
 
-    # post1 matches (ends with ?), post2 filtered out, post3 matches (ends with ?)
+    # post1 → relevant (ends with ?, matches vfd|fault|troubleshoot)
+    # post2 → filtered (no diagnostic keywords, no question shape)
+    # post3 → relevant (ends with ?, matches motor|keeps|trip)
     assert result["harvested"] == 2
+    assert result["total"] == 2
     assert result["total"] >= 2


### PR DESCRIPTION
## Summary

Unwinds every skip marker added on [#116](https://github.com/Mikecranesync/MIRA/pull/116) and replaces them with real fixes. Four pre-existing broken tests, all exposed when #116 turned the Lint & Format gate green and let `test-unit` actually run for the first time in a while.

**Base:** `claude/ci-ruff-format-cleanup` (stacked on #116). Will auto-retarget to `main` when #116 merges.

**Commit order on this branch (top to bottom):**
1. `d799a72` — fix stale image_downscale + reranking tests (removes #116 skips)
2. `9417742` — rewrite reddit_harvest test to mock _fetch_search seam

## Why each test was broken (all pre-existing on `main`)

All four failures reproduce identically against `origin/main` with unmodified test files — verified by checking out `main`'s copy and running the same pytest commands. #116 didn't cause any of them; it merely turned the red lint gate green so `test-unit` stopped being skipped, which exposed the rot.

### 1. `test_benchmark.py::test_harvest_parses_json_and_filters`

`mira-core/scripts/reddit_harvest.py` was refactored to:
- route all Reddit fetches through a private `_fetch_search(sub, query, client)` helper that hits `/r/{sub}/search.json`, not the old top-level listing
- filter posts through a `DIAGNOSTIC_KEYWORDS` regex plus a question-shape check in `_is_relevant()`
- require `is_self=True` on each post
- throttle with `time.sleep(2)` between 5 subs × 6 queries = 30 searches

The existing test mocked `httpx.Client.get` at the class level — a seam `_fetch_search()` doesn't hit the way the test expects. The patch silently fell through and the test made **real** Reddit API calls, returning `0` harvested instead of the expected `2`. Plus: no `is_self=True`, no `selftext`, no `time.sleep` stub.

**Fix:** patch `reddit_harvest._fetch_search` directly (the single seam between `harvest()` and Reddit), plus `reddit_harvest.time.sleep` to keep the test fast (~1 s vs ~60 s). Updated fake fixture to include `is_self=True` + realistic `selftext`. Added a second assertion on `result["total"]` to anchor the dedup path.

### 2. `test_image_downscale.py::test_large_image_resized_to_512`

`_resize_for_vision()` was retuned to `MAX_VISION_PX=1024` (see `mira-bots/telegram/bot.py:97`) but the test still pinned the old 512 cap.

**Fix:** rename to `test_large_image_resized_to_vision_max_px` and read `MAX_VISION_PX` from the same env var the production code uses. The test now tracks tuning changes automatically instead of re-breaking every time someone tweaks the cap. Drops the now-unused `pytest` import.

### 3. `test_reranking.py::test_rerank_called_for_photo_query`
### 4. `test_reranking.py::test_photo_query_embeds_with_asset_context`

Same root cause. `RAGWorker.process()` was refactored to add a `_visual_search()` dual-modality retrieval path: when `photo_b64` is set **and** `self._ingest_url` is set, photo queries route through an HTTP call to `mira-ingest/ingest/search-visual`, silently bypassing the `_neon_recall` mock these tests rely on. The mocks never fired; `_visual_search` 403'd to the real mira-ingest URL; `rerank` and `_embed_ollama` were never invoked; the assertions blew up.

**Fix:** set `worker._ingest_url = None` at the top of each test, forcing `process()` into the `else` branch (text-embed + `_neon_recall`) the tests were originally written against. Smallest change that preserves the tests' intent (verify rerank gets called on photo queries; verify the embed query includes asset context).

## Also on this branch: test_tts.py path fix

Came in via the rebase from #116 (`9c9dbc6`). `test_tts.py` imported from `mira-bots/telegram/tts.py`, but `tts.py` lives at `mira-bots/shared/tts.py` (refactor moved it without updating the test). One-line fix: sys.path insert now points at `../shared`. Without this fix, the entire `mira-bots/tests/` collection died fast at import time, which is why the CI Unit Tests job was finishing in ~21 s instead of ~80 s.

## Verification (all under CI-pinned `ruff==0.9.10`)

- [x] `pytest mira-core/mira-ingest/tests/test_benchmark.py::test_harvest_parses_json_and_filters` → **passed**
- [x] `pytest mira-bots/tests/test_image_downscale.py` → **3 passed**
- [x] `pytest mira-bots/tests/test_reranking.py` → **9 passed**
- [x] `pytest mira-bots/tests/ --ignore=mira-bots/tests/test_slack_relay.py` → **39 passed, 8 skipped** (was 36+11 on cleanup branch — the 3 temporary skips I added on #116 are now real passes)
- [x] `pytest mira-core/mira-ingest/tests/` → **28 passed** (was 27+1 on cleanup — reddit skip is now a real pass)
- [x] `ruff check <CI paths>` → **All checks passed**
- [x] `ruff format --check <CI paths>` → **42 files already formatted**
- [x] Zero `@pytest.mark.skip` markers remain from the cleanup sequence

## Test plan

- [ ] Merge [#116](https://github.com/Mikecranesync/MIRA/pull/116) first (the style cleanup + skip markers)
- [ ] GitHub auto-retargets this PR from `claude/ci-ruff-format-cleanup` to `main`
- [ ] CI Lint & Format + Unit Tests + License Check all green on this PR
- [ ] Merge this PR
- [ ] Rebase [#115](https://github.com/Mikecranesync/MIRA/pull/115) (`feat: set hnsw.ef_search=100`) onto new `main` — should go fully green in one shot

## Risks / caveats

1. **Scope creep from #118's original title.** Originally this PR only covered the Reddit test; now it covers 4 stale tests. Title and body updated to reflect.
2. **The `seen_post_ids` dedup in the reddit test is what makes the 90 mocked calls collapse to 2 inserts.** If a future refactor changes dedup semantics, the assertion will drift. Pinned via both `result["harvested"] == 2` and `result["total"] == 2` as anchors.
3. **The reranking tests still only cover the text-embed branch.** They don't exercise `_visual_search()` itself — that's a separate test that needs its own mock of the mira-ingest HTTP endpoint. Out of scope for this PR.
4. **`test_image_downscale` now depends on the MAX_VISION_PX env var.** If CI sets `MAX_VISION_PX` to something non-default, the test uses that value. This is intentional — the test should track production behavior, not a hardcoded snapshot.

https://claude.ai/code/session_016AceA9WFkgpF2dqXBwFGJw