### PR TITLE
fix(lead-hunter): upsert ON CONFLICT target to (name, address) — closes #496

### DIFF
--- a/tools/lead-hunter/hunt.py
+++ b/tools/lead-hunter/hunt.py
@@ -1466,7 +1466,8 @@ def upsert_facilities(facilities: list[Facility], db_url: str) -> int:
               (name, address, city, state, zip, phone, website, category,
                rating, review_count, distance_miles, icp_score, notes)
             VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-            ON CONFLICT (name, city) DO UPDATE SET
+            ON CONFLICT (name, address) DO UPDATE SET
+              city           = COALESCE(NULLIF(EXCLUDED.city,''), prospect_facilities.city),
               icp_score      = GREATEST(prospect_facilities.icp_score, EXCLUDED.icp_score),
               phone          = COALESCE(NULLIF(EXCLUDED.phone,''), prospect_facilities.phone),
               website        = COALESCE(NULLIF(EXCLUDED.website,''), prospect_facilities.website),
@@ -1499,7 +1500,9 @@ def upsert_facilities(facilities: list[Facility], db_url: str) -> int:
         if not f.contacts:
             continue
         cur.execute(
-            "SELECT id FROM prospect_facilities WHERE name=%s AND city=%s", (f.name, f.city)
+            "SELECT id FROM prospect_facilities "
+            "WHERE name=%s AND COALESCE(address,'')=COALESCE(%s,'')",
+            (f.name, f.address),
         )
         frow = cur.fetchone()
         if not frow:


### PR DESCRIPTION
## Summary
`prospect_facilities` has a unique constraint on `(name, address)` but the upsert code said `ON CONFLICT (name, city)`. Any insert colliding on name+address — common when two rows have the same name and empty address — crashed with UniqueViolation, aborting the whole transaction.

Observed on 2026-04-21 during a 100-query Serper enrichment run. All enriched contacts for that run were lost because the commit never happened.

## Fix
- `ON CONFLICT (name, city)` → `ON CONFLICT (name, address)`
- Added `city` to the DO UPDATE SET so the update still pulls in fresher city values
- Contact-lookup SELECT uses `name + address` matching, `COALESCE` for NULL vs '' safety

## Test plan
- [x] Syntax check passes
- [x] Diff is minimal (+5/-2 lines in one function)
- [ ] Post-merge: `hunt.py --enrich-only --enrich-budget 10` completes without UniqueViolation
- [ ] Post-merge: `SELECT COUNT(*) FROM prospect_contacts` non-decreasing (125 pre-existing rows preserved)

Closes #496.