### PR TITLE
feat(hub): persist OAuth connections to NeonDB + validate CSRF state

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -306,6 +306,10 @@ services:
     environment:
       - NEON_DATABASE_URL=${NEON_DATABASE_URL:-}
       - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-https://app.factorylm.com}
+      # AES-256-GCM key for at-rest encryption of OAuth tokens in hub_channel_bindings
+      - OAUTH_TOKEN_ENC_KEY=${OAUTH_TOKEN_ENC_KEY:-}
+      # Default tenant for the dogfood / single-user Hub pass
+      - HUB_TENANT_ID=${HUB_TENANT_ID:-mike}
       # Google Workspace OAuth
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}

--- a/mira-hub/src/app/(hub)/channels/page.tsx
+++ b/mira-hub/src/app/(hub)/channels/page.tsx
@@ -6,10 +6,8 @@ import { Settings, X, Loader2, CheckCircle, AlertCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
-  getConnection,
-  setConnection,
-  removeConnection,
-  getAllConnections,
+  fetchConnections,
+  disconnect as apiDisconnect,
   type Provider,
   type ConnectionMeta,
 } from "@/lib/connections";
@@ -175,63 +173,60 @@ function ChannelsInner() {
   const [telegramError, setTelegramError] = useState<string | null>(null);
   const [openwebuiUrl, setOpenwebuiUrl] = useState("http://localhost:3000");
 
-  const refresh = useCallback(() => {
-    setConnections(getAllConnections());
+  const [transientErrors, setTransientErrors] = useState<Partial<Record<Provider, string>>>({});
+
+  const refresh = useCallback(async () => {
+    const data = await fetchConnections();
+    setConnections(data);
   }, []);
 
   useEffect(() => {
+    // The DB (via the OAuth callback) is the source of truth; URL params are
+    // only used to surface transient error reasons from a failed round-trip.
     const provider = searchParams.get("provider") as Provider | null;
     const status = searchParams.get("status");
-    const meta = searchParams.get("meta");
     const reason = searchParams.get("reason");
 
-    if (provider && status === "connected" && meta) {
-      try {
-        const parsed = JSON.parse(decodeURIComponent(meta));
-        setConnection(provider, { connected: true, ...parsed });
-      } catch { /* malformed meta */ }
+    if (provider && status === "error") {
+      setTransientErrors((prev) => ({ ...prev, [provider]: reason ?? "unknown" }));
       window.history.replaceState({}, "", window.location.pathname);
-    } else if (provider && status === "error") {
-      setConnection(provider, { connected: false, error: reason ?? "unknown" });
+    } else if (provider && status === "connected") {
       window.history.replaceState({}, "", window.location.pathname);
     }
 
     refresh();
 
-    fetch("/api/auth/status")
-      .then(r => r.json())
+    fetch("/hub/api/auth/status")
+      .then((r) => r.json())
       .then((d: AuthStatus) => setAuthStatus(d))
       .catch(() => {});
   }, [searchParams, refresh]);
 
   function conn(p: Provider): ConnectionMeta {
-    return connections[p] ?? { connected: false };
+    const base = connections[p] ?? { connected: false };
+    const err = transientErrors[p];
+    return err ? { ...base, error: err } : base;
   }
 
-  function disconnect(p: Provider) {
-    removeConnection(p);
-    refresh();
+  async function disconnect(p: Provider) {
+    await apiDisconnect(p);
+    await refresh();
   }
 
   async function handleTelegramConnect() {
     setTelegramLoading(true);
     setTelegramError(null);
     try {
-      const res = await fetch("/api/auth/telegram", {
+      const res = await fetch("/hub/api/auth/telegram", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token: telegramToken.trim() }),
       });
       const data = await res.json();
       if (data.valid) {
-        setConnection("telegram", {
-          connected: true,
-          botUsername: data.bot?.username,
-          displayName: data.bot?.firstName ?? "MIRA Bot",
-        });
         setModal(null);
         setTelegramToken("");
-        refresh();
+        await refresh();
       } else {
         setTelegramError(data.error ?? "Invalid token — check with @BotFather");
       }
@@ -242,14 +237,19 @@ function ChannelsInner() {
     }
   }
 
-  function handleOpenWebuiConnect() {
-    setConnection("openwebui", {
-      connected: true,
-      displayName: "Open WebUI",
-      workspace: openwebuiUrl.trim(),
-    });
-    setModal(null);
-    refresh();
+  async function handleOpenWebuiConnect() {
+    try {
+      const res = await fetch("/hub/api/auth/openwebui", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: openwebuiUrl.trim() }),
+      });
+      if (!res.ok) return;
+      setModal(null);
+      await refresh();
+    } catch {
+      /* swallow; user can retry */
+    }
   }
 
   const telegramConn = conn("telegram");

--- a/mira-hub/src/app/api/auth/confluence/callback/route.ts
+++ b/mira-hub/src/app/api/auth/confluence/callback/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { upsertBinding } from "@/lib/bindings";
+import { validateState, stateCookieName } from "@/lib/oauth-state";
 
 export const dynamic = "force-dynamic";
 
@@ -6,12 +8,14 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const code = searchParams.get("code");
   const error = searchParams.get("error");
+  const state = searchParams.get("state");
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.factorylm.com";
 
   if (error || !code) {
-    return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=confluence&status=error&reason=${error ?? "no_code"}`
-    );
+    return errorRedirect(appUrl, error ?? "no_code");
+  }
+  if (!validateState(req, "confluence", state)) {
+    return errorRedirect(appUrl, "state_mismatch");
   }
 
   const tokenRes = await fetch("https://auth.atlassian.com/oauth/token", {
@@ -25,28 +29,45 @@ export async function GET(req: NextRequest) {
       redirect_uri: `${appUrl}/hub/api/auth/confluence/callback`,
     }),
   });
-
   const tokens = await tokenRes.json();
   if (tokens.error) {
-    return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=confluence&status=error&reason=${tokens.error}`
-    );
+    return errorRedirect(appUrl, tokens.error);
   }
 
-  // Get accessible resources (cloud IDs)
-  const resourceRes = await fetch("https://api.atlassian.com/oauth/token/accessible-resources", {
-    headers: { Authorization: `Bearer ${tokens.access_token}`, Accept: "application/json" },
-  });
-  const resources = await resourceRes.json();
+  // Atlassian OAuth returns accessible sites separately; fetch the first as primary.
+  const resourceRes = await fetch(
+    "https://api.atlassian.com/oauth/token/accessible-resources",
+    { headers: { Authorization: `Bearer ${tokens.access_token}`, Accept: "application/json" } },
+  );
+  const resources = resourceRes.ok ? await resourceRes.json() : [];
   const site = Array.isArray(resources) ? resources[0] : null;
 
-  const meta = encodeURIComponent(JSON.stringify({
-    siteName: site?.name ?? "Confluence",
-    siteUrl: site?.url ?? "",
-    cloudId: site?.id ?? "",
-  }));
+  const expiresAt = tokens.expires_in
+    ? new Date(Date.now() + Number(tokens.expires_in) * 1000)
+    : null;
 
+  await upsertBinding({
+    provider: "confluence",
+    externalId: site?.id ?? null,
+    accessToken: tokens.access_token ?? null,
+    refreshToken: tokens.refresh_token ?? null,
+    tokenExpiresAt: expiresAt,
+    scopes: (tokens.scope ?? "").split(" ").filter(Boolean),
+    meta: {
+      siteName: site?.name ?? "Confluence",
+      siteUrl: site?.url ?? "",
+      cloudId: site?.id ?? "",
+      displayName: site?.name ?? "Confluence",
+    },
+  });
+
+  const res = NextResponse.redirect(`${appUrl}/hub/channels?provider=confluence&status=connected`);
+  res.cookies.delete(stateCookieName("confluence"));
+  return res;
+}
+
+function errorRedirect(appUrl: string, reason: string) {
   return NextResponse.redirect(
-    `${appUrl}/hub/channels?provider=confluence&status=connected&meta=${meta}`
+    `${appUrl}/hub/channels?provider=confluence&status=error&reason=${encodeURIComponent(reason)}`,
   );
 }

--- a/mira-hub/src/app/api/auth/confluence/route.ts
+++ b/mira-hub/src/app/api/auth/confluence/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { newState, stateCookieName } from "@/lib/oauth-state";
 
 export const dynamic = "force-dynamic";
 
@@ -8,21 +9,30 @@ export async function GET() {
 
   if (!clientId) {
     return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=confluence&status=error&reason=oauth_not_configured`
+      `${appUrl}/hub/channels?provider=confluence&status=error&reason=oauth_not_configured`,
     );
   }
 
-  const state = Buffer.from(Math.random().toString(36)).toString("base64url");
+  const state = newState();
   const url = new URL("https://auth.atlassian.com/authorize");
   url.searchParams.set("audience", "api.atlassian.com");
   url.searchParams.set("client_id", clientId);
-  url.searchParams.set("scope", "read:confluence-content.all read:confluence-space.summary offline_access");
+  url.searchParams.set(
+    "scope",
+    "read:confluence-content.all read:confluence-space.summary offline_access",
+  );
   url.searchParams.set("redirect_uri", `${appUrl}/hub/api/auth/confluence/callback`);
   url.searchParams.set("state", state);
   url.searchParams.set("response_type", "code");
   url.searchParams.set("prompt", "consent");
 
   const res = NextResponse.redirect(url.toString());
-  res.cookies.set("oauth_state_confluence", state, { httpOnly: true, maxAge: 600, path: "/" });
+  res.cookies.set(stateCookieName("confluence"), state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    maxAge: 600,
+    path: "/",
+  });
   return res;
 }

--- a/mira-hub/src/app/api/auth/dropbox/callback/route.ts
+++ b/mira-hub/src/app/api/auth/dropbox/callback/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { upsertBinding } from "@/lib/bindings";
+import { validateState, stateCookieName } from "@/lib/oauth-state";
 
 export const dynamic = "force-dynamic";
 
@@ -6,12 +8,14 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const code = searchParams.get("code");
   const error = searchParams.get("error");
+  const state = searchParams.get("state");
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.factorylm.com";
 
   if (error || !code) {
-    return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=dropbox&status=error&reason=${error ?? "no_code"}`
-    );
+    return errorRedirect(appUrl, error ?? "no_code");
+  }
+  if (!validateState(req, "dropbox", state)) {
+    return errorRedirect(appUrl, "state_mismatch");
   }
 
   const tokenRes = await fetch("https://api.dropboxapi.com/oauth2/token", {
@@ -25,20 +29,53 @@ export async function GET(req: NextRequest) {
       redirect_uri: `${appUrl}/hub/api/auth/dropbox/callback`,
     }),
   });
