### PR TITLE
feat: velocity #2 — CI accel (xdist + gha cache + split SAST + docs-skip)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
 
       - name: Run bot tests with coverage
         run: |
-          pytest mira-bots/tests/ -v -n auto \
+          pytest mira-bots/tests/ -v \
             --ignore=mira-bots/tests/test_slack_relay.py \
             --cov=mira-bots/shared --cov-report=term-missing \
             --cov-fail-under=30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,8 @@ jobs:
         run: |
           docker buildx build \
             -f mira-core/mira-ingest/Dockerfile mira-core/mira-ingest/ \
+            --cache-from type=gha,scope=mira-ingest \
+            --cache-to type=gha,mode=max,scope=mira-ingest \
             -t mira-ingest:scan --load
 
       - name: Scan mira-ingest
@@ -241,6 +243,8 @@ jobs:
         run: |
           docker buildx build \
             -f mira-bots/telegram/Dockerfile mira-bots/ \
+            --cache-from type=gha,scope=mira-telegram \
+            --cache-to type=gha,mode=max,scope=mira-telegram \
             -t mira-telegram:scan --load
 
       - name: Scan mira-bot-telegram
@@ -250,6 +254,8 @@ jobs:
         run: |
           docker buildx build \
             -f mira-bots/slack/Dockerfile mira-bots/ \
+            --cache-from type=gha,scope=mira-slack \
+            --cache-to type=gha,mode=max,scope=mira-slack \
             -t mira-slack:scan --load
 
       - name: Scan mira-bot-slack
@@ -259,6 +265,8 @@ jobs:
         run: |
           docker buildx build \
             -f mira-mcp/Dockerfile mira-mcp/ \
+            --cache-from type=gha,scope=mira-mcp \
+            --cache-to type=gha,mode=max,scope=mira-mcp \
             -t mira-mcp:scan --load
 
       - name: Scan mira-mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,35 @@
 name: CI
 
+# paths-ignore: docs-only changes skip the whole workflow.
+# The list below covers prose (markdown, wiki), the .claude config tree, and
+# image-only changes. Any PR or push that also touches code outside these
+# paths runs the full pipeline normally. Main pushes are always post-merge
+# (code flows through PRs), so a docs-only main push has no code to test —
+# the safety-net intent is preserved: any code-touching main push triggers
+# the full pipeline regardless of path filter.
 on:
   push:
     branches: [main, dev]
+    paths-ignore:
+      - 'docs/**'
+      - 'wiki/**'
+      - '**/*.md'
+      - '.claude/**'
+      - '**/*.webp'
+      - '**/*.png'
+      - '**/*.jpg'
+      - '**/*.gif'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'wiki/**'
+      - '**/*.md'
+      - '.claude/**'
+      - '**/*.webp'
+      - '**/*.png'
+      - '**/*.jpg'
+      - '**/*.gif'
 
 jobs:
   lint-and-type-check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,17 +106,17 @@ jobs:
         run: |
           pip install -r mira-core/mira-ingest/requirements.txt
           pip install -r mira-bots/telegram/requirements.txt
-          pip install pytest pytest-asyncio pytest-cov
+          pip install pytest pytest-asyncio pytest-cov pytest-xdist
 
       - name: Run ingest tests with coverage
         run: |
-          pytest mira-core/mira-ingest/tests/ -v \
+          pytest mira-core/mira-ingest/tests/ -v -n auto \
             --cov=mira-core/mira-ingest --cov-report=term-missing \
             --cov-fail-under=20
 
       - name: Run bot tests with coverage
         run: |
-          pytest mira-bots/tests/ -v \
+          pytest mira-bots/tests/ -v -n auto \
             --ignore=mira-bots/tests/test_slack_relay.py \
             --cov=mira-bots/shared --cov-report=term-missing \
             --cov-fail-under=30
@@ -177,7 +177,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pytest pytest-asyncio pyyaml hypothesis
+          pip install pytest pytest-asyncio pytest-xdist pyyaml hypothesis
           pip install -r mira-core/mira-ingest/requirements.txt
           pip install -r mira-bots/telegram/requirements.txt
           pip install chromadb
@@ -188,8 +188,11 @@ jobs:
         #   (move to a dedicated integration job when sidecar stack is containerized in CI)
         # test_symlink_outside_base_returns_403 — latent path-traversal bug surfaced by
         #   this PR finally running the offline suite; tracked for dedicated fix
+        # -n auto (pytest-xdist) parallelises across runner CPUs; if any regime proves
+        # order-dependent, narrow that regime to `-n 0` with a one-line comment citing
+        # the shared-state bug.
         run: |
-          pytest tests/ -v -m "not network and not slow" \
+          pytest tests/ -v -n auto -m "not network and not slow" \
             --ignore=tests/regime5_nemotron/ \
             --ignore=tests/regime6_sidecar/ \
             --ignore=tests/test_mira_pipeline.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
-  sast-scan:
-    name: Security Scan (SAST)
+  sast-semgrep:
+    name: Security Scan (Semgrep)
     runs-on: ubuntu-latest
     needs: lint-and-type-check
     steps:
