### PR TITLE
fix(ingest): crawlerType playwright → playwright:chrome

### DIFF
--- a/config/crawl_routes.yaml
+++ b/config/crawl_routes.yaml
@@ -53,7 +53,7 @@ strategies:
   apify_playwright:
     # Apify website-content-crawler with Playwright (JS rendering)
     actor: apify/website-content-crawler
-    crawlerType: playwright  # headless Chromium
+    crawlerType: playwright:chrome  # headless Chromium
     maxCrawlPages: 20        # fewer pages — JS rendering is slower
     maxCrawlDepth: 2         # go deeper than cheerio to find actual docs
     waitUntil: networkidle   # wait for React/Angular to finish loading

--- a/mira-core/mira-ingest/crawl_routes.yaml
+++ b/mira-core/mira-ingest/crawl_routes.yaml
@@ -53,7 +53,7 @@ strategies:
   apify_playwright:
     # Apify website-content-crawler with Playwright (JS rendering)
     actor: apify/website-content-crawler
-    crawlerType: playwright  # headless Chromium
+    crawlerType: playwright:chrome  # headless Chromium
     maxCrawlPages: 20        # fewer pages — JS rendering is slower
     maxCrawlDepth: 2         # go deeper than cheerio to find actual docs
     waitUntil: networkidle   # wait for React/Angular to finish loading

--- a/mira-core/mira-ingest/route_fallback.py
+++ b/mira-core/mira-ingest/route_fallback.py
@@ -101,7 +101,7 @@ async def _run_apify_playwright(
         "startUrls": [{"url": base_url}],
         "maxCrawlDepth": params.get("maxCrawlDepth", 2),
         "maxCrawlPages": params.get("maxCrawlPages", 20),
-        "crawlerType": "playwright",
+        "crawlerType": params.get("crawlerType", "playwright:chrome"),
         "outputFormats": ["markdown"],
         "globs": globs or [{"glob": "**/*manual*"}, {"glob": "**/*.pdf"}],
     }


### PR DESCRIPTION
## Summary

Apify `website-content-crawler` rejects `crawlerType: playwright` — valid enum values are `playwright:chrome`, `playwright:firefox`, `playwright:adaptive`, `cheerio`, `jsdom`.

- `config/crawl_routes.yaml` + `mira-core/mira-ingest/crawl_routes.yaml`: `playwright:chrome`
- `route_fallback.py` line 104: reads `params.get("crawlerType", "playwright:chrome")` instead of hardcoding

**Evidence:** e2e Pilz job `2f78ae8b` — `Input is not valid: Field input.crawlerType must be equal to one of the allowed values`

🤖 Generated with [Claude Code](https://claude.com/claude-code)