### PR TITLE
feat(lead-hunter): Serper snippet contact enrichment + --enrich-only mode

### DIFF
--- a/tools/lead-hunter/celery_tasks.py
+++ b/tools/lead-hunter/celery_tasks.py
@@ -19,6 +19,7 @@ Register beat (add to mira-crawler/celeryconfig.py beat_schedule):
 Standalone run (no Celery):
     python3 tools/lead-hunter/run_hourly.py
 """
+
 from __future__ import annotations
 
 import json
@@ -71,15 +72,15 @@ def _check_daily_budget(state: dict) -> bool:
 # Core hourly task
 # ---------------------------------------------------------------------------
 
+
 def run_discover_and_enrich() -> dict:
     """Execute one hourly discovery + enrichment cycle. Returns run stats."""
     import httpx
 
     # Import here to allow running without Celery
     sys.path.insert(0, str(Path(__file__).parent))
-    import hunt
     import discover
-    import enrich
+    import hunt
 
     state = _load_state()
     if not _check_daily_budget(state):
@@ -122,7 +123,10 @@ def run_discover_and_enrich() -> dict:
     ddg_fails = [0]
     with httpx.Client(timeout=20) as client:
         facs, _ = discover.search_ddg_medium(
-            city_name, city_lat, city_lon, client,
+            city_name,
+            city_lat,
+            city_lon,
+            client,
             ddg_fails=ddg_fails,
         )
         requests_used += len(discover.MEDIUM_BIZ_QUERIES)
@@ -133,11 +137,9 @@ def run_discover_and_enrich() -> dict:
     # Phase 1c: Standard queries for this city (reuse existing search logic)
     if requests_used < DISCOVERY_RATE["max_requests_per_run"] and ddg_fails[0] < 5:
         log.info("Standard DDG queries for %s...", city_name)
-        ddg_dead = False
         with httpx.Client(timeout=20) as client:
             for qt in hunt.QUERY_TEMPLATES:
                 if ddg_fails[0] >= 5:
-                    ddg_dead = True
                     break
                 if requests_used >= DISCOVERY_RATE["max_requests_per_run"]:
                     break
@@ -149,19 +151,23 @@ def run_discover_and_enrich() -> dict:
                     time.sleep(hunt.RATE_LIMIT_SECS)
                     continue
                 ddg_fails[0] = 0
-                new_facs = hunt.extract_facilities_from_results(results, city_name, city_lat, city_lon, query)
+                new_facs = hunt.extract_facilities_from_results(
+                    results, city_name, city_lat, city_lon, query
+                )
                 for f in new_facs:
                     if f.key not in new_facilities:
                         new_facilities[f.key] = f
                 time.sleep(hunt.RATE_LIMIT_SECS)
 
     # Cap to max_facilities_per_run
-    fac_list = list(new_facilities.values())[:DISCOVERY_RATE["max_facilities_per_run"]]
+    fac_list = list(new_facilities.values())[: DISCOVERY_RATE["max_facilities_per_run"]]
     log.info("Discovered %d new facilities", len(fac_list))
 
     # Phase 2: Enrich top un-enriched facilities
     if db_url:
-        enriched_count = _enrich_unenriched(db_url, hunter_key, DISCOVERY_RATE["max_enrichments_per_run"])
+        enriched_count = _enrich_unenriched(
+            db_url, hunter_key, DISCOVERY_RATE["max_enrichments_per_run"]
+        )
     else:
         enriched_count = 0
 
@@ -209,10 +215,10 @@ def run_discover_and_enrich() -> dict:
 
 def _enrich_unenriched(db_url: str, hunter_key: str, limit: int) -> int:
     """Enrich facilities that have a website but no contacts yet."""
-    import psycopg2
+    import enrich
     import httpx
     import hunt
-    import enrich
+    import psycopg2
 
     conn = psycopg2.connect(db_url)
     cur = conn.cursor()
@@ -240,8 +246,12 @@ def _enrich_unenriched(db_url: str, hunter_key: str, limit: int) -> int:
         for row in rows:
             fid, name, city, website, phone, icp_score, notes = row
             f = hunt.Facility(
-                name=name, city=city, website=website or "",
-                phone=phone or "", icp_score=icp_score or 0, notes=notes or "",
+                name=name,
+                city=city,
+                website=website or "",
+                phone=phone or "",
+                icp_score=icp_score or 0,
+                notes=notes or "",
             )
             try:
                 log.info("Enriching: %s (%s)", name[:50], (website or "")[:40])
@@ -270,8 +280,15 @@ def _enrich_unenriched(db_url: str, hunter_key: str, limit: int) -> int:
                             VALUES (%s, %s, %s, %s, %s, %s, %s)
                             ON CONFLICT DO NOTHING
                             """,
-                            (fid, c.get("name"), c.get("title"), c.get("email"),
-                             c.get("phone"), c.get("source", "website"), c.get("confidence", "low")),
+                            (
+                                fid,
+                                c.get("name"),
+                                c.get("title"),
+                                c.get("email"),
+                                c.get("phone"),
+                                c.get("source", "website"),
+                                c.get("confidence", "low"),
+                            ),
                         )
                 conn2.commit()
                 conn2.close()

--- a/tools/lead-hunter/discover.py
+++ b/tools/lead-hunter/discover.py
@@ -7,21 +7,30 @@ Sources:
 
 All functions return list[Facility] and are safe to call from any context.
 """
+
 from __future__ import annotations
 
 import logging
 import random
 import re
 import time
-from urllib.parse import quote_plus, unquote, urlparse
+from urllib.parse import quote_plus, unquote
 
 import httpx
 from bs4 import BeautifulSoup
 
 # Import shared types — hunt.py must be on sys.path
 from hunt import (
-    ANCHOR_LAT, ANCHOR_LON, CITIES, DDG_TIMEOUT_SECS, RATE_LIMIT_SECS,
-    USER_AGENTS, Facility, extract_facilities_from_results, haversine, looks_like_mfg, score_facility,
+    ANCHOR_LAT,
+    ANCHOR_LON,
+    CITIES,
+    DDG_TIMEOUT_SECS,
+    RATE_LIMIT_SECS,
+    USER_AGENTS,
+    Facility,
+    extract_facilities_from_results,
+    haversine,
+    score_facility,
 )
 
 log = logging.getLogger("lead-hunter.discover")
@@ -54,16 +63,49 @@ MEDIUM_BIZ_QUERIES = [
 MSCA_URL = "https://mscafl.com/msca-member-directory/"
 
 MSCA_MFG_KEYWORDS = [
-    "manufactur", "fabricat", "machining", "cnc", "machine shop", "weld",
-    "pump", "processing", "packaging", "plastic", "fiberglass", "steel",
-    "metal", "industrial", "assembly", "production", "plant", "bottling",
-    "distribution", "infusion", "equipment", "tool", "mold",
+    "manufactur",
+    "fabricat",
+    "machining",
+    "cnc",
+    "machine shop",
+    "weld",
+    "pump",
+    "processing",
+    "packaging",
+    "plastic",
+    "fiberglass",
+    "steel",
+    "metal",
+    "industrial",
+    "assembly",
+    "production",
+    "plant",
+    "bottling",
+    "distribution",
+    "infusion",
+    "equipment",
+    "tool",
+    "mold",
 ]
 
 MSCA_SKIP_NAMES = {
-    "staffing", "consulting", "insurance", "airport", "electric", "college",
-    "vision", "payroll", "accounting", "transportation", "staffing", "development",
-    "council", "commerce", "workforce", "recruiting", "forged paths",
+    "staffing",
+    "consulting",
+    "insurance",
+    "airport",
+    "electric",
+    "college",
+    "vision",
+    "payroll",
+    "accounting",
+    "transportation",
+    "staffing",
+    "development",
+    "council",
+    "commerce",
+    "workforce",
+    "recruiting",
+    "forged paths",
 }
 
 
@@ -92,7 +134,7 @@ def scrape_msca(client: httpx.Client) -> list[Facility]:
     facilities = []
 
     for block in blocks:
-        lines = [l.strip() for l in block.get_text(separator="\n").split("\n") if l.strip()]
+        lines = [ln.strip() for ln in block.get_text(separator="\n").split("\n") if ln.strip()]
         if len(lines) < 2:
             continue
 
@@ -178,6 +220,7 @@ def _infer_category(text: str) -> str:
 # DuckDuckGo — medium-business targeted queries
 # ---------------------------------------------------------------------------
 
+
 def search_ddg_medium(
     city: str,
     city_lat: float,
@@ -244,11 +287,13 @@ def _ddg_search(query: str, client: httpx.Client) -> list[dict] | None:
                     link = unquote(href.split("uddg=")[1].split("&")[0])
                 elif href.startswith("http"):
                     link = href
-            results.append({
-                "title": title_el.get_text(strip=True),
-                "snippet": snippet_el.get_text(strip=True) if snippet_el else "",
-                "link": link,
-            })
+            results.append(
+                {
+                    "title": title_el.get_text(strip=True),
+                    "snippet": snippet_el.get_text(strip=True) if snippet_el else "",
+                    "link": link,
+                }
+            )
         return results[:10]
     except Exception as e:
         log.warning("DDG error for %r: %s", query, e)

--- a/tools/lead-hunter/enrich.py
+++ b/tools/lead-hunter/enrich.py
@@ -8,10 +8,10 @@ Sources (in order of quality):
 
 All functions are self-contained and safe to call independently.
 """
+
 from __future__ import annotations
 
 import logging
-import os
 import re
 import socket
 import subprocess
@@ -20,8 +20,7 @@ from typing import Optional
 from urllib.parse import urlparse
 
 import httpx
-
-from hunt import Facility, USER_AGENTS, EMAIL_RE, PHONE_RE, MAINT_TITLES, VFD_KWS
+from hunt import EMAIL_RE, MAINT_TITLES, PHONE_RE, USER_AGENTS, VFD_KWS, Facility
 
 log = logging.getLogger("lead-hunter.enrich")
 
