### PR TITLE
feat(ingest): ISA-95 path + data_type on knowledge_entries (closes #312)

### DIFF
--- a/mira-core/mira-ingest/db/conftest.py
+++ b/mira-core/mira-ingest/db/conftest.py
@@ -1,0 +1,10 @@
+"""Hyphenated parent dirs (mira-core, mira-ingest) can't be imported as
+Python packages. This conftest puts `mira-ingest/` on sys.path so test
+files can `from db import neon, data_types`.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/mira-core/mira-ingest/db/conftest.py
+++ b/mira-core/mira-ingest/db/conftest.py
@@ -2,6 +2,7 @@
 Python packages. This conftest puts `mira-ingest/` on sys.path so test
 files can `from db import neon, data_types`.
 """
+
 from __future__ import annotations
 
 import sys

--- a/mira-core/mira-ingest/db/data_types.py
+++ b/mira-core/mira-ingest/db/data_types.py
@@ -1,0 +1,35 @@
+"""Valid data_type values for knowledge_entries (vision doc Problem 1).
+
+Used by the ingest + recall paths to scope retrieval by the semantic
+type of knowledge (manual vs live telemetry vs fault event vs tribal
+knowledge captured from tech resolution, etc.).
+"""
+from __future__ import annotations
+
+MANUAL = "manual"
+TELEMETRY = "telemetry"
+FAULT_EVENT = "fault_event"
+TRIBAL_KNOWLEDGE = "tribal_knowledge"
+WORK_ORDER = "work_order"
+OEM_NOTE = "oem_note"
+PHOTO_DESCRIPTION = "photo_description"
+
+ALL: tuple[str, ...] = (
+    MANUAL,
+    TELEMETRY,
+    FAULT_EVENT,
+    TRIBAL_KNOWLEDGE,
+    WORK_ORDER,
+    OEM_NOTE,
+    PHOTO_DESCRIPTION,
+)
+
+
+def is_valid(value: str) -> bool:
+    return value in ALL
+
+
+def validate(value: str) -> str:
+    if not is_valid(value):
+        raise ValueError(f"invalid data_type: {value!r}; allowed: {ALL}")
+    return value

--- a/mira-core/mira-ingest/db/data_types.py
+++ b/mira-core/mira-ingest/db/data_types.py
@@ -4,6 +4,7 @@ Used by the ingest + recall paths to scope retrieval by the semantic
 type of knowledge (manual vs live telemetry vs fault event vs tribal
 knowledge captured from tech resolution, etc.).
 """
+
 from __future__ import annotations
 
 MANUAL = "manual"

--- a/mira-core/mira-ingest/db/neon.py
+++ b/mira-core/mira-ingest/db/neon.py
@@ -14,6 +14,8 @@ from typing import Any
 from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 
+from . import data_types as _data_types
+
 
 def _engine():
     url = os.environ.get("NEON_DATABASE_URL")
@@ -54,32 +56,51 @@ def get_tier_limits(tier: str) -> dict[str, Any] | None:
 
 
 def recall_knowledge(
-    embedding: list[float], tenant_id: str, limit: int = 5
+    embedding: list[float],
+    tenant_id: str,
+    limit: int = 5,
+    *,
+    isa95_prefix: str | None = None,
+    data_types: list[str] | None = None,
 ) -> list[dict[str, Any]]:
-    """pgvector cosine similarity search over knowledge_entries."""
+    """pgvector cosine similarity search over knowledge_entries.
+
+    Optional filters (vision doc Problem 1):
+      isa95_prefix — scope to an ISA-95 subtree (e.g. 'Plant/Line2/').
+      data_types   — one of data_types.ALL values; multiple OK.
+    """
+    clauses = ["tenant_id = :tid", "embedding IS NOT NULL"]
+    params: dict[str, Any] = {
+        "emb": str(embedding),
+        "tid": tenant_id,
+        "lim": limit,
+    }
+    if isa95_prefix is not None:
+        clauses.append("isa95_path LIKE :prefix || '%'")
+        params["prefix"] = isa95_prefix
+    if data_types:
+        clauses.append("data_type = ANY(:dtypes)")
+        params["dtypes"] = list(data_types)
+    where = " AND ".join(clauses)
+    sql = f"""
+        SELECT
+            content,
+            manufacturer,
+            model_number,
+            equipment_type,
+            source_type,
+            isa95_path,
+            equipment_id,
+            data_type,
+            metadata,
+            1 - (embedding <=> cast(:emb AS vector)) AS similarity
+        FROM knowledge_entries
+        WHERE {where}
+        ORDER BY embedding <=> cast(:emb AS vector)
+        LIMIT :lim
+    """
     with _engine().connect() as conn:
-        rows = (
-            conn.execute(
-                text("""
-                SELECT
-                    content,
-                    manufacturer,
-                    model_number,
-                    equipment_type,
-                    source_type,
-                    metadata,
-                    1 - (embedding <=> cast(:emb AS vector)) AS similarity
-                FROM knowledge_entries
-                WHERE tenant_id = :tid
-                  AND embedding IS NOT NULL
-                ORDER BY embedding <=> cast(:emb AS vector)
-                LIMIT :lim
-            """),
-                {"emb": str(embedding), "tid": tenant_id, "lim": limit},
-            )
-            .mappings()
-            .fetchall()
-        )
+        rows = conn.execute(text(sql), params).mappings().fetchall()
     return [dict(r) for r in rows]
 
 
@@ -129,6 +150,36 @@ def ensure_image_embedding_column() -> None:
 
         logging.getLogger("mira-ingest").warning(
             "image_embedding column migration failed (non-fatal): %s", exc
+        )
+
+
+def ensure_knowledge_hierarchy_columns() -> None:
+    """Additive migration: ISA-95 hierarchy columns (vision doc Problem 1).
+
+    Adds isa95_path, equipment_id, data_type to knowledge_entries and
+    creates btree indexes for (tenant_id, isa95_path) prefix scans and
+    (tenant_id, data_type) exact match. Idempotent.
+    """
+    statements = [
+        "ALTER TABLE knowledge_entries ADD COLUMN IF NOT EXISTS isa95_path TEXT",
+        "ALTER TABLE knowledge_entries ADD COLUMN IF NOT EXISTS equipment_id TEXT",
+        "ALTER TABLE knowledge_entries "
+        "ADD COLUMN IF NOT EXISTS data_type TEXT NOT NULL DEFAULT 'manual'",
+        "CREATE INDEX IF NOT EXISTS idx_knowledge_entries_isa95_path "
+        "ON knowledge_entries (tenant_id, isa95_path text_pattern_ops)",
+        "CREATE INDEX IF NOT EXISTS idx_knowledge_entries_data_type "
+        "ON knowledge_entries (tenant_id, data_type)",
+    ]
+    try:
+        with _engine().connect() as conn:
+            for stmt in statements:
+                conn.execute(text(stmt))
+            conn.commit()
+    except Exception as exc:
+        import logging
+
+        logging.getLogger("mira-ingest").warning(
+            "knowledge hierarchy migration failed (non-fatal): %s", exc
         )
 
 
@@ -303,8 +354,13 @@ def insert_knowledge_entry(
     section: str | None,
     source_type: str = "manual",
     chunk_type: str = "text",
+    *,
+    isa95_path: str | None = None,
+    equipment_id: str | None = None,
+    data_type: str = "manual",
 ) -> str:
     """Insert one chunk into knowledge_entries. Returns the new row id."""
+    _data_types.validate(data_type)
     entry_id = str(uuid.uuid4())
     meta = {
         "source_url": source_url,
@@ -319,11 +375,13 @@ def insert_knowledge_entry(
             INSERT INTO knowledge_entries
                 (id, tenant_id, source_type, manufacturer, model_number,
                  content, embedding, source_url, source_page, metadata,
-                 is_private, verified, chunk_type)
+                 is_private, verified, chunk_type,
+                 isa95_path, equipment_id, data_type)
             VALUES
                 (:id, :tenant_id, :source_type, :manufacturer, :model_number,
                  :content, cast(:embedding AS vector), :source_url, :source_page, cast(:metadata AS jsonb),
-                 false, false, :chunk_type)
+                 false, false, :chunk_type,
+                 :isa95_path, :equipment_id, :data_type)
         """),
             {
                 "id": entry_id,
@@ -337,6 +395,9 @@ def insert_knowledge_entry(
                 "source_page": chunk_index,
                 "metadata": json.dumps(meta),
                 "chunk_type": chunk_type,
+                "isa95_path": isa95_path,
+                "equipment_id": equipment_id,
+                "data_type": data_type,
             },
         )
         conn.commit()
