### PR TITLE
fix(lead-hunter): name-quality gate filters CTA / role-noun snippet noise

### DIFF
--- a/tests/lead_hunter/test_snippet_parser.py
+++ b/tests/lead_hunter/test_snippet_parser.py
@@ -1,0 +1,106 @@
+"""Snippet-parser name-quality gate tests.
+
+Covers `_is_real_name` and its interaction with `_TITLE_SNIPPET_RE` in
+tools/lead-hunter/hunt.py. Origin incident: 2026-04-22 Central Florida
+re-probe run captured 6 noise rows like "Apply to Utility Manager" and
+"Pressure Washing Program GM" that looked like names because they happen
+to be capitalized tokens followed by a maintenance-manager title.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_HUNT_PATH = Path(__file__).resolve().parents[2] / "tools" / "lead-hunter" / "hunt.py"
+_spec = importlib.util.spec_from_file_location("hunt", _HUNT_PATH)
+hunt = importlib.util.module_from_spec(_spec)
+sys.modules["hunt"] = hunt
+_spec.loader.exec_module(hunt)
+
+
+class TestIsRealName:
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "Carlos Quinones",
+            "Brad Mincey",
+            "Nils Goddard",
+            "Eric Vogt",
+            "Daniel Boynton",
+            "Vernon Prevatt",
+            "Warren Chandler CMRP",  # credentialed
+            "Mary Jo Smith-Jones",  # multi-part
+        ],
+    )
+    def test_accepts_real_names(self, value: str) -> None:
+        assert hunt._is_real_name(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            # Observed in 2026-04-22 run
+            "Apply to Utility Manager",
+            "from the Facility Manager",
+            "Pressure Washing Program GM",
+            "to Field Service Technician",
+            # Single-token rejects
+            "John",
+            "Smith",
+            # Generic tokens
+            "Info",
+            "Contact Us",
+            "Our Team",
+            # All-caps headings
+            "CONTACT US",
+            "JOHN SMITH",
+            # Empty / whitespace
+            "",
+            "   ",
+            None,
+        ],
+    )
+    def test_rejects_noise(self, value: str | None) -> None:
+        assert hunt._is_real_name(value) is False
+
+
+class TestTitleSnippetInteraction:
+    """End-to-end: regex parses snippet, _is_real_name filters noise."""
+
+    def _extract(self, snippet: str) -> list[str]:
+        """Mimic the search_contacts_via_serper loop's name extraction."""
+        names: list[str] = []
+        for m in hunt._TITLE_SNIPPET_RE.finditer(snippet):
+            name = m.group(1).strip()
+            if hunt._is_real_name(name):
+                names.append(name)
+        return names
+
+    def test_real_contact_snippet_passes(self) -> None:
+        # Typical LinkedIn-snippet shape
+        snippet = "Carlos Quinones - Plant Manager at Toho Water Authority"
+        assert self._extract(snippet) == ["Carlos Quinones"]
+
+    def test_cta_snippet_filtered(self) -> None:
+        snippet = "Apply to Maintenance Manager jobs at our Florida plant"
+        assert self._extract(snippet) == []
+
+    def test_prose_fragment_filtered(self) -> None:
+        snippet = "...instructions from the Facility Manager in charge..."
+        assert self._extract(snippet) == []
+
+    def test_all_observed_noise_rejected(self) -> None:
+        """The 6 exact noise strings from the 2026-04-22 run must all be filtered."""
+        observed_noise = [
+            "Apply to Utility Manager - Maintenance Manager",
+            "from the Facility Manager - Maintenance Manager",
+            "Pressure Washing Program GM - Maintenance Manager",
+            "to Field Service Technician - Maintenance Manager",
+        ]
+        for snippet in observed_noise:
+            assert self._extract(snippet) == [], (
+                f"Noise leaked through filter: {snippet!r}"
+            )

--- a/tools/lead-hunter/hunt.py
+++ b/tools/lead-hunter/hunt.py
@@ -1336,6 +1336,64 @@ _TITLE_SNIPPET_RE = re.compile(
 )
 
 
