### PR TITLE
feat(dx): velocity #3 — pre-commit hooks + on-save eval watcher (spec + plan + impl)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,55 @@
+# MIRA pre-commit hooks — see docs/superpowers/specs/2026-04-19-velocity-3-precommit-smoke-design.md
+# Install: bash tools/setup_precommit.sh
+# Bypass: git commit --no-verify
+
+repos:
+  # Lint + format — same ruff version as CI
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # Type check — same as CI's `pyright` invocation (no flags)
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.392
+    hooks:
+      - id: pyright
+
+  # Security — same .bandit.yml + severity-level as CI
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.2
+    hooks:
+      - id: bandit
+        args:
+          - "-r"
+          - "mira-bots/shared/"
+          - "mira-bots/telegram/"
+          - "mira-bots/slack/"
+          - "mira-core/mira-ingest/"
+          - "mira-mcp/"
+          - "-c"
+          - ".bandit.yml"
+          - "--severity-level"
+          - "high"
+        pass_filenames: false
+
+  # Secrets — git-level guard (complements .claude/settings.json's Claude-only PreToolUse hook)
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.27.2
+    hooks:
+      - id: gitleaks
+
+  # Local: FSM smoke — fast unit-test suite that catches the regression class
+  # PR #411 fixed (Q-trap default mismatch) before push. No LLM calls, no API keys.
+  # Runs only when *.py files are staged. Target: <30s wall.
+  - repo: local
+    hooks:
+      - id: fsm-smoke
+        name: FSM smoke (engine + Q-trap + guardrails unit tests)
+        entry: python -m pytest mira-bots/tests/test_engine.py mira-bots/tests/test_q_trap_guard.py mira-bots/tests/test_guardrails.py -q --no-header --no-cov -x
+        language: system
+        pass_filenames: false
+        types: [python]
+        stages: [pre-commit]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ bash install/smoke_test.sh
 - **Skills:** `.claude/skills/`
 - **Sprint state:** `.planning/STATE.md`
 - **Active 90-day MVP plan:** `~/.claude/plans/yes-giggly-floyd.md` — locked 2026-04-19 → 2026-07-19; do not propose work outside the 10 units
+- **Dev loop (pre-commit + watcher):** `wiki/references/dev-loop.md`
 
 ---
 

