### PR TITLE
fix(engine): strip LLM-prefixed numbering from options — no more '1. 1. Drives'

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -2658,7 +2658,14 @@ class Supervisor:
         """Format parsed response for display."""
         reply = parsed["reply"]
         options = parsed.get("options", [])
-        meaningful = [o for o in options if len(str(o).strip()) > 2]
+        # LLMs often pre-number their options ("1. Drives"). Strip any leading
+        # "N." / "N)" prefix so the enumerate() below doesn't emit "1. 1. Drives".
+        meaningful = [
+            re.sub(r"^\s*\d+[.):\-]\s*", "", str(o)).strip()
+            for o in options
+            if len(str(o).strip()) > 2
+        ]
+        meaningful = [o for o in meaningful if len(o) > 2]
         if meaningful and len(meaningful) >= 2:
             reply = deduplicate_options(reply, meaningful)
             reply += "\n\n" + "\n".join(f"{i + 1}. {opt}" for i, opt in enumerate(meaningful))


### PR DESCRIPTION
## Summary
Live-tested CMMS prompts through mira-pipeline on prod and found a user-facing cosmetic bug: options render with doubled numbers.

**Before:**
\`\`\`
What type of equipment?

1. 1. Drives
2. 2. Network Devices
3. 3. Other
\`\`\`

**After:**
\`\`\`
What type of equipment?

1. Drives
2. Network Devices
3. Other
\`\`\`

## Root cause
LLM emits options like \`["1. Drives", "2. Network"]\`. \`_format_reply\` then wraps each with \`f"{i+1}. {opt}"\` — yielding \`1. 1. Drives\`.

## Fix
Strip any leading \`N.\` / \`N)\` / \`N:\` / \`N-\` prefix from each option in \`_format_reply\` before re-numbering.

## Surfaced via
Item 2 of hamburger-readiness punch-list (#389). Probed prod directly:
\`\`\`bash
curl -X POST http://localhost:9099/v1/chat/completions -H "Authorization: Bearer ..." \
  -d '{"messages":[{"role":"user","content":"What preventive maintenance is due this week?"}]}'
# returned "1. 1. Drives\n2. 2. Network Devices..."
\`\`\`

## Test
- [x] Sanity-check on 4 option-formatting cases (with / without LLM prefix, with \`)\` separator, single option)
- [x] 63/63 \`test_engine.py\` pass