### PR TITLE
feat: Redis dedup set backup/restore to NeonDB

### DIFF
--- a/docs/migrations/003_kb_dedup_state.sql
+++ b/docs/migrations/003_kb_dedup_state.sql
@@ -1,0 +1,21 @@
+-- Migration 003: kb_dedup_state table for Redis dedup set backups
+-- Status: PENDING — run via psql or ingest container
+-- Write path: tools/backup_redis_dedup.py
+-- Read path:  tools/restore_redis_dedup.py
+--
+-- Stores snapshots of Redis dedup sets so they can be restored after
+-- a volume loss without re-ingesting the entire knowledge base.
+
+CREATE TABLE IF NOT EXISTS kb_dedup_state (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    key_name         TEXT NOT NULL,          -- e.g. "mira:rss:seen_guids"
+    key_type         TEXT NOT NULL,          -- "set" or "hash"
+    members          JSONB NOT NULL,         -- set: ["id1","id2"], hash: {"url":"lastmod"}
+    member_count     INTEGER NOT NULL,       -- for quick audit without parsing JSONB
+    ttl_seconds      INTEGER,               -- NULL = no TTL, otherwise seconds
+    backed_up_at     TIMESTAMP NOT NULL DEFAULT now(),
+    UNIQUE (key_name)                        -- one row per key, upserted each run
+);
+
+CREATE INDEX IF NOT EXISTS kb_dedup_state_key_idx
+    ON kb_dedup_state (key_name);

