### PR TITLE
feat(web): Unit 3 — magic email inbox for manuals

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -40,3 +40,6 @@ Full reference. Top 10 are in `CLAUDE.md`; this file has all of them.
 | `MIRA_RRF_K`         | mira-bots — Reciprocal Rank Fusion constant. Default `60` (Cormack et al. 2009). Raise to flatten rank influence, lower to sharpen it. Change only with an eval to back it. |
 | `SESSION_RECORDING_PATH` | mira-pipeline — directory for per-chat NDJSON session files. Default `/data/sessions`. VPS host path: `/opt/mira/mira-bridge/data/sessions`. Read by `tests/eval/analyze_sessions.py` cron to auto-generate eval fixtures. |
 | `EVAL_DISABLE_JUDGE` | `tests/eval/analyze_sessions.py` — set `"1"` to skip LLM grading (deterministic grades only; saves Groq tokens). |
+| `POSTMARK_INBOUND_TOKEN` | mira-web — shared secret Postmark sends back in `X-Auth-Token` header on inbound webhook (Unit 3 magic email inbox). Generate: `openssl rand -hex 24`. Set the same value in Postmark dashboard → Inbound Stream → Webhook auth. |
+| `MIRA_INGEST_URL`    | mira-web — base URL for mira-ingest (Unit 3 magic inbox forwards PDFs here). Default in container: `http://mira-ingest:8001`. |
+| `INBOX_DOMAIN`       | mira-web — domain shown in `/api/me` for the per-tenant address `kb+<slug>@<INBOX_DOMAIN>`. Default `inbox.factorylm.com`. |

--- a/mira-web/src/lib/mailer.ts
+++ b/mira-web/src/lib/mailer.ts
@@ -122,6 +122,116 @@ export async function sendActivatedEmail(
   });
 }
 
