### PR TITLE
feat: Notebook Intelligence Layer — Open WebUI + MIRA Pipeline + Docling

### DIFF
--- a/docs/adr/0007-notebook-intelligence-layer.md
+++ b/docs/adr/0007-notebook-intelligence-layer.md
@@ -1,0 +1,157 @@
+# ADR-0007: Notebook Intelligence Layer — Open WebUI + MIRA Pipeline
+
+## Status
+Accepted
+
+## Context
+
+MIRA's ingest problem is not technical — it is a mental model mismatch. Ingestion
+currently happens as a side effect of using the Telegram/Slack bots: a tech gets
+a diagnostic response and knowledge is indexed incidentally. This means ingest
+quality is bounded by bot usage patterns and the friction of those interfaces.
+
+The goal is a tool where **ingestion is the primary action**: a tech pulls out
+their phone, builds a knowledge base scoped to one piece of equipment, and
+interrogates it. This is the NotebookLM pattern applied to industrial maintenance.
+
+Additionally, the PDF processing pipeline was upgraded from pdfplumber to Docling
+(`mira-core/scripts/docling_adapter.py`), which adds semantic chunking,
+table-to-Markdown conversion (TableFormer), and OCR for scanned manuals. Open WebUI
+has native Docling support via `DOCLING_SERVER_URL` — when set, every document
+uploaded through the browser UI is processed by Docling automatically.
+
+## Considered Options
+
+1. **Build a purpose-built React PWA** — new frontend container, new document upload
+   API, new chat UI. Full control, maximum flexibility, 4-6 weeks of frontend work.
+
+2. **Build on top of Open WebUI** — use Open WebUI's existing shell (knowledge
+   collections, document upload UI, chat interface, mobile layout) and add MIRA
+   intelligence via the Pipelines extension mechanism. 1 week delta.
+
+3. **Extend the Telegram bot UX** — add PDF handling and better feedback to the
+   existing bot. Keeps everything in one adapter but doesn't solve the cross-device
+   or cross-platform ingest problem.
+
+## Decision
+
+**Build on top of Open WebUI using its Pipelines and Tools extension points.**
+
+Open WebUI's knowledge collection model maps directly to the notebook concept:
+one collection per equipment job, documents dragged in through the browser, chat
+scoped to that collection. The hard parts — document upload UI, knowledge storage,
+RAG-grounded chat, mobile layout — are already built and already deployed in
+`mira-core` at port 3000.
+
+The delta is three components:
+
+### 1. Docling server container (new in `mira-core/docker-compose.yml`)
+
+```yaml
+docling-serve:
+  image: ghcr.io/docling-project/docling-serve:<pinned-tag>
+  restart: unless-stopped
+  networks: [core-net]
+  healthcheck:
+    test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+```
+
+Set `DOCLING_SERVER_URL=http://docling-serve:5001` in the Open WebUI environment.
+Now every PDF uploaded through the browser — GS10 manuals, wiring diagrams, scanned
+work orders — is processed by Docling: fault code tables preserved as Markdown,
+scanned pages OCR'd, section headings used as semantic chunk boundaries.
+
+### 2. MIRA Pipeline container (new `mira-pipeline/` in `mira-core/`)
+
+Open WebUI Pipelines is a separate container that intercepts every chat message
+before it reaches the model. The MIRA pipeline runs:
+
+1. `classify_intent()` from `mira-bots/shared/guardrails.py` — safety short-circuit,
+   intent classification
+2. GSD FSM step from `mira-bots/shared/gsd_engine.py` — diagnostic state machine
+3. NeonDB recall augmentation — cross-session equipment fault history
+4. KB gap detection — if RAG score < 0.45 and equipment identified, fire scrape trigger
+5. Response post-processing — citation injection, work order trigger detection
+
+The pipeline reuses the existing shared engine directly — no logic duplication.
+A tech using Open WebUI gets MIRA's full diagnostic intelligence transparently.
+
+### 3. Three Open WebUI Tool functions
+
+Exposed as callable tools (function-calling pattern):
+
+| Tool | Action |
+|------|--------|
+| `create_work_order(equipment_id, fault_description)` | POST to Atlas CMMS |
+| `recall_fault_history(equipment_id)` | Query NeonDB across all sessions |
+| `trigger_doc_scrape(manufacturer, model)` | Fire `POST /ingest/scrape-trigger` |
+
+## Notebook UX
+
+A technician opens Open WebUI in a browser (phone or laptop):
+
+1. Creates a knowledge collection: **"Line 3 VFD — GS10 — Apr 2026"**
+2. Drags in the GS10 manual PDF → Docling processes it; fault code tables land
+   as clean Markdown, scanned wiring diagram pages are OCR'd
+3. Uploads a nameplate photo → vision model describes it, indexed to collection
+4. Opens chat scoped to this collection with the MIRA pipeline active
+5. Types: *"showing E.OP.1"*
+6. MIRA pipeline: classifies as fault code query → RAG pulls fault table from
+   manual page 47 → GSD FSM generates follow-up diagnostic question →
+   response cites source page
+7. Diagnosis confirmed → one-tap work order generated in Atlas
+
+The collection persists. Next tech who works the same machine inherits the full
+knowledge base. NeonDB recall can surface this history across notebooks.
+
+## FactoryLM-Specific Advantages Over NotebookLM
+
+- **Equipment memory across notebooks** — NeonDB stores resolved faults; a new
+  notebook for the same model can pull prior repair history as a source
+- **Nameplate → auto-discovery** — upload nameplate photo → manufacturer/model
+  identified → Apify scraper auto-runs → manufacturer docs land in the notebook
+  without manual URL entry
+- **Work order as notebook output** — diagnosis produces an Atlas CMMS work order,
+  not just a text summary
+- **Offline mode** — PWA service worker caches the notebook; local inference path
+  (qwen2.5vl:7b on Bravo) handles chat when factory floor WiFi drops
+- **Safety guardrails** — 21 safety keywords short-circuit to hazard response;
+  this never fires in NotebookLM because it has no industrial safety context
+
+## Implementation Order
+
+1. Add Docling server to `mira-core/docker-compose.yml` and wire `DOCLING_SERVER_URL`
+2. Write `mira-pipeline/pipeline.py` wrapping GSD engine
+3. Add pipeline container to `mira-core/docker-compose.yml`
+4. Write three Tool functions and register in Open WebUI
+5. Configure Open WebUI system prompt, branding, model defaults
+
+## Consequences
+
+### Positive
+- No new frontend to build or maintain — Open WebUI handles UI, mobile layout,
+  file upload UX, and collection management
+- Docling's table detection resolves the most significant quality gap in equipment
+  manual ingestion (fault code tables were previously lost or malformed)
+- Pipelines architecture keeps MIRA's intelligence portable — the same GSD engine
+  powers Telegram, Slack, and now the notebook interface
+- Version-pinned Open WebUI already satisfies the MIRA hard constraint (no `:latest`)
+
+### Negative
+- Open WebUI Pipeline API can change between releases — pipeline adapter must be
+  tested after any Open WebUI version bump
+- Docling server adds ~2GB to the image footprint (ML models for TableFormer + OCR)
+- Collection scoping requires the tech to consciously create and select the right
+  collection; there is no automatic per-equipment isolation
+- Open WebUI branding must be suppressed for customer-facing deployments;
+  white-labeling is supported but requires config discipline
+
+### Risks
+- If Open WebUI deprecates the Pipelines extension point, the intelligence layer
+  falls back to the bot adapters — no data loss, just UX regression
+- Docling server cold-start is ~30s (model load); first PDF after container restart
+  will be slow; subsequent documents are fast
+
+## Related ADRs
+- ADR-0003: Edge Inference Strategy — local model fallback applies here
+- ADR-0005: AR HUD Architecture — notebook becomes the data layer for HUD overlays

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,3 +14,5 @@ decision, the options considered, what was chosen and why, and the consequences.
 | [0003](0003-edge-inference-strategy.md) | Edge Inference Strategy | Accepted |
 | [0004](0004-multi-machine-sync.md) | Multi-Machine Claude Config Sync | Accepted |
 | [0005](0005-ar-hud-architecture.md) | AR HUD Architecture | Accepted |
