### PR TITLE
feat: Unit 3.5 — magic-inbox safety gates (dedup + relevance + [force])

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -43,3 +43,5 @@ Full reference. Top 10 are in `CLAUDE.md`; this file has all of them.
 | `POSTMARK_INBOUND_TOKEN` | mira-web — shared secret Postmark sends back in `X-Auth-Token` header on inbound webhook (Unit 3 magic email inbox). Generate: `openssl rand -hex 24`. Set the same value in Postmark dashboard → Inbound Stream → Webhook auth. |
 | `MIRA_INGEST_URL`    | mira-web — base URL for mira-ingest (Unit 3 magic inbox forwards PDFs here). Default in container: `http://mira-ingest:8001`. |
 | `INBOX_DOMAIN`       | mira-web — domain shown in `/api/me` for the per-tenant address `kb+<slug>@<INBOX_DOMAIN>`. Default `inbox.factorylm.com`. |
+| `RELEVANCE_GATE_ENABLED` | mira-ingest — set `"true"` to run the LLM relevance check on PDFs ingested via the inbox path (Unit 3.5). Default off (backward-compat for web upload + nightly cron callers, which leave the gate's `relevance_gate=on` form field unset). Cost ~$0.00005/file via Groq. Fail-open on any Groq error. |
+| `GROQ_API_KEY`       | mira-bots, mira-pipeline (existing); also mira-ingest when `RELEVANCE_GATE_ENABLED=true` for the magic-inbox relevance classifier. |

--- a/mira-core/mira-ingest/db/migrations/007_tenant_ingested_files.sql
+++ b/mira-core/mira-ingest/db/migrations/007_tenant_ingested_files.sql
@@ -1,0 +1,45 @@
+-- mira-core/mira-ingest/db/migrations/007_tenant_ingested_files.sql
+--
+-- Unit 3.5 (90-day MVP): magic-inbox safety gates.
+-- Per-tenant dedup ledger. Tracks every successfully-ingested file by
+-- SHA-256 of its raw bytes so the same PDF forwarded twice doesn't
+-- create double the chunks and noise.
+--
+-- Decoupled from knowledge_entries on purpose: that table is managed by
+-- Open WebUI's chunking pipeline, and adding a hash column there would
+-- require coordinating with OW's insert path. This is a separate ledger
+-- with a single concern: "have we seen this exact file for this tenant
+-- before?" Same pattern Pinecone, Mem.ai, Reflect use for inbox dedup.
+--
+-- Single-block transactional. New table, no existing readers, so no
+-- CREATE INDEX CONCURRENTLY needed.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS tenant_ingested_files (
+  tenant_id    TEXT NOT NULL,
+  content_hash TEXT NOT NULL,                          -- SHA-256 hex of raw file bytes
+  filename     TEXT NOT NULL,
+  source       TEXT NOT NULL DEFAULT 'unknown',        -- 'inbox' | 'web-upload' | 'cron-oem' | 'unknown'
+  ingested_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, content_hash)
+);
+
+-- Recent-files lookup (admin / support queries; not on the hot path).
+CREATE INDEX IF NOT EXISTS idx_tenant_ingested_files_tenant_recent
+  ON tenant_ingested_files (tenant_id, ingested_at DESC);
+
+COMMIT;
+
+-- Verification:
+--   \d tenant_ingested_files                                       -- PK on (tenant_id, content_hash)
+--   \di idx_tenant_ingested_files_tenant_recent                    -- btree
+--   INSERT INTO tenant_ingested_files (tenant_id, content_hash, filename, source)
+--     VALUES ('00000000-...test', 'abc123', 'test.pdf', 'inbox');
+--   INSERT INTO tenant_ingested_files (tenant_id, content_hash, filename, source)
+--     VALUES ('00000000-...test', 'abc123', 'test.pdf', 'inbox');
+--                                                                  -- second INSERT errors with "duplicate key"
+--   DELETE FROM tenant_ingested_files WHERE tenant_id = '00000000-...test';
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS tenant_ingested_files;

--- a/mira-core/mira-ingest/db/neon.py
+++ b/mira-core/mira-ingest/db/neon.py
@@ -610,3 +610,66 @@ def write_session_analysis(result: dict) -> None:
             },
         )
         conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Magic-inbox safety gate (Unit 3.5): per-tenant content-hash dedup ledger.
