### PR TITLE
fix(tests): accept @mcp.tool bare-decorator usage for fastmcp 3.2

### DIFF
--- a/tests/test_create_asset_from_nameplate.py
+++ b/tests/test_create_asset_from_nameplate.py
@@ -40,7 +40,12 @@ def _install_server_stubs() -> None:
             def __init__(self, *args, **kwargs):
                 pass
 
-            def tool(self):
+            def tool(self, *args, **kwargs):
+                # fastmcp 3.2 uses @mcp.tool (bare, no parens) — args[0] is the fn.
+                # Older fastmcp used @mcp.tool() — returns a decorator.
+                if args and callable(args[0]) and not kwargs:
+                    return args[0]
+
                 def decorator(fn):
                     return fn
 


### PR DESCRIPTION
## Summary

PR #400 merged just now bumped fastmcp 0.4.1 → 3.2.*. In fastmcp 3.2 the decorator API changed from `@mcp.tool()` to `@mcp.tool` (bare, no parens). `mira-mcp/server.py` uses the new style — see any of the `@mcp.tool` decorators at server.py:150, 165, 177, etc.

The `_FakeMCP` stub in `tests/test_create_asset_from_nameplate.py` still modeled the old pattern (assumed `.tool()` returns a decorator). After #400 merged to main, the Eval Offline check regressed — 8/8 tests in this file error at import-time with `TypeError: _FakeMCP.tool() takes 1 positional argument but 2 were given`.

## Fix

Make the stub accept both patterns:
- `@mcp.tool` — `args[0]` is the function, return it directly
- `@mcp.tool(...)` — return a passthrough decorator (for any legacy callers)

One-file, +6/-1. Pure test infrastructure; no production code changes.

## Test plan

- [x] `python -m pytest tests/test_create_asset_from_nameplate.py -q` → **8 passed** (was 8 failed pre-fix)
- [ ] CI Eval Offline check returns to green

Found while pushing through main CI recovery as part of PR #412 prep.