### PR TITLE
feat(sm_profiles): SM Profile schema + loader + 3 seed profiles (closes #313)

### DIFF
--- a/mira-core/mira-ingest/tests/test_structured_vision.py
+++ b/mira-core/mira-ingest/tests/test_structured_vision.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 # Add mira-ingest to path so we can import main's helpers without running the app
 INGEST_ROOT = Path(__file__).parent.parent
 if str(INGEST_ROOT) not in sys.path:

--- a/mira-core/sm_profiles/__init__.py
+++ b/mira-core/sm_profiles/__init__.py
@@ -1,0 +1,19 @@
+"""SM Profile module — typed equipment nodes (vision doc Problem 4)."""
+from .profile_loader import (
+    list_profiles,
+    load_all_profiles,
+    load_profile,
+    profiles_dir,
+)
+from .schema import EdgeType, SmProfile, SmProperty, SmRelationship
+
+__all__ = [
+    "EdgeType",
+    "SmProfile",
+    "SmProperty",
+    "SmRelationship",
+    "list_profiles",
+    "load_all_profiles",
+    "load_profile",
+    "profiles_dir",
+]

--- a/mira-core/sm_profiles/cli.py
+++ b/mira-core/sm_profiles/cli.py
@@ -1,0 +1,51 @@
+"""CLI for SM Profile inspection.
+
+Usage:
+    python mira-core/sm_profiles/cli.py list
+    python mira-core/sm_profiles/cli.py show <name>
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow direct script invocation without the parent (hyphenated dir) on sys.path.
+if __package__ in (None, ""):
+    _ROOT = Path(__file__).resolve().parent
+    sys.path.insert(0, str(_ROOT.parent))
+    from sm_profiles.profile_loader import list_profiles, load_profile  # type: ignore
+else:
+    from .profile_loader import list_profiles, load_profile
+
+
+def _cmd_list() -> int:
+    for name in list_profiles():
+        print(name)
+    return 0
+
+
+def _cmd_show(name: str) -> int:
+    try:
+        profile = load_profile(name)
+    except FileNotFoundError as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+    print(profile.model_dump_json(indent=2))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    if not args:
+        sys.stderr.write("usage: cli.py list | show <name>\n")
+        return 2
+    if args[0] == "list":
+        return _cmd_list()
+    if args[0] == "show" and len(args) == 2:
+        return _cmd_show(args[1])
+    sys.stderr.write(f"unknown command: {' '.join(args)}\n")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/mira-core/sm_profiles/profile_loader.py
+++ b/mira-core/sm_profiles/profile_loader.py
@@ -1,0 +1,29 @@
+"""SM Profile loader — reads + validates JSON files from profiles/."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .schema import SmProfile
+
+_PROFILE_DIR = Path(__file__).resolve().parent / "profiles"
+
+
+def profiles_dir() -> Path:
+    return _PROFILE_DIR
+
+
+def list_profiles() -> list[str]:
+    return sorted(p.stem for p in _PROFILE_DIR.glob("*.json"))
+
+
+def load_profile(name: str) -> SmProfile:
+    path = _PROFILE_DIR / f"{name}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"SM Profile not found: {name}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return SmProfile(**data)
+
+
+def load_all_profiles() -> dict[str, SmProfile]:
+    return {name: load_profile(name) for name in list_profiles()}

--- a/mira-core/sm_profiles/profiles/centrifugal_pump_v1.json
+++ b/mira-core/sm_profiles/profiles/centrifugal_pump_v1.json
@@ -1,0 +1,16 @@
+{
+  "type": "CentrifugalPump",
+  "version": "1.0.0",
+  "description": "Centrifugal pump moving process fluid between tanks.",
+  "properties": [
+    {"name": "dischargePressure", "engineeringUnit": "psi", "normalRangeMin": 40.0, "normalRangeMax": 85.0, "alarmHigh": 100.0, "alarmLow": 20.0, "description": "Pump discharge pressure."},
+    {"name": "flowRate", "engineeringUnit": "gpm", "normalRangeMin": 50.0, "normalRangeMax": 300.0, "alarmHigh": 350.0, "alarmLow": 10.0, "description": "Volumetric flow rate."},
+    {"name": "motorCurrent", "engineeringUnit": "A", "normalRangeMin": 8.0, "normalRangeMax": 40.0, "alarmHigh": 48.0, "alarmLow": 1.0, "description": "Pump motor current."},
+    {"name": "suctionPressure", "engineeringUnit": "psi", "normalRangeMin": 10.0, "normalRangeMax": 40.0, "alarmHigh": 50.0, "alarmLow": 2.0, "description": "Pump suction pressure."}
+  ],
+  "relationships": [
+    {"edge": "partOf", "targetType": "PumpSkid"},
+    {"edge": "feedsInto", "targetType": "ProcessTank"},
+    {"edge": "monitoredBy", "targetType": "VibrationSensor"}
+  ]
+}

--- a/mira-core/sm_profiles/profiles/conveyor_drive_v1.json
+++ b/mira-core/sm_profiles/profiles/conveyor_drive_v1.json
@@ -1,0 +1,16 @@
+{
+  "type": "ConveyorDrive",
+  "version": "1.0.0",
+  "description": "Variable-frequency drive controlling a conveyor motor.",
+  "properties": [
+    {"name": "outputFrequency", "engineeringUnit": "Hz", "normalRangeMin": 45.0, "normalRangeMax": 65.0, "alarmHigh": 70.0, "alarmLow": 40.0, "description": "Drive output frequency."},
+    {"name": "motorCurrent", "engineeringUnit": "A", "normalRangeMin": 2.0, "normalRangeMax": 15.0, "alarmHigh": 18.0, "alarmLow": 0.5, "description": "Motor current draw."},
+    {"name": "dcBusVoltage", "engineeringUnit": "V", "normalRangeMin": 580.0, "normalRangeMax": 700.0, "alarmHigh": 810.0, "alarmLow": 420.0, "description": "DC bus voltage."},
+    {"name": "heatsinkTemp", "engineeringUnit": "degC", "normalRangeMin": 30.0, "normalRangeMax": 70.0, "alarmHigh": 85.0, "alarmLow": 0.0, "description": "IGBT heatsink temperature."}
+  ],
+  "relationships": [
+    {"edge": "partOf", "targetType": "ConveyorLine"},
+    {"edge": "monitoredBy", "targetType": "VibrationSensor"},
+    {"edge": "feedsInto", "targetType": "Motor"}
+  ]
+}

--- a/mira-core/sm_profiles/profiles/zone_heater_v1.json
+++ b/mira-core/sm_profiles/profiles/zone_heater_v1.json
@@ -1,0 +1,15 @@
+{
+  "type": "ZoneHeater",
+  "version": "1.0.0",
+  "description": "Electrically-heated zone in an industrial oven.",
+  "properties": [
+    {"name": "zoneTemperature", "engineeringUnit": "degF", "normalRangeMin": 350.0, "normalRangeMax": 425.0, "alarmHigh": 450.0, "alarmLow": 300.0, "description": "Measured zone temperature."},
+    {"name": "setpoint", "engineeringUnit": "degF", "normalRangeMin": 350.0, "normalRangeMax": 425.0, "alarmHigh": 425.0, "alarmLow": 300.0, "description": "Operator-commanded temperature setpoint."},
+    {"name": "heaterOutputPct", "engineeringUnit": "percent", "normalRangeMin": 0.0, "normalRangeMax": 100.0, "alarmHigh": 100.0, "alarmLow": 0.0, "description": "Heater element duty cycle."}
+  ],
+  "relationships": [
+    {"edge": "partOf", "targetType": "Oven"},
+    {"edge": "adjacentTo", "targetType": "ZoneHeater"},
+    {"edge": "monitoredBy", "targetType": "Thermocouple"}
+  ]
+}

--- a/mira-core/sm_profiles/schema.py
+++ b/mira-core/sm_profiles/schema.py
@@ -1,0 +1,55 @@
+"""SM Profile schema — typed equipment nodes (vision doc Problem 4).
+
+An SM Profile is a versioned JSON document describing a class of
+industrial equipment: its measurable properties (with units + ranges +
+alarm thresholds) and its valid relationships to other equipment.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+EdgeType = Literal["partOf", "adjacentTo", "monitoredBy", "feedsInto"]
+
+
+class SmProperty(BaseModel):
+    name: str = Field(min_length=1)
+    engineeringUnit: str = Field(min_length=1)
+    normalRangeMin: float
+    normalRangeMax: float
+    alarmHigh: float
+    alarmLow: float
+    description: str = ""
+
+    @model_validator(mode="after")
+    def _check_ranges(self) -> "SmProperty":
+        if self.normalRangeMin >= self.normalRangeMax:
+            raise ValueError(
+                f"{self.name}: normalRangeMin ({self.normalRangeMin}) must be "
+                f"< normalRangeMax ({self.normalRangeMax})"
+            )
+        if self.alarmLow > self.normalRangeMin:
+            raise ValueError(
+                f"{self.name}: alarmLow ({self.alarmLow}) must be "
+                f"<= normalRangeMin ({self.normalRangeMin})"
+            )
+        if self.alarmHigh < self.normalRangeMax:
+            raise ValueError(
+                f"{self.name}: alarmHigh ({self.alarmHigh}) must be "
+                f">= normalRangeMax ({self.normalRangeMax})"
+            )
+        return self
+
+
+class SmRelationship(BaseModel):
+    edge: EdgeType
+    targetType: str = Field(min_length=1)
+
+
+class SmProfile(BaseModel):
+    type: str = Field(min_length=1)
+    version: str = Field(pattern=r"^\d+\.\d+\.\d+$")
+    description: str = ""
+    properties: list[SmProperty] = Field(min_length=1)
+    relationships: list[SmRelationship] = []

--- a/mira-core/sm_profiles/test_profiles.py
+++ b/mira-core/sm_profiles/test_profiles.py
@@ -1,0 +1,108 @@
+"""Tests for SM Profile schema, loader, and CLI."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Hyphenated parent dir (mira-core) isn't a valid package. Inject parent.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest  # noqa: E402
+from pydantic import ValidationError  # noqa: E402
+
+from sm_profiles import cli as profiles_cli  # noqa: E402
+from sm_profiles.profile_loader import list_profiles, load_profile  # noqa: E402
+from sm_profiles.schema import SmProfile, SmProperty, SmRelationship  # noqa: E402
+
+
+SEED_NAMES = ("conveyor_drive_v1", "zone_heater_v1", "centrifugal_pump_v1")
+
+
+def test_list_profiles_returns_three_seeds():
+    names = list_profiles()
+    for seed in SEED_NAMES:
+        assert seed in names
+
+
+@pytest.mark.parametrize("name", SEED_NAMES)
+def test_load_each_seed_profile_validates(name: str):
+    profile = load_profile(name)
+    assert profile.type
+    assert profile.version.count(".") == 2
+    assert len(profile.properties) >= 1
+
+
+def test_load_missing_profile_raises_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        load_profile("not_a_real_profile")
+
+
+def test_property_rejects_inverted_normal_range():
+    with pytest.raises(ValidationError):
+        SmProperty(
+            name="x", engineeringUnit="u",
+            normalRangeMin=10.0, normalRangeMax=5.0,
+            alarmHigh=20.0, alarmLow=1.0,
+        )
+
+
+def test_property_rejects_alarm_low_above_normal_min():
+    with pytest.raises(ValidationError):
+        SmProperty(
+            name="x", engineeringUnit="u",
+            normalRangeMin=10.0, normalRangeMax=20.0,
+            alarmHigh=30.0, alarmLow=12.0,
+        )
+
+
+def test_property_rejects_alarm_high_below_normal_max():
+    with pytest.raises(ValidationError):
+        SmProperty(
+            name="x", engineeringUnit="u",
+            normalRangeMin=10.0, normalRangeMax=20.0,
+            alarmHigh=15.0, alarmLow=5.0,
+        )
+
+
+def test_relationship_rejects_unknown_edge():
+    with pytest.raises(ValidationError):
+        SmRelationship(edge="childOf", targetType="Machine")  # type: ignore[arg-type]
+
+
+def test_profile_rejects_empty_properties_list():
+    with pytest.raises(ValidationError):
+        SmProfile(type="T", version="1.0.0", properties=[], relationships=[])
+
+
+def test_profile_rejects_invalid_version():
+    prop = dict(
+        name="x", engineeringUnit="u",
+        normalRangeMin=0.0, normalRangeMax=1.0,
+        alarmHigh=1.0, alarmLow=0.0,
+    )
+    with pytest.raises(ValidationError):
+        SmProfile(type="T", version="1.0", properties=[prop])  # missing patch
+
+
+def test_cli_list_prints_three_names(capsys):
+    rc = profiles_cli.main(["list"])
+    out = capsys.readouterr().out.strip().splitlines()
+    assert rc == 0
+    assert set(SEED_NAMES).issubset(set(out))
+
+
+def test_cli_show_missing_returns_code_2(capsys):
+    rc = profiles_cli.main(["show", "not_a_profile"])
+    assert rc == 2
+
+
+def test_cli_show_valid_prints_json(capsys):
+    rc = profiles_cli.main(["show", "conveyor_drive_v1"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert '"type"' in out
+    assert "ConveyorDrive" in out
+
+
+def test_cli_no_args_returns_2():
+    assert profiles_cli.main([]) == 2


### PR DESCRIPTION
Closes #313. MVP vision Problem 4 + 10.

New `mira-core/sm_profiles/` module with pydantic schema (SmProfile, SmProperty, SmRelationship), profile_loader (list_profiles / load_profile), CLI (`python mira-core/sm_profiles/cli.py list|show <name>`), and three seed JSON profiles: ConveyorDrive, ZoneHeater, CentrifugalPump.

Each property carries `engineeringUnit` + `normalRangeMin/Max` + `alarmHigh/Low`. Typed relationship edges restricted to `partOf` / `adjacentTo` / `monitoredBy` / `feedsInto`.

Validation rules enforced at load time: `normalMin < normalMax`, `alarmLow <= normalMin`, `alarmHigh >= normalMax`. 15/15 pytest passing.

Enables: Problem 5 (quality metadata now has a home), Problem 7 (tag mapping targets these types), Problem 12 (vendor-neutral template library starts here).

🤖 Generated with Claude Code