### PR TITLE
feat: Oracle Cloud free-tier deployment — zero-cost hosting for all services

### DIFF
--- a/mira-cmms/docker-compose.local.yml
+++ b/mira-cmms/docker-compose.local.yml
@@ -1,0 +1,14 @@
+# Oracle / local override — official frontend image, env-var URLs.
+# Usage: docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
+services:
+  atlas-api:
+    environment:
+      PUBLIC_API_URL: ${ATLAS_PUBLIC_API_URL:-http://localhost:8088}
+      PUBLIC_FRONT_URL: ${ATLAS_PUBLIC_FRONT_URL:-http://localhost:3100}
+      PUBLIC_MINIO_ENDPOINT: ${ATLAS_PUBLIC_MINIO_URL:-http://localhost:9000}
+
+  atlas-frontend:
+    build: !reset null
+    image: intelloop/atlas-cmms-frontend
+    environment:
+      API_URL: ${ATLAS_PUBLIC_API_URL:-http://localhost:8088}

--- a/mira-core/docker-compose.oracle.yml
+++ b/mira-core/docker-compose.oracle.yml
@@ -1,0 +1,28 @@
+# Oracle Cloud overrides — routes Ollama to Bravo via Tailscale.
+# Usage: docker compose -f docker-compose.yml -f docker-compose.oracle.yml up -d
+services:
+  open-webui:
+    environment:
+      - OLLAMA_BASE_URL=http://100.86.236.11:11434
+    extra_hosts:
+      - "host.docker.internal:100.86.236.11"
+
+  mira-mcpo:
+    image: mira-core-mira-mcpo:latest
+    build:
+      context: .
+      dockerfile: Dockerfile.mcpo
+
+  mira-ingest:
+    environment:
+      - OLLAMA_BASE_URL=http://100.86.236.11:11434
+    ports:
+      - "8002:8001"
+    extra_hosts:
+      - "host.docker.internal:100.86.236.11"
+
+  mira-pipeline:
+    environment:
+      - OLLAMA_BASE_URL=http://100.86.236.11:11434
+    extra_hosts:
+      - "host.docker.internal:100.86.236.11"

--- a/nginx-oracle.conf
+++ b/nginx-oracle.conf
@@ -1,0 +1,57 @@
+# nginx for Oracle VM — deploy to /etc/nginx/sites-available/factorylm
+# sudo ln -sf /etc/nginx/sites-available/factorylm /etc/nginx/sites-enabled/factorylm
+# sudo nginx -t && sudo systemctl reload nginx
+# TLS: sudo certbot --nginx -d factorylm.com -d www.factorylm.com -d app.factorylm.com -d cmms.factorylm.com
+
+server {
+    listen 80 default_server;
+    server_name _;
+    return 301 https://$host$request_uri;
+}
+
+# MIRA (Open WebUI)
+server {
+    listen 443 ssl;
+    server_name app.factorylm.com;
+    client_max_body_size 50M;
+
+    location / {
+        proxy_pass         http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header   Upgrade $http_upgrade;
+        proxy_set_header   Connection "upgrade";
+        proxy_set_header   Host $host;
+        proxy_set_header   X-Real-IP $remote_addr;
+        proxy_set_header   X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+    }
+}
+
+# Atlas CMMS
+server {
+    listen 443 ssl;
+    server_name cmms.factorylm.com;
+    client_max_body_size 50M;
+
+    location / {
+        proxy_pass http://127.0.0.1:3100;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:8088/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+}
+
+# Landing page
+server {
+    listen 443 ssl;
+    server_name factorylm.com www.factorylm.com;
+    root /var/www/factorylm;
+    index index.html;
+    location / { try_files $uri $uri/ /index.html; }
+}

--- a/oracle-bootstrap.sh
+++ b/oracle-bootstrap.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# oracle-bootstrap.sh — run ONCE on Oracle VM as ubuntu user
+# scp this file to Oracle then: bash oracle-bootstrap.sh
+set -e
+
+echo "==> [1/8] System update"
+sudo apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -qq
+
+echo "==> [2/8] Install Docker"
+curl -fsSL https://get.docker.com | sudo bash
+sudo usermod -aG docker "$USER"
+
+echo "==> [3/8] Install tools (git, nginx, certbot, redis-tools, jq)"
+sudo apt-get install -y git nginx certbot python3-certbot-nginx redis-tools jq curl
+
+echo "==> [4/8] Install Tailscale"
+curl -fsSL https://tailscale.com/install.sh | sudo bash
+echo "  ** ACTION REQUIRED: run 'sudo tailscale up' and log in to join the tailnet **"
+echo "     After joining, Bravo (100.86.236.11) will be reachable for Ollama."
+
+echo "==> [5/8] Install Doppler CLI"
+curl -Ls https://cli.doppler.com/install.sh | sudo sh
+
+echo "==> [6/8] Clone repos"
+if [ ! -d ~/MIRA ]; then
+  git clone https://github.com/Mikecranesync/MIRA.git ~/MIRA
+else
+  git -C ~/MIRA pull
+fi
+if [ ! -d ~/factorylm ]; then
+  git clone https://github.com/Mikecranesync/factorylm.git ~/factorylm
+else
+  git -C ~/factorylm pull
+fi
+
+echo "==> [7/8] Create Docker networks and directories"
+docker network create core-net  2>/dev/null || true
+docker network create bot-net   2>/dev/null || true
+docker network create cmms-net  2>/dev/null || true
+
+mkdir -p ~/MIRA/mira-core/data/photos
+touch ~/MIRA/mira-core/mira.db
+mkdir -p ~/MIRA/mira-bridge/data
+
+echo "==> [8/8] Pre-pull heavy images"
+docker pull ghcr.io/open-webui/open-webui:v0.8.10 &
+docker pull postgres:16-alpine &
+docker pull intelloop/atlas-cmms-backend &
+docker pull intelloop/atlas-cmms-frontend &
+docker pull "minio/minio:RELEASE.2025-04-22T22-12-26Z" &
+docker pull apache/tika:3.1.0.0 &
+docker pull nodered/node-red:4.1.7-22 &
+docker pull quay.io/docling-project/docling-serve:v1.16.1 &
+wait
+echo "  All images pulled."
+
+echo ""
+echo "=== Bootstrap complete ==="
+echo "NEXT STEPS:"
+echo "  1. sudo tailscale up        — join tailnet"
+echo "  2. doppler login            — authenticate"
+echo "  3. doppler run --project factorylm --config prd -- bash ~/MIRA/oracle-deploy.sh"

--- a/oracle-deploy.sh
+++ b/oracle-deploy.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# oracle-deploy.sh — start all FactoryLM services
+# Run with: doppler run --project factorylm --config prd -- bash oracle-deploy.sh
+set -e
+
+ORACLE_IP=$(curl -s ifconfig.me)
+echo "Oracle IP: $ORACLE_IP"
+
+# Networks
+docker network create core-net  2>/dev/null || true
+docker network create bot-net   2>/dev/null || true
+docker network create cmms-net  2>/dev/null || true
+
+# Check Bravo Ollama
+echo "==> Checking Bravo Ollama (Tailscale required)"
+curl -s --max-time 5 http://100.86.236.11:11434/api/tags > /dev/null \
+  && echo "    Bravo Ollama: OK" \
+  || echo "    WARNING: Bravo unreachable — run 'sudo tailscale up' first"
+
+# MIRA core
+echo "==> MIRA core"
+cd ~/MIRA/mira-core
+docker compose -f docker-compose.yml -f docker-compose.oracle.yml build --no-cache mira-mcpo
+docker compose -f docker-compose.yml -f docker-compose.oracle.yml build mira-ingest mira-pipeline
+docker compose -f docker-compose.yml -f docker-compose.oracle.yml up -d
+sleep 30
+
+# MIRA bots
+echo "==> MIRA bots"
+cd ~/MIRA/mira-bots
+docker compose up -d telegram-bot slack-bot
+
+# Atlas CMMS
+echo "==> Atlas CMMS"
+cd ~/MIRA/mira-cmms
+docker compose -f docker-compose.yml -f docker-compose.local.yml up -d
+sleep 15
+
+# Node-RED bridge
+echo "==> Node-RED bridge"
+cd ~/MIRA/mira-bridge
+docker compose up -d
+
+# nginx + landing page
+echo "==> nginx"
+sudo cp ~/MIRA/nginx-oracle.conf /etc/nginx/sites-available/factorylm
+sudo ln -sf /etc/nginx/sites-available/factorylm /etc/nginx/sites-enabled/factorylm
+sudo rm -f /etc/nginx/sites-enabled/default
+
+if [ ! -d /var/www/factorylm ]; then
+  sudo mkdir -p /var/www/factorylm
+  sudo git clone https://github.com/Mikecranesync/factorylm-landing.git /var/www/factorylm \
+    || echo "  Could not clone landing page — add manually"
+fi
+
+sudo nginx -t && sudo systemctl reload nginx
+
+echo ""
+echo "============================================"
+echo "  MIRA:  http://$ORACLE_IP:3000"
+echo "  CMMS:  http://$ORACLE_IP:3100"
+echo "  nginx: http://$ORACLE_IP"
+echo ""
+echo "  After DNS points here, get TLS:"
+echo "  sudo certbot --nginx \\"
+echo "    -d factorylm.com -d www.factorylm.com \\"
+echo "    -d app.factorylm.com -d cmms.factorylm.com"
+echo "============================================"
+
+docker ps --format "table {{.Names}}\t{{.Status}}"


### PR DESCRIPTION
## Summary
- Moves all FactoryLM services off DigitalOcean VPS (offline, unpaid) to Oracle Cloud Always-Free ARM VM (4 OCPU / 24 GB RAM / $0/month)
- One-shot bootstrap + deploy scripts so any new VM is live in under 20 minutes

## Changes
- `oracle-bootstrap.sh` — installs Docker, Tailscale, Doppler, nginx, certbot; clones repos; pre-pulls all images
- `oracle-deploy.sh` — starts MIRA core, bots, CMMS, Node-RED bridge, nginx in one `doppler run` command
- `mira-core/docker-compose.oracle.yml` — overrides `OLLAMA_BASE_URL` → Bravo Tailscale IP (`100.86.236.11:11434`) so vision/embed models still work
- `mira-cmms/docker-compose.local.yml` — uses official `intelloop/atlas-cmms-frontend` image (no build needed) with env-var API URLs
- `nginx-oracle.conf` — reverse proxy: `app.factorylm.com` → Open WebUI `:3000`, `cmms.factorylm.com` → Atlas `:3100`; certbot-ready SSL stubs

## Deploy Instructions
```bash
# On Oracle VM (ubuntu user, ARM)
bash oracle-bootstrap.sh
sudo tailscale up          # join tailnet so Bravo Ollama is reachable
doppler login && doppler setup --project factorylm --config prd
doppler run --project factorylm --config prd -- bash oracle-deploy.sh

# After DNS propagates
sudo certbot --nginx -d factorylm.com -d www.factorylm.com -d app.factorylm.com -d cmms.factorylm.com
```

## Services Hosted
| URL | Service |
|-----|---------|
| app.factorylm.com | MIRA (Open WebUI + GSD pipeline) |
| cmms.factorylm.com | Atlas CMMS |
| factorylm.com | Landing page |

## Test plan
- [ ] SSH to Oracle VM, run bootstrap, verify Docker installed
- [ ] `sudo tailscale up` → confirm Bravo reachable (`redis-cli -h 100.86.236.11 ping`)
- [ ] `doppler run -- bash oracle-deploy.sh` → all containers healthy
- [ ] `curl http://<oracle-ip>:3000/health` → 200
- [ ] `curl http://<oracle-ip>:3100` → 200
- [ ] DNS updated, certbot runs, HTTPS works

🤖 Generated with [Claude Code](https://claude.com/claude-code)