+# Decoupled from knowledge_entries (which Open WebUI manages) — see
+# migrations/007_tenant_ingested_files.sql for the table definition.
+# ---------------------------------------------------------------------------
+
+
+def tenant_ingested_files_lookup(
+    tenant_id: str, content_hash: str
+) -> dict[str, Any] | None:
+    """Return existing ledger row for (tenant_id, content_hash) or None.
+
+    Fail-open on DB error: returns None so the caller proceeds with ingest
+    rather than silently dropping the file. (Same convention as
+    check_tier_limit — never block ingest on infra failures.)
+    """
+    if not tenant_id or not content_hash:
+        return None
+    try:
+        with _engine().connect() as conn:
+            row = (
+                conn.execute(
+                    text(
+                        "SELECT filename, ingested_at, source "
+                        "FROM tenant_ingested_files "
+                        "WHERE tenant_id = :tid AND content_hash = :h LIMIT 1"
+                    ),
+                    {"tid": tenant_id, "h": content_hash},
+                )
+                .mappings()
+                .fetchone()
+            )
+        return dict(row) if row else None
+    except Exception:
+        return None
+
+
+def tenant_ingested_files_record(
+    tenant_id: str, content_hash: str, filename: str, source: str = "unknown"
+) -> None:
+    """Insert a ledger row. ON CONFLICT DO NOTHING — idempotent on retry.
+
+    Fail-open on DB error: logs nothing, swallows exception. The file is
+    already in Open WebUI by the time this runs; failing here would just
+    mean the next forward of the same file gets re-ingested.
+    """
+    if not tenant_id or not content_hash:
+        return
+    try:
+        with _engine().begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO tenant_ingested_files "
+                    "  (tenant_id, content_hash, filename, source) "
+                    "VALUES (:tid, :h, :fn, :src) "
+                    "ON CONFLICT (tenant_id, content_hash) DO NOTHING"
+                ),
+                {"tid": tenant_id, "h": content_hash, "fn": filename, "src": source},
+            )
+    except Exception:
+        pass

--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import hashlib
 import io
 import json
 import logging
