### PR TITLE
fix(deploy): inject Doppler at compose time + health route env guard

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -48,13 +48,13 @@ jobs:
           echo "=== Rebuild containers ==="
           if [ -n "${SERVICES:-}" ]; then
             echo "Selective rebuild: $SERVICES"
-            DOCKER_BUILDKIT=1 docker compose -f docker-compose.saas.yml build $SERVICES
-            docker compose -f docker-compose.saas.yml up -d --no-deps $SERVICES
+            DOCKER_BUILDKIT=1 doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml build $SERVICES
+            doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml up -d --no-deps $SERVICES
           else
             echo "Full rebuild (mira-pipeline-saas, mira-bots)"
-            DOCKER_BUILDKIT=1 docker compose -f docker-compose.saas.yml build \
+            DOCKER_BUILDKIT=1 doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml build \
               mira-pipeline mira-ingest mira-mcp
-            docker compose -f docker-compose.saas.yml up -d --no-deps \
+            doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml up -d --no-deps \
               mira-pipeline mira-ingest mira-mcp
           fi
 
@@ -64,16 +64,16 @@ jobs:
           echo "mira-pipeline health: $STATUS"
           if [ "$STATUS" != "ok" ]; then
             echo "WARNING: health check returned $STATUS — check container logs"
-            docker compose -f docker-compose.saas.yml logs --tail=20 mira-pipeline-saas
+            doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml logs --tail=20 mira-pipeline-saas
             exit 1
           fi
 
           echo "=== Deploy complete ==="
-          docker compose -f docker-compose.saas.yml ps --format "table {{.Name}}\t{{.Status}}"
+          doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml ps --format "table {{.Name}}\t{{.Status}}"
           ENDSSH
 
       - name: Notify failure
         if: failure()
         run: |
           echo "::error::VPS deploy failed — check logs above. SSH to 165.245.138.91 and run:"
-          echo "::error::  cd /opt/mira && docker compose -f docker-compose.saas.yml logs --tail=50"
+          echo "::error::  cd /opt/mira && doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml logs --tail=50"

--- a/mira-hub/src/app/api/health/route.ts
+++ b/mira-hub/src/app/api/health/route.ts
@@ -1,5 +1,24 @@
 import { NextResponse } from "next/server";
 
+export const dynamic = "force-dynamic";
+
+/**
+ * Liveness + env-sanity probe. Returns 503 if a secret the hub depends on
+ * is missing, which flips the container's Docker healthcheck to "unhealthy"
+ * so a deploy that forgot to inject secrets (e.g. missing `doppler run --`)
+ * fails loud in `docker ps` instead of silently serving 503s from every
+ * other API route.
+ */
 export function GET() {
+  const required = ["NEON_DATABASE_URL", "INGEST_URL"] as const;
+  const missing = required.filter((k) => !process.env[k]);
+
+  if (missing.length > 0) {
+    return NextResponse.json(
+      { status: "unhealthy", service: "mira-hub", missing, ts: Date.now() },
+      { status: 503 },
+    );
+  }
+
   return NextResponse.json({ status: "ok", service: "mira-hub", ts: Date.now() });
 }


### PR DESCRIPTION
## Why
The v1.2.0 mira-hub rollout broke because `docker compose` substitutes `\` against a shell that doesn't export the secrets. The old containers survived because they were manually bootstrapped with Doppler once; today's rebuild wiped that state and the new container came up with empty env.

Two-part fix:

## 1. Workflow — `doppler run --` on every compose call
`.github/workflows/deploy-vps.yml` prepends `doppler run --project factorylm --config prd --` to build/up/logs/ps. Matches the canonical pattern in `CLAUDE.md` (`doppler run -- docker compose up -d`). Secrets get pulled fresh on every deploy, so rotations are picked up automatically.

## 2. Health route — fail loud
`mira-hub/src/app/api/health/route.ts` now returns 503 if `NEON_DATABASE_URL` or `INGEST_URL` is unset. Combined with the existing wget healthcheck in `docker-compose.saas.yml`, a container with missing env goes `unhealthy` in `docker ps` within ~30s instead of silently serving broken responses.

Together: future deploys get secrets correctly, and if any don't, we find out from `docker ps` in 30s instead of from a Playwright probe an hour later.

Requires: Doppler CLI + service token already present on VPS (already true per `project_saas_deployment.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)