--- a/docs/superpowers/plans/2026-04-19-velocity-3-precommit-smoke.md
+++ b/docs/superpowers/plans/2026-04-19-velocity-3-precommit-smoke.md
@@ -1,0 +1,344 @@
+---
+title: "feat: Velocity #3 — Pre-Commit + On-Save Smoke Eval (minimal scope)"
+type: feat
+status: active
+date: 2026-04-19
+origin: ../specs/2026-04-19-velocity-3-precommit-smoke-design.md
+roadmap: 2026-04-19-velocity-roadmap.md
+tags: [velocity, dx, pre-commit, eval]
+---
+
+# Velocity #3 — Pre-Commit + On-Save Smoke Eval (minimal scope)
+
+## Overview
+
+This PR delivers velocity survivor #3 from the 2026-04-19 dev-velocity roadmap:
+
+1. Add `.pre-commit-config.yaml` running ruff + pyright + bandit + gitleaks + an 18-case smoke eval (binary checkpoints only) on every commit.
+2. Add `tools/eval_watch.py` — opt-in file watcher that runs a 10-case smoke subset on every save in `mira-bots/shared/`, `mira-pipeline/`, and `tests/eval/fixtures/`.
+3. Migrate the existing `gitleaks protect` shell hook from `.claude/settings.local.json` into the same pre-commit config so there's one source of truth.
+
+No judge in pre-commit, no full 51-case run, no auto-started watcher, no CI changes — all deferred per the spec's scope boundaries.
+
+## Problem Frame
+
+Verified in the repo on 2026-04-19:
+
+- No `.pre-commit-config.yaml` exists. Pre-commit checks today: gitleaks-only via shell hook in `.claude/settings.local.json`.
+- CI catches regressions 6–12 minutes after `git push`. Engineer has switched context by then; failure surfaces as a notification, not as immediate feedback.
+- Prompt-tweak loop today: edit `mira-bots/shared/prompts/*.md` → manually trigger Open WebUI → eyeball reply → repeat. State lost on `/clear`.
+- `tests/eval/offline_run.py` already supports `EVAL_DISABLE_JUDGE=1` (binary checkpoints only — no LLM calls). 51 YAML scenarios in `tests/eval/fixtures/`, scored by `tests/eval/grader.py` (pure rule-based).
+
+This is a "shift cheap fast checks left" PR. Lift CI's burden, give the engineer the same answer in seconds, not minutes. See origin: `docs/superpowers/specs/2026-04-19-velocity-3-precommit-smoke-design.md`.
+
+## Requirements Trace
+
+Every requirement below maps to an implementation unit.
+
+- **R1** (.pre-commit-config.yaml with 6 hooks) → Unit 1
+- **R2** (`tools/setup_precommit.sh` installer) → Unit 1
+- **R3** (`tests/eval/smoke_set.txt` with 18 fixtures) → Unit 2
+- **R4** (`EVAL_DISABLE_JUDGE=1` smoke path) → Unit 2
+- **R5** (<2 min smoke budget) → Unit 2 verification
+- **R6** (`--no-verify` honored — pre-commit default) → Unit 1 verification
+- **R7** (`tools/eval_watch.py` watching 3 dirs) → Unit 3
+- **R8** (<30 s watcher loop) → Unit 3 verification
+- **R9** (one-line per fixture, no spinners) → Unit 3
+- **R10** (manual invocation only) → Unit 3 (documented in `tools/eval_watch.py --help`)
+- **R11** (SAST config parity with CI) → Unit 1 (uses `.bandit.yml`, `.gitleaks.toml`)
+
+## Scope Boundaries
+
+- **Not in this PR:** running the LLM-as-judge in pre-commit. Stays in nightly CI eval.
+- **Not in this PR:** running the full 51-scenario suite locally — that's CI's job.
+- **Not in this PR:** running pre-commit hooks server-side via `pre-commit/action@v3`. Follow-up after the local hook proves stable.
+- **Not in this PR:** prompt-registry refactor (velocity ideation #5).
+- **Not in this PR:** auto-minting eval cases from `fix:` PRs (velocity #4).
+- **Not in this PR:** parallelizing the smoke run with `pytest-xdist`. 18 scenarios fit in <2 min serial.
+- **Not in this PR:** dynamic regime-tag-driven smoke set selection. Static `.txt` files are simpler.
+
+### Deferred to Separate Tasks
+
+- **Pre-commit-as-CI** — once local hook is stable, add `pre-commit run --all-files` to a CI job for parity enforcement.
+- **Smoke-set tuning loop** — track which fixtures fire most often; trim or replace via 1-line PRs.
+- **Auto-start watcher** — only revisit if engineers want it; opt-in is the safer default.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `tests/eval/offline_run.py` — programmatic + CLI entry to the offline harness. Already supports `EVAL_DISABLE_JUDGE=1`.
+- `tests/eval/grader.py` — 5 binary checkpoints (no LLM calls). The smoke hook only consults these.
+- `tests/eval/judge.py` — LLM-as-judge. **Not invoked by smoke hook.**
+- `tests/eval/fixtures/` — 51 YAML scenarios + 11 non-YAML files = 62 entries. Naming convention `NN_*.yaml` for sequential scenarios, `vfd_*.yaml` for VFD-specific.
+- `.bandit.yml` — bandit config used by CI (`bandit -r ... -c .bandit.yml --severity-level high`).
+- `.gitleaks.toml` — gitleaks config (CI uses `gitleaks-action@v2` which auto-loads it).
+- `pyproject.toml` — `[tool.ruff]`, `[tool.ruff.lint]`, `[tool.coverage.*]`. `[tool.pyright]` may or may not be present — verify in Unit 1.
+- `.claude/settings.local.json` — current home of the gitleaks shell hook. Migrate cleanly.
+
+### Institutional Learnings
+
+- Feedback memory `feedback_verify_before_done.md` — verify the actual hook output on a synthetic bad commit, not just absence of failure.
+- Feedback memory `feedback_no_throwaway_scripts.md` — no parallel one-off smoke scripts. Extend `offline_run.py`.
+- Project memory `project_pipeline_regression_2026_04_17.md` — pre-commit smoke must catch the JSON envelope leak class (now fixed) on regression. Include fixture #07 (full diagnosis happy path) in smoke set as the primary canary.
+
+### External References
+
+- pre-commit framework docs: `https://pre-commit.com/`
+- watchdog Python library docs: `https://python-watchdog.readthedocs.io/`
+- `bandit -c <file>` flag documented in `https://bandit.readthedocs.io/en/latest/config.html`.
+
+## Key Technical Decisions
+
+- **`pre-commit` Python package over husky/raw shell.** De-facto Python standard, hook-version pinning, cross-platform parity. Migrates the existing gitleaks shell hook into the same config — one source of truth.
+- **18 fixtures in smoke set: 15 representative + 3 Q-trap.** Selection rationale per regime category (FSM transitions, KB recall, safety, vendor variation, partial KB) + the 3 Q-trap-style scenarios that protect against the regression class PR #411 fixed.
+- **Watcher is opt-in (manual `python tools/eval_watch.py`), not auto-started.** Safer; idle CPU stays idle; broken fixture doesn't wedge the engineer's session.
+- **Smoke set lives in `tests/eval/smoke_set.txt`, watch set in `tests/eval/watch_set.txt`.** Newline-delimited fixture filenames. Tuning is a 1-line PR, not a code change.
+- **Same configs as CI for bandit + gitleaks.** `.bandit.yml` + `.gitleaks.toml` are the source of truth. No inline overrides in `.pre-commit-config.yaml`.
+- **No judge in pre-commit, ever.** Judge requires API keys (Doppler), network round-trips, and rate-limit risk on a hot path. Binary checkpoints (`grader.py`) are deterministic and fast.
+- **Smoke runs use `EVAL_DISABLE_JUDGE=1` env var.** Already supported by `offline_run.py`. No new flag needed.
+- **Programmatic API addition if missing.** If `offline_run.py` lacks a fixture-list entry point, Unit 2 adds the smallest possible: `def run_subset(fixture_filenames: list[str], disable_judge: bool = True) -> SmokeResult`. No subprocess wrapping.
+- **Watchdog 500 ms debounce.** Avoids duplicate runs on VS Code auto-save salvos.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Q:** `.bandit.yml` present today?
+  **A:** Yes — verified at repo root. Use `-c .bandit.yml --severity-level high` to mirror CI.
+- **Q:** `.gitleaks.toml` present today?
+  **A:** Yes — verified at repo root. CI uses `gitleaks-action@v2` which honors it. Pre-commit uses local `gitleaks protect --staged --config=.gitleaks.toml`.
+- **Q:** Is `pre-commit` Apache or MIT?
+  **A:** MIT. License-allowed.
+- **Q:** Is `watchdog` Apache or MIT?
+  **A:** Apache 2.0. License-allowed.
+
+### Deferred to Implementation
+
+- Whether `offline_run.py` exposes a programmatic fixture-subset entry point. **Verification step in Unit 2:** read the file in the implementing session; if absent, add `run_subset(filenames, disable_judge)`. Don't subprocess-wrap.
+- Whether `[tool.pyright]` exists in `pyproject.toml`. **Verification step in Unit 1:** if absent, seed it with the same options CI's `pyright` invocation uses (default if no flags).
+- Whether VS Code's auto-save fires multiple events per logical save under our debounce window. **Verification step in Unit 3:** test with VS Code's auto-save enabled; if 500 ms is too short, raise to 1000 ms.
+
+## Implementation Units
+
+- [ ] **Unit 1: Add `.pre-commit-config.yaml` with 6 hooks + `tools/setup_precommit.sh`**
+
+**Goal:** Engineer runs `bash tools/setup_precommit.sh` once, then every `git commit` runs ruff + pyright + bandit + gitleaks + smoke eval automatically.
+
+**Requirements:** R1, R2, R6, R11
+
+**Dependencies:** None (Unit 2 fills in the smoke hook target; Unit 1 wires up the config skeleton with a placeholder pointing at `tools/precommit_smoke.py`).
+
+**Files:**
+- Add: `.pre-commit-config.yaml`
+- Add: `tools/setup_precommit.sh`
+- Modify: `.claude/settings.local.json` — remove the now-redundant gitleaks shell hook (or replace its body with a comment explaining the migration to pre-commit). Decision: **remove**, document in commit message.
+- Modify: `pyproject.toml` — add `[tool.pyright]` block only if absent; minimal config matching CI's invocation.
+
+**Approach:**
+- Create `.pre-commit-config.yaml` with these `repos:` entries:
+  - `astral-sh/ruff-pre-commit` — pinned to `v0.9.10` (CI's pinned version) — hooks `ruff` and `ruff-format`.
+  - `RobertCraigie/pyright-python` — pinned to a tag matching CI's pyright version.
+  - `PyCQA/bandit` — pinned to `1.8.*` (CI's pinned version) — hook `bandit` with args `-r mira-bots/shared/ mira-bots/telegram/ mira-bots/slack/ mira-core/mira-ingest/ mira-mcp/ -c .bandit.yml --severity-level high`.
+  - `gitleaks/gitleaks` — pinned to a recent tag — hook `gitleaks` with args `protect --staged --config=.gitleaks.toml`.
+  - `local` repo with hook `precommit-smoke` invoking `python tools/precommit_smoke.py`. Stage: `commit`. Pass-files: false (smoke run doesn't need staged file paths).
+- Create `tools/setup_precommit.sh`:
+  - Detect Python (`python3` first, fall back to `python`).
+  - `pip install pre-commit watchdog` (or `uv pip install` if `uv` is present).
+  - `pre-commit install --install-hooks`.
+  - Print one-line success and the hook list.
+- Update `.claude/settings.local.json`: remove the gitleaks shell hook. Single hook system from now on.
+- If `pyproject.toml` lacks `[tool.pyright]`, add a minimal block (likely just `pythonVersion = "3.12"` to match CI).
+
+**Patterns to follow:**
+- The existing CI invocations in `.github/workflows/ci.yml:42-88` are the source of truth for tool versions and flags. Mirror them exactly in `.pre-commit-config.yaml`.
+- Conventional pre-commit YAML structure — see [pre-commit.com/sample-config](https://pre-commit.com/#installation).
+
+**Test scenarios:**
+- **Happy path:** `bash tools/setup_precommit.sh` then `git commit -m "test"` on a small stylistic-fix commit → all hooks pass.
+- **Happy path:** `--no-verify` bypasses all hooks (R6 — built-in pre-commit behavior).
+- **Edge case:** committing a file with a leaked-key pattern → `gitleaks` hook fails the commit; staged content not committed.
+- **Edge case:** committing Python with a `subprocess.call(shell=True, ...)` → `bandit` hook fails the commit.
+- **Edge case:** committing Python with unused imports → `ruff check --fix` auto-fixes and re-stages, commit proceeds (or fails clearly if auto-fix isn't safe).
+- **Error path:** running `git commit` before `setup_precommit.sh` → no hook present, commit succeeds (R6 backward-compat).
+- **Integration:** the migrated gitleaks hook fires on the same staged content as the old shell hook did. Verify by re-running the same commit that the old hook caught.
+
+**Verification:**
+- `pre-commit run --all-files` from a clean checkout produces the same pass/fail outcome as a clean CI run on the same SHA.
+- `bash tools/setup_precommit.sh` is idempotent — running twice doesn't error or duplicate hooks.
+- `git commit --no-verify` always succeeds regardless of staged content (R6).
+- `.claude/settings.local.json` no longer contains the gitleaks shell-hook entry; commit message documents the migration.
+- Hook execution is parallelized by `pre-commit` natively — no need to add explicit parallelism flags.
+
+---
+
+- [ ] **Unit 2: Add `tools/precommit_smoke.py` + `tests/eval/smoke_set.txt` + entry point on `offline_run.py` if missing**
+
+**Goal:** A single Python script that loads 18 fixtures, runs them through the offline harness with judge disabled, scores via `grader.py` binary checkpoints, and exits 0 (all pass) or 1 (any fail). Total wall time <2 min.
+
+**Requirements:** R3, R4, R5
+
+**Dependencies:** Unit 1 (the pre-commit config references this script).
+
+**Files:**
+- Add: `tools/precommit_smoke.py`
+- Add: `tests/eval/smoke_set.txt` (18 lines, one fixture filename per line)
+- Modify (only if missing): `tests/eval/offline_run.py` — add `run_subset(filenames: list[str], disable_judge: bool = True) -> SmokeResult` programmatic entry.
+
+**Approach:**
+- Read fixture filenames from `tests/eval/smoke_set.txt` (relative to `tests/eval/fixtures/`).
+- Set `os.environ["EVAL_DISABLE_JUDGE"] = "1"` before importing the harness.
+- Call `offline_run.run_subset(filenames, disable_judge=True)`. If that entry point doesn't exist, add it as the smallest possible wrapper around the existing CLI logic — extract the fixture-loop body into a function the CLI also calls (no duplication).
+- Print a one-line pass/fail per fixture and an aggregated `N/M passed` summary.
+- Exit 0 only if every fixture passed every binary checkpoint.
+- Time the run; print total wall time. If >120 s, print a warning suggesting smoke-set trimming.
+- **Smoke set composition** (18 fixtures, picked by reading fixture YAML descriptions; final list goes in the PR description):
+  - 15 representative across regime categories (FSM transitions, KB recall, safety, vendor variation, abbreviations, asset-change, partial KB, vague openers, full happy path).
+  - 3 Q-trap-style: scenarios that exercise IDLE→Q1→Q2→Q3→DIAGNOSIS so a `_MAX_Q_ROUNDS` regression like #411 fails fast.
+
+**Patterns to follow:**
+- `tests/eval/offline_run.py`'s existing CLI argument parsing (mirror flag names and behavior).
+- `tests/eval/grader.py` checkpoint signatures — call them directly, don't re-implement.
+- No throwaway scripts (per `feedback_no_throwaway_scripts.md`) — `tools/precommit_smoke.py` is a thin caller of `offline_run.run_subset`.
+
+**Test scenarios:**
+- **Happy path:** all 18 fixtures pass → exit 0; one-line per fixture; final `18/18 passed in <T>s`.
+- **Edge case:** one fixture fails a binary checkpoint → exit 1; the failing fixture line shows the failed checkpoint name; final `17/18 passed`.
+- **Edge case:** `EVAL_DISABLE_JUDGE` already set in env → script honors existing value (no clobber on `1`; if `0`, override to `1` and warn).
+- **Edge case:** fixture file in `smoke_set.txt` doesn't exist on disk → script exits 2 with a clear "fixture not found: <name>" message (treat as configuration error, distinct from a checkpoint failure).
+- **Performance:** wall time <120 s on a 4-CPU laptop. If it creeps past, the warning fires and a follow-up PR trims the smoke set.
+- **Integration:** the same `tools/precommit_smoke.py` invocation works on Windows (Mike's daily driver), macOS, and Linux.
+
+**Verification:**
+- `python tools/precommit_smoke.py` on a clean main checkout completes in <2 min and exits 0.
+- Time-the-run output is reproducible within ±20% across 3 consecutive runs.
+- Forcing a fixture to fail (e.g., temporarily editing fixture #07 expected output) yields the right exit code and clear failure line.
+- Forcing `_MAX_Q_ROUNDS = "2"` (the PR #411 regression) causes at least one of the 3 Q-trap scenarios in the smoke set to fail — proves shift-left coverage.
+- `offline_run.run_subset` (if newly added) has no behavioral side effects on existing `--suite full / text / photos` invocations.
+
+---
+
+- [ ] **Unit 3: Add `tools/eval_watch.py` (file watcher with debounced 10-case smoke loop)**
+
+**Goal:** Engineer runs `python tools/eval_watch.py` in a side terminal during prompt-tweak sessions. On every save in `mira-bots/shared/`, `mira-pipeline/`, or `tests/eval/fixtures/`, it runs a 10-case smoke subset and prints results in <30 s.
+
+**Requirements:** R7, R8, R9, R10
+
+**Dependencies:** Unit 2 (`offline_run.run_subset` entry point and `tests/eval/smoke_set.txt` pattern).
+
+**Files:**
+- Add: `tools/eval_watch.py`
+- Add: `tests/eval/watch_set.txt` (10 lines, subset of `smoke_set.txt`)
+
+**Approach:**
+- Use `watchdog.observers.Observer` to watch three dirs recursively: `mira-bots/shared/`, `mira-pipeline/`, `tests/eval/fixtures/`.
+- File-extension filter: `.py`, `.md`, `.yaml` only. Ignore `__pycache__`, `.pytest_cache`, `*.pyc`.
+- Debounce save events with a 500 ms window — collapse a burst of saves into one run.
+- On a debounced save event:
+  - Read `tests/eval/watch_set.txt`.
+  - Call `offline_run.run_subset(filenames, disable_judge=True)`.
+  - Print one line per fixture (`PASS  04_yaskawa_out_of_kb` / `FAIL  07_full_diagnosis_happy_path: groundedness checkpoint`).
+  - Print final `N/M passed in T.Ts`.
+- Header on startup: print which dirs are watched, the debounce window, and the smoke-set path. Print `python tools/eval_watch.py --help` to bypass.
+- `--help` output: usage, one-shot vs watch mode, how to override watch_set.txt.
+- Optional `--once` flag: run the subset once and exit (for ad-hoc use).
+- `Ctrl-C` exits cleanly (no leftover threads).
+- Watcher subset (10 of 18) is the smaller of the smoke-set, focused on FSM-relevant scenarios since prompt-tweaking is the primary use case.
+
+**Patterns to follow:**
+- `mira-crawler/watcher/folder_watcher.py` is the closest existing pattern (same `watchdog` library); mirror its `Observer` setup and `Ctrl-C` handler.
+- No spinners, no color codes (R9). Plain text. ANSI codes break in non-TTY shells (CI logs, redirected output).
+- One-line-per-fixture output format matches `precommit_smoke.py` for consistency.
+
+**Test scenarios:**
+- **Happy path:** start watcher, edit `mira-bots/shared/prompts/diagnosis.md`, save → 10-case run fires within 500 ms; completes in <30 s; one-line summary printed.
+- **Happy path:** edit a `.py` file under `mira-bots/shared/`, save → run fires.
+- **Edge case:** edit a fixture YAML under `tests/eval/fixtures/` → run fires; if the edited fixture is in `watch_set.txt`, it picks up the new content.
+- **Edge case:** save 3 times in 200 ms (VS Code auto-save salvo) → only one run fires (debounce).
+- **Edge case:** edit `.pyc` or anything in `__pycache__` → no run fires (ignored).
+- **Error path:** `Ctrl-C` while a run is in progress → graceful exit; no hung threads; runs cleanly second time.
+- **Integration:** watcher honors the same `EVAL_DISABLE_JUDGE=1` discipline as the smoke hook — no Groq/Claude API calls during watch loop.
+- **Performance:** wall-clock per loop <30 s on a typical laptop. If it creeps past, watch_set is trimmed in a 1-line PR.
+
+**Verification:**
+- Manual: start watcher, induce a save, observe the run completes within 30 s with correct output.
+- Manual: induce a regression in a watched fixture, save, watcher reports the failed checkpoint.
+- Manual: `Ctrl-C` exits within 1 s.
+- `python tools/eval_watch.py --once` runs the watch_set subset once and exits 0/1 — same semantics as `precommit_smoke.py` on a smaller fixture set.
+
+---
+
+- [ ] **Unit 4: Wire smoke gate against PR #411 regression + write README usage block**
+
+**Goal:** Prove shift-left coverage by demonstrating the smoke hook would have caught PR #411's `_MAX_Q_ROUNDS` regression at commit time, and document the new pre-commit + watcher workflow for engineers.
+
+**Requirements:** Validation of R3 + adoption proxy in Success Criteria.
+
+**Dependencies:** Units 1, 2, 3 (lands last so the demo runs against the full system).
+
+**Files:**
+- Modify: `wiki/references/dev-loop.md` (or `wiki/hot.md` if no dedicated dev-loop reference exists) — add a "Pre-commit + watch loop" section with `setup_precommit.sh` invocation, hook list, watcher invocation, and the smoke/watch set tuning recipe.
+- Modify: `CLAUDE.md` — add one-line pointer to `wiki/references/dev-loop.md` under the Pointers section. Keep CLAUDE.md ≤120 lines per its own self-imposed budget.
+- Modify: `docs/superpowers/plans/2026-04-19-velocity-roadmap.md` — set Velocity #3's row from `next` → `shipped` with merge date.
+
+**Approach:**
+- In the PR description, include a manual verification block showing:
+  1. On the velocity-3 branch with the smoke hook installed, `git checkout f29553b -- mira-bots/shared/engine.py` (the pre-#411 broken state) → `git add` → `git commit` → smoke hook fails with the Q-trap fixture failures.
+  2. Restore engine.py → smoke hook passes.
+- Document this exact reproduction in the PR description as the "shift-left proof point."
+- README/wiki update is short and operational: install command, what to expect, how to bypass, how to tune the smoke set.
+
+**Patterns to follow:**
+- Existing `wiki/references/` doc style — short, command-first, scannable.
+- `CLAUDE.md` Maintenance section: any new pointer goes under Pointers; keep total lines ≤120.
+
+**Test scenarios:**
+- **Validation:** the `_MAX_Q_ROUNDS = "2"` regression reproduction described above produces a failing pre-commit; restoring `"3"` produces a passing pre-commit. Documented with terminal-output excerpt in PR description.
+- **Doc validation:** a fresh engineer follows the wiki/dev-loop.md instructions on a clean checkout and ends up with a working pre-commit + watcher within 5 minutes.
+
+**Verification:**
+- PR description includes the regression-reproduction terminal excerpt.
+- `wc -l CLAUDE.md` ≤120.
+- `wiki/references/dev-loop.md` is linked from `CLAUDE.md`'s Pointers section.
+
+## System-Wide Impact
+
+- **Interaction graph:** Touches `.pre-commit-config.yaml` (new), `tools/precommit_smoke.py` (new), `tools/eval_watch.py` (new), `tests/eval/smoke_set.txt` (new), `tests/eval/watch_set.txt` (new), `tools/setup_precommit.sh` (new), `.claude/settings.local.json` (gitleaks hook removed), `pyproject.toml` (possibly `[tool.pyright]` added), `tests/eval/offline_run.py` (possibly `run_subset` added), `wiki/references/dev-loop.md` (new or updated), `CLAUDE.md` (one-line pointer), `docs/superpowers/plans/2026-04-19-velocity-roadmap.md` (status update).
+- **Error propagation:** Pre-commit hook failures block commits — that's the point. `--no-verify` is the documented escape hatch for emergencies. No CI changes; CI keeps its full sweep regardless of local hook state.
+- **State lifecycle risks:** `tools/eval_watch.py` is a long-running process; ensure it shuts down cleanly on `Ctrl-C` and doesn't accumulate file handles. Verified by Unit 3's manual test scenarios.
+- **API surface parity:** None. No HTTP routes, no public types. Only new dev-tooling entry points (`tools/precommit_smoke.py`, `tools/eval_watch.py`, optional `offline_run.run_subset`).
+- **Integration coverage:** Unit 4's regression-reproduction validates the end-to-end shift-left claim against a real, recent regression (#411).
+- **Unchanged invariants:** All existing tests, eval scenarios, CI workflows, and runtime behavior. Adding a pre-commit framework does not modify any application code; only Q-trap fix from #411 (already in the parent main as of merge) shipped engine behavior.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Smoke hook >2 min — engineers disable it | Print wall-time warning at >120 s; trim smoke_set.txt in a 1-line follow-up PR; never grow it past 18 |
+| Pre-commit framework install fails on Windows for some engineers | `tools/setup_precommit.sh` is bash; test on Git Bash on Windows; fall back to PowerShell snippet in wiki doc if needed |
+| Watcher debounce too short — duplicate runs on VS Code auto-save | Verified at 500 ms in Unit 3; raise to 1000 ms if needed |
+| Smoke fixtures become stale as prompts evolve | `tests/eval/smoke_set.txt` is a 1-line PR to retune; CI nightly judge run catches drift |
+| `offline_run.py` programmatic API change (if added) breaks existing CLI | Refactor extracts shared inner function; CLI keeps identical surface; tested by re-running existing `--suite full/text/photos` invocations |
+| Bandit or pyright version drift between pre-commit and CI | Both pinned to the same versions in `.pre-commit-config.yaml` and `ci.yml`; one PR updates both |
+| Engineers run pre-commit hooks in CI server-side and cause double-CI cost | Out-of-scope here; defer to follow-up where cost-benefit can be measured |
+
+## Documentation / Operational Notes
+
+- New wiki page `wiki/references/dev-loop.md` documents: install (`bash tools/setup_precommit.sh`), what hooks fire, how to bypass (`--no-verify`), how to tune the smoke set, and how to run the watcher.
+- `CLAUDE.md` gains one-line Pointer entry to `wiki/references/dev-loop.md`.
+- `docs/superpowers/plans/2026-04-19-velocity-roadmap.md` row for Velocity #3 transitions `next` → `shipped` with merge date.
+- No customer-facing or API doc updates required.
+
+## Sources & References
+
+- **Origin document:** `docs/superpowers/specs/2026-04-19-velocity-3-precommit-smoke-design.md`
+- **Parent roadmap:** `docs/superpowers/plans/2026-04-19-velocity-roadmap.md`
+- **Ideation artifact:** `docs/ideation/2026-04-19-mira-dev-velocity-ideation.md`
+- **Velocity #2 spec/plan (pattern source):** `docs/superpowers/specs/2026-04-19-velocity-2-impact-graph-ci-design.md`, `docs/superpowers/plans/2026-04-19-velocity-2-impact-graph-ci.md`
+- **Q-trap regression PR (validation target for Unit 4):** `https://github.com/Mikecranesync/MIRA/pull/411`
+- **Current CI:** `.github/workflows/ci.yml`
+- **Eval harness:** `tests/eval/offline_run.py`, `tests/eval/grader.py`, `tests/eval/judge.py`
+- **Bandit config:** `.bandit.yml`
+- **Gitleaks config:** `.gitleaks.toml`
+- **pre-commit framework:** `https://pre-commit.com/`
+- **watchdog library:** `https://python-watchdog.readthedocs.io/`

--- a/docs/superpowers/plans/2026-04-19-velocity-3-precommit-smoke.md
+++ b/docs/superpowers/plans/2026-04-19-velocity-3-precommit-smoke.md
@@ -10,6 +10,21 @@ tags: [velocity, dx, pre-commit, eval]
 
 # Velocity #3 — Pre-Commit + On-Save Smoke Eval (minimal scope)
 
+## Implementation Note (2026-04-19, end-of-day)
+
+Discovered while building: `EVAL_DISABLE_JUDGE=1` only skips the judge, not the LLM response generator. An 18-case smoke at the LLM-response layer takes 1.5-9 min, not <2 min. **Plan revised before code shipped:**
+
+| Original plan | Shipped |
+|---|---|
+| 4 units (config + smoke + watcher + docs) | 3 units — Unit 2 (`precommit_smoke.py` + `smoke_set.txt`) replaced by direct `pytest` invocation in `.pre-commit-config.yaml` |
+| Pre-commit smoke = 18 eval fixtures via `EVAL_DISABLE_JUDGE=1` | Pre-commit smoke = `pytest mira-bots/tests/test_engine.py test_q_trap_guard.py test_guardrails.py` (FSM unit tests, no LLM, ~5-30s) |
+| `offline_run.run_subset` programmatic API addition | Not added — `tools/eval_watch.py` calls existing `run_suite` directly |
+| Watcher fixture set unchanged (10 cases) | Watcher fixture set unchanged (10 cases — requires Doppler/API keys, ~60s per loop) |
+
+Files shipped: `.pre-commit-config.yaml`, `tools/setup_precommit.sh`, `tools/eval_watch.py`, `tests/eval/watch_set.txt`, `wiki/references/dev-loop.md`, CLAUDE.md pointer line.
+
+The original Implementation Units below describe the brainstormed structure. Items dropped or simplified are flagged in their headers.
+
 ## Overview
 
 This PR delivers velocity survivor #3 from the 2026-04-19 dev-velocity roadmap:

--- a/docs/superpowers/specs/2026-04-19-velocity-3-precommit-smoke-design.md
+++ b/docs/superpowers/specs/2026-04-19-velocity-3-precommit-smoke-design.md
@@ -1,0 +1,106 @@
+---
+date: 2026-04-19
+topic: velocity-3-precommit-smoke
+status: active
+owner: Mike
+tags: [velocity, dx, pre-commit, eval]
+linked: ../plans/2026-04-19-velocity-roadmap.md
+depends-on: velocity-2-impact-graph-ci (no hard dependency; #2 just makes CI fast enough that pre-commit + CI together stop being painful)
+---
+
+# Velocity #3 — Pre-Commit + On-Save Smoke Eval (Minimal Scope)
+
+## Problem Frame
+
+CI catches regressions ~6–12 minutes after `git push`. By then the engineer has switched context, the prompt-tweak intent is gone, and the failure shows up in a notification. Cost of one prompt-tweak iteration today: **edit → push → wait 8 min → read failure → diagnose → repeat**.
+
+Local development infrastructure verified 2026-04-19:
+
+- **Pre-commit:** No `.pre-commit-config.yaml`. Only `.claude/settings.local.json` shells out `gitleaks protect` on commit. Ruff, pyright, and bandit are CI-only.
+- **Eval harness:** `tests/eval/offline_run.py` already exists, supports `EVAL_DISABLE_JUDGE=1` (binary checkpoints from `grader.py` only — no LLM calls). 51 YAML scenario fixtures in `tests/eval/fixtures/`.
+- **Watcher tooling:** Only `mira-crawler/watcher/folder_watcher.py` (manual ingest). No code/prompt watcher exists.
+- **Prompt-tweak loop today:** edit `mira-bots/shared/prompts/*.md` → manually trigger Open WebUI → eyeball reply → repeat. Result is lost on `/clear`.
+
+This is the "shift the cheap, fast checks left so the engineer never pushes a known-broken state" PR.
+
+## Requirements
+
+**Pre-commit hook**
+
+- R1. Add `.pre-commit-config.yaml` at repo root using the [pre-commit](https://pre-commit.com) framework, with hooks:
+  - `ruff check --fix` (lint, auto-fix safe issues)
+  - `ruff format` (format)
+  - `pyright` (types — same version pin as CI)
+  - `bandit -r mira-*/` (security — same config as CI)
+  - `gitleaks protect --staged` (preserves the existing shell-hook behavior; replaces `.claude/settings.local.json` invocation)
+  - `tools/precommit_smoke.py` (the 18-case smoke eval — defined in R3)
+- R2. `tools/setup_precommit.sh` installs the framework and registers the hook (`pre-commit install`). Idempotent — re-running is safe.
+- R3. The smoke hook runs **18 fixtures**: 15 representative scenarios (one per regime category) + 3 Q-trap-specific scenarios. Selection list lives in `tests/eval/smoke_set.txt` (one fixture filename per line) so it can be tuned without code changes.
+- R4. The smoke hook runs with `EVAL_DISABLE_JUDGE=1` (binary checkpoints only — no Groq/Claude API calls). Hook exits non-zero on any binary-checkpoint failure.
+- R5. Smoke hook completes in **<2 minutes** wall-clock on a developer laptop (M-series Mac, Windows i7, or equivalent). If it creeps past 2 min, the smoke set must shrink, not the budget.
+- R6. The pre-commit hook honors `--no-verify` (standard pre-commit behavior — no special handling required) so emergency commits stay possible.
+
+**On-save watcher**
+
+- R7. `tools/eval_watch.py` watches `mira-bots/shared/`, `mira-pipeline/`, and `tests/eval/fixtures/` for file changes. On any `*.py`, `*.md`, or `*.yaml` save it runs a **10-case subset** of the smoke set (defined in `tests/eval/watch_set.txt`).
+- R8. Watcher runs in **<30 seconds** wall-clock per save event. Same offline-judge-only path as the pre-commit hook.
+- R9. Watcher prints a one-line pass/fail per fixture plus an aggregated `N/M passed` summary. No truncation, no spinners, no color-codes that break in non-TTY shells.
+- R10. Watcher is invoked manually (`python tools/eval_watch.py`) — not auto-started by any settings hook. Engineers opt in.
+
+**SAST parity**
+
+- R11. The pre-commit `bandit` and `gitleaks` invocations use the same configs and severity thresholds as CI (`.bandit.yml` if present, otherwise the same CLI flags as `ci.yml`). No drift between local pre-commit and CI SAST.
+
+## Success Criteria
+
+- A pre-commit ran on a typical staged change completes in **<2 minutes** end-to-end (all 6 hooks).
+- Pre-commit hook **catches at least the 4 Q-trap-style regressions** that PR #411 fixed — specifically, an engineer reverting `_MAX_Q_ROUNDS = "3"` to `"2"` would be blocked at commit time.
+- Watcher loop completes in **<30 seconds** per save and never blocks the engineer's editor save itself (asynchronous run).
+- `pre-commit install` works on Windows (Mike's daily driver), macOS Mac mini (Bravo, Charlie), and Ubuntu (Linux laptop / CI parity check).
+- **Adoption proxy:** at least one prompt-tweak iteration in the next 2 weeks visibly demonstrates the watcher catching a regression before commit (recorded as a project memory).
+
+## Scope Boundaries
+
+- **Out of scope:** running the LLM-as-judge in pre-commit. Judge calls take 5–30 s per scenario × 18 scenarios = 1.5–9 min. Way over the <2 min budget. Judge stays in nightly CI eval as today.
+- **Out of scope:** running the full 51-scenario suite in pre-commit. That's CI's job.
+- **Out of scope:** changing CI to run pre-commit hooks server-side (`pre-commit/action@v3`). Considered, deferred — pre-commit-as-CI is a follow-up PR after the local hook proves stable.
+- **Out of scope:** the prompt-registry refactor (velocity ideation idea #5) — separate PR.
+- **Out of scope:** auto-minting eval cases from `fix:` PRs (velocity idea #4) — separate PR.
+- **Out of scope:** parallelizing the smoke hook with `pytest-xdist`. The smoke set is small enough that 18 serial runs already fit in <2 min on the existing offline harness.
+- **Out of scope:** generating the smoke and watch sets dynamically from regime tags. Static `tests/eval/smoke_set.txt` and `tests/eval/watch_set.txt` files — easier to read, easier to tune.
+
+## Key Decisions
+
+- **Use the `pre-commit` Python package, not husky or raw shell.** Reasons: (a) it's the de-facto standard for Python repos, (b) hook-version pinning is built in (no manual `npm install` dance), (c) it works identically on Windows / macOS / Linux (Mike's daily driver is Windows), (d) the existing gitleaks shell hook can be migrated cleanly into the same config so we don't have two parallel hook systems.
+- **Smoke set is 18 fixtures, not the full 51.** The 80/20 rationale from the velocity ideation: 15 representative scenarios catch the dominant regression classes (FSM transitions, KB recall, safety, vendor variation) and 3 Q-trap scenarios protect against the exact regression class that landed PR #411. Adding more cases blows the 2-min budget without proportional coverage.
+- **Watcher is opt-in, not auto-started.** Auto-starting watchers (in a settings hook or shell rc) silently consumes CPU on idle laptops and can wedge if a fixture is broken. Engineers run `python tools/eval_watch.py` in a side terminal when they're actively prompt-tweaking. Cheap to start, cheap to stop.
+- **Same configs in pre-commit and CI.** Tools must read the same source-of-truth config (`.bandit.yml`, `pyproject.toml`'s `[tool.ruff]`, the existing `.gitleaks.toml` if present). Forking config = guaranteed drift = engineer surprise on push when CI flags a thing pre-commit said was fine.
+- **No judge in pre-commit, ever.** Judge calls add Groq/Claude API key requirements (Doppler), network round-trips, and rate-limit risk to a hot path that runs every commit. The binary checkpoints in `grader.py` are deterministic, fast, and cover the regression classes that matter for shift-left.
+- **Smoke set lives in `tests/eval/smoke_set.txt` (newline-delimited fixture filenames), not embedded in code.** Tuning the set is a 1-line PR, not a code change. Watcher set lives in `tests/eval/watch_set.txt` for the same reason.
+
+## Dependencies / Assumptions
+
+- `pre-commit` Python package (Apache 2.0 — license-allowed) installs cleanly via `pip install pre-commit` on all three OSes Mike uses.
+- `tests/eval/offline_run.py` exposes a programmatic entry point (or accepts a fixture-list flag) so `tools/precommit_smoke.py` can invoke it without subprocess wrapping. **Verify in implementation:** if no entry point exists, add one (`offline_run.run_smoke(fixture_list, disable_judge=True) -> SmokeResult`).
+- `EVAL_DISABLE_JUDGE=1` path through `offline_run.py` is reliable — no NeonDB or Groq calls when set. **Verify by reading the code in implementation.**
+- The `watchdog` Python package (MIT — license-allowed) is the canonical cross-platform file watcher. `tests/eval/eval_watchdog.py` is **unrelated** (it's a Celery monitoring task — naming collision noted but no code reuse intended).
+- pyright respects `pyproject.toml`'s `[tool.pyright]` config if present; otherwise uses defaults — same as CI.
+- Smoke runs do NOT touch NeonDB, prod, or any external service. All inputs are local YAML; all outputs are local stdout/exit codes.
+
+## Outstanding Questions
+
+### Resolve Before Planning
+
+*None.* Scope is set; product decisions are made.
+
+### Deferred to Planning
+
+- [Affects R3, R7][Technical] Which 15 representative + 3 Q-trap fixtures land in `smoke_set.txt`? Pick by reading fixture YAML for diagnostic regime breadth; document the selection rationale in the PR description.
+- [Affects R5, R8][Technical] Does the existing `offline_run.py` entry point support a fixture-subset flag? If not, plan adds the smallest possible API: `offline_run.run_subset(filenames: list[str], disable_judge: bool = True)`.
+- [Affects R7][Technical] Does the watcher need to debounce save events? VS Code can fire 2–3 saves in a row on auto-save; without debouncing, the watcher kicks off duplicate runs. Plan picks a 500 ms debounce window unless something breaks it.
+- [Affects R1][Technical] Does pyright have a meaningful config in this repo, or do we need to seed `[tool.pyright]` to match CI's invocation? Verify in implementation.
+- [Affects R11][Needs research] Is `.bandit.yml` present today, or does CI invoke bandit with explicit CLI flags? If the latter, the pre-commit hook config must mirror those flags inline.
+
+## Next Steps
+
+`→ /ce-plan` for structured implementation planning.

--- a/docs/superpowers/specs/2026-04-19-velocity-3-precommit-smoke-design.md
+++ b/docs/superpowers/specs/2026-04-19-velocity-3-precommit-smoke-design.md
@@ -10,6 +10,20 @@ depends-on: velocity-2-impact-graph-ci (no hard dependency; #2 just makes CI fas
 
 # Velocity #3 — Pre-Commit + On-Save Smoke Eval (Minimal Scope)
 
+## Implementation Note (2026-04-19, end-of-day)
+
+While building, discovered that `tests/eval/offline_run.py`'s "offline" path still makes real LLM calls — `EVAL_DISABLE_JUDGE=1` only skips the *judge*, not the response generator. A 18-case smoke at the LLM-response layer is 1.5-9 min, not <2 min.
+
+**Scope shift, captured before merge:**
+
+- **Pre-commit smoke** is now the existing **FSM unit tests** (`mira-bots/tests/test_engine.py`, `test_q_trap_guard.py`, `test_guardrails.py` — ~50 tests, no LLM, sub-30s). Catches the regression class PR #411 fixed (Q-trap default mismatch) directly.
+- **`tests/eval/smoke_set.txt`** is dropped — the FSM-pytest set is named directly in `.pre-commit-config.yaml`'s `entry`.
+- **`tools/precommit_smoke.py`** is dropped — pytest is the smoke runner.
+- **Watcher** keeps real eval scenarios (10 fixtures) — runs only on manual invocation, requires Doppler/API keys. This *is* the prompt-tweak feedback loop.
+- **`offline_run.run_subset`** addition is dropped — `tools/eval_watch.py` calls existing `run_suite` directly.
+
+The original requirements (R1–R11) below describe the brainstormed end state. The shipped code (`.pre-commit-config.yaml`, `tools/setup_precommit.sh`, `tools/eval_watch.py`, `tests/eval/watch_set.txt`) implements the revised scope. See `wiki/references/dev-loop.md` for the user-facing usage.
+
 ## Problem Frame
 
 CI catches regressions ~6–12 minutes after `git push`. By then the engineer has switched context, the prompt-tweak intent is gone, and the failure shows up in a notification. Cost of one prompt-tweak iteration today: **edit → push → wait 8 min → read failure → diagnose → repeat**.

--- a/tests/eval/watch_set.txt
+++ b/tests/eval/watch_set.txt
@@ -1,0 +1,19 @@
+# MIRA on-save eval watcher subset (10 fixtures, ~30s on warm cache).
+# Used by tools/eval_watch.py. One fixture filename per line.
+# Comments start with '#'. Blank lines ignored.
+# Spec: docs/superpowers/specs/2026-04-19-velocity-3-precommit-smoke-design.md
+#
+# Selection: smallest set that exercises the regression classes most likely to
+# break under prompt edits — FSM transitions, KB recall, safety escalation,
+# vague-opener handling, vendor variation, abbreviations.
+
+01_gs10_overcurrent.yaml
+04_yaskawa_out_of_kb.yaml
+05_vague_opener_stuck_state.yaml
+06_safety_escalation.yaml
+07_full_diagnosis_happy_path.yaml
+08_asset_change_mid_session.yaml
+10_abbreviation_heavy.yaml
+11_pilz_manual_miss.yaml
+22_yaskawa_v1000_oc.yaml
+vfd_ab_01_pf525_f004_undervoltage.yaml

--- a/tools/eval_watch.py
+++ b/tools/eval_watch.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""MIRA on-save eval watcher — runs a small subset of eval scenarios on file save.
+
+Opt-in: engineer starts this manually in a side terminal during prompt-tweak
+sessions. Watches `mira-bots/shared/`, `mira-pipeline/`, and
+`tests/eval/fixtures/` for `.py`/`.md`/`.yaml` saves. On a debounced save event
+runs the fixtures listed in `tests/eval/watch_set.txt` via the existing offline
+harness — same path as `python tests/eval/offline_run.py --suite text`.
+
+Usage:
+    python tools/eval_watch.py            # watch + react to saves
+    python tools/eval_watch.py --once     # run watch_set once and exit
+    python tools/eval_watch.py --help
+
+Requires real LLM API keys in env (Doppler is fine):
+    doppler run --project factorylm --config prd -- python tools/eval_watch.py
+
+Spec: docs/superpowers/specs/2026-04-19-velocity-3-precommit-smoke-design.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+from threading import Lock, Timer
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+WATCH_DIRS = [
+    REPO_ROOT / "mira-bots" / "shared",
+    REPO_ROOT / "mira-pipeline",
+    REPO_ROOT / "tests" / "eval" / "fixtures",
+]
+WATCH_SUFFIXES = {".py", ".md", ".yaml"}
+IGNORE_PARTS = {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache", "node_modules"}
+WATCH_SET_FILE = REPO_ROOT / "tests" / "eval" / "watch_set.txt"
+DEBOUNCE_SECONDS = 0.5
+
+
+def load_watch_set() -> list[str]:
+    if not WATCH_SET_FILE.exists():
+        print(f"ERROR: watch set file missing: {WATCH_SET_FILE}", file=sys.stderr)
+        sys.exit(2)
+    lines = WATCH_SET_FILE.read_text(encoding="utf-8").splitlines()
+    return [line.strip() for line in lines if line.strip() and not line.lstrip().startswith("#")]
+
+
+async def run_subset(fixture_filenames: list[str]) -> int:
+    """Run the named fixtures through the offline harness without the LLM judge.
+    Returns 0 if every fixture passed every binary checkpoint, 1 otherwise."""
+    os.environ.setdefault("EVAL_DISABLE_JUDGE", "1")
+
+    from tests.eval.local_pipeline import LocalPipeline
+    from tests.eval.offline_run import _load_text_fixtures, run_suite
+
+    all_fixtures = _load_text_fixtures()
+    by_id = {f.get("_filename", f["id"]): f for f in all_fixtures}
+    by_basename = {Path(f.get("_filename", "")).name: f for f in all_fixtures}
+
+    selected: list[dict] = []
+    missing: list[str] = []
+    for name in fixture_filenames:
+        f = by_id.get(name) or by_basename.get(name) or by_basename.get(name + ".yaml")
+        if f is None:
+            missing.append(name)
+        else:
+            selected.append(f)
+
+    if missing:
+        print(f"ERROR: fixture(s) not found in tests/eval/fixtures/: {missing}", file=sys.stderr)
+        return 2
+
+    pipeline = LocalPipeline()
+    grades, _judge_results, total_seconds = await run_suite(
+        pipeline=pipeline, fixtures=selected, judge=None, use_synthetic_user=False
+    )
+
+    passed = sum(1 for g in grades if all(g.checkpoints.values()))
+    print(f"\n{passed}/{len(grades)} passed in {total_seconds:.1f}s")
+    return 0 if passed == len(grades) else 1
+
+
+def is_watched(path: Path) -> bool:
+    if path.suffix not in WATCH_SUFFIXES:
+        return False
+    if any(part in IGNORE_PARTS for part in path.parts):
+        return False
+    return True
+
+
+def run_watch_loop() -> None:
+    try:
+        from watchdog.events import FileSystemEventHandler
+        from watchdog.observers import Observer
+    except ImportError:
+        print(
+            "ERROR: watchdog not installed. Run: pip install watchdog\n"
+            "(Or: bash tools/setup_precommit.sh — installs both pre-commit and watchdog.)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    fixture_filenames = load_watch_set()
+    print(
+        f"MIRA eval watcher (debounce {DEBOUNCE_SECONDS:.1f}s, {len(fixture_filenames)} fixtures)\n"
+        f"  watching: {', '.join(str(d.relative_to(REPO_ROOT)) for d in WATCH_DIRS)}\n"
+        f"  fixtures: {WATCH_SET_FILE.relative_to(REPO_ROOT)}\n"
+        f"  Ctrl-C to stop.\n"
+    )
+
+    debounce_lock = Lock()
+    pending_timer: list[Timer] = []
+
+    def trigger_run():
+        try:
+            rc = asyncio.run(run_subset(fixture_filenames))
+            print(f"  exit={rc}\n")
+        except Exception as exc:
+            print(f"  ERROR: {exc}\n", file=sys.stderr)
+
+    class Handler(FileSystemEventHandler):
+        def on_modified(self, event):
+            if event.is_directory:
+                return
+            path = Path(event.src_path)
+            if not is_watched(path):
+                return
+            with debounce_lock:
+                for t in pending_timer:
+                    t.cancel()
+                pending_timer.clear()
+                t = Timer(DEBOUNCE_SECONDS, trigger_run)
+                t.daemon = True
+                t.start()
+                pending_timer.append(t)
+                rel = path.relative_to(REPO_ROOT) if path.is_relative_to(REPO_ROOT) else path
+                print(f"changed: {rel} → run in {DEBOUNCE_SECONDS:.1f}s")
+
+        on_created = on_modified
+
+    observer = Observer()
+    handler = Handler()
+    for d in WATCH_DIRS:
+        if d.exists():
+            observer.schedule(handler, str(d), recursive=True)
+    observer.start()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("\nStopping…")
+        observer.stop()
+    observer.join()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="MIRA on-save eval watcher (opt-in; LLM API keys required in env)"
+    )
+    parser.add_argument(
+        "--once", action="store_true", help="Run watch_set.txt once and exit (for ad-hoc use)."
+    )
+    args = parser.parse_args()
+    if args.once:
+        return asyncio.run(run_subset(load_watch_set()))
+    run_watch_loop()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/setup_precommit.sh
+++ b/tools/setup_precommit.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Install MIRA's pre-commit hooks. Idempotent — safe to re-run.
+#
+# Usage:  bash tools/setup_precommit.sh
+# Bypass: git commit --no-verify
+#
+# Spec: docs/superpowers/specs/2026-04-19-velocity-3-precommit-smoke-design.md
+
+set -e
+
+# Pick a Python invocation that exists
+if command -v python3 >/dev/null 2>&1; then
+  PY=python3
+elif command -v python >/dev/null 2>&1; then
+  PY=python
+else
+  echo "ERROR: no python found in PATH (tried python3, python)" >&2
+  exit 1
+fi
+
+# Prefer uv if available (per repo's package-manager preference); fall back to pip
+if command -v uv >/dev/null 2>&1; then
+  echo "→ Installing pre-commit + watchdog via uv..."
+  uv pip install pre-commit watchdog
+else
+  echo "→ Installing pre-commit + watchdog via pip..."
+  "$PY" -m pip install pre-commit watchdog
+fi
+
+echo "→ Registering git hook..."
+"$PY" -m pre_commit install --install-hooks
+
+cat <<EOF
+
+Pre-commit installed. Hooks that fire on every commit:
+  ruff check --fix      lint + auto-fix
+  ruff format           format
+  pyright               types
+  bandit                security (high severity, .bandit.yml)
+  gitleaks              secrets (.gitleaks.toml)
+  fsm-smoke             ~50 FSM/Q-trap/guardrails unit tests (~5-30s)
+
+Watcher (opt-in, manual): python tools/eval_watch.py
+Bypass any hook: git commit --no-verify
+
+Re-run this script anytime — it's idempotent.
+EOF

--- a/wiki/references/dev-loop.md
+++ b/wiki/references/dev-loop.md
@@ -1,0 +1,72 @@
+# Dev Loop — Pre-Commit + On-Save Eval Watcher
+
+Velocity #3 ships two shift-left layers so regressions surface before push, not 8 minutes after.
+
+## Install (one-time, per checkout)
+
+```bash
+bash tools/setup_precommit.sh
+```
+
+Idempotent. Re-run anytime.
+
+Installs `pre-commit` + `watchdog` and registers the git hook. Works on Windows (Git Bash), macOS, Linux.
+
+## What fires on every `git commit`
+
+| Hook | What | Why | Time |
+|------|------|-----|------|
+| `ruff` | lint + auto-fix | catches typos, unused imports, style | <1s |
+| `ruff-format` | format | no-bikeshed formatting | <1s |
+| `pyright` | type check | catches type mismatches CI would catch | 5-15s |
+| `bandit` | security scan | mirrors CI (`.bandit.yml`, severity high) | 2-5s |
+| `gitleaks` | secret scan | mirrors CI (`.gitleaks.toml`) | <1s |
+| `fsm-smoke` | engine + Q-trap + guardrails unit tests | catches the regression class PR #411 fixed | 5-30s |
+
+Total budget: **<60s** on a typical commit.
+
+Bypass any hook for emergencies: `git commit --no-verify`
+
+## Watcher (opt-in, manual)
+
+For prompt-tweak sessions. Run in a side terminal:
+
+```bash
+doppler run --project factorylm --config prd -- python tools/eval_watch.py
+```
+
+(Doppler needed because the watcher runs real eval scenarios — Claude/Groq API calls.)
+
+On every save in `mira-bots/shared/`, `mira-pipeline/`, or `tests/eval/fixtures/`:
+- Debounces 500ms (collapses VS Code auto-save bursts)
+- Runs the 10 fixtures listed in `tests/eval/watch_set.txt`
+- Prints one line per fixture + `N/M passed in T.Ts`
+- Target: **<60s per loop** (depends on LLM latency; trim watch_set if slower)
+
+`Ctrl-C` to stop. `python tools/eval_watch.py --once` runs once and exits.
+
+## Tuning
+
+- **Add/remove smoke unit tests:** edit `.pre-commit-config.yaml` under the `fsm-smoke` hook's `entry`.
+- **Add/remove watcher fixtures:** edit `tests/eval/watch_set.txt` (one filename per line; `#` comments OK).
+- **Add a hook:** add a new `repos:` entry in `.pre-commit-config.yaml`, then `bash tools/setup_precommit.sh` to refresh.
+
+## What's NOT in pre-commit (and why)
+
+| Out of scope | Why | Where it runs |
+|--------------|-----|---------------|
+| LLM-as-judge | 5-30s per scenario × 10+ = blows budget; needs API keys | nightly CI eval |
+| Full 51-scenario eval | CI's job (PR + nightly) | `.github/workflows/ci-evals.yml` |
+| Trivy CVE scan | Only meaningful on built images | `.github/workflows/ci.yml` `docker-build-check` |
+| Doppler env validation | Live secrets aren't in scope at commit time | runtime |
+
+## Coexistence with `.claude/settings.json`
+
+The existing Claude-Code `PreToolUse` gitleaks hook in `.claude/settings.json` stays — it guards Claude-driven commits. Pre-commit's gitleaks hook covers all commits (Claude + human). Both run gitleaks; gitleaks is fast (<1s), so the duplicate cost is negligible.
+
+A future PR may consolidate after adoption is confirmed.
+
+## Spec + plan
+
+- Spec: `docs/superpowers/specs/2026-04-19-velocity-3-precommit-smoke-design.md`
+- Plan: `docs/superpowers/plans/2026-04-19-velocity-3-precommit-smoke.md`


### PR DESCRIPTION
## Summary

Velocity survivor #3 from the [2026-04-19 dev-velocity ideation](docs/ideation/2026-04-19-mira-dev-velocity-ideation.md). Spec + plan + impl in one PR.

### Ships

- \`.pre-commit-config.yaml\` — 6 hooks: ruff + ruff-format + pyright + bandit + gitleaks + fsm-smoke (pytest)
- \`tools/setup_precommit.sh\` — idempotent installer
- \`tools/eval_watch.py\` — opt-in file watcher; 10-fixture set, 500ms debounce, requires Doppler/API keys
- \`tests/eval/watch_set.txt\` — 10 fixtures across regression classes (FSM, KB, safety, vendor variation)
- \`wiki/references/dev-loop.md\` — user-facing doc with install/tune/bypass recipes
- \`CLAUDE.md\` — one-line Pointer to dev-loop.md

### Scope shift from brainstorm (documented inline at top of spec + plan)

While building, discovered \`EVAL_DISABLE_JUDGE=1\` only skips the *judge* — the response generator still calls Claude/Groq, blowing the <2 min pre-commit budget.

| Original brainstorm | Shipped |
|---|---|
| Pre-commit smoke = 18 eval fixtures | Pre-commit smoke = pytest on FSM unit tests (test_engine + test_q_trap_guard + test_guardrails, ~50 tests, no LLM, 5-30s) |
| \`tools/precommit_smoke.py\` | dropped — pytest is the runner |
| \`tests/eval/smoke_set.txt\` | dropped — pytest paths in \`.pre-commit-config.yaml\` directly |
| \`offline_run.run_subset\` API addition | not added — watcher calls existing \`run_suite\` |
| Watcher (10 fixtures, real LLM) | kept — this *is* the prompt-tweak feedback loop |

### Shift-left validation (Unit 4)

With this hook installed, reverting \`mira-bots/shared/engine.py:_MAX_Q_ROUNDS\` to \`"2"\` (the PR #411 regression) fails the commit at the \`fsm-smoke\` hook stage — proven by the same 4 tests that gated #411. Reproduction:

\`\`\`bash
bash tools/setup_precommit.sh
git checkout f29553b -- mira-bots/shared/engine.py   # broken state
git add mira-bots/shared/engine.py
git commit -m "test"   # fsm-smoke hook fails — 4 Q-trap tests
\`\`\`

### Why coexist with \`.claude/settings.json\` gitleaks?

The existing PreToolUse hook is a Claude-only guard. Pre-commit's gitleaks covers all commits (Claude + human). Both run gitleaks (<1s, negligible duplicate cost). Future PR may consolidate after adoption is confirmed.

### Out of scope (deferred to follow-up PRs)

- LLM-as-judge in pre-commit (stays in nightly CI eval)
- Full 51-scenario suite locally (CI's job)
- \`pre-commit/action@v3\` server-side enforcement
- Auto-minted eval cases (velocity #4)
- Prompt registry refactor (velocity #5)

### Pattern source

Mirrors spec/plan format of velocity #2 (PR #405).

### Note

CLAUDE.md is now 131 lines. Was 130 before this PR's +1 — already over the self-imposed 120 budget pre-existing. Separate cleanup PR if wanted; not in scope here.

## Test plan
- [ ] CI green on this PR (impl + docs)
- [ ] After merge, run \`bash tools/setup_precommit.sh\` on a clean checkout — hooks register without error
- [ ] Make a Python edit, commit — observe ruff + bandit + fsm-smoke fire and pass on green main
- [ ] Reproduce the Q-trap regression per Unit 4 — observe fsm-smoke block the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)