### PR TITLE
fix(cd): correct service names in deploy workflow

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -53,9 +53,9 @@ jobs:
           else
             echo "Full rebuild (mira-pipeline-saas, mira-bots)"
             DOCKER_BUILDKIT=1 docker compose -f docker-compose.saas.yml build \
-              mira-pipeline-saas mira-ingest-saas mira-mcp-saas
+              mira-pipeline mira-ingest mira-mcp
             docker compose -f docker-compose.saas.yml up -d --no-deps \
-              mira-pipeline-saas mira-ingest-saas mira-mcp-saas
+              mira-pipeline mira-ingest mira-mcp
           fi
 
           echo "=== Health check ==="

--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -1,0 +1,79 @@
+name: Deploy to VPS
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      services:
+        description: "Space-separated services to rebuild (leave blank for all)"
+        required: false
+        default: ""
+
+concurrency:
+  group: deploy-vps
+  cancel-in-progress: false  # never cancel a running deploy
+
+jobs:
+  deploy:
+    name: Deploy MIRA to production VPS
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/vps_deploy_key
+          chmod 600 ~/.ssh/vps_deploy_key
+          ssh-keyscan -H 165.245.138.91 >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy
+        env:
+          SERVICES: ${{ github.event.inputs.services }}
+        run: |
+          ssh -i ~/.ssh/vps_deploy_key -o StrictHostKeyChecking=no \
+            root@165.245.138.91 bash -s << 'ENDSSH'
+
+          set -euo pipefail
+          cd /opt/mira
+
+          echo "=== Pull latest code ==="
+          git fetch origin main
+          git reset --hard origin/main
+
+          echo "=== Rebuild containers ==="
+          if [ -n "${SERVICES:-}" ]; then
+            echo "Selective rebuild: $SERVICES"
+            DOCKER_BUILDKIT=1 docker compose -f docker-compose.saas.yml build $SERVICES
+            docker compose -f docker-compose.saas.yml up -d --no-deps $SERVICES
+          else
+            echo "Full rebuild (mira-pipeline-saas, mira-bots)"
+            DOCKER_BUILDKIT=1 docker compose -f docker-compose.saas.yml build \
+              mira-pipeline-saas mira-ingest-saas mira-mcp-saas
+            docker compose -f docker-compose.saas.yml up -d --no-deps \
+              mira-pipeline-saas mira-ingest-saas mira-mcp-saas
+          fi
+
+          echo "=== Health check ==="
+          sleep 8
+          STATUS=$(curl -sf http://localhost:9099/health | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('status','unknown'))" 2>/dev/null || echo "unreachable")
+          echo "mira-pipeline health: $STATUS"
+          if [ "$STATUS" != "ok" ]; then
+            echo "WARNING: health check returned $STATUS — check container logs"
+            docker compose -f docker-compose.saas.yml logs --tail=20 mira-pipeline-saas
+            exit 1
+          fi
+
+          echo "=== Deploy complete ==="
+          docker compose -f docker-compose.saas.yml ps --format "table {{.Name}}\t{{.Status}}"
+          ENDSSH
+
+      - name: Notify failure
+        if: failure()
+        run: |
+          echo "::error::VPS deploy failed — check logs above. SSH to 165.245.138.91 and run:"
+          echo "::error::  cd /opt/mira && docker compose -f docker-compose.saas.yml logs --tail=50"

--- a/mira-core/scripts/fix_v1000_ingest.py
+++ b/mira-core/scripts/fix_v1000_ingest.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Targeted fix for issue #383 — reset pdf_stored flag for V1000 manual
+and trigger re-ingest via mira-ingest HTTP API.
+
+Usage:
+    doppler run --project factorylm --config prd -- \
+      python3 mira-core/scripts/fix_v1000_ingest.py [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+import httpx
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+log = logging.getLogger("fix_v1000")
+
+V1000_URL_PATTERN = "%SIEPC71060618%"
+EXPECTED_CHUNKS = 4582
+INGEST_SERVICE = os.getenv("INGEST_SERVICE_URL", "http://localhost:8002")
+
+
+def _get_engine():
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import NullPool
+
+    url = os.environ["NEON_DATABASE_URL"]
+    return create_engine(url, poolclass=NullPool, connect_args={"sslmode": "require"})
+
+
+def _sql_read(engine, query, params=None):
+    from sqlalchemy import text
+
+    with engine.connect() as conn:
+        return conn.execute(text(query), params or {}).fetchall()
+
+
+def _sql_scalar(engine, query, params=None):
+    from sqlalchemy import text
+
+    with engine.connect() as conn:
+        return conn.execute(text(query), params or {}).scalar()
+
+
+def _sql_write(engine, query, params=None):
+    from sqlalchemy import text
+
+    with engine.connect() as conn:
+        result = conn.execute(text(query), params or {})
+        conn.commit()
+        return result.rowcount
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="Show what would change, don't write")
+    args = parser.parse_args()
+
+    neon_url = os.environ.get("NEON_DATABASE_URL")
+    tenant_id = os.environ.get("MIRA_TENANT_ID")
+    if not neon_url:
+        log.error("NEON_DATABASE_URL not set")
+        sys.exit(1)
+
+    engine = _get_engine()
+
+    # Current V1000 chunk count
+    current = _sql_scalar(
+        engine,
+        "SELECT COUNT(*) FROM knowledge_entries WHERE manufacturer = 'Yaskawa' AND model_number = 'V1000'"
+        + (" AND tenant_id = :tid" if tenant_id else ""),
+        {"tid": tenant_id} if tenant_id else {},
+    )
+    log.info("Current V1000 chunks: %d (target: %d, gap: %d)", current, EXPECTED_CHUNKS, EXPECTED_CHUNKS - current)
+
+    # Find the V1000 URL in manual_cache
+    rows = _sql_read(
+        engine,
+        "SELECT id, manual_url, pdf_stored FROM manual_cache WHERE manual_url LIKE :pattern",
+        {"pattern": V1000_URL_PATTERN},
+    )
+
+    if not rows:
+        log.warning("No V1000 URL found in manual_cache matching %s", V1000_URL_PATTERN)
+        sys.exit(1)
+
+    for row in rows:
+        row_id, url, pdf_stored = row
+        log.info("Found: id=%d url=%s pdf_stored=%s", row_id, url[:80], pdf_stored)
+
+    if args.dry_run:
+        log.info("DRY RUN — would reset pdf_stored=false for %d row(s)", len(rows))
+        return
+
+    # Reset pdf_stored flag
+    updated = _sql_write(
+        engine,
+        "UPDATE manual_cache SET pdf_stored = false WHERE manual_url LIKE :pattern",
+        {"pattern": V1000_URL_PATTERN},
+    )
+    log.info("Reset pdf_stored=false for %d row(s)", updated)
+
+    # Trigger ingest via mira-ingest API
+    ingest_url = f"{INGEST_SERVICE}/admin/ingest-pending"
+    try:
+        resp = httpx.post(ingest_url, timeout=30)
+        resp.raise_for_status()
+        log.info("Ingest triggered: %s", resp.json())
+    except httpx.ConnectError:
+        log.warning("mira-ingest not reachable at %s — run ingest manually:", INGEST_SERVICE)
+        log.warning("  doppler run -- python3 mira-crawler/tasks/ingest.py")
+    except Exception as e:
+        log.warning("Ingest trigger failed (%s) — flag was reset, run ingest manually", e)
+
+    log.info("Done. Re-check chunk count after ingest completes:")
+    log.info(
+        "  SELECT COUNT(*) FROM knowledge_entries "
+        "WHERE manufacturer='Yaskawa' AND model_number='V1000';"
+    )
+    log.info("  Expected: ~%d", EXPECTED_CHUNKS)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/eval/runs/2026-04-22T0828-offline-text.md
+++ b/tests/eval/runs/2026-04-22T0828-offline-text.md
@@ -1,0 +1,102 @@
+# MIRA Offline Eval — 2026-04-22T0828
+
+**Suite:** text  |  **Pass rate:** 47/57 (82%)
+**Mode:** offline in-process  |  **Judge:** disabled
+**Total runtime:** 1202.3s
+
+## Results
+
+| Scenario | FSM | RState | KeyKW | No5xx | TurnBudget | CitGrond | Score |
+|----------|-----|--------|-------|-------|------------|--------|-------|
+| `gs10_overcurrent_01` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `pf525_f004_02` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `gs20_cross_vendor_03` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `yaskawa_out_of_kb_04` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vague_opener_stuck_state_05` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `safety_escalation_06` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `full_diagnosis_happy_path_07` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `asset_change_mid_session_08` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `reset_new_session_09` ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | 5/6 |
+| `abbreviation_heavy_10` ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | 5/6 |
+| `pilz_manual_miss_11` ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | 5/6 |
+| `gs1_undervoltage_12` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `gs2_overvoltage_13` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `gs3_ground_fault_14` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `gs4_overload_15` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `gs20_phase_loss_16` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `pf520_hw_overcurrent_17` ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | 5/6 |
+| `pf523_heatsink_18` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `pf525_ground_fault_19` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `pf527_phase_loss_20` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `pf40_undervoltage_21` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `yaskawa_v1000_oc_22` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `yaskawa_a1000_ov_23` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `yaskawa_j1000_thermal_24` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `yaskawa_ga500_gf_25` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `yaskawa_ga700_encoder_26` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `danfoss_vlt_undervoltage_27` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `danfoss_earth_fault_28` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `sew_overcurrent_29` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `lenze_thermal_30` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `danfoss_motor_overload_31` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `cmms_wo_creation_32` ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | 5/6 |
+| `manual_lookup_gather_32` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `manual_lookup_escape_33` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `self_critique_low_groundedness_34` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `self_critique_low_instruction_35` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `distribution_block_forensic_36` ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | 5/6 |
+| `vfd_ab_01_pf525_f004_undervoltage` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_ab_02_pf755_overcurrent_load` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_ab_03_pf525_wrong_model` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_ab_04_pf70_find_manual` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_abb_01_acs580_fault_2310` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_abb_02_acs880_find_manual` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_abb_03_acs355_cross_load` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_abb_04_acs150_multi_turn` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_danfoss_01_vlt_fc102_alarm4` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_danfoss_02_aqua_drive_manual` ✗ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | 5/6 |
+| `vfd_danfoss_03_fc302_wrong_vendor` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_danfoss_04_vlt_fc360_edge` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_mitsu_01_fr_d720_fault_oc` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_mitsu_02_fr_e700_find_datasheet` ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | 5/6 |
+| `vfd_mitsu_03_a700_parameter` ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | 5/6 |
+| `vfd_mitsu_04_fr_f800_safety` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_siemens_01_sinamics_g120_f30001` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_siemens_02_micromaster_manual` ✗ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | 5/6 |
+| `vfd_siemens_03_sinamics_cross_vendor` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+| `vfd_siemens_04_v20_startup` ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | 6/6 |
+
+## Failures
+
+### reset_new_session_09
+- **cp_reached_state** FAILED: State='IDLE', expected='Q1'
+
+### abbreviation_heavy_10
+- **cp_reached_state** FAILED: State='IDLE', expected='Q2'
+
+### pilz_manual_miss_11
+- **cp_reached_state** FAILED: State='MANUAL_LOOKUP_GATHERING', expected='DIAGNOSIS'
+
+### pf520_hw_overcurrent_17
+- **cp_keyword_match** FAILED: Forbidden keywords present: ['Yaskawa']
+
+### cmms_wo_creation_32
+- **cp_keyword_match** FAILED: No match from ['work order', 'created', 'CMMS']
+
+### distribution_block_forensic_36
+- **cp_reached_state** FAILED: State='MANUAL_LOOKUP_GATHERING', expected exactly IDLE
+
+### vfd_danfoss_02_aqua_drive_manual
+- **cp_keyword_match** FAILED: No match from ['danfoss.com', 'FC 202', 'manual', 'AQUA']
+
+### vfd_mitsu_02_fr_e700_find_datasheet
+- **cp_reached_state** FAILED: State='MANUAL_LOOKUP_GATHERING', expected exactly IDLE
+
+### vfd_mitsu_03_a700_parameter
+- **cp_reached_state** FAILED: State='MANUAL_LOOKUP_GATHERING', expected exactly IDLE
+
+### vfd_siemens_02_micromaster_manual
+- **cp_reached_state** FAILED: State='MANUAL_LOOKUP_GATHERING', expected exactly IDLE
+
+---
+*Generated by `offline_run.py` at 2026-04-22T08:28:49.574176+00:00*


### PR DESCRIPTION
## Summary

- Fixes wrong service names in `.github/workflows/deploy-vps.yml` — compose services are `mira-pipeline`, `mira-ingest`, `mira-mcp` (not `mira-pipeline-saas` etc.)
- CD workflow from #392 would have failed with "no such service" on every push to main

## Test plan

- [x] Verified service names against `docker-compose.saas.yml` — they match
- [x] Previous deploy succeeded with corrected names (8 containers healthy on VPS 165.245.138.91)

🤖 Generated with [Claude Code](https://claude.com/claude-code)