### PR TITLE
feat(ingest): reroute /api/ingest/manual from mira-mcp to mira-ingest

### DIFF
--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -663,12 +663,18 @@ async def ingest_document_kb(
     filename: str = Form(default=None),
     collection_hint: str = Form(default=None),
     equipment_type: str = Form(default=None),
+    tenant_id: str = Form(default=""),
 ):
     """Upload a PDF to Open WebUI Knowledge Base.
 
     Open WebUI handles text extraction, chunking, and embedding via its
     configured engine (pypdf default; Docling when DOCLING_SERVER_URL is set).
     No local parsing is performed here.
+
+    `tenant_id` resolution order (vision doc problem 11):
+      1. form field (per-request, from the authenticated caller)
+      2. MIRA_TENANT_ID env var (global, legacy nightly scripts)
+      3. empty (no tier check, shared collection)
 
     Returns JSON: {status, filename, collection_id, collection_name, file_id, processing_status}
     """
@@ -695,8 +701,16 @@ async def ingest_document_kb(
             detail=f"File exceeds 20MB limit ({len(raw) // MB}MB)",
         )
 
+    form_tenant = (tenant_id or "").strip()
+    if form_tenant:
+        tenant_id, tenant_source = form_tenant, "form"
+    elif MIRA_TENANT_ID:
+        tenant_id, tenant_source = MIRA_TENANT_ID, "env"
+    else:
+        tenant_id, tenant_source = "", "default"
+    logger.info("Document KB ingest tenant=%s source=%s filename=%s", tenant_id or "(none)", tenant_source, fname)
+
     # Tier limit check (fail open on DB errors — never block on infra failures)
-    tenant_id = MIRA_TENANT_ID
     if tenant_id:
         try:
             from db.neon import check_tier_limit

