### PR TITLE
feat(rag): MVP Unit 2 — source citations end-to-end

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -2439,6 +2439,8 @@ class Supervisor:
         - When remaining options are a Yes/No pair, render inline prose
           ("Reply: Yes or No.") instead of a numbered block — form-feel fix.
         - Otherwise fall back to the numbered-list rendering.
+        - MVP Unit 2 (2026-04-20): if KB chunks were used and reply lacks
+          a [Source: ...] block, append a citation footer from kb_status.
         """
         reply = parsed["reply"]
         options = parsed.get("options", [])
@@ -2461,9 +2463,8 @@ class Supervisor:
             cleaned.append(text)
 
         if len(cleaned) < 2:
-            return reply
-
-        if (
+            pass  # no options block — reply alone
+        elif (
             len(cleaned) == 2
             and _YES_OPTION_RE.match(cleaned[0])
             and _NO_OPTION_RE.match(cleaned[1])
@@ -2472,8 +2473,43 @@ class Supervisor:
             suffix = f"Reply: {cleaned[0]} or {cleaned[1]}."
             if not reply.rstrip().endswith((".", "?", "!")):
                 reply = reply.rstrip() + "."
-            return f"{reply} {suffix}"
+            reply = f"{reply} {suffix}"
+        else:
+            reply = deduplicate_options(reply, cleaned)
+            reply += "\n\n" + "\n".join(f"{i + 1}. {opt}" for i, opt in enumerate(cleaned))
 
-        reply = deduplicate_options(reply, cleaned)
-        reply += "\n\n" + "\n".join(f"{i + 1}. {opt}" for i, opt in enumerate(cleaned))
-        return reply
+        return self._maybe_append_citation_footer(reply)
+
+    def _maybe_append_citation_footer(self, reply: str) -> str:
+        """Append a Sources footer if KB chunks were used but the reply doesn't cite them.
+
+        MVP Unit 2 — LLM compliance enforcement for Rule 16 in active.yaml. The
+        system prompt instructs the model to emit `[Source: ...]` blocks when
+        retrieval informed the answer; this is a safety net for when it doesn't.
+
+        Rules:
+        - Only fires when self.rag.kb_status has citations (i.e., chunks were used)
+        - Only fires when reply doesn't already contain a `[Source:` substring
+        - Append-only — never modifies the LLM body
+        - Idempotent — running this on already-cited reply is a no-op
+        """
+        try:
+            kb_status = getattr(self.rag, "kb_status", None) or {}
+        except AttributeError:
+            return reply
+        citations = kb_status.get("citations") or []
+        if not citations:
+            return reply
+        if "[Source:" in reply or "--- Sources ---" in reply:
+            return reply
+        lines = ["", "", "--- Sources ---"]
+        for i, c in enumerate(citations, 1):
+            mfr = c.get("manufacturer", "") or ""
+            mdl = c.get("model_number", "") or ""
+            section = c.get("section", "") or ""
+            label_parts = [p for p in [mfr, mdl] if p]
+            label = " ".join(label_parts) if label_parts else "knowledge base"
+            if section:
+                label += f" — {section}"
+            lines.append(f"[{i}] {label}")
+        return reply + "\n".join(lines)

--- a/mira-bots/shared/neon_recall.py
+++ b/mira-bots/shared/neon_recall.py
@@ -192,6 +192,9 @@ def _like_search(conn, text_fn, tenant_id: str, codes: list[str], limit: int) ->
             model_number,
             equipment_type,
             source_type,
+            source_url,
+            source_page,
+            metadata,
             0.5 AS similarity
         FROM knowledge_entries
         WHERE (tenant_id = :tid OR tenant_id = :shared_tid)
@@ -237,7 +240,7 @@ def _product_search(
                 text_fn(
                     "WITH product_chunks AS ("
                     "  SELECT content, manufacturer, model_number, equipment_type, "
-                    "  source_type, embedding "
+                    "  source_type, source_url, source_page, metadata, embedding "
                     "  FROM knowledge_entries "
                     "  WHERE (tenant_id = :tid OR tenant_id = :shared_tid) "
                     "  AND model_number ILIKE :pat "
@@ -245,7 +248,7 @@ def _product_search(
                     "  AND embedding IS NOT NULL"
                     ") "
                     "SELECT content, manufacturer, model_number, equipment_type, "
-                    "source_type, "
+                    "source_type, source_url, source_page, metadata, "
                     "1 - (embedding <=> cast(:emb AS vector)) AS similarity "
                     "FROM product_chunks "
                     "ORDER BY embedding <=> cast(:emb AS vector) "
@@ -376,6 +379,9 @@ def recall_knowledge(
                         model_number,
                         equipment_type,
                         source_type,
+                        source_url,
+                        source_page,
+                        metadata,
                         1 - (embedding <=> cast(:emb AS vector)) AS similarity
                     FROM knowledge_entries
                     WHERE (tenant_id = :tid OR tenant_id = :shared_tid)
@@ -419,6 +425,9 @@ def recall_knowledge(
                                 "model_number": row.get("equipment_model", ""),
                                 "equipment_type": "",
                                 "source_type": "fault_code_table",
+                                "source_url": None,
+                                "source_page": None,
+                                "metadata": {"section": "Fault Code Table"},
                                 "similarity": 0.95,  # high confidence — deterministic match
                             }
                         )


### PR DESCRIPTION
## Summary

**Unit 2 of the 90-day MVP plan** ([\`~/.claude/plans/yes-giggly-floyd.md\`](https://github.com/Mikecranesync/MIRA)). Closes the citation transport layer that PR #418's citation gate already had the consumer side for.

Net: every diagnostic answer that uses KB chunks now ends with a verifiable source footer like:

\`\`\`
--- Sources ---
[1] Yaskawa GS20 — §3.4 Overcurrent
[2] AutomationDirect GS10 — Fault Codes Reference
\`\`\`

## Three coordinated changes

### 1. \`mira-bots/shared/neon_recall.py\` — surface chunk metadata
All 3 SELECTs (vector, ILIKE fallback, product-name reranked) now return \`source_url\`, \`source_page\`, and \`metadata\` JSONB. Structured fault-code pseudo-chunks carry \`metadata={"section": "Fault Code Table"}\` so they render correctly too.

**Before:** chunks returned 6 fields (content, mfr, model, equipment_type, source_type, similarity)
**After:** chunks return 9 fields (+ source_url, source_page, metadata)

### 2. \`mira-bots/shared/workers/rag_worker.py\` — UNCHANGED
The chunk-header builder at line 367-378 already reads \`meta.get("section")\` and assembles \`[Source: {mfr} {mdl} — {section}]\`. Once Step 1 surfaces metadata, headers go from \`[Source: GS20]\` → \`[Source: GS20 — §3.4 Overcurrent]\` automatically.

### 3. \`mira-bots/shared/engine.py\` — LLM compliance enforcement
- Refactored \`_format_reply\` to single-return (clean for the new hook)
- New \`_maybe_append_citation_footer(reply)\` helper:
  - Reads \`self.rag.kb_status.citations\` (populated by PR #418's \`_compute_kb_status\`)
  - If chunks were used AND reply lacks \`[Source:\` substring → append \`--- Sources ---\` footer
  - **Append-only, idempotent, never modifies LLM body**

Safety net for when the LLM ignores Rule 16 in \`mira-bots/prompts/diagnose/active.yaml:38\` (\"CITE YOUR SOURCE\").

## Honesty constraint applied

- \`source_page\` in DB is a chunk index, NOT a PDF page number. Citations show \`{section}\` from metadata if present (text label like \"§3.4 Overcurrent\"); fall back to bare \`[Source: {mfr} {mdl}]\` when no section. **We do NOT show \"p.47\" when we mean \"chunk 47\"** — would mislead technicians.
- Backfilling real PDF page numbers from PDF re-extraction is a separate ~1-week task, explicitly out of Unit 2 scope.

## Verification

- ✅ **25/25** \`test_citation_gate.py\` tests pass (was 25/25 before — backward compat)
- ✅ Module imports clean (sanity-checked \`from shared import neon_recall, engine\` and \`from shared.workers import rag_worker\`)
- ⚠️ **Pre-existing failures NOT from this PR**: \`test_engine.py\` import of \`_FAULT_INFO_RE\` (deleted in v1.1 prompt audit, test not updated) + 4 \`test_q_trap_guard.py\` tests. Verified by running tests on main *unmodified* — same failures. Separate hotfix needed.

## Token-budget impact

Per-chunk header overhead: +~30 tokens × limit=3 chunks = ~90 tokens on top of typical 2-3K context. <5% of budget — well within safe range.

## Plan progress: 3 / 10 units done

| # | Unit | Status |
|---|---|---|
| 0 | Anchor MVP objective in global CLAUDE.md | ✅ DONE |
| 1 | Codebase consolidation | ✅ DONE (PR #419) |
| **2** | **Source citations in RAG** | **THIS PR** |
| 6 | Hybrid BM25 + pgvector retrieval | next (W2) |

## Pre-execution gate (from plan)

Main is currently RED on 3 unrelated commits (post-merge QR pipeline work + Dockerfile COPY issue, NOT from this plan). Shipping Unit 2 here on \`feat/mvp-unit-2-citations\` with **local-only verification** per plan §pre-execution-gate. Merge once main is green.

## Test plan
- [ ] CI green on this PR (assuming main fixes land)
- [ ] After merge, run a real diagnostic via Telegram with a known KB-covered query (e.g., \"GS20 fault F23\") — confirm response ends with \`--- Sources ---\` footer
- [ ] Pick 3 cited chunks; verify the cited section actually contains the cited fact (no hallucination)
- [ ] Fault-code path: query \"GS20 fault F23\"; verify it cites \`[Source: ... — Fault Code Table]\` for the structured-table hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)