### PR TITLE
fix(engine): restore q-trap escape + 3 silent regressions hidden behind import error

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -110,6 +110,26 @@ STATE_ORDER = ["IDLE", "Q1", "Q2", "Q3", "DIAGNOSIS", "FIX_STEP", "RESOLVED"]
 _CRITIQUE_DISABLED = os.getenv("MIRA_DISABLE_SELF_CRITIQUE", "0") == "1"
 _CRITIQUE_THRESHOLD = int(os.getenv("MIRA_CRITIQUE_THRESHOLD", "3"))
 _CRITIQUE_MAX_ATTEMPTS = int(os.getenv("MIRA_CRITIQUE_MAX_ATTEMPTS", "2"))
+
+# Patterns that indicate the user has already supplied fault/alarm specifics.
+# Imported by tests/test_engine.py — restored after PR #422 inadvertently removed it
+# alongside the q-trap escape (see fix/q-trap-restore-from-422 PR).
+_FAULT_INFO_RE = re.compile(
+    r"""
+    (?:[A-Z]{1,3}-?\d{3,})              # F30001, AL-14, E001
+    | \b[A-Z]{2,3}\b(?=\s+fault)        # OC fault, OL fault (common VFD 2-letter codes)
+    | \b(?:fault\s+code|alarm\s+(?:code|number)|error\s+code|fault\s+number)\b
+    | \b(?:tripping\s+on|tripped\s+on|showing\s+(?:fault|error|alarm))\b
+    | \b(?:displays?|shows?|reading)\s+[A-Z0-9]{2,}  # "shows OC", "displays F7"
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Q-trap escape: hard ceiling on consecutive Q-state turns so techs aren't
+# interrogated forever. Restored from pre-#422 state. See #387 for off-by-one.
+_Q_STATES = frozenset({"Q1", "Q2", "Q3"})
+_MAX_Q_ROUNDS = int(os.getenv("MIRA_MAX_Q_ROUNDS", "3"))
+
 # Compact judge prompt — returns only the three actionable dims to keep token cost low.
 _CRITIQUE_PROMPT = """\
 Score this maintenance-AI response. Return ONLY valid JSON — no markdown, no prose.
@@ -1771,6 +1791,10 @@ class Supervisor:
             "queued_at": datetime.now(timezone.utc).isoformat(),
         }
         state["context"] = ctx