@@ -81,6 +81,17 @@ jobs:
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: semgrep.sarif
+
+  sast-bandit:
+    name: Security Scan (Bandit)
+    runs-on: ubuntu-latest
+    needs: lint-and-type-check
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
 
       - name: Install bandit
         run: pip install "bandit[toml]==1.8.*"

--- a/mira-bots/shared/notifications/daily_briefing.py
+++ b/mira-bots/shared/notifications/daily_briefing.py
@@ -187,9 +187,9 @@ async def summarize_briefing(context: str, profile: dict) -> str:
         # Fallback: plain text summary without LLM
         lines = context.split("\n")
         activity_lines = [
-            l
-            for l in lines
-            if l.strip() and not l.startswith("Role:") and not l.startswith("Digest:")
+            ln
+            for ln in lines
+            if ln.strip() and not ln.startswith("Role:") and not ln.startswith("Digest:")
         ]
         return "MIRA Daily Briefing\n\n" + "\n".join(activity_lines[:8])
 


### PR DESCRIPTION
## Summary

Velocity survivor #2 from the 2026-04-19 dev-velocity roadmap. Minimal-scope CI accel: four independent changes that each lift a known bottleneck. Zero architectural risk — every change is reversible per-commit.

1. **Unit 1** — `pytest-xdist -n auto` in `test-unit` and `test-eval-offline`. Parallelises pytest across the 4 vCPUs on `ubuntu-latest`. Coverage gates (ingest 20%, bots 30%) and `--ignore` flags preserved.
2. **Unit 2** — Split `sast-scan` into parallel `sast-semgrep` + `sast-bandit` jobs, both gated only on `lint-and-type-check`. Total SAST wall time goes from `sum(semgrep, bandit)` to `max(semgrep, bandit)`.
3. **Unit 3** — `--cache-from type=gha,scope=<image>` + `--cache-to type=gha,mode=max,scope=<image>` on all 4 buildx builds. Warm-cache build time drops from ~3–4 min to <90s per image. Per-image scope isolation.
4. **Unit 4** — Workflow-level `paths-ignore:` for docs-only changes (`docs/**`, `wiki/**`, `**/*.md`, `.claude/**`, and image formats). No more billable CI runs on pure ideation/plan PRs.

## ⚠️ Branch-protection action required (merge-blocker)

Unit 2 renames the SAST status checks. **Before merging**, update `Settings → Branches → main` required-checks:

- Remove: `Security Scan (SAST)`
- Add: `Security Scan (Semgrep)`, `Security Scan (Bandit)`

Otherwise merges will silently bypass the SAST gate on this and every subsequent PR until the rule is corrected.

## Test plan

- [ ] CI on this PR itself runs green (meta: this PR touches `.github/` and `docs/`, so the full pipeline fires)
- [ ] `test-unit` duration drops ≥30% vs a recent baseline PR — compare with `gh run list --workflow CI --branch main --limit 10 --json durationMS,name,conclusion,createdAt`
- [ ] `test-eval-offline` duration drops ≥30%
- [ ] `sast-semgrep` and `sast-bandit` appear as two separate checks, both green, running in parallel
- [ ] Intentionally break a test on a throwaway branch → xdist-parallelized run still reports the failure with a readable traceback
- [ ] After one cache-warming run, rerun this PR's CI — `docker-build-check` warm-cache step takes <90s per image
- [ ] Open a follow-up docs-only PR (touch only `docs/foo.md`) → no workflow runs
- [ ] Update branch-protection required-checks per the block above before merging

## What is deliberately NOT in this PR

Per the brainstorm's scope boundaries:
- Selective test runs, `pytest --testmon`, or a `tools/impact.py` import-graph walker — deferred to a later velocity PR
- Matrix-fanning 4 Dockerfile builds into parallel jobs — revisit when build count grows
- Fix for the chromadb/starlette version conflict (5 ignored test files) — velocity ideation idea #8, separate PR
- Pre-commit hooks — velocity survivor #3
- Building the 13 non-prod Dockerfiles
- Eval judge caching — velocity survivors #3 / #5

## Commits (per implementation unit — atomic rollback)

1. `5b7cd77` docs(velocity): capture brainstorm + plan for velocity #2 (CI accel)
2. `9755092` ci: enable pytest-xdist -n auto in test-unit and test-eval-offline
3. `fef32b9` ci: split sast-scan into parallel sast-semgrep and sast-bandit jobs
4. `462c836` ci: add type=gha Docker buildx cache per image scope
5. `a2a823d` ci: skip docs-only PRs and pushes via workflow-level paths-ignore

## Links

- Ideation: `docs/ideation/2026-04-19-mira-dev-velocity-ideation.md` (PR #404)
- Roadmap: `docs/superpowers/plans/2026-04-19-velocity-roadmap.md` (PR #404)
- Brainstorm (included here): `docs/superpowers/specs/2026-04-19-velocity-2-impact-graph-ci-design.md`
- Plan (included here): `docs/superpowers/plans/2026-04-19-velocity-2-impact-graph-ci.md`

## Follow-ups

- Update the velocity roadmap's Unit 2 status to `shipped` once this merges (done in a separate PR on top of roadmap PR #404 to avoid branch conflicts).
- Monitor per-scope cache size for 2 weeks; if any scope exceeds ~2 GB, revisit with per-layer splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)