### PR TITLE
feat: continuous eval — Celery task + /eval/latest dashboard

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -190,10 +190,12 @@ services:
       - MCP_REST_API_KEY=${MCP_REST_API_KEY:-}
       - MCP_BASE_URL=http://mira-mcp-saas:8001
       - INGEST_SERVICE_URL=http://mira-ingest-saas:8001
+      - EVAL_RUNS_DIR=/eval-runs
     volumes:
       - /opt/mira/data:/mira-db
       - /opt/mira/data/mem0:/data/mem0
       - mira-webui-data:/app/backend/data:ro
+      - /opt/mira/tests/eval/runs:/eval-runs:ro
     networks:
       - mira-net
     restart: unless-stopped

--- a/mira-pipeline/eval_api.py
+++ b/mira-pipeline/eval_api.py
@@ -1,0 +1,225 @@
+"""MIRA Eval API — /eval/latest endpoint.
+
+Reads the most recent eval scorecard from EVAL_RUNS_DIR and serves it as
+JSON (machine-readable) and HTML (human-readable).
+
+Mounted in main.py:
+    from eval_api import router as eval_router
+    app.include_router(eval_router)
+
+Env vars:
+    EVAL_RUNS_DIR   Directory containing YYYY-MM-DDTHHMM.md scorecards.
+                    Default: /eval-runs (mounted from /opt/mira/tests/eval/runs on VPS).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse, JSONResponse
+
+router = APIRouter()
+
+EVAL_RUNS_DIR = Path(os.getenv("EVAL_RUNS_DIR", "/eval-runs"))
+
+# Minimal CSS for the HTML view — no external deps
+_HTML_STYLE = """
+<style>
+  body { font-family: monospace; max-width: 900px; margin: 2rem auto; padding: 0 1rem; background: #0d1117; color: #c9d1d9; }
+  h1 { color: #58a6ff; }
+  h2 { color: #8b949e; border-bottom: 1px solid #30363d; padding-bottom: .25rem; }
+  h3 { color: #f0883e; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th { background: #161b22; color: #8b949e; text-align: left; padding: .4rem .6rem; }
+  td { padding: .4rem .6rem; border-top: 1px solid #21262d; }
+  td:nth-child(n+2) { text-align: center; }
+  .pass { color: #3fb950; font-weight: bold; }
+  .fail { color: #f85149; font-weight: bold; }
+  code { background: #161b22; padding: .15rem .3rem; border-radius: 3px; }
+  blockquote { border-left: 3px solid #30363d; margin-left: 0; padding-left: 1rem; color: #8b949e; }
+  pre { background: #161b22; padding: 1rem; border-radius: 6px; overflow-x: auto; }
+</style>
+"""
+
+
+def _latest_scorecard() -> tuple[Path | None, str]:
+    """Return (path, content) of the most recent scorecard, or (None, '')."""
+    if not EVAL_RUNS_DIR.exists():
+        return None, ""
+    candidates = sorted(EVAL_RUNS_DIR.glob("*.md"), reverse=True)
+    if not candidates:
+        return None, ""
+    p = candidates[0]
+    return p, p.read_text()
+
+
+def _parse_scorecard(content: str) -> dict:
+    """Extract structured data from markdown scorecard."""
+    result: dict = {
+        "pass_rate": None,
+        "total": None,
+        "passed": None,
+        "mode": None,
+        "failures": [],
+        "regressions": [],
+        "recoveries": [],
+        "scenarios": [],
+    }
+
+    # Pass rate: "**Pass rate:** 8/10 scenarios (80%)"
+    m = re.search(r"\*\*Pass rate:\*\*\s*(\d+)/(\d+).*?\((\d+)%\)", content)
+    if m:
+        result["passed"] = int(m.group(1))
+        result["total"] = int(m.group(2))
+        result["pass_rate"] = int(m.group(3))
+
+    # Mode
+    m = re.search(r"\*\*Mode:\*\*\s*(\S+)", content)
+    if m:
+        result["mode"] = m.group(1)
+
+    # Scenario rows: | `id` | PASS | PASS | FAIL | ... |
+    for row in re.finditer(r"\|\s*`([\w_]+)`\s*\|(.*?)\|", content):
+        sid = row.group(1)
+        cells = [c.strip() for c in row.group(2).split("|")]
+        result["scenarios"].append({
+            "id": sid,
+            "checkpoints": cells[:5] if len(cells) >= 5 else cells,
+            "score": cells[5] if len(cells) > 5 else None,
+            "fsm_state": cells[6] if len(cells) > 6 else None,
+        })
+
+    # Failures section
+    for m in re.finditer(r"### ([\w_]+)\n(.*?)(?=###|\Z)", content, re.DOTALL):
+        sid = m.group(1)
+        body = m.group(2).strip()
+        cp_fails = re.findall(r"\*\*(cp_\w+)\*\* FAILED: (.+)", body)
+        resp_m = re.search(r"Last response: `(.+?)\.\.\.", body)
+        result["failures"].append({
+            "id": sid,
+            "checkpoint_failures": [{"name": n, "reason": r} for n, r in cp_fails],
+            "last_response_preview": resp_m.group(1) if resp_m else None,
+        })
+
+    # Delta
+    reg_m = re.search(
+        r"\*\*Regressions.*?\*\*\n(.*?)(?=\*\*Recoveries|\Z)", content, re.DOTALL
+    )
+    if reg_m:
+        result["regressions"] = re.findall(r"- ([\w_]+)", reg_m.group(1))
+
+    rec_m = re.search(r"\*\*Recoveries.*?\*\*\n(.*?)(?=##|\Z)", content, re.DOTALL)
+    if rec_m:
+        result["recoveries"] = re.findall(r"- ([\w_]+)", rec_m.group(1))
+
+    return result
+
+
+def _markdown_to_html(content: str, title: str) -> str:
+    """Very lightweight markdown → HTML (tables, headers, bold, code, lists)."""
+    lines = content.splitlines()
+    html_lines: list[str] = [f"<html><head><title>{title}</title>{_HTML_STYLE}</head><body>"]
+    in_table = False
+
+    for line in lines:
+        # Table row
+        if line.strip().startswith("|"):
+            if not in_table:
+                html_lines.append("<table>")
+                in_table = True
+            if re.match(r"^\|[-| :]+\|$", line.strip()):
+                continue  # separator row
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
+            is_header = not any(c in ("PASS", "FAIL") for c in cells)
+            tag = "th" if is_header else "td"
+            row = "<tr>" + "".join(
+                f'<{tag}><span class="{c.lower() if c in ("PASS","FAIL") else ""}">{c}</span></{tag}>'
+                for c in cells
+            ) + "</tr>"
+            html_lines.append(row)
+            continue
+
+        if in_table:
+            html_lines.append("</table>")
+            in_table = False
+
+        # Headers
+        if line.startswith("### "):
+            html_lines.append(f"<h3>{line[4:]}</h3>")
+        elif line.startswith("## "):
+            html_lines.append(f"<h2>{line[3:]}</h2>")
+        elif line.startswith("# "):
+            html_lines.append(f"<h1>{line[2:]}</h1>")
+        elif line.startswith("> "):
+            html_lines.append(f"<blockquote>{line[2:]}</blockquote>")
+        elif line.startswith("- "):
+            body = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", line[2:])
+            body = re.sub(r"`(.+?)`", r"<code>\1</code>", body)
+            html_lines.append(f"<li>{body}</li>")
+        elif line.startswith("---"):
+            html_lines.append("<hr>")
+        elif line.strip() == "":
+            html_lines.append("<br>")
+        else:
+            body = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", line)
+            body = re.sub(r"`(.+?)`", r"<code>\1</code>", body)
+            body = re.sub(r"\*(.+?)\*", r"<em>\1</em>", body)
+            html_lines.append(f"<p>{body}</p>")
+
+    if in_table:
+        html_lines.append("</table>")
+
+    html_lines.append("</body></html>")
+    return "\n".join(html_lines)
+
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+
+@router.get("/eval/latest", tags=["eval"])
+async def eval_latest(format: str = "json"):
+    """Return the most recent eval scorecard.
+
+    ?format=json  (default) — structured JSON
+    ?format=html            — rendered HTML scorecard
+    ?format=raw             — raw markdown
+    """
+    path, content = _latest_scorecard()
+
+    if path is None:
+        return JSONResponse(
+            status_code=404,
+            content={"error": "No scorecards found", "eval_runs_dir": str(EVAL_RUNS_DIR)},
+        )
+
+    if format == "html":
+        html = _markdown_to_html(content, path.stem)
+        return HTMLResponse(content=html)
+
+    if format == "raw":
+        from fastapi.responses import PlainTextResponse
+        return PlainTextResponse(content=content, media_type="text/markdown")
+
+    # JSON (default)
+    parsed = _parse_scorecard(content)
+    return JSONResponse(content={
+        "scorecard_file": path.name,
+        **parsed,
+        "raw_url": f"/eval/latest?format=raw",
+        "html_url": f"/eval/latest?format=html",
+    })
+
+
+@router.get("/eval/list", tags=["eval"])
+async def eval_list():
+    """List all available eval scorecard files."""
+    if not EVAL_RUNS_DIR.exists():
+        return JSONResponse(content={"scorecards": [], "eval_runs_dir": str(EVAL_RUNS_DIR)})
+    files = sorted(EVAL_RUNS_DIR.glob("*.md"), reverse=True)
+    return JSONResponse(content={
+        "count": len(files),
+        "scorecards": [f.name for f in files],
+    })

--- a/mira-pipeline/main.py
+++ b/mira-pipeline/main.py
@@ -269,13 +269,16 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(title="MIRA Pipeline", docs_url=None, redoc_url=None, lifespan=lifespan)
 
+from eval_api import router as _eval_router  # noqa: E402
+app.include_router(_eval_router)
+
 
 # ── Auth middleware ──────────────────────────────────────────────────────────
 
 
 @app.middleware("http")
 async def _auth(request: Request, call_next):
-    if request.url.path in ("/health", "/v1/models"):
+    if request.url.path in ("/health", "/v1/models", "/eval/latest", "/eval/list"):
         return await call_next(request)
     if PIPELINE_API_KEY:
         auth = request.headers.get("Authorization", "")

--- a/tests/eval/celery_tasks.py
+++ b/tests/eval/celery_tasks.py
@@ -1,0 +1,142 @@
+"""MIRA Eval Celery Task — continuous eval harness, 60-minute schedule.
+
+This file is deployed to /opt/master_of_puppets/workers/mira_eval_tasks.py
+on the VPS. It registers as a shared_task so it binds to whatever Celery
+app is active at import time (master_of_puppets on VPS).
+
+Beat schedule entry (in /opt/master_of_puppets/celery_app.py):
+    'mira-eval-every-60-min': {
+        'task': 'mira_eval.run_batch',
+        'schedule': 3600.0,
+    }
+
+Concurrency guard: file-based lock at /tmp/mira_eval.lock.
+A run older than 15 minutes is considered stale and cleared.
+
+Failure policy:
+  - If run_eval.py returns rc not in {0, 1}: log, do NOT commit.
+  - If scorecard file is missing after run: log, do NOT commit.
+  - If git push fails: log warning, scorecard stays local.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from celery import shared_task
+
+logger = logging.getLogger("mira-eval-task")
+
+MIRA_DIR = Path(os.getenv("MIRA_DIR", "/opt/mira"))
+EVAL_LOG = Path("/var/log/mira-eval.log")
+LOCK_FILE = Path("/tmp/mira_eval.lock")
+LOCK_MAX_AGE_S = 900  # 15 min — stale lock timeout
+
+
+# ── Lock helpers ──────────────────────────────────────────────────────────────
+
+
+def _acquire_lock() -> bool:
+    """Return True if lock acquired, False if another run is in progress."""
+    if LOCK_FILE.exists():
+        age = time.monotonic() - LOCK_FILE.stat().st_mtime
+        if age < LOCK_MAX_AGE_S:
+            logger.warning("MIRA eval already running (lock age=%.0fs) — skipping", age)
+            return False
+        logger.warning("MIRA eval lock stale (age=%.0fs) — clearing and proceeding", age)
+        LOCK_FILE.unlink(missing_ok=True)
+    LOCK_FILE.write_text(str(os.getpid()))
+    return True
+
+
+def _release_lock() -> None:
+    LOCK_FILE.unlink(missing_ok=True)
+
+
+# ── Celery task ───────────────────────────────────────────────────────────────
+
+
+@shared_task(name="mira_eval.run_batch", max_retries=0, ignore_result=False)
+def run_eval_batch() -> dict:
+    """Run MIRA eval harness. Returns status dict for Celery result backend."""
+    if not _acquire_lock():
+        return {"status": "skipped", "reason": "lock_held"}
+
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M")
+    out_file = MIRA_DIR / "tests" / "eval" / "runs" / f"{ts}.md"
+
+    try:
+        # Pull latest eval fixtures (non-fatal if offline)
+        subprocess.run(
+            ["git", "fetch", "origin", "main"],
+            cwd=MIRA_DIR, capture_output=True, timeout=30,
+        )
+        subprocess.run(
+            ["git", "checkout", "origin/main", "--", "tests/eval/"],
+            cwd=MIRA_DIR, capture_output=True, timeout=30,
+        )
+
+        # Run harness — exit 0 = all pass, exit 1 = some fail (both valid)
+        result = subprocess.run(
+            ["python3", "tests/eval/run_eval.py", "--output", str(out_file)],
+            cwd=MIRA_DIR,
+            capture_output=True,
+            text=True,
+            timeout=360,
+        )
+
+        # Always log
+        with EVAL_LOG.open("a") as f:
+            f.write(f"\n=== mira_eval.run_batch {ts} UTC ===\n")
+            if result.stdout:
+                f.write(result.stdout)
+            if result.stderr:
+                f.write(result.stderr)
+
+        if result.returncode not in (0, 1):
+            logger.error(
+                "MIRA eval errored (rc=%d) — not committing scorecard", result.returncode
+            )
+            return {"status": "error", "rc": result.returncode, "ts": ts}
+
+        if not out_file.exists():
+            logger.error("MIRA eval finished but scorecard missing: %s", out_file)
+            return {"status": "error", "reason": "missing_scorecard", "ts": ts}
+
+        # Stage and commit
+        subprocess.run(["git", "add", str(out_file)], cwd=MIRA_DIR, check=True)
+        commit_msg = (
+            f"chore: eval run {ts} UTC\n\n"
+            "Signed-off-by: mira-eval-bot <eval@mira.local>"
+        )
+        commit_r = subprocess.run(
+            ["git", "commit", "-m", commit_msg],
+            cwd=MIRA_DIR, capture_output=True, text=True,
+        )
+        if commit_r.returncode != 0:
+            logger.warning("Git commit failed: %s", commit_r.stderr[:300])
+            return {"status": "ok_no_commit", "scorecard": str(out_file), "ts": ts}
+
+        push_r = subprocess.run(
+            ["git", "push", "origin", "main"],
+            cwd=MIRA_DIR, capture_output=True, text=True, timeout=60,
+        )
+        if push_r.returncode != 0:
+            logger.warning("Git push failed: %s", push_r.stderr[:300])
+
+        logger.info("MIRA eval complete: %s (rc=%d)", out_file.name, result.returncode)
+        return {"status": "ok", "scorecard": str(out_file), "ts": ts}
+
+    except subprocess.TimeoutExpired as e:
+        logger.error("MIRA eval timed out: %s", e)
+        return {"status": "error", "reason": "timeout", "ts": ts}
+    except Exception as e:
+        logger.error("MIRA eval unexpected error: %s", e)
+        return {"status": "error", "reason": str(e), "ts": ts}
+    finally:
+        _release_lock()

--- a/tests/eval/run_eval.py
+++ b/tests/eval/run_eval.py
@@ -160,11 +160,19 @@ def _read_fsm_state(chat_id: str) -> str:
 
 
 def _load_fixtures(fixtures_dir: Path) -> list[dict]:
-    """Load all YAML fixtures from fixtures_dir, sorted by filename."""
+    """Load scenario fixtures from fixtures_dir, sorted by filename.
+
+    Only loads files matching NN_*.yaml (two leading digits + underscore).
+    Other YAML files (vision fixtures, smoke tests, etc.) are skipped — they
+    use a different schema and must be run by their own dedicated runners.
+    """
     fixtures = []
-    for path in sorted(fixtures_dir.glob("*.yaml")):
+    for path in sorted(fixtures_dir.glob("[0-9][0-9]_*.yaml")):
         with open(path) as f:
             fixture = yaml.safe_load(f)
+        if "id" not in fixture:
+            logger.warning("Skipping %s — missing required 'id' field", path.name)
+            continue
         fixture["_path"] = str(path)
         fixtures.append(fixture)
     return fixtures
@@ -362,7 +370,12 @@ def main() -> int:
     parser.add_argument("--dry-run", action="store_true", help="Load fixtures only, no HTTP calls")
     parser.add_argument(
         "--output", default=str(RUNS_DIR),
-        help="Directory to write scorecards (default: tests/eval/runs/)",
+        help=(
+            "Output path. If ends with .md, used as the scorecard file directly "
+            "(useful for timestamped Celery runs). Otherwise treated as a directory "
+            "and the scorecard is written as YYYY-MM-DD.md inside it. "
+            "Default: tests/eval/runs/"
+        ),
     )
     parser.add_argument(
         "--fixtures", default=str(FIXTURES_DIR),
@@ -370,13 +383,19 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    run_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    output_dir = Path(args.output)
-    output_path = output_dir / f"{run_date}.md"
+    # Support --output as either a directory or a direct .md file path
+    output_arg = Path(args.output)
+    if args.output.endswith(".md"):
+        output_path = output_arg
+        output_dir = output_path.parent
+    else:
+        run_date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        output_dir = output_arg
+        output_path = output_dir / f"{run_date}.md"
 
     # Find previous scorecard for diff
     existing = sorted(output_dir.glob("*.md"))
-    prev_path = existing[-1] if existing else None
+    prev_path = existing[-2] if output_path in existing and len(existing) >= 2 else (existing[-1] if existing else None)
 
     # Load fixtures
     fixtures = _load_fixtures(Path(args.fixtures))


### PR DESCRIPTION
## Summary

- **Celery task** (`tests/eval/celery_tasks.py`): `mira_eval.run_batch` shared_task wraps `run_eval.py`. Deploys to `/opt/master_of_puppets/workers/` (existing Celery cluster — worker + beat already live at `/opt/master_of_puppets/`). Lock-file singleton prevents overlapping runs. Auto-commits valid scorecards, skips broken ones.
- **Fixture loader fix**: `run_eval.py` now globs `[0-9][0-9]_*.yaml` only, skipping `vision_gemini_smoke.yaml` and other non-standard schemas that caused `KeyError: 'id'` during tonight's live run.
- **`--output` file path support**: `run_eval.py --output /path/to/2026-04-14T0200.md` writes a timestamped scorecard (used by Celery task for hourly runs).
- **`/eval/latest` endpoint** (`mira-pipeline/eval_api.py`): reads most recent scorecard from `/eval-runs` volume, serves JSON + HTML + raw markdown. No auth required.
- **`/eval/list`**: lists all available scorecards.
- **docker-compose**: mounts `/opt/mira/tests/eval/runs:/eval-runs:ro` into `mira-pipeline-saas`.

## Deploy steps (VPS)

```bash
# 1. Pull + deploy pipeline
cd /opt/mira
git pull origin main
doppler run -p factorylm -c prd -- docker compose -f docker-compose.saas.yml up -d --build mira-pipeline-saas

# 2. Deploy Celery task to master_of_puppets
cp tests/eval/celery_tasks.py /opt/master_of_puppets/workers/mira_eval_tasks.py

# 3. Register in celery_app.py (one-time edit on VPS):
#    - Add 'workers.mira_eval_tasks' to include list
#    - Add beat_schedule entry (60 min)

# 4. Restart beat
kill $(pgrep -f "celery.*beat") && cd /opt/master_of_puppets && \
  nohup venv/bin/celery -A celery_app beat --loglevel=info >> logs/beat.log 2>&1 &
```

## Test plan

- [ ] `GET /eval/latest` returns JSON with pass_rate, failures
- [ ] `GET /eval/latest?format=html` renders scorecard
- [ ] `GET /eval/list` returns list of scorecard files
- [ ] Celery beat picks up `mira_eval.run_batch` within 60 min
- [ ] Lock file prevents parallel runs
- [ ] Broken scorecard (rc > 1) is NOT committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)