### PR TITLE
fix(pipeline): add qr_bridge.py to Dockerfile COPY

### DIFF
--- a/mira-pipeline/Dockerfile
+++ b/mira-pipeline/Dockerfile
@@ -16,6 +16,7 @@ COPY mira-pipeline/main.py .
 COPY mira-pipeline/memory.py .
 COPY mira-pipeline/feedback_sync.py .
 COPY mira-pipeline/eval_api.py .
+COPY mira-pipeline/qr_bridge.py .
 
 ENV PYTHONUNBUFFERED=1
 EXPOSE 9099


### PR DESCRIPTION
## Summary
- `qr_bridge.py` was added in #412 but never included in the `COPY` instructions in `mira-pipeline/Dockerfile`
- This caused `mira-pipeline-saas` to crash with `ModuleNotFoundError: No module named 'qr_bridge'` on every restart

## Test plan
- [ ] `mira-pipeline-saas` starts and stays Up after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)