-
   const tokens = await tokenRes.json();
   if (tokens.error) {
-    return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=dropbox&status=error&reason=${tokens.error}`
-    );
+    return errorRedirect(appUrl, tokens.error_description ?? tokens.error);
   }
 
-  const meta = encodeURIComponent(JSON.stringify({
-    email: tokens.account_id ?? "",
-    displayName: "Dropbox",
-  }));
+  // Fetch account info for display meta
+  let email = "";
+  let displayName = "Dropbox";
+  try {
+    const accountRes = await fetch("https://api.dropboxapi.com/2/users/get_current_account", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${tokens.access_token}` },
+    });
+    if (accountRes.ok) {
+      const acc = await accountRes.json();
+      email = acc.email ?? "";
+      displayName = acc.name?.display_name ?? "Dropbox";
+    }
+  } catch {
+    /* non-fatal; meta stays minimal */
+  }
 
+  const expiresAt = tokens.expires_in
+    ? new Date(Date.now() + Number(tokens.expires_in) * 1000)
+    : null;
+
+  await upsertBinding({
+    provider: "dropbox",
+    externalId: tokens.account_id ?? null,
+    accessToken: tokens.access_token ?? null,
+    refreshToken: tokens.refresh_token ?? null,
+    tokenExpiresAt: expiresAt,
+    scopes: (tokens.scope ?? "").split(" ").filter(Boolean),
+    meta: {
+      accountId: tokens.account_id ?? "",
+      email,
+      displayName,
+    },
+  });
+
+  const res = NextResponse.redirect(`${appUrl}/hub/channels?provider=dropbox&status=connected`);
+  res.cookies.delete(stateCookieName("dropbox"));
+  return res;
+}
+
+function errorRedirect(appUrl: string, reason: string) {
   return NextResponse.redirect(
-    `${appUrl}/hub/channels?provider=dropbox&status=connected&meta=${meta}`
+    `${appUrl}/hub/channels?provider=dropbox&status=error&reason=${encodeURIComponent(reason)}`,
   );
 }

