### PR TITLE
feat(eval): distribution-shift monitor

### DIFF
--- a/mira-bots/tools/drift_monitor.py
+++ b/mira-bots/tools/drift_monitor.py
@@ -1,0 +1,390 @@
+"""drift_monitor.py — Production query distribution vs. fixture coverage.
+
+Samples recent production queries from the interactions table, embeds them
+via Ollama nomic-embed-text, and measures cosine distance to the centroid
+of fixture inputs. When the drift score exceeds threshold, flags the top
+unfamiliar queries as fixture candidates.
+
+This is the eval framework's "measure what you're not measuring" step —
+Karpathy's jagged intelligence warning applied to MIRA: the fixture suite
+can pass 90% while production queries drift into a region the fixtures
+don't cover.
+
+Usage (dry-run — no Discord post):
+    python drift_monitor.py --dry-run
+
+Environment:
+    MIRA_DB_PATH              SQLite path (default: /opt/mira/data/mira.db)
+    OLLAMA_BASE_URL           Ollama URL (default: http://host.docker.internal:11434)
+    EMBED_TEXT_MODEL          Embedding model (default: nomic-embed-text:latest)
+    DRIFT_THRESHOLD           Cosine distance threshold (default: 0.15)
+    DRIFT_SAMPLE_SIZE         Max prod queries to sample (default: 500)
+    DRIFT_TOP_N               Top-N unfamiliar queries to report (default: 10)
+    DRIFT_LOOKBACK_DAYS       Days of prod data to sample (default: 7)
+    DRIFT_OUTPUT_DIR          Where to write weekly JSON (default: tests/eval/drift)
+    DRIFT_FIXTURES_DIR        Eval fixtures dir (default: tests/eval/fixtures)
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import math
+import os
+import sqlite3
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import httpx
+import yaml
+
+logger = logging.getLogger("mira-drift-monitor")
+
+_DEFAULT_THRESHOLD = 0.15
+_DEFAULT_SAMPLE = 500
+_DEFAULT_TOP_N = 10
+_DEFAULT_LOOKBACK_DAYS = 7
+
+
+# ── Math helpers ───────────────────────────────────────────────────────────
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Cosine similarity in [-1, 1]. Returns 0 for zero vectors."""
+    if len(a) != len(b):
+        raise ValueError(f"Vector dim mismatch: {len(a)} vs {len(b)}")
+    dot = sum(x * y for x, y in zip(a, b))
+    na = math.sqrt(sum(x * x for x in a))
+    nb = math.sqrt(sum(y * y for y in b))
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def cosine_distance(a: list[float], b: list[float]) -> float:
+    """Cosine distance in [0, 2]. 0 = identical, 1 = orthogonal, 2 = opposite."""
+    return 1.0 - cosine_similarity(a, b)
+
+
+def centroid(vectors: list[list[float]]) -> list[float]:
+    """Return the mean vector (centroid) of a list of vectors."""
+    if not vectors:
+        return []
+    dim = len(vectors[0])
+    sums = [0.0] * dim
+    for v in vectors:
+        if len(v) != dim:
+            raise ValueError("Inconsistent vector dimensions in centroid")
+        for i, x in enumerate(v):
+            sums[i] += x
+    return [s / len(vectors) for s in sums]
+
+
+# ── Data collection ────────────────────────────────────────────────────────
+
+
+def sample_production_queries(
+    db_path: Path, sample_size: int, lookback_days: int
+) -> list[str]:
+    """Return up to sample_size recent user_message strings from interactions."""
+    if not db_path.exists():
+        logger.warning("DB not found: %s", db_path)
+        return []
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=lookback_days)
+    cutoff_iso = cutoff.isoformat()
+
+    try:
+        db = sqlite3.connect(str(db_path))
+        db.row_factory = sqlite3.Row
+        rows = db.execute(
+            "SELECT DISTINCT user_message FROM interactions "
+            "WHERE created_at >= ? AND user_message IS NOT NULL "
+            "AND length(user_message) > 2 "
+            "ORDER BY created_at DESC LIMIT ?",
+            (cutoff_iso, sample_size),
+        ).fetchall()
+        db.close()
+        return [r["user_message"] for r in rows if r["user_message"]]
+    except Exception as e:
+        logger.error("sample_production_queries failed: %s", e)
+        return []
+
+
+def load_fixture_inputs(fixtures_dir: Path) -> list[tuple[str, str]]:
+    """Return list of (scenario_id, first_user_turn_content) for every fixture."""
+    results: list[tuple[str, str]] = []
+    for f in sorted(fixtures_dir.glob("[0-9][0-9]_*.yaml")):
+        try:
+            data = yaml.safe_load(f.read_text())
+            turns = data.get("turns", [])
+            if turns:
+                # Use first user turn — represents how a technician opens the chat
+                first = next(
+                    (t for t in turns if t.get("role") == "user"), None
+                )
+                if first and first.get("content"):
+                    results.append((data.get("id", f.stem), first["content"]))
+        except Exception as e:
+            logger.warning("Failed to load %s: %s", f, e)
+    return results
+
+
+# ── Embedding via Ollama ───────────────────────────────────────────────────
+
+
+async def embed_text(
+    text: str, ollama_url: str, embed_model: str
+) -> list[float] | None:
+    """Embed text via Ollama nomic-embed-text. Returns None on failure."""
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.post(
+                f"{ollama_url}/api/embeddings",
+                json={"model": embed_model, "prompt": text},
+            )
+            resp.raise_for_status()
+            return resp.json()["embedding"]
+    except Exception as e:
+        logger.warning("Ollama embed failed for %r: %s", text[:60], e)
+        return None
+
+
+async def embed_batch(
+    texts: list[str], ollama_url: str, embed_model: str, concurrency: int = 4
+) -> list[tuple[str, list[float]]]:
+    """Embed a list of texts, returning (text, embedding) pairs for successes."""
+    sem = asyncio.Semaphore(concurrency)
+
+    async def _one(t: str) -> tuple[str, list[float]] | None:
+        async with sem:
+            emb = await embed_text(t, ollama_url, embed_model)
+            return (t, emb) if emb else None
+
+    results = await asyncio.gather(*(_one(t) for t in texts))
+    return [r for r in results if r]
+
+
+# ── Drift analysis ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class DriftReport:
+    drift_score: float  # cosine distance between prod centroid and fixture centroid
+    threshold: float
+    drift_flagged: bool
+    prod_sample_size: int
+    fixture_count: int
+    top_unfamiliar: list[dict] = field(default_factory=list)
+    timestamp: str = ""
+    error: str | None = None
+
+    def to_dict(self) -> dict:
+        return {
+            "drift_score": round(self.drift_score, 4),
+            "threshold": self.threshold,
+            "drift_flagged": self.drift_flagged,
+            "prod_sample_size": self.prod_sample_size,
+            "fixture_count": self.fixture_count,
+            "top_unfamiliar": self.top_unfamiliar,
+            "timestamp": self.timestamp,
+            "error": self.error,
+        }
+
+    def to_markdown(self) -> str:
+        status = "⚠️ DRIFT" if self.drift_flagged else "✓ stable"
+        lines = [
+            f"# Drift Monitor Report — {self.timestamp}",
+            "",
+            f"**Status:** {status}",
+            f"**Drift score:** {self.drift_score:.4f} (threshold: {self.threshold})",
+            f"**Production sample:** {self.prod_sample_size} queries",
+            f"**Fixtures:** {self.fixture_count}",
+            "",
+        ]
+        if self.top_unfamiliar:
+            lines.append(f"## Top {len(self.top_unfamiliar)} unfamiliar production queries")
+            lines.append("")
+            lines.append("| Min distance | Query |")
+            lines.append("|---|---|")
+            for item in self.top_unfamiliar:
+                q = item["query"][:80].replace("|", "\\|").replace("\n", " ")
+                lines.append(f"| {item['min_distance']:.3f} | {q} |")
+        if self.error:
+            lines.append("")
+            lines.append(f"**Error:** {self.error}")
+        return "\n".join(lines)
+
+
+def compute_drift(
+    prod_embeddings: list[tuple[str, list[float]]],
+    fixture_embeddings: list[tuple[str, list[float]]],
+    threshold: float,
+    top_n: int,
+) -> DriftReport:
+    """Compute drift score and top-N unfamiliar prod queries."""
+    ts = datetime.now(timezone.utc).isoformat()
+
+    if not prod_embeddings:
+        return DriftReport(
+            drift_score=0.0, threshold=threshold, drift_flagged=False,
+            prod_sample_size=0,
+            fixture_count=len(fixture_embeddings),
+            timestamp=ts,
+            error="no_prod_queries",
+        )
+    if not fixture_embeddings:
+        return DriftReport(
+            drift_score=0.0, threshold=threshold, drift_flagged=False,
+            prod_sample_size=len(prod_embeddings),
+            fixture_count=0,
+            timestamp=ts,
+            error="no_fixtures",
+        )
+
+    prod_vecs = [v for _, v in prod_embeddings]
+    fixture_vecs = [v for _, v in fixture_embeddings]
+
+    prod_centroid = centroid(prod_vecs)
+    fixture_centroid = centroid(fixture_vecs)
+    drift_score = cosine_distance(prod_centroid, fixture_centroid)
+
+    # Top-N unfamiliar: for each prod query, find its MIN distance to any fixture.
+    # High min distance = far from all fixtures = unfamiliar pattern.
+    unfamiliar: list[tuple[float, str]] = []
+    for text, pv in prod_embeddings:
+        min_dist = min(cosine_distance(pv, fv) for fv in fixture_vecs)
+        unfamiliar.append((min_dist, text))
+    unfamiliar.sort(key=lambda x: -x[0])  # largest distance first
+
+    return DriftReport(
+        drift_score=drift_score,
+        threshold=threshold,
+        drift_flagged=drift_score > threshold,
+        prod_sample_size=len(prod_embeddings),
+        fixture_count=len(fixture_embeddings),
+        top_unfamiliar=[
+            {"min_distance": round(d, 4), "query": t}
+            for d, t in unfamiliar[:top_n]
+        ],
+        timestamp=ts,
+    )
+
+
+# ── Monitor class ───────────────────────────────────────────────────────────
+
+
+@dataclass
+class DriftMonitorConfig:
+    db_path: Path
+    ollama_url: str
+    embed_model: str
+    fixtures_dir: Path
+    output_dir: Path
+    threshold: float = _DEFAULT_THRESHOLD
+    sample_size: int = _DEFAULT_SAMPLE
+    top_n: int = _DEFAULT_TOP_N
+    lookback_days: int = _DEFAULT_LOOKBACK_DAYS
+
+
+class DriftMonitor:
+    def __init__(self, config: DriftMonitorConfig) -> None:
+        self.cfg = config
+
+    async def run(self, dry_run: bool = False) -> DriftReport:
+        logger.info(
+            "Drift monitor starting (lookback=%d days, sample=%d)",
+            self.cfg.lookback_days, self.cfg.sample_size,
+        )
+
+        prod_queries = sample_production_queries(
+            self.cfg.db_path, self.cfg.sample_size, self.cfg.lookback_days
+        )
+        logger.info("Sampled %d production queries", len(prod_queries))
+
+        fixture_inputs = load_fixture_inputs(self.cfg.fixtures_dir)
+        logger.info("Loaded %d fixture inputs", len(fixture_inputs))
+
+        if not prod_queries or not fixture_inputs:
+            report = DriftReport(
+                drift_score=0.0, threshold=self.cfg.threshold, drift_flagged=False,
+                prod_sample_size=len(prod_queries),
+                fixture_count=len(fixture_inputs),
+                timestamp=datetime.now(timezone.utc).isoformat(),
+                error="insufficient_data",
+            )
+            if not dry_run:
+                self._write_report(report)
+            return report
+
+        # Embed
+        prod_embs = await embed_batch(
+            prod_queries, self.cfg.ollama_url, self.cfg.embed_model
+        )
+        fixture_texts = [t for _, t in fixture_inputs]
+        fixture_embs = await embed_batch(
+            fixture_texts, self.cfg.ollama_url, self.cfg.embed_model
+        )
+        logger.info(
+            "Embedded %d prod + %d fixture queries",
+            len(prod_embs), len(fixture_embs),
+        )
+
+        report = compute_drift(
+            prod_embs, fixture_embs, self.cfg.threshold, self.cfg.top_n
+        )
+
+        if not dry_run:
+            self._write_report(report)
+        return report
+
+    def _write_report(self, report: DriftReport) -> Path:
+        """Write JSON report to output_dir/YYYY-WW.json (ISO week)."""
+        self.cfg.output_dir.mkdir(parents=True, exist_ok=True)
+        now = datetime.now(timezone.utc)
+        year, week, _ = now.isocalendar()
+        filename = f"{year}-W{week:02d}.json"
+        path = self.cfg.output_dir / filename
+        path.write_text(json.dumps(report.to_dict(), indent=2))
+        logger.info("Wrote drift report to %s", path)
+        return path
+
+
+# ── CLI entry point ────────────────────────────────────────────────────────
+
+
+def _build_monitor() -> DriftMonitor:
+    return DriftMonitor(DriftMonitorConfig(
+        db_path=Path(os.getenv("MIRA_DB_PATH", "/opt/mira/data/mira.db")),
+        ollama_url=os.getenv("OLLAMA_BASE_URL", "http://host.docker.internal:11434"),
+        embed_model=os.getenv("EMBED_TEXT_MODEL", "nomic-embed-text:latest"),
+        fixtures_dir=Path(os.getenv(
+            "DRIFT_FIXTURES_DIR", "/opt/mira/tests/eval/fixtures"
+        )),
+        output_dir=Path(os.getenv(
+            "DRIFT_OUTPUT_DIR", "/opt/mira/tests/eval/drift"
+        )),
+        threshold=float(os.getenv("DRIFT_THRESHOLD", _DEFAULT_THRESHOLD)),
+        sample_size=int(os.getenv("DRIFT_SAMPLE_SIZE", _DEFAULT_SAMPLE)),
+        top_n=int(os.getenv("DRIFT_TOP_N", _DEFAULT_TOP_N)),
+        lookback_days=int(os.getenv("DRIFT_LOOKBACK_DAYS", _DEFAULT_LOOKBACK_DAYS)),
+    ))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="MIRA eval drift monitor")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Compute report but do not write JSON or post")
+    args = parser.parse_args()
+
+    monitor = _build_monitor()
+    report = asyncio.run(monitor.run(dry_run=args.dry_run))
+    print(report.to_markdown())
+    print()
+    print(json.dumps(report.to_dict(), indent=2))
+    sys.exit(0)

