### PR TITLE
feat(rag): Learning Pipeline Phase 3 — 👍 feedback to KB FAQ chunks

### DIFF
--- a/mira-bots/tools/learning_ingester.py
+++ b/mira-bots/tools/learning_ingester.py
@@ -1,0 +1,292 @@
+"""learning_ingester.py — Nightly: 👍 feedback → FAQ chunks in NeonDB KB (#189).
+
+Closes the learning loop: every night at 02:00 UTC, query ``mira.db``
+feedback_log for thumbs-up entries since last run, reconstruct the
+conversation, format as a structured FAQ markdown, embed via Ollama, and
+insert into NeonDB ``knowledge_entries`` with ``source_type='approved_faq'``.
+
+These approved Q&A pairs become retrieval context for future conversations,
+so tomorrow's MIRA answers the same question better than today's.
+
+Usage (dry-run — no KB write):
+    python learning_ingester.py --dry-run --output /tmp/learning_dryrun
+
+Environment:
+    MIRA_DB_PATH              SQLite path (default: /opt/mira/data/mira.db)
+    NEON_DATABASE_URL         NeonDB connection string
+    MIRA_TENANT_ID            Tenant for KB writes
+    OLLAMA_BASE_URL           Ollama URL (default: http://host.docker.internal:11434)
+    EMBED_TEXT_MODEL          Embedding model (default: nomic-embed-text:latest)
+    LEARNING_STATE_PATH       State JSON (default: /opt/mira/data/learning_state.json)
+    LEARNING_MAX_PER_RUN      Max entries per run (default: 50)
+    LEARNING_INGEST_DISABLED  Set to "1" to disable
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger("mira-learning-ingester")
+
+
+@dataclass
+class LearningIngesterConfig:
+    db_path: Path
+    neon_url: str
+    tenant_id: str
+    ollama_url: str
+    embed_model: str
+    state_path: Path
+    max_per_run: int = 50
+
+
+class LearningIngester:
+    """Ingest positive-feedback conversations into the KB as FAQ chunks."""
+
+    def __init__(self, config: LearningIngesterConfig) -> None:
+        self.cfg = config
+
+    # ── State persistence ───────────────────────────────────────────────────
+
+    def _load_state(self) -> dict:
+        if self.cfg.state_path.exists():
+            try:
+                return json.loads(self.cfg.state_path.read_text())
+            except Exception:
+                pass
+        return {"last_run_ts": None, "ingested_total": 0}
+
+    def _save_state(self, state: dict) -> None:
+        self.cfg.state_path.parent.mkdir(parents=True, exist_ok=True)
+        self.cfg.state_path.write_text(json.dumps(state, indent=2))
+
+    # ── SQLite queries ──────────────────────────────────────────────────────
+
+    def collect_positives_since(self, checkpoint_ts: str | None) -> list[dict]:
+        """Return feedback_log rows with feedback='good' since checkpoint_ts."""
+        if not self.cfg.db_path.exists():
+            logger.warning("DB not found: %s", self.cfg.db_path)
+            return []
+        try:
+            db = sqlite3.connect(str(self.cfg.db_path))
+            db.row_factory = sqlite3.Row
+            if checkpoint_ts:
+                rows = db.execute(
+                    "SELECT * FROM feedback_log "
+                    "WHERE feedback = 'good' AND created_at > ? "
+                    "ORDER BY created_at LIMIT ?",
+                    (checkpoint_ts, self.cfg.max_per_run),
+                ).fetchall()
+            else:
+                rows = db.execute(
+                    "SELECT * FROM feedback_log WHERE feedback = 'good' "
+                    "ORDER BY created_at LIMIT ?",
+                    (self.cfg.max_per_run,),
+                ).fetchall()
+            db.close()
+            return [dict(r) for r in rows]
+        except Exception as e:
+            logger.error("collect_positives_since failed: %s", e)
+            return []
+
+    def reconstruct_qa(self, chat_id: str, up_to_ts: str) -> tuple[str, str] | None:
+        """Return (question, answer) pair from the interactions table.
+
+        The "question" is the last user_message before the thumbs-up, and
+        the "answer" is the corresponding bot_response.
+        """
+        try:
+            db = sqlite3.connect(str(self.cfg.db_path))
+            db.row_factory = sqlite3.Row
+            row = db.execute(
+                "SELECT user_message, bot_response FROM interactions "
+                "WHERE chat_id = ? AND created_at <= ? "
+                "ORDER BY created_at DESC LIMIT 1",
+                (chat_id, up_to_ts),
+            ).fetchone()
+            db.close()
+            if not row:
+                return None
+            q = (row["user_message"] or "").strip()
+            a = (row["bot_response"] or "").strip()
+            if len(q) < 5 or len(a) < 20:
+                # Too short to be useful as KB content
+                return None
+            return q, a
+        except Exception as e:
+            logger.error("reconstruct_qa failed for %s: %s", chat_id, e)
+            return None
+
+    # ── Formatting ──────────────────────────────────────────────────────────
+
+    @staticmethod
+    def format_faq(question: str, answer: str, chat_id: str, rated_at: str) -> str:
+        """Format a Q&A pair as a retrievable FAQ chunk with provenance."""
+        chat_hash = hashlib.sha256(chat_id.encode()).hexdigest()[:12]
+        return (
+            "## Approved FAQ\n\n"
+            f"**Question:** {question}\n\n"
+            f"**Answer:** {answer}\n\n"
+            f"_Approved by technician on {rated_at[:10]}. "
+            f"Source: production conversation {chat_hash}._\n"
+        )
+
+    # ── Embedding ──────────────────────────────────────────────────────────
+
+    def embed(self, text: str) -> list[float] | None:
+        try:
+            resp = httpx.post(
+                f"{self.cfg.ollama_url}/api/embeddings",
+                json={"model": self.cfg.embed_model, "prompt": text},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            return resp.json()["embedding"]
+        except Exception as e:
+            logger.warning("embed failed: %s", e)
+            return None
+
+    # ── NeonDB insert ──────────────────────────────────────────────────────
+
+    def insert_faq(self, content: str, embedding: list[float], chat_id: str) -> bool:
+        """Insert one FAQ chunk into NeonDB knowledge_entries."""
+        try:
+            from sqlalchemy import create_engine, text
+            from sqlalchemy.pool import NullPool
+        except ImportError:
+            logger.error("sqlalchemy not available — cannot insert")
+            return False
+
+        try:
+            engine = create_engine(
+                self.cfg.neon_url, poolclass=NullPool,
+                connect_args={"sslmode": "require"}, pool_pre_ping=True,
+            )
+            chat_hash = hashlib.sha256(chat_id.encode()).hexdigest()[:12]
+            with engine.connect() as conn:
+                conn.execute(text(
+                    "INSERT INTO knowledge_entries "
+                    "(id, tenant_id, source_type, manufacturer, model_number, "
+                    " equipment_type, content, embedding, source_url, source_page, "
+                    " metadata, is_private, verified, chunk_type, created_at) "
+                    "VALUES (:id, :tid, 'approved_faq', '', '', '', :content, "
+                    "        cast(:emb AS vector), :url, 0, cast(:meta AS jsonb), "
+                    "        false, true, 'faq', now())"
+                ), {
+                    "id": str(uuid.uuid4()),
+                    "tid": self.cfg.tenant_id,
+                    "content": content,
+                    "emb": str(embedding),
+                    "url": f"feedback://approved/{chat_hash}",
+                    "meta": json.dumps({"source_chat_hash": chat_hash}),
+                })
+                conn.commit()
+            return True
+        except Exception as e:
+            logger.warning("Insert FAQ failed: %s", e)
+            return False
+
+    # ── Orchestrator ───────────────────────────────────────────────────────
+
+    def run(self, dry_run: bool = False, output_dir: Path | None = None) -> dict:
+        run_ts = datetime.now(timezone.utc).isoformat()
+        state = self._load_state()
+        checkpoint_ts = state.get("last_run_ts")
+
+        logger.info("Learning ingester start (checkpoint=%s)", checkpoint_ts)
+
+        positives = self.collect_positives_since(checkpoint_ts)
+        logger.info("Found %d positive feedback entries", len(positives))
+
+        ingested = 0
+        skipped = 0
+        samples: list[str] = []
+
+        for entry in positives:
+            chat_id = entry["chat_id"]
+            created_at = entry["created_at"]
+
+            qa = self.reconstruct_qa(chat_id, created_at)
+            if not qa:
+                skipped += 1
+                continue
+            question, answer = qa
+
+            content = self.format_faq(question, answer, chat_id, created_at)
+
+            if dry_run:
+                out_dir = output_dir or Path("/tmp/learning_dryrun")
+                out_dir.mkdir(parents=True, exist_ok=True)
+                chat_hash = hashlib.sha256(chat_id.encode()).hexdigest()[:12]
+                (out_dir / f"faq_{chat_hash}.md").write_text(content)
+                samples.append(content[:200])
+                ingested += 1
+                continue
+
+            emb = self.embed(content)
+            if not emb:
+                skipped += 1
+                continue
+
+            if self.insert_faq(content, emb, chat_id):
+                ingested += 1
+            else:
+                skipped += 1
+
+        self._save_state({
+            "last_run_ts": run_ts,
+            "ingested_total": state.get("ingested_total", 0) + ingested,
+        })
+
+        result = {
+            "status": "ok",
+            "ingested": ingested,
+            "skipped": skipped,
+            "positives_found": len(positives),
+            "ts": run_ts,
+        }
+        if dry_run:
+            result["dry_run"] = True
+            result["samples"] = samples[:3]
+        return result
+
+
+def _build_ingester() -> LearningIngester:
+    return LearningIngester(LearningIngesterConfig(
+        db_path=Path(os.getenv("MIRA_DB_PATH", "/opt/mira/data/mira.db")),
+        neon_url=os.getenv("NEON_DATABASE_URL", ""),
+        tenant_id=os.getenv("MIRA_TENANT_ID", ""),
+        ollama_url=os.getenv("OLLAMA_BASE_URL", "http://host.docker.internal:11434"),
+        embed_model=os.getenv("EMBED_TEXT_MODEL", "nomic-embed-text:latest"),
+        state_path=Path(os.getenv(
+            "LEARNING_STATE_PATH", "/opt/mira/data/learning_state.json"
+        )),
+        max_per_run=int(os.getenv("LEARNING_MAX_PER_RUN", "50")),
+    ))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description="MIRA learning ingester")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Write FAQs to disk, skip NeonDB insert")
+    parser.add_argument("--output", type=Path,
+                        default=Path("/tmp/learning_dryrun"),
+                        help="Dry-run output dir")
+    args = parser.parse_args()
+
+    ingester = _build_ingester()
+    result = ingester.run(dry_run=args.dry_run, output_dir=args.output)
+    print(json.dumps(result, indent=2))

--- a/tests/eval/learning_ingester_tasks.py
+++ b/tests/eval/learning_ingester_tasks.py
@@ -1,0 +1,104 @@
+"""MIRA Learning Ingester Celery Task — nightly 02:00 UTC (#189).
+
+Queries feedback_log for thumbs-up entries since last run, formats Q&A
+pairs as approved_faq chunks, embeds via Ollama, inserts into NeonDB.
+
+Beat schedule entry:
+    'mira-learning-ingest-nightly': {
+        'task': 'mira_learning_ingest.run_nightly',
+        'schedule': crontab(hour=2, minute=0),
+    }
+
+Runs BEFORE the 03:00 eval run so new FAQ chunks are available for
+retrieval during that night's eval.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from celery import shared_task
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+from mira_bots.tools.learning_ingester import (  # noqa: E402
+    LearningIngester,
+    LearningIngesterConfig,
+)
+
+logger = logging.getLogger("mira-learning-ingest-task")
+
+MIRA_DIR = Path(os.getenv("MIRA_DIR", "/opt/mira"))
+LOCK_FILE = Path("/tmp/mira_learning_ingest.lock")
+LOCK_MAX_AGE_S = 900  # 15 min
+
+
+def _acquire_lock() -> bool:
+    if LOCK_FILE.exists():
+        age = time.monotonic() - LOCK_FILE.stat().st_mtime
+        if age < LOCK_MAX_AGE_S:
+            logger.warning("Learning ingester already running — skipping")
+            return False
+        logger.warning("Stale lock (age=%.0fs) — clearing", age)
+        LOCK_FILE.unlink(missing_ok=True)
+    LOCK_FILE.write_text(str(os.getpid()))
+    return True
+
+
+def _release_lock() -> None:
+    LOCK_FILE.unlink(missing_ok=True)
+
+
+@shared_task(name="mira_learning_ingest.run_nightly", max_retries=0, ignore_result=False)
+def run_nightly() -> dict:
+    """Nightly: 👍 feedback → approved_faq chunks in NeonDB."""
+    if os.getenv("LEARNING_INGEST_DISABLED", "").strip() == "1":
+        logger.info("Learning ingest disabled — skipping")
+        return {"status": "skipped", "reason": "disabled"}
+
+    if not _acquire_lock():
+        return {"status": "skipped", "reason": "lock_held"}
+
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M")
+
+    try:
+        neon_url = os.getenv("NEON_DATABASE_URL", "")
+        tenant_id = os.getenv("MIRA_TENANT_ID", "")
+
+        if not neon_url:
+            return {"status": "error", "reason": "missing_neon_url", "ts": ts}
+        if not tenant_id:
+            return {"status": "error", "reason": "missing_tenant_id", "ts": ts}
+
+        ingester = LearningIngester(LearningIngesterConfig(
+            db_path=Path(os.getenv("MIRA_DB_PATH", "/opt/mira/data/mira.db")),
+            neon_url=neon_url,
+            tenant_id=tenant_id,
+            ollama_url=os.getenv("OLLAMA_BASE_URL",
+                                 "http://host.docker.internal:11434"),
+            embed_model=os.getenv("EMBED_TEXT_MODEL", "nomic-embed-text:latest"),
+            state_path=Path(os.getenv(
+                "LEARNING_STATE_PATH", "/opt/mira/data/learning_state.json"
+            )),
+            max_per_run=int(os.getenv("LEARNING_MAX_PER_RUN", "50")),
+        ))
+
+        result = ingester.run(dry_run=False)
+
+        logger.info(
+            "Learning ingester complete: %d ingested, %d skipped (of %d positives)",
+            result.get("ingested", 0), result.get("skipped", 0),
+            result.get("positives_found", 0),
+        )
+        return result
+
+    except Exception as e:
+        logger.error("Learning ingester unexpected error: %s", e)
+        return {"status": "error", "reason": str(e), "ts": ts}
+    finally:
+        _release_lock()

--- a/tests/test_learning_ingester.py
+++ b/tests/test_learning_ingester.py
@@ -1,0 +1,273 @@
+"""Tests for learning_ingester (#189) — 👍 feedback → FAQ chunks."""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+MIRA_BOTS = REPO_ROOT / "mira-bots"
+if str(MIRA_BOTS) not in sys.path:
+    sys.path.insert(0, str(MIRA_BOTS))
+
+from tools.learning_ingester import (
+    LearningIngester,
+    LearningIngesterConfig,
+)
+
+
+# ── Test helpers ───────────────────────────────────────────────────────────
+
+
+def _make_db(tmp_path: Path) -> Path:
+    """Create a mock mira.db with feedback_log + interactions schema."""
+    db_path = tmp_path / "mira.db"
+    con = sqlite3.connect(str(db_path))
+    con.execute("""
+        CREATE TABLE feedback_log (
+            id INTEGER PRIMARY KEY,
+            chat_id TEXT,
+            feedback TEXT,
+            reason TEXT,
+            last_reply TEXT,
+            created_at TIMESTAMP
+        )
+    """)
+    con.execute("""
+        CREATE TABLE interactions (
+            id INTEGER PRIMARY KEY,
+            chat_id TEXT,
+            user_message TEXT,
+            bot_response TEXT,
+            created_at TIMESTAMP
+        )
+    """)
+    con.commit()
+    con.close()
+    return db_path
+
+
+def _make_ingester(tmp_path: Path, db_path: Path | None = None) -> LearningIngester:
+    return LearningIngester(LearningIngesterConfig(
+        db_path=db_path or _make_db(tmp_path),
+        neon_url="postgres://fake",
+        tenant_id="test-tenant",
+        ollama_url="http://fake",
+        embed_model="nomic-embed-text",
+        state_path=tmp_path / "state.json",
+    ))
+
+
+# ── collect_positives_since tests ──────────────────────────────────────────
+
+
+class TestCollectPositives:
+
+    def test_empty_db_returns_empty(self, tmp_path):
+        ingester = _make_ingester(tmp_path)
+        assert ingester.collect_positives_since(None) == []
+
+    def test_collects_good_feedback(self, tmp_path):
+        db = _make_db(tmp_path)
+        now = datetime.now(timezone.utc).isoformat()
+        con = sqlite3.connect(str(db))
+        con.execute(
+            "INSERT INTO feedback_log (chat_id, feedback, reason, last_reply, created_at) "
+            "VALUES (?, 'good', 'helpful', 'reply text', ?)",
+            ("chat1", now),
+        )
+        con.execute(
+            "INSERT INTO feedback_log (chat_id, feedback, reason, last_reply, created_at) "
+            "VALUES (?, 'bad', 'wrong answer', 'bad reply', ?)",
+            ("chat2", now),
+        )
+        con.commit()
+        con.close()
+
+        ingester = _make_ingester(tmp_path, db_path=db)
+        positives = ingester.collect_positives_since(None)
+        assert len(positives) == 1
+        assert positives[0]["chat_id"] == "chat1"
+
+    def test_filters_by_checkpoint_ts(self, tmp_path):
+        db = _make_db(tmp_path)
+        con = sqlite3.connect(str(db))
+        # Two entries, one before checkpoint, one after
+        con.execute(
+            "INSERT INTO feedback_log (chat_id, feedback, created_at) "
+            "VALUES ('old', 'good', '2026-04-01T00:00:00+00:00')"
+        )
+        con.execute(
+            "INSERT INTO feedback_log (chat_id, feedback, created_at) "
+            "VALUES ('new', 'good', '2026-04-14T00:00:00+00:00')"
+        )
+        con.commit()
+        con.close()
+
+        ingester = _make_ingester(tmp_path, db_path=db)
+        positives = ingester.collect_positives_since("2026-04-10T00:00:00+00:00")
+        assert len(positives) == 1
+        assert positives[0]["chat_id"] == "new"
+
+    def test_respects_max_per_run(self, tmp_path):
+        db = _make_db(tmp_path)
+        now = datetime.now(timezone.utc).isoformat()
+        con = sqlite3.connect(str(db))
+        for i in range(100):
+            con.execute(
+                "INSERT INTO feedback_log (chat_id, feedback, created_at) "
+                "VALUES (?, 'good', ?)",
+                (f"chat{i}", now),
+            )
+        con.commit()
+        con.close()
+
+        ingester = _make_ingester(tmp_path, db_path=db)
+        ingester.cfg.max_per_run = 10
+        positives = ingester.collect_positives_since(None)
+        assert len(positives) == 10
+
+
+# ── reconstruct_qa tests ──────────────────────────────────────────────────
+
+
+class TestReconstructQA:
+
+    def test_returns_last_qa_pair(self, tmp_path):
+        db = _make_db(tmp_path)
+        con = sqlite3.connect(str(db))
+        con.execute(
+            "INSERT INTO interactions (chat_id, user_message, bot_response, created_at) "
+            "VALUES ('c1', 'earlier question', 'earlier answer longer than 20 chars', '2026-04-14T10:00:00+00:00')"
+        )
+        con.execute(
+            "INSERT INTO interactions (chat_id, user_message, bot_response, created_at) "
+            "VALUES ('c1', 'final question?', 'this is the final answer with enough content', '2026-04-14T11:00:00+00:00')"
+        )
+        con.commit()
+        con.close()
+
+        ingester = _make_ingester(tmp_path, db_path=db)
+        qa = ingester.reconstruct_qa("c1", "2026-04-14T12:00:00+00:00")
+        assert qa is not None
+        question, answer = qa
+        assert question == "final question?"
+
+    def test_drops_short_qa(self, tmp_path):
+        """Q&A too short is rejected (low signal)."""
+        db = _make_db(tmp_path)
+        con = sqlite3.connect(str(db))
+        con.execute(
+            "INSERT INTO interactions (chat_id, user_message, bot_response, created_at) "
+            "VALUES ('c1', 'hi', 'bye', '2026-04-14T10:00:00+00:00')"
+        )
+        con.commit()
+        con.close()
+
+        ingester = _make_ingester(tmp_path, db_path=db)
+        assert ingester.reconstruct_qa("c1", "2026-04-14T12:00:00+00:00") is None
+
+    def test_no_matching_chat_returns_none(self, tmp_path):
+        ingester = _make_ingester(tmp_path)
+        assert ingester.reconstruct_qa("ghost", "2026-04-14T12:00:00+00:00") is None
+
+
+# ── Formatting tests ──────────────────────────────────────────────────────
+
+
+class TestFormatFaq:
+
+    def test_contains_question_and_answer(self):
+        out = LearningIngester.format_faq(
+            "What does F4 mean?",
+            "F4 is undervoltage. Check input AC.",
+            "chat123",
+            "2026-04-14T12:00:00+00:00",
+        )
+        assert "What does F4 mean?" in out
+        assert "F4 is undervoltage" in out
+
+    def test_includes_provenance(self):
+        """Provenance line with date and hashed chat_id."""
+        out = LearningIngester.format_faq(
+            "question", "answer text of sufficient length",
+            "chat-secret-123", "2026-04-14T12:00:00+00:00",
+        )
+        assert "2026-04-14" in out
+        # Raw chat_id should not appear — only a hash
+        assert "chat-secret-123" not in out
+
+    def test_markdown_structure(self):
+        out = LearningIngester.format_faq(
+            "q", "answer long enough for check",
+            "c", "2026-04-14T12:00:00+00:00",
+        )
+        assert out.startswith("## Approved FAQ")
+        assert "**Question:**" in out
+        assert "**Answer:**" in out
+
+
+# ── Orchestrator integration ──────────────────────────────────────────────
+
+
+class TestOrchestrator:
+
+    def test_empty_feedback_returns_ok(self, tmp_path):
+        ingester = _make_ingester(tmp_path)
+        result = ingester.run(dry_run=True)
+        assert result["status"] == "ok"
+        assert result["ingested"] == 0
+
+    def test_dry_run_writes_to_disk(self, tmp_path):
+        db = _make_db(tmp_path)
+        now = datetime.now(timezone.utc).isoformat()
+        con = sqlite3.connect(str(db))
+        con.execute(
+            "INSERT INTO feedback_log (chat_id, feedback, created_at) "
+            "VALUES ('c1', 'good', ?)",
+            (now,),
+        )
+        con.execute(
+            "INSERT INTO interactions (chat_id, user_message, bot_response, created_at) "
+            "VALUES ('c1', 'valid question', 'this answer is long enough to keep', ?)",
+            (now,),
+        )
+        con.commit()
+        con.close()
+
+        ingester = _make_ingester(tmp_path, db_path=db)
+        out_dir = tmp_path / "out"
+        result = ingester.run(dry_run=True, output_dir=out_dir)
+        assert result["ingested"] == 1
+        assert result["dry_run"] is True
+        # One file written
+        files = list(out_dir.glob("*.md"))
+        assert len(files) == 1
+
+    def test_state_updated_after_run(self, tmp_path):
+        ingester = _make_ingester(tmp_path)
+        ingester.run(dry_run=True)
+        state = json.loads(ingester.cfg.state_path.read_text())
+        assert state["last_run_ts"] is not None
+
+    def test_state_persists_across_runs(self, tmp_path):
+        ingester = _make_ingester(tmp_path)
+        ingester.run(dry_run=True)
+        first_state = ingester._load_state()
+
+        # Reuse the same DB so we don't recreate tables
+        ingester2 = LearningIngester(LearningIngesterConfig(
+            db_path=ingester.cfg.db_path,
+            neon_url="postgres://fake",
+            tenant_id="test-tenant",
+            ollama_url="http://fake",
+            embed_model="nomic-embed-text",
+            state_path=ingester.cfg.state_path,
+        ))
+        state2 = ingester2._load_state()
+        assert state2["last_run_ts"] == first_state["last_run_ts"]


### PR DESCRIPTION
## Summary
Completes the autoresearch loop: nightly at 02:00 UTC, approved production conversations flow back into the KB as retrievable FAQ chunks.

**Today's thumbs-up becomes tomorrow's knowledge.**

### Pipeline
\`\`\`
02:00 UTC nightly
  → query feedback_log WHERE feedback = 'good' AND created_at > last_run
  → for each positive:
      → reconstruct Q&A from interactions table (last turn)
      → format as "## Approved FAQ" markdown with provenance
      → embed via Ollama nomic-embed-text
      → INSERT into knowledge_entries (source_type='approved_faq', chunk_type='faq')
  → save state.last_run_ts
03:00 UTC eval runs with new FAQs available for retrieval
\`\`\`

### Provenance
Chat IDs are SHA-256 hashed in the source_url so FAQs are linkable back to their approval without exposing the original session. Only approved date + chat_hash are embedded in the FAQ content.

### Files
| File | Purpose |
|------|---------|
| \`mira-bots/tools/learning_ingester.py\` | LearningIngester class + CLI |
| \`tests/eval/learning_ingester_tasks.py\` | Celery task wrapper (\`mira_learning_ingest.run_nightly\`) |
| \`tests/test_learning_ingester.py\` | 14 offline tests |

### The 3 Learning Pipeline phases
- **Phase 1** (shipped) — feedback_log table + Open WebUI rating sync
- **Phase 2** (shipped) — active learner: 👎 feedback → fixture candidates (#219)
- **Phase 3** (this PR) — 👍 feedback → KB FAQ chunks (#189)
- Phase 4 (#190) — monthly fine-tune scripts (future)

Closes #189

## Test plan
- [x] \`pytest tests/test_learning_ingester.py\` — 14/14 pass
- [ ] Dry-run on Bravo: \`python mira-bots/tools/learning_ingester.py --dry-run\`
- [ ] Verify FAQ chunks appear in NeonDB with \`source_type='approved_faq'\`
- [ ] Register Celery task in beat schedule (02:00 UTC, before 03:00 eval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)