### PR TITLE
fix: guarantee PIPELINE_CALL log lines emit from uvicorn-managed process

### DIFF
--- a/mira-pipeline/Dockerfile
+++ b/mira-pipeline/Dockerfile
@@ -20,4 +20,4 @@ EXPOSE 9099
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=10s \
     CMD curl -f http://localhost:9099/health || exit 1
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9099"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9099", "--log-level", "info"]

--- a/mira-pipeline/main.py
+++ b/mira-pipeline/main.py
@@ -30,11 +30,16 @@ from starlette.responses import JSONResponse
 sys.path.insert(0, os.path.dirname(__file__))
 from shared.gsd_engine import GSDEngine
 
+# Explicit handler setup: logging.basicConfig() is a no-op once uvicorn has
+# already installed its own handlers on the root logger, so we configure our
+# named logger directly to guarantee PIPELINE_CALL lines appear in docker logs.
 logger = logging.getLogger("mira-pipeline")
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(name)s %(levelname)s %(message)s",
-)
+logger.setLevel(logging.INFO)
+if not logger.handlers:
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s"))
+    logger.addHandler(_handler)
+logger.propagate = True
 
 # ── Configuration ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

`logging.basicConfig()` is a no-op once uvicorn installs its own handlers on the root logger before the application module loads. This caused `PIPELINE_CALL chat_id=... latency_ms=...` lines to be silently dropped even though the call was at `logger.info`. Confirmed by VPS investigation: `docker logs mira-pipeline-saas | grep PIPELINE_CALL` returned 0 results during a 4,231-request stress test.

## Fix

Two changes:

1. **`mira-pipeline/main.py`** — Replace `logging.basicConfig()` with explicit handler configuration on the named logger:
   ```python
   logger = logging.getLogger("mira-pipeline")
   logger.setLevel(logging.INFO)
   if not logger.handlers:
       _handler = logging.StreamHandler()
       _handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(levelname)s %(message)s"))
       logger.addHandler(_handler)
   logger.propagate = True
   ```

2. **`mira-pipeline/Dockerfile`** — Add `--log-level info` to uvicorn CMD so container-level verbosity is explicit and consistent.

## Verification

After deploy:
```bash
ssh factorylm-prod "docker compose -f /opt/mira/docker-compose.saas.yml restart mira-pipeline-saas"
# Send a test chat message via Open WebUI, then:
ssh factorylm-prod "docker logs mira-pipeline-saas 2>&1 | grep PIPELINE_CALL | tail -5"
# Expected: PIPELINE_CALL chat_id=<id> latency_ms=<N> len=<N>
```

## Context

Prerequisite from `docs/plans/auto-research-eval-loop.md` — the eval harness reads `PIPELINE_CALL` log lines to capture per-request latency and provider data. Without this fix, grader falls back to FSM SQLite only (state data, no retrieval details).

🤖 Generated with [Claude Code](https://claude.com/claude-code)