### PR TITLE
fix(deploy): propagate SERVICES env var through ssh heredoc

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -36,7 +36,7 @@ jobs:
           SERVICES: ${{ github.event.inputs.services }}
         run: |
           ssh -i ~/.ssh/vps_deploy_key -o StrictHostKeyChecking=no \
-            root@165.245.138.91 bash -s << 'ENDSSH'
+            root@165.245.138.91 "SERVICES='$SERVICES' bash -s" << 'ENDSSH'
 
           set -euo pipefail
           cd /opt/mira


### PR DESCRIPTION
## Summary
- Workflow dispatch's `services` input was always ignored. $SERVICES is set as a step env var on the runner, but `<< 'ENDSSH'` single-quoted heredoc blocks expansion, so the VPS bash process never saw it.
- Every dispatched run fell into the `else` full-rebuild branch (mira-pipeline, mira-ingest, mira-mcp), skipping mira-hub entirely.

## Evidence
Run `24885539394`:
```
SERVICES: mira-hub          ← CI step env set
=== Rebuild containers ===
Full rebuild (mira-pipeline-saas, mira-bots)   ← WRONG branch
```

## Fix
Pass SERVICES as a command-line env prefix on the remote bash invocation: `ssh ... "SERVICES='$SERVICES' bash -s" << 'ENDSSH'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)