### PR TITLE
feat(eval): fix-proposal automation — failure clusters to draft PR

### DIFF
--- a/mira-bots/tools/fix_proposer.py
+++ b/mira-bots/tools/fix_proposer.py
@@ -1,0 +1,554 @@
+"""fix_proposer.py — Eval failure clusters → Claude-drafted patch → draft PR.
+
+Runs after the nightly eval. Loads the latest scorecard, clusters failing
+scenarios by failure mode (checkpoint + reason-prefix), and for each cluster
+of 3+ failures, asks Claude to propose a minimal patch to the relevant
+prompt rules or fixture. Opens a draft GitHub PR with the proposed change
+and the failure cluster as evidence.
+
+**No auto-merge.** Mike reviews every draft PR before it lands.
+
+This is the autoresearch pattern's "fix proposal" step: when the eval
+surfaces a reproducible failure pattern, the system proposes the patch so
+the human only has to review, not investigate.
+
+Usage (dry-run — no PR opened):
+    python fix_proposer.py --dry-run --runs-dir tests/eval/runs
+
+Environment:
+    FIX_PROPOSER_GH_TOKEN         GitHub PAT (contents:write + pull_requests:write)
+    ANTHROPIC_API_KEY             Claude API key
+    CLAUDE_MODEL                  Model override (default: claude-sonnet-4-6)
+    FIX_PROPOSER_DISABLED         Set to "1" to disable
+    FIX_PROPOSER_STATE_PATH       State JSON (default: /opt/mira/data/fix_proposer_state.json)
+    FIX_PROPOSER_MIN_CLUSTER      Min failures per cluster to propose a fix (default: 3)
+    FIX_PROPOSER_MAX_CLUSTERS     Max clusters per run (default: 3)
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger("mira-fix-proposer")
+
+REPO = "Mikecranesync/MIRA"
+_ANTHROPIC_API = "https://api.anthropic.com/v1/messages"
+_DEFAULT_MODEL = "claude-sonnet-4-6"
+
+
+# ── Parsing: scorecard .md → failing scenarios ──────────────────────────────
+
+# Scorecard Failures section:
+#   ### scenario_id
+#   - **cp_name** FAILED: <reason>
+#   - Last response: `...`
+_FAILURE_HEADER_RE = re.compile(r"^### (?P<scenario_id>[\w_-]+)\s*$")
+_FAILURE_LINE_RE = re.compile(
+    r"^\s*-\s+\*\*(?P<checkpoint>cp_\w+)\*\*\s+FAILED:\s*(?P<reason>.+?)\s*$"
+)
+
+
+@dataclass
+class FailureRecord:
+    """A single failing checkpoint within a scenario."""
+
+    scenario_id: str
+    checkpoint: str
+    reason: str
+
+
+def parse_scorecard(md_path: Path) -> list[FailureRecord]:
+    """Extract failing (scenario, checkpoint, reason) tuples from a scorecard .md."""
+    failures: list[FailureRecord] = []
+    try:
+        text = md_path.read_text()
+    except OSError as e:
+        logger.error("Cannot read %s: %s", md_path, e)
+        return failures
+
+    # Only parse lines after the "## Failures" section
+    in_failures = False
+    current_scenario: str | None = None
+    for raw_line in text.splitlines():
+        if raw_line.strip().startswith("## Failures"):
+            in_failures = True
+            continue
+        if in_failures and raw_line.strip().startswith("## "):
+            # Next top-level section — failures done
+            break
+        if not in_failures:
+            continue
+
+        hdr = _FAILURE_HEADER_RE.match(raw_line)
+        if hdr:
+            current_scenario = hdr.group("scenario_id")
+            continue
+
+        fail = _FAILURE_LINE_RE.match(raw_line)
+        if fail and current_scenario:
+            failures.append(FailureRecord(
+                scenario_id=current_scenario,
+                checkpoint=fail.group("checkpoint"),
+                reason=fail.group("reason"),
+            ))
+
+    return failures
+
+
+def find_latest_scorecard(runs_dir: Path) -> Path | None:
+    """Return the newest scorecard .md file in runs_dir."""
+    if not runs_dir.exists():
+        return None
+    candidates = sorted(runs_dir.glob("*.md"), reverse=True)
+    # Prefer judge-enabled runs (they have more signal)
+    judge_first = [c for c in candidates if "judge" in c.stem]
+    return (judge_first or candidates)[0] if (judge_first or candidates) else None
+
+
+# ── Clustering: group failures by signature ─────────────────────────────────
+
+
+def _reason_signature(reason: str, max_chars: int = 40) -> str:
+    """Normalize a failure reason to a cluster key.
+
+    Strips scenario-specific details (quoted strings, numbers, brackets) and
+    keeps the stable prefix so the same failure mode in different scenarios
+    clusters together.
+    """
+    # Remove quoted strings and brackets
+    s = re.sub(r"['\"].*?['\"]", "STR", reason)
+    s = re.sub(r"\[.*?\]", "LIST", s)
+    s = re.sub(r"\{.*?\}", "DICT", s)
+    # Remove numbers
+    s = re.sub(r"\b\d+\b", "N", s)
+    # Collapse whitespace
+    s = re.sub(r"\s+", " ", s).strip().lower()
+    return s[:max_chars]
+
+
+@dataclass
+class FailureCluster:
+    """Group of failures that share the same checkpoint + reason signature."""
+
+    checkpoint: str
+    reason_signature: str
+    failures: list[FailureRecord] = field(default_factory=list)
+
+    @property
+    def size(self) -> int:
+        return len(self.failures)
+
+    @property
+    def cluster_id(self) -> str:
+        # Stable ID for branch naming / PR titles
+        slug = re.sub(r"[^a-z0-9]+", "-", self.reason_signature).strip("-")[:30]
+        return f"{self.checkpoint}-{slug}"
+
+
+def cluster_failures(
+    failures: list[FailureRecord], min_size: int = 3
+) -> list[FailureCluster]:
+    """Group failures by (checkpoint, reason-signature). Return clusters ≥ min_size."""
+    groups: dict[tuple[str, str], list[FailureRecord]] = defaultdict(list)
+    for f in failures:
+        key = (f.checkpoint, _reason_signature(f.reason))
+        groups[key].append(f)
+
+    clusters = [
+        FailureCluster(checkpoint=cp, reason_signature=sig, failures=fs)
+        for (cp, sig), fs in groups.items()
+        if len(fs) >= min_size
+    ]
+    # Largest clusters first — they're the most impactful to fix
+    clusters.sort(key=lambda c: -c.size)
+    return clusters
+
+
+# ── LLM patch proposal ──────────────────────────────────────────────────────
+
+
+_PATCH_SYSTEM = """\
+You are a MIRA eval fix-proposer. A cluster of eval scenarios fail the same
+checkpoint for the same reason. Propose a minimal, targeted fix.
+
+Scope of allowed fixes:
+- Modify rules in mira-bots/prompts/diagnose/active.yaml (the system prompt)
+- Modify or add entries in mira-bots/shared/guardrails.py (keyword lists, etc.)
+- Correct a test fixture's expected_keywords or forbidden_keywords if the
+  fixture was over-specified
+
+Do NOT propose:
+- Changes to engine.py, workers/, or inference/router.py (risk too high for auto-proposals)
+- Large refactors or new features
+- Changes spanning more than 2 files
+- Changes to more than one cluster's root cause (one PR = one fix)
+
+Return ONLY valid JSON — no commentary outside the JSON:
+{
+  "hypothesis": "One-sentence root-cause hypothesis.",
+  "file_path": "relative path from repo root, e.g. mira-bots/prompts/diagnose/active.yaml",
+  "change_type": "edit" | "add-rule" | "fixture-correction",
+  "rationale": "2-3 sentences explaining why this fix addresses the cluster.",
+  "proposed_patch": "The exact text to add/modify. For YAML, include the full new/modified key.",
+  "projected_impact": "Which scenarios in the cluster this should convert from FAIL to PASS, and why.",
+  "confidence": 0.0 to 1.0
+}"""
+
+_PATCH_USER = """\
+Failure cluster:
+  checkpoint: {checkpoint}
+  reason signature: {signature}
+  failing scenarios ({count}):
+{scenario_list}
+
+Sample raw failure reasons:
+{sample_reasons}
+
+Relevant repo context:
+{repo_context}
+
+Propose a minimal fix."""
+
+
+def _build_repo_context(cluster: FailureCluster, repo_root: Path) -> str:
+    """Return a short blurb of relevant file snippets for the LLM prompt."""
+    parts: list[str] = []
+    # For cp_keyword_match failures — include guardrails keyword lists
+    if cluster.checkpoint == "cp_keyword_match":
+        gr = repo_root / "mira-bots" / "shared" / "guardrails.py"
+        if gr.exists():
+            snippet = gr.read_text()[:2000]
+            parts.append(f"--- guardrails.py (first 2000 chars) ---\n{snippet}")
+
+    # For cp_reached_state failures — include FSM state list from engine
+    if cluster.checkpoint == "cp_reached_state":
+        eng = repo_root / "mira-bots" / "shared" / "engine.py"
+        if eng.exists():
+            text = eng.read_text()
+            idx = text.find("STATE_ORDER")
+            if idx >= 0:
+                parts.append(f"--- engine.py:STATE_ORDER ---\n{text[idx:idx+500]}")
+
+    # Always include active prompt rules
+    prompt = repo_root / "mira-bots" / "prompts" / "diagnose" / "active.yaml"
+    if prompt.exists():
+        parts.append(f"--- active.yaml ---\n{prompt.read_text()[:3000]}")
+
+    return "\n\n".join(parts) if parts else "(no repo context available)"
+
+
+# ── FixProposer class ───────────────────────────────────────────────────────
+
+
+@dataclass
+class FixProposerConfig:
+    anthropic_api_key: str
+    gh_token: str
+    repo_root: Path
+    state_path: Path
+    runs_dir: Path
+    claude_model: str = _DEFAULT_MODEL
+    min_cluster_size: int = 3
+    max_clusters_per_run: int = 3
+    repo: str = REPO
+
+
+class FixProposer:
+    """Turn eval failure clusters into draft PR proposals."""
+
+    def __init__(self, config: FixProposerConfig) -> None:
+        self.cfg = config
+
+    # ── State management ────────────────────────────────────────────────────
+
+    def _load_state(self) -> dict:
+        if self.cfg.state_path.exists():
+            try:
+                return json.loads(self.cfg.state_path.read_text())
+            except Exception:
+                pass
+        return {"last_run_ts": None, "clusters_proposed": []}
+
+    def _save_state(self, state: dict) -> None:
+        self.cfg.state_path.parent.mkdir(parents=True, exist_ok=True)
+        self.cfg.state_path.write_text(json.dumps(state, indent=2))
+
+    # ── Claude API ──────────────────────────────────────────────────────────
+
+    async def _claude_json(self, system: str, user: str) -> dict | None:
+        """Call Claude, return parsed JSON or None on failure."""
+        try:
+            async with httpx.AsyncClient(timeout=60) as client:
+                resp = await client.post(
+                    _ANTHROPIC_API,
+                    headers={
+                        "x-api-key": self.cfg.anthropic_api_key,
+                        "anthropic-version": "2023-06-01",
+                        "anthropic-beta": "prompt-caching-2024-07-31",
+                        "content-type": "application/json",
+                    },
+                    json={
+                        "model": self.cfg.claude_model,
+                        "max_tokens": 2048,
+                        "system": [
+                            {"type": "text", "text": system,
+                             "cache_control": {"type": "ephemeral"}},
+                        ],
+                        "messages": [{"role": "user", "content": user}],
+                    },
+                )
+                resp.raise_for_status()
+                text = resp.json()["content"][0]["text"].strip()
+                text = re.sub(r"^```(?:json)?\s*|\s*```$", "", text, flags=re.DOTALL)
+                return json.loads(text)
+        except httpx.HTTPStatusError as e:
+            logger.error("Claude HTTP %s: %s", e.response.status_code, e.response.text[:200])
+        except json.JSONDecodeError as e:
+            logger.error("Claude returned non-JSON: %s", e)
+        except Exception as e:
+            logger.error("Claude call failed: %s", e)
+        return None
+
+    async def propose_fix(self, cluster: FailureCluster) -> dict | None:
+        """Ask Claude to propose a patch for a failure cluster."""
+        scenario_list = "\n".join(
+            f"    - {f.scenario_id}" for f in cluster.failures[:10]
+        )
+        sample_reasons = "\n".join(
+            f"    - {f.reason}" for f in cluster.failures[:5]
+        )
+        repo_context = _build_repo_context(cluster, self.cfg.repo_root)
+
+        user_msg = _PATCH_USER.format(
+            checkpoint=cluster.checkpoint,
+            signature=cluster.reason_signature,
+            count=cluster.size,
+            scenario_list=scenario_list,
+            sample_reasons=sample_reasons,
+            repo_context=repo_context,
+        )
+
+        return await self._claude_json(_PATCH_SYSTEM, user_msg)
+
+    # ── PR creation ─────────────────────────────────────────────────────────
+
+    def open_draft_pr(
+        self, cluster: FailureCluster, patch: dict
+    ) -> str | None:
+        """Open a draft PR with the proposed patch. Returns PR URL or None."""
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        branch = f"auto/fix-proposal-{date_str}-{cluster.cluster_id}"[:80]
+        pr_title = (
+            f"auto: fix-proposal for {cluster.checkpoint} cluster "
+            f"({cluster.size} failing scenarios)"
+        )
+
+        scenarios_table = "\n".join(
+            f"| `{f.scenario_id}` | `{f.checkpoint}` | {f.reason[:80]} |"
+            for f in cluster.failures
+        )
+        pr_body = f"""\
+## Auto-generated fix proposal
+
+**Hypothesis:** {patch.get('hypothesis', '(none)')}
+
+**Confidence:** {patch.get('confidence', 0.0):.2f}
+
+### Failure cluster ({cluster.size} scenarios)
+
+| Scenario | Checkpoint | Reason |
+|---|---|---|
+{scenarios_table}
+
+### Proposed change
+
+**File:** `{patch.get('file_path', '(none)')}`
+**Type:** `{patch.get('change_type', 'edit')}`
+
+**Rationale:** {patch.get('rationale', '(none)')}
+
+**Projected impact:** {patch.get('projected_impact', '(none)')}
+
+### Patch
+
+```
+{patch.get('proposed_patch', '(no patch)')}
+```
+
+### Review checklist
+- [ ] Patch fixes the failure cluster without regressing other scenarios
+- [ ] Change is scoped (single file, no side-effects)
+- [ ] Rationale matches the actual root cause
+- [ ] Run eval locally before merging: `python tests/eval/run_eval.py`
+
+---
+*Auto-generated by `fix_proposer.py`. No auto-merge — human review required.*
+"""
+
+        worktree_dir = tempfile.mkdtemp(prefix="mira-fix-proposer-")
+        try:
+            def _run(cmd: list[str], cwd: str, check: bool = True) -> subprocess.CompletedProcess:
+                return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=check)
+
+            _run(["git", "worktree", "add", "-b", branch, worktree_dir, "HEAD"],
+                 str(self.cfg.repo_root))
+
+            # Write a small marker file so the branch has a commit even if
+            # the LLM-proposed patch can't be applied programmatically.
+            # The human reviews the PR body for the actual change.
+            notes_path = Path(worktree_dir) / "docs" / "fix-proposals"
+            notes_path.mkdir(parents=True, exist_ok=True)
+            proposal_file = notes_path / f"{date_str}-{cluster.cluster_id}.md"
+            proposal_file.write_text(pr_body)
+
+            _run(["git", "add", str(proposal_file.relative_to(worktree_dir))], worktree_dir)
+            _run(["git", "commit", "-m",
+                  f"auto: fix proposal for {cluster.checkpoint} cluster "
+                  f"({cluster.size} scenarios)\n\n"
+                  f"Signed-off-by: mira-fix-proposer <eval@mira.local>"],
+                 worktree_dir)
+
+            env = {**os.environ, "GH_TOKEN": self.cfg.gh_token}
+            push_r = subprocess.run(
+                ["git", "push", "-u", "origin", branch],
+                cwd=worktree_dir, capture_output=True, text=True, env=env,
+            )
+            if push_r.returncode != 0:
+                logger.error("git push failed: %s", push_r.stderr[:300])
+                return None
+
+            pr_r = subprocess.run(
+                ["gh", "pr", "create", "--draft",
+                 "--title", pr_title, "--body", pr_body,
+                 "--repo", self.cfg.repo],
+                cwd=worktree_dir, capture_output=True, text=True, env=env,
+            )
+            if pr_r.returncode != 0:
+                logger.error("gh pr create failed: %s", pr_r.stderr[:300])
+                return None
+            return pr_r.stdout.strip()
+
+        except Exception as e:
+            logger.error("open_draft_pr failed: %s", e)
+            return None
+        finally:
+            subprocess.run(
+                ["git", "worktree", "remove", "--force", worktree_dir],
+                cwd=str(self.cfg.repo_root), capture_output=True,
+            )
+
+    # ── Orchestrator ────────────────────────────────────────────────────────
+
+    async def run(self, dry_run: bool = False) -> dict:
+        """Main pipeline: scorecard → clusters → patches → PRs."""
+        run_ts = datetime.now(timezone.utc).isoformat()
+
+        scorecard = find_latest_scorecard(self.cfg.runs_dir)
+        if not scorecard:
+            logger.warning("No scorecard found in %s", self.cfg.runs_dir)
+            return {"status": "ok", "reason": "no_scorecard", "ts": run_ts}
+
+        failures = parse_scorecard(scorecard)
+        if not failures:
+            logger.info("No failures in %s — nothing to propose", scorecard)
+            return {"status": "ok", "reason": "no_failures",
+                    "scorecard": str(scorecard), "ts": run_ts}
+
+        clusters = cluster_failures(failures, self.cfg.min_cluster_size)
+        if not clusters:
+            logger.info("No clusters ≥%d failures — nothing to propose",
+                        self.cfg.min_cluster_size)
+            return {"status": "ok", "reason": "no_clusters",
+                    "failures_total": len(failures), "ts": run_ts}
+
+        logger.info("Found %d failure clusters (processing top %d)",
+                    len(clusters), self.cfg.max_clusters_per_run)
+
+        pr_urls: list[str] = []
+        proposals: list[dict] = []
+        for cluster in clusters[: self.cfg.max_clusters_per_run]:
+            logger.info("Proposing fix for cluster %s (%d scenarios)",
+                        cluster.cluster_id, cluster.size)
+            patch = await self.propose_fix(cluster)
+            if not patch:
+                logger.warning("No patch generated for %s", cluster.cluster_id)
+                continue
+
+            proposal = {
+                "cluster_id": cluster.cluster_id,
+                "size": cluster.size,
+                "checkpoint": cluster.checkpoint,
+                "hypothesis": patch.get("hypothesis", ""),
+                "confidence": patch.get("confidence", 0.0),
+            }
+            proposals.append(proposal)
+
+            if dry_run:
+                logger.info("DRY-RUN: would open PR for %s", cluster.cluster_id)
+                continue
+
+            pr_url = self.open_draft_pr(cluster, patch)
+            if pr_url:
+                pr_urls.append(pr_url)
+                proposal["pr_url"] = pr_url
+
+        self._save_state({"last_run_ts": run_ts, "proposals": proposals})
+
+        return {
+            "status": "ok",
+            "scorecard": str(scorecard),
+            "failures_total": len(failures),
+            "clusters_found": len(clusters),
+            "proposals": proposals,
+            "pr_urls": pr_urls,
+            "ts": run_ts,
+        }
+
+
+# ── CLI entry point ─────────────────────────────────────────────────────────
+
+
+def _build_proposer() -> FixProposer:
+    return FixProposer(FixProposerConfig(
+        anthropic_api_key=os.getenv("ANTHROPIC_API_KEY", ""),
+        gh_token=os.getenv("FIX_PROPOSER_GH_TOKEN", ""),
+        repo_root=Path(os.getenv("MIRA_DIR", "/opt/mira")),
+        state_path=Path(os.getenv("FIX_PROPOSER_STATE_PATH",
+                                   "/opt/mira/data/fix_proposer_state.json")),
+        runs_dir=Path(os.getenv("FIX_PROPOSER_RUNS_DIR",
+                                 "/opt/mira/tests/eval/runs")),
+        claude_model=os.getenv("CLAUDE_MODEL", _DEFAULT_MODEL),
+        min_cluster_size=int(os.getenv("FIX_PROPOSER_MIN_CLUSTER", "3")),
+        max_clusters_per_run=int(os.getenv("FIX_PROPOSER_MAX_CLUSTERS", "3")),
+    ))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="MIRA eval fix-proposal automation")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Print proposals without opening PRs")
+    parser.add_argument("--runs-dir", type=Path,
+                        help="Override runs directory")
+    args = parser.parse_args()
+
+    proposer = _build_proposer()
+    if args.runs_dir:
+        proposer.cfg.runs_dir = args.runs_dir
+
+    result = asyncio.run(proposer.run(dry_run=args.dry_run))
+    print(json.dumps(result, indent=2))

--- a/tests/eval/fix_proposer_tasks.py
+++ b/tests/eval/fix_proposer_tasks.py
@@ -1,0 +1,130 @@
+"""MIRA Fix Proposer Celery Task — nightly 04:30 UTC.
+
+Runs after the nightly eval (03:00) and active learning (04:00). Clusters
+failing scenarios, asks Claude for a minimal patch proposal, opens a draft
+GitHub PR for each cluster.
+
+Beat schedule entry (add to /opt/master_of_puppets/celery_app.py):
+    'mira-fix-proposer-nightly': {
+        'task': 'mira_fix_proposer.run_nightly',
+        'schedule': crontab(hour=4, minute=30),   # 04:30 UTC
+    }
+
+Environment variables required:
+    FIX_PROPOSER_GH_TOKEN      GitHub PAT with contents:write + pull_requests:write
+    ANTHROPIC_API_KEY          Claude API key
+    FIX_PROPOSER_DISABLED      Set to "1" to disable without removing the schedule
+
+Optional tuning:
+    FIX_PROPOSER_MIN_CLUSTER       Min failures per cluster (default: 3)
+    FIX_PROPOSER_MAX_CLUSTERS      Max clusters per run (default: 3)
+    FIX_PROPOSER_STATE_PATH        State JSON (default: /opt/mira/data/fix_proposer_state.json)
+    FIX_PROPOSER_RUNS_DIR          Scorecards directory (default: /opt/mira/tests/eval/runs)
+    CLAUDE_MODEL                   Model override (default: claude-sonnet-4-6)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from celery import shared_task
+
+# Resolve repo root so we can import FixProposer regardless of CWD
+_REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from mira_bots.tools.fix_proposer import (  # noqa: E402
+    FixProposer,
+    FixProposerConfig,
+)
+
+logger = logging.getLogger("mira-fix-proposer-task")
+
+MIRA_DIR = Path(os.getenv("MIRA_DIR", "/opt/mira"))
+LOCK_FILE = Path("/tmp/mira_fix_proposer.lock")
+LOCK_MAX_AGE_S = 1800  # 30 min — Claude + git operations can take a while
+
+
+def _acquire_lock() -> bool:
+    if LOCK_FILE.exists():
+        age = time.monotonic() - LOCK_FILE.stat().st_mtime
+        if age < LOCK_MAX_AGE_S:
+            logger.warning("Fix proposer already running (lock age=%.0fs) — skipping", age)
+            return False
+        logger.warning("Fix proposer lock stale (age=%.0fs) — clearing", age)
+        LOCK_FILE.unlink(missing_ok=True)
+    LOCK_FILE.write_text(str(os.getpid()))
+    return True
+
+
+def _release_lock() -> None:
+    LOCK_FILE.unlink(missing_ok=True)
+
+
+@shared_task(name="mira_fix_proposer.run_nightly", max_retries=0, ignore_result=False)
+def run_nightly() -> dict:
+    """Nightly fix-proposal automation: failure clusters → Claude → draft PR."""
+    if os.getenv("FIX_PROPOSER_DISABLED", "").strip() == "1":
+        logger.info("Fix proposer disabled via FIX_PROPOSER_DISABLED=1 — skipping")
+        return {"status": "skipped", "reason": "disabled"}
+
+    if not _acquire_lock():
+        return {"status": "skipped", "reason": "lock_held"}
+
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M")
+
+    try:
+        gh_token = os.getenv("FIX_PROPOSER_GH_TOKEN", "")
+        api_key = os.getenv("ANTHROPIC_API_KEY", "")
+
+        if not gh_token:
+            logger.error("FIX_PROPOSER_GH_TOKEN not set — cannot open PR")
+            return {"status": "error", "reason": "missing_gh_token", "ts": ts}
+        if not api_key:
+            logger.error("ANTHROPIC_API_KEY not set — cannot call Claude")
+            return {"status": "error", "reason": "missing_api_key", "ts": ts}
+
+        proposer = FixProposer(FixProposerConfig(
+            anthropic_api_key=api_key,
+            gh_token=gh_token,
+            repo_root=MIRA_DIR,
+            state_path=Path(os.getenv(
+                "FIX_PROPOSER_STATE_PATH",
+                "/opt/mira/data/fix_proposer_state.json",
+            )),
+            runs_dir=Path(os.getenv(
+                "FIX_PROPOSER_RUNS_DIR",
+                str(MIRA_DIR / "tests" / "eval" / "runs"),
+            )),
+            claude_model=os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6"),
+            min_cluster_size=int(os.getenv("FIX_PROPOSER_MIN_CLUSTER", "3")),
+            max_clusters_per_run=int(os.getenv("FIX_PROPOSER_MAX_CLUSTERS", "3")),
+        ))
+
+        result = asyncio.run(proposer.run(dry_run=False))
+
+        if result.get("pr_urls"):
+            logger.info(
+                "Fix proposer complete: %d clusters → %d PRs",
+                result.get("clusters_found", 0),
+                len(result["pr_urls"]),
+            )
+        else:
+            logger.info(
+                "Fix proposer complete: %d failures, %d clusters (no PRs)",
+                result.get("failures_total", 0),
+                result.get("clusters_found", 0),
+            )
+
+        return result
+
+    except Exception as e:
+        logger.error("Fix proposer unexpected error: %s", e)
+        return {"status": "error", "reason": str(e), "ts": ts}
+    finally:
+        _release_lock()