--- a/mira-hub/src/app/api/auth/dropbox/route.ts
+++ b/mira-hub/src/app/api/auth/dropbox/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { newState, stateCookieName } from "@/lib/oauth-state";
 
 export const dynamic = "force-dynamic";
 
@@ -8,11 +9,11 @@ export async function GET() {
 
   if (!appKey) {
     return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=dropbox&status=error&reason=oauth_not_configured`
+      `${appUrl}/hub/channels?provider=dropbox&status=error&reason=oauth_not_configured`,
     );
   }
 
-  const state = Buffer.from(Math.random().toString(36)).toString("base64url");
+  const state = newState();
   const url = new URL("https://www.dropbox.com/oauth2/authorize");
   url.searchParams.set("client_id", appKey);
   url.searchParams.set("response_type", "code");
@@ -21,6 +22,12 @@ export async function GET() {
   url.searchParams.set("state", state);
 
   const res = NextResponse.redirect(url.toString());
-  res.cookies.set("oauth_state_dropbox", state, { httpOnly: true, maxAge: 600, path: "/" });
+  res.cookies.set(stateCookieName("dropbox"), state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    maxAge: 600,
+    path: "/",
+  });
   return res;
 }

--- a/mira-hub/src/app/api/auth/google/callback/route.ts
+++ b/mira-hub/src/app/api/auth/google/callback/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { upsertBinding } from "@/lib/bindings";
+import { validateState, stateCookieName } from "@/lib/oauth-state";
 
 export const dynamic = "force-dynamic";
 
@@ -6,19 +8,20 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const code = searchParams.get("code");
   const error = searchParams.get("error");
+  const state = searchParams.get("state");
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.factorylm.com";
 
   if (error || !code) {
-    return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=google&status=error&reason=${error ?? "no_code"}`
-    );
+    return errorRedirect(appUrl, error ?? "no_code");
+  }
+  if (!validateState(req, "google", state)) {
+    return errorRedirect(appUrl, "state_mismatch");
   }
 
   const clientId = process.env.GOOGLE_CLIENT_ID!;
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET!;
   const redirectUri = `${appUrl}/hub/api/auth/google/callback`;
 
-  // Exchange code for tokens
   const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -30,39 +33,41 @@ export async function GET(req: NextRequest) {
       grant_type: "authorization_code",
     }),
   });
-
   const tokens = await tokenRes.json();
-
   if (!tokenRes.ok || tokens.error) {
-    return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=google&status=error&reason=${tokens.error ?? "token_exchange_failed"}`
-    );
+    return errorRedirect(appUrl, tokens.error ?? "token_exchange_failed");
   }
 
-  // Get user info to show connected email
   const userRes = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
     headers: { Authorization: `Bearer ${tokens.access_token}` },
   });
   const user = await userRes.json();
 
-  // Get Drive file count (rough)
-  let fileCount = 0;
-  try {
-    const driveRes = await fetch(
-      "https://www.googleapis.com/drive/v3/files?pageSize=1&fields=nextPageToken",
-      { headers: { Authorization: `Bearer ${tokens.access_token}` } }
-    );
-    if (driveRes.ok) fileCount = -1; // -1 = "has files, count pending"
-  } catch {/* ignore */}
+  const expiresAt = tokens.expires_in
+    ? new Date(Date.now() + Number(tokens.expires_in) * 1000)
+    : null;
 
-  const meta = encodeURIComponent(JSON.stringify({
-    email: user.email ?? "",
-    name: user.name ?? "",
-    picture: user.picture ?? "",
-    fileCount,
-  }));
+  await upsertBinding({
+    provider: "google",
+    externalId: user.id ?? user.email ?? null,
+    accessToken: tokens.access_token ?? null,
+    refreshToken: tokens.refresh_token ?? null,
+    tokenExpiresAt: expiresAt,
+    scopes: (tokens.scope ?? "").split(" ").filter(Boolean),
+    meta: {
+      email: user.email ?? "",
+      displayName: user.name ?? user.email ?? "Google",
+      picture: user.picture ?? "",
+    },
+  });
 
+  const res = NextResponse.redirect(`${appUrl}/hub/channels?provider=google&status=connected`);
+  res.cookies.delete(stateCookieName("google"));
+  return res;
+}
+
+function errorRedirect(appUrl: string, reason: string) {
   return NextResponse.redirect(
-    `${appUrl}/hub/channels?provider=google&status=connected&meta=${meta}`
+    `${appUrl}/hub/channels?provider=google&status=error&reason=${encodeURIComponent(reason)}`,
   );
 }

--- a/mira-hub/src/app/api/auth/google/route.ts
+++ b/mira-hub/src/app/api/auth/google/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { newState, stateCookieName } from "@/lib/oauth-state";
 
 export const dynamic = "force-dynamic";
 
@@ -17,11 +18,7 @@ export async function GET() {
     return NextResponse.json({ error: "Google OAuth not configured" }, { status: 503 });
   }
 
-  const state = Buffer.from(JSON.stringify({
-    nonce: Math.random().toString(36).slice(2),
-    ts: Date.now(),
-  })).toString("base64url");
-
+  const state = newState();
   const redirectUri = `${appUrl}/hub/api/auth/google/callback`;
 
   const url = new URL("https://accounts.google.com/o/oauth2/v2/auth");
@@ -34,6 +31,12 @@ export async function GET() {
   url.searchParams.set("state", state);
 
   const res = NextResponse.redirect(url.toString());
-  res.cookies.set("oauth_state_google", state, { httpOnly: true, maxAge: 600, path: "/" });
+  res.cookies.set(stateCookieName("google"), state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    maxAge: 600,
+    path: "/",
+  });
   return res;
 }

--- a/mira-hub/src/app/api/auth/microsoft/callback/route.ts
+++ b/mira-hub/src/app/api/auth/microsoft/callback/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { upsertBinding } from "@/lib/bindings";
+import { validateState, stateCookieName } from "@/lib/oauth-state";
 
 export const dynamic = "force-dynamic";
 
@@ -6,12 +8,14 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const code = searchParams.get("code");
   const error = searchParams.get("error");
+  const state = searchParams.get("state");
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.factorylm.com";
 
   if (error || !code) {
-    return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=microsoft&status=error&reason=${error ?? "no_code"}`
-    );
+    return errorRedirect(appUrl, error ?? "no_code");
+  }
+  if (!validateState(req, "microsoft", state)) {
+    return errorRedirect(appUrl, "state_mismatch");
   }
 
   const tokenRes = await fetch("https://login.microsoftonline.com/common/oauth2/v2.0/token", {
@@ -25,12 +29,9 @@ export async function GET(req: NextRequest) {
       grant_type: "authorization_code",
     }),
   });
