### PR TITLE
feat(crawler): add AutomationDirect + fleet vendors to manual discovery

### DIFF
--- a/mira-core/scripts/discover_manuals.py
+++ b/mira-core/scripts/discover_manuals.py
@@ -70,6 +70,57 @@ CRAWL_TARGETS = [
         "crawler_type": "playwright",
         "max_pages": 150,
     },
+    # GS10 is the centerpiece of the demo F05 escalation pattern (Pump-001);
+    # AutomationDirect documentation must be crawlable to keep that corpus
+    # current. (#142)
+    {
+        "manufacturer": "AutomationDirect",
+        "start_url": "https://www.automationdirect.com/support/manuals",
+        "crawler_type": "cheerio",
+        "max_pages": 200,
+    },
+    # SEW-Eurodrive — Conv-001 gearmotor fleet unit
+    {
+        "manufacturer": "SEW-Eurodrive",
+        "start_url": "https://download.sew-eurodrive.com/download/documentation/en",
+        "crawler_type": "cheerio",
+        "max_pages": 150,
+    },
+    # Ingersoll Rand — Comp-001 compressor fleet unit
+    {
+        "manufacturer": "Ingersoll Rand",
+        "start_url": "https://www.ingersollrand.com/en-us/service-and-support/technical-library",
+        "crawler_type": "playwright",
+        "max_pages": 100,
+    },
+    # Dake — Press-001 hydraulic press fleet unit
+    {
+        "manufacturer": "Dake",
+        "start_url": "https://www.dakecorp.com/customer-service/manuals",
+        "crawler_type": "cheerio",
+        "max_pages": 100,
+    },
+    # FANUC — Robot-001 industrial robot fleet unit
+    {
+        "manufacturer": "FANUC",
+        "start_url": "https://www.fanucamerica.com/support",
+        "crawler_type": "playwright",
+        "max_pages": 100,
+    },
+    # Yaskawa — A1000/V1000/J1000/GA500/GA700 VFD families
+    {
+        "manufacturer": "Yaskawa",
+        "start_url": "https://www.yaskawa.com/downloads/search-manuals",
+        "crawler_type": "playwright",
+        "max_pages": 150,
+    },
+    # Danfoss — VLT FC Series (seeded fault codes)
+    {
+        "manufacturer": "Danfoss",
+        "start_url": "https://www.danfoss.com/en/service-and-support/downloads",
+        "crawler_type": "playwright",
+        "max_pages": 150,
+    },
 ]
 
 # Link patterns that suggest manuals / technical docs

--- a/tests/test_discover_manuals_targets.py
+++ b/tests/test_discover_manuals_targets.py
@@ -1,0 +1,87 @@
+"""Tests for the CRAWL_TARGETS registry in discover_manuals.py (#142)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPTS = REPO_ROOT / "mira-core" / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+
+def test_automationdirect_is_registered():
+    """GS10 / GS20 centerpiece models need a crawl target (#142)."""
+    from discover_manuals import CRAWL_TARGETS
+    mfrs = {t["manufacturer"] for t in CRAWL_TARGETS}
+    assert "AutomationDirect" in mfrs
+
+
+def test_all_fleet_vendors_registered():
+    """Each fleet-registry vendor has a crawl target."""
+    from discover_manuals import CRAWL_TARGETS
+    mfrs = {t["manufacturer"] for t in CRAWL_TARGETS}
+    expected = {
+        "AutomationDirect",   # Pump-001
+        "SEW-Eurodrive",      # Conv-001
+        "Ingersoll Rand",     # Comp-001
+        "Dake",               # Press-001
+        "FANUC",              # Robot-001
+    }
+    missing = expected - mfrs
+    assert not missing, f"Missing fleet vendors: {missing}"
+
+
+def test_new_vfd_vendors_registered():
+    """VFD vendors backing the structured fault-code table have crawl targets."""
+    from discover_manuals import CRAWL_TARGETS
+    mfrs = {t["manufacturer"] for t in CRAWL_TARGETS}
+    for mfr in ("Yaskawa", "Danfoss"):
+        assert mfr in mfrs, f"Missing {mfr} — needed for fault-code seed coverage"
+
+
+def test_every_target_has_required_fields():
+    """Every crawl target has the 4 required fields."""
+    from discover_manuals import CRAWL_TARGETS
+    required = {"manufacturer", "start_url", "crawler_type", "max_pages"}
+    for target in CRAWL_TARGETS:
+        missing = required - set(target.keys())
+        assert not missing, f"{target.get('manufacturer')} missing: {missing}"
+
+
+def test_crawler_type_is_valid():
+    """crawler_type is either 'cheerio' or 'playwright'."""
+    from discover_manuals import CRAWL_TARGETS
+    valid = {"cheerio", "playwright"}
+    for target in CRAWL_TARGETS:
+        assert target["crawler_type"] in valid, (
+            f"{target['manufacturer']} has invalid crawler_type: "
+            f"{target['crawler_type']}"
+        )
+
+
+def test_start_url_is_https():
+    """All start_urls are HTTPS."""
+    from discover_manuals import CRAWL_TARGETS
+    for target in CRAWL_TARGETS:
+        assert target["start_url"].startswith("https://"), (
+            f"{target['manufacturer']} start_url not HTTPS: {target['start_url']}"
+        )
+
+
+def test_no_duplicate_manufacturers():
+    from discover_manuals import CRAWL_TARGETS
+    mfrs = [t["manufacturer"] for t in CRAWL_TARGETS]
+    assert len(mfrs) == len(set(mfrs)), "Duplicate manufacturer entries"
+
+
+def test_max_pages_reasonable():
+    """max_pages is between 50 and 300 (not zero, not runaway)."""
+    from discover_manuals import CRAWL_TARGETS
+    for target in CRAWL_TARGETS:
+        assert 50 <= target["max_pages"] <= 300, (
+            f"{target['manufacturer']} max_pages out of range: "
+            f"{target['max_pages']}"
+        )


### PR DESCRIPTION
## Summary
Extends \`CRAWL_TARGETS\` in \`discover_manuals.py\` from 5 to 11 vendors.

### Added
| Vendor | Why |
|--------|-----|
| AutomationDirect | GS10/GS20 — demo centerpiece |
| SEW-Eurodrive | Conv-001 gearmotor fleet unit |
| Ingersoll Rand | Comp-001 compressor fleet unit |
| Dake | Press-001 hydraulic press fleet unit |
| FANUC | Robot-001 industrial robot fleet unit |
| Yaskawa | A1000/V1000/J1000/GA500/GA700 VFD families |
| Danfoss | VLT FC Series (fault-codes seed) |

These cover the full fleet-registry roster plus the VFD vendors seeded into the fault-codes table (#193), so nightly manual discovery keeps the KB aligned with what the bot is expected to know.

### Tests (8 passing)
Registry integrity — required fields, HTTPS URLs, valid crawler_type (cheerio/playwright), no duplicates, reasonable max_pages range.

Closes #142

## Test plan
- [x] \`pytest tests/test_discover_manuals_targets.py\` — 8/8 pass
- [ ] Run discover_manuals.py on Bravo against new targets to verify selectors work
- [ ] Verify new PDFs land in manual_cache table

🤖 Generated with [Claude Code](https://claude.com/claude-code)