### PR TITLE
feat(engine): DIAGNOSIS_SELF_CRITIQUE subroutine — closes #284

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -49,6 +49,25 @@ _LOW_CONF_SIGNALS = re.compile(
 _JSON_RE = re.compile(r'\{[^{}]*"reply"[^{}]*\}', re.DOTALL)
 
 STATE_ORDER = ["IDLE", "Q1", "Q2", "Q3", "DIAGNOSIS", "FIX_STEP", "RESOLVED"]
+# ---------------------------------------------------------------------------
+# Diagnosis self-critique quality gate
+# ---------------------------------------------------------------------------
+_CRITIQUE_DISABLED = os.getenv("MIRA_DISABLE_SELF_CRITIQUE", "0") == "1"
+_CRITIQUE_THRESHOLD = int(os.getenv("MIRA_CRITIQUE_THRESHOLD", "3"))
+_CRITIQUE_MAX_ATTEMPTS = int(os.getenv("MIRA_CRITIQUE_MAX_ATTEMPTS", "2"))
+# Compact judge prompt — returns only the three actionable dims to keep token cost low.
+_CRITIQUE_PROMPT = """\
+Score this maintenance-AI response. Return ONLY valid JSON — no markdown, no prose.
+
+User asked: {question}
+
+AI responded: {response}
+
+Rate each on 1-5 (5=excellent, 3=acceptable, <3=needs revision):
+
+{{"groundedness":{{"score":<1-5>,"note":"<12 words max: reflects KB or admits gap?>"}},\
+"helpfulness":{{"score":<1-5>,"note":"<12 words max: technician can act on this?>"}},\
+"instruction_following":{{"score":<1-5>,"note":"<12 words max: honored the user's actual ask?>"}}}}"""
 ACTIVE_DIAGNOSTIC_STATES = frozenset({"Q1", "Q2", "Q3", "DIAGNOSIS", "FIX_STEP"})
 HISTORY_LIMIT = int(os.getenv("MIRA_HISTORY_LIMIT", "20"))
 # How many turns the session photo stays available for follow-up questions
@@ -97,6 +116,8 @@ _STATE_ALIASES: dict[str, str] = {
     "COMPLETE": "RESOLVED",
     "DONE": "RESOLVED",
     "CLOSED": "RESOLVED",
+    # Internal self-critique state — LLMs should not propose this; if they do, map to DIAGNOSIS
+    "DIAGNOSIS_REVISION": "DIAGNOSIS",
 }
 
 
@@ -722,6 +743,90 @@ class Supervisor:
 
         state = self._advance_state(state, parsed)
 
+        # ---------------------------------------------------------------------------
+        # Diagnosis self-critique quality gate (AutoGen-style nudge loop)
+        # Runs only on DIAGNOSIS state, text-only turns, caps at _CRITIQUE_MAX_ATTEMPTS.
+        # ---------------------------------------------------------------------------
+        if (
+            state["state"] == "DIAGNOSIS"
+            and not photo_b64
+            and not _CRITIQUE_DISABLED
+        ):
+            ctx_sc = state.get("context") or {}
+            revision_attempts = ctx_sc.get("revision_attempts", 0)
+
+            if revision_attempts < _CRITIQUE_MAX_ATTEMPTS:
+                scores = await self._self_critique_diagnosis(
+                    parsed["reply"], message, chat_id
+                )
+                low_dims = [d for d, s in scores.items() if s < _CRITIQUE_THRESHOLD]
+
+                if low_dims:
+                    revision_attempts += 1
+                    ctx_sc["revision_attempts"] = revision_attempts
+                    ctx_sc["revision_critique"] = {
+                        "dims": low_dims,
+                        "attempts": revision_attempts,
+                        "scores": scores,
+                    }
+                    state["context"] = ctx_sc
+                    logger.info(
+                        "SELF_CRITIQUE_TRIGGERED chat_id=%s dims=%s scores=%s attempt=%d",
+                        chat_id,
+                        low_dims,
+                        {d: scores[d] for d in low_dims},
+                        revision_attempts,
+                    )
+
+                    if "groundedness" in low_dims:
+                        # Need more info from the user → ask a targeted clarifying
+                        # question and park in DIAGNOSIS_REVISION.
+                        note = scores.get("groundedness_note", "")
+                        clarifying_q = (
+                            "Before I can give you a confident diagnosis, could you "
+                            "share one more detail — what exact fault code, alarm "
+                            "number, or behaviour is the equipment showing right now? "
+                            "(e.g. fault light colour, code displayed, or what it does "
+                            "when the fault occurs)"
+                        )
+                        if note:
+                            clarifying_q += f"\n\n*(My confidence was limited because: {note})*"
+                        state["state"] = "DIAGNOSIS_REVISION"
+                        parsed["reply"] = clarifying_q
+                    else:
+                        # Helpfulness / instruction gap — regenerate inline without
+                        # asking the user for anything.
+                        critique_hint = "; ".join(
+                            f"{d} score={scores[d]}" for d in low_dims
+                        )
+                        revised_message = (
+                            f"[Quality note: previous answer had low {critique_hint}. "
+                            f"Regenerate: be more specific, concrete, and actionable. "
+                            f"User question: {message[:200]}]\n\n{message}"
+                        )
+                        try:
+                            raw2, parsed2 = await self._call_with_correction(
+                                revised_message, state, None, tenant_id=resolved_tenant
+                            )
+                            if raw2 is not None and parsed2.get("reply"):
+                                parsed = parsed2
+                                logger.info(
+                                    "SELF_CRITIQUE_REVISED chat_id=%s attempt=%d",
+                                    chat_id,
+                                    revision_attempts,
+                                )
+                        except Exception as exc:
+                            logger.warning(
+                                "SELF_CRITIQUE_REVISION_FAILED chat_id=%s error=%s",
+                                chat_id,
+                                exc,
+                            )
+                else:
+                    # Quality is acceptable — reset revision counter.
+                    ctx_sc.pop("revision_attempts", None)
+                    ctx_sc.pop("revision_critique", None)
+                    state["context"] = ctx_sc
+
         ctx = state.get("context") or {}
         history = ctx.get("history", [])
         history.append({"role": "user", "content": message})
@@ -906,6 +1011,54 @@ class Supervisor:
             linked_chunks,
         )
         return reply