+| [0006](0006-paperclip-dev-orchestration.md) | Paperclip Dev Orchestration | Accepted |
+| [0007](0007-notebook-intelligence-layer.md) | Notebook Intelligence Layer — Open WebUI + MIRA Pipeline | Accepted |


### PR DESCRIPTION
## What This Is

A NotebookLM-equivalent for industrial maintenance techs, built on top of the Open WebUI instance already running in `mira-core`. A technician creates a knowledge collection per job (e.g., "Line 3 VFD — GS10"), drops in PDFs and nameplate photos, and gets MIRA's full diagnostic intelligence grounded to exactly those sources.

**The ingest problem this solves:** ingestion currently happens as a side effect of using the Telegram bot. This inverts the model — ingestion is the primary action. Build the context first, then interrogate it.

**Architecture decision:** See [ADR-0007](docs/adr/0007-notebook-intelligence-layer.md) committed in this PR.

---

## Three Components to Build

### Component 1 — Docling Server Container
**Effort:** ~2 hours | **File:** `mira-core/docker-compose.yml`

Open WebUI has native Docling support. When `DOCLING_SERVER_URL` is set in Open WebUI's environment, every PDF uploaded through the browser UI is processed by Docling instead of pypdf — semantic chunking, fault code tables preserved as Markdown, scanned manuals OCR'd.