-
   const tokens = await tokenRes.json();
   if (tokens.error) {
-    return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=microsoft&status=error&reason=${tokens.error}`
-    );
+    return errorRedirect(appUrl, tokens.error);
   }
 
   const userRes = await fetch("https://graph.microsoft.com/v1.0/me", {
@@ -38,12 +39,30 @@ export async function GET(req: NextRequest) {
   });
   const user = await userRes.json();
 
-  const meta = encodeURIComponent(JSON.stringify({
-    email: user.mail ?? user.userPrincipalName ?? "",
-    name: user.displayName ?? "",
-  }));
+  const expiresAt = tokens.expires_in
+    ? new Date(Date.now() + Number(tokens.expires_in) * 1000)
+    : null;
 
+  await upsertBinding({
+    provider: "microsoft",
+    externalId: user.id ?? user.mail ?? user.userPrincipalName ?? null,
+    accessToken: tokens.access_token ?? null,
+    refreshToken: tokens.refresh_token ?? null,
+    tokenExpiresAt: expiresAt,
+    scopes: (tokens.scope ?? "").split(" ").filter(Boolean),
+    meta: {
+      email: user.mail ?? user.userPrincipalName ?? "",
+      displayName: user.displayName ?? "Microsoft 365",
+    },
+  });
+
+  const res = NextResponse.redirect(`${appUrl}/hub/channels?provider=microsoft&status=connected`);
+  res.cookies.delete(stateCookieName("microsoft"));
+  return res;
+}
+
+function errorRedirect(appUrl: string, reason: string) {
   return NextResponse.redirect(
-    `${appUrl}/hub/channels?provider=microsoft&status=connected&meta=${meta}`
+    `${appUrl}/hub/channels?provider=microsoft&status=error&reason=${encodeURIComponent(reason)}`,
   );
 }

--- a/mira-hub/src/app/api/auth/microsoft/route.ts
+++ b/mira-hub/src/app/api/auth/microsoft/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { newState, stateCookieName } from "@/lib/oauth-state";
 
 export const dynamic = "force-dynamic";
 
@@ -10,11 +11,11 @@ export async function GET() {
 
   if (!clientId) {
     return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=microsoft&status=error&reason=oauth_not_configured`
+      `${appUrl}/hub/channels?provider=microsoft&status=error&reason=oauth_not_configured`,
     );
   }
 
-  const state = Buffer.from(Math.random().toString(36)).toString("base64url");
+  const state = newState();
   const url = new URL("https://login.microsoftonline.com/common/oauth2/v2.0/authorize");
   url.searchParams.set("client_id", clientId);
   url.searchParams.set("response_type", "code");
@@ -23,6 +24,12 @@ export async function GET() {
   url.searchParams.set("state", state);
 
   const res = NextResponse.redirect(url.toString());
-  res.cookies.set("oauth_state_microsoft", state, { httpOnly: true, maxAge: 600, path: "/" });
+  res.cookies.set(stateCookieName("microsoft"), state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    maxAge: 600,
+    path: "/",
+  });
   return res;
 }

--- a/mira-hub/src/app/api/auth/openwebui/route.ts
+++ b/mira-hub/src/app/api/auth/openwebui/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { upsertBinding } from "@/lib/bindings";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /hub/api/auth/openwebui
+ *
+ * Open WebUI has no OAuth flow; Mike runs his own instance. We just record
+ * the base URL so the Hub knows which instance to talk to (and so the card
+ * persists across browser clears).
+ */
+export async function POST(req: NextRequest) {
+  const { url, apiKey } = await req.json();
+
+  if (!url || typeof url !== "string") {
+    return NextResponse.json({ error: "Missing url" }, { status: 400 });
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return NextResponse.json({ error: "Invalid URL" }, { status: 400 });
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return NextResponse.json({ error: "URL must be http or https" }, { status: 400 });
+  }
+
+  // Best-effort reachability probe — non-fatal if the instance is temporarily down.
+  let reachable = false;
+  try {
+    const probe = await fetch(`${parsed.origin}/api/version`, {
+      signal: AbortSignal.timeout(3_000),
+    });
+    reachable = probe.ok;
+  } catch {
+    /* leave reachable=false */
+  }
+
+  await upsertBinding({
+    provider: "openwebui",
+    externalId: parsed.origin,
+    accessToken: apiKey ?? null,
+    meta: {
+      workspace: parsed.origin,
+      displayName: "Open WebUI",
+      reachable,
+    },
+  });
+
+  return NextResponse.json({ ok: true, reachable });
+}

