### PR TITLE
fix(ci): add --ignore-unfixed to trivy scans — unblock Docker Build Check (#379)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
             -t mira-ingest:scan --load
 
       - name: Scan mira-ingest
-        run: trivy image --severity HIGH,CRITICAL --exit-code 1 mira-ingest:scan
+        run: trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 mira-ingest:scan
 
       - name: Build mira-bot-telegram
         run: |
@@ -224,7 +224,7 @@ jobs:
             -t mira-telegram:scan --load
 
       - name: Scan mira-bot-telegram
-        run: trivy image --severity HIGH,CRITICAL --exit-code 1 mira-telegram:scan
+        run: trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 mira-telegram:scan
 
       - name: Build mira-bot-slack
         run: |
@@ -233,7 +233,7 @@ jobs:
             -t mira-slack:scan --load
 
       - name: Scan mira-bot-slack
-        run: trivy image --severity HIGH,CRITICAL --exit-code 1 mira-slack:scan
+        run: trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 mira-slack:scan
 
       - name: Build mira-mcp
         run: |
@@ -242,4 +242,4 @@ jobs:
             -t mira-mcp:scan --load
 
       - name: Scan mira-mcp
-        run: trivy image --severity HIGH,CRITICAL --exit-code 1 mira-mcp:scan
+        run: trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 mira-mcp:scan

--- a/mira-bots/slack/Dockerfile
+++ b/mira-bots/slack/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12.13-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends tesseract-ocr && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends tesseract-ocr && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY slack/requirements.txt .

--- a/mira-bots/telegram/Dockerfile
+++ b/mira-bots/telegram/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12.13-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends tesseract-ocr && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends tesseract-ocr && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY telegram/requirements.txt .

--- a/mira-core/mira-ingest/Dockerfile
+++ b/mira-core/mira-ingest/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.12.13-slim
 
+# Pull Debian security updates at build time (catches HIGH/CRITICAL CVEs
+# with upstream fixes — e.g. openssl DoS CVE-2026-28390). Does not affect
+# runtime behavior; kept in a single RUN layer to minimize image size.
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/mira-mcp/Dockerfile
+++ b/mira-mcp/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.12.13-slim
 
+# Pull Debian security updates at build time (catches fixable HIGH/CRITICAL CVEs).
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
## Summary
Addresses #379's specific scope: **OS-layer CVEs in base image**. Applied issue #379's recommended Option A + apt-upgrade in a single PR:

1. \`--ignore-unfixed\` on all 4 trivy scans → filter unfixable OS CVEs (9 HIGH in \`mira-ingest\` base that have no upstream fix)
2. \`apt-get update && apt-get upgrade -y\` added to all 4 Dockerfiles → pull patched versions for OS CVEs that DO have fixes (OpenSSL CVE-2026-28390 et al)

## Verification post-fix
All 4 images now report **0 debian vulnerabilities** — OS layer is clean.

## Exposes new work (tracked separately)
Post-patch, Trivy now correctly surfaces app-level CVEs that were previously masked by the OS-level noise:
- \`fastmcp\` 0.4.1 CRITICAL SSRF + 3 related → needs major version bump (0.4 → 3.2 is breaking)
- Go binary \`stdlib\` CRITICAL crypto/tls + 7 HIGH → source package unknown

Filed **#398** for those. \`Docker Build Check\` will still be red against main until #398 is resolved, but it's catching *real* issues now instead of being permanently stuck on unfixable CVEs.

## Test plan
- [x] Lint / Unit Tests / Architecture / License / Security SAST all pass
- [x] OS-layer CVE count = 0 in all 4 images post-merge
- [ ] Docker Build Check still red — tracked in #398 (fastmcp + Go stdlib)

Closes #379