**What to add to `mira-core/docker-compose.yml`:**
```yaml
docling-serve:
  image: ghcr.io/docling-project/docling-serve:0.4.0   # pin exact version
  restart: unless-stopped
  networks: [core-net]
  healthcheck:
    test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
    interval: 30s
    timeout: 10s
    retries: 3
```

**What to add to the `open-webui` service environment:**
```yaml
DOCLING_SERVER_URL: "http://docling-serve:5001"
```

**Verify:** Upload any equipment manual PDF through the Open WebUI browser UI → check that tables in the document appear as Markdown in the knowledge collection chunks (visible via Open WebUI's collection detail view).

---

### Component 2 — MIRA Pipeline Container
**Effort:** 3-4 days | **New directory:** `mira-core/mira-pipeline/`

Open WebUI Pipelines is a separate container that intercepts every chat message before it reaches the model. This is where MIRA's diagnostic brain lives for the notebook interface.

**Container structure:**
```
mira-core/mira-pipeline/
├── Dockerfile
├── requirements.txt
├── pipeline.py          ← the pipeline entrypoint
└── CLAUDE.md
```

**`pipeline.py` must implement the Open WebUI Pipelines interface:**

```python
from typing import Generator, Iterator
from pydantic import BaseModel

class Pipeline:
    class Valves(BaseModel):
        MIRA_INGEST_URL: str = "http://mira-ingest:8001"
        MCP_BASE_URL: str = "http://mira-mcp:8001"
        NEON_DATABASE_URL: str = ""

    def __init__(self):
        self.name = "MIRA Diagnostic Pipeline"
        self.valves = self.Valves()

    async def on_startup(self): ...
    async def on_shutdown(self): ...

    async def pipe(
        self,
        user_message: str,
        model_id: str,
        messages: list[dict],
        body: dict,
    ) -> str | Generator | Iterator:
        # 1. classify_intent() — safety short-circuit + intent type
        # 2. If equipment diagnostic: step GSD FSM
        # 3. Augment context with NeonDB recall (cross-session fault history)
        # 4. Check RAG score — if < 0.45 and equipment identified: fire scrape trigger
        # 5. Return augmented messages to Open WebUI for model completion
        ...
```

**Reuse — do NOT rewrite these:**
- `mira-bots/shared/guardrails.py` → `classify_intent()`, `SAFETY_KEYWORDS`
- `mira-bots/shared/gsd_engine.py` → `GSDEngine.process_full()`
- `mira-bots/shared/workers/rag_worker.py` → RAG call with collection scoping
- `mira-bots/shared/inference/router.py` → `InferenceRouter`

The pipeline calls these via the `mira-bots` shared package OR via HTTP to the MCP REST API — do not copy logic. If calling via HTTP, reuse `MCP_BASE_URL` which is already in every bot's env.

**What to add to `mira-core/docker-compose.yml`:**
```yaml
mira-pipeline:
  build: ./mira-pipeline
  restart: unless-stopped
  environment:
    MIRA_INGEST_URL: "http://mira-ingest:8001"
    MCP_BASE_URL: "http://mira-mcp:8001"
    NEON_DATABASE_URL: "${NEON_DATABASE_URL}"
  networks: [core-net]
  ports:
    - "9099:9099"    # Open WebUI Pipelines default port
  healthcheck:
    test: ["CMD", "curl", "-f", "http://localhost:9099/"]
    interval: 30s
    timeout: 10s
    retries: 3
```

**Register in Open WebUI:** Admin → Settings → Pipelines → add `http://mira-pipeline:9099`

**Verify:** In Open WebUI chat, ask "what fault code means overtemperature on a GS10 VFD" — response should cite a source chunk from a previously uploaded GS10 manual, not hallucinate a page number.

---

### Component 3 — Three Open WebUI Tool Functions
**Effort:** 1 day | **Location:** Open WebUI Admin → Tools (Python functions, stored in Open WebUI's DB)

Tools are Python functions the model calls via function-calling. Register these three through the Open WebUI UI or via `POST /api/v1/tools/`:

**Tool 1: `create_work_order`**
```python
async def create_work_order(equipment_id: str, fault_description: str) -> str:
    """Create a corrective maintenance work order in Atlas CMMS."""
    import httpx, os
    url = os.getenv("MCP_BASE_URL", "") + "/api/cmms/work-orders"
    headers = {"Authorization": f"Bearer {os.getenv('MCP_REST_API_KEY','')}"}
    async with httpx.AsyncClient(timeout=30) as client:
        r = await client.post(url, json={"equipment_id": equipment_id,
                                          "description": fault_description}, headers=headers)
        r.raise_for_status()
        wo = r.json()
    return f"Work order {wo.get('work_order_id','?')} created."
```

**Tool 2: `recall_fault_history`**
```python
async def recall_fault_history(equipment_id: str) -> str:
    """Retrieve prior fault history for this equipment from the knowledge base."""
    import httpx, os
    url = os.getenv("MCP_BASE_URL", "") + "/api/recall"
    headers = {"Authorization": f"Bearer {os.getenv('MCP_REST_API_KEY','')}"}
    async with httpx.AsyncClient(timeout=30) as client:
        r = await client.post(url, json={"query": f"{equipment_id} fault history repair",
                                          "limit": 5}, headers=headers)
        r.raise_for_status()
    results = r.json().get("results", [])
    if not results:
        return f"No prior fault history found for {equipment_id}."
    return "\n\n".join(f"- {x['text'][:300]}" for x in results)
```

**Tool 3: `trigger_doc_scrape`**
```python
async def trigger_doc_scrape(manufacturer: str, model: str) -> str:
    """Search and index manufacturer documentation for this equipment."""
    import httpx, os
    url = os.getenv("MIRA_INGEST_URL", "") + "/ingest/scrape-trigger"
    payload = {"equipment_id": f"{manufacturer} {model}", "manufacturer": manufacturer,
               "model": model, "tenant_id": os.getenv("MIRA_TENANT_ID",""), "context": ""}
    async with httpx.AsyncClient(timeout=30) as client:
        r = await client.post(url, json=payload)
        r.raise_for_status()
    return f"Documentation search started (job {r.json().get('job_id','?')}). Results will appear in the knowledge base within ~90 seconds."
```

**Verify:** In Open WebUI chat (with MIRA pipeline active), ask "create a work order for this fault" after a diagnosis — the model should call the tool and return a WO ID.

---

## Existing Code — Do Not Reinstate or Duplicate

| What | Where | Notes |
|------|-------|-------|
| Docling adapter | `mira-core/scripts/docling_adapter.py` | Already wraps `DocumentConverter` + `HybridChunker` |
| PDF route | `mira-core/mira-ingest/main.py` → `POST /ingest/document-kb` | Already pushes to Open WebUI file/collection API |
| Scrape trigger | `mira-core/mira-ingest/main.py` → `POST /ingest/scrape-trigger` | Apify backend wired (see `feat/path-b-local-inference`) |
| GSD engine | `mira-bots/shared/gsd_engine.py` | Full diagnostic FSM — reuse, don't rewrite |
| Guardrails | `mira-bots/shared/guardrails.py` | `classify_intent()`, safety keywords |
| NeonDB recall | `mira-core/mira-ingest/db/neon.py` → `recall_knowledge()` | pgvector cosine search |
| WO creation | `mira-mcp/server.py` → `POST /api/cmms/work-orders` | Atlas CMMS integration |

---

## Environment Variables Needed

Add to Doppler `factorylm/prd` (none of these exist yet):

| Var | Value | Used By |
|-----|-------|---------|
| `DOCLING_SERVER_URL` | `http://docling-serve:5001` | Open WebUI (enables Docling processing) |
| `PIPELINE_API_KEY` | generate a secret | Open WebUI ↔ mira-pipeline auth |

Existing vars the pipeline needs (already in Doppler):
`NEON_DATABASE_URL`, `MCP_BASE_URL`, `MCP_REST_API_KEY`, `MIRA_TENANT_ID`, `ANTHROPIC_API_KEY`

---

## Implementation Order

1. **Docling server** — one compose stanza + one env var. Immediate quality win for all PDF uploads, no pipeline needed.
2. **MIRA Pipeline** — the intelligence layer. Start with a pass-through pipeline that just logs, then layer in `classify_intent` → GSD FSM → NeonDB recall one step at a time.
3. **Tools** — wire after the pipeline is stable.

Do NOT build all three in parallel. Get Docling working and verified first — it's independent and gives you confidence the Open WebUI integration is healthy before you add the pipeline.

---

## Hard Constraints (from MIRA PRD §4)
- No LangChain, no n8n, no framework that abstracts the Claude API call
- All secrets via Doppler — never in `.env` files
- Docker images pinned to exact semver — never `:latest`
- One service per container, every container has `restart: unless-stopped` + healthcheck
- Apache 2.0 or MIT licenses only — check Docling (`MIT ✓`), Open WebUI Pipelines (`MIT ✓`)

---

## References
- [ADR-0007](docs/adr/0007-notebook-intelligence-layer.md) — full architectural rationale
- [Open WebUI Pipelines docs](https://docs.openwebui.com/pipelines/) — pipeline interface spec
- [Docling serve image](https://github.com/docling-project/docling-serve) — ghcr.io/docling-project/docling-serve
- `mira-bots/shared/` — all reusable intelligence components

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)