@@ -14,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
+import pdfplumber
 from crawl_verifier import (
     OUTCOME_SUCCESS,
     classify_historical,
@@ -691,6 +693,8 @@ async def ingest_document_kb(
     collection_hint: str = Form(default=None),
     equipment_type: str = Form(default=None),
     tenant_id: str = Form(default=""),
+    relevance_gate: str = Form(default="off"),  # 'on' opts in (also requires RELEVANCE_GATE_ENABLED env)
+    source: str = Form(default="unknown"),  # 'inbox' | 'web-upload' | 'cron-oem' | 'unknown'
 ):
     """Upload a PDF to Open WebUI Knowledge Base.
 
@@ -736,11 +740,65 @@ async def ingest_document_kb(
     else:
         tenant_id, tenant_source = "", "default"
     logger.info(
-        "Document KB ingest tenant=%s source=%s filename=%s",
+        "Document KB ingest tenant=%s source=%s filename=%s ingest_source=%s",
         tenant_id or "(none)",
         tenant_source,
         fname,
+        source,
     )
+
+    # Compute content hash up front — used by both dedup gate and the
+    # post-success ledger record below.
+    content_hash = hashlib.sha256(raw).hexdigest()
+
+    # GATE 1: per-tenant content-hash dedup (Unit 3.5).
+    # Cheap DB lookup; fail-open via tenant_ingested_files_lookup itself.
+    if tenant_id:
+        from db.neon import tenant_ingested_files_lookup
+
+        existing = tenant_ingested_files_lookup(tenant_id, content_hash)
+        if existing:
+            logger.info(
+                "[dedup] hit tenant=%s hash=%s original=%s",
+                tenant_id,
+                content_hash[:12],
+                existing["filename"],
+            )
+            return {
+                "status": "duplicate",
+                "filename": fname,
+                "original_filename": existing["filename"],
+                "original_uploaded_at": existing["ingested_at"].isoformat()
+                if hasattr(existing["ingested_at"], "isoformat")
+                else str(existing["ingested_at"]),
+                "content_hash": content_hash,
+            }
+
+    # GATE 2: LLM relevance check (Unit 3.5). Opt-in via env + form flag.
+    # Inbox path always sets relevance_gate=on; web upload picker leaves
+    # it default-off so the existing UX doesn't change.
+    if (
+        relevance_gate == "on"
+        and os.getenv("RELEVANCE_GATE_ENABLED", "").lower() == "true"
+    ):
+        from relevance import classify_document
+
+        first_text = _extract_first_pages_text(raw, n=2)
+        is_manual, reason = await classify_document(first_text)
+        logger.info(
+            "[relevance] tenant=%s file=%s verdict=%s reason=%s",
+            tenant_id or "(none)",
+            fname,
+            "YES" if is_manual else "NO",
+            reason,
+        )
+        if not is_manual:
+            return {
+                "status": "rejected",
+                "filename": fname,
+                "reason": reason,
+                "content_hash": content_hash,
+            }
 
     # Tier limit check (fail open on DB errors — never block on infra failures)
     if tenant_id:
@@ -817,6 +875,14 @@ async def ingest_document_kb(
     except Exception as e:
         logger.warning("KB attach failed (non-fatal, file is uploaded): %s", e)
 
+    # Record the file in the per-tenant dedup ledger (Unit 3.5).
+    # Runs after OW attach so we only mark files we actually shipped to
+    # the KB. Fail-open: ledger record failure is not a user-visible error.
+    if tenant_id:
+        from db.neon import tenant_ingested_files_record
+
+        tenant_ingested_files_record(tenant_id, content_hash, fname, source=source)
+
     logger.info(
         "Document KB ingest complete: %s → collection='%s' processing_status=%s",
         fname,
@@ -832,7 +898,28 @@ async def ingest_document_kb(
         "file_id": file_id,
         "processing_status": processing_status,
         "equipment_type": equipment_type or "",
+        "content_hash": content_hash,
     }
+
+
+def _extract_first_pages_text(raw: bytes, n: int = 2) -> str:
+    """Extract text from the first N pages of a PDF for the relevance gate.
+
+    Returns "" on parse failure (relevance.classify_document treats empty
+    text as fail-open).
+    """
+    try:
+        with pdfplumber.open(io.BytesIO(raw)) as doc:
+            pages = doc.pages[:n]
+            chunks: list[str] = []
+            for page in pages:
+                txt = page.extract_text() or ""
+                if txt:
+                    chunks.append(txt)
+            return "\n\n".join(chunks)
+    except Exception as exc:
+        logger.warning("[relevance] pdfplumber extract failed: %s", exc)
+        return ""
 
 
 # ---------------------------------------------------------------------------

--- a/mira-core/mira-ingest/relevance.py
+++ b/mira-core/mira-ingest/relevance.py
@@ -1,0 +1,114 @@
+"""Magic-inbox relevance gate (Unit 3.5).
+
+Groq llama-3.1-8b-instant classifier that decides whether the first 1-2
+pages of a PDF look like an industrial equipment manual / datasheet /
+service bulletin / wiring diagram. Anything else (meeting agendas,
+purchase orders, marketing PDFs) gets rejected with a brief reason so
+the inbox receipt email can explain why and offer the [force] override.
+
+Cost: ~$0.00005 per file at current Groq pricing.
+Latency: ~600ms typical; capped at 5s.
+
+Fail-open: any error (no API key, network blip, parse failure, timeout)
+returns (True, "skipped-error"). The KB pollution risk from a single
+through-leak is far smaller than the trust-loss from rejecting a real
+manual because the classifier hiccupped.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import httpx
+
+logger = logging.getLogger("mira-ingest.relevance")
+
+GROQ_URL = "https://api.groq.com/openai/v1/chat/completions"
+GROQ_MODEL = "llama-3.1-8b-instant"
+MAX_INPUT_CHARS = 4000  # ~1000 tokens; one page of dense text
+
+
+_PROMPT = (
+    "You decide whether a document is an industrial equipment reference. "
+    "Reply with exactly one of:\n"
+    "  YES <one-word category: manual|datasheet|bulletin|wiring|spec>\n"
+    "  NO <short reason, max 10 words>\n"
+    "\n"
+    "Accept: equipment manuals, OEM datasheets, service bulletins, wiring "
+    "diagrams, parts catalogs, instruction sheets, technical specifications.\n"
+    "Reject: meeting notes, agendas, invoices, purchase orders, contracts, "
+    "marketing, newsletters, resumes, generic letters.\n"
+    "\n"
+    "Document text:\n"
+    "---\n"
+    "{text}\n"
+    "---\n"
+    "Reply now (YES <category> or NO <reason>):"
+)
+
+
+async def classify_document(
+    first_page_text: str, *, timeout_s: float = 5.0
+) -> tuple[bool, str]:
+    """Returns (is_manual, reason).
+
+    On YES: returns (True, "<category>") e.g. (True, "manual").
+    On NO: returns (False, "<reason>") e.g. (False, "looks like a meeting agenda").
+    On any error: returns (True, "skipped-error") — fail-open.
+    """
+    if not first_page_text or not first_page_text.strip():
+        return (True, "empty-text")
+
+    api_key = os.getenv("GROQ_API_KEY", "").strip()
+    if not api_key:
+        logger.warning("GROQ_API_KEY not set; relevance gate failing open")
+        return (True, "skipped-error")
+
+    truncated = first_page_text[:MAX_INPUT_CHARS]
+    prompt = _PROMPT.format(text=truncated)
+
+    payload = {
+        "model": GROQ_MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": 64,
+        "temperature": 0,
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout_s) as client:
+            resp = await client.post(GROQ_URL, json=payload, headers=headers)
+            resp.raise_for_status()
+            body = resp.json()
+    except Exception as exc:
+        logger.warning("groq classifier error (fail-open): %s", exc)
+        return (True, "skipped-error")
+
+    try:
+        content = body["choices"][0]["message"]["content"].strip()
+    except (KeyError, IndexError, TypeError) as exc:
+        logger.warning("groq response shape unexpected (fail-open): %s", exc)
+        return (True, "skipped-error")
+
+    return _parse_verdict(content)
+
+
+def _parse_verdict(content: str) -> tuple[bool, str]:
+    """Extract YES/NO + reason from the model's first line. Fail-open on parse miss."""
+    first_line = content.splitlines()[0].strip() if content else ""
+    if not first_line:
+        return (True, "skipped-error")
+    upper = first_line.upper()
+    if upper.startswith("YES"):
+        rest = first_line[3:].strip(" :-")
+        return (True, rest or "manual")
+    if upper.startswith("NO"):
+        rest = first_line[2:].strip(" :-")
+        return (False, rest or "not a manual")
+    # Model didn't follow the format — fail open with a flag.
+    logger.info("groq verdict unparseable: %r (fail-open)", first_line[:80])
+    return (True, "skipped-error")

--- a/mira-core/mira-ingest/tests/test_ingest_safety_gates.py
+++ b/mira-core/mira-ingest/tests/test_ingest_safety_gates.py
@@ -1,0 +1,299 @@
+"""Unit 3.5 tests — magic-inbox safety gates on /ingest/document-kb.
+
+Mocks db.neon helpers, the Open WebUI HTTP path, and the Groq classifier
+so the tests run without infrastructure. Each test exercises one decision
+branch in main.ingest_document_kb (lines ~708-835).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import main as ingest_main  # noqa: E402
+
+TENANT = "00000000-0000-0000-0000-000000000099"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _minimal_pdf_bytes() -> bytes:
+    """Return a tiny but valid-enough PDF byte sequence for upload tests.
+
+    pdfplumber will likely fail to parse this — that's fine; the
+    relevance gate's pdfplumber call falls back to "" on parse error,
+    which the classifier handles via fail-open.
+    """
+    return b"%PDF-1.4\n1 0 obj <<>> endobj\ntrailer <<>>\n%%EOF\n"
+
+
+@pytest.fixture
+def client():
+    return TestClient(ingest_main.app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch):
+    monkeypatch.delenv("RELEVANCE_GATE_ENABLED", raising=False)
+    monkeypatch.delenv("MIRA_TENANT_ID", raising=False)
+
+
+# Patches the Open WebUI HTTP path so the success branch can run end-to-end
+# without a live OW. Returns the mock for assertion in tests that care.
+def _mock_openwebui():
+    return (
+        patch.object(
+            ingest_main,
+            "_get_or_create_kb_collection",
+            new=AsyncMock(return_value="col-fake-uuid"),
+        ),
+        patch.object(
+            ingest_main,
+            "_poll_file_status",
+            new=AsyncMock(return_value="ready"),
+        ),
+        patch(
+            "main.httpx.AsyncClient",
+            new=lambda *a, **kw: _AsyncClientStub(),
+        ),
+    )
+
+
+class _AsyncClientStub:
+    """Replaces httpx.AsyncClient for OW upload + attach. Both return 200/{id}."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, **kwargs):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.text = ""
+        if "/api/v1/files/" in url and "/process/status" not in url:
+            resp.json = lambda: {"id": "file-fake-uuid"}
+        elif "/file/add" in url:
+            resp.json = lambda: {}
+        else:
+            resp.json = lambda: {}
+        resp.raise_for_status = lambda: None
+        return resp
+
+
+def _post_doc(client, *, content: bytes | None = None, **form):
+    payload = content if content is not None else _minimal_pdf_bytes()
+    return client.post(
+        "/ingest/document-kb",
+        files={"file": ("manual-yaskawa.pdf", payload, "application/pdf")},
+        data={"tenant_id": TENANT, **form},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gate 1: content-hash dedup
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_hit_returns_duplicate_status_and_skips_openwebui(client):
+    """When the hash already exists for the tenant, return early; no OW call."""
+    existing = {
+        "filename": "manual-yaskawa-gs20.pdf",
+        "ingested_at": MagicMock(isoformat=lambda: "2026-04-19T10:00:00+00:00"),
+        "source": "inbox",
+    }
+    with patch.object(
+        ingest_main,
+        "_get_or_create_kb_collection",
+        new=AsyncMock(),
+    ) as mock_collection, patch(
+        "db.neon.tenant_ingested_files_lookup",
+        return_value=existing,
+    ), patch(
+        "db.neon.check_tier_limit",
+        return_value=(True, ""),
+    ):
+        resp = _post_doc(client)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "duplicate"
+    assert body["original_filename"] == "manual-yaskawa-gs20.pdf"
+    assert body["original_uploaded_at"] == "2026-04-19T10:00:00+00:00"
+    assert "content_hash" in body and len(body["content_hash"]) == 64
+    # Critical: dedup short-circuits before OW. Collection was never created.
+    mock_collection.assert_not_called()
+
+
+def test_dedup_miss_records_after_openwebui_success(client):
+    """First-seen file completes the ingest path AND records the hash ledger row."""
+    record_calls = []
+
+    def fake_record(tenant, h, fn, source="unknown"):
+        record_calls.append((tenant, h, fn, source))
+
+    patches = [
+        patch("db.neon.tenant_ingested_files_lookup", return_value=None),
+        patch("db.neon.tenant_ingested_files_record", side_effect=fake_record),
+        patch("db.neon.check_tier_limit", return_value=(True, "")),
+        *_mock_openwebui(),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        resp = _post_doc(client, source="inbox")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert len(record_calls) == 1
+    tenant, content_hash, filename, source = record_calls[0]
+    assert tenant == TENANT
+    assert len(content_hash) == 64  # SHA-256 hex
+    assert filename == "manual-yaskawa.pdf"
+    assert source == "inbox"
+
+
+# ---------------------------------------------------------------------------
+# Gate 2: relevance classifier
+# ---------------------------------------------------------------------------
+
+
+def test_relevance_gate_yes_proceeds_with_ingest(client, monkeypatch):
+    monkeypatch.setenv("RELEVANCE_GATE_ENABLED", "true")
+    patches = [
+        patch("db.neon.tenant_ingested_files_lookup", return_value=None),
+        patch("db.neon.tenant_ingested_files_record"),
+        patch("db.neon.check_tier_limit", return_value=(True, "")),
+        patch(
+            "relevance.classify_document",
+            new=AsyncMock(return_value=(True, "manual")),
+        ),
+        *_mock_openwebui(),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        resp = _post_doc(client, relevance_gate="on")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_relevance_gate_no_returns_rejected_status_and_skips_openwebui(
+    client, monkeypatch
+):
+    monkeypatch.setenv("RELEVANCE_GATE_ENABLED", "true")
+    with patch.object(
+        ingest_main,
+        "_get_or_create_kb_collection",
+        new=AsyncMock(),
+    ) as mock_collection, patch(
+        "db.neon.tenant_ingested_files_lookup", return_value=None
+    ), patch(
+        "db.neon.check_tier_limit", return_value=(True, "")
+    ), patch(
+        "relevance.classify_document",
+        new=AsyncMock(return_value=(False, "looks like a meeting agenda")),
+    ):
+        resp = _post_doc(client, relevance_gate="on")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "rejected"
+    assert body["reason"] == "looks like a meeting agenda"
+    assert "content_hash" in body
+    mock_collection.assert_not_called()
+
+
+def test_relevance_gate_groq_error_fails_open_and_ingests(client, monkeypatch):
+    """If Groq raises, the gate returns (True, 'skipped-error') → ingest proceeds."""
+    monkeypatch.setenv("RELEVANCE_GATE_ENABLED", "true")
+    patches = [
+        patch("db.neon.tenant_ingested_files_lookup", return_value=None),
+        patch("db.neon.tenant_ingested_files_record"),
+        patch("db.neon.check_tier_limit", return_value=(True, "")),
+        # classify_document is the public wrapper that itself fails open;
+        # simulate that by returning the fail-open value.
+        patch(
+            "relevance.classify_document",
+            new=AsyncMock(return_value=(True, "skipped-error")),
+        ),
+        *_mock_openwebui(),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        resp = _post_doc(client, relevance_gate="on")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_relevance_gate_disabled_by_default_skips_classifier(client, monkeypatch):
+    """RELEVANCE_GATE_ENABLED unset → classifier never called even if form says on."""
+    # NOTE: env is reset by autouse _reset_env fixture
+    classify_mock = AsyncMock(return_value=(False, "should not be called"))
+    patches = [
+        patch("db.neon.tenant_ingested_files_lookup", return_value=None),
+        patch("db.neon.tenant_ingested_files_record"),
+        patch("db.neon.check_tier_limit", return_value=(True, "")),
+        patch("relevance.classify_document", new=classify_mock),
+        *_mock_openwebui(),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        resp = _post_doc(client, relevance_gate="on")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    classify_mock.assert_not_called()
+
+
+def test_relevance_gate_form_off_skips_classifier_even_when_env_on(
+    client, monkeypatch
+):
+    """Web upload picker leaves relevance_gate=off; gate stays off even with env on."""
+    monkeypatch.setenv("RELEVANCE_GATE_ENABLED", "true")
+    classify_mock = AsyncMock(return_value=(False, "should not be called"))
+    patches = [
+        patch("db.neon.tenant_ingested_files_lookup", return_value=None),
+        patch("db.neon.tenant_ingested_files_record"),
+        patch("db.neon.check_tier_limit", return_value=(True, "")),
+        patch("relevance.classify_document", new=classify_mock),
+        *_mock_openwebui(),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        # No relevance_gate field → defaults to "off"
+        resp = _post_doc(client, source="web-upload")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert resp.status_code == 200
+    classify_mock.assert_not_called()

--- a/mira-web/src/lib/mailer.ts
+++ b/mira-web/src/lib/mailer.ts
@@ -130,7 +130,23 @@ export interface InboxReceiptResult {
   ingested: { filename: string }[];
   skipped: { filename: string; reason: string }[];
   too_large: { filename: string; size_mb: number }[];
+  duplicates: { filename: string; original_filename: string; original_uploaded_at: string }[];
+  rejected: { filename: string; reason: string }[];
   errors: { filename: string; status: number | string }[];
+}
+
+function formatDate(iso: string): string {
+  if (!iso) return "earlier";
+  // Trim to YYYY-MM-DD if we can parse it; otherwise pass through.
+  try {
+    const d = new Date(iso);
+    if (Number.isFinite(d.getTime())) {
+      return d.toISOString().slice(0, 10);
+    }
+  } catch {
+    // fall through
+  }
+  return iso;
 }
 
 function formatInboxReceiptBody(firstName: string, r: InboxReceiptResult): string {
@@ -147,6 +163,25 @@ function formatInboxReceiptBody(firstName: string, r: InboxReceiptResult): strin
     lines.push("");
   } else {
     lines.push("Nothing landed in your knowledge base from that email — see why below.");
+    lines.push("");
+  }
+
+  if (r.duplicates.length > 0) {
+    lines.push("Already in your KB (skipped to avoid duplicates):");
+    for (const f of r.duplicates) {
+      const when = formatDate(f.original_uploaded_at);
+      lines.push(`  - ${f.filename}  (original: ${f.original_filename}, uploaded ${when})`);
+    }
+    lines.push("");
+  }
+
+  if (r.rejected.length > 0) {
+    lines.push("Didn't look like a manual to me, so I left them out:");
+    for (const f of r.rejected) {
+      lines.push(`  - ${f.filename}  (${f.reason})`);
+    }
+    lines.push("");
+    lines.push("If I'm wrong, forward the file again with [force] at the start of the subject line.");
     lines.push("");
   }
 

--- a/mira-web/src/routes/__tests__/inbox.test.ts
+++ b/mira-web/src/routes/__tests__/inbox.test.ts
@@ -174,11 +174,89 @@ describe("POST /api/v1/inbox/postmark", () => {
     expect(fd.get("filename")).toBe("manual-yaskawa.pdf");
     expect(fd.get("file")).toBeInstanceOf(Blob);
 
+    // inbox path always opts the relevance gate ON (env still gates whether
+    // mira-ingest actually runs it)
+    expect(fd.get("relevance_gate")).toBe("on");
+    expect(fd.get("source")).toBe("inbox");
+
     await new Promise((r) => setTimeout(r, 5));
     expect(sentReceipts.length).toBe(1);
     expect(sentReceipts[0].email).toBe(FAKE_TENANT.email);
     expect(sentReceipts[0].result.ingested.map((x: any) => x.filename)).toEqual([
       "manual-yaskawa.pdf",
+    ]);
+    fetchSpy.mockRestore();
+  });
+
+  test("[force] in Subject sets relevance_gate=off on the forwarded form", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response('{"status":"ok"}', { status: 200 }),
+    );
+    const body = JSON.stringify({
+      MessageID: "test-msg-force",
+      From: "user@example.com",
+      To: "kb+abc12345@inbox.factorylm.com",
+      Subject: "[force] Re: Yaskawa drive",
+      Attachments: [pdfAttachment("ambiguous.pdf")],
+    });
+    const res = await postWebhook(body, { "X-Auth-Token": "test-token" });
+    expect(res.status).toBe(200);
+    const fd = (fetchSpy.mock.calls[0]![1] as RequestInit).body as FormData;
+    expect(fd.get("relevance_gate")).toBe("off");
+    fetchSpy.mockRestore();
+  });
+
+  test("mira-ingest returns status:duplicate → surfaces in receipt duplicates[]", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "duplicate",
+          filename: "manual-yaskawa.pdf",
+          original_filename: "manual-yaskawa-gs20.pdf",
+          original_uploaded_at: "2026-04-19T10:00:00Z",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const res = await postWebhook(
+      postmarkBody({ attachments: [pdfAttachment("manual-yaskawa.pdf")] }),
+      { "X-Auth-Token": "test-token" },
+    );
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 5));
+    const r0 = sentReceipts[0].result;
+    expect(r0.ingested.length).toBe(0);
+    expect(r0.duplicates).toEqual([
+      {
+        filename: "manual-yaskawa.pdf",
+        original_filename: "manual-yaskawa-gs20.pdf",
+        original_uploaded_at: "2026-04-19T10:00:00Z",
+      },
+    ]);
+    fetchSpy.mockRestore();
+  });
+
+  test("mira-ingest returns status:rejected → surfaces in receipt rejected[]", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: "rejected",
+          filename: "agenda.pdf",
+          reason: "looks like a meeting agenda",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const res = await postWebhook(
+      postmarkBody({ attachments: [pdfAttachment("agenda.pdf")] }),
+      { "X-Auth-Token": "test-token" },
+    );
+    expect(res.status).toBe(200);
+    await new Promise((r) => setTimeout(r, 5));
+    const r0 = sentReceipts[0].result;
+    expect(r0.ingested.length).toBe(0);
+    expect(r0.rejected).toEqual([
+      { filename: "agenda.pdf", reason: "looks like a meeting agenda" },
     ]);
     fetchSpy.mockRestore();
   });

--- a/mira-web/src/routes/inbox.ts
+++ b/mira-web/src/routes/inbox.ts
@@ -65,14 +65,18 @@ function base64ToBytes(b64: string): Uint8Array {
 
 interface ProcessAttachmentResult {
   filename: string;
-  outcome: "ingested" | "skipped" | "too_large" | "error";
+  outcome: "ingested" | "skipped" | "too_large" | "duplicate" | "rejected" | "error";
   reason?: string;
   status?: number | string;
+  // populated when outcome === "duplicate"
+  original_filename?: string;
+  original_uploaded_at?: string;
 }
 
 async function forwardAttachment(
   att: PostmarkAttachment,
   tenant: Tenant,
+  relevanceGate: "on" | "off",
 ): Promise<ProcessAttachmentResult> {
   const filename = att.Name || "attachment.pdf";
   const ct = (att.ContentType || "").toLowerCase();
@@ -119,16 +123,50 @@ async function forwardAttachment(
   form.append("file", blob, filename);
   form.append("filename", filename);
   form.append("tenant_id", tenant.id);
+  form.append("source", "inbox");
+  form.append("relevance_gate", relevanceGate);
 
   try {
     const resp = await fetch(`${MIRA_INGEST_URL()}/ingest/document-kb`, {
       method: "POST",
       body: form,
     });
-    if (resp.ok) {
-      return { filename, outcome: "ingested", status: resp.status };
+
+    // mira-ingest returns 200 for success, duplicate, AND rejected (relevance gate).
+    // The status field in the JSON body is what we route on.
+    let body: any = null;
+    try {
+      body = await resp.json();
+    } catch {
+      // fall through — body stays null
     }
-    return { filename, outcome: "error", status: resp.status };
+
+    if (!resp.ok) {
+      return {
+        filename,
+        outcome: "error",
+        status: resp.status,
+        reason: body?.detail || undefined,
+      };
+    }
+
+    const ingestStatus = body?.status as string | undefined;
+    if (ingestStatus === "duplicate") {
+      return {
+        filename,
+        outcome: "duplicate",
+        original_filename: body?.original_filename || filename,
+        original_uploaded_at: body?.original_uploaded_at || "",
+      };
+    }
+    if (ingestStatus === "rejected") {
+      return {
+        filename,
+        outcome: "rejected",
+        reason: body?.reason || "didn't look like a manual",
+      };
+    }
+    return { filename, outcome: "ingested", status: resp.status };
   } catch (err) {
     console.error("[inbox] forward failed:", filename, err);
     return { filename, outcome: "error", status: "upstream-unreachable" };
@@ -172,12 +210,18 @@ inbox.post("/postmark", async (c) => {
     return c.json({ ok: true, ignored: "unknown-recipient" }, 200);
   }
 
+  // [force] in the Subject disables the relevance gate — escape hatch for
+  // when a user disagrees with a "didn't look like a manual" rejection.
+  const subject = payload.Subject || "";
+  const relevanceGate: "on" | "off" = /\[force\]/i.test(subject) ? "off" : "on";
+
   console.log(
-    "[inbox] received message=%s tenant=%s from=%s attachments=%d",
+    "[inbox] received message=%s tenant=%s from=%s attachments=%d gate=%s",
     payload.MessageID || "(none)",
     tenant.id,
     payload.From || "(none)",
     payload.Attachments?.length || 0,
+    relevanceGate,
   );
 
   // 5. Process attachments (sequential — keeps mira-ingest load bounded per email)
@@ -185,10 +229,12 @@ inbox.post("/postmark", async (c) => {
     ingested: [],
     skipped: [],
     too_large: [],
+    duplicates: [],
+    rejected: [],
     errors: [],
   };
   for (const att of payload.Attachments || []) {
-    const r = await forwardAttachment(att, tenant);
+    const r = await forwardAttachment(att, tenant, relevanceGate);
     if (r.outcome === "ingested") result.ingested.push({ filename: r.filename });
     else if (r.outcome === "skipped")
       result.skipped.push({ filename: r.filename, reason: r.reason || "not a PDF" });
@@ -196,6 +242,17 @@ inbox.post("/postmark", async (c) => {
       result.too_large.push({
         filename: r.filename,
         size_mb: Number((r.reason || "0").replace(/[^0-9.]/g, "")) || 0,
+      });
+    else if (r.outcome === "duplicate")
+      result.duplicates.push({
+        filename: r.filename,
+        original_filename: r.original_filename || r.filename,
+        original_uploaded_at: r.original_uploaded_at || "",
+      });
+    else if (r.outcome === "rejected")
+      result.rejected.push({
+        filename: r.filename,
+        reason: r.reason || "didn't look like a manual",
       });
     else
       result.errors.push({


### PR DESCRIPTION
## Summary

Follow-up to Unit 3 (PR #541). Adds two safety gates to `/ingest/document-kb` so the magic email inbox doesn't pollute the KB on first customer use:

1. **Per-tenant content-hash dedup** — same PDF forwarded twice → second is rejected with the original filename + uploaded date in the receipt.
2. **LLM relevance gate (opt-in)** — first 2 pages → Groq llama-3.1-8b-instant → YES/NO. Non-manuals (meeting agendas, marketing PDFs, POs) get rejected with a brief reason.

Plus the **`[force]` subject override** — if the customer disagrees with a rejection, they re-forward the email with `[force]` at the start of the subject line and the relevance gate is skipped for that send.

## What this PR does

- **NEW migration `007_tenant_ingested_files.sql`** — separate dedup ledger table (PK on `tenant_id, content_hash`). Decoupled from `knowledge_entries` because that table is Open-WebUI-managed and adding a hash column there would require coordinating with OW's insert path. Same pattern Pinecone, Mem.ai, Reflect use.
- **NEW `relevance.py`** — single `classify_document()` function calling Groq. Cost ~$0.00005/file; latency ~600ms; 5s timeout. Fail-open on every error path (no API key, network blip, parse failure, unparseable verdict).
- **`main.py:ingest_document_kb`** — both gates inserted between PDF/size validation and the existing tier-limit check. New form params `relevance_gate` and `source` so callers can opt in. Post-success ledger record after OW attach.
- **`db/neon.py`** — two new helpers `tenant_ingested_files_lookup` and `tenant_ingested_files_record`, both fail-open on DB error (same convention as `check_tier_limit`).
- **mira-web `inbox.ts`** — parse mira-ingest JSON body always (not just on `resp.ok`); switch on `body.status` for `duplicate`/`rejected`/`ok`; detect `[force]` in Subject and pass `relevance_gate=off` accordingly.
- **mira-web `mailer.ts`** — two new sections in the receipt body: "Already in your KB" and "Didn't look like a manual to me, so I left them out", with the [force] hint.

## What this PR does NOT change

- The web upload picker, nightly OEM cron, and nameplate provisioning all leave `relevance_gate` at its default `"off"` form value, so their UX is identical. Only the inbox path opts in.
- The relevance gate is also **double-flagged**: even with `relevance_gate=on`, mira-ingest only runs the classifier when env `RELEVANCE_GATE_ENABLED=true`. Lets us roll it out gradually if needed.
- Sender allowlist, Postgres RLS, semantic dedup, DOCX/XLSX, quarantine tier — all explicitly out of scope and documented as such in the plan.

## Test plan

- [x] **mira-ingest pytest** — 7 new tests in `tests/test_ingest_safety_gates.py` covering all decision branches (dedup hit/miss/record, gate yes/no/groq-error/env-disabled/form-disabled). All 46 mira-ingest tests pass (39 existing + 7 new), `pytest tests/`, ~65s.
- [x] **mira-web bun test** — 3 new cases in `inbox.test.ts` ([force] sets gate=off; status=duplicate surfaces; status=rejected surfaces). All 16 inbox tests pass; full mira-web suite still 64/71 (same 7 pre-existing DB-dependent failures, none new).
- [ ] **Mike, before merge**: confirm Groq is acceptable as the classifier vendor (already in Doppler for mira-bots/pipeline; reusing the same key).
- [ ] **After merge** (Mike's ops handoff — agent can't do these per data-exfiltration rule):
  - [ ] `psql -f mira-core/mira-ingest/db/migrations/007_tenant_ingested_files.sql` on production NeonDB
  - [ ] `doppler secrets set RELEVANCE_GATE_ENABLED=true --project factorylm --config prd`
  - [ ] Redeploy mira-ingest + mira-web from `/opt/mira/docker-compose.saas.yml` (`up -d --build --force-recreate mira-ingest mira-web`)
- [ ] **DoD verification (Mike forwards from real Gmail)**:
  - [ ] Same OEM PDF twice → second receipt under "Already in your KB" with first filename + date
  - [ ] Meeting-agenda PDF → receipt under "Didn't look like a manual"; zero rows in `tenant_ingested_files` for that hash
  - [ ] Same agenda re-forwarded with `Subject: [force] try again` → ingested; row appears in ledger; chunks in OW

## Plan reference

- 90-day MVP plan: `docs/plans/2026-04-19-mira-90-day-mvp.md` §Unit 3 (this PR closes the safety-gate follow-up that the conversation around #541 surfaced)
- Decision rationale (where dedup state lives, why no sender allowlist, why fail-open everywhere): `~/.claude/plans/implementation-complete-branch-pure-bee.md`

## Notes for review

- The dedup ledger is a separate table, not a column on `knowledge_entries`. This is intentional — `knowledge_entries` is the chunk-level table that Open WebUI populates as part of its embed pipeline; touching it risked breaking OW's contract. The ledger has one job: "have we seen this file before for this tenant?"
- Both gates fail open. This is deliberate. The cost of a false reject (real manual blocked) is much higher than a false accept (one polluted file out of thousands).
- The `[force]` escape hatch gives users a recovery path without us having to maintain a queue or a UI. Trello + Postmark + Mem.ai all use the same subject-line-prefix pattern for similar one-shot overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)