### PR TITLE
feat(mira-bots): FewShotTrainer — confidence boosting from tech confirmations (closes #314)

### DIFF
--- a/mira-bots/shared/few_shot_trainer.py
+++ b/mira-bots/shared/few_shot_trainer.py
@@ -29,6 +29,7 @@ Formula: boost = 1.0 + min(log1p(good_count) * 0.5, 2.0)
   20 -> ~2.522
   1k -> 3.000 (capped)
 """
+
 from __future__ import annotations
 
 import logging
@@ -83,7 +84,10 @@ class FewShotTrainer:
         self._cache[key] = (boost, now)
         logger.info(
             "few-shot lookup vendor=%s intent=%s good=%d boost=%.3f",
-            key[0], key[1], count, boost,
+            key[0],
+            key[1],
+            count,
+            boost,
         )
         return boost
 
@@ -175,6 +179,7 @@ class FewShotTrainer:
 
 def _cli() -> int:
     import argparse
+
     parser = argparse.ArgumentParser(description="FewShotTrainer inspection")
     parser.add_argument("--vendor", required=True)
     parser.add_argument("--intent", required=True)
@@ -184,9 +189,7 @@ def _cli() -> int:
     logging.basicConfig(level=logging.WARNING)
     trainer = FewShotTrainer(db_path=args.db_path)
     boost = trainer.confidence_boost(args.vendor, args.intent)
-    print(
-        f"vendor={args.vendor} intent={args.intent} boost={boost:.3f}"
-    )
+    print(f"vendor={args.vendor} intent={args.intent} boost={boost:.3f}")
     return 0
 
 

--- a/mira-bots/shared/few_shot_trainer.py
+++ b/mira-bots/shared/few_shot_trainer.py
@@ -1,0 +1,194 @@
+"""FewShotTrainer — confidence boosting from tech /good confirmations.
+
+Reads historical /good feedback counts per (vendor, intent) from the
+mira.db SQLite store (WAL). Returns a multiplier intended to scale
+base confidence scores at run-time so the system compounds with every
+confirmation rather than plateauing.
+
+Vision doc Problem 6.
+
+Schema (confirmed 2026-04-15):
+
+  feedback_log(chat_id, feedback, reason, last_reply, exchange_count, created_at)
+      feedback is 'good' | 'bad' (set by Supervisor.log_feedback).
+  interactions(chat_id, platform, user_message, bot_response, fsm_state, intent, ...)
+      intent is the ('industrial' | 'safety' | 'greeting' | ...) label
+      produced by guardrails.classify_intent() at the time of the turn.
+  conversation_state(chat_id, state, context, asset_identified, ...)
+      asset_identified is typically "Manufacturer, Model" — we take
+      the substring before the comma as the vendor.
+
+Vendor + intent buckets are joined three-way on chat_id. A /good
+feedback row contributes to the bucket (vendor, intent) if BOTH the
+intent (from any interaction on that chat) AND the vendor (from
+conversation_state.asset_identified) resolve.
+
+Formula: boost = 1.0 + min(log1p(good_count) * 0.5, 2.0)
+  0 confirmations   -> 1.000
+  1  -> 1.347
+  20 -> ~2.522
+  1k -> 3.000 (capped)
+"""
+from __future__ import annotations
+
+import logging
+import math
+import os
+import sqlite3
+import time
+from pathlib import Path
+
+logger = logging.getLogger("mira-few-shot")
+
+_CAP = 3.0
+_COEF = 0.5
+_MAX_BOOST_DELTA = 2.0  # 1.0 + 2.0 = 3.0 cap
+
+
+def _resolve_db_path(explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    return os.environ.get("MIRA_DB_PATH", "./mira.db")
+
+
+def _boost_from_count(count: int) -> float:
+    if count <= 0:
+        return 1.0
+    delta = min(math.log1p(count) * _COEF, _MAX_BOOST_DELTA)
+    return round(1.0 + delta, 6)
+
+
+class FewShotTrainer:
+    """In-memory cached reader for historical /good confirmation counts."""
+
+    def __init__(self, db_path: str | None = None, cache_ttl_s: int = 3600):
+        self.db_path = _resolve_db_path(db_path)
+        self.cache_ttl_s = cache_ttl_s
+        self._cache: dict[tuple[str, str], tuple[float, float]] = {}
+        self._missing_logged = False
+
+    def confidence_boost(self, vendor: str, intent: str) -> float:
+        """Return a multiplier in [1.0, 3.0] for (vendor, intent).
+
+        Normalizes both keys to lowercase. Falls back to 1.0 on any DB
+        error, missing file, or missing table (fail-open).
+        """
+        key = (vendor.lower().strip(), intent.lower().strip())
+        now = time.time()
+        cached = self._cache.get(key)
+        if cached is not None and (now - cached[1]) < self.cache_ttl_s:
+            return cached[0]
+        count = self._count_good(key[0], key[1])
+        boost = _boost_from_count(count)
+        self._cache[key] = (boost, now)
+        logger.info(
+            "few-shot lookup vendor=%s intent=%s good=%d boost=%.3f",
+            key[0], key[1], count, boost,
+        )
+        return boost
+
+    def refresh(self) -> None:
+        """Clear the in-memory cache; next lookup re-queries SQLite."""
+        self._cache.clear()
+
+    def stats(self) -> dict[str, object]:
+        good = bad = 0
+        try:
+            with sqlite3.connect(self.db_path) as db:
+                db.execute("PRAGMA journal_mode=WAL")
+                good = db.execute(
+                    "SELECT COUNT(*) FROM feedback_log WHERE feedback = 'good'"
+                ).fetchone()[0]
+                bad = db.execute(
+                    "SELECT COUNT(*) FROM feedback_log WHERE feedback = 'bad'"
+                ).fetchone()[0]
+        except sqlite3.Error:
+            pass
+        return {
+            "db_path": self.db_path,
+            "good_count": int(good or 0),
+            "bad_count": int(bad or 0),
+            "cache_size": len(self._cache),
+            "cache_ttl_s": self.cache_ttl_s,
+        }
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _count_good(self, vendor_lc: str, intent_lc: str) -> int:
+        """Count distinct /good feedback rows whose chat has BOTH a matching
+        intent (in interactions) and a matching vendor (prefix of
+        conversation_state.asset_identified, case-insensitive)."""
+        if not Path(self.db_path).exists():
+            if not self._missing_logged:
+                logger.warning(
+                    "few-shot DB path missing: %s — boost defaults to 1.0",
+                    self.db_path,
+                )
+                self._missing_logged = True
+            return 0
+        try:
+            with sqlite3.connect(self.db_path) as db:
+                db.execute("PRAGMA journal_mode=WAL")
+                row = db.execute(
+                    """
+                    SELECT COUNT(DISTINCT f.id)
+                      FROM feedback_log f
+                     WHERE f.feedback = 'good'
+                       AND EXISTS (
+                           SELECT 1 FROM interactions i
+                            WHERE i.chat_id = f.chat_id
+                              AND LOWER(IFNULL(i.intent, '')) = ?
+                       )
+                       AND EXISTS (
+                           SELECT 1 FROM conversation_state cs
+                            WHERE cs.chat_id = f.chat_id
+                              AND LOWER(
+                                  IFNULL(
+                                      SUBSTR(
+                                          cs.asset_identified,
+                                          1,
+                                          CASE
+                                              WHEN INSTR(cs.asset_identified, ',') > 0
+                                              THEN INSTR(cs.asset_identified, ',') - 1
+                                              ELSE LENGTH(cs.asset_identified)
+                                          END
+                                      ),
+                                      ''
+                                  )
+                              ) = ?
+                       )
+                    """,
+                    (intent_lc, vendor_lc),
+                ).fetchone()
+                return int(row[0] or 0)
+        except sqlite3.Error as exc:
+            logger.warning("few-shot DB query failed (fail-open): %s", exc)
+            return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _cli() -> int:
+    import argparse
+    parser = argparse.ArgumentParser(description="FewShotTrainer inspection")
+    parser.add_argument("--vendor", required=True)
+    parser.add_argument("--intent", required=True)
+    parser.add_argument("--db-path", default=None)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.WARNING)
+    trainer = FewShotTrainer(db_path=args.db_path)
+    boost = trainer.confidence_boost(args.vendor, args.intent)
+    print(
+        f"vendor={args.vendor} intent={args.intent} boost={boost:.3f}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/mira-bots/shared/test_few_shot_trainer.py
+++ b/mira-bots/shared/test_few_shot_trainer.py
@@ -1,0 +1,249 @@
+"""Tests for FewShotTrainer (issue #314)."""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+# Hyphenated parent dir (mira-bots) — inject so `from shared import ...` works.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest  # noqa: E402
+
+from shared.few_shot_trainer import FewShotTrainer, _boost_from_count  # noqa: E402
+
+
+def _init_schema(db_path: Path) -> None:
+    with sqlite3.connect(db_path) as db:
+        db.execute("PRAGMA journal_mode=WAL")
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS feedback_log (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                chat_id         TEXT NOT NULL,
+                feedback        TEXT NOT NULL,
+                reason          TEXT,
+                last_reply      TEXT,
+                exchange_count  INTEGER,
+                created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS interactions (
+                id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                chat_id          TEXT NOT NULL,
+                platform         TEXT NOT NULL DEFAULT 'telegram',
+                user_message     TEXT NOT NULL,
+                bot_response     TEXT NOT NULL,
+                fsm_state        TEXT,
+                intent           TEXT
+            )
+            """
+        )
+        db.execute(
+            """
+            CREATE TABLE IF NOT EXISTS conversation_state (
+                chat_id          TEXT PRIMARY KEY,
+                state            TEXT NOT NULL DEFAULT 'IDLE',
+                asset_identified TEXT
+            )
+            """
+        )
+
+
+def _seed_chat(
+    db_path: Path,
+    chat_id: str,
+    *,
+    vendor: str,
+    intent: str,
+    good_count: int,
+    bad_count: int = 0,
+) -> None:
+    with sqlite3.connect(db_path) as db:
+        db.execute(
+            "INSERT OR REPLACE INTO conversation_state (chat_id, state, asset_identified) VALUES (?, 'IDLE', ?)",
+            (chat_id, f"{vendor}, Model-X"),
+        )
+        db.execute(
+            "INSERT INTO interactions (chat_id, platform, user_message, bot_response, fsm_state, intent) "
+            "VALUES (?, 'telegram', 'q', 'r', 'IDLE', ?)",
+            (chat_id, intent),
+        )
+        for _ in range(good_count):
+            db.execute(
+                "INSERT INTO feedback_log (chat_id, feedback) VALUES (?, 'good')",
+                (chat_id,),
+            )
+        for _ in range(bad_count):
+            db.execute(
+                "INSERT INTO feedback_log (chat_id, feedback) VALUES (?, 'bad')",
+                (chat_id,),
+            )
+
+
+# ---------------------------------------------------------------------------
+# boost formula
+# ---------------------------------------------------------------------------
+
+
+def test_boost_zero_returns_1():
+    assert _boost_from_count(0) == 1.0
+
+
+def test_boost_one_between_1_3_and_1_4():
+    v = _boost_from_count(1)
+    assert 1.3 <= v <= 1.4
+
+
+def test_boost_twenty_between_2_4_and_2_6():
+    v = _boost_from_count(20)
+    assert 2.4 <= v <= 2.6
+
+
+def test_boost_caps_at_3():
+    assert _boost_from_count(1_000) == 3.0
+    assert _boost_from_count(10_000) == 3.0
+
+
+# ---------------------------------------------------------------------------
+# confidence_boost
+# ---------------------------------------------------------------------------
+
+
+def test_missing_db_path_returns_1_0(tmp_path):
+    trainer = FewShotTrainer(db_path=str(tmp_path / "does-not-exist.db"))
+    assert trainer.confidence_boost("Pilz", "industrial") == 1.0
+
+
+def test_empty_db_returns_1_0(tmp_path):
+    db = tmp_path / "mira.db"
+    _init_schema(db)
+    trainer = FewShotTrainer(db_path=str(db))
+    assert trainer.confidence_boost("Pilz", "industrial") == 1.0
+
+
+def test_one_confirmation_boosts_modestly(tmp_path):
+    db = tmp_path / "mira.db"
+    _init_schema(db)
+    _seed_chat(db, "c1", vendor="Pilz", intent="industrial", good_count=1)
+    trainer = FewShotTrainer(db_path=str(db))
+    boost = trainer.confidence_boost("Pilz", "industrial")
+    assert 1.3 <= boost <= 1.4
+
+
+def test_twenty_confirmations_boost_strong(tmp_path):
+    db = tmp_path / "mira.db"
+    _init_schema(db)
+    for i in range(20):
+        _seed_chat(
+            db,
+            f"c{i}",
+            vendor="Pilz",
+            intent="industrial",
+            good_count=1,
+        )
+    trainer = FewShotTrainer(db_path=str(db))
+    boost = trainer.confidence_boost("Pilz", "industrial")
+    assert 2.4 <= boost <= 2.6
+
+
+def test_bad_ratings_are_not_counted(tmp_path):
+    db = tmp_path / "mira.db"
+    _init_schema(db)
+    _seed_chat(db, "c1", vendor="Pilz", intent="industrial", good_count=0, bad_count=10)
+    trainer = FewShotTrainer(db_path=str(db))
+    assert trainer.confidence_boost("Pilz", "industrial") == 1.0
+
+
+def test_vendor_normalization_case_insensitive(tmp_path):
+    db = tmp_path / "mira.db"
+    _init_schema(db)
+    _seed_chat(db, "c1", vendor="PILZ", intent="INDUSTRIAL", good_count=1)
+    trainer = FewShotTrainer(db_path=str(db))
+    # Query with a different case — still finds it.
+    assert trainer.confidence_boost("pilz", "industrial") > 1.0
+
+
+def test_different_vendor_intent_buckets_independent(tmp_path):
+    db = tmp_path / "mira.db"
+    _init_schema(db)
+    for i in range(5):
+        _seed_chat(db, f"p{i}", vendor="Pilz", intent="industrial", good_count=1)
+    trainer = FewShotTrainer(db_path=str(db))
+    pilz_ind = trainer.confidence_boost("Pilz", "industrial")
+    yaskawa_doc = trainer.confidence_boost("Yaskawa", "documentation")
+    assert pilz_ind > 1.0
+    assert yaskawa_doc == 1.0
+
+
+def test_cache_ttl_returns_same_value(tmp_path):
+    db = tmp_path / "mira.db"
+    _init_schema(db)
+    _seed_chat(db, "c1", vendor="Pilz", intent="industrial", good_count=1)
+    trainer = FewShotTrainer(db_path=str(db), cache_ttl_s=3600)
+    first = trainer.confidence_boost("Pilz", "industrial")
+    # Delete the backing row — cache should still return first value.
+    with sqlite3.connect(db) as dbc:
+        dbc.execute("DELETE FROM feedback_log")
+    second = trainer.confidence_boost("Pilz", "industrial")
+    assert first == second
+
+
+def test_refresh_clears_cache(tmp_path):
+    db = tmp_path / "mira.db"
+    _init_schema(db)
+    trainer = FewShotTrainer(db_path=str(db), cache_ttl_s=3600)
+    assert trainer.confidence_boost("Pilz", "industrial") == 1.0  # cold
+    _seed_chat(db, "c1", vendor="Pilz", intent="industrial", good_count=1)
+    # Still cached at 1.0
+    assert trainer.confidence_boost("Pilz", "industrial") == 1.0
+    trainer.refresh()
+    # Now reflects new row
+    assert trainer.confidence_boost("Pilz", "industrial") > 1.0
+
+
+def test_stats_returns_expected_keys(tmp_path):
+    db = tmp_path / "mira.db"
+    _init_schema(db)
+    _seed_chat(db, "c1", vendor="Pilz", intent="industrial", good_count=2, bad_count=1)
+    trainer = FewShotTrainer(db_path=str(db))
+    s = trainer.stats()
+    for key in ("db_path", "good_count", "bad_count", "cache_size", "cache_ttl_s"):
+        assert key in s
+    assert s["good_count"] == 2
+    assert s["bad_count"] == 1
+
+
+def test_stats_on_missing_db_is_safe(tmp_path):
+    trainer = FewShotTrainer(db_path=str(tmp_path / "nope.db"))
+    s = trainer.stats()
+    assert s["good_count"] == 0
+    assert s["bad_count"] == 0
+
+
+@pytest.mark.parametrize("malformed_asset", ["", "NoCommaVendor"])
+def test_asset_without_comma_still_matches(tmp_path, malformed_asset):
+    """asset_identified may be just a vendor without a model comma."""
+    db = tmp_path / "mira.db"
+    _init_schema(db)
+    with sqlite3.connect(db) as dbc:
+        dbc.execute(
+            "INSERT INTO conversation_state (chat_id, asset_identified) VALUES (?, ?)",
+            ("c1", malformed_asset),
+        )
+        dbc.execute(
+            "INSERT INTO interactions (chat_id, user_message, bot_response, intent) "
+            "VALUES ('c1', 'q', 'r', 'industrial')"
+        )
+        dbc.execute(
+            "INSERT INTO feedback_log (chat_id, feedback) VALUES ('c1', 'good')"
+        )
+    trainer = FewShotTrainer(db_path=str(db))
+    if malformed_asset == "":
+        # empty asset → vendor substring is empty, only matches empty vendor query
+        assert trainer.confidence_boost("", "industrial") > 1.0
+    else:
+        assert trainer.confidence_boost("NoCommaVendor", "industrial") > 1.0

--- a/mira-bots/shared/test_few_shot_trainer.py
+++ b/mira-bots/shared/test_few_shot_trainer.py
@@ -1,4 +1,5 @@
 """Tests for FewShotTrainer (issue #314)."""
+
 from __future__ import annotations
 
 import sqlite3
@@ -238,9 +239,7 @@ def test_asset_without_comma_still_matches(tmp_path, malformed_asset):
             "INSERT INTO interactions (chat_id, user_message, bot_response, intent) "
             "VALUES ('c1', 'q', 'r', 'industrial')"
         )
-        dbc.execute(
-            "INSERT INTO feedback_log (chat_id, feedback) VALUES ('c1', 'good')"
-        )
+        dbc.execute("INSERT INTO feedback_log (chat_id, feedback) VALUES ('c1', 'good')")
     trainer = FewShotTrainer(db_path=str(db))
     if malformed_asset == "":
         # empty asset → vendor substring is empty, only matches empty vendor query

--- a/mira-core/mira-ingest/tests/test_structured_vision.py
+++ b/mira-core/mira-ingest/tests/test_structured_vision.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 # Add mira-ingest to path so we can import main's helpers without running the app
 INGEST_ROOT = Path(__file__).parent.parent
 if str(INGEST_ROOT) not in sys.path:


### PR DESCRIPTION
Closes #314. MVP vision Problem 6.

New `mira-bots/shared/few_shot_trainer.py` reads /good confirmation counts per (vendor, intent) by joining `feedback_log` + `interactions` + `conversation_state` on `chat_id`. Vendor is the substring of `asset_identified` before the first comma; intent comes from the interaction row.

Formula: `boost = 1.0 + min(log1p(n) * 0.5, 2.0)`
- 0 → 1.000, 1 → 1.347, 20 → 2.522, 1000 → 3.000 (capped)

Features: 1hr in-memory cache, `refresh()`, `stats()`, fail-open on missing DB/tables/errors. Case-insensitive normalization. CLI:
`python mira-bots/shared/few_shot_trainer.py --vendor Pilz --intent industrial`

17/17 pytest passing.

Wiring into `gsd_engine.py` confidence scoring is a separate follow-up PR (~3 lines + test).

🤖 Generated with Claude Code