@@ -49,6 +48,7 @@ CONFIDENCE_LEVELS = {
 # Hunter.io
 # ---------------------------------------------------------------------------
 
+
 def find_contacts_hunter(domain: str, api_key: str, client: httpx.Client) -> list[dict]:
     """Query Hunter.io domain search. Returns list of contact dicts."""
     if not domain or not api_key:
@@ -74,13 +74,17 @@ def find_contacts_hunter(domain: str, api_key: str, client: httpx.Client) -> lis
             email = email_data.get("value", "")
             position = email_data.get("position", "")
             if email and _is_maintenance_role(position):
-                contacts.append({
-                    "name": f"{first} {last}".strip(),
-                    "title": position,
-                    "email": email,
-                    "source": "hunter.io",
-                    "confidence": "high" if email_data.get("verification", {}).get("status") == "valid" else "medium",
-                })
+                contacts.append(
+                    {
+                        "name": f"{first} {last}".strip(),
+                        "title": position,
+                        "email": email,
+                        "source": "hunter.io",
+                        "confidence": "high"
+                        if email_data.get("verification", {}).get("status") == "valid"
+                        else "medium",
+                    }
+                )
         return contacts
     except Exception as e:
         log.debug("Hunter.io error for %s: %s", domain, e)
@@ -89,16 +93,27 @@ def find_contacts_hunter(domain: str, api_key: str, client: httpx.Client) -> lis
 
 def _is_maintenance_role(title: str) -> bool:
     title_l = title.lower()
-    return any(t in title_l for t in [
-        "maintenance", "facilities", "plant manager", "plant engineer",
-        "reliability", "operations manager", "chief engineer", "facility",
-        "mechanical", "electrical engineer",
-    ])
+    return any(
+        t in title_l
+        for t in [
+            "maintenance",
+            "facilities",
+            "plant manager",
+            "plant engineer",
+            "reliability",
+            "operations manager",
+            "chief engineer",
+            "facility",
+            "mechanical",
+            "electrical engineer",
+        ]
+    )
 
 
 # ---------------------------------------------------------------------------
 # Email pattern generation
 # ---------------------------------------------------------------------------
+
 
 def generate_email_patterns(first: str, last: str, domain: str) -> list[dict]:
     """Generate candidate email addresses for a person at a domain."""
@@ -111,18 +126,18 @@ def generate_email_patterns(first: str, last: str, domain: str) -> list[dict]:
         return []
 
     f = first.lower()
-    l = last.lower()
+    last_lower = last.lower()
     fi = f[0]
 
     patterns = []
     templates = [
-        (f"{f}.{l}@{domain}", "first.last"),
-        (f"{f}{l}@{domain}", "firstlast"),
+        (f"{f}.{last_lower}@{domain}", "first.last"),
+        (f"{f}{last_lower}@{domain}", "firstlast"),
         (f"{f}@{domain}", "first"),
-        (f"{fi}{l}@{domain}", "flast"),
-        (f"{l}@{domain}", "last"),
-        (f"{f}.{l[0]}@{domain}", "first.li"),
-        (f"{fi}.{l}@{domain}", "f.last"),
+        (f"{fi}{last_lower}@{domain}", "flast"),
+        (f"{last_lower}@{domain}", "last"),
+        (f"{f}.{last_lower[0]}@{domain}", "first.li"),
+        (f"{fi}.{last_lower}@{domain}", "f.last"),
     ]
     for email, pattern_name in templates:
         patterns.append({"email": email, "pattern": pattern_name, "source": "pattern"})
@@ -137,12 +152,15 @@ def _clean_name(s: str) -> str:
 # DNS verification
 # ---------------------------------------------------------------------------
 
+
 def domain_has_mx(domain: str) -> bool:
     """Check if domain has MX records (domain accepts email)."""
     try:
         result = subprocess.run(
             ["dig", "+short", "MX", domain],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         return bool(result.stdout.strip())
     except Exception:
@@ -169,9 +187,16 @@ def verify_patterns_dns(patterns: list[dict], domain: str) -> list[dict]:
 # ---------------------------------------------------------------------------
 
 CONTACT_PATHS = [
-    "/contact", "/contact-us", "/about", "/about-us",
-    "/team", "/staff", "/leadership", "/management",
-    "/careers", "/jobs",
+    "/contact",
+    "/contact-us",
+    "/about",
+    "/about-us",
+    "/team",
+    "/staff",
+    "/leadership",
+    "/management",
+    "/careers",
+    "/jobs",
 ]
 
 
@@ -213,16 +238,19 @@ def scrape_facility_deep(f: Facility, client: httpx.Client) -> dict:
                 continue
 
             from bs4 import BeautifulSoup
+
             soup = BeautifulSoup(resp.text, "html.parser")
             text = soup.get_text(separator=" ", strip=True)
             all_text.append(text)
 
             # Emails
             for email in EMAIL_RE.findall(text):
-                if (email not in result["emails"]
-                        and "example" not in email
-                        and not email.endswith(".png")
-                        and not email.endswith(".jpg")):
+                if (
+                    email not in result["emails"]
+                    and "example" not in email
+                    and not email.endswith(".png")
+                    and not email.endswith(".jpg")
+                ):
                     result["emails"].append(email)
 
             # Phones
@@ -235,7 +263,8 @@ def scrape_facility_deep(f: Facility, client: httpx.Client) -> dict:
                 r"([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3})\s*[,\-–|]\s*("
                 + "|".join(re.escape(t) for t in MAINT_TITLES)
                 + r")",
-                text, re.IGNORECASE,
+                text,
+                re.IGNORECASE,
             ):
                 contact = {
                     "name": m.group(1).strip(),
@@ -249,7 +278,8 @@ def scrape_facility_deep(f: Facility, client: httpx.Client) -> dict:
             # Employee count hints
             emp_match = re.search(
                 r"(\d{1,4})\+?\s+(?:employees|associates|team members|staff|people)",
-                text, re.IGNORECASE,
+                text,
+                re.IGNORECASE,
             )
             if emp_match:
                 result["employee_count_hint"] = int(emp_match.group(1))
@@ -263,7 +293,9 @@ def scrape_facility_deep(f: Facility, client: httpx.Client) -> dict:
     return result
 
 
-def apply_enrichment(f: Facility, enrichment: dict, hunter_key: str = "", client: Optional[httpx.Client] = None) -> None:
+def apply_enrichment(
+    f: Facility, enrichment: dict, hunter_key: str = "", client: Optional[httpx.Client] = None
+) -> None:
     """Apply enrichment results to facility in-place. Optionally run Hunter.io."""
     if enrichment.get("emails"):
         for em in enrichment["emails"][:3]:

--- a/tools/lead-hunter/hunt.py
+++ b/tools/lead-hunter/hunt.py
@@ -14,18 +14,18 @@ Env / Doppler:
   NEON_DATABASE_URL   — persist results; skipped if not set
   HUBSPOT_API_KEY     — HubSpot private app token (or set HUBSPOT_ACCESS_TOKEN)
 """
+
 from __future__ import annotations
 
 import argparse
 import csv
-import json
 import logging
 import math
 import os
+import random
 import re
 import sys
 import time
-import random
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -53,28 +53,28 @@ ANCHOR_LAT = 27.9014
 ANCHOR_LON = -81.5862
 
 CITIES = [
-    ("Lake Wales",    27.9014, -81.5862,   0),
-    ("Winter Haven",  28.0222, -81.7329,  13),
-    ("Haines City",   28.1136, -81.6181,  14),
-    ("Bartow",        27.8975, -81.8431,  18),
-    ("Auburndale",    28.0661, -81.7887,  19),
-    ("Fort Meade",    27.7517, -81.8012,  15),
-    ("Mulberry",      27.8950, -81.9731,  22),
-    ("Kissimmee",     28.2919, -81.4076,  27),
-    ("Lakeland",      28.0395, -81.9498,  29),
-    ("Sebring",       27.4958, -81.4509,  38),
-    ("Plant City",    28.0192, -82.1145,  38),
-    ("Clermont",      28.5494, -81.7729,  44),
-    ("Orlando",       28.5383, -81.3792,  45),
-    ("Clewiston",     26.7534, -80.9340,  83),
-    ("Tampa",         27.9506, -82.4572,  62),
-    ("Sanford",       28.8006, -81.2731,  63),
-    ("Bradenton",     27.4989, -82.5748,  78),
-    ("Sarasota",      27.3364, -82.5307,  89),
-    ("Melbourne",     28.0836, -80.6081,  91),
-    ("Ocala",         29.1872, -82.1401,  99),
+    ("Lake Wales", 27.9014, -81.5862, 0),
+    ("Winter Haven", 28.0222, -81.7329, 13),
+    ("Haines City", 28.1136, -81.6181, 14),
+    ("Bartow", 27.8975, -81.8431, 18),
+    ("Auburndale", 28.0661, -81.7887, 19),
+    ("Fort Meade", 27.7517, -81.8012, 15),
+    ("Mulberry", 27.8950, -81.9731, 22),
+    ("Kissimmee", 28.2919, -81.4076, 27),
+    ("Lakeland", 28.0395, -81.9498, 29),
+    ("Sebring", 27.4958, -81.4509, 38),
+    ("Plant City", 28.0192, -82.1145, 38),
+    ("Clermont", 28.5494, -81.7729, 44),
+    ("Orlando", 28.5383, -81.3792, 45),
+    ("Clewiston", 26.7534, -80.9340, 83),
+    ("Tampa", 27.9506, -82.4572, 62),
+    ("Sanford", 28.8006, -81.2731, 63),
+    ("Bradenton", 27.4989, -82.5748, 78),
+    ("Sarasota", 27.3364, -82.5307, 89),
+    ("Melbourne", 28.0836, -80.6081, 91),
+    ("Ocala", 29.1872, -82.1401, 99),
     ("Daytona Beach", 29.2108, -81.0228, 102),
-    ("Fort Myers",    26.6406, -81.8723, 113),
+    ("Fort Myers", 26.6406, -81.8723, 113),
 ]
 
 QUERY_TEMPLATES = [
@@ -89,17 +89,17 @@ QUERY_TEMPLATES = [
 ]
 
 ICP_WEIGHTS = {
-    "manufacturing":      3,
-    "food_bev_chemical":  3,
-    "has_website":        1,
-    "has_phone":          1,
-    "within_60mi":        2,
-    "within_100mi":       1,
-    "medium_large":       2,
-    "has_email":          2,
-    "maintenance_title":  3,
-    "multi_site":         2,
-    "vfd_keywords":       4,
+    "manufacturing": 3,
+    "food_bev_chemical": 3,
+    "has_website": 1,
+    "has_phone": 1,
+    "within_60mi": 2,
+    "within_100mi": 1,
+    "medium_large": 2,
+    "has_email": 2,
+    "maintenance_title": 3,
+    "multi_site": 2,
+    "vfd_keywords": 4,
 }
 
 USER_AGENTS = [
@@ -110,13 +110,14 @@ USER_AGENTS = [
 
 RATE_LIMIT_SECS = 3.0
 DDG_TIMEOUT_SECS = 8.0
-DDG_FAIL_LIMIT = 5   # stop DDG after this many consecutive failures
+DDG_FAIL_LIMIT = 5  # stop DDG after this many consecutive failures
 SERPER_URL = "https://google.serper.dev/search"
 HUBSPOT_BASE = "https://api.hubapi.com"
 
 # ---------------------------------------------------------------------------
 # Data model
 # ---------------------------------------------------------------------------
+
 
 @dataclass
 class Facility:
@@ -147,99 +148,670 @@ class Facility:
 
 _SEEDS: list[dict] = [
     # Lake Wales (anchor, ~0mi)
-    dict(name="Lake Wales Water Treatment Plant", city="Lake Wales", phone="(863) 678-4182", website="https://www.lakewalesfl.gov", category="water treatment", distance_miles=0, notes="water treatment vfd pump motor"),
-    dict(name="Heartland BioEnergy", city="Lake Wales", phone="(863) 676-9224", website="", category="chemical", distance_miles=0, notes="biofuel ethanol processing pump vfd conveyor"),
+    dict(
+        name="Lake Wales Water Treatment Plant",
+        city="Lake Wales",
+        phone="(863) 678-4182",
+        website="https://www.lakewalesfl.gov",
+        category="water treatment",
+        distance_miles=0,
+        notes="water treatment vfd pump motor",
+    ),
+    dict(
+        name="Heartland BioEnergy",
+        city="Lake Wales",
+        phone="(863) 676-9224",
+        website="",
+        category="chemical",
+        distance_miles=0,
+        notes="biofuel ethanol processing pump vfd conveyor",
+    ),
     # Winter Haven (~13mi)
-    dict(name="Winter Haven Water Utility", city="Winter Haven", phone="(863) 291-5600", website="https://www.mywinterhaven.com", category="water treatment", distance_miles=13, notes="water treatment plant vfd pump motor"),
-    dict(name="Legoland Florida Resort Operations", city="Winter Haven", address="1 Legoland Way", phone="(877) 350-5346", website="https://www.legoland.com", category="industrial", distance_miles=13, notes="park facility maintenance hvac vfd chiller pump"),
+    dict(
+        name="Winter Haven Water Utility",
+        city="Winter Haven",
+        phone="(863) 291-5600",
+        website="https://www.mywinterhaven.com",
+        category="water treatment",
+        distance_miles=13,
+        notes="water treatment plant vfd pump motor",
+    ),
+    dict(
+        name="Legoland Florida Resort Operations",
+        city="Winter Haven",
+        address="1 Legoland Way",
+        phone="(877) 350-5346",
+        website="https://www.legoland.com",
+        category="industrial",
+        distance_miles=13,
+        notes="park facility maintenance hvac vfd chiller pump",
+    ),
     # Haines City (~14mi)
-    dict(name="Sun Pacific Shippers", city="Haines City", phone="(863) 422-5100", website="https://www.sunpacific.com", category="food processing", distance_miles=14, notes="citrus packing fruit processing conveyor vfd"),
+    dict(
+        name="Sun Pacific Shippers",
+        city="Haines City",
+        phone="(863) 422-5100",
+        website="https://www.sunpacific.com",
+        category="food processing",
+        distance_miles=14,
+        notes="citrus packing fruit processing conveyor vfd",
+    ),
     # Fort Meade (~15mi)
-    dict(name="Mosaic Fertilizer South Pierce", city="Fort Meade", address="2250 W Polk Mine Rd", phone="(863) 285-5500", website="https://www.mosaicco.com", category="chemical", distance_miles=15, notes="phosphate fertilizer processing vfd pump motor conveyor"),
+    dict(
+        name="Mosaic Fertilizer South Pierce",
+        city="Fort Meade",
+        address="2250 W Polk Mine Rd",
+        phone="(863) 285-5500",
+        website="https://www.mosaicco.com",
+        category="chemical",
+        distance_miles=15,
+        notes="phosphate fertilizer processing vfd pump motor conveyor",
+    ),
     # Mulberry (~22mi)
-    dict(name="Mosaic New Wales Mine", city="Mulberry", phone="(863) 425-1361", website="https://www.mosaicco.com", category="chemical", distance_miles=22, notes="phosphate mining processing vfd motor conveyor pump"),
-    dict(name="TECO Polk Power Station", city="Mulberry", address="6280 Power House Rd", phone="(813) 228-1111", website="https://www.tecoenergy.com", category="power generation", distance_miles=22, notes="power plant vfd motor pump turbine"),
+    dict(
+        name="Mosaic New Wales Mine",
+        city="Mulberry",
+        phone="(863) 425-1361",
+        website="https://www.mosaicco.com",
+        category="chemical",
+        distance_miles=22,
+        notes="phosphate mining processing vfd motor conveyor pump",
+    ),
+    dict(
+        name="TECO Polk Power Station",
+        city="Mulberry",
+        address="6280 Power House Rd",
+        phone="(813) 228-1111",
+        website="https://www.tecoenergy.com",
+        category="power generation",
+        distance_miles=22,
+        notes="power plant vfd motor pump turbine",
+    ),
     # Bartow (~18mi)
-    dict(name="CF Industries Bartow", city="Bartow", address="2014 N Hendry Rd", phone="(863) 533-3163", website="https://www.cfindustries.com", category="chemical", distance_miles=18, notes="nitrogen fertilizer ammonia vfd pump motor"),
-    dict(name="Peace River Phosphates Bartow", city="Bartow", phone="(863) 533-2210", website="https://www.mosaicco.com", category="chemical", distance_miles=18, notes="phosphate processing vfd pump motor conveyor"),
-    dict(name="Vulcan Materials Bartow", city="Bartow", phone="(863) 533-2500", website="https://www.vulcanmaterials.com", category="manufacturing", distance_miles=18, notes="aggregate mining conveyor motor vfd"),
-    dict(name="Bartow Municipal Airport Industrial", city="Bartow", phone="(863) 534-0470", website="https://www.bartowfl.gov", category="industrial", distance_miles=18, notes="industrial maintenance facility"),
+    dict(
+        name="CF Industries Bartow",
+        city="Bartow",
+        address="2014 N Hendry Rd",
+        phone="(863) 533-3163",
+        website="https://www.cfindustries.com",
+        category="chemical",
+        distance_miles=18,
+        notes="nitrogen fertilizer ammonia vfd pump motor",
+    ),
+    dict(
+        name="Peace River Phosphates Bartow",
+        city="Bartow",
+        phone="(863) 533-2210",
+        website="https://www.mosaicco.com",
+        category="chemical",
+        distance_miles=18,
+        notes="phosphate processing vfd pump motor conveyor",
+    ),
+    dict(
+        name="Vulcan Materials Bartow",
+        city="Bartow",
+        phone="(863) 533-2500",
+        website="https://www.vulcanmaterials.com",
+        category="manufacturing",
+        distance_miles=18,
+        notes="aggregate mining conveyor motor vfd",
+    ),
+    dict(
+        name="Bartow Municipal Airport Industrial",
+        city="Bartow",
+        phone="(863) 534-0470",
+        website="https://www.bartowfl.gov",
+        category="industrial",
+        distance_miles=18,
+        notes="industrial maintenance facility",
+    ),
     # Auburndale (~25mi)
-    dict(name="Florida Natural Growers", city="Auburndale", address="20205 US Hwy 27 N", phone="(863) 965-5000", website="https://www.floridanatural.com", category="food processing", distance_miles=25, notes="orange juice citrus processing conveyor pump vfd"),
-    dict(name="Minute Maid Coca-Cola Auburndale", city="Auburndale", phone="(863) 965-1000", website="https://www.minutemaid.com", category="food processing", distance_miles=25, notes="orange juice citrus bottling conveyor pump vfd"),
-    dict(name="Louis Dreyfus Company Citrus", city="Auburndale", address="1800 Recker Hwy", phone="(863) 967-2000", website="https://www.ldc.com", category="food processing", distance_miles=25, notes="citrus juice processing conveyor pump vfd"),
+    dict(
+        name="Florida Natural Growers",
+        city="Auburndale",
+        address="20205 US Hwy 27 N",
+        phone="(863) 965-5000",
+        website="https://www.floridanatural.com",
+        category="food processing",
+        distance_miles=25,
+        notes="orange juice citrus processing conveyor pump vfd",
+    ),
+    dict(
+        name="Minute Maid Coca-Cola Auburndale",
+        city="Auburndale",
+        phone="(863) 965-1000",
+        website="https://www.minutemaid.com",
+        category="food processing",
+        distance_miles=25,
+        notes="orange juice citrus bottling conveyor pump vfd",
+    ),
+    dict(
+        name="Louis Dreyfus Company Citrus",
+        city="Auburndale",
+        address="1800 Recker Hwy",
+        phone="(863) 967-2000",
+        website="https://www.ldc.com",
+        category="food processing",
+        distance_miles=25,
+        notes="citrus juice processing conveyor pump vfd",
+    ),
     # Kissimmee (~27mi)
-    dict(name="Toho Water Authority", city="Kissimmee", address="101 N Church St", phone="(407) 944-5000", website="https://www.tohowater.com", category="water treatment", distance_miles=27, notes="water treatment reclamation vfd pump motor drive"),
-    dict(name="Osceola County Water Resources", city="Kissimmee", phone="(407) 742-0200", website="https://www.osceola.org", category="water treatment", distance_miles=27, notes="water wastewater treatment vfd pump motor"),
+    dict(
+        name="Toho Water Authority",
+        city="Kissimmee",
+        address="101 N Church St",
+        phone="(407) 944-5000",
+        website="https://www.tohowater.com",
+        category="water treatment",
+        distance_miles=27,
+        notes="water treatment reclamation vfd pump motor drive",
+    ),
+    dict(
+        name="Osceola County Water Resources",
+        city="Kissimmee",
+        phone="(407) 742-0200",
+        website="https://www.osceola.org",
+        category="water treatment",
+        distance_miles=27,
+        notes="water wastewater treatment vfd pump motor",
+    ),
     # Lakeland (~29mi)
-    dict(name="Publix Distribution Center Lakeland", city="Lakeland", address="1936 George Jenkins Blvd", phone="(863) 688-1188", website="https://www.publix.com", category="food distribution", distance_miles=29, notes="large distribution center conveyor vfd pump automation"),
-    dict(name="Saddle Creek Logistics Lakeland", city="Lakeland", address="3010 Saddle Creek Rd", phone="(863) 665-4505", website="https://www.saddlecreeklogistics.com", category="warehouse distribution", distance_miles=29, notes="distribution center conveyor automation plc vfd"),
-    dict(name="Coca-Cola Bottling Company Lakeland", city="Lakeland", address="1715 S Florida Ave", phone="(863) 686-6154", website="https://www.cocacolacompany.com", category="beverage", distance_miles=29, notes="bottling plant vfd conveyor pump automated"),
-    dict(name="Pepsi Bottling Group Lakeland", city="Lakeland", address="1635 New York Ave", phone="(863) 683-5484", website="https://www.pepsico.com", category="beverage", distance_miles=29, notes="bottling plant vfd conveyor pump automated"),
-    dict(name="Amazon Fulfillment Center Lakeland", city="Lakeland", address="6050 Lakeland Park Dr", website="https://www.amazon.com", category="warehouse distribution", distance_miles=29, notes="distribution center conveyor automation plc vfd"),
-    dict(name="US Foods Distribution Lakeland", city="Lakeland", address="3105 Drane Field Rd", phone="(863) 647-4400", website="https://www.usfoods.com", category="food distribution", distance_miles=29, notes="food distribution refrigeration conveyor vfd compressor"),
-    dict(name="Walmart Grocery Distribution Lakeland", city="Lakeland", phone="(863) 413-1100", website="https://www.walmart.com", category="warehouse distribution", distance_miles=29, notes="distribution center conveyor vfd automation"),
-    dict(name="Rooms To Go Distribution Center", city="Lakeland", address="11540 US Hwy 92 E", phone="(863) 688-6669", website="https://www.roomstogo.com", category="warehouse distribution", distance_miles=29, notes="distribution center conveyor vfd automation"),
-    dict(name="Layne Water Technologies Lakeland", city="Lakeland", phone="(863) 686-3900", website="https://www.layne.com", category="water treatment", distance_miles=29, notes="water systems pump vfd motor treatment"),
-    dict(name="Lakeland Regional Medical Center", city="Lakeland", address="1324 Lakeland Hills Blvd", phone="(863) 687-1100", website="https://www.lrmc.com", category="industrial", distance_miles=29, notes="hospital facility maintenance vfd pump chiller hvac compressor"),
-    dict(name="SYSCO Central Florida Lakeland", city="Lakeland", phone="(863) 646-3300", website="https://www.sysco.com", category="food distribution", distance_miles=29, notes="food distribution refrigeration conveyor vfd"),
+    dict(
+        name="Publix Distribution Center Lakeland",
+        city="Lakeland",
+        address="1936 George Jenkins Blvd",
+        phone="(863) 688-1188",
+        website="https://www.publix.com",
+        category="food distribution",
+        distance_miles=29,
+        notes="large distribution center conveyor vfd pump automation",
+    ),
+    dict(
+        name="Saddle Creek Logistics Lakeland",
+        city="Lakeland",
+        address="3010 Saddle Creek Rd",
+        phone="(863) 665-4505",
+        website="https://www.saddlecreeklogistics.com",
+        category="warehouse distribution",
+        distance_miles=29,
+        notes="distribution center conveyor automation plc vfd",
+    ),
+    dict(
+        name="Coca-Cola Bottling Company Lakeland",
+        city="Lakeland",
+        address="1715 S Florida Ave",
+        phone="(863) 686-6154",
+        website="https://www.cocacolacompany.com",
+        category="beverage",
+        distance_miles=29,
+        notes="bottling plant vfd conveyor pump automated",
+    ),
+    dict(
+        name="Pepsi Bottling Group Lakeland",
+        city="Lakeland",
+        address="1635 New York Ave",
+        phone="(863) 683-5484",
+        website="https://www.pepsico.com",
+        category="beverage",
+        distance_miles=29,
+        notes="bottling plant vfd conveyor pump automated",
+    ),
+    dict(
+        name="Amazon Fulfillment Center Lakeland",
+        city="Lakeland",
+        address="6050 Lakeland Park Dr",
+        website="https://www.amazon.com",
+        category="warehouse distribution",
+        distance_miles=29,
+        notes="distribution center conveyor automation plc vfd",
+    ),
+    dict(
+        name="US Foods Distribution Lakeland",
+        city="Lakeland",
+        address="3105 Drane Field Rd",
+        phone="(863) 647-4400",
+        website="https://www.usfoods.com",
+        category="food distribution",
+        distance_miles=29,
+        notes="food distribution refrigeration conveyor vfd compressor",
+    ),
+    dict(
+        name="Walmart Grocery Distribution Lakeland",
+        city="Lakeland",
+        phone="(863) 413-1100",
+        website="https://www.walmart.com",
+        category="warehouse distribution",
+        distance_miles=29,
+        notes="distribution center conveyor vfd automation",
+    ),
+    dict(
+        name="Rooms To Go Distribution Center",
+        city="Lakeland",
+        address="11540 US Hwy 92 E",
+        phone="(863) 688-6669",
+        website="https://www.roomstogo.com",
+        category="warehouse distribution",
+        distance_miles=29,
+        notes="distribution center conveyor vfd automation",
+    ),
+    dict(
+        name="Layne Water Technologies Lakeland",
+        city="Lakeland",
+        phone="(863) 686-3900",
+        website="https://www.layne.com",
+        category="water treatment",
+        distance_miles=29,
+        notes="water systems pump vfd motor treatment",
+    ),
+    dict(
+        name="Lakeland Regional Medical Center",
+        city="Lakeland",
+        address="1324 Lakeland Hills Blvd",
+        phone="(863) 687-1100",
+        website="https://www.lrmc.com",
+        category="industrial",
+        distance_miles=29,
+        notes="hospital facility maintenance vfd pump chiller hvac compressor",
+    ),
+    dict(
+        name="SYSCO Central Florida Lakeland",
+        city="Lakeland",
+        phone="(863) 646-3300",
+        website="https://www.sysco.com",
+        category="food distribution",
+        distance_miles=29,
+        notes="food distribution refrigeration conveyor vfd",
+    ),
     # Sebring (~38mi)
-    dict(name="Highlands County Water Systems", city="Sebring", address="600 S Commerce Ave", phone="(863) 402-6650", website="https://www.hcbcc.net", category="water treatment", distance_miles=38, notes="water utility treatment vfd pump motor"),
-    dict(name="AdventHealth Sebring", city="Sebring", address="4200 Sun N Lake Blvd", phone="(863) 314-4466", website="https://www.adventhealth.com", category="industrial", distance_miles=38, notes="hospital facility maintenance vfd pump chiller hvac"),
+    dict(
+        name="Highlands County Water Systems",
+        city="Sebring",
+        address="600 S Commerce Ave",
+        phone="(863) 402-6650",
+        website="https://www.hcbcc.net",
+        category="water treatment",
+        distance_miles=38,
+        notes="water utility treatment vfd pump motor",
+    ),
+    dict(
+        name="AdventHealth Sebring",
+        city="Sebring",
+        address="4200 Sun N Lake Blvd",
+        phone="(863) 314-4466",
+        website="https://www.adventhealth.com",
+        category="industrial",
+        distance_miles=38,
+        notes="hospital facility maintenance vfd pump chiller hvac",
+    ),
     # Plant City (~38mi)
-    dict(name="Pfizer Manufacturing Plant City", city="Plant City", address="1 Pfizer Plaza", phone="(813) 754-3900", website="https://www.pfizer.com", category="pharmaceutical", distance_miles=38, notes="pharmaceutical manufacturing vfd pump motor conveyor plc scada"),
-    dict(name="FreshPoint Central Florida", city="Plant City", phone="(813) 754-1200", website="https://www.freshpoint.com", category="food distribution", distance_miles=38, notes="food distribution conveyor vfd refrigeration"),
-    dict(name="Hillsborough County Water Treatment", city="Plant City", address="7602 N US Hwy 301", phone="(813) 757-3870", website="https://www.hillsboroughcounty.org", category="water treatment", distance_miles=38, notes="water treatment plant vfd pump motor"),
+    dict(
+        name="Pfizer Manufacturing Plant City",
+        city="Plant City",
+        address="1 Pfizer Plaza",
+        phone="(813) 754-3900",
+        website="https://www.pfizer.com",
+        category="pharmaceutical",
+        distance_miles=38,
+        notes="pharmaceutical manufacturing vfd pump motor conveyor plc scada",
+    ),
+    dict(
+        name="FreshPoint Central Florida",
+        city="Plant City",
+        phone="(813) 754-1200",
+        website="https://www.freshpoint.com",
+        category="food distribution",
+        distance_miles=38,
+        notes="food distribution conveyor vfd refrigeration",
+    ),
+    dict(
+        name="Hillsborough County Water Treatment",
+        city="Plant City",
+        address="7602 N US Hwy 301",
+        phone="(813) 757-3870",
+        website="https://www.hillsboroughcounty.org",
+        category="water treatment",
+        distance_miles=38,
+        notes="water treatment plant vfd pump motor",
+    ),
     # Clermont (~44mi)
-    dict(name="Lake County Utilities Clermont", city="Clermont", phone="(352) 343-9723", website="https://www.lakecountyfl.gov", category="water treatment", distance_miles=44, notes="water wastewater treatment vfd pump motor"),
-    dict(name="South Lake Hospital Clermont", city="Clermont", address="1900 Don Wickham Dr", phone="(352) 394-4071", website="https://www.southlakehospital.com", category="industrial", distance_miles=44, notes="hospital facility maintenance vfd pump hvac chiller"),
+    dict(
+        name="Lake County Utilities Clermont",
+        city="Clermont",
+        phone="(352) 343-9723",
+        website="https://www.lakecountyfl.gov",
+        category="water treatment",
+        distance_miles=44,
+        notes="water wastewater treatment vfd pump motor",
+    ),
+    dict(
+        name="South Lake Hospital Clermont",
+        city="Clermont",
+        address="1900 Don Wickham Dr",
+        phone="(352) 394-4071",
+        website="https://www.southlakehospital.com",
+        category="industrial",
+        distance_miles=44,
+        notes="hospital facility maintenance vfd pump hvac chiller",
+    ),
     # Orlando (~45mi)
-    dict(name="Siemens Energy Orlando", city="Orlando", address="4400 Alafaya Trail", phone="(407) 736-2000", website="https://www.siemens-energy.com", category="manufacturing", distance_miles=45, notes="gas turbines generators vfd motor drive maintenance"),
-    dict(name="Lockheed Martin Missiles Fire Control", city="Orlando", address="5600 Sand Lake Rd", phone="(407) 356-2000", website="https://www.lockheedmartin.com", category="aerospace defense", distance_miles=45, notes="defense manufacturing automation plc scada"),
-    dict(name="Orlando Utilities Commission", city="Orlando", address="100 W Anderson St", phone="(407) 423-9100", website="https://www.ouc.com", category="utility", distance_miles=45, notes="utility power plant vfd motor pump conveyor"),
-    dict(name="Orange County Water Utilities", city="Orlando", address="9150 Curry Ford Rd", phone="(407) 254-9756", website="https://www.ocfl.net", category="water treatment", distance_miles=45, notes="water treatment plant vfd pump motor conveyor"),
-    dict(name="Darden Restaurants Supply Orlando", city="Orlando", address="1000 Darden Center Dr", phone="(407) 245-4000", website="https://www.darden.com", category="food distribution", distance_miles=45, notes="food processing distribution vfd conveyor"),
-    dict(name="Tupperware Brands Corporation", city="Orlando", address="14901 S Orange Blossom Trail", phone="(407) 826-5050", website="https://www.tupperware.com", category="manufacturing", distance_miles=45, notes="plastic manufacturing injection molding conveyor motor vfd automation"),
+    dict(
+        name="Siemens Energy Orlando",
+        city="Orlando",
+        address="4400 Alafaya Trail",
+        phone="(407) 736-2000",
+        website="https://www.siemens-energy.com",
+        category="manufacturing",
+        distance_miles=45,
+        notes="gas turbines generators vfd motor drive maintenance",
+    ),
+    dict(
+        name="Lockheed Martin Missiles Fire Control",
+        city="Orlando",
+        address="5600 Sand Lake Rd",
+        phone="(407) 356-2000",
+        website="https://www.lockheedmartin.com",
+        category="aerospace defense",
+        distance_miles=45,
+        notes="defense manufacturing automation plc scada",
+    ),
+    dict(
+        name="Orlando Utilities Commission",
+        city="Orlando",
+        address="100 W Anderson St",
+        phone="(407) 423-9100",
+        website="https://www.ouc.com",
+        category="utility",
+        distance_miles=45,
+        notes="utility power plant vfd motor pump conveyor",
+    ),
+    dict(
+        name="Orange County Water Utilities",
+        city="Orlando",
+        address="9150 Curry Ford Rd",
+        phone="(407) 254-9756",
+        website="https://www.ocfl.net",
+        category="water treatment",
+        distance_miles=45,
+        notes="water treatment plant vfd pump motor conveyor",
+    ),
+    dict(
+        name="Darden Restaurants Supply Orlando",
+        city="Orlando",
+        address="1000 Darden Center Dr",
+        phone="(407) 245-4000",
+        website="https://www.darden.com",
+        category="food distribution",
+        distance_miles=45,
+        notes="food processing distribution vfd conveyor",
+    ),
+    dict(
+        name="Tupperware Brands Corporation",
+        city="Orlando",
+        address="14901 S Orange Blossom Trail",
+        phone="(407) 826-5050",
+        website="https://www.tupperware.com",
+        category="manufacturing",
+        distance_miles=45,
+        notes="plastic manufacturing injection molding conveyor motor vfd automation",
+    ),
     # Clewiston (~83mi)
-    dict(name="US Sugar Corporation Clewiston", city="Clewiston", address="111 Ponce De Leon Ave", phone="(863) 983-8121", website="https://www.ussugar.com", category="food processing", distance_miles=83, notes="sugar processing cane mill conveyor vfd pump motor drive"),
-    dict(name="Florida Crystals Sugar Division", city="Clewiston", phone="(561) 996-9072", website="https://www.floridacrystals.com", category="food processing", distance_miles=83, notes="sugar processing conveyor vfd pump motor"),
+    dict(
+        name="US Sugar Corporation Clewiston",
+        city="Clewiston",
+        address="111 Ponce De Leon Ave",
+        phone="(863) 983-8121",
+        website="https://www.ussugar.com",
+        category="food processing",
+        distance_miles=83,
+        notes="sugar processing cane mill conveyor vfd pump motor drive",
+    ),
+    dict(
+        name="Florida Crystals Sugar Division",
+        city="Clewiston",
+        phone="(561) 996-9072",
+        website="https://www.floridacrystals.com",
+        category="food processing",
+        distance_miles=83,
+        notes="sugar processing conveyor vfd pump motor",
+    ),
     # Tampa (~62mi)
-    dict(name="CEMEX Tampa Cement Plant", city="Tampa", address="2800 N 41st St", phone="(813) 247-2400", website="https://www.cemex.com", category="manufacturing", distance_miles=62, notes="cement manufacturing conveyor vfd motor pump"),
-    dict(name="Gerdau AmeriSteel Tampa", city="Tampa", address="4221 W Boy Scout Blvd", phone="(813) 286-8383", website="https://www.gerdau.com", category="metal fabrication", distance_miles=62, notes="steel mill vfd motor drives conveyor pump"),
-    dict(name="Tampa Electric Gannon Station", city="Tampa", phone="(813) 223-0800", website="https://www.tecoenergy.com", category="utility", distance_miles=62, notes="power plant vfd motor pump turbine"),
-    dict(name="Mosaic Fertilizer Riverview", city="Tampa", address="13830 US Hwy 41 S", phone="(813) 677-9811", website="https://www.mosaicco.com", category="chemical", distance_miles=62, notes="fertilizer processing vfd pump conveyor"),
-    dict(name="Tampa Bay Water Authority", city="Tampa", address="2575 Enterprise Rd", phone="(727) 796-2355", website="https://www.tampabaywater.org", category="water treatment", distance_miles=62, notes="water treatment plant vfd pump motor"),
-    dict(name="Brenntag Chemical Tampa", city="Tampa", phone="(813) 621-4710", website="https://www.brenntag.com", category="chemical", distance_miles=62, notes="chemical distribution conveyor pump vfd motor"),
+    dict(
+        name="CEMEX Tampa Cement Plant",
+        city="Tampa",
+        address="2800 N 41st St",
+        phone="(813) 247-2400",
+        website="https://www.cemex.com",
+        category="manufacturing",
+        distance_miles=62,
+        notes="cement manufacturing conveyor vfd motor pump",
+    ),
+    dict(
+        name="Gerdau AmeriSteel Tampa",
+        city="Tampa",
+        address="4221 W Boy Scout Blvd",
+        phone="(813) 286-8383",
+        website="https://www.gerdau.com",
+        category="metal fabrication",
+        distance_miles=62,
+        notes="steel mill vfd motor drives conveyor pump",
+    ),
+    dict(
+        name="Tampa Electric Gannon Station",
+        city="Tampa",
+        phone="(813) 223-0800",
+        website="https://www.tecoenergy.com",
+        category="utility",
+        distance_miles=62,
+        notes="power plant vfd motor pump turbine",
+    ),
+    dict(
+        name="Mosaic Fertilizer Riverview",
+        city="Tampa",
+        address="13830 US Hwy 41 S",
+        phone="(813) 677-9811",
+        website="https://www.mosaicco.com",
+        category="chemical",
+        distance_miles=62,
+        notes="fertilizer processing vfd pump conveyor",
+    ),
+    dict(
+        name="Tampa Bay Water Authority",
+        city="Tampa",
+        address="2575 Enterprise Rd",
+        phone="(727) 796-2355",
+        website="https://www.tampabaywater.org",
+        category="water treatment",
+        distance_miles=62,
+        notes="water treatment plant vfd pump motor",
+    ),
+    dict(
+        name="Brenntag Chemical Tampa",
+        city="Tampa",
+        phone="(813) 621-4710",
+        website="https://www.brenntag.com",
+        category="chemical",
+        distance_miles=62,
+        notes="chemical distribution conveyor pump vfd motor",
+    ),
     # Sanford (~63mi)
-    dict(name="Seminole County Water Utilities", city="Sanford", address="3160 McCampbell Rd", phone="(407) 665-2600", website="https://www.seminolecountyfl.gov", category="water treatment", distance_miles=63, notes="water wastewater vfd pump motor"),
+    dict(
+        name="Seminole County Water Utilities",
+        city="Sanford",
+        address="3160 McCampbell Rd",
+        phone="(407) 665-2600",
+        website="https://www.seminolecountyfl.gov",
+        category="water treatment",
+        distance_miles=63,
+        notes="water wastewater vfd pump motor",
+    ),
     # Bradenton (~78mi)
-    dict(name="Tropicana Products Inc", city="Bradenton", address="1001 13th Ave E", phone="(941) 747-4461", website="https://www.tropicana.com", category="food processing", distance_miles=78, notes="orange juice processing vfd conveyor pump bottling motor"),
-    dict(name="Florida Rock Industries Bradenton", city="Bradenton", address="2600 30th St E", phone="(941) 747-2671", website="https://www.vulcanmaterials.com", category="manufacturing", distance_miles=78, notes="concrete aggregate conveyor motor vfd"),
-    dict(name="Manatee County Water System", city="Bradenton", phone="(941) 748-4501", website="https://www.mymanatee.org", category="water treatment", distance_miles=78, notes="water treatment plant vfd pump motor"),
+    dict(
+        name="Tropicana Products Inc",
+        city="Bradenton",
+        address="1001 13th Ave E",
+        phone="(941) 747-4461",
+        website="https://www.tropicana.com",
+        category="food processing",
+        distance_miles=78,
+        notes="orange juice processing vfd conveyor pump bottling motor",
+    ),
+    dict(
+        name="Florida Rock Industries Bradenton",
+        city="Bradenton",
+        address="2600 30th St E",
+        phone="(941) 747-2671",
+        website="https://www.vulcanmaterials.com",
+        category="manufacturing",
+        distance_miles=78,
+        notes="concrete aggregate conveyor motor vfd",
+    ),
+    dict(
+        name="Manatee County Water System",
+        city="Bradenton",
+        phone="(941) 748-4501",
+        website="https://www.mymanatee.org",
+        category="water treatment",
+        distance_miles=78,
+        notes="water treatment plant vfd pump motor",
+    ),
     # Sarasota (~89mi)
-    dict(name="PGT Innovations Nokomis", city="Sarasota", address="1070 Technology Dr", phone="(941) 480-1600", website="https://www.pgtinnovations.com", category="manufacturing", distance_miles=89, notes="impact windows doors manufacturing motor vfd conveyor"),
-    dict(name="Sarasota County Water Utilities", city="Sarasota", phone="(941) 861-0300", website="https://www.scgov.net", category="water treatment", distance_miles=89, notes="water treatment plant vfd pump motor"),
+    dict(
+        name="PGT Innovations Nokomis",
+        city="Sarasota",
+        address="1070 Technology Dr",
+        phone="(941) 480-1600",
+        website="https://www.pgtinnovations.com",
+        category="manufacturing",
+        distance_miles=89,
+        notes="impact windows doors manufacturing motor vfd conveyor",
+    ),
+    dict(
+        name="Sarasota County Water Utilities",
+        city="Sarasota",
+        phone="(941) 861-0300",
+        website="https://www.scgov.net",
+        category="water treatment",
+        distance_miles=89,
+        notes="water treatment plant vfd pump motor",
+    ),
     # Melbourne (~91mi)
-    dict(name="L3Harris Technologies Melbourne", city="Melbourne", address="1025 W NASA Blvd", phone="(321) 727-9100", website="https://www.l3harris.com", category="aerospace defense", distance_miles=91, notes="electronics manufacturing assembly automation plc scada"),
-    dict(name="Northrop Grumman Melbourne", city="Melbourne", address="7575 Columbiana Dr", phone="(321) 951-6100", website="https://www.northropgrumman.com", category="aerospace defense", distance_miles=91, notes="aerospace defense manufacturing assembly plc scada"),
-    dict(name="Embraer Aircraft Melbourne", city="Melbourne", address="276 SW 34th St", phone="(321) 751-0600", website="https://www.embraer.com", category="aerospace", distance_miles=91, notes="aircraft manufacturing maintenance vfd"),
-    dict(name="Brevard County Water Reclamation", city="Melbourne", address="5555 N Wickham Rd", phone="(321) 633-2075", website="https://www.brevardfl.gov", category="water treatment", distance_miles=91, notes="wastewater treatment vfd pump motor conveyor"),
+    dict(
+        name="L3Harris Technologies Melbourne",
+        city="Melbourne",
+        address="1025 W NASA Blvd",
+        phone="(321) 727-9100",
+        website="https://www.l3harris.com",
+        category="aerospace defense",
+        distance_miles=91,
+        notes="electronics manufacturing assembly automation plc scada",
+    ),
+    dict(
+        name="Northrop Grumman Melbourne",
+        city="Melbourne",
+        address="7575 Columbiana Dr",
+        phone="(321) 951-6100",
+        website="https://www.northropgrumman.com",
+        category="aerospace defense",
+        distance_miles=91,
+        notes="aerospace defense manufacturing assembly plc scada",
+    ),
+    dict(
+        name="Embraer Aircraft Melbourne",
+        city="Melbourne",
+        address="276 SW 34th St",
+        phone="(321) 751-0600",
+        website="https://www.embraer.com",
+        category="aerospace",
+        distance_miles=91,
+        notes="aircraft manufacturing maintenance vfd",
+    ),
+    dict(
+        name="Brevard County Water Reclamation",
+        city="Melbourne",
+        address="5555 N Wickham Rd",
+        phone="(321) 633-2075",
+        website="https://www.brevardfl.gov",
+        category="water treatment",
+        distance_miles=91,
+        notes="wastewater treatment vfd pump motor conveyor",
+    ),
     # Ocala (~99mi)
-    dict(name="Marion County Utilities Ocala", city="Ocala", address="8 SE 3rd Ave", phone="(352) 671-8686", website="https://www.marioncountyfl.org", category="water treatment", distance_miles=99, notes="water wastewater treatment vfd pump motor"),
-    dict(name="Preferred Freezer Services Ocala", city="Ocala", phone="(352) 622-1234", website="https://www.preferredfreezer.com", category="warehouse distribution", distance_miles=99, notes="cold storage refrigeration vfd compressor"),
+    dict(
+        name="Marion County Utilities Ocala",
+        city="Ocala",
+        address="8 SE 3rd Ave",
+        phone="(352) 671-8686",
+        website="https://www.marioncountyfl.org",
+        category="water treatment",
+        distance_miles=99,
+        notes="water wastewater treatment vfd pump motor",
+    ),
+    dict(
+        name="Preferred Freezer Services Ocala",
+        city="Ocala",
+        phone="(352) 622-1234",
+        website="https://www.preferredfreezer.com",
+        category="warehouse distribution",
+        distance_miles=99,
+        notes="cold storage refrigeration vfd compressor",
+    ),
     # Daytona Beach (~102mi)
-    dict(name="Daytona Beach Water Treatment", city="Daytona Beach", address="3940 Nova Rd", phone="(386) 671-8100", website="https://www.codb.us", category="water treatment", distance_miles=102, notes="water treatment plant vfd pump motor"),
-    dict(name="Consolidated Tomoka Land Daytona", city="Daytona Beach", address="1530 Cornerstone Blvd", phone="(386) 274-2202", website="https://www.ctlc.com", category="industrial", distance_miles=102, notes="industrial facility maintenance"),
+    dict(
+        name="Daytona Beach Water Treatment",
+        city="Daytona Beach",
+        address="3940 Nova Rd",
+        phone="(386) 671-8100",
+        website="https://www.codb.us",
+        category="water treatment",
+        distance_miles=102,
+        notes="water treatment plant vfd pump motor",
+    ),
+    dict(
+        name="Consolidated Tomoka Land Daytona",
+        city="Daytona Beach",
+        address="1530 Cornerstone Blvd",
+        phone="(386) 274-2202",
+        website="https://www.ctlc.com",
+        category="industrial",
+        distance_miles=102,
+        notes="industrial facility maintenance",
+    ),
     # Fort Myers (~113mi)
-    dict(name="Lee County Electric Cooperative", city="Fort Myers", address="4980 Bayline Dr", phone="(239) 656-2300", website="https://www.lcec.net", category="utility", distance_miles=113, notes="utility vfd motor pump"),
-    dict(name="Lee County Water Reclamation", city="Fort Myers", phone="(239) 533-8800", website="https://www.leegov.com", category="water treatment", distance_miles=113, notes="wastewater treatment plant vfd pump motor"),
-    dict(name="Cape Coral Water Treatment Plant", city="Fort Myers", phone="(239) 574-0882", website="https://www.capecoral.net", category="water treatment", distance_miles=113, notes="water treatment plant vfd pump motor"),
+    dict(
+        name="Lee County Electric Cooperative",
+        city="Fort Myers",
+        address="4980 Bayline Dr",
+        phone="(239) 656-2300",
+        website="https://www.lcec.net",
+        category="utility",
+        distance_miles=113,
+        notes="utility vfd motor pump",
+    ),
+    dict(
+        name="Lee County Water Reclamation",
+        city="Fort Myers",
+        phone="(239) 533-8800",
+        website="https://www.leegov.com",
+        category="water treatment",
+        distance_miles=113,
+        notes="wastewater treatment plant vfd pump motor",
+    ),
+    dict(
+        name="Cape Coral Water Treatment Plant",
+        city="Fort Myers",
+        phone="(239) 574-0882",
+        website="https://www.capecoral.net",
+        category="water treatment",
+        distance_miles=113,
+        notes="water treatment plant vfd pump motor",
+    ),
 ]
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     R = 3958.8
@@ -256,16 +828,53 @@ def score_facility(f: Facility) -> int:
     name = f.name.lower()
     notes = (f.notes or "").lower()
 
-    mfg_words = ["manufactur", "process", "packaging", "fabricat", "plant", "factory",
-                 "machine", "foundry", "assembly", "industrial", "chemical", "pharma",
-                 "food", "beverage", "treatment", "bottl", "mill", "refin", "distribution",
-                 "power", "utility", "aerospace", "defense", "pharmaceutical"]
+    mfg_words = [
+        "manufactur",
+        "process",
+        "packaging",
+        "fabricat",
+        "plant",
+        "factory",
+        "machine",
+        "foundry",
+        "assembly",
+        "industrial",
+        "chemical",
+        "pharma",
+        "food",
+        "beverage",
+        "treatment",
+        "bottl",
+        "mill",
+        "refin",
+        "distribution",
+        "power",
+        "utility",
+        "aerospace",
+        "defense",
+        "pharmaceutical",
+    ]
     if any(w in cat or w in name for w in mfg_words):
         s += ICP_WEIGHTS["manufacturing"]
 
-    fb_words = ["food", "beverage", "juice", "citrus", "dairy", "chemical", "pharma",
-                "water treatment", "waste water", "wastewater", "packaging", "bottl", "brew",
-                "sugar", "citrus", "pharmaceutical"]
+    fb_words = [
+        "food",
+        "beverage",
+        "juice",
+        "citrus",
+        "dairy",
+        "chemical",
+        "pharma",
+        "water treatment",
+        "waste water",
+        "wastewater",
+        "packaging",
+        "bottl",
+        "brew",
+        "sugar",
+        "citrus",
+        "pharmaceutical",
+    ]
     if any(w in cat or w in name or w in notes for w in fb_words):
         s += ICP_WEIGHTS["food_bev_chemical"]
 
@@ -285,14 +894,30 @@ def score_facility(f: Facility) -> int:
     if f.contacts:
         if any(c.get("email") for c in f.contacts):
             s += ICP_WEIGHTS["has_email"]
-        maint = [c for c in f.contacts
-                 if any(t in (c.get("title") or "").lower()
-                        for t in ["maintenance", "facilities", "plant", "engineer", "operations"])]
+        maint = [
+            c
+            for c in f.contacts
+            if any(
+                t in (c.get("title") or "").lower()
+                for t in ["maintenance", "facilities", "plant", "engineer", "operations"]
+            )
+        ]
         if maint:
             s += ICP_WEIGHTS["maintenance_title"]
 
-    vfd_words = ["vfd", "variable frequency", "drive", "motor", "conveyor", "pump", "compressor",
-                 "hvac", "automation", "plc", "scada"]
+    vfd_words = [
+        "vfd",
+        "variable frequency",
+        "drive",
+        "motor",
+        "conveyor",
+        "pump",
+        "compressor",
+        "hvac",
+        "automation",
+        "plc",
+        "scada",
+    ]
     if any(w in notes for w in vfd_words):
         s += ICP_WEIGHTS["vfd_keywords"]
 
@@ -326,6 +951,7 @@ def seed_facilities() -> list[Facility]:
 # Discovery — Serper API (preferred)
 # ---------------------------------------------------------------------------
 
+
 def search_serper(query: str, api_key: str, client: httpx.Client) -> list[dict]:
     try:
         resp = client.post(
@@ -338,21 +964,25 @@ def search_serper(query: str, api_key: str, client: httpx.Client) -> list[dict]:
         data = resp.json()
         results = []
         for item in data.get("organic", []):
-            results.append({
-                "title": item.get("title", ""),
-                "snippet": item.get("snippet", ""),
-                "link": item.get("link", ""),
-            })
+            results.append(
+                {
+                    "title": item.get("title", ""),
+                    "snippet": item.get("snippet", ""),
+                    "link": item.get("link", ""),
+                }
+            )
         for place in data.get("places", []):
-            results.append({
-                "title": place.get("title", ""),
-                "snippet": place.get("address", ""),
-                "link": place.get("website", ""),
-                "phone": place.get("phoneNumber", ""),
-                "rating": place.get("rating"),
-                "reviews": place.get("reviews"),
-                "is_place": True,
-            })
+            results.append(
+                {
+                    "title": place.get("title", ""),
+                    "snippet": place.get("address", ""),
+                    "link": place.get("website", ""),
+                    "phone": place.get("phoneNumber", ""),
+                    "rating": place.get("rating"),
+                    "reviews": place.get("reviews"),
+                    "is_place": True,
+                }
+            )
         return results
     except Exception as e:
         log.warning("Serper error for %r: %s", query, e)
@@ -362,6 +992,7 @@ def search_serper(query: str, api_key: str, client: httpx.Client) -> list[dict]:
 # ---------------------------------------------------------------------------
 # Discovery — DuckDuckGo HTML scraping fallback
 # ---------------------------------------------------------------------------
+
 
 def search_duckduckgo(query: str, client: httpx.Client) -> list[dict]:
     ua = random.choice(USER_AGENTS)
@@ -395,11 +1026,13 @@ def search_duckduckgo(query: str, client: httpx.Client) -> list[dict]:
                     link = unquote(href.split("uddg=")[1].split("&")[0])
                 elif href.startswith("http"):
                     link = href
-            results.append({
-                "title": title_el.get_text(strip=True),
-                "snippet": snippet_el.get_text(strip=True) if snippet_el else "",
-                "link": link,
-            })
+            results.append(
+                {
+                    "title": title_el.get_text(strip=True),
+                    "snippet": snippet_el.get_text(strip=True) if snippet_el else "",
+                    "link": link,
+                }
+            )
         return results[:10]
     except Exception as e:
         log.warning("DDG scrape error: %s", e)
@@ -410,17 +1043,55 @@ def search_duckduckgo(query: str, client: httpx.Client) -> list[dict]:
 # Parse facilities from search results
 # ---------------------------------------------------------------------------
 
-SKIP_DOMAINS = {"yelp.com", "yellowpages.com", "manta.com", "bbb.org",
-                "linkedin.com", "facebook.com", "google.com", "indeed.com",
-                "ziprecruiter.com", "glassdoor.com", "mapquest.com",
-                "duckduckgo.com", "wikipedia.org", "chamber.com"}
+SKIP_DOMAINS = {
+    "yelp.com",
+    "yellowpages.com",
+    "manta.com",
+    "bbb.org",
+    "linkedin.com",
+    "facebook.com",
+    "google.com",
+    "indeed.com",
+    "ziprecruiter.com",
+    "glassdoor.com",
+    "mapquest.com",
+    "duckduckgo.com",
+    "wikipedia.org",
+    "chamber.com",
+}
 
 MFG_CATEGORIES = [
-    "food", "beverage", "juice", "citrus", "dairy", "water treatment", "wastewater",
-    "chemical", "pharma", "pharmaceutical", "packaging", "fabricat", "machine",
-    "manufactur", "bottl", "processing", "assembly", "industrial", "foundry",
-    "metal", "plastic", "rubber", "printing", "paper", "lumber", "textile",
-    "aerospace", "automotive", "electronics", "warehouse", "distribution",
+    "food",
+    "beverage",
+    "juice",
+    "citrus",
+    "dairy",
+    "water treatment",
+    "wastewater",
+    "chemical",
+    "pharma",
+    "pharmaceutical",
+    "packaging",
+    "fabricat",
+    "machine",
+    "manufactur",
+    "bottl",
+    "processing",
+    "assembly",
+    "industrial",
+    "foundry",
+    "metal",
+    "plastic",
+    "rubber",
+    "printing",
+    "paper",
+    "lumber",
+    "textile",
+    "aerospace",
+    "automotive",
+    "electronics",
+    "warehouse",
+    "distribution",
 ]
 
 
@@ -454,9 +1125,21 @@ def extract_facilities_from_results(
             continue
 
         cat = "manufacturing"
-        for kw in ["food", "beverage", "juice", "citrus", "water treatment", "wastewater",
-                   "chemical", "pharmaceutical", "packaging", "machine shop", "fabricat",
-                   "bottling", "processing"]:
+        for kw in [
+            "food",
+            "beverage",
+            "juice",
+            "citrus",
+            "water treatment",
+            "wastewater",
+            "chemical",
+            "pharmaceutical",
+            "packaging",
+            "machine shop",
+            "fabricat",
+            "bottling",
+            "processing",
+        ]:
             if kw in combined:
                 cat = kw
                 break
@@ -464,8 +1147,7 @@ def extract_facilities_from_results(
         dist = haversine(ANCHOR_LAT, ANCHOR_LON, city_lat, city_lon)
 
         address_match = re.search(
-            r"\d+\s+[A-Za-z].*?(?:St|Ave|Rd|Blvd|Dr|Way|Ln|Hwy)\b[.,]?",
-            snippet, re.IGNORECASE
+            r"\d+\s+[A-Za-z].*?(?:St|Ave|Rd|Blvd|Dr|Way|Ln|Hwy)\b[.,]?", snippet, re.IGNORECASE
         )
         address = address_match.group(0).strip() if address_match else ""
 
@@ -497,16 +1179,42 @@ def extract_facilities_from_results(
 # Enrichment — scrape facility website
 # ---------------------------------------------------------------------------
 
-CONTACT_PATHS = ["/contact", "/contact-us", "/about", "/about-us", "/team",
-                 "/staff", "/management", "/leadership"]
+CONTACT_PATHS = [
+    "/contact",
+    "/contact-us",
+    "/about",
+    "/about-us",
+    "/team",
+    "/staff",
+    "/management",
+    "/leadership",
+]
 
 EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}")
 PHONE_RE = re.compile(r"\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}")
-MAINT_TITLES = ["maintenance manager", "facilities manager", "plant manager",
-                "plant engineer", "maintenance director", "operations manager",
-                "maintenance supervisor", "facilities director", "chief engineer"]
-VFD_KWS = ["vfd", "variable frequency", "motor drive", "conveyor", "pump system",
-           "compressor", "automation", "plc", "scada", "hvac system"]
+MAINT_TITLES = [
+    "maintenance manager",
+    "facilities manager",
+    "plant manager",
+    "plant engineer",
+    "maintenance director",
+    "operations manager",
+    "maintenance supervisor",
+    "facilities director",
+    "chief engineer",
+]
+VFD_KWS = [
+    "vfd",
+    "variable frequency",
+    "motor drive",
+    "conveyor",
+    "pump system",
+    "compressor",
+    "automation",
+    "plc",
+    "scada",
+    "hvac system",
+]
 
 
 def scrape_site(url: str, client: httpx.Client) -> dict:
@@ -553,9 +1261,14 @@ def scrape_site(url: str, client: httpx.Client) -> dict:
                 r"([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3})\s*[,\-|]\s*("
                 + "|".join(re.escape(t) for t in MAINT_TITLES)
                 + r")",
-                text, re.IGNORECASE
+                text,
+                re.IGNORECASE,
             ):
-                contact = {"name": m.group(1).strip(), "title": m.group(2).strip(), "source": page_url}
+                contact = {
+                    "name": m.group(1).strip(),
+                    "title": m.group(2).strip(),
+                    "source": page_url,
+                }
                 if contact not in result["contacts"]:
                     result["contacts"].append(contact)
 
@@ -618,12 +1331,14 @@ def search_contacts_via_serper(
                 if key in seen:
                     continue
                 seen.add(key)
-                contacts.append({
-                    "name": name,
-                    "title": title,
-                    "source": r.get("link") or q,
-                    "confidence": "search-snippet",
-                })
+                contacts.append(
+                    {
+                        "name": name,
+                        "title": title,
+                        "source": r.get("link") or q,
+                        "confidence": "search-snippet",
+                    }
+                )
         time.sleep(1.0)
 
     return contacts
@@ -632,6 +1347,7 @@ def search_contacts_via_serper(
 # ---------------------------------------------------------------------------
 # Enrichment orchestrator — website scrape + Serper contact probe
 # ---------------------------------------------------------------------------
+
 
 def enrich_facilities(
     fac_list: list["Facility"],
@@ -647,8 +1363,12 @@ def enrich_facilities(
     """
     to_enrich = [f for f in fac_list if f.website and f.icp_score >= 4]
     log.info("=== ENRICHMENT PHASE ===")
-    log.info("Enriching %d high-score sites (serper=%s, budget=%d queries)",
-             len(to_enrich), "on" if serper_key else "off", budget)
+    log.info(
+        "Enriching %d high-score sites (serper=%s, budget=%d queries)",
+        len(to_enrich),
+        "on" if serper_key else "off",
+        budget,
+    )
 
     queries_used = 0
     with httpx.Client(timeout=15) as client:
@@ -658,11 +1378,13 @@ def enrich_facilities(
                 enrichment = scrape_site(f.website, client)
                 if enrichment.get("emails"):
                     for em in enrichment["emails"][:3]:
-                        f.contacts.append({
-                            "email": em,
-                            "source": f.website,
-                            "confidence": "website-direct",
-                        })
+                        f.contacts.append(
+                            {
+                                "email": em,
+                                "source": f.website,
+                                "confidence": "website-direct",
+                            }
+                        )
                 if enrichment.get("phones") and not f.phone:
                     f.phone = enrichment["phones"][0]
                 for c in enrichment.get("contacts", []):
@@ -682,12 +1404,14 @@ def enrich_facilities(
                         except Exception:
                             domain = ""
                     probe_results = search_contacts_via_serper(
-                        f.name, domain, client, serper_key,
+                        f.name,
+                        domain,
+                        client,
+                        serper_key,
                     )
                     queries_used += 3 if domain else 2
                     if probe_results:
-                        existing = {c.get("name", "").lower()
-                                    for c in f.contacts if c.get("name")}
+                        existing = {c.get("name", "").lower() for c in f.contacts if c.get("name")}
                         for c in probe_results:
                             if c["name"].lower() not in existing:
                                 f.contacts.append(c)
@@ -699,16 +1423,17 @@ def enrich_facilities(
             f.icp_score = score_facility(f)
 
     if serper_key:
-        log.info("Enrichment complete — %d Serper queries used (budget %d)",
-                 queries_used, budget)
+        log.info("Enrichment complete — %d Serper queries used (budget %d)", queries_used, budget)
 
 
 # ---------------------------------------------------------------------------
 # NeonDB persistence
 # ---------------------------------------------------------------------------
 
+
 def apply_schema(db_url: str) -> None:
     import psycopg2
+
     schema_sql = (Path(__file__).parent / "schema.sql").read_text()
     conn = psycopg2.connect(db_url)
     cur = conn.cursor()
@@ -723,6 +1448,7 @@ def apply_schema(db_url: str) -> None:
 
 def upsert_facilities(facilities: list[Facility], db_url: str) -> int:
     import psycopg2
+
     conn = psycopg2.connect(db_url)
     cur = conn.cursor()
     inserted = 0
@@ -741,9 +1467,21 @@ def upsert_facilities(facilities: list[Facility], db_url: str) -> int:
               updated_at     = NOW()
             RETURNING (xmax = 0)
             """,
-            (f.name, f.address, f.city, f.state, f.zip_code, f.phone,
-             f.website, f.category, f.rating, f.review_count,
-             f.distance_miles, f.icp_score, f.notes),
+            (
+                f.name,
+                f.address,
+                f.city,
+                f.state,
+                f.zip_code,
+                f.phone,
+                f.website,
+                f.category,
+                f.rating,
+                f.review_count,
+                f.distance_miles,
+                f.icp_score,
+                f.notes,
+            ),
         )
         row = cur.fetchone()
         if row and row[0]:
@@ -754,8 +1492,7 @@ def upsert_facilities(facilities: list[Facility], db_url: str) -> int:
         if not f.contacts:
             continue
         cur.execute(
-            "SELECT id FROM prospect_facilities WHERE name=%s AND city=%s",
-            (f.name, f.city)
+            "SELECT id FROM prospect_facilities WHERE name=%s AND city=%s", (f.name, f.city)
         )
         frow = cur.fetchone()
         if not frow:
@@ -768,8 +1505,15 @@ def upsert_facilities(facilities: list[Facility], db_url: str) -> int:
                 VALUES (%s,%s,%s,%s,%s,%s,%s)
                 ON CONFLICT DO NOTHING
                 """,
-                (fid, c.get("name"), c.get("title"), c.get("email"), c.get("phone"),
-                 c.get("source"), c.get("confidence", "medium")),
+                (
+                    fid,
+                    c.get("name"),
+                    c.get("title"),
+                    c.get("email"),
+                    c.get("phone"),
+                    c.get("source"),
+                    c.get("confidence", "medium"),
+                ),
             )
     conn.commit()
     conn.close()
@@ -779,6 +1523,7 @@ def upsert_facilities(facilities: list[Facility], db_url: str) -> int:
 # ---------------------------------------------------------------------------
 # HubSpot CRM push
 # ---------------------------------------------------------------------------
+
 
 def _hs_headers(token: str) -> dict:
     return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
@@ -793,7 +1538,16 @@ def _hs_search_company(name: str, domain: str, token: str, client: httpx.Client)
             resp = client.post(
                 f"{HUBSPOT_BASE}/crm/v3/objects/companies/search",
                 headers=_hs_headers(token),
-                json={"filterGroups": [{"filters": [{"propertyName": field_name, "operator": "EQ", "value": value}]}], "limit": 1},
+                json={
+                    "filterGroups": [
+                        {
+                            "filters": [
+                                {"propertyName": field_name, "operator": "EQ", "value": value}
+                            ]
+                        }
+                    ],
+                    "limit": 1,
+                },
                 timeout=10,
             )
             if resp.status_code == 200:
@@ -812,7 +1566,12 @@ def _hs_search_contact(email: str, token: str, client: httpx.Client) -> Optional
         resp = client.post(
             f"{HUBSPOT_BASE}/crm/v3/objects/contacts/search",
             headers=_hs_headers(token),
-            json={"filterGroups": [{"filters": [{"propertyName": "email", "operator": "EQ", "value": email}]}], "limit": 1},
+            json={
+                "filterGroups": [
+                    {"filters": [{"propertyName": "email", "operator": "EQ", "value": email}]}
+                ],
+                "limit": 1,
+            },
             timeout=10,
         )
         if resp.status_code == 200:
@@ -825,7 +1584,15 @@ def _hs_search_contact(email: str, token: str, client: httpx.Client) -> Optional
 
 
 def push_to_hubspot(facilities: list[Facility], token: str, min_score: int = 10) -> dict:
-    stats = {"companies_created": 0, "companies_updated": 0, "contacts_created": 0, "deals_created": 0, "skipped": 0, "errors": 0, "_total_attempted": 0}
+    stats = {
+        "companies_created": 0,
+        "companies_updated": 0,
+        "contacts_created": 0,
+        "deals_created": 0,
+        "skipped": 0,
+        "errors": 0,
+        "_total_attempted": 0,
+    }
     qualified = [f for f in facilities if f.icp_score >= min_score]
     log.info("HubSpot push: %d qualified facilities (ICP >= %d)", len(qualified), min_score)
 
@@ -877,7 +1644,9 @@ def push_to_hubspot(facilities: list[Facility], token: str, min_score: int = 10)
                         stats["companies_created"] += 1
                         log.info("  HS created company: %s (id=%s)", f.name[:50], company_id)
                     else:
-                        log.warning("  HS company create failed %d: %s", r.status_code, r.text[:120])
+                        log.warning(
+                            "  HS company create failed %d: %s", r.status_code, r.text[:120]
+                        )
                         stats["errors"] += 1
                         continue
             except Exception as e:
@@ -926,12 +1695,14 @@ def push_to_hubspot(facilities: list[Facility], token: str, min_score: int = 10)
                     dr = client.post(
                         f"{HUBSPOT_BASE}/crm/v3/objects/deals",
                         headers=_hs_headers(token),
-                        json={"properties": {
-                            "dealname": f"MIRA Pilot — {f.name[:60]}",
-                            "amount": "499",
-                            "pipeline": "default",
-                            "dealstage": "appointmentscheduled",
-                        }},
+                        json={
+                            "properties": {
+                                "dealname": f"MIRA Pilot — {f.name[:60]}",
+                                "amount": "499",
+                                "pipeline": "default",
+                                "dealstage": "appointmentscheduled",
+                            }
+                        },
                         timeout=10,
                     )
                     if dr.status_code in (200, 201):
@@ -962,7 +1733,28 @@ def write_hubspot_csv(facilities: list[Facility], path: Path, min_score: int = 1
         if f.contacts:
             for c in f.contacts:
                 name_parts = (c.get("name") or "").split(" ", 1)
-                rows.append({
+                rows.append(
+                    {
+                        "Company Name": f.name,
+                        "Company Domain": domain,
+                        "Company Phone": f.phone,
+                        "Company City": f.city,
+                        "Company State": f.state,
+                        "Company Address": f.address,
+                        "Company Industry": f.category,
+                        "ICP Score": f.icp_score,
+                        "Contact First Name": name_parts[0] if name_parts else "",
+                        "Contact Last Name": name_parts[1] if len(name_parts) > 1 else "",
+                        "Contact Email": c.get("email", ""),
+                        "Contact Phone": c.get("phone", ""),
+                        "Contact Job Title": c.get("title", ""),
+                        "Deal Name": f"MIRA Pilot — {f.name[:60]}" if f.icp_score >= 15 else "",
+                        "Deal Amount": "499" if f.icp_score >= 15 else "",
+                    }
+                )
+        else:
+            rows.append(
+                {
                     "Company Name": f.name,
                     "Company Domain": domain,
                     "Company Phone": f.phone,
@@ -971,29 +1763,15 @@ def write_hubspot_csv(facilities: list[Facility], path: Path, min_score: int = 1
                     "Company Address": f.address,
                     "Company Industry": f.category,
                     "ICP Score": f.icp_score,
-                    "Contact First Name": name_parts[0] if name_parts else "",
-                    "Contact Last Name": name_parts[1] if len(name_parts) > 1 else "",
-                    "Contact Email": c.get("email", ""),
-                    "Contact Phone": c.get("phone", ""),
-                    "Contact Job Title": c.get("title", ""),
+                    "Contact First Name": "",
+                    "Contact Last Name": "",
+                    "Contact Email": "",
+                    "Contact Phone": "",
+                    "Contact Job Title": "",
                     "Deal Name": f"MIRA Pilot — {f.name[:60]}" if f.icp_score >= 15 else "",
                     "Deal Amount": "499" if f.icp_score >= 15 else "",
-                })
-        else:
-            rows.append({
-                "Company Name": f.name,
-                "Company Domain": domain,
-                "Company Phone": f.phone,
-                "Company City": f.city,
-                "Company State": f.state,
-                "Company Address": f.address,
-                "Company Industry": f.category,
-                "ICP Score": f.icp_score,
-                "Contact First Name": "", "Contact Last Name": "",
-                "Contact Email": "", "Contact Phone": "", "Contact Job Title": "",
-                "Deal Name": f"MIRA Pilot — {f.name[:60]}" if f.icp_score >= 15 else "",
-                "Deal Amount": "499" if f.icp_score >= 15 else "",
-            })
+                }
+            )
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w", newline="") as fh:
         if rows:
@@ -1006,6 +1784,7 @@ def write_hubspot_csv(facilities: list[Facility], path: Path, min_score: int = 1
 # ---------------------------------------------------------------------------
 # Report generation
 # ---------------------------------------------------------------------------
+
 
 def write_report(facilities: list[Facility], path: Path, hs_stats: Optional[dict] = None) -> None:
     today = date.today().isoformat()
@@ -1072,7 +1851,9 @@ def write_report(facilities: list[Facility], path: Path, hs_stats: Optional[dict
         ]
     else:
         today_str = date.today().isoformat()
-        lines.append(f"HubSpot CSV ready for import at `marketing/prospects/hubspot-import-{today_str}.csv`")
+        lines.append(
+            f"HubSpot CSV ready for import at `marketing/prospects/hubspot-import-{today_str}.csv`"
+        )
         lines.append("_(To enable live push: set `HUBSPOT_API_KEY` in Doppler `factorylm/prd`)_")
 
     lines += [
@@ -1090,18 +1871,28 @@ def write_report(facilities: list[Facility], path: Path, hs_stats: Optional[dict
 # Main
 # ---------------------------------------------------------------------------
 
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="MIRA Lead Hunter")
     parser.add_argument("--discover-only", action="store_true")
-    parser.add_argument("--enrich-only", action="store_true",
-                        help="Skip discovery; enrich facilities already in NeonDB that have no contacts")
+    parser.add_argument(
+        "--enrich-only",
+        action="store_true",
+        help="Skip discovery; enrich facilities already in NeonDB that have no contacts",
+    )
     parser.add_argument("--report-only", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--limit", type=int, default=0, help="Cap city count (0=all)")
     parser.add_argument("--no-enrich", action="store_true", help="Skip website scraping")
-    parser.add_argument("--push-hubspot", action="store_true", help="Push qualified leads to HubSpot")
-    parser.add_argument("--enrich-budget", type=int, default=500,
-                        help="Max Serper queries to spend on contact probing (default 500)")
+    parser.add_argument(
+        "--push-hubspot", action="store_true", help="Push qualified leads to HubSpot"
+    )
+    parser.add_argument(
+        "--enrich-budget",
+        type=int,
+        default=500,
+        help="Max Serper queries to spend on contact probing (default 500)",
+    )
     args = parser.parse_args()
 
     serper_key = os.environ.get("SERPER_API_KEY", "")
@@ -1111,7 +1902,7 @@ def main() -> None:
     report_path = PROSPECTS_DIR / f"central-florida-{today}.md"
     hs_csv_path = PROSPECTS_DIR / f"hubspot-import-{today}.csv"
 
-    cities = CITIES[:args.limit] if args.limit else CITIES
+    cities = CITIES[: args.limit] if args.limit else CITIES
 
     if args.report_only:
         log.info("--report-only: loading from DB")
@@ -1119,14 +1910,24 @@ def main() -> None:
             log.error("NEON_DATABASE_URL required for --report-only")
             sys.exit(1)
         import psycopg2
+
         conn = psycopg2.connect(db_url)
         cur = conn.cursor()
-        cur.execute("SELECT name,city,phone,website,category,distance_miles,icp_score,notes FROM prospect_facilities ORDER BY icp_score DESC")
+        cur.execute(
+            "SELECT name,city,phone,website,category,distance_miles,icp_score,notes FROM prospect_facilities ORDER BY icp_score DESC"
+        )
         facilities_list = []
         for row in cur.fetchall():
-            f = Facility(name=row[0], city=row[1], phone=row[2] or "", website=row[3] or "",
-                         category=row[4] or "", distance_miles=row[5] or 0, icp_score=row[6] or 0,
-                         notes=row[7] or "")
+            f = Facility(
+                name=row[0],
+                city=row[1],
+                phone=row[2] or "",
+                website=row[3] or "",
+                category=row[4] or "",
+                distance_miles=row[5] or 0,
+                icp_score=row[6] or 0,
+                notes=row[7] or "",
+            )
             facilities_list.append(f)
         conn.close()
         write_report(facilities_list, report_path)
@@ -1138,6 +1939,7 @@ def main() -> None:
             log.error("NEON_DATABASE_URL required for --enrich-only")
             sys.exit(1)
         import psycopg2
+
         conn = psycopg2.connect(db_url)
         cur = conn.cursor()
         cur.execute(
@@ -1154,9 +1956,16 @@ def main() -> None:
         )
         fac_list = []
         for row in cur.fetchall():
-            f = Facility(name=row[0], city=row[1], phone=row[2] or "", website=row[3] or "",
-                         category=row[4] or "", distance_miles=row[5] or 0, icp_score=row[6] or 0,
-                         notes=row[7] or "")
+            f = Facility(
+                name=row[0],
+                city=row[1],
+                phone=row[2] or "",
+                website=row[3] or "",
+                category=row[4] or "",
+                distance_miles=row[5] or 0,
+                icp_score=row[6] or 0,
+                notes=row[7] or "",
+            )
             fac_list.append(f)
         conn.close()
         log.info("Loaded %d facilities needing contact enrichment", len(fac_list))
@@ -1200,10 +2009,12 @@ def main() -> None:
     log.info("Seeded %d known facilities", len(facilities))
 
     log.info("=== DISCOVERY PHASE ===")
-    log.info("Mode: %s | Cities: %d | Backend: %s",
-             "dry-run" if args.dry_run else "live",
-             len(cities),
-             "serper" if serper_key else "duckduckgo")
+    log.info(
+        "Mode: %s | Cities: %d | Backend: %s",
+        "dry-run" if args.dry_run else "live",
+        len(cities),
+        "serper" if serper_key else "duckduckgo",
+    )
 
     ddg_consecutive_fails = 0
     ddg_dead = False
@@ -1227,14 +2038,19 @@ def main() -> None:
                     if results is None:
                         ddg_consecutive_fails += 1
                         if ddg_consecutive_fails >= DDG_FAIL_LIMIT:
-                            log.warning("DDG circuit breaker tripped after %d failures — skipping remaining web queries", DDG_FAIL_LIMIT)
+                            log.warning(
+                                "DDG circuit breaker tripped after %d failures — skipping remaining web queries",
+                                DDG_FAIL_LIMIT,
+                            )
                             ddg_dead = True
                         results = []
                     else:
                         ddg_consecutive_fails = 0
                     time.sleep(RATE_LIMIT_SECS)
 
-                new_facs = extract_facilities_from_results(results, city_name, city_lat, city_lon, query)
+                new_facs = extract_facilities_from_results(
+                    results, city_name, city_lat, city_lon, query
+                )
                 for f in new_facs:
                     if f.key not in facilities:
                         facilities[f.key] = f

--- a/tools/lead-hunter/hunt.py
+++ b/tools/lead-hunter/hunt.py
@@ -569,6 +569,141 @@ def scrape_site(url: str, client: httpx.Client) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Enrichment — Google search contact probe (Serper)
+# ---------------------------------------------------------------------------
+
+_TITLE_SNIPPET_RE = re.compile(
+    r"([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,3})\s*[,\-|\u2013\u2014]\s*("
+    + "|".join(re.escape(t) for t in MAINT_TITLES)
+    + r")",
+    re.IGNORECASE,
+)
+
+
+def search_contacts_via_serper(
+    company_name: str,
+    domain: str,
+    client: httpx.Client,
+    serper_key: str,
+) -> list[dict]:
+    """Probe Google snippets for Name/Title at a facility.
+
+    Returns list of {name, title, source, confidence='search-snippet'}.
+    Reads Serper's organic snippets only — never fetches LinkedIn pages directly.
+    """
+    if not serper_key or not company_name:
+        return []
+
+    queries = [f'"maintenance manager" OR "plant manager" "{company_name}"']
+    if domain:
+        queries.append(f'"maintenance manager" OR "facilities manager" site:{domain}')
+    queries.append(f'"{company_name}" "linkedin.com/in"')
+
+    contacts: list[dict] = []
+    seen: set[str] = set()
+
+    for q in queries:
+        try:
+            results = search_serper(q, serper_key, client)
+        except Exception as e:
+            log.debug("Contact probe failed for %r: %s", q, e)
+            continue
+
+        for r in results:
+            text = f"{r.get('title', '')} {r.get('snippet', '')}"
+            for m in _TITLE_SNIPPET_RE.finditer(text):
+                name = m.group(1).strip()
+                title = m.group(2).strip().title()
+                key = name.lower()
+                if key in seen:
+                    continue
+                seen.add(key)
+                contacts.append({
+                    "name": name,
+                    "title": title,
+                    "source": r.get("link") or q,
+                    "confidence": "search-snippet",
+                })
+        time.sleep(1.0)
+
+    return contacts
+
+
+# ---------------------------------------------------------------------------
+# Enrichment orchestrator — website scrape + Serper contact probe
+# ---------------------------------------------------------------------------
+
+def enrich_facilities(
+    fac_list: list["Facility"],
+    serper_key: str,
+    budget: int = 500,
+) -> None:
+    """Enrich facilities in place: scrape website, optionally probe Serper for contacts.
+
+    Each contact appended gets a `confidence` field:
+      - "website-direct": scraped from the facility's own site
+      - "search-snippet": parsed from Google snippets via Serper
+    Aborts Serper probing when `budget` queries have been used.
+    """
+    to_enrich = [f for f in fac_list if f.website and f.icp_score >= 4]
+    log.info("=== ENRICHMENT PHASE ===")
+    log.info("Enriching %d high-score sites (serper=%s, budget=%d queries)",
+             len(to_enrich), "on" if serper_key else "off", budget)
+
+    queries_used = 0
+    with httpx.Client(timeout=15) as client:
+        for f in to_enrich:
+            log.info("  Enriching: %s (%s)", f.name[:50], f.website[:40])
+            try:
+                enrichment = scrape_site(f.website, client)
+                if enrichment.get("emails"):
+                    for em in enrichment["emails"][:3]:
+                        f.contacts.append({
+                            "email": em,
+                            "source": f.website,
+                            "confidence": "website-direct",
+                        })
+                if enrichment.get("phones") and not f.phone:
+                    f.phone = enrichment["phones"][0]
+                for c in enrichment.get("contacts", []):
+                    c.setdefault("confidence", "website-direct")
+                    f.contacts.append(c)
+                if enrichment.get("vfd_hit"):
+                    f.notes = (f.notes + " vfd_keywords_found").strip()
+            except Exception as e:
+                log.debug("Website scrape failed %s: %s", f.name, e)
+
+            if serper_key and queries_used < budget:
+                try:
+                    domain = ""
+                    if f.website:
+                        try:
+                            domain = urlparse(f.website).netloc.replace("www.", "")
+                        except Exception:
+                            domain = ""
+                    probe_results = search_contacts_via_serper(
+                        f.name, domain, client, serper_key,
+                    )
+                    queries_used += 3 if domain else 2
+                    if probe_results:
+                        existing = {c.get("name", "").lower()
+                                    for c in f.contacts if c.get("name")}
+                        for c in probe_results:
+                            if c["name"].lower() not in existing:
+                                f.contacts.append(c)
+                                existing.add(c["name"].lower())
+                        log.info("    + %d contact(s) from Serper probe", len(probe_results))
+                except Exception as e:
+                    log.debug("Serper probe failed %s: %s", f.name, e)
+
+            f.icp_score = score_facility(f)
+
+    if serper_key:
+        log.info("Enrichment complete — %d Serper queries used (budget %d)",
+                 queries_used, budget)
+
+
+# ---------------------------------------------------------------------------
 # NeonDB persistence
 # ---------------------------------------------------------------------------
 
@@ -630,10 +765,11 @@ def upsert_facilities(facilities: list[Facility], db_url: str) -> int:
             cur.execute(
                 """
                 INSERT INTO prospect_contacts (facility_id, name, title, email, phone, source, confidence)
-                VALUES (%s,%s,%s,%s,%s,%s,'medium')
+                VALUES (%s,%s,%s,%s,%s,%s,%s)
                 ON CONFLICT DO NOTHING
                 """,
-                (fid, c.get("name"), c.get("title"), c.get("email"), c.get("phone"), c.get("source")),
+                (fid, c.get("name"), c.get("title"), c.get("email"), c.get("phone"),
+                 c.get("source"), c.get("confidence", "medium")),
             )
     conn.commit()
     conn.close()
@@ -957,11 +1093,15 @@ def write_report(facilities: list[Facility], path: Path, hs_stats: Optional[dict
 def main() -> None:
     parser = argparse.ArgumentParser(description="MIRA Lead Hunter")
     parser.add_argument("--discover-only", action="store_true")
+    parser.add_argument("--enrich-only", action="store_true",
+                        help="Skip discovery; enrich facilities already in NeonDB that have no contacts")
     parser.add_argument("--report-only", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--limit", type=int, default=0, help="Cap city count (0=all)")
     parser.add_argument("--no-enrich", action="store_true", help="Skip website scraping")
     parser.add_argument("--push-hubspot", action="store_true", help="Push qualified leads to HubSpot")
+    parser.add_argument("--enrich-budget", type=int, default=500,
+                        help="Max Serper queries to spend on contact probing (default 500)")
     args = parser.parse_args()
 
     serper_key = os.environ.get("SERPER_API_KEY", "")
@@ -990,6 +1130,59 @@ def main() -> None:
             facilities_list.append(f)
         conn.close()
         write_report(facilities_list, report_path)
+        return
+
+    if args.enrich_only:
+        log.info("--enrich-only: loading facilities from DB for contact probing")
+        if not db_url:
+            log.error("NEON_DATABASE_URL required for --enrich-only")
+            sys.exit(1)
+        import psycopg2
+        conn = psycopg2.connect(db_url)
+        cur = conn.cursor()
+        cur.execute(
+            """
+            SELECT name, city, phone, website, category, distance_miles, icp_score, notes
+            FROM prospect_facilities
+            WHERE website IS NOT NULL AND website <> ''
+              AND id NOT IN (
+                  SELECT DISTINCT facility_id FROM prospect_contacts
+                  WHERE facility_id IS NOT NULL
+              )
+            ORDER BY icp_score DESC
+            """
+        )
+        fac_list = []
+        for row in cur.fetchall():
+            f = Facility(name=row[0], city=row[1], phone=row[2] or "", website=row[3] or "",
+                         category=row[4] or "", distance_miles=row[5] or 0, icp_score=row[6] or 0,
+                         notes=row[7] or "")
+            fac_list.append(f)
+        conn.close()
+        log.info("Loaded %d facilities needing contact enrichment", len(fac_list))
+
+        if not fac_list:
+            log.info("Nothing to enrich — all facilities already have contacts.")
+            return
+
+        enrich_facilities(fac_list, serper_key, budget=args.enrich_budget)
+
+        inserted = upsert_facilities(fac_list, db_url)
+        log.info("DB: %d new, %d updated", inserted, len(fac_list) - inserted)
+
+        hs_stats: Optional[dict] = None
+        if args.push_hubspot and hs_token:
+            log.info("=== HUBSPOT PUSH ===")
+            hs_stats = push_to_hubspot(fac_list, hs_token)
+            if hs_stats is None or hs_stats.get("errors", 0) == hs_stats.get("_total_attempted", 1):
+                log.info("HubSpot auth failed — writing CSV fallback")
+                write_hubspot_csv(fac_list, hs_csv_path)
+        elif args.push_hubspot:
+            log.info("No HUBSPOT_API_KEY — writing CSV fallback")
+            write_hubspot_csv(fac_list, hs_csv_path)
+
+        write_report(fac_list, report_path, hs_stats)
+        log.info("Enrichment run complete — report at %s", report_path)
         return
 
     if db_url and not args.dry_run:
@@ -1059,26 +1252,7 @@ def main() -> None:
     log.info("Discovery complete: %d facilities total", len(fac_list))
 
     if not args.discover_only and not args.no_enrich and not args.dry_run:
-        log.info("=== ENRICHMENT PHASE ===")
-        to_enrich = [f for f in fac_list if f.website and f.icp_score >= 4]
-        log.info("Enriching %d high-score sites", len(to_enrich))
-        with httpx.Client(timeout=15) as client:
-            for f in to_enrich:
-                log.info("  Enriching: %s (%s)", f.name[:50], f.website[:40])
-                try:
-                    enrichment = scrape_site(f.website, client)
-                    if enrichment.get("emails"):
-                        for em in enrichment["emails"][:3]:
-                            f.contacts.append({"email": em, "source": f.website})
-                    if enrichment.get("phones") and not f.phone:
-                        f.phone = enrichment["phones"][0]
-                    for c in enrichment.get("contacts", []):
-                        f.contacts.append(c)
-                    if enrichment.get("vfd_hit"):
-                        f.notes = (f.notes + " vfd_keywords_found").strip()
-                    f.icp_score = score_facility(f)
-                except Exception as e:
-                    log.debug("Enrichment failed %s: %s", f.name, e)
+        enrich_facilities(fac_list, serper_key, budget=500)
 
     hs_stats: Optional[dict] = None
     if not args.dry_run:

--- a/tools/lead-hunter/run_hourly.py
+++ b/tools/lead-hunter/run_hourly.py
@@ -4,8 +4,8 @@
 Called by: com.mira.lead-hunter.plist (launchd)
 Doppler injects secrets automatically via the plist EnvironmentVariables.
 """
+
 import logging
-import os
 import sys
 from pathlib import Path
 
@@ -24,7 +24,7 @@ logging.basicConfig(
     ],
 )
 
-from celery_tasks import run_discover_and_enrich
+from celery_tasks import run_discover_and_enrich  # noqa: E402
 
 if __name__ == "__main__":
     result = run_discover_and_enrich()


### PR DESCRIPTION
## Summary
- Adds Serper Google-snippet contact probe alongside existing site-scraping — surfaces Name+Title from organic snippets (incl. LinkedIn-adjacent) without fetching LinkedIn directly.
- New CLI: `--enrich-only` (pull facilities missing contacts from NeonDB and enrich in place) and `--enrich-budget N` (cap Serper spend).
- Single file: `tools/lead-hunter/hunt.py`, +196/-22 lines.

## Why
Existing enrichment was web-scraping only — many facility sites don't publish maintenance manager names, but Google snippets often do. Serper is already in use elsewhere in lead-hunter so no new dependency.

## Test plan
- [ ] `SERPER_API_KEY=... python tools/lead-hunter/hunt.py --enrich-only --limit 5 --dry-run` on a NeonDB branch — verify probe fires and returns plausible contacts without writing
- [ ] Budget cap works: set `--enrich-budget 2`, confirm Serper stops after 2 calls

## Known pre-existing issue (not in scope)
- `tools/lead-hunter/hunt.py:246` contains a U+2020 dagger where a Greek phi (φ) was intended. File parses on macOS/Linux but fails on Windows Python 3.11 due to encoding. Lives on main; orthogonal to this PR.