@@ -350,27 +411,44 @@ def insert_knowledge_entries_batch(entries: list[dict]) -> int:
     model_number, content, embedding, source_url, source_page, metadata,
     chunk_type.
 
+    Optional per-entry keys (vision doc Problem 1): isa95_path, equipment_id,
+    data_type (defaults to 'manual'). data_type is validated per entry.
+
     Returns count of rows inserted.
     """
     if not entries:
         return 0
+    prepared: list[dict] = []
+    for e in entries:
+        dt = e.get("data_type", "manual")
+        _data_types.validate(dt)
+        prepared.append(
+            {
+                **e,
+                "isa95_path": e.get("isa95_path"),
+                "equipment_id": e.get("equipment_id"),
+                "data_type": dt,
+            }
+        )
     with _engine().connect() as conn:
-        for entry in entries:
+        for entry in prepared:
             conn.execute(
                 text("""
                 INSERT INTO knowledge_entries
                     (id, tenant_id, source_type, manufacturer, model_number,
                      content, embedding, source_url, source_page, metadata,
-                     is_private, verified, chunk_type)
+                     is_private, verified, chunk_type,
+                     isa95_path, equipment_id, data_type)
                 VALUES
                     (:id, :tenant_id, :source_type, :manufacturer, :model_number,
                      :content, cast(:embedding AS vector), :source_url, :source_page,
-                     cast(:metadata AS jsonb), false, false, :chunk_type)
+                     cast(:metadata AS jsonb), false, false, :chunk_type,
+                     :isa95_path, :equipment_id, :data_type)
             """),
                 entry,
             )
         conn.commit()
-    return len(entries)
+    return len(prepared)
 
 
 def mark_source_fingerprint_done(row_id: int, atoms_created: int) -> None:

--- a/mira-core/mira-ingest/db/test_knowledge_entries.py
+++ b/mira-core/mira-ingest/db/test_knowledge_entries.py
@@ -1,0 +1,280 @@
+"""Tests for ISA-95 + data_type extensions on knowledge_entries (issue #312)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from db import data_types
+from db import neon
+
+
+# ---------------------------------------------------------------------------
+# data_types module
+# ---------------------------------------------------------------------------
+
+
+def test_data_types_validate_accepts_known():
+    for value in data_types.ALL:
+        assert data_types.validate(value) == value
+
+
+def test_data_types_validate_rejects_unknown():
+    with pytest.raises(ValueError):
+        data_types.validate("bogus")
+
+
+def test_data_types_is_valid():
+    assert data_types.is_valid(data_types.MANUAL)
+    assert not data_types.is_valid("bogus")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_conn() -> MagicMock:
+    """Build a MagicMock mimicking the sqlalchemy connection surface neon.py uses."""
+    conn = MagicMock()
+    result = MagicMock()
+    result.mappings.return_value.fetchall.return_value = []
+    conn.execute.return_value = result
+    return conn
+
+
+def _install_engine_mock(engine_patch: MagicMock) -> MagicMock:
+    """Wire the _engine() patch target so `with _engine().connect() as conn:` yields our mock."""
+    conn = _make_conn()
+    engine = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = conn
+    cm.__exit__.return_value = False
+    engine.connect.return_value = cm
+    engine_patch.return_value = engine
+    return conn
+
+
+def _sql_and_params(conn: MagicMock) -> tuple[str, dict]:
+    """Extract (sql_text, params_dict) from the last execute() call."""
+    args = conn.execute.call_args
+    sql_arg = args[0][0]
+    sql_text = str(sql_arg) if not isinstance(sql_arg, str) else sql_arg
+    params = args[0][1] if len(args[0]) > 1 else {}
+    return sql_text, params
+
+
+# ---------------------------------------------------------------------------
+# ensure_knowledge_hierarchy_columns
+# ---------------------------------------------------------------------------
+
+
+@patch.object(neon, "_engine")
+def test_ensure_migration_runs_five_statements(engine_patch):
+    conn = _install_engine_mock(engine_patch)
+    neon.ensure_knowledge_hierarchy_columns()
+    assert conn.execute.call_count == 5
+    assert conn.commit.call_count == 1
+
+
+@patch.object(neon, "_engine")
+def test_ensure_migration_swallows_errors(engine_patch):
+    engine_patch.side_effect = RuntimeError("connection refused")
+    # Must not raise — migration failures are non-fatal by design.
+    neon.ensure_knowledge_hierarchy_columns()
+
+
+# ---------------------------------------------------------------------------
+# insert_knowledge_entry
+# ---------------------------------------------------------------------------
+
+
+@patch.object(neon, "_engine")
+def test_insert_includes_new_columns_in_sql_and_params(engine_patch):
+    conn = _install_engine_mock(engine_patch)
+    neon.insert_knowledge_entry(
+        tenant_id="t1",
+        content="c",
+        embedding=[0.1, 0.2],
+        manufacturer="Pilz",
+        model_number="PNOZ X3",
+        source_url="s",
+        chunk_index=0,
+        page_num=1,
+        section=None,
+        isa95_path="AcmePlant/Line2/Oven1",
+        equipment_id="Oven1",
+        data_type=data_types.FAULT_EVENT,
+    )
+    sql_text, params = _sql_and_params(conn)
+    assert "isa95_path" in sql_text
+    assert "equipment_id" in sql_text
+    assert "data_type" in sql_text
+    assert params["isa95_path"] == "AcmePlant/Line2/Oven1"
+    assert params["equipment_id"] == "Oven1"
+    assert params["data_type"] == data_types.FAULT_EVENT
+
+
+@patch.object(neon, "_engine")
+def test_insert_defaults_data_type_to_manual(engine_patch):
+    conn = _install_engine_mock(engine_patch)
+    neon.insert_knowledge_entry(
+        tenant_id="t1",
+        content="c",
+        embedding=[0.1],
+        manufacturer=None,
+        model_number=None,
+        source_url="s",
+        chunk_index=0,
+        page_num=None,
+        section=None,
+    )
+    _, params = _sql_and_params(conn)
+    assert params["data_type"] == "manual"
+    assert params["isa95_path"] is None
+    assert params["equipment_id"] is None
+
+
+@patch.object(neon, "_engine")
+def test_insert_rejects_invalid_data_type(engine_patch):
+    _install_engine_mock(engine_patch)
+    with pytest.raises(ValueError):
+        neon.insert_knowledge_entry(
+            tenant_id="t1",
+            content="c",
+            embedding=[0.1],
+            manufacturer=None,
+            model_number=None,
+            source_url="s",
+            chunk_index=0,
+            page_num=None,
+            section=None,
+            data_type="bogus",
+        )
+
+
+# ---------------------------------------------------------------------------
+# insert_knowledge_entries_batch
+# ---------------------------------------------------------------------------
+
+
+@patch.object(neon, "_engine")
+def test_batch_insert_validates_each_data_type(engine_patch):
+    _install_engine_mock(engine_patch)
+    with pytest.raises(ValueError):
+        neon.insert_knowledge_entries_batch(
+            [
+                {
+                    "id": "x",
+                    "tenant_id": "t1",
+                    "source_type": "manual",
+                    "manufacturer": None,
+                    "model_number": None,
+                    "content": "c",
+                    "embedding": "[0.1]",
+                    "source_url": "s",
+                    "source_page": 0,
+                    "metadata": "{}",
+                    "chunk_type": "text",
+                    "data_type": "bogus",
+                }
+            ]
+        )
+
+
+@patch.object(neon, "_engine")
+def test_batch_insert_defaults_missing_optionals(engine_patch):
+    conn = _install_engine_mock(engine_patch)
+    count = neon.insert_knowledge_entries_batch(
+        [
+            {
+                "id": "x",
+                "tenant_id": "t1",
+                "source_type": "manual",
+                "manufacturer": None,
+                "model_number": None,
+                "content": "c",
+                "embedding": "[0.1]",
+                "source_url": "s",
+                "source_page": 0,
+                "metadata": "{}",
+                "chunk_type": "text",
+            }
+        ]
+    )
+    assert count == 1
+    _, params = _sql_and_params(conn)
+    assert params["data_type"] == "manual"
+    assert params["isa95_path"] is None
+    assert params["equipment_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# recall_knowledge
+# ---------------------------------------------------------------------------
+
+
+@patch.object(neon, "_engine")
+def test_recall_no_filters_uses_base_where(engine_patch):
+    conn = _install_engine_mock(engine_patch)
+    neon.recall_knowledge([0.1, 0.2], "t1", limit=5)
+    sql_text, params = _sql_and_params(conn)
+    assert "LIKE" not in sql_text
+    assert "ANY" not in sql_text
+    assert "prefix" not in params
+    assert "dtypes" not in params
+    assert params["tid"] == "t1"
+    assert params["lim"] == 5
+
+
+@patch.object(neon, "_engine")
+def test_recall_with_isa95_prefix_adds_like_clause(engine_patch):
+    conn = _install_engine_mock(engine_patch)
+    neon.recall_knowledge(
+        [0.1], "t1", isa95_prefix="AcmePlant/Line2/"
+    )
+    sql_text, params = _sql_and_params(conn)
+    assert "isa95_path LIKE" in sql_text
+    assert params["prefix"] == "AcmePlant/Line2/"
+
+
+@patch.object(neon, "_engine")
+def test_recall_with_data_types_adds_any_clause(engine_patch):
+    conn = _install_engine_mock(engine_patch)
+    neon.recall_knowledge(
+        [0.1],
+        "t1",
+        data_types=[data_types.FAULT_EVENT, data_types.TRIBAL_KNOWLEDGE],
+    )
+    sql_text, params = _sql_and_params(conn)
+    assert "data_type = ANY" in sql_text
+    assert params["dtypes"] == [
+        data_types.FAULT_EVENT,
+        data_types.TRIBAL_KNOWLEDGE,
+    ]
+
+
+@patch.object(neon, "_engine")
+def test_recall_with_both_filters(engine_patch):
+    conn = _install_engine_mock(engine_patch)
+    neon.recall_knowledge(
+        [0.1],
+        "t1",
+        isa95_prefix="Plant/",
+        data_types=[data_types.TELEMETRY],
+    )
+    sql_text, params = _sql_and_params(conn)
+    assert "isa95_path LIKE" in sql_text
+    assert "data_type = ANY" in sql_text
+    assert params["prefix"] == "Plant/"
+    assert params["dtypes"] == [data_types.TELEMETRY]
+
+
+@patch.object(neon, "_engine")
+def test_recall_select_exposes_new_columns(engine_patch):
+    conn = _install_engine_mock(engine_patch)
+    neon.recall_knowledge([0.1], "t1")
+    sql_text, _ = _sql_and_params(conn)
+    assert "isa95_path" in sql_text
+    assert "equipment_id" in sql_text
+    assert "data_type" in sql_text

--- a/mira-core/mira-ingest/db/test_knowledge_entries.py
+++ b/mira-core/mira-ingest/db/test_knowledge_entries.py
@@ -5,9 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from db import data_types
-from db import neon
-
+from db import data_types, neon
 
 # ---------------------------------------------------------------------------
 # data_types module

--- a/mira-core/mira-ingest/db/test_knowledge_entries.py
+++ b/mira-core/mira-ingest/db/test_knowledge_entries.py
@@ -1,4 +1,5 @@
 """Tests for ISA-95 + data_type extensions on knowledge_entries (issue #312)."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
@@ -228,9 +229,7 @@ def test_recall_no_filters_uses_base_where(engine_patch):
 @patch.object(neon, "_engine")
 def test_recall_with_isa95_prefix_adds_like_clause(engine_patch):
     conn = _install_engine_mock(engine_patch)
-    neon.recall_knowledge(
-        [0.1], "t1", isa95_prefix="AcmePlant/Line2/"
-    )
+    neon.recall_knowledge([0.1], "t1", isa95_prefix="AcmePlant/Line2/")
     sql_text, params = _sql_and_params(conn)
     assert "isa95_path LIKE" in sql_text
     assert params["prefix"] == "AcmePlant/Line2/"

--- a/mira-core/mira-ingest/tests/test_structured_vision.py
+++ b/mira-core/mira-ingest/tests/test_structured_vision.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 # Add mira-ingest to path so we can import main's helpers without running the app
 INGEST_ROOT = Path(__file__).parent.parent
 if str(INGEST_ROOT) not in sys.path:


### PR DESCRIPTION
Closes #312. MVP vision Problem 1.

Adds `isa95_path`, `equipment_id`, `data_type` columns to `knowledge_entries` via idempotent `ensure_knowledge_hierarchy_columns()` migration (btree on (tenant_id, isa95_path text_pattern_ops); btree on (tenant_id, data_type)).

`insert_knowledge_entry` + `insert_knowledge_entries_batch` accept the new fields as kwargs (default `data_type='manual'`). `recall_knowledge` gains optional `isa95_prefix` and `data_types` filters that add `LIKE prefix||'%'` and `= ANY(array)` clauses to the WHERE.

Backward compatible — existing 2-arg callers unchanged. 15/15 pytest passing.

Enables: Problem 2 (tribal_knowledge auto-capture), Problem 5 (quality metadata), Problem 9 (trusted-delegation citations).

🤖 Generated with Claude Code