### PR TITLE
feat(saas): wire mira-hub into docker-compose.saas.yml

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -298,6 +298,43 @@ services:
       retries: 3
       start_period: 10s
 
+  mira-hub:
+    build: ./mira-hub
+    container_name: mira-hub
+    ports:
+      - "127.0.0.1:3101:3000"
+    environment:
+      - NEON_DATABASE_URL=${NEON_DATABASE_URL:-}
+      - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-https://app.factorylm.com}
+      # Google Workspace OAuth
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
+      # Slack — both bot-token shortcut and full OAuth are supported by the route
+      - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN:-}
+      - SLACK_CLIENT_ID=${SLACK_CLIENT_ID:-}
+      - SLACK_CLIENT_SECRET=${SLACK_CLIENT_SECRET:-}
+      # Microsoft 365 / Teams (single Azure app covers both)
+      - MICROSOFT_CLIENT_ID=${MICROSOFT_CLIENT_ID:-}
+      - MICROSOFT_CLIENT_SECRET=${MICROSOFT_CLIENT_SECRET:-}
+      # Dropbox
+      - DROPBOX_APP_KEY=${DROPBOX_APP_KEY:-}
+      - DROPBOX_APP_SECRET=${DROPBOX_APP_SECRET:-}
+      # Atlassian Confluence
+      - ATLASSIAN_CLIENT_ID=${ATLASSIAN_CLIENT_ID:-}
+      - ATLASSIAN_CLIENT_SECRET=${ATLASSIAN_CLIENT_SECRET:-}
+      # Telegram (status endpoint reads these; route validates pasted tokens separately)
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN:-}
+      - TELEGRAM_BOT_USERNAME=${TELEGRAM_BOT_USERNAME:-}
+    networks:
+      - mira-net
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/hub/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
 networks:
   mira-net:
     driver: bridge


### PR DESCRIPTION
## Summary
- Adds `mira-hub` service to `docker-compose.saas.yml` so the Hub's env vars flow from Doppler on every deploy.
- Fixes empty `NEON_DATABASE_URL` on the running container (root cause of blank Channels/Knowledge pages on app.factorylm.com/hub).
- Plumbs env vars for every provider the Hub's existing OAuth routes already support: Google, Slack, Microsoft, Dropbox, Atlassian, plus Telegram helpers. Missing Doppler keys degrade gracefully — `/hub/api/auth/status` just reports `hasOAuth: false` and the cards render disabled.
- Port mapping `127.0.0.1:3101:3000` matches the existing nginx `proxy_pass` target so no nginx reload needed.

## Background
- Hub shipped in `factorylm-hub-phase1` merge but was running on the VPS via bare `docker run` with only 3 env vars set. OAuth routes (`mira-hub/src/app/api/auth/{slack,google,microsoft,dropbox,confluence}/route.ts`) were fully implemented, just starved of credentials.
- Dogfood acceptance (per Mike): "I am the test client once I can log into all of these accounts and connect them I will consider this done."

## Deploy plan (after merge)
```bash
# On VPS (/opt/mira)
doppler run --project factorylm --config prd -- \
  docker compose -f docker-compose.saas.yml up -d --build mira-hub
# Verify
curl -s https://app.factorylm.com/hub/api/auth/status | jq
```

Expected after deploy: `telegram`, `slack`, `google` → `configured/hasOAuth: true`. Microsoft/Dropbox/Atlassian → `hasOAuth: false` until Mike registers those OAuth apps in their vendor portals and adds the 6 secrets to Doppler.

## Test plan
- [ ] `docker compose -f docker-compose.saas.yml config` parses without error locally (✅ confirmed)
- [ ] After deploy, `/hub/api/auth/status` returns 200 JSON with expected provider flags
- [ ] `/hub/api/channels` returns 200 with channel traffic data (no more 503 from empty NEON_DATABASE_URL)
- [ ] `/hub/channels` page renders cards: Google Connect live, Slack auto-connected via bot token, Telegram modal accepts paste, Microsoft/Dropbox/Confluence show "Connect" disabled with helper text
- [ ] Mike clicks Connect on Google → Google OAuth screen → approve → card flips green

## Out of scope (follow-ups)
- Token persistence to DB after OAuth callback (currently tokens exchanged then discarded — fine for login test, needed for MIRA to actually read from providers)
- CSRF state cookie validation on callback (cookies set but never read — security debt)
- Email channel wiring (Unit 3 — separate PR)
- Vendor-portal OAuth app registration for Microsoft, Dropbox, Atlassian (Mike's task with guidance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)