### PR TITLE
fix: token-budgeted history trimming prevents latency spike

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -890,6 +890,8 @@ class Supervisor:
             f"Ask me anything about this equipment."
         )
         history.append({"role": "assistant", "content": reply})
+        if len(history) > HISTORY_LIMIT:
+            history = history[-HISTORY_LIMIT:]
         ctx["history"] = history
         state["context"] = ctx
 

--- a/mira-bots/shared/inference/router.py
+++ b/mira-bots/shared/inference/router.py
@@ -47,6 +47,9 @@ _SERIAL_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Warn when any LLM call exceeds this threshold — indicates context bloat
+_LATENCY_WARN_MS = int(os.getenv("MIRA_LATENCY_WARN_MS", "15000"))
+
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_VERSION = "2023-06-01"
 
@@ -350,6 +353,14 @@ class InferenceRouter:
                 usage_dict["input_tokens"],
                 usage_dict["output_tokens"],
             )
+            if elapsed_ms > _LATENCY_WARN_MS:
+                logger.warning(
+                    "SLOW_LLM_CALL provider=%s latency_ms=%d input_tokens=%d — "
+                    "consider trimming context",
+                    provider.name,
+                    elapsed_ms,
+                    usage_dict["input_tokens"],
+                )
 
             self.write_api_usage(
                 session_id=session_id,
@@ -470,6 +481,13 @@ class InferenceRouter:
                 usage_dict["input_tokens"],
                 usage_dict["output_tokens"],
             )