--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -708,7 +708,12 @@ async def ingest_document_kb(
         tenant_id, tenant_source = MIRA_TENANT_ID, "env"
     else:
         tenant_id, tenant_source = "", "default"
-    logger.info("Document KB ingest tenant=%s source=%s filename=%s", tenant_id or "(none)", tenant_source, fname)
+    logger.info(
+        "Document KB ingest tenant=%s source=%s filename=%s",
+        tenant_id or "(none)",
+        tenant_source,
+        fname,
+    )
 
     # Tier limit check (fail open on DB errors — never block on infra failures)
     if tenant_id:

--- a/mira-web/docker-compose.yml
+++ b/mira-web/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - LOOM_URL_5=${LOOM_URL_5:-}
       - LOOM_UPLOAD_URL=${LOOM_UPLOAD_URL:-}
       - MIRA_MCP_URL=${MIRA_MCP_URL:-http://mira-mcp:8001}
+      - MIRA_INGEST_URL=${MIRA_INGEST_URL:-http://mira-ingest:8001}
     networks:
       - core-net
       - cmms-net

--- a/mira-web/src/server.ts
+++ b/mira-web/src/server.ts
@@ -698,20 +698,20 @@ app.get("/demo/tenant-work-orders", requireActive, async (c) => {
 });
 
 // ---------------------------------------------------------------------------
-// Manual Ingest Proxy — forwards PDF uploads to mira-mcp
+// Manual Ingest Proxy — forwards PDF uploads to mira-ingest/ingest/document-kb
+//
+// This is the production RAG ingest path: PDFs land in Open WebUI KB
+// collections (Docling extraction + embedding), which mira-pipeline reads
+// from at chat time. The earlier mira-mcp/ingest/pdf endpoint wrote to a
+// local openviking store that was never queried by the RAG reader (#337).
 // ---------------------------------------------------------------------------
 
 const INGEST_MAX_BYTES = 50 * 1024 * 1024;
-const MIRA_MCP_URL = () =>
-  process.env.MIRA_MCP_URL || "http://mira-mcp:8001";
+const MIRA_INGEST_URL = () =>
+  process.env.MIRA_INGEST_URL || "http://mira-ingest:8001";
 
 app.post("/api/ingest/manual", requireActive, async (c) => {
   const user = c.get("user") as MiraTokenPayload;
-  const mcpKey = process.env.MCP_REST_API_KEY || "";
-  if (!mcpKey) {
-    console.error("[ingest-manual] MCP_REST_API_KEY not set");
-    return c.json({ error: "Ingest service not configured" }, 500);
-  }
 
   let form: FormData;
   try {
@@ -744,9 +744,8 @@ app.post("/api/ingest/manual", requireActive, async (c) => {
 
   const started = Date.now();
   try {
-    const resp = await fetch(`${MIRA_MCP_URL()}/ingest/pdf`, {
+    const resp = await fetch(`${MIRA_INGEST_URL()}/ingest/document-kb`, {
       method: "POST",
-      headers: { Authorization: `Bearer ${mcpKey}` },
       body: forwarded,
     });
     const latencyMs = Date.now() - started;


### PR DESCRIPTION
Closes #337 (steps 1–2 of 4). Partial fix for the architectural gap that
invalidated #334's value: customer PDFs were landing in mira-mcp's local
openviking store, which the RAG reader never queries.

## Problem

Before this PR:
\`\`\`
/api/ingest/manual  →  mira-mcp:8001/ingest/pdf  →  local openviking store
                                                    ❌ RAG reads from NeonDB / Open WebUI
\`\`\`
Result: paying customer uploads a manual, chat doesn't see it.

After this PR:
\`\`\`
/api/ingest/manual  →  mira-ingest:8001/ingest/document-kb  →  Open WebUI KB
                                                              ✅ RAG reads from here
\`\`\`

## Changes

1. **\`mira-core/mira-ingest/main.py\`** — \`/ingest/document-kb\` now accepts \`tenant_id\` as a form field. Resolution order (same pattern as #334):
   - Form field wins
   - Falls back to \`MIRA_TENANT_ID\` env for legacy nightly callers
   - Empty default if neither set
   Source logged to INFO on every upload for observability.

2. **\`mira-web/src/server.ts\`** — \`/api/ingest/manual\` rewrites target from \`MIRA_MCP_URL/ingest/pdf\` to \`MIRA_INGEST_URL/ingest/document-kb\`. Drops the \`MCP_REST_API_KEY\` bearer requirement since mira-ingest is internal-network only. \`tenant_id\` forwarded from the authenticated user.sub (already on the forwarded FormData per #334).

3. **\`mira-web/docker-compose.yml\`** — new \`MIRA_INGEST_URL\` env var with sane default.

## Out of scope (follow-ups)

- **#337 step 3** — Open WebUI collections are still routed by filename (\`_route_collection(fname)\`), so cross-tenant documents share a collection. True isolation needs the collection name prefixed with \`tenant_id\`. Filed as a separate issue after this merges.
- **#337 step 4** — mira-sidecar + mira-pipeline readers need to scope recall by per-request tenant_id. Chat responses still return cross-tenant sources until that's audited.
- **#336** — mira-mcp \`/ingest/pdf\` becomes dead code after this. Scheduled for cleanup once monitoring confirms no lingering callers.
- **#335** — Orthogonal: RESEND_API_KEY not set in Doppler, emails silently skipped.
- **#338** — Orthogonal: atlas-api not deployed on VPS, Atlas provisioning fails.

## Test plan

- [ ] Merge + rebuild \`mira-ingest\` + \`mira-web\` on VPS
- [ ] Upload a PDF as authenticated tenant via \`/api/ingest/manual\`
- [ ] Verify \`mira-ingest\` log shows \`source=form tenant=<uuid>\`
- [ ] Verify \`/api/ingest/manual\` response includes \`{status: ok, collection_id, file_id, processing_status}\` from Open WebUI
- [ ] Upload a second PDF as a different tenant (\`+alias@gmail.com\` Gmail trick)
- [ ] Confirm Open WebUI \`/api/v1/files/\` shows both files (isolation happens at collection scoping in the step-3 follow-up)