### PR TITLE
fix(engine): _MAX_Q_ROUNDS default 2 → 3 to match counting + tests

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -150,10 +150,10 @@ def _safety_is_observational(reply_lower: str) -> bool:
     return False
 
 
-# After this many consecutive Q-state turns the FSM forces a commit to DIAGNOSIS.
-# 2 means: if the LLM stays in Q-states through turn 2 (both current and new are Q),
-# turn 3 triggers the commit. Covers 3-turn fixtures that end at Q3 without diagnosing.
-_MAX_Q_ROUNDS = int(os.getenv("MIRA_MAX_Q_ROUNDS", "2"))
+# After this many entries into a Q-state the FSM forces a commit to DIAGNOSIS.
+# Counting includes the first non-Q→Q transition, so IDLE→Q1→Q2→Q3 reaches
+# q_rounds=3 at Q3 and triggers. See #387 for the off-by-one fix.
+_MAX_Q_ROUNDS = int(os.getenv("MIRA_MAX_Q_ROUNDS", "3"))
 HISTORY_LIMIT = int(os.getenv("MIRA_HISTORY_LIMIT", "20"))
 # How many turns the session photo stays available for follow-up questions
 PHOTO_MEMORY_TURNS = int(os.getenv("MIRA_PHOTO_MEMORY_TURNS", "10"))


### PR DESCRIPTION
## Summary

**Unblocks main CI** (red 3 days running) and **PR #405** (which inherited the same 4 failing tests).

Two prior commits silently disagreed on the Q-trap escape ceiling:

| Commit | What it did | Constant value |
|--------|-------------|----------------|
| `c5d5905` "Q-trap tightening" | Lowered ceiling pre-off-by-one | `2` |
| `e069c84` (#387) "Q-trap off-by-one" | Fixed engine to count every Q-state entry; commit message says "fires at round 3 → DIAGNOSIS"; updated tests to expect ceiling=3 | constant **not** updated, still `2` |

After #387 the engine counts `IDLE→Q1=1, Q1→Q2=2, Q2→Q3=3`. With ceiling=2, the FSM commits to DIAGNOSIS at Q2, bypassing the third question entirely. That contradicts both #387's stated intent ("fires at round 3") and 4 tests that assert exactly that.

## Fix

One-line change to `mira-bots/shared/engine.py:156`:
- `_MAX_Q_ROUNDS = int(os.getenv("MIRA_MAX_Q_ROUNDS", "2"))` → `"3"`
- Rewrote the 3-line preceding comment to describe the post-#387 counting semantics

## Behavior change

The source default now matches what #387 already documented as intent. Production behavior on hosts running with the explicit `MIRA_MAX_Q_ROUNDS` env var is unchanged. Hosts relying on the default get one additional clarifying question (Q3) before MIRA force-commits to a diagnosis — matching the original 3-question diagnostic protocol.

## Verification

Locally on Windows (Python 3.11):

\`\`\`
mira-bots/tests/test_engine.py::TestAdvanceState::test_normal_progression PASSED
mira-bots/tests/test_engine.py::TestAdvanceState::test_q_trap_escape_forces_diagnosis PASSED
mira-bots/tests/test_engine.py::TestAdvanceState::test_q_trap_env_override PASSED
mira-bots/tests/test_q_trap_guard.py::test_q_trap_does_not_fire_before_ceiling PASSED
4 passed in 1.70s
\`\`\`

Full mira-bots suite: 202 passed, 8 skipped, 3 unrelated failures in `tools/test_active_learner.py` (Windows-path issues, pass on Linux CI).

## Test plan
- [ ] CI green on this PR (full unit test suite)
- [ ] After merge, rebase #405 onto main and confirm its CI goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)