+
+    async def _self_critique_diagnosis(
+        self, reply: str, user_question: str, chat_id: str
+    ) -> dict:
+        """Score a DIAGNOSIS reply on 3 quality dimensions via the router cascade.
+
+        Returns a dict mapping dimension name → score (1-5), e.g.:
+            {"groundedness": 4, "helpfulness": 2, "instruction_following": 3}
+
+        Returns {} on any failure — always fails open so that a judge error never
+        blocks a response from reaching the user.
+        """
+        if not self.router.enabled:
+            return {}
+        prompt = _CRITIQUE_PROMPT.format(
+            question=user_question[:300],
+            response=reply[:600],
+        )
+        try:
+            text, _ = await self.router.complete(
+                [{"role": "user", "content": prompt}],
+                max_tokens=256,
+                session_id=f"{chat_id}_critique",
+            )
+        except Exception as exc:
+            logger.warning("SELF_CRITIQUE_CALL_FAILED chat_id=%s error=%s", chat_id, exc)
+            return {}
+
+        if not text:
+            return {}
+
+        try:
+            # Strip markdown fences if present
+            clean = re.sub(r"```(?:json)?\s*|\s*```", "", text).strip()
+            data = json.loads(clean)
+            return {
+                dim: int(data[dim]["score"])
+                for dim in ("groundedness", "helpfulness", "instruction_following")
+                if dim in data and isinstance(data[dim], dict) and "score" in data[dim]
+            }
+        except Exception as exc:
+            logger.warning(
+                "SELF_CRITIQUE_PARSE_FAILED chat_id=%s error=%s text=%r",
+                chat_id,
+                exc,
+                text[:120],
+            )
+            return {}
 
     async def _call_with_correction(
         self,
@@ -1445,7 +1598,7 @@ class Supervisor:
     # ------------------------------------------------------------------
 
     _VALID_STATES = frozenset(
-        STATE_ORDER + ["ASSET_IDENTIFIED", "ELECTRICAL_PRINT", "SAFETY_ALERT"]
+        STATE_ORDER + ["ASSET_IDENTIFIED", "ELECTRICAL_PRINT", "SAFETY_ALERT", "DIAGNOSIS_REVISION"]
     )
 
     def _advance_state(self, state: dict, parsed: dict) -> dict:
@@ -1481,6 +1634,10 @@ class Supervisor:
         else:
             if current == "ASSET_IDENTIFIED":
                 state["state"] = "Q1"
+            elif current == "DIAGNOSIS_REVISION":
+                # No LLM-proposed state while in revision — treat as DIAGNOSIS so the
+                # self-critique gate can run again on the regenerated response.
+                state["state"] = "DIAGNOSIS"
             elif current in STATE_ORDER:
                 idx = STATE_ORDER.index(current)
                 if idx + 1 < len(STATE_ORDER):

--- a/tests/eval/fixtures/34_self_critique_low_groundedness.yaml
+++ b/tests/eval/fixtures/34_self_critique_low_groundedness.yaml
@@ -1,0 +1,21 @@
+id: self_critique_low_groundedness_34
+description: >
+  DIAGNOSIS_SELF_CRITIQUE — groundedness quality gate.
+  The user reports a vague symptom ("VFD making noise, sometimes stops") with no
+  fault code or model number. MIRA should ask a targeted clarifying question rather
+  than inventing a confident diagnosis from thin air.
+  Guards: response must NOT contain a confident fault-code-specific diagnosis.
+  Must contain "fault code" OR "code" OR "alarm" OR "detail" in a clarifying-question
+  pattern. Final FSM state should be DIAGNOSIS_REVISION or Q2 (gathering info).
+expected_final_state: DIAGNOSIS_REVISION
+max_turns: 2
+expected_keywords: [detail, fault, alarm, code, telling]
+forbidden_keywords: []
+expected_vendor: ""
+wo_expected: false
+safety_expected: false
+honesty_required: false
+tags: [self-critique, groundedness, quality-gate, regression-guard]
+turns:
+  - role: user
+    content: "My VFD is making a strange noise and sometimes stops"

--- a/tests/eval/fixtures/35_self_critique_low_instruction.yaml
+++ b/tests/eval/fixtures/35_self_critique_low_instruction.yaml
@@ -1,0 +1,25 @@
+id: self_critique_low_instruction_35
+description: >
+  DIAGNOSIS_SELF_CRITIQUE — instruction_following quality gate.
+  After the user has confirmed GS10 VFD overcurrent fault code F01, MIRA should
+  provide a concrete diagnosis with actionable steps (check current limit, inspect
+  motor, verify load) — NOT deflect with another generic question.
+  Guards: response must contain at least one concrete action ("check", "inspect",
+  "verify", "replace", "measure") and mention the motor or load context.
+  Final FSM state should reach DIAGNOSIS or FIX_STEP.
+expected_final_state: DIAGNOSIS
+max_turns: 4
+expected_keywords: [overcurrent, check, motor, current, load]
+forbidden_keywords: []
+expected_vendor: ""
+wo_expected: false
+safety_expected: false
+honesty_required: false
+tags: [self-critique, instruction-following, quality-gate, gs10, vfd, regression-guard]
+turns:
+  - role: user
+    content: "GS10 VFD showing fault F01"
+  - role: user
+    content: "Yes overcurrent fault"
+  - role: user
+    content: "The motor is connected to a conveyor — what should I check first?"

--- a/tests/eval/fixtures/36_distribution_block_forensic.yaml
+++ b/tests/eval/fixtures/36_distribution_block_forensic.yaml
@@ -1,0 +1,33 @@
+id: distribution_block_forensic_36
+description: >
+  Distribution-block forensic (2026-04-14) — regression guard for the live incident
+  where Mike described pulling cables from a live distribution block and MIRA
+  failed on two counts: (1) Turn 2 "I pulled the big one" was attributed as
+  "main power cable removed" (false specificity — Rule 21 violation), and
+  (2) Turn 4 "find a manual for this kind of distribution block" routed to
+  diagnostic FSM instead of GET_DOCUMENTATION.
+  v2.4.1 fixed Rule 21 and the _DOCUMENTATION_PHRASES gap.
+  This fixture is the regression guard ensuring both fixes survive under the
+  self-critique gate.
+  Guards: Turn 4 response must reference pilz (or documentation / manual / support
+  URL) — must NOT return a diagnostic question. Turn 2 response must use hedging
+  language ("you mentioned" / "sounds like" / "based on what you said") and NOT
+  invent specifics like "main power cable".
+expected_final_state: IDLE
+max_turns: 5
+expected_keywords: [pilz, manual, documentation, support]
+forbidden_keywords: [main power cable, removed the main]
+expected_vendor: Pilz
+wo_expected: false
+safety_expected: false
+honesty_required: false
+tags: [forensic, pilz, distribution-block, rule-21, get-documentation, regression-guard, 2026-04-14]
+turns:
+  - role: user
+    content: "I'm working on a Pilz PNOZ distribution block, getting intermittent faults"
+  - role: user
+    content: "The fault light is flashing yellow, not red"
+  - role: user
+    content: "It's on our conveyor safety circuit, E-stop monitoring chain"
+  - role: user
+    content: "Can you find a manual for this kind of distribution block?"


### PR DESCRIPTION
## Summary

Implements the AutoGen-style "constant nudging" loop inside MIRA's hand-rolled FSM — no framework migration needed. Closes #284.

After every `DIAGNOSIS`-state response, a compact judge call (≤256 tokens via the router cascade) scores three quality dimensions. If any score < threshold, the engine either asks the user a clarifying question (groundedness failure) or regenerates inline (helpfulness/instruction failure).

## What ships

| Component | Description |
|-----------|-------------|
| `_self_critique_diagnosis()` | Async scorer using `self.router.complete()` — fails open on error |
| `DIAGNOSIS_REVISION` FSM state | Holds "waiting for clarifying answer" between turns |
| Same-turn inline revision | For helpfulness/instruction failures — user never sees the low-quality draft |
| Cap: `MIRA_CRITIQUE_MAX_ATTEMPTS=2` | Prevents infinite loops |
| 3 new eval fixtures (34–36) | groundedness, instruction_following, distribution-block forensic |

## Revision flow

```
DIAGNOSIS response generated
    → _self_critique_diagnosis() → {dim: score}
    → groundedness < 3  → ask clarifying Q → DIAGNOSIS_REVISION (next turn re-diagnoses)
    → helpfulness < 3   → regenerate inline with critique prefix
    → all ≥ 3           → return as-is, clear revision counter
```

## Env vars

| Var | Default | Effect |
|-----|---------|--------|
| `MIRA_DISABLE_SELF_CRITIQUE` | `0` | Set to `1` to skip all critique calls |
| `MIRA_CRITIQUE_THRESHOLD` | `3` | Dims below this trigger revision |
| `MIRA_CRITIQUE_MAX_ATTEMPTS` | `2` | Cap on revision loops per session |

## Test plan

- [x] `ruff check` — clean
- [x] 67 offline tests pass
- [ ] e2e with live router (VPS down — blocked)
- [ ] Deploy — blocked on VPS

## Depends on

- ADR-0011 (#285) — documents the no-LangGraph decision this implements
- Can merge after #283 (v3.2.0) since this branches from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)