--- a/mira-hub/src/app/api/auth/slack/callback/route.ts
+++ b/mira-hub/src/app/api/auth/slack/callback/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
+import { upsertBinding } from "@/lib/bindings";
+import { validateState, stateCookieName } from "@/lib/oauth-state";
 
 export const dynamic = "force-dynamic";
 
@@ -6,12 +8,14 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const code = searchParams.get("code");
   const error = searchParams.get("error");
+  const state = searchParams.get("state");
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.factorylm.com";
 
   if (error || !code) {
-    return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=slack&status=error&reason=${error ?? "no_code"}`
-    );
+    return errorRedirect(appUrl, error ?? "no_code");
+  }
+  if (!validateState(req, "slack", state)) {
+    return errorRedirect(appUrl, "state_mismatch");
   }
 
   const tokenRes = await fetch("https://slack.com/api/oauth.v2.access", {
@@ -27,18 +31,29 @@ export async function GET(req: NextRequest) {
 
   const data = await tokenRes.json();
   if (!data.ok) {
-    return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=slack&status=error&reason=${data.error}`
-    );
+    return errorRedirect(appUrl, data.error ?? "token_exchange_failed");
   }
 
-  const meta = encodeURIComponent(JSON.stringify({
-    workspace: data.team?.name ?? "Slack Workspace",
-    workspaceId: data.team?.id ?? "",
-    botUserId: data.bot_user_id ?? "",
-  }));
+  await upsertBinding({
+    provider: "slack",
+    externalId: data.team?.id ?? null,
+    accessToken: data.access_token ?? null,
+    scopes: (data.scope ?? "").split(",").filter(Boolean),
+    meta: {
+      workspace: data.team?.name ?? "Slack Workspace",
+      workspaceId: data.team?.id ?? "",
+      botUserId: data.bot_user_id ?? "",
+      displayName: data.team?.name ?? "Slack",
+    },
+  });
 
+  const res = NextResponse.redirect(`${appUrl}/hub/channels?provider=slack&status=connected`);
+  res.cookies.delete(stateCookieName("slack"));
+  return res;
+}
+
+function errorRedirect(appUrl: string, reason: string) {
   return NextResponse.redirect(
-    `${appUrl}/hub/channels?provider=slack&status=connected&meta=${meta}`
+    `${appUrl}/hub/channels?provider=slack&status=error&reason=${encodeURIComponent(reason)}`,
   );
 }

--- a/mira-hub/src/app/api/auth/slack/route.ts
+++ b/mira-hub/src/app/api/auth/slack/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { upsertBinding } from "@/lib/bindings";
+import { newState, stateCookieName } from "@/lib/oauth-state";
 
 export const dynamic = "force-dynamic";
 
@@ -7,19 +9,23 @@ export async function GET() {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "https://app.factorylm.com";
 
   if (!clientId) {
-    // We have a bot token already — show as connected without web OAuth
+    // Bot-token shortcut: if we already have a Slack bot token, mark connected.
     const botToken = process.env.SLACK_BOT_TOKEN;
     if (botToken) {
-      return NextResponse.redirect(
-        `${appUrl}/hub/channels?provider=slack&status=connected&meta=${encodeURIComponent(JSON.stringify({ workspace: "FactoryLM", method: "bot_token" }))}`
-      );
+      await upsertBinding({
+        provider: "slack",
+        accessToken: botToken,
+        scopes: ["chat:write", "channels:read", "im:read", "im:write", "users:read"],
+        meta: { workspace: "FactoryLM", displayName: "Slack (bot token)", method: "bot_token" },
+      });
+      return NextResponse.redirect(`${appUrl}/hub/channels?provider=slack&status=connected`);
     }
     return NextResponse.redirect(
-      `${appUrl}/hub/channels?provider=slack&status=error&reason=oauth_not_configured`
+      `${appUrl}/hub/channels?provider=slack&status=error&reason=oauth_not_configured`,
     );
   }
 
-  const state = Buffer.from(Math.random().toString(36)).toString("base64url");
+  const state = newState();
   const url = new URL("https://slack.com/oauth/v2/authorize");
   url.searchParams.set("client_id", clientId);
   url.searchParams.set("scope", "chat:write,channels:read,im:read,im:write,users:read");
@@ -27,6 +33,12 @@ export async function GET() {
   url.searchParams.set("state", state);
 
   const res = NextResponse.redirect(url.toString());
-  res.cookies.set("oauth_state_slack", state, { httpOnly: true, maxAge: 600, path: "/" });
+  res.cookies.set(stateCookieName("slack"), state, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "lax",
+    maxAge: 600,
+    path: "/",
+  });
   return res;
 }

--- a/mira-hub/src/app/api/auth/telegram/route.ts
+++ b/mira-hub/src/app/api/auth/telegram/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { upsertBinding } from "@/lib/bindings";
 
 export const dynamic = "force-dynamic";
 