--- a/tests/eval/drift_monitor_tasks.py
+++ b/tests/eval/drift_monitor_tasks.py
@@ -1,0 +1,117 @@
+"""MIRA Drift Monitor Celery Task — weekly Sundays 03:00 UTC.
+
+Samples recent production queries, computes cosine distance from fixture
+centroid, flags drift when score > threshold.
+
+Beat schedule entry (add to /opt/master_of_puppets/celery_app.py):
+    'mira-drift-monitor-weekly': {
+        'task': 'mira_drift_monitor.run_weekly',
+        'schedule': crontab(hour=3, minute=0, day_of_week='sunday'),
+    }
+
+Environment:
+    MIRA_DB_PATH            SQLite path (default: /opt/mira/data/mira.db)
+    OLLAMA_BASE_URL         Ollama URL (default: http://host.docker.internal:11434)
+    DRIFT_THRESHOLD         Cosine distance threshold (default: 0.15)
+    DRIFT_SAMPLE_SIZE       Max prod queries (default: 500)
+    DRIFT_LOOKBACK_DAYS     Days to sample (default: 7)
+    DRIFT_MONITOR_DISABLED  Set to "1" to disable
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from celery import shared_task
+
+# Resolve repo root so we can import DriftMonitor
+_REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from mira_bots.tools.drift_monitor import (  # noqa: E402
+    DriftMonitor,
+    DriftMonitorConfig,
+)
+
+logger = logging.getLogger("mira-drift-monitor-task")
+
+MIRA_DIR = Path(os.getenv("MIRA_DIR", "/opt/mira"))
+LOCK_FILE = Path("/tmp/mira_drift_monitor.lock")
+LOCK_MAX_AGE_S = 1200  # 20 min — embedding 500 queries takes time
+
+
+def _acquire_lock() -> bool:
+    if LOCK_FILE.exists():
+        age = time.monotonic() - LOCK_FILE.stat().st_mtime
+        if age < LOCK_MAX_AGE_S:
+            logger.warning("Drift monitor already running (lock age=%.0fs) — skipping", age)
+            return False
+        logger.warning("Drift monitor lock stale (age=%.0fs) — clearing", age)
+        LOCK_FILE.unlink(missing_ok=True)
+    LOCK_FILE.write_text(str(os.getpid()))
+    return True
+
+
+def _release_lock() -> None:
+    LOCK_FILE.unlink(missing_ok=True)
+
+
+@shared_task(name="mira_drift_monitor.run_weekly", max_retries=0, ignore_result=False)
+def run_weekly() -> dict:
+    """Weekly drift check: prod queries vs fixture centroid."""
+    if os.getenv("DRIFT_MONITOR_DISABLED", "").strip() == "1":
+        logger.info("Drift monitor disabled — skipping")
+        return {"status": "skipped", "reason": "disabled"}
+
+    if not _acquire_lock():
+        return {"status": "skipped", "reason": "lock_held"}
+
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M")
+
+    try:
+        monitor = DriftMonitor(DriftMonitorConfig(
+            db_path=Path(os.getenv("MIRA_DB_PATH", "/opt/mira/data/mira.db")),
+            ollama_url=os.getenv("OLLAMA_BASE_URL", "http://host.docker.internal:11434"),
+            embed_model=os.getenv("EMBED_TEXT_MODEL", "nomic-embed-text:latest"),
+            fixtures_dir=Path(os.getenv(
+                "DRIFT_FIXTURES_DIR", str(MIRA_DIR / "tests" / "eval" / "fixtures")
+            )),
+            output_dir=Path(os.getenv(
+                "DRIFT_OUTPUT_DIR", str(MIRA_DIR / "tests" / "eval" / "drift")
+            )),
+            threshold=float(os.getenv("DRIFT_THRESHOLD", "0.15")),
+            sample_size=int(os.getenv("DRIFT_SAMPLE_SIZE", "500")),
+            top_n=int(os.getenv("DRIFT_TOP_N", "10")),
+            lookback_days=int(os.getenv("DRIFT_LOOKBACK_DAYS", "7")),
+        ))
+
+        report = asyncio.run(monitor.run(dry_run=False))
+
+        level = logging.WARNING if report.drift_flagged else logging.INFO
+        logger.log(
+            level,
+            "Drift monitor: score=%.4f threshold=%.4f flagged=%s (%d prod / %d fixtures)",
+            report.drift_score, report.threshold, report.drift_flagged,
+            report.prod_sample_size, report.fixture_count,
+        )
+
+        return {
+            "status": "ok",
+            "drift_score": report.drift_score,
+            "drift_flagged": report.drift_flagged,
+            "prod_sample_size": report.prod_sample_size,
+            "fixture_count": report.fixture_count,
+            "top_unfamiliar_count": len(report.top_unfamiliar),
+            "ts": ts,
+        }
+
+    except Exception as e:
+        logger.error("Drift monitor unexpected error: %s", e)
+        return {"status": "error", "reason": str(e), "ts": ts}
+    finally:
+        _release_lock()

--- a/tests/eval/test_drift_monitor.py
+++ b/tests/eval/test_drift_monitor.py
@@ -1,0 +1,293 @@
+"""Tests for drift_monitor — cosine math, sampling, drift computation.
+
+Offline tests covering vector math, query sampling with mock SQLite,
+fixture loading, and end-to-end drift computation with synthetic embeddings.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent.parent
+MIRA_BOTS = REPO_ROOT / "mira-bots"
+if str(MIRA_BOTS) not in sys.path:
+    sys.path.insert(0, str(MIRA_BOTS))
+
+from tools.drift_monitor import (
+    DriftMonitor,
+    DriftMonitorConfig,
+    centroid,
+    compute_drift,
+    cosine_distance,
+    cosine_similarity,
+    load_fixture_inputs,
+    sample_production_queries,
+)
+
+
+# ── Math tests ─────────────────────────────────────────────────────────────
+
+
+class TestCosine:
+
+    def test_identical_vectors(self):
+        v = [1.0, 2.0, 3.0]
+        assert cosine_similarity(v, v) == pytest.approx(1.0)
+        assert cosine_distance(v, v) == pytest.approx(0.0)
+
+    def test_orthogonal_vectors(self):
+        assert cosine_similarity([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+        assert cosine_distance([1.0, 0.0], [0.0, 1.0]) == pytest.approx(1.0)
+
+    def test_opposite_vectors(self):
+        assert cosine_similarity([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(-1.0)
+        assert cosine_distance([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(2.0)
+
+    def test_zero_vector(self):
+        """Zero vectors return similarity 0 (avoid divide-by-zero)."""
+        assert cosine_similarity([0.0, 0.0], [1.0, 1.0]) == 0.0
+
+    def test_dim_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            cosine_similarity([1.0], [1.0, 2.0])
+
+
+class TestCentroid:
+
+    def test_single_vector(self):
+        assert centroid([[1.0, 2.0, 3.0]]) == [1.0, 2.0, 3.0]
+
+    def test_two_vectors(self):
+        result = centroid([[0.0, 0.0], [2.0, 4.0]])
+        assert result == [1.0, 2.0]
+
+    def test_empty_list(self):
+        assert centroid([]) == []
+
+    def test_dim_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            centroid([[1.0, 2.0], [1.0]])
+
+
+# ── Sampling tests ─────────────────────────────────────────────────────────
+
+
+class TestSampleQueries:
+
+    def test_samples_recent_messages(self, tmp_path):
+        db = tmp_path / "mira.db"
+        con = sqlite3.connect(str(db))
+        con.execute("""
+            CREATE TABLE interactions (
+                id INTEGER PRIMARY KEY,
+                chat_id TEXT,
+                user_message TEXT,
+                bot_response TEXT,
+                created_at TIMESTAMP
+            )
+        """)
+        now = datetime.now(timezone.utc).isoformat()
+        con.execute(
+            "INSERT INTO interactions (chat_id, user_message, bot_response, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("c1", "GS20 overcurrent fault", "reply", now),
+        )
+        con.execute(
+            "INSERT INTO interactions (chat_id, user_message, bot_response, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("c2", "PowerFlex 525 F4 undervoltage", "reply", now),
+        )
+        con.commit()
+        con.close()
+
+        queries = sample_production_queries(db, 10, 7)
+        assert len(queries) == 2
+        assert any("GS20" in q for q in queries)
+
+    def test_filters_short_messages(self, tmp_path):
+        db = tmp_path / "mira.db"
+        con = sqlite3.connect(str(db))
+        con.execute("""
+            CREATE TABLE interactions (
+                id INTEGER PRIMARY KEY,
+                chat_id TEXT,
+                user_message TEXT,
+                bot_response TEXT,
+                created_at TIMESTAMP
+            )
+        """)
+        now = datetime.now(timezone.utc).isoformat()
+        con.execute(
+            "INSERT INTO interactions (chat_id, user_message, bot_response, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("c1", "hi", "reply", now),  # too short
+        )
+        con.execute(
+            "INSERT INTO interactions (chat_id, user_message, bot_response, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            ("c2", "long enough query", "reply", now),
+        )
+        con.commit()
+        con.close()
+
+        queries = sample_production_queries(db, 10, 7)
+        assert queries == ["long enough query"]
+
+    def test_missing_db_returns_empty(self, tmp_path):
+        queries = sample_production_queries(tmp_path / "nope.db", 10, 7)
+        assert queries == []
+
+
+class TestLoadFixtures:
+
+    def test_loads_first_user_turn(self, tmp_path):
+        f = tmp_path / "01_test.yaml"
+        f.write_text(
+            "id: test_01\n"
+            "description: test fixture\n"
+            "expected_final_state: Q1\n"
+            "max_turns: 3\n"
+            "expected_keywords: []\n"
+            "expected_vendor: Test\n"
+            "turns:\n"
+            "  - role: user\n"
+            "    content: first user message\n"
+            "  - role: user\n"
+            "    content: second user message\n"
+        )
+        results = load_fixture_inputs(tmp_path)
+        assert len(results) == 1
+        assert results[0][0] == "test_01"
+        assert results[0][1] == "first user message"
+
+    def test_skips_non_numeric_prefix(self, tmp_path):
+        (tmp_path / "vision_smoke.yaml").write_text(
+            "id: vsmoke\nturns:\n  - role: user\n    content: test\n"
+        )
+        results = load_fixture_inputs(tmp_path)
+        assert results == []
+
+
+# ── Drift computation tests ────────────────────────────────────────────────
+
+
+class TestComputeDrift:
+
+    def test_identical_distributions_no_drift(self):
+        # Prod and fixtures have same centroid
+        prod = [("q1", [1.0, 0.0]), ("q2", [0.0, 1.0])]
+        fixt = [("f1", [1.0, 0.0]), ("f2", [0.0, 1.0])]
+        report = compute_drift(prod, fixt, threshold=0.15, top_n=5)
+        assert report.drift_score < 0.01
+        assert not report.drift_flagged
+
+    def test_shifted_distribution_flags_drift(self):
+        # Prod vectors are in one region, fixtures in another
+        prod = [("q1", [1.0, 0.0, 0.0]), ("q2", [1.0, 0.0, 0.1])]
+        fixt = [("f1", [0.0, 1.0, 0.0]), ("f2", [0.0, 1.0, 0.1])]
+        report = compute_drift(prod, fixt, threshold=0.15, top_n=5)
+        assert report.drift_score > 0.15
+        assert report.drift_flagged
+
+    def test_top_unfamiliar_ordered_by_distance(self):
+        """Queries farthest from any fixture come first in top_unfamiliar."""
+        prod = [
+            ("close", [1.0, 0.0, 0.0]),   # matches fixture
+            ("far", [0.0, 0.0, 1.0]),     # no fixture nearby
+            ("medium", [0.5, 0.5, 0.5]),
+        ]
+        fixt = [("f1", [1.0, 0.0, 0.0])]
+        report = compute_drift(prod, fixt, threshold=0.15, top_n=3)
+        assert len(report.top_unfamiliar) == 3
+        # "far" should be first (most unfamiliar)
+        assert report.top_unfamiliar[0]["query"] == "far"
+
+    def test_empty_prod_returns_error(self):
+        fixt = [("f1", [1.0, 0.0])]
+        report = compute_drift([], fixt, threshold=0.15, top_n=5)
+        assert report.error == "no_prod_queries"
+        assert not report.drift_flagged
+
+    def test_empty_fixtures_returns_error(self):
+        prod = [("q1", [1.0, 0.0])]
+        report = compute_drift(prod, [], threshold=0.15, top_n=5)
+        assert report.error == "no_fixtures"
+        assert not report.drift_flagged
+
+    def test_top_n_limits_output(self):
+        prod = [(f"q{i}", [float(i), 0.0, 0.0]) for i in range(20)]
+        fixt = [("f1", [5.0, 0.0, 0.0])]
+        report = compute_drift(prod, fixt, threshold=0.15, top_n=3)
+        assert len(report.top_unfamiliar) == 3
+
+
+# ── Report output tests ────────────────────────────────────────────────────
+
+
+class TestReportOutput:
+
+    def test_to_dict_serializable(self, tmp_path):
+        prod = [("q1", [1.0, 0.0])]
+        fixt = [("f1", [1.0, 0.0])]
+        report = compute_drift(prod, fixt, threshold=0.15, top_n=5)
+        d = report.to_dict()
+        # Must be JSON-serializable
+        json.dumps(d)
+
+    def test_markdown_format(self):
+        prod = [("q1", [1.0, 0.0])]
+        fixt = [("f1", [1.0, 0.0])]
+        report = compute_drift(prod, fixt, threshold=0.15, top_n=5)
+        md = report.to_markdown()
+        assert "Drift score" in md
+        assert "stable" in md or "DRIFT" in md
+
+    def test_drift_flagged_in_markdown(self):
+        prod = [("q1", [1.0, 0.0, 0.0])]
+        fixt = [("f1", [0.0, 0.0, 1.0])]
+        report = compute_drift(prod, fixt, threshold=0.15, top_n=5)
+        md = report.to_markdown()
+        assert "DRIFT" in md
+
+
+# ── Monitor class integration ──────────────────────────────────────────────
+
+
+class TestDriftMonitorIntegration:
+
+    def test_missing_data_returns_insufficient(self, tmp_path):
+        """Missing DB + no fixtures → report with error flag."""
+        cfg = DriftMonitorConfig(
+            db_path=tmp_path / "nope.db",
+            ollama_url="http://nope",
+            embed_model="nomic-embed-text",
+            fixtures_dir=tmp_path / "empty",
+            output_dir=tmp_path / "out",
+        )
+        monitor = DriftMonitor(cfg)
+        report = asyncio.run(monitor.run(dry_run=True))
+        assert report.error == "insufficient_data"
+
+    def test_write_report_creates_weekly_file(self, tmp_path):
+        cfg = DriftMonitorConfig(
+            db_path=tmp_path / "nope.db",
+            ollama_url="http://nope",
+            embed_model="nomic-embed-text",
+            fixtures_dir=tmp_path / "empty",
+            output_dir=tmp_path / "drift",
+        )
+        monitor = DriftMonitor(cfg)
+        # Run to generate a report even with insufficient data — should write
+        report = asyncio.run(monitor.run(dry_run=False))
+        # One JSON file in the output dir, named YYYY-WNN.json
+        files = list((tmp_path / "drift").glob("*.json"))
+        assert len(files) == 1
+        data = json.loads(files[0].read_text())
+        assert "drift_score" in data


### PR DESCRIPTION
## Summary
Weekly drift check measures production query distribution vs. fixture centroid. When prod has moved to a region fixtures don't cover (cosine distance > 0.15), the top-10 unfamiliar queries feed back into active learning (#219) as fixture candidates.

- **DriftMonitor class** — samples prod queries, embeds via Ollama nomic-embed-text, computes centroid distance
- **Celery task** (`mira_drift_monitor.run_weekly`) — Sundays 03:00 UTC
- **25 offline tests** — cosine math, centroid, sampling, drift computation, report output

## Pipeline
```
Sundays 03:00 UTC
  → sample 500 recent prod queries (7-day lookback)
  → embed via Ollama nomic-embed-text:latest
  → compute centroid
  → embed all fixture first-user-turns
  → cosine distance between centroids = drift score
  → write YYYY-WNN.json with top-10 unfamiliar queries
  → (future: post to Discord #mira-eval)
```

## Karpathy alignment
ADR-0010 Enhancement 6. Plugs the "jagged intelligence" gap: fixture pass rate can be 90% while production drifts into uncovered territory. Top-10 unfamiliar queries flow into active learning.

Closes #226

## Test plan
- [x] `pytest tests/eval/test_drift_monitor.py` — 25/25 pass
- [ ] Register Celery task in beat schedule
- [ ] Dry-run on Bravo: `python mira-bots/tools/drift_monitor.py --dry-run`
- [ ] Verify JSON output at `tests/eval/drift/YYYY-WNN.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)