+        # KB miss → exit Q-state loop and return to IDLE so the technician can ask
+        # something else while the crawl runs. Without this, the FSM gets stuck in
+        # whatever Q-state triggered the lookup (pilz_11, dist_36 fixtures).
+        state["state"] = "IDLE"
         asyncio.create_task(self._fire_scrape_trigger(message, mfr, resolved_tenant or "", chat_id))
         logger.info(
             "DOC_INTENT_ROUTING chat_id=%s manufacturer=%r support_url=%s",
@@ -2208,8 +2232,12 @@ class Supervisor:
         """
         raw_stripped = raw.strip()
 
+        # strict=False allows literal control chars (newlines, tabs) inside JSON string
+        # values. LLMs regularly emit envelopes with raw \n in the reply field; without
+        # this, json.loads rejects them per RFC 8259 and the envelope leaks to chat.
+        # Restored from the P0 #380 fix that was lost in a recent merge. See #387.
         try:
-            parsed = json.loads(raw_stripped)
+            parsed = json.loads(raw_stripped, strict=False)
             if isinstance(parsed, dict):
                 if "reply" in parsed:
                     return self._extract_parsed(parsed)
@@ -2226,7 +2254,7 @@ class Supervisor:
                 if block.startswith("json"):
                     block = block[4:].strip()
                 try:
-                    parsed = json.loads(block)
+                    parsed = json.loads(block, strict=False)
                     if isinstance(parsed, dict) and "reply" in parsed:
                         return self._extract_parsed(parsed)
                 except (json.JSONDecodeError, TypeError):
@@ -2237,7 +2265,7 @@ class Supervisor:
                 for j in range(len(raw_stripped), i, -1):
                     if raw_stripped[j - 1] == "}":
                         try:
-                            parsed = json.loads(raw_stripped[i:j])
+                            parsed = json.loads(raw_stripped[i:j], strict=False)
                             if isinstance(parsed, dict) and "reply" in parsed:
                                 return self._extract_parsed(parsed)
                         except (json.JSONDecodeError, TypeError):
@@ -2350,6 +2378,27 @@ class Supervisor:
 
         if state["state"] in ("RESOLVED", "SAFETY_ALERT"):
             state["final_state"] = state["state"]
+
+        # Q-trap escape (restored from pre-#422 state — see fix/q-trap-restore-from-422):
+        # if the FSM has been in Q-states for _MAX_Q_ROUNDS consecutive turns, force a
+        # commit to DIAGNOSIS so the technician gets an answer. Count every entry into
+        # a Q-state (including the first one from a non-Q current) so IDLE→Q1→Q2→Q3
+        # commits on round 3 rather than round 4.
+        ctx_q = state.get("context") or {}
+        if state["state"] in _Q_STATES:
+            ctx_q["q_rounds"] = ctx_q.get("q_rounds", 0) + 1
+            if ctx_q["q_rounds"] >= _MAX_Q_ROUNDS:
+                logger.info(
+                    "Q_TRAP_COMMIT chat_id=%s q_rounds=%d current=%s → DIAGNOSIS",
+                    state.get("chat_id", "?"),
+                    ctx_q["q_rounds"],
+                    state["state"],
+                )
+                state["state"] = "DIAGNOSIS"
+                ctx_q["q_rounds"] = 0
+        else:
+            ctx_q.pop("q_rounds", None)
+        state["context"] = ctx_q
 
         if not state.get("fault_category"):
             for cat in (


### PR DESCRIPTION
## Summary

PR #422 (\"kanban triage\") inadvertently deleted the q-trap escape system along with the gsd_engine.py compat-wrapper removal. The deletion took out 4 things bots/tests depend on, but only one failure was visible — the rest were hidden because \`test_engine.py\` couldn't even be COLLECTED (\`ImportError\` on \`_FAULT_INFO_RE\`), so 100+ assertions never ran.

This hotfix restores the deleted code AND fixes the 3 regressions that surfaced once \`test_engine.py\` started collecting again.

## Restored from pre-#422 (commit \`c0789a6^\`)

1. **\`_FAULT_INFO_RE\`** — regex constant. \`tests/test_engine.py\` imports it. Restored as a constant; the original \`.search()\` callsite (in self-critique loop) is NOT restored — that's a separate behavior decision PR #422 may have intentionally changed.
2. **\`_Q_STATES\` + \`_MAX_Q_ROUNDS\`** — frozenset + env-var ceiling for q-trap.
3. **Q-trap escape block in \`_advance_state\`** — counts every entry into a Q-state; forces commit to DIAGNOSIS when \`q_rounds >= _MAX_Q_ROUNDS\` so technicians aren't interrogated indefinitely. Restored verbatim from pre-#422 (with the off-by-one fix from #387).

## Re-fixed (silently broken; surfaced once test_engine.py collected again)

4. **\`_parse_response\`** — added \`strict=False\` to all 3 \`json.loads\` calls. RFC 8259 rejects unescaped control chars in JSON strings; LLMs regularly emit envelopes with raw \`\n\` in the reply field. Without \`strict=False\` the parse fails and the raw envelope leaks to chat output. **This was the original P0 #380 fix that was lost in a recent merge.**
5. **\`_do_documentation_lookup\` KB-miss path** — set \`state[\"state\"] = \"IDLE\"\` before the return so the FSM exits the Q-state loop when no vendor documentation is found. Without this the FSM stays stuck in whatever Q-state triggered the lookup (pilz_11, dist_36 fixtures). One-line fix.

## Verification

Local Python 3.11 on Windows:

| Test file | Result |
|---|---|
| \`test_q_trap_guard.py\` | **6/6 PASS** (was 4 fail / 2 pass) |
| \`test_engine.py\` | collects cleanly; previously-hidden \`test_envelope_with_literal_newline_in_reply_p0_issue_380\`, \`test_envelope_parse_failure_never_leaks_raw_json_keys\`, and \`test_doc_lookup_kb_miss_transitions_to_idle\` now all PASS |
| \`test_citation_gate.py\` | 25/25 PASS |
| Full \`mira-bots/tests/\` | **216 PASS**, 8 skipped, 3 Windows-only failures in \`tools/test_active_learner.py\` (\`WinError 32\` SQLite file-lock — passes on Linux CI) |

## Why 5 fixes in one PR

All 5 trace to the same root cause (PR #422's bundled removal). Splitting them would multiply review surface for fixes that share context. The blast radius is bounded — \`engine.py\` only.

## Why this matters

**Unblocks PR #428** (MVP Unit 2 — source citations) which is currently red on CI due to these same pre-existing failures.

**Restores production safety net** — without the q-trap escape, MIRA can interrogate technicians indefinitely with clarifying questions. The Q-trap fixes specifically protect the \"GS20 fault → infinite Q1/Q2/Q3 loop\" failure mode that was the original motivation for #387.

## Test plan

- [ ] CI green on this PR (Linux runners; Windows file-lock failures don't apply)
- [ ] After merge, rebase PR #428 onto green main → its CI should also go green
- [ ] Spot-check live diagnostic: query \"GS20 fault F23\" repeatedly without supplying detail → MIRA should commit to DIAGNOSIS by Q3 instead of asking a 4th clarifying question

🤖 Generated with [Claude Code](https://claude.com/claude-code)