+# Name-quality gate. The TITLE_SNIPPET regex above matches any capitalized
+# token sequence followed by a title, which lets noise through:
+#   "Apply to Utility Manager"   → looks like name "Apply to Utility"
+#   "from the Facility Manager"  → looks like name "from the Facility"
+#   "Pressure Washing Program GM"→ looks like name "Pressure Washing Program"
+# These were all observed in the 2026-04-22 Central Florida re-probe run.
+# _is_real_name filters them out so only actual person-names survive to the
+# DB and the report.
+
+_GENERIC_NAME_TOKENS = frozenset({
+    "info", "contact", "contact us", "team", "our team",
+    "staff", "support", "sales", "admin", "webmaster",
+})
+
+_NAME_STOPWORDS = frozenset({
+    # Verbs / CTAs that appear in search snippets and job listings
+    "apply", "visit", "call", "click", "contact", "view", "learn", "hiring",
+    "see", "find", "post", "posted", "hire", "meet", "read", "get",
+    # Prepositions / articles common in misread snippet prose
+    "from", "the", "our", "us", "here", "all", "by", "to",
+    # Adverbs / fillers common in CTAs
+    "now", "today", "more", "about",
+    # Role nouns — indicate the token is part of a title, not a name
+    "maintenance", "facilities", "plant", "operations", "manager", "director",
+    "supervisor", "engineer", "technician", "specialist", "program",
+    # Job-site / search-result boilerplate
+    "jobs", "job", "openings", "opening", "career", "careers",
+    "indeed", "glassdoor", "linkedin", "monster", "ziprecruiter",
+    # Service-description noise observed in snippets
+    "pressure", "washing",
+})
+
+
+def _is_real_name(value: str | None) -> bool:
+    """Return True iff value looks like a real person's name.
+
+    Rejects empties, generic tokens like "Info"/"Team", single-word strings,
+    all-caps strings (likely page headings), and multi-word strings that
+    contain a stopword (e.g. "Apply to Utility Manager" is not a person).
+    """
+    if not value:
+        return False
+    stripped = value.strip()
+    if not stripped:
+        return False
+    lower = stripped.lower()
+    if lower in _GENERIC_NAME_TOKENS:
+        return False
+    if stripped == stripped.upper() and any(c.isalpha() for c in stripped):
+        return False
+    tokens = stripped.split()
+    if len(tokens) < 2:
+        return False
+    if any(t.lower() in _NAME_STOPWORDS for t in tokens):
+        return False
+    return True
+
+
 def search_contacts_via_serper(
     company_name: str,
     domain: str,
@@ -1370,6 +1428,8 @@ def search_contacts_via_serper(
             for m in _TITLE_SNIPPET_RE.finditer(text):
                 name = m.group(1).strip()
                 title = m.group(2).strip().title()
+                if not _is_real_name(name):
+                    continue
                 key = name.lower()
                 if key in seen:
                     continue


### PR DESCRIPTION
## Summary
Adds `_is_real_name` name-quality gate to `search_contacts_via_serper`. Rejects the 4 noise patterns observed in the 2026-04-22 Central Florida re-probe run:
- "Apply to Utility Manager"
- "from the Facility Manager"
- "Pressure Washing Program GM"
- "to Field Service Technician"

These happen because `_TITLE_SNIPPET_RE` matches any capitalized token sequence followed by a maintenance title. CTAs and prose fragments share that shape.

## Gate rules
1. Rejects `_GENERIC_NAME_TOKENS` (Info, Team, Contact Us, …)
2. Rejects all-caps headings
3. Requires ≥2 whitespace tokens
4. Rejects any multi-word string containing a `_NAME_STOPWORDS` token (verbs, prepositions, role nouns, job-site boilerplate, service-description words)

## Tests
`tests/lead_hunter/test_snippet_parser.py` — 26 cases, all pass:
- 8 real-name accepts (incl. all 6 contacts surfaced 2026-04-22)
- 14 noise rejects (incl. the 4 observed in the run)
- 4 integration tests on end-to-end regex + filter

## Follow-on
Origin issue not formally filed — this is a direct follow-on to the 2026-04-22 --reprobe-generic pipeline (PRs #499, #500, #501, #503, #504). Next re-probe will add only real named managers.