### PR TITLE
fix(session-loop): deploy Telegram bot with session recording + fix push ASCII encoding

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -202,6 +202,8 @@ services:
       - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
       - LANGFUSE_HOST=${LANGFUSE_HOST:-}
+      - NTFY_URL=${NTFY_URL:-https://ntfy.sh}
+      - NTFY_TOPIC=${NTFY_TOPIC:-mira-factorylm-alerts}
     volumes:
       - /opt/mira/data:/mira-db
       - /opt/mira/data/mem0:/data/mem0
@@ -217,6 +219,45 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+
+  mira-bot-telegram:
+    build:
+      context: .
+      dockerfile: mira-bots/telegram/Dockerfile
+    container_name: mira-bot-telegram
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+      - MIRA_DB_PATH=/mira-db/mira.db
+      - OPENWEBUI_BASE_URL=http://mira-core-saas:8080
+      - OPENWEBUI_API_KEY=${OPENWEBUI_API_KEY:-}
+      - KNOWLEDGE_COLLECTION_ID=${KNOWLEDGE_COLLECTION_ID:-}
+      - NEON_DATABASE_URL=${NEON_DATABASE_URL:-}
+      - MIRA_TENANT_ID=${MIRA_TENANT_ID:-}
+      - VISION_MODEL=qwen2.5vl:7b
+      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+      - INFERENCE_BACKEND=cloud
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
+      - GROQ_MODEL=llama-3.3-70b-versatile
+      - GROQ_VISION_MODEL=meta-llama/llama-4-scout-17b-16e-instruct
+      - CEREBRAS_API_KEY=${CEREBRAS_API_KEY:-}
+      - CEREBRAS_MODEL=llama3.1-8b
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - GEMINI_MODEL=${GEMINI_MODEL:-gemini-2.5-flash}
+      - GEMINI_VISION_MODEL=${GEMINI_VISION_MODEL:-gemini-2.5-flash}
+      - MCP_REST_API_KEY=${MCP_REST_API_KEY:-}
+      - MCP_BASE_URL=http://mira-mcp-saas:8001
+      - SESSION_RECORDING_PATH=/data/sessions
+      - NTFY_URL=${NTFY_URL:-https://ntfy.sh}
+      - NTFY_TOPIC=${NTFY_TOPIC:-mira-factorylm-alerts}
+    volumes:
+      - /opt/mira/data:/mira-db
+      - /opt/mira/mira-bridge/data/sessions:/data/sessions
+    networks:
+      - mira-net
+    restart: unless-stopped
 
   mira-docling:
     image: quay.io/docling-project/docling-serve:v1.16.1

--- a/mira-bots/shared/analysis/session_analyzer.py
+++ b/mira-bots/shared/analysis/session_analyzer.py
@@ -235,11 +235,11 @@ class SessionAnalyzer:
             worst = min(grades, key=lambda k: grades.get(k, 0)) if grades else "unknown"
             platform = turns[0].get("platform", "?") if turns else "?"
             msg = (
-                f"Session scored {overall:.0%} — {worst} was {grades.get(worst, 0):.0%}\n"
+                f"Session scored {overall:.0%} - {worst} was {grades.get(worst, 0):.0%}\n"
                 f"Platform: {platform} | Turns: {len(turns)}\n"
                 f"Fixture: {fixture_path.name}"
             )
-            title = f"MIRA Quality Alert — {overall:.0%}"
+            title = f"MIRA Quality Alert - {overall:.0%}"
             priority = "default" if overall >= 0.60 else "high"
             tags = ["chart_with_downwards_trend"] if overall < 0.60 else ["bar_chart"]
             asyncio.run(send_push(message=msg, title=title, priority=priority, tags=tags))


### PR DESCRIPTION
## Summary

- **Add `mira-bot-telegram` to `docker-compose.saas.yml`** — the Telegram bot was never in the saas compose file, so no real user conversations were being recorded. Now it deploys with `SESSION_RECORDING_PATH=/data/sessions` and a shared volume mount to `/opt/mira/mira-bridge/data/sessions` so the session analyzer cron can pick up real conversations.
- **Add `NTFY_URL`/`NTFY_TOPIC` to `mira-pipeline` and `mira-bot-telegram`** — push alerts from the session analyzer were failing silently because ntfy env vars were missing from both containers.
- **Fix ASCII encoding bug in `session_analyzer._alert()`** — em dash characters (`\u2014`) in the alert title/message caused `'ascii' codec can't encode character '\u2014'` → `PUSH_FAILED` on every quality-regression alert. Replaced with ASCII dashes.

## Test plan

- [ ] After CD deploys: `docker ps` on VPS shows `mira-bot-telegram` container running
- [ ] Send a test message to the Telegram bot → verify NDJSON file appears in `/opt/mira/mira-bridge/data/sessions/`
- [ ] Wait 10+ min idle → session analyzer cron picks up session, logs `analyzed=1`
- [ ] If score < 0.80: verify push notification fires without ASCII error in analyzer log

🤖 Generated with [Claude Code](https://claude.com/claude-code)