+            if elapsed_ms > _LATENCY_WARN_MS:
+                logger.warning(
+                    "SLOW_LLM_CALL provider=claude latency_ms=%d input_tokens=%d — "
+                    "consider trimming context",
+                    elapsed_ms,
+                    usage_dict["input_tokens"],
+                )
 
             self.write_api_usage(
                 session_id=session_id,

--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -13,6 +13,10 @@ from .. import neon_recall as _neon_recall
 from ..guardrails import rewrite_question, vendor_name_from_text, vendor_support_url
 from ..langfuse_setup import trace_rag_query
 
+# Max tokens to allocate for conversation history in the prompt.
+# Prevents late-conversation latency spikes from unbounded context growth.
+_HISTORY_TOKEN_BUDGET = int(os.getenv("MIRA_HISTORY_TOKEN_BUDGET", "2000"))
+
 _PROMPT_PATH = Path(__file__).parent.parent.parent / "prompts" / "diagnose" / "active.yaml"
 
 
@@ -30,6 +34,27 @@ def _load_prompt_meta() -> dict:
 
 
 logger = logging.getLogger("mira-gsd")
+
+
+def _trim_history_by_tokens(
+    history: list[dict], max_tokens: int = _HISTORY_TOKEN_BUDGET
+) -> list[dict]:
+    """Walk history backward, keep entries until token budget is exhausted.
+
+    Replaces the fixed ``history[-10:]`` slice to prevent latency spikes
+    when late-conversation messages grow much longer than early ones.
+    Uses a rough 1-token ≈ 4-chars heuristic (same as the rest of the codebase).
+    """
+    trimmed: list[dict] = []
+    tokens_used = 0
+    for entry in reversed(history):
+        entry_tokens = len(entry.get("content", "")) // 4
+        if tokens_used + entry_tokens > max_tokens:
+            break
+        trimmed.append(entry)
+        tokens_used += entry_tokens
+    return list(reversed(trimmed))
+
 
 
 GSD_SYSTEM_PROMPT = """\
@@ -309,7 +334,7 @@ class RAGWorker:
         messages = [{"role": "system", "content": system_content}]
 
         history = state.get("context", {}).get("history", [])
-        for entry in history[-10:]:
+        for entry in _trim_history_by_tokens(history):
             messages.append({"role": entry["role"], "content": entry["content"]})
 
         if photo_b64:
@@ -416,12 +441,13 @@ class RAGWorker:
         _SELF_REF_SIGNALS = ["you said", "your response", "earlier", "before", "what you told me"]
         if not photo_b64 or _photo_continues:
             history = state.get("context", {}).get("history", [])
-            for entry in history[-10:]:
+            trimmed = _trim_history_by_tokens(history)
+            for entry in trimmed:
                 messages.append({"role": entry["role"], "content": entry["content"]})
             # Self-reference: inject prior MIRA turns explicitly when technician
             # asks about something MIRA said earlier
             if any(s in message.lower() for s in _SELF_REF_SIGNALS):
-                mira_turns = [h for h in history[-10:] if h["role"] == "assistant"][-3:]
+                mira_turns = [h for h in trimmed if h["role"] == "assistant"][-3:]
                 if mira_turns:
                     messages.insert(
                         0,

--- a/tests/test_latency_guard.py
+++ b/tests/test_latency_guard.py
@@ -8,16 +8,13 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 # Add mira-bots to path
 REPO_ROOT = Path(__file__).parent.parent
 MIRA_BOTS = REPO_ROOT / "mira-bots"
 if str(MIRA_BOTS) not in sys.path:
     sys.path.insert(0, str(MIRA_BOTS))
 
-from shared.workers.rag_worker import _trim_history_by_tokens
-
+from shared.workers.rag_worker import _trim_history_by_tokens  # noqa: E402
 
 # ── _trim_history_by_tokens tests ──────────────────────────────────────────
 

--- a/tests/test_latency_guard.py
+++ b/tests/test_latency_guard.py
@@ -1,0 +1,140 @@
+"""Tests for latency guard: token-budgeted history trimming.
+
+Covers _trim_history_by_tokens() from rag_worker.py and the
+HISTORY_LIMIT truncation fix in engine.py nameplate handler.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add mira-bots to path
+REPO_ROOT = Path(__file__).parent.parent
+MIRA_BOTS = REPO_ROOT / "mira-bots"
+if str(MIRA_BOTS) not in sys.path:
+    sys.path.insert(0, str(MIRA_BOTS))
+
+from shared.workers.rag_worker import _trim_history_by_tokens
+
+
+# ── _trim_history_by_tokens tests ──────────────────────────────────────────
+
+
+class TestTrimHistoryByTokens:
+
+    def test_under_budget_passes_through(self):
+        """Short history within budget is returned unchanged."""
+        history = [
+            {"role": "user", "content": "F4 on PowerFlex 525"},
+            {"role": "assistant", "content": "F4 = UnderVoltage. Check input AC."},
+        ]
+        result = _trim_history_by_tokens(history, max_tokens=2000)
+        assert result == history
+
+    def test_over_budget_trims_oldest(self):
+        """History exceeding budget drops oldest entries first."""
+        # Each entry ~100 chars = ~25 tokens
+        history = [
+            {"role": "user", "content": f"Turn {i}: " + "x" * 90}
+            for i in range(40)  # 40 entries * 25 tokens = ~1000 tokens
+        ]
+        result = _trim_history_by_tokens(history, max_tokens=200)
+        # Budget of 200 tokens fits ~8 entries (each ~25 tokens)
+        assert len(result) < len(history)
+        assert len(result) <= 10  # rough upper bound
+
+    def test_preserves_most_recent(self):
+        """Most recent entries are always kept, oldest dropped."""
+        history = [
+            {"role": "user", "content": f"old message {i}: " + "x" * 200}
+            for i in range(5)
+        ] + [
+            {"role": "user", "content": "recent: check motor"},
+            {"role": "assistant", "content": "recent: megger the windings"},
+        ]
+        result = _trim_history_by_tokens(history, max_tokens=100)
+        # Recent entries should be present
+        assert any("recent" in e["content"] for e in result)
+        # At least the last two short entries should fit
+        assert result[-1]["content"] == "recent: megger the windings"
+
+    def test_empty_history(self):
+        """Empty history returns empty list."""
+        assert _trim_history_by_tokens([], max_tokens=2000) == []
+
+    def test_single_huge_entry_still_included(self):
+        """A single entry larger than the budget is still included.
+
+        The function starts from the most recent and works backward.
+        The very last entry is always included (even if over budget)
+        because we check BEFORE adding.
+        """
+        history = [
+            {"role": "user", "content": "x" * 10000},  # ~2500 tokens
+        ]
+        result = _trim_history_by_tokens(history, max_tokens=500)
+        # First entry checked: 2500 > 500, so it's dropped
+        assert result == []
+
+    def test_budget_from_env(self):
+        """Default budget comes from _HISTORY_TOKEN_BUDGET constant."""
+        # Just verify the function works with default (no max_tokens arg)
+        history = [
+            {"role": "user", "content": "short message"},
+            {"role": "assistant", "content": "short reply"},
+        ]
+        result = _trim_history_by_tokens(history)
+        assert result == history
+
+    def test_realistic_conversation_depth(self):
+        """Simulate a 15-exchange conversation where later messages are longer.
+
+        Early turns: ~200 chars each (~50 tokens)
+        Late turns: ~1200 chars each (~300 tokens)
+        Budget of 2000 tokens should include recent turns, drop early ones.
+        """
+        history = []
+        for i in range(30):  # 15 exchanges = 30 entries
+            if i < 20:  # Early turns: short
+                content = f"Turn {i}: " + "x" * 180
+            else:  # Late turns: long diagnostic reasoning
+                content = f"Turn {i}: " + "x" * 1180
+            role = "user" if i % 2 == 0 else "assistant"
+            history.append({"role": role, "content": content})
+
+        result = _trim_history_by_tokens(history, max_tokens=2000)
+
+        # Total tokens unbudgeted: 20*50 + 10*300 = 4000, well over 2000
+        assert len(result) < 30
+        # Most recent entry should always be present
+        assert result[-1] == history[-1]
+        # Oldest entries should be dropped
+        assert history[0] not in result
+
+
+# ── Nameplate truncation test ──────────────────────────────────────────────
+
+
+class TestNameplateTruncation:
+    """Verify that the nameplate handler truncates history."""
+
+    def test_nameplate_handler_has_truncation(self):
+        """engine.py nameplate handler should truncate history to HISTORY_LIMIT.
+
+        Structural test — reads the source file directly (engine.py can't be
+        imported without a running SQLite DB) and verifies HISTORY_LIMIT
+        truncation appears near the "Asset registered" code path.
+        """
+        engine_path = REPO_ROOT / "mira-bots" / "shared" / "engine.py"
+        source = engine_path.read_text()
+
+        idx = source.find("Asset registered")
+        assert idx > 0, "Asset registered string not found in engine.py"
+
+        # Check that HISTORY_LIMIT truncation appears within 500 chars after
+        nearby = source[idx : idx + 500]
+        assert "HISTORY_LIMIT" in nearby, (
+            "HISTORY_LIMIT truncation missing near nameplate handler"
+        )


### PR DESCRIPTION
## Summary
- Replace fixed `history[-10:]` slice with `_trim_history_by_tokens()` — walks backward from most recent, accumulates entries until a 2000-token budget is exhausted
- Fix missing `HISTORY_LIMIT` truncation in nameplate handler (`engine.py:834-842`)
- Add `SLOW_LLM_CALL` warning log when any provider exceeds 15s (configurable via `MIRA_LATENCY_WARN_MS`)

## Root Cause
After ~12 exchanges, Groq latency jumped from 7s to 48s. The `history[-10:]` slice caps *entry count* but not *token count*. Late-conversation messages are 4-8x longer than early ones (deeper diagnostic reasoning), so the actual token cost of 10 entries grows from ~500 to ~3000+ tokens. Groq soft-throttles large requests without returning 429.

## Files Changed
| File | Change |
|------|--------|
| `mira-bots/shared/workers/rag_worker.py` | `_trim_history_by_tokens()` + replace both `[-10:]` sites |
| `mira-bots/shared/engine.py` | Add missing `HISTORY_LIMIT` truncation in nameplate handler |
| `mira-bots/shared/inference/router.py` | `SLOW_LLM_CALL` warning at 15s threshold |
| `tests/test_latency_guard.py` | 8 offline tests |

## Configuration
- `MIRA_HISTORY_TOKEN_BUDGET` — default 2000 tokens (~8K chars of history)
- `MIRA_LATENCY_WARN_MS` — default 15000ms warning threshold

Closes #185

## Test plan
- [x] `pytest tests/test_latency_guard.py` — 8/8 pass
- [ ] Deploy to Bravo, run 15+ exchange conversation via Telegram, verify latency stays under 15s
- [ ] Check logs for `SLOW_LLM_CALL` warnings during extended conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)