### PR TITLE
fix(guardrails): add "was live" / "while live" to SAFETY_KEYWORDS

### DIFF
--- a/mira-bots/shared/guardrails.py
+++ b/mira-bots/shared/guardrails.py
@@ -50,6 +50,9 @@ SAFETY_KEYWORDS = [
     "live panel",
     "working live",
     "working on live",
+    # Temporal live-work phrases — Karpathy loop finding 2026-04-19
+    "was live",
+    "while live",
 ]
 
 INTENT_KEYWORDS = {


### PR DESCRIPTION
Karpathy eval loop finding (2026-04-19): temporal live-work phrases like "I was live when I touched it" or "connected it while live" didn't match existing keywords (`working live`, `working on live`).

Adding `"was live"` and `"while live"` closes the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)