--- a/tests/test_redis_dedup_backup.py
+++ b/tests/test_redis_dedup_backup.py
@@ -1,0 +1,193 @@
+"""Tests for Redis dedup backup/restore logic.
+
+Offline tests covering serialization, deserialization, key registry
+completeness, and restore skip-if-exists behavior. No live Redis needed.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Add tools/ to path for imports
+REPO_ROOT = Path(__file__).parent.parent
+TOOLS = REPO_ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+
+# ── Key registry tests ────────────────────────────────────────────────────
+
+
+class TestKeyRegistry:
+    """Verify DEDUP_KEYS covers all known Redis dedup keys."""
+
+    def test_all_keys_registered(self):
+        """All 6 dedup keys from crawler tasks are in DEDUP_KEYS."""
+        from backup_redis_dedup import DEDUP_KEYS
+
+        key_names = {k[0] for k in DEDUP_KEYS}
+        expected = {
+            "mira:rss:seen_guids",
+            "mira:reddit:seen_posts",
+            "mira:youtube:seen_videos",
+            "mira:sitemaps:lastmod",
+            "mira:gdrive:processed_files",
+            "mira:patents:seen_ids",
+        }
+        assert key_names == expected
+
+    def test_youtube_has_ttl(self):
+        """YouTube key is the only one with a TTL (90 days)."""
+        from backup_redis_dedup import DEDUP_KEYS
+
+        ttl_keys = {k[0]: k[2] for k in DEDUP_KEYS if k[2] is not None}
+        assert "mira:youtube:seen_videos" in ttl_keys
+        assert ttl_keys["mira:youtube:seen_videos"] == 90 * 86400
+
+    def test_sitemaps_is_hash(self):
+        """Sitemaps key is a hash (not a set) — different data structure."""
+        from backup_redis_dedup import DEDUP_KEYS
+
+        types = {k[0]: k[1] for k in DEDUP_KEYS}
+        assert types["mira:sitemaps:lastmod"] == "hash"
+        # All others should be sets
+        for key_name, key_type, _ in DEDUP_KEYS:
+            if key_name != "mira:sitemaps:lastmod":
+                assert key_type == "set", f"{key_name} should be 'set', got '{key_type}'"
+
+
+# ── Serialization tests ──────────────────────────────────────────────────
+
+
+class TestSerialization:
+    """Verify backup data can round-trip through JSON/NeonDB."""
+
+    def test_set_serialization(self):
+        """Set members serialize to sorted JSON array."""
+        members = {"guid3", "guid1", "guid2"}
+        serialized = json.dumps(sorted(members))
+        deserialized = json.loads(serialized)
+        assert deserialized == ["guid1", "guid2", "guid3"]
+        assert set(deserialized) == members
+
+    def test_hash_serialization(self):
+        """Hash members serialize to JSON object."""
+        members = {
+            "https://example.com/sitemap.xml": "2026-04-01T00:00:00Z",
+            "https://example.com/products.xml": "2026-03-15T12:00:00Z",
+        }
+        serialized = json.dumps(members)
+        deserialized = json.loads(serialized)
+        assert deserialized == members
+
+    def test_empty_set(self):
+        """Empty set serializes to empty array."""
+        assert json.dumps([]) == "[]"
+        assert json.loads("[]") == []
+
+    def test_large_set_serialization(self):
+        """Large sets (10K+ members) serialize correctly."""
+        members = [f"guid_{i:06d}" for i in range(10000)]
+        serialized = json.dumps(members)
+        deserialized = json.loads(serialized)
+        assert len(deserialized) == 10000
+        assert deserialized[0] == "guid_000000"
+
+
+# ── Read key tests ────────────────────────────────────────────────────────
+
+
+class TestReadKey:
+    """Test _read_key with mocked Redis."""
+
+    def test_read_set(self):
+        from backup_redis_dedup import _read_key
+
+        r = MagicMock()
+        r.exists.return_value = True
+        r.smembers.return_value = {"c", "a", "b"}
+
+        result = _read_key(r, "mira:rss:seen_guids", "set")
+        assert result == ["a", "b", "c"]  # sorted
+
+    def test_read_hash(self):
+        from backup_redis_dedup import _read_key
+
+        r = MagicMock()
+        r.exists.return_value = True
+        r.hgetall.return_value = {"url1": "2026-04-01", "url2": "2026-03-15"}
+
+        result = _read_key(r, "mira:sitemaps:lastmod", "hash")
+        assert result == {"url1": "2026-04-01", "url2": "2026-03-15"}
+
+    def test_read_nonexistent_key(self):
+        from backup_redis_dedup import _read_key
+
+        r = MagicMock()
+        r.exists.return_value = False
+
+        assert _read_key(r, "mira:rss:seen_guids", "set") == []
+        assert _read_key(r, "mira:sitemaps:lastmod", "hash") == {}
+
+
+# ── Restore tests ─────────────────────────────────────────────────────────
+
+
+class TestRestoreKey:
+    """Test _restore_key with mocked Redis."""
+
+    def test_restore_set(self):
+        from restore_redis_dedup import _restore_key
+
+        r = MagicMock()
+        pipe = MagicMock()
+        r.pipeline.return_value = pipe
+
+        count = _restore_key(r, "mira:rss:seen_guids", "set",
+                             ["guid1", "guid2", "guid3"], None)
+        assert count == 3
+        pipe.sadd.assert_called_once()
+        pipe.execute.assert_called_once()
+
+    def test_restore_set_with_ttl(self):
+        from restore_redis_dedup import _restore_key
+
+        r = MagicMock()
+        pipe = MagicMock()
+        r.pipeline.return_value = pipe
+
+        ttl = 90 * 86400
+        count = _restore_key(r, "mira:youtube:seen_videos", "set",
+                             ["vid1", "vid2"], ttl)
+        assert count == 2
+        pipe.expire.assert_called_once_with("mira:youtube:seen_videos", ttl)
+
+    def test_restore_hash(self):
+        from restore_redis_dedup import _restore_key
+
+        r = MagicMock()
+        pipe = MagicMock()
+        r.pipeline.return_value = pipe
+
+        data = {"url1": "2026-04-01", "url2": "2026-03-15"}
+        count = _restore_key(r, "mira:sitemaps:lastmod", "hash", data, None)
+        assert count == 2
+        pipe.hset.assert_called_once()
+
+    def test_restore_empty_skips(self):
+        from restore_redis_dedup import _restore_key
+
+        r = MagicMock()
+        assert _restore_key(r, "mira:rss:seen_guids", "set", [], None) == 0
+        r.pipeline.assert_not_called()
+
+    def test_restore_wrong_type_skips(self):
+        from restore_redis_dedup import _restore_key
+
+        r = MagicMock()
+        assert _restore_key(r, "mira:rss:seen_guids", "set",
+                            {"wrong": "type"}, None) == 0

--- a/tools/backup_redis_dedup.py
+++ b/tools/backup_redis_dedup.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Backup Redis dedup sets to NeonDB kb_dedup_state table.
+
+Dumps all mira:*:seen_* sets and mira:sitemaps:lastmod hash so they
+can be restored after a Redis volume loss without re-ingesting the
+entire knowledge base.
+
+Usage:
+    doppler run --project factorylm --config prd -- \
+      uv run --with sqlalchemy --with psycopg2-binary --with redis \
+      python tools/backup_redis_dedup.py [--dry-run]
+
+Designed to run nightly after the ingest window (e.g. 04:30 UTC).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import uuid
+from urllib.parse import urlparse
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+log = logging.getLogger("backup_redis_dedup")
+
+NEON_DATABASE_URL = os.environ.get("NEON_DATABASE_URL")
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0")
+
+# All Redis keys used for dedup state across crawler tasks.
+# Format: (key_name, key_type, ttl_seconds_or_None)
+DEDUP_KEYS: list[tuple[str, str, int | None]] = [
+    ("mira:rss:seen_guids", "set", None),
+    ("mira:reddit:seen_posts", "set", None),
+    ("mira:youtube:seen_videos", "set", 90 * 86400),  # 90 days
+    ("mira:sitemaps:lastmod", "hash", None),
+    ("mira:gdrive:processed_files", "set", None),
+    ("mira:patents:seen_ids", "set", None),
+]
+
+
+def _get_redis():
+    """Build a Redis client from CELERY_BROKER_URL."""
+    import redis
+
+    parsed = urlparse(CELERY_BROKER_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6379
+    return redis.Redis(host=host, port=port, db=0, decode_responses=True)
+
+
+def _read_key(r, key_name: str, key_type: str) -> list | dict:
+    """Read a Redis key and return its contents as a serializable structure."""
+    if not r.exists(key_name):
+        return [] if key_type == "set" else {}
+
+    if key_type == "set":
+        return sorted(r.smembers(key_name))
+    elif key_type == "hash":
+        return dict(r.hgetall(key_name))
+    else:
+        log.warning("Unknown key type %s for %s", key_type, key_name)
+        return []
+
+
+def _upsert_backup(conn, text_fn, key_name: str, key_type: str,
+                   members: list | dict, ttl_seconds: int | None) -> bool:
+    """Upsert one dedup key backup into kb_dedup_state."""
+    member_count = len(members)
+    try:
+        conn.execute(text_fn(
+            "INSERT INTO kb_dedup_state "
+            "(id, key_name, key_type, members, member_count, ttl_seconds, backed_up_at) "
+            "VALUES (:id, :key, :type, :members, :count, :ttl, now()) "
+            "ON CONFLICT (key_name) DO UPDATE SET "
+            "members = EXCLUDED.members, member_count = EXCLUDED.member_count, "
+            "ttl_seconds = EXCLUDED.ttl_seconds, backed_up_at = now()"
+        ), {
+            "id": str(uuid.uuid4()),
+            "key": key_name,
+            "type": key_type,
+            "members": json.dumps(members),
+            "count": member_count,
+            "ttl": ttl_seconds,
+        })
+        return True
+    except Exception as e:
+        log.error("Failed to backup %s: %s", key_name, e)
+        return False
+
+
+def main() -> None:
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.pool import NullPool
+
+    parser = argparse.ArgumentParser(description="Backup Redis dedup sets to NeonDB")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print what would be backed up without writing to NeonDB")
+    args = parser.parse_args()
+
+    if not NEON_DATABASE_URL:
+        sys.exit("ERROR: NEON_DATABASE_URL required")
+
+    r = _get_redis()
+    log.info("Connected to Redis at %s", CELERY_BROKER_URL.split("@")[-1])
+
+    # Ensure table exists
+    engine = create_engine(
+        NEON_DATABASE_URL, poolclass=NullPool,
+        connect_args={"sslmode": "require"}, pool_pre_ping=True,
+    )
+
+    total_members = 0
+    backed_up = 0
+
+    with engine.connect() as conn:
+        # Create table if not exists (idempotent)
+        conn.execute(text(
+            "CREATE TABLE IF NOT EXISTS kb_dedup_state ("
+            "  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),"
+            "  key_name TEXT NOT NULL,"
+            "  key_type TEXT NOT NULL,"
+            "  members JSONB NOT NULL,"
+            "  member_count INTEGER NOT NULL,"
+            "  ttl_seconds INTEGER,"
+            "  backed_up_at TIMESTAMP NOT NULL DEFAULT now(),"
+            "  UNIQUE (key_name)"
+            ")"
+        ))
+        conn.commit()
+
+        for key_name, key_type, ttl_seconds in DEDUP_KEYS:
+            members = _read_key(r, key_name, key_type)
+            count = len(members)
+            total_members += count
+
+            if args.dry_run:
+                log.info("  [DRY-RUN] %s (%s): %d members, TTL=%s",
+                         key_name, key_type, count,
+                         f"{ttl_seconds}s" if ttl_seconds else "none")
+                continue
+
+            if count == 0:
+                log.info("  %s: empty — skipping", key_name)
+                continue
+
+            if _upsert_backup(conn, text, key_name, key_type, members, ttl_seconds):
+                backed_up += 1
+                log.info("  %s: backed up %d members", key_name, count)
+
+        if not args.dry_run:
+            conn.commit()
+
+    if args.dry_run:
+        log.info("Dry run complete — %d total members across %d keys",
+                 total_members, len(DEDUP_KEYS))
+    else:
+        log.info("Backup complete — %d keys backed up, %d total members",
+                 backed_up, total_members)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/restore_redis_dedup.py
+++ b/tools/restore_redis_dedup.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Restore Redis dedup sets from NeonDB kb_dedup_state backup.
+
+Rehydrates all dedup keys from the most recent backup, preserving
+original TTLs. Run this after a Redis volume loss to prevent
+re-ingesting the entire knowledge base.
+
+Usage:
+    doppler run --project factorylm --config prd -- \
+      uv run --with sqlalchemy --with psycopg2-binary --with redis \
+      python tools/restore_redis_dedup.py [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from urllib.parse import urlparse
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[logging.StreamHandler(sys.stdout)],
+)
+log = logging.getLogger("restore_redis_dedup")
+
+NEON_DATABASE_URL = os.environ.get("NEON_DATABASE_URL")
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0")
+
+
+def _get_redis():
+    """Build a Redis client from CELERY_BROKER_URL."""
+    import redis
+
+    parsed = urlparse(CELERY_BROKER_URL)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 6379
+    return redis.Redis(host=host, port=port, db=0, decode_responses=True)
+
+
+def _restore_key(r, key_name: str, key_type: str,
+                 members: list | dict, ttl_seconds: int | None) -> int:
+    """Restore a single Redis key from backup data.
+
+    Returns the number of members restored.
+    """
+    if not members:
+        return 0
+
+    if key_type == "set":
+        if not isinstance(members, list):
+            log.warning("Expected list for set key %s, got %s", key_name, type(members).__name__)
+            return 0
+        # Pipeline for efficiency
+        pipe = r.pipeline()
+        # Add in batches of 1000 to avoid huge SADD commands
+        for i in range(0, len(members), 1000):
+            batch = members[i : i + 1000]
+            pipe.sadd(key_name, *batch)
+        if ttl_seconds:
+            pipe.expire(key_name, ttl_seconds)
+        pipe.execute()
+        return len(members)
+
+    elif key_type == "hash":
+        if not isinstance(members, dict):
+            log.warning("Expected dict for hash key %s, got %s", key_name, type(members).__name__)
+            return 0
+        # HSET in batches
+        pipe = r.pipeline()
+        items = list(members.items())
+        for i in range(0, len(items), 500):
+            batch = dict(items[i : i + 500])
+            pipe.hset(key_name, mapping=batch)
+        if ttl_seconds:
+            pipe.expire(key_name, ttl_seconds)
+        pipe.execute()
+        return len(members)
+
+    else:
+        log.warning("Unknown key type %s for %s", key_type, key_name)
+        return 0
+
+
+def main() -> None:
+    from sqlalchemy import create_engine, text
+    from sqlalchemy.pool import NullPool
+
+    parser = argparse.ArgumentParser(description="Restore Redis dedup sets from NeonDB")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print what would be restored without writing to Redis")
+    args = parser.parse_args()
+
+    if not NEON_DATABASE_URL:
+        sys.exit("ERROR: NEON_DATABASE_URL required")
+
+    engine = create_engine(
+        NEON_DATABASE_URL, poolclass=NullPool,
+        connect_args={"sslmode": "require"}, pool_pre_ping=True,
+    )
+
+    with engine.connect() as conn:
+        rows = conn.execute(text(
+            "SELECT key_name, key_type, members, member_count, ttl_seconds, backed_up_at "
+            "FROM kb_dedup_state ORDER BY key_name"
+        )).fetchall()
+
+    if not rows:
+        log.warning("No backup data found in kb_dedup_state — nothing to restore")
+        return
+
+    log.info("Found %d backed-up keys in NeonDB", len(rows))
+
+    if args.dry_run:
+        for row in rows:
+            key_name, key_type, members_json, count, ttl, backed_up = row
+            log.info("  [DRY-RUN] %s (%s): %d members, TTL=%s, backed_up=%s",
+                     key_name, key_type, count,
+                     f"{ttl}s" if ttl else "none",
+                     backed_up)
+        log.info("Dry run complete — would restore %d keys",
+                 sum(1 for r in rows if r[3] > 0))
+        return
+
+    r = _get_redis()
+    log.info("Connected to Redis at %s", CELERY_BROKER_URL.split("@")[-1])
+
+    total_restored = 0
+    keys_restored = 0
+
+    for row in rows:
+        key_name, key_type, members_json, count, ttl, backed_up = row
+
+        # Check if key already exists in Redis
+        if r.exists(key_name):
+            existing_size = r.scard(key_name) if key_type == "set" else r.hlen(key_name)
+            log.info("  %s: already has %d members in Redis — skipping (backup has %d)",
+                     key_name, existing_size, count)
+            continue
+
+        if count == 0:
+            log.info("  %s: backup is empty — skipping", key_name)
+            continue
+
+        members = json.loads(members_json) if isinstance(members_json, str) else members_json
+        restored = _restore_key(r, key_name, key_type, members, ttl)
+        total_restored += restored
+        keys_restored += 1
+        log.info("  %s: restored %d members (backup from %s)", key_name, restored, backed_up)
+
+    log.info("Restore complete — %d keys, %d total members restored", keys_restored, total_restored)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- **backup_redis_dedup.py** — dumps all 6 crawler dedup keys to NeonDB `kb_dedup_state` table
- **restore_redis_dedup.py** — rehydrates Redis from NeonDB backup, skips existing keys, preserves TTLs
- **Migration 003** — `kb_dedup_state` schema with UPSERT on key_name

## Dedup Keys Covered
| Key | Type | TTL | Source |
|-----|------|-----|--------|
| `mira:rss:seen_guids` | SET | none | rss.py |
| `mira:reddit:seen_posts` | SET | none | reddit.py |
| `mira:youtube:seen_videos` | SET | 90 days | youtube.py |
| `mira:sitemaps:lastmod` | HASH | none | sitemaps.py |
| `mira:gdrive:processed_files` | SET | none | gdrive.py |
| `mira:patents:seen_ids` | SET | none | patents.py |

## Files
| File | Purpose |
|------|---------|
| `tools/backup_redis_dedup.py` | Nightly backup script |
| `tools/restore_redis_dedup.py` | Disaster recovery restore |
| `docs/migrations/003_kb_dedup_state.sql` | NeonDB schema |
| `tests/test_redis_dedup_backup.py` | 15 offline tests |

Closes #110

## Test plan
- [x] `pytest tests/test_redis_dedup_backup.py` — 15/15 pass
- [ ] Run migration 003 on NeonDB via psql
- [ ] Run `backup_redis_dedup.py --dry-run` on Bravo to verify Redis connectivity
- [ ] Run `backup_redis_dedup.py` for real, verify `kb_dedup_state` rows in NeonDB
- [ ] Schedule nightly run (Celery beat or cron at 04:30 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)