### PR TITLE
fix(tests): allow 'playwright:<browser>' crawler_type variants

### DIFF
--- a/tests/test_discover_manuals_targets.py
+++ b/tests/test_discover_manuals_targets.py
@@ -52,11 +52,13 @@ def test_every_target_has_required_fields():
 
 
 def test_crawler_type_is_valid():
-    """crawler_type is either 'cheerio' or 'playwright'."""
+    """crawler_type is 'cheerio' or 'playwright[:<browser>]' (e.g. 'playwright:chrome')."""
     from discover_manuals import CRAWL_TARGETS
     valid = {"cheerio", "playwright"}
     for target in CRAWL_TARGETS:
-        assert target["crawler_type"] in valid, (
+        # Allow "playwright:<browser>" variants per Apify crawler_type convention
+        base_type = target["crawler_type"].split(":", 1)[0]
+        assert base_type in valid, (
             f"{target['manufacturer']} has invalid crawler_type: "
             f"{target['crawler_type']}"
         )


### PR DESCRIPTION
## Summary

Eval Offline failure on main: \`test_crawler_type_is_valid\` asserts \`crawler_type in {'cheerio','playwright'}\` but PR #374 set SEW-Eurodrive's crawler_type to \`'playwright:chrome'\` without updating the allowlist.

**Pre-existing main failure** — only surfaced now that PR #411's Q-trap fix lets Eval Offline run for the first time in days (CI was bailing at Unit Tests).

## Fix

One-method change: split on \`:\` so \`'playwright'\`, \`'playwright:chrome'\`, and any future browser-specific variants all pass.

\`\`\`python
base_type = target["crawler_type"].split(":", 1)[0]
assert base_type in valid
\`\`\`

## Verification

\`\`\`
tests/test_discover_manuals_targets.py::test_crawler_type_is_valid PASSED
8 passed in 0.76s
\`\`\`

## Test plan
- [ ] CI Eval Offline passes this test on the PR
- [ ] After merge, main's Eval Offline job clears one of two known failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)