@@ -16,7 +17,7 @@ export async function POST(req: NextRequest) {
   if (!me.ok) {
     return NextResponse.json(
       { error: me.description ?? "Invalid bot token" },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
@@ -32,10 +33,23 @@ export async function POST(req: NextRequest) {
     });
     webhookResult = await whRes.json();
   } else {
-    // Get current webhook info
     const whInfoRes = await fetch(`https://api.telegram.org/bot${token}/getWebhookInfo`);
     webhookResult = await whInfoRes.json();
   }
+
+  // Persist binding (bot token stored encrypted). Scopes are implicit in Telegram Bot API.
+  await upsertBinding({
+    provider: "telegram",
+    externalId: String(bot.id),
+    accessToken: token,
+    meta: {
+      botUsername: `@${bot.username}`,
+      displayName: bot.first_name,
+      canJoinGroups: bot.can_join_groups,
+      supportsInlineQueries: bot.supports_inline_queries,
+      webhookUrl: webhookResult?.result?.url ?? null,
+    },
+  });
 
   return NextResponse.json({
     valid: true,

--- a/mira-hub/src/app/api/connections/[provider]/route.ts
+++ b/mira-hub/src/app/api/connections/[provider]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revokeBinding, type Provider } from "@/lib/bindings";
+
+export const dynamic = "force-dynamic";
+
+const VALID: Provider[] = [
+  "telegram",
+  "slack",
+  "teams",
+  "openwebui",
+  "google",
+  "microsoft",
+  "dropbox",
+  "confluence",
+];
+
+/**
+ * DELETE /hub/api/connections/:provider
+ *
+ * Marks the binding revoked and clears stored tokens. Vendor-side revocation
+ * (e.g. Slack's auth.revoke, Dropbox's token/revoke) is intentionally NOT
+ * called here — we don't want a partially-completed delete if vendor APIs
+ * rate-limit or are down. The local binding is the source of truth for the UI.
+ */
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ provider: string }> },
+) {
+  const { provider } = await params;
+  if (!VALID.includes(provider as Provider)) {
+    return NextResponse.json({ error: "Unknown provider" }, { status: 400 });
+  }
+  try {
+    const ok = await revokeBinding(provider as Provider);
+    return NextResponse.json({ ok });
+  } catch (err) {
+    console.error(`[api/connections/${provider}] DELETE`, err);
+    return NextResponse.json({ error: "Revoke failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/connections/route.ts
+++ b/mira-hub/src/app/api/connections/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { listBindings, type Binding } from "@/lib/bindings";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /hub/api/connections
+ *
+ * Returns the current user's channel/integration bindings. Shape matches
+ * Partial<Record<Provider, ConnectionMeta>> so the client can swap in place
+ * for its previous localStorage reads.
+ */
+export async function GET() {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  try {
+    const bindings = await listBindings();
+    return NextResponse.json(toClientShape(bindings));
+  } catch (err) {
+    console.error("[api/connections] GET", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}
+
+function toClientShape(bindings: Binding[]) {
+  const out: Record<string, unknown> = {};
+  for (const b of bindings) {
+    const meta = b.meta ?? {};
+    out[b.provider] = {
+      connected: true,
+      connectedAt: b.connectedAt,
+      displayName: meta.displayName,
+      workspace: meta.workspace,
+      botUsername: meta.botUsername,
+      email: meta.email,
+      siteName: meta.siteName,
+      siteUrl: meta.siteUrl,
+      cloudId: meta.cloudId,
+    };
+  }
+  return out;
+}

--- a/mira-hub/src/lib/bindings.ts
+++ b/mira-hub/src/lib/bindings.ts
@@ -1,0 +1,178 @@
+import pool from "@/lib/db";
+import { encrypt, decrypt } from "@/lib/token-crypto";
+
+export const DEFAULT_TENANT_ID = process.env.HUB_TENANT_ID ?? "mike";
+
+export type Provider =
+  | "telegram"
+  | "slack"
+  | "teams"
+  | "openwebui"
+  | "google"
+  | "microsoft"
+  | "dropbox"
+  | "confluence";
+
+export interface BindingMeta {
+  displayName?: string;
+  email?: string;
+  workspace?: string;
+  workspaceId?: string;
+  botUsername?: string;
+  botUserId?: string;
+  siteName?: string;
+  siteUrl?: string;
+  cloudId?: string;
+  accountId?: string;
+  [k: string]: unknown;
+}
+
+export interface Binding {
+  provider: Provider;
+  externalId: string | null;
+  scopes: string[];
+  meta: BindingMeta;
+  status: "connected" | "revoked";
+  connectedAt: string;
+  updatedAt: string;
+}
+
+let schemaReady: Promise<void> | null = null;
+
+export function ensureSchema(): Promise<void> {
+  if (schemaReady) return schemaReady;
+  schemaReady = (async () => {
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS hub_channel_bindings (
+        id                 SERIAL PRIMARY KEY,
+        tenant_id          TEXT NOT NULL DEFAULT 'mike',
+        provider           TEXT NOT NULL,
+        external_id        TEXT,
+        access_token_enc   TEXT,
+        refresh_token_enc  TEXT,
+        token_expires_at   TIMESTAMPTZ,
+        scopes             TEXT[] NOT NULL DEFAULT '{}',
+        meta               JSONB NOT NULL DEFAULT '{}'::jsonb,
+        status             TEXT NOT NULL DEFAULT 'connected',
+        connected_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        UNIQUE (tenant_id, provider)
+      )
+    `);
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_hub_channel_bindings_tenant
+        ON hub_channel_bindings (tenant_id, status)
+    `);
+  })();
+  return schemaReady;
+}
+
+export interface UpsertInput {
+  tenantId?: string;
+  provider: Provider;
+  externalId?: string | null;
+  accessToken?: string | null;
+  refreshToken?: string | null;
+  tokenExpiresAt?: Date | string | null;
+  scopes?: string[];
+  meta?: BindingMeta;
+}
+
+export async function upsertBinding(input: UpsertInput): Promise<void> {
+  await ensureSchema();
+  const tenantId = input.tenantId ?? DEFAULT_TENANT_ID;
+  const scopes = input.scopes ?? [];
+  const meta = input.meta ?? {};
+  const accessEnc = encrypt(input.accessToken ?? null);
+  const refreshEnc = encrypt(input.refreshToken ?? null);
+  const expires =
+    input.tokenExpiresAt instanceof Date
+      ? input.tokenExpiresAt.toISOString()
+      : input.tokenExpiresAt ?? null;
+
+  await pool.query(
+    `
+    INSERT INTO hub_channel_bindings
+      (tenant_id, provider, external_id, access_token_enc, refresh_token_enc,
+       token_expires_at, scopes, meta, status, connected_at, updated_at)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'connected', NOW(), NOW())
+    ON CONFLICT (tenant_id, provider) DO UPDATE SET
+      external_id       = COALESCE(EXCLUDED.external_id, hub_channel_bindings.external_id),
+      access_token_enc  = COALESCE(EXCLUDED.access_token_enc, hub_channel_bindings.access_token_enc),
+      refresh_token_enc = COALESCE(EXCLUDED.refresh_token_enc, hub_channel_bindings.refresh_token_enc),
+      token_expires_at  = COALESCE(EXCLUDED.token_expires_at, hub_channel_bindings.token_expires_at),
+      scopes            = EXCLUDED.scopes,
+      meta              = hub_channel_bindings.meta || EXCLUDED.meta,
+      status            = 'connected',
+      updated_at        = NOW()
+  `,
+    [
+      tenantId,
+      input.provider,
+      input.externalId ?? null,
+      accessEnc,
+      refreshEnc,
+      expires,
+      scopes,
+      JSON.stringify(meta),
+    ],
+  );
+}
+
+export async function listBindings(tenantId: string = DEFAULT_TENANT_ID): Promise<Binding[]> {
+  await ensureSchema();
+  const { rows } = await pool.query(
+    `
+    SELECT provider, external_id, scopes, meta, status, connected_at, updated_at
+      FROM hub_channel_bindings
+     WHERE tenant_id = $1 AND status = 'connected'
+     ORDER BY connected_at
+  `,
+    [tenantId],
+  );
+  return rows.map((r) => ({
+    provider: r.provider as Provider,
+    externalId: r.external_id,
+    scopes: r.scopes ?? [],
+    meta: r.meta ?? {},
+    status: r.status,
+    connectedAt: r.connected_at,
+    updatedAt: r.updated_at,
+  }));
+}
+
+export async function getAccessToken(
+  provider: Provider,
+  tenantId: string = DEFAULT_TENANT_ID,
+): Promise<string | null> {
+  await ensureSchema();
+  const { rows } = await pool.query(
+    `
+    SELECT access_token_enc FROM hub_channel_bindings
+     WHERE tenant_id = $1 AND provider = $2 AND status = 'connected'
+     LIMIT 1
+  `,
+    [tenantId, provider],
+  );
+  if (!rows[0]?.access_token_enc) return null;
+  return decrypt(rows[0].access_token_enc);
+}
+
+export async function revokeBinding(
+  provider: Provider,
+  tenantId: string = DEFAULT_TENANT_ID,
+): Promise<boolean> {
+  await ensureSchema();
+  const { rowCount } = await pool.query(
+    `
+    UPDATE hub_channel_bindings
+       SET status = 'revoked',
+           access_token_enc = NULL,
+           refresh_token_enc = NULL,
+           updated_at = NOW()
+     WHERE tenant_id = $1 AND provider = $2
+  `,
+    [tenantId, provider],
+  );
+  return (rowCount ?? 0) > 0;
+}

--- a/mira-hub/src/lib/connections.ts
+++ b/mira-hub/src/lib/connections.ts
@@ -1,3 +1,14 @@
+/**
+ * Client-side connection state.
+ *
+ * Previously localStorage-only; now the Hub's /api/connections is the source
+ * of truth. This module is a thin async wrapper around that endpoint.
+ *
+ * The returned ConnectionMeta shape is preserved for backwards-compat with
+ * the channels page's existing card props — callers just need to await
+ * fetchConnections() up front and treat the result as read-only.
+ */
+
 export type Provider =
   | "telegram"
   | "slack"
@@ -22,38 +33,25 @@ export type ConnectionMeta = {
   error?: string;
 };
 
-const STORAGE_KEY = "mira_connections_v2";
+type ConnectionMap = Partial<Record<Provider, ConnectionMeta>>;
 
-function read(): Partial<Record<Provider, ConnectionMeta>> {
-  if (typeof window === "undefined") return {};
+export async function fetchConnections(): Promise<ConnectionMap> {
   try {
-    return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "{}");
+    const res = await fetch("/hub/api/connections", { cache: "no-store" });
+    if (!res.ok) return {};
+    return (await res.json()) as ConnectionMap;
   } catch {
     return {};
   }
 }
 
-function write(data: Partial<Record<Provider, ConnectionMeta>>) {
-  if (typeof window === "undefined") return;
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-}
-
-export function getConnection(provider: Provider): ConnectionMeta {
-  return read()[provider] ?? { connected: false };
-}
-
-export function setConnection(provider: Provider, meta: ConnectionMeta) {
-  const all = read();
-  all[provider] = { ...meta, connectedAt: meta.connectedAt ?? new Date().toISOString() };
-  write(all);
-}
-
-export function removeConnection(provider: Provider) {
-  const all = read();
-  delete all[provider];
-  write(all);
-}
-
-export function getAllConnections(): Partial<Record<Provider, ConnectionMeta>> {
-  return read();
+export async function disconnect(provider: Provider): Promise<boolean> {
+  try {
+    const res = await fetch(`/hub/api/connections/${provider}`, {
+      method: "DELETE",
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
 }

--- a/mira-hub/src/lib/oauth-state.ts
+++ b/mira-hub/src/lib/oauth-state.ts
@@ -1,0 +1,24 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import type { NextRequest } from "next/server";
+
+export function newState(): string {
+  return randomBytes(24).toString("base64url");
+}
+
+export function stateCookieName(provider: string): string {
+  return `oauth_state_${provider}`;
+}
+
+/**
+ * Validate the `state` query param against the cookie set at OAuth start.
+ * Returns true iff both are present, equal length, and match in constant time.
+ */
+export function validateState(req: NextRequest, provider: string, stateFromQuery: string | null): boolean {
+  if (!stateFromQuery) return false;
+  const cookie = req.cookies.get(stateCookieName(provider))?.value;
+  if (!cookie) return false;
+  const a = Buffer.from(stateFromQuery);
+  const b = Buffer.from(cookie);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}

--- a/mira-hub/src/lib/token-crypto.ts
+++ b/mira-hub/src/lib/token-crypto.ts
@@ -1,0 +1,42 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGO = "aes-256-gcm";
+const IV_LEN = 12;
+const TAG_LEN = 16;
+
+function key(): Buffer {
+  const raw = process.env.OAUTH_TOKEN_ENC_KEY;
+  if (!raw) {
+    throw new Error("OAUTH_TOKEN_ENC_KEY not set");
+  }
+  const buf = Buffer.from(raw, "base64");
+  if (buf.length !== 32) {
+    throw new Error(
+      `OAUTH_TOKEN_ENC_KEY must decode to 32 bytes (got ${buf.length}). Generate with: openssl rand -base64 32`,
+    );
+  }
+  return buf;
+}
+
+export function encrypt(plaintext: string | null | undefined): string | null {
+  if (!plaintext) return null;
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALGO, key(), iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, ct]).toString("base64");
+}
+
+export function decrypt(blob: string | null | undefined): string | null {
+  if (!blob) return null;
+  const buf = Buffer.from(blob, "base64");
+  if (buf.length < IV_LEN + TAG_LEN) {
+    throw new Error("ciphertext too short");
+  }
+  const iv = buf.subarray(0, IV_LEN);
+  const tag = buf.subarray(IV_LEN, IV_LEN + TAG_LEN);
+  const ct = buf.subarray(IV_LEN + TAG_LEN);
+  const decipher = createDecipheriv(ALGO, key(), iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ct), decipher.final()]).toString("utf8");
+}


### PR DESCRIPTION
## Summary

Closes the three gaps that were flagged during the dogfood triage against the live Hub:

1. **OAuth tokens were thrown away** — callbacks fetched user info once, then discarded the `access_token`/`refresh_token`. MIRA had no way to later read from Slack/Drive/Confluence on the user's behalf.
2. **localStorage-only connection state** — clearing the browser wiped every green card even though the OAuth round-trip had succeeded on the server.
3. **CSRF state not validated** — `oauth_state_<provider>` cookie was set on start but never read on callback.

## What's new

### Backend
- `mira-hub/src/lib/token-crypto.ts` — AES-256-GCM (node:crypto, no deps) using `OAUTH_TOKEN_ENC_KEY` (32 bytes, base64). Already generated and stored in Doppler `factorylm/prd`.
- `mira-hub/src/lib/bindings.ts` — `hub_channel_bindings` table (lazy `CREATE IF NOT EXISTS`), `upsertBinding` / `listBindings` / `revokeBinding` / `getAccessToken` helpers. UNIQUE (tenant_id, provider).
- `mira-hub/src/lib/oauth-state.ts` — constant-time cookie-vs-query comparison.
- `mira-hub/src/app/api/connections/route.ts` — `GET` replaces localStorage as source of truth for the Channels cards.
- `mira-hub/src/app/api/connections/[provider]/route.ts` — `DELETE` marks binding revoked and nulls tokens.
- `mira-hub/src/app/api/auth/openwebui/route.ts` — `POST` records the user's Open WebUI instance URL (no OAuth flow; persists across browser clears).

### OAuth flows (all 5 providers + Telegram)
- Start routes: use shared `newState()` + `secure` / `sameSite=lax` cookie attrs.
- Callbacks: validate state before anything else → exchange code → encrypt + upsert → redirect to `/hub/channels?provider=X&status=connected` (no more `meta` in query string; client re-reads from DB).
- Telegram POST route: after Telegram's `/getMe` validation, persists the encrypted bot token with metadata.

### Frontend
- `mira-hub/src/lib/connections.ts` — async `fetchConnections()` + `disconnect()` replacing the localStorage API. `ConnectionMeta` shape unchanged.
- `mira-hub/src/app/(hub)/channels/page.tsx` — `useEffect` awaits `fetchConnections()` instead of parsing `meta` from URL; `disconnect()` awaits the DELETE endpoint.

### Ops
- `docker-compose.saas.yml` — plumbs `OAUTH_TOKEN_ENC_KEY` + `HUB_TENANT_ID` into the container.

## Single-tenant scope

Bindings are keyed by `(tenant_id, provider)` with `HUB_TENANT_ID` defaulting to `mike`. Matches the Hub's current single-user login (`mike@factorylm.com` / `admin123`). When real session-based tenancy lands, swap `DEFAULT_TENANT_ID` for `session.user.id` — no schema change needed.

## Deploy plan (after merge)
```bash
# On VPS
cd /opt/mira && git pull
doppler run --project factorylm --config prd -- \
  docker compose -f docker-compose.saas.yml up -d --build mira-hub
# Verify
curl -s https://app.factorylm.com/hub/api/connections | jq
# Walk each Connect card, confirm /hub/api/connections grows a row per provider.
```

## Safety
- Schema is additive — only new tables created.
- Existing `/hub/api/channels` (work-order aggregates) is untouched.
- Bot-token Slack shortcut path also writes a binding so the card is honest.
- `revokeBinding` nulls tokens but keeps the row for audit — DELETE endpoint uses it.

## Out of scope (follow-up)
- Token refresh on expiry (`refresh_token` is stored but nothing calls it yet).
- Vendor-side revocation (e.g. `https://slack.com/api/auth.revoke`) — local revoke only.
- Unit 3 Email channel backend.
- CMMS paste-token modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)