+// ---------------------------------------------------------------------------
+// Magic email inbox (Unit 3) — receipt email after Postmark webhook fires
+// ---------------------------------------------------------------------------
+
+export interface InboxReceiptResult {
+  ingested: { filename: string }[];
+  skipped: { filename: string; reason: string }[];
+  too_large: { filename: string; size_mb: number }[];
+  errors: { filename: string; status: number | string }[];
+}
+
+function formatInboxReceiptBody(firstName: string, r: InboxReceiptResult): string {
+  const lines: string[] = [];
+  lines.push(`Hey ${firstName || "there"},`);
+  lines.push("");
+
+  if (r.ingested.length > 0) {
+    lines.push("Got it. Here's what landed in your knowledge base just now:");
+    lines.push("");
+    for (const f of r.ingested) {
+      lines.push(`  ${f.filename}  (searchable in Telegram within 2 min)`);
+    }
+    lines.push("");
+  } else {
+    lines.push("Nothing landed in your knowledge base from that email — see why below.");
+    lines.push("");
+  }
+
+  if (r.skipped.length > 0) {
+    lines.push("Skipped because they aren't PDFs:");
+    for (const f of r.skipped) {
+      lines.push(`  - ${f.filename}  (${f.reason})`);
+    }
+    lines.push("");
+  }
+
+  if (r.too_large.length > 0) {
+    lines.push("Too big (20 MB max per file):");
+    for (const f of r.too_large) {
+      lines.push(`  - ${f.filename}  (${f.size_mb} MB - reply and I'll share an upload link)`);
+    }
+    lines.push("");
+  }
+
+  if (r.errors.length > 0) {
+    lines.push("Hit a problem on these (we'll auto-retry once, but reply if it persists):");
+    for (const f of r.errors) {
+      lines.push(`  - ${f.filename}  (status ${f.status})`);
+    }
+    lines.push("");
+  }
+
+  if (r.ingested.length > 0) {
+    lines.push("Try it: ask MIRA in Telegram about anything from the new manual.");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Send the inbox receipt email via Resend (plain text, no HTML template).
+ * Variable-length file lists don't fit the {{VAR}} system, so this bypasses sendEmail().
+ * Dev-mode short-circuit: logs body instead of sending when RESEND_API_KEY is unset.
+ */
+export async function sendInboxReceiptEmail(
+  toEmail: string,
+  firstName: string,
+  result: InboxReceiptResult
+): Promise<boolean> {
+  const total = result.ingested.length;
+  const subject = total > 0
+    ? `MIRA - ${total} ${total === 1 ? "file" : "files"} added to your knowledge base`
+    : "MIRA - couldn't add anything from your last email";
+  const body = formatInboxReceiptBody(firstName, result);
+
+  const apiKey = RESEND_API_KEY();
+  if (!apiKey) {
+    console.log("[mailer] (dev-mode) RESEND_API_KEY unset; would send to", toEmail);
+    console.log("[mailer] subject:", subject);
+    console.log("[mailer] body:\n" + body);
+    return false;
+  }
+
+  try {
+    const resp = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: `${FROM_NAME} <${FROM_EMAIL()}>`,
+        to: [toEmail],
+        subject,
+        text: body,
+      }),
+    });
+    if (!resp.ok) {
+      const err = await resp.text();
+      console.error("[mailer] inbox receipt Resend error:", resp.status, err);
+      return false;
+    }
+    console.log("[mailer] inbox receipt sent to", toEmail);
+    return true;
+  } catch (err) {
+    console.error("[mailer] inbox receipt send failed:", err);
+    return false;
+  }
+}
+
 /**
  * Beta nurture drip schedule — Loom-heavy education → payment at Day 7.
  *

--- a/mira-web/src/lib/quota.ts
+++ b/mira-web/src/lib/quota.ts
@@ -38,7 +38,28 @@ export interface Tenant {
   provisioning_attempts: number;
   provisioning_last_attempt_at: string | null;
   provisioning_last_error: string | null;
+  inbox_slug: string | null;
   created_at: string;
+}
+
+// 8-char [a-z0-9] slug, e.g. "k7m3xp9q". Used in kb+<slug>@inbox.factorylm.com.
+export function generateInboxSlug(): string {
+  const alphabet = "abcdefghijklmnopqrstuvwxyz0123456789";
+  let out = "";
+  for (let i = 0; i < 8; i++) {
+    out += alphabet[Math.floor(Math.random() * alphabet.length)];
+  }
+  return out;
+}
+
+async function generateUniqueInboxSlug(): Promise<string> {
+  const db = sql();
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const candidate = generateInboxSlug();
+    const rows = await db`SELECT 1 FROM plg_tenants WHERE inbox_slug = ${candidate} LIMIT 1`;
+    if (rows.length === 0) return candidate;
+  }
+  throw new Error("Failed to generate unique inbox_slug after 5 attempts");
 }
 
 // ---------------------------------------------------------------------------
@@ -56,7 +77,7 @@ export async function findTenantByEmail(
            atlas_provisioning_status,
            activation_email_status, demo_seed_status,
            provisioning_attempts, provisioning_last_attempt_at,
-           provisioning_last_error, created_at
+           provisioning_last_error, inbox_slug, created_at
     FROM plg_tenants WHERE email = ${email} LIMIT 1`;
   return (rows[0] as Tenant) || null;
 }
@@ -72,7 +93,7 @@ export async function findTenantById(
            atlas_provisioning_status,
            activation_email_status, demo_seed_status,
            provisioning_attempts, provisioning_last_attempt_at,
-           provisioning_last_error, created_at
+           provisioning_last_error, inbox_slug, created_at
     FROM plg_tenants WHERE id = ${tenantId} LIMIT 1`;
   return (rows[0] as Tenant) || null;
 }
@@ -88,8 +109,24 @@ export async function findTenantByStripeCustomerId(
            atlas_provisioning_status,
            activation_email_status, demo_seed_status,
            provisioning_attempts, provisioning_last_attempt_at,
-           provisioning_last_error, created_at
+           provisioning_last_error, inbox_slug, created_at
     FROM plg_tenants WHERE stripe_customer_id = ${stripeCustomerId} LIMIT 1`;
+  return (rows[0] as Tenant) || null;
+}
+
+export async function findTenantByInboxSlug(
+  slug: string
+): Promise<Tenant | null> {
+  const db = sql();
+  const rows = await db`
+    SELECT id, email, company, tier, first_name,
+           stripe_customer_id, stripe_subscription_id,
+           atlas_password, atlas_company_id, atlas_user_id,
+           atlas_provisioning_status,
+           activation_email_status, demo_seed_status,
+           provisioning_attempts, provisioning_last_attempt_at,
+           provisioning_last_error, inbox_slug, created_at
+    FROM plg_tenants WHERE inbox_slug = ${slug} LIMIT 1`;
   return (rows[0] as Tenant) || null;
 }
 
@@ -108,14 +145,16 @@ export async function createTenant(tenant: {
   atlasUserId: number;
 }): Promise<void> {
   const db = sql();
+  const inboxSlug = await generateUniqueInboxSlug();
   await db`
     INSERT INTO plg_tenants (id, email, company, first_name, tier,
                              atlas_password, atlas_company_id, atlas_user_id,
-                             created_at)
+                             inbox_slug, created_at)
     VALUES (${tenant.id}, ${tenant.email}, ${tenant.company},
             ${tenant.firstName}, ${tenant.tier},
             ${tenant.atlasPassword}, ${tenant.atlasCompanyId},
-            ${tenant.atlasUserId}, NOW())`;
+            ${tenant.atlasUserId},
+            ${inboxSlug}, NOW())`;
 }
 
 export async function updateTenantTier(
@@ -298,6 +337,19 @@ export async function ensureSchema(): Promise<void> {
   await db`ALTER TABLE plg_tenants ADD COLUMN IF NOT EXISTS provisioning_attempts INTEGER NOT NULL DEFAULT 0`;
   await db`ALTER TABLE plg_tenants ADD COLUMN IF NOT EXISTS provisioning_last_attempt_at TIMESTAMPTZ`;
   await db`ALTER TABLE plg_tenants ADD COLUMN IF NOT EXISTS provisioning_last_error TEXT`;
+
+  // Magic email inbox (Unit 3): each tenant gets a stable slug for kb+<slug>@inbox.factorylm.com.
+  await db`ALTER TABLE plg_tenants ADD COLUMN IF NOT EXISTS inbox_slug TEXT`;
+  await db`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_plg_tenants_inbox_slug
+      ON plg_tenants (inbox_slug)
+      WHERE inbox_slug IS NOT NULL`;
+  // Backfill: any existing tenant without a slug gets one. Procedural to honor uniqueness.
+  const nullSlugRows = await db`SELECT id FROM plg_tenants WHERE inbox_slug IS NULL`;
+  for (const row of nullSlugRows) {
+    const slug = await generateUniqueInboxSlug();
+    await db`UPDATE plg_tenants SET inbox_slug = ${slug} WHERE id = ${row.id}`;
+  }
 
   // Backfill: existing active tenants with atlas='ok' had email+seed succeed historically.
   // Mark them 'sent'/'ok' so /api/me doesn't show a false "unfinished setup" banner.

--- a/mira-web/src/routes/__tests__/inbox.test.ts
+++ b/mira-web/src/routes/__tests__/inbox.test.ts
@@ -1,0 +1,246 @@
+import {
+  describe,
+  test,
+  expect,
+  beforeEach,
+  mock,
+  spyOn,
+} from "bun:test";
+
+// --- env setup BEFORE mocks/imports ---------------------------------------
+process.env.POSTMARK_INBOUND_TOKEN = "test-token";
+process.env.MIRA_INGEST_URL = "http://fake-ingest:8001";
+delete process.env.RESEND_API_KEY; // forces mailer dev-mode (logs only)
+
+// --- module mocks ----------------------------------------------------------
+const FAKE_TENANT = {
+  id: "00000000-0000-0000-0000-000000000099",
+  email: "tester@example.com",
+  company: "Test Co",
+  tier: "active",
+  first_name: "Tester",
+  stripe_customer_id: null,
+  stripe_subscription_id: null,
+  atlas_password: "",
+  atlas_company_id: 0,
+  atlas_user_id: 0,
+  atlas_provisioning_status: "ok",
+  activation_email_status: "sent",
+  demo_seed_status: "ok",
+  provisioning_attempts: 0,
+  provisioning_last_attempt_at: null,
+  provisioning_last_error: null,
+  inbox_slug: "abc12345",
+  created_at: "2026-04-24T00:00:00Z",
+};
+
+mock.module("../../lib/quota.js", () => ({
+  findTenantByInboxSlug: async (slug: string) =>
+    slug === "abc12345" ? FAKE_TENANT : null,
+}));
+
+const sentReceipts: { email: string; firstName: string; result: any }[] = [];
+mock.module("../../lib/mailer.js", () => ({
+  sendInboxReceiptEmail: async (email: string, firstName: string, result: any) => {
+    sentReceipts.push({ email, firstName, result });
+    return true;
+  },
+}));
+
+// --- now load module under test -------------------------------------------
+const { inbox, extractSlug } = await import("../inbox.js");
+
+// --- helpers ---------------------------------------------------------------
+function pdfAttachment(name: string, sizeBytes?: number) {
+  const fakeBytes = "%PDF-1.4 fake content";
+  const length = sizeBytes ?? fakeBytes.length;
+  return {
+    Name: name,
+    Content: btoa(fakeBytes),
+    ContentType: "application/pdf",
+    ContentLength: length,
+  };
+}
+
+function postmarkBody(opts: {
+  to?: string;
+  attachments?: Array<Record<string, unknown>>;
+}) {
+  return JSON.stringify({
+    MessageID: "test-msg-1",
+    From: "user@example.com",
+    To: opts.to ?? "kb+abc12345@inbox.factorylm.com",
+    Subject: "Test",
+    Attachments: opts.attachments ?? [],
+  });
+}
+
+async function postWebhook(body: string, headers: Record<string, string> = {}) {
+  return inbox.request("/postmark", {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+beforeEach(() => {
+  sentReceipts.length = 0;
+});
+
+// --- pure-function tests ---------------------------------------------------
+describe("extractSlug", () => {
+  test("plain address", () => {
+    expect(extractSlug("kb+abc12345@inbox.factorylm.com")).toBe("abc12345");
+  });
+
+  test("display name + angle brackets", () => {
+    expect(extractSlug('"MIRA Inbox" <kb+abc12345@inbox.factorylm.com>')).toBe(
+      "abc12345",
+    );
+  });
+
+  test("normalizes uppercase", () => {
+    expect(extractSlug("KB+ABC12345@inbox.factorylm.com")).toBe("abc12345");
+  });
+
+  test("returns null when no kb+ prefix", () => {
+    expect(extractSlug("hello@inbox.factorylm.com")).toBeNull();
+  });
+
+  test("returns null on empty/null/undefined", () => {
+    expect(extractSlug("")).toBeNull();
+    expect(extractSlug(null)).toBeNull();
+    expect(extractSlug(undefined)).toBeNull();
+  });
+});
+
+// --- handler tests ---------------------------------------------------------
+describe("POST /api/v1/inbox/postmark", () => {
+  test("401 on missing X-Auth-Token", async () => {
+    const res = await postWebhook(postmarkBody({}));
+    expect(res.status).toBe(401);
+  });
+
+  test("401 on wrong X-Auth-Token", async () => {
+    const res = await postWebhook(postmarkBody({}), { "X-Auth-Token": "nope" });
+    expect(res.status).toBe(401);
+  });
+
+  test("400 on malformed To address", async () => {
+    const res = await postWebhook(
+      postmarkBody({ to: "hello@inbox.factorylm.com" }),
+      { "X-Auth-Token": "test-token" },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("200 + no forward + no receipt on unknown slug", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch");
+    const res = await postWebhook(
+      postmarkBody({
+        to: "kb+nopenope@inbox.factorylm.com",
+        attachments: [pdfAttachment("doc.pdf")],
+      }),
+      { "X-Auth-Token": "test-token" },
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // give any fire-and-forget a chance to run, then assert nothing fired
+    await new Promise((r) => setTimeout(r, 5));
+    expect(sentReceipts.length).toBe(0);
+    fetchSpy.mockRestore();
+  });
+
+  test("single PDF: forwarded once with correct FormData; receipt fires", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('{"status":"ok"}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const res = await postWebhook(
+      postmarkBody({ attachments: [pdfAttachment("manual-yaskawa.pdf")] }),
+      { "X-Auth-Token": "test-token" },
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const call = fetchSpy.mock.calls[0]!;
+    expect(call[0]).toBe("http://fake-ingest:8001/ingest/document-kb");
+    const init = call[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    const fd = init.body as FormData;
+    expect(fd.get("tenant_id")).toBe(FAKE_TENANT.id);
+    expect(fd.get("filename")).toBe("manual-yaskawa.pdf");
+    expect(fd.get("file")).toBeInstanceOf(Blob);
+
+    await new Promise((r) => setTimeout(r, 5));
+    expect(sentReceipts.length).toBe(1);
+    expect(sentReceipts[0].email).toBe(FAKE_TENANT.email);
+    expect(sentReceipts[0].result.ingested.map((x: any) => x.filename)).toEqual([
+      "manual-yaskawa.pdf",
+    ]);
+    fetchSpy.mockRestore();
+  });
+
+  test("mixed bag (good PDF + xlsx + 30MB PDF): only good PDF forwarded; rest categorized", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+    const xlsx = {
+      Name: "spreadsheet.xlsx",
+      Content: btoa("PK"),
+      ContentType:
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      ContentLength: 2,
+    };
+    const oversize = pdfAttachment("huge.pdf", 30 * 1024 * 1024);
+
+    const res = await postWebhook(
+      postmarkBody({
+        attachments: [pdfAttachment("good.pdf"), xlsx, oversize],
+      }),
+      { "X-Auth-Token": "test-token" },
+    );
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    await new Promise((r) => setTimeout(r, 5));
+    const r0 = sentReceipts[0].result;
+    expect(r0.ingested.map((x: any) => x.filename)).toEqual(["good.pdf"]);
+    expect(r0.skipped.map((x: any) => x.filename)).toEqual(["spreadsheet.xlsx"]);
+    expect(r0.too_large.map((x: any) => x.filename)).toEqual(["huge.pdf"]);
+    fetchSpy.mockRestore();
+  });
+
+  test("mira-ingest returns 429: captured in errors[]; webhook still returns 200", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("tier limit", { status: 429 }),
+    );
+    const res = await postWebhook(
+      postmarkBody({ attachments: [pdfAttachment("doc.pdf")] }),
+      { "X-Auth-Token": "test-token" },
+    );
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(sentReceipts[0].result.errors).toEqual([
+      { filename: "doc.pdf", status: 429 },
+    ]);
+    expect(sentReceipts[0].result.ingested.length).toBe(0);
+    fetchSpy.mockRestore();
+  });
+
+  test("mira-ingest network error: captured; webhook still returns 200", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+    const res = await postWebhook(
+      postmarkBody({ attachments: [pdfAttachment("doc.pdf")] }),
+      { "X-Auth-Token": "test-token" },
+    );
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 5));
+    expect(sentReceipts[0].result.errors[0].status).toBe("upstream-unreachable");
+    fetchSpy.mockRestore();
+  });
+});

--- a/mira-web/src/routes/inbox.ts
+++ b/mira-web/src/routes/inbox.ts
@@ -1,0 +1,215 @@
+// mira-web/src/routes/inbox.ts
+//
+// Magic email inbox (Unit 3): customer forwards an email with PDF attachments
+// to kb+<slug>@inbox.factorylm.com; Postmark Inbound POSTs JSON here. We
+// resolve the tenant by inbox_slug, stream each PDF to mira-ingest's
+// /ingest/document-kb endpoint, and fire a receipt email back to the sender.
+//
+// Always returns 200 to Postmark on parse-able payloads (Postmark retries
+// non-2xx, which would cause storms on real customer issues like an unknown
+// slug). Auth failures and bad payloads are 401/400 — Postmark handles those.
+
+import { Hono } from "hono";
+import { findTenantByInboxSlug, type Tenant } from "../lib/quota.js";
+import { sendInboxReceiptEmail, type InboxReceiptResult } from "../lib/mailer.js";
+
+export const inbox = new Hono();
+
+const MIRA_INGEST_URL = () =>
+  process.env.MIRA_INGEST_URL || "http://mira-ingest:8001";
+const POSTMARK_INBOUND_TOKEN = () => process.env.POSTMARK_INBOUND_TOKEN || "";
+
+const MAX_PDF_BYTES = 20 * 1024 * 1024; // matches mira-ingest enforcement
+
+// Postmark Inbound webhook schema (subset we use)
+interface PostmarkAttachment {
+  Name?: string;
+  Content?: string; // base64
+  ContentType?: string;
+  ContentLength?: number;
+}
+interface PostmarkInboundPayload {
+  MessageID?: string;
+  To?: string;
+  ToFull?: { Email?: string }[];
+  From?: string;
+  Subject?: string;
+  Attachments?: PostmarkAttachment[];
+}
+
+// Extract the slug from kb+<slug>@inbox.factorylm.com (or any host).
+// Returns null when address shape doesn't match.
+export function extractSlug(toAddress: string | undefined | null): string | null {
+  if (!toAddress) return null;
+  // Local-part may be inside angle brackets ("Inbox <kb+abc@...>")
+  const angle = toAddress.match(/<([^>]+)>/);
+  const addr = angle ? angle[1] : toAddress;
+  const m = addr.match(/^kb\+([a-z0-9]{6,32})@/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+// Pull the To address from either the canonical To string or ToFull[0].Email.
+function resolveToAddress(payload: PostmarkInboundPayload): string | null {
+  if (payload.To && payload.To.trim()) return payload.To;
+  const first = payload.ToFull?.[0]?.Email;
+  return first || null;
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  // atob is available in Bun runtime
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+interface ProcessAttachmentResult {
+  filename: string;
+  outcome: "ingested" | "skipped" | "too_large" | "error";
+  reason?: string;
+  status?: number | string;
+}
+
+async function forwardAttachment(
+  att: PostmarkAttachment,
+  tenant: Tenant,
+): Promise<ProcessAttachmentResult> {
+  const filename = att.Name || "attachment.pdf";
+  const ct = (att.ContentType || "").toLowerCase();
+  const isPdfMime = ct === "application/pdf";
+  const isPdfExt = filename.toLowerCase().endsWith(".pdf");
+
+  if (!isPdfMime && !isPdfExt) {
+    return {
+      filename,
+      outcome: "skipped",
+      reason: "I only accept PDFs for now",
+    };
+  }
+
+  if (typeof att.ContentLength === "number" && att.ContentLength > MAX_PDF_BYTES) {
+    return {
+      filename,
+      outcome: "too_large",
+      reason: `${Math.round(att.ContentLength / (1024 * 1024))} MB`,
+    };
+  }
+
+  if (!att.Content) {
+    return { filename, outcome: "error", status: "empty" };
+  }
+
+  let bytes: Uint8Array;
+  try {
+    bytes = base64ToBytes(att.Content);
+  } catch {
+    return { filename, outcome: "error", status: "bad-base64" };
+  }
+  if (bytes.length === 0) return { filename, outcome: "error", status: "empty" };
+  if (bytes.length > MAX_PDF_BYTES) {
+    return {
+      filename,
+      outcome: "too_large",
+      reason: `${Math.round(bytes.length / (1024 * 1024))} MB`,
+    };
+  }
+
+  const blob = new Blob([bytes], { type: "application/pdf" });
+  const form = new FormData();
+  form.append("file", blob, filename);
+  form.append("filename", filename);
+  form.append("tenant_id", tenant.id);
+
+  try {
+    const resp = await fetch(`${MIRA_INGEST_URL()}/ingest/document-kb`, {
+      method: "POST",
+      body: form,
+    });
+    if (resp.ok) {
+      return { filename, outcome: "ingested", status: resp.status };
+    }
+    return { filename, outcome: "error", status: resp.status };
+  } catch (err) {
+    console.error("[inbox] forward failed:", filename, err);
+    return { filename, outcome: "error", status: "upstream-unreachable" };
+  }
+}
+
+inbox.post("/postmark", async (c) => {
+  // 1. Auth
+  const expectedToken = POSTMARK_INBOUND_TOKEN();
+  const presentedToken = c.req.header("X-Auth-Token") || "";
+  if (!expectedToken) {
+    console.error("[inbox] POSTMARK_INBOUND_TOKEN not set; refusing all webhooks");
+    return c.json({ error: "Webhook not configured" }, 500);
+  }
+  if (presentedToken !== expectedToken) {
+    console.warn("[inbox] auth failure: bad X-Auth-Token");
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  // 2. Parse JSON
+  let payload: PostmarkInboundPayload;
+  try {
+    payload = await c.req.json();
+  } catch {
+    return c.json({ error: "Invalid JSON" }, 400);
+  }
+
+  // 3. Resolve slug
+  const toAddress = resolveToAddress(payload);
+  const slug = extractSlug(toAddress);
+  if (!slug) {
+    console.warn("[inbox] malformed To address:", toAddress);
+    return c.json({ error: "Bad recipient address" }, 400);
+  }
+
+  // 4. Look up tenant
+  const tenant = await findTenantByInboxSlug(slug);
+  if (!tenant) {
+    // Don't reveal slug-existence to outsiders. Log and 200.
+    console.warn("[inbox] unknown slug:", slug, "from", payload.From);
+    return c.json({ ok: true, ignored: "unknown-recipient" }, 200);
+  }
+
+  console.log(
+    "[inbox] received message=%s tenant=%s from=%s attachments=%d",
+    payload.MessageID || "(none)",
+    tenant.id,
+    payload.From || "(none)",
+    payload.Attachments?.length || 0,
+  );
+
+  // 5. Process attachments (sequential — keeps mira-ingest load bounded per email)
+  const result: InboxReceiptResult = {
+    ingested: [],
+    skipped: [],
+    too_large: [],
+    errors: [],
+  };
+  for (const att of payload.Attachments || []) {
+    const r = await forwardAttachment(att, tenant);
+    if (r.outcome === "ingested") result.ingested.push({ filename: r.filename });
+    else if (r.outcome === "skipped")
+      result.skipped.push({ filename: r.filename, reason: r.reason || "not a PDF" });
+    else if (r.outcome === "too_large")
+      result.too_large.push({
+        filename: r.filename,
+        size_mb: Number((r.reason || "0").replace(/[^0-9.]/g, "")) || 0,
+      });
+    else
+      result.errors.push({
+        filename: r.filename,
+        status: r.status ?? "unknown",
+      });
+  }
+
+  // 6. Receipt email — fire and forget; don't block the 200 to Postmark
+  sendInboxReceiptEmail(tenant.email, tenant.first_name || "", result).catch((err) =>
+    console.error("[inbox] receipt email send error:", err),
+  );
+
+  return c.json({ ok: true, summary: result }, 200);
+});
+
+export default inbox;

--- a/mira-web/src/server.ts
+++ b/mira-web/src/server.ts
@@ -96,6 +96,7 @@ import { adminPages, adminApi } from "./routes/admin/qr-print.js";
 import { qrAnalytics } from "./routes/admin/qr-analytics.js";
 import { adminChannelPages, adminChannelApi } from "./routes/admin/channels.js";
 import { qrTest } from "./routes/qr-test.js";
+import { inbox } from "./routes/inbox.js";
 
 // Merged content: static seed + NeonDB live drafts
 let allFaultCodes = [...FAULT_CODES];
@@ -152,6 +153,9 @@ app.route("/", adminApi);               // handles POST /api/admin/qr-print-batc
 app.route("/admin", qrAnalytics);       // handles GET /admin/qr-analytics
 app.route("/admin", adminChannelPages); // handles GET /admin/channels
 app.route("/", adminChannelApi);        // handles POST /api/admin/channels
+
+// Magic email inbox (Unit 3): Postmark Inbound webhook
+app.route("/api/v1/inbox", inbox);       // POST /api/v1/inbox/postmark
 
 // ---------------------------------------------------------------------------
 // Static files
@@ -649,12 +653,17 @@ app.get("/api/me", requireActive, async (c) => {
     ready: tenant.atlas_provisioning_status === "ok"
         && tenant.activation_email_status !== "pending",
   };
+  const inboxDomain = process.env.INBOX_DOMAIN || "inbox.factorylm.com";
+  const inboxAddress = tenant.inbox_slug
+    ? `kb+${tenant.inbox_slug}@${inboxDomain}`
+    : null;
   return c.json({
     tenantId: user.sub,
     email: user.email,
     tier: "active",
     quota,
     provisioning,
+    inbox: { slug: tenant.inbox_slug, address: inboxAddress },
   });
 });
 


### PR DESCRIPTION
## Summary

Closes Unit 3 of the [90-day MVP plan](docs/plans/2026-04-19-mira-90-day-mvp.md). Customers forward an email with PDF attachments to `kb+<slug>@inbox.factorylm.com`; Postmark Inbound POSTs the JSON payload to a new `mira-web` route, which resolves the tenant by slug and proxies each PDF to mira-ingest's existing `/ingest/document-kb` endpoint, then sends a Resend receipt.

## What this PR does

- **NEW** `mira-web/src/routes/inbox.ts` — Hono handler at `POST /api/v1/inbox/postmark`. Validates `X-Auth-Token`, parses Postmark JSON, extracts the slug from the `To:` address, looks up the tenant, forwards each PDF, and fires a fire-and-forget receipt email. Always returns 200 on parseable payloads (Postmark retries non-2xx → storms).
- **NEW** `inbox_slug` column on `plg_tenants` — additive migration in `ensureSchema()` with unique partial index and procedural backfill for existing tenants. New tenants get a slug at creation time.
- **NEW** `findTenantByInboxSlug()` lookup; `inbox_slug` exposed on existing `findTenantByEmail/Id/StripeCustomerId` and on the `/api/me` response (`inbox.{slug,address}`).
- **NEW** `sendInboxReceiptEmail()` in `lib/mailer.ts` — plain-text Resend send with dev-mode log-only fallback when `RESEND_API_KEY` is unset.
- **TESTS** — 13 unit/handler tests (5 `extractSlug`, 8 webhook). All pass; runs in ~1.2s. Mocks `findTenantByInboxSlug` and `sendInboxReceiptEmail` via `mock.module()` — no DB or Resend dependency.
- **DOCS** — `docs/env-vars.md` row for `POSTMARK_INBOUND_TOKEN`, `MIRA_INGEST_URL`, `INBOX_DOMAIN`.

## What this PR does NOT change

- `mira-ingest` is untouched. `/ingest/document-kb` already enforces PDF-only, 20 MB cap, and tier-limit checks (`main.py:687`). mira-web pre-checks size to avoid wasted base64 decode + multipart construction.
- No new outbound email vendor — receipt uses the existing Resend plumbing.
- No new database tables — single additive column.

## Test plan

- [x] All 13 inbox tests green: `bun test ./src/routes/__tests__/inbox.test.ts`
- [x] No regressions: pre-existing test failures (7) are the same DB-required tests that fail without `NEON_DATABASE_URL` (pre-existing condition; my branch adds 13 passing tests with zero new failures)
- [ ] **Mike, before merge**: confirm Postmark account + DNS MX record path is acceptable (alternative was SES — Postmark wins on simpler signature scheme)
- [ ] **After deploy** (Mike to do, not the agent — no data exfiltration in auto mode):
  - [ ] Postmark dashboard: create Inbound Stream `mira-kb-inbound`; webhook URL = `https://app.factorylm.com/api/v1/inbox/postmark`; set `X-Auth-Token` = `openssl rand -hex 24`
  - [ ] Doppler `factorylm/prd`: set `POSTMARK_INBOUND_TOKEN` to that same value
  - [ ] DNS: add MX record at `inbox.factorylm.com` → Postmark inbound MX (24-48h propagation per plan risk #1)
- [ ] **DoD verification** (binary, blocks ship): forward a real OEM PDF from Mike's Gmail to `kb+<his-slug>@inbox.factorylm.com`; receipt email arrives ≤30s; Telegram `recall yaskawa` returns chunks from that manual ≤90s.

## Plan reference

Full per-unit detail: `docs/plans/2026-04-19-mira-90-day-mvp.md` §Unit 3.
Decision rationale (slug strategy, vendor choice, no double tier-check): `~/.claude/plans/implementation-complete-branch-pure-bee.md`.

## Notes for review

- `sendInboxReceiptEmail()` bypasses the existing `sendEmail()` template helper because variable-length file lists don't fit the `{{VAR}}` substitution model. It mirrors the same Resend POST shape, just with `text:` instead of `html:`.
- The slug regex `^kb\+([a-z0-9]{6,32})@` accepts 6–32 chars to leave room for a future "pretty slug" upgrade (`kb+acme-mfg@...`) without breaking the route. Today's `generateInboxSlug()` always emits 8.
- `findTenantByInboxSlug()` returns `null` and the route returns 200 + log only — deliberately doesn't reveal slug-existence to outsiders sending crafted addresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)