--- a/tests/eval/test_fix_proposer.py
+++ b/tests/eval/test_fix_proposer.py
@@ -1,0 +1,279 @@
+"""Tests for fix_proposer — eval failure clustering + patch proposal.
+
+Offline tests covering scorecard parsing, cluster grouping, reason
+signatures, and the orchestrator flow with mocked Claude calls.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+MIRA_BOTS = REPO_ROOT / "mira-bots"
+if str(MIRA_BOTS) not in sys.path:
+    sys.path.insert(0, str(MIRA_BOTS))
+
+from tools.fix_proposer import (
+    FailureCluster,
+    FailureRecord,
+    FixProposer,
+    FixProposerConfig,
+    _reason_signature,
+    cluster_failures,
+    find_latest_scorecard,
+    parse_scorecard,
+)
+
+
+# ── Parsing tests ──────────────────────────────────────────────────────────
+
+
+SAMPLE_SCORECARD = """\
+# MIRA Eval Scorecard — 2026-04-14
+
+**Pass rate:** 6/10 scenarios (60%)
+
+## Results
+| Scenario | ... |
+|---|---|
+| `gs10_overcurrent_01` | ... |
+
+## Failures
+
+### gs20_cross_vendor_03
+- **cp_keyword_match** FAILED: Forbidden keyword 'PowerFlex 525' found in response
+- Last response: `PF525 parameter...`
+
+### yaskawa_out_of_kb_04
+- **cp_keyword_match** FAILED: No honesty signal detected in response
+- Last response: `Check the motor...`
+
+### gs1_undervoltage_12
+- **cp_keyword_match** FAILED: No match from ['undervoltage', 'voltage']
+- Last response: `Something vague...`
+
+### pf523_heatsink_18
+- **cp_reached_state** FAILED: State='Q1' expected Q2
+- Last response: `Question...`
+
+## Judge Summary
+..."""
+
+
+def test_parse_scorecard_extracts_failures(tmp_path):
+    """Scorecard parser pulls scenario, checkpoint, and reason."""
+    p = tmp_path / "scorecard.md"
+    p.write_text(SAMPLE_SCORECARD)
+
+    failures = parse_scorecard(p)
+    assert len(failures) == 4
+
+    by_scenario = {f.scenario_id: f for f in failures}
+    assert "gs20_cross_vendor_03" in by_scenario
+    assert by_scenario["gs20_cross_vendor_03"].checkpoint == "cp_keyword_match"
+    assert "PowerFlex 525" in by_scenario["gs20_cross_vendor_03"].reason
+
+
+def test_parse_scorecard_ignores_non_failures_section(tmp_path):
+    """Content outside ## Failures is not picked up."""
+    p = tmp_path / "scorecard.md"
+    p.write_text(
+        "# Scorecard\n## Results\n### fake_scenario\n- **cp_x** FAILED: outside\n\n## Failures\n\n### real\n- **cp_y** FAILED: inside\n\n## Summary\n"
+    )
+    failures = parse_scorecard(p)
+    assert len(failures) == 1
+    assert failures[0].scenario_id == "real"
+
+
+def test_parse_scorecard_missing_file(tmp_path):
+    """Missing scorecard returns empty list, no exception."""
+    failures = parse_scorecard(tmp_path / "does_not_exist.md")
+    assert failures == []
+
+
+def test_find_latest_scorecard_prefers_judge(tmp_path):
+    """Judge-enabled scorecards are preferred over plain ones."""
+    (tmp_path / "2026-04-13.md").write_text("")
+    (tmp_path / "2026-04-14T0300-judge.md").write_text("")
+    (tmp_path / "2026-04-14.md").write_text("")
+    latest = find_latest_scorecard(tmp_path)
+    assert latest is not None
+    assert "judge" in latest.stem
+
+
+def test_find_latest_scorecard_empty_dir(tmp_path):
+    assert find_latest_scorecard(tmp_path) is None
+
+
+# ── Signature + clustering tests ──────────────────────────────────────────
+
+
+def test_reason_signature_strips_specifics():
+    """Reason signatures normalize away scenario-specific details."""
+    sig1 = _reason_signature("No match from ['foo', 'bar']")
+    sig2 = _reason_signature("No match from ['baz', 'qux', 'quux']")
+    assert sig1 == sig2  # Same signature despite different keyword lists
+
+
+def test_reason_signature_strips_numbers():
+    sig1 = _reason_signature("State='Q1' expected Q2")
+    sig2 = _reason_signature("State='Q3' expected Q2")
+    assert sig1 == sig2
+
+
+def test_cluster_failures_groups_by_checkpoint_and_signature():
+    """Failures with same checkpoint + reason signature cluster together."""
+    failures = [
+        FailureRecord("sc1", "cp_keyword_match", "No match from ['foo']"),
+        FailureRecord("sc2", "cp_keyword_match", "No match from ['bar']"),
+        FailureRecord("sc3", "cp_keyword_match", "No match from ['baz']"),
+        FailureRecord("sc4", "cp_reached_state", "State='Q1' expected Q2"),
+        FailureRecord("sc5", "cp_reached_state", "State='Q1' expected Q3"),
+    ]
+    clusters = cluster_failures(failures, min_size=3)
+    assert len(clusters) == 1  # Only keyword_match cluster reaches size 3
+    assert clusters[0].size == 3
+    assert clusters[0].checkpoint == "cp_keyword_match"
+
+
+def test_cluster_failures_respects_min_size():
+    """Clusters below min_size are filtered out."""
+    failures = [
+        FailureRecord("sc1", "cp_x", "reason A"),
+        FailureRecord("sc2", "cp_x", "reason A"),
+    ]
+    assert cluster_failures(failures, min_size=3) == []
+    clusters = cluster_failures(failures, min_size=2)
+    assert len(clusters) == 1
+
+
+def test_cluster_failures_sorted_by_size():
+    """Largest clusters come first."""
+    failures = []
+    for i in range(5):
+        failures.append(FailureRecord(f"sc{i}", "cp_a", "reason A"))
+    for i in range(3):
+        failures.append(FailureRecord(f"sc_b{i}", "cp_b", "reason B"))
+    clusters = cluster_failures(failures, min_size=2)
+    assert len(clusters) == 2
+    assert clusters[0].size == 5
+    assert clusters[1].size == 3
+
+
+def test_failure_cluster_id_is_slug_safe():
+    """Cluster IDs are safe for git branch names."""
+    cluster = FailureCluster(
+        checkpoint="cp_keyword_match",
+        reason_signature="no match from list / keywords!",
+        failures=[],
+    )
+    cid = cluster.cluster_id
+    assert "/" not in cid
+    assert "!" not in cid
+    assert " " not in cid
+
+
+# ── Orchestrator tests ─────────────────────────────────────────────────────
+
+
+def _make_proposer(tmp_path: Path) -> FixProposer:
+    return FixProposer(FixProposerConfig(
+        anthropic_api_key="test-key",
+        gh_token="test-gh",
+        repo_root=REPO_ROOT,
+        state_path=tmp_path / "state.json",
+        runs_dir=tmp_path / "runs",
+        min_cluster_size=3,
+        max_clusters_per_run=3,
+    ))
+
+
+def test_run_no_scorecard_returns_cleanly(tmp_path):
+    """Empty runs dir returns ok + no_scorecard."""
+    proposer = _make_proposer(tmp_path)
+    result = asyncio.run(proposer.run(dry_run=True))
+    assert result["status"] == "ok"
+    assert result["reason"] == "no_scorecard"
+
+
+def test_run_no_failures_returns_cleanly(tmp_path):
+    """Scorecard with no failures returns ok + no_failures."""
+    proposer = _make_proposer(tmp_path)
+    proposer.cfg.runs_dir.mkdir()
+    (proposer.cfg.runs_dir / "ok.md").write_text(
+        "# Scorecard\n\n## Failures\n\n## Summary\nAll passed"
+    )
+    result = asyncio.run(proposer.run(dry_run=True))
+    assert result["status"] == "ok"
+    assert result["reason"] == "no_failures"
+
+
+def test_run_no_clusters_below_threshold(tmp_path):
+    """Failures below min_cluster_size return ok + no_clusters."""
+    proposer = _make_proposer(tmp_path)
+    proposer.cfg.runs_dir.mkdir()
+    # Only 2 failures of the same type — below default threshold of 3
+    (proposer.cfg.runs_dir / "x.md").write_text("""\
+# Scorecard
+
+## Failures
+
+### sc1
+- **cp_x** FAILED: some reason
+
+### sc2
+- **cp_x** FAILED: some reason
+
+## Summary
+""")
+    result = asyncio.run(proposer.run(dry_run=True))
+    assert result["status"] == "ok"
+    assert result["reason"] == "no_clusters"
+
+
+def test_run_dry_run_does_not_open_pr(tmp_path, monkeypatch):
+    """Dry-run with a qualifying cluster generates proposal but no PR."""
+    proposer = _make_proposer(tmp_path)
+    proposer.cfg.runs_dir.mkdir()
+    (proposer.cfg.runs_dir / "x.md").write_text(SAMPLE_SCORECARD.replace(
+        "### yaskawa_out_of_kb_04\n- **cp_keyword_match** FAILED: No honesty signal detected in response",
+        "### yaskawa_out_of_kb_04\n- **cp_keyword_match** FAILED: Forbidden keyword 'Foo' found in response\n\n### extra_cluster\n- **cp_keyword_match** FAILED: Forbidden keyword 'Bar' found in response"
+    ))
+
+    # Mock Claude to return a fake patch
+    async def fake_claude_json(system, user):
+        return {
+            "hypothesis": "test hypothesis",
+            "file_path": "test.yaml",
+            "change_type": "edit",
+            "rationale": "test rationale",
+            "proposed_patch": "test patch",
+            "projected_impact": "test impact",
+            "confidence": 0.8,
+        }
+    monkeypatch.setattr(proposer, "_claude_json", fake_claude_json)
+
+    result = asyncio.run(proposer.run(dry_run=True))
+    assert result["status"] == "ok"
+    # Dry-run: proposals generated but no PRs
+    assert result.get("pr_urls") == []
+
+
+def test_state_persistence(tmp_path):
+    """State is saved and reloaded correctly."""
+    proposer = _make_proposer(tmp_path)
+    proposer._save_state({"last_run_ts": "2026-04-14T00:00:00Z", "proposals": []})
+
+    state = proposer._load_state()
+    assert state["last_run_ts"] == "2026-04-14T00:00:00Z"
+
+
+def test_state_missing_returns_defaults(tmp_path):
+    """Missing state file returns fresh defaults."""
+    proposer = _make_proposer(tmp_path)
+    state = proposer._load_state()
+    assert state["last_run_ts"] is None


### PR DESCRIPTION
## Summary
The autoresearch loop's **fix proposer**: eval surfaces failures → clusterer groups them → Claude proposes a minimal patch → draft PR opens with evidence. Human reviews before merge.

**No auto-merge.** Every proposal is a draft PR Mike reviews.

### Components

| File | Purpose |
|------|---------|
| `mira-bots/tools/fix_proposer.py` | `FixProposer` class + `cluster_failures()` + CLI |
| `tests/eval/fix_proposer_tasks.py` | Celery task `mira_fix_proposer.run_nightly` (04:30 UTC) |
| `tests/eval/test_fix_proposer.py` | 17 offline tests |

### Pipeline
```
nightly eval (03:00)
  → active learning (04:00, new fixtures from 👎 feedback)
  → fix proposer (04:30, THIS PR)
    → parse latest scorecard.md
    → cluster failures by (checkpoint + reason-signature)
    → for each cluster ≥ 3 scenarios:
      → Claude proposes minimal patch
      → open draft PR with cluster evidence
```

### Safety scope
The system prompt constrains Claude to only propose changes to:
- `mira-bots/prompts/diagnose/active.yaml` (rule edits)
- `mira-bots/shared/guardrails.py` (keyword lists)
- Fixture corrections

**Not allowed**: engine.py, workers/, inference/router.py. Risky code changes stay human-driven.

### Karpathy alignment
Completes ADR-0010 Enhancement 5. With #217 (judge), #219 (active learning), #221 (Elo), #223 (100+ corpus), and now #225, MIRA has a full `change → eval → compare → propose-fix` loop.

Closes #225

## Test plan
- [x] `pytest tests/eval/test_fix_proposer.py` — 17/17 pass
- [ ] Register Celery task in `/opt/master_of_puppets/celery_app.py` beat schedule
- [ ] Set `FIX_PROPOSER_GH_TOKEN` in Doppler
- [ ] Dry-run on Bravo: `python mira-bots/tools/fix_proposer.py --dry-run --runs-dir tests/eval/runs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)