### PR TITLE
chore(saas): plumb Unit 3 + 3.5 env vars through SaaS compose (hotfix)

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -96,6 +96,9 @@ services:
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
       - EMBED_TEXT_MODEL=nomic-embed-text
       - APIFY_API_KEY=${APIFY_API_KEY}
+      # Unit 3.5 — magic-inbox safety gates
+      - RELEVANCE_GATE_ENABLED=${RELEVANCE_GATE_ENABLED:-}
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
     networks:
       - mira-net
     restart: unless-stopped
@@ -153,6 +156,10 @@ services:
       - STRIPE_PRICE_ID=${STRIPE_PRICE_ID:-}
       - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET:-}
       - RESEND_FROM_EMAIL=${RESEND_FROM_EMAIL:-noreply@factorylm.com}
+      # Unit 3 — magic email inbox
+      - POSTMARK_INBOUND_TOKEN=${POSTMARK_INBOUND_TOKEN:-}
+      - MIRA_INGEST_URL=${MIRA_INGEST_URL:-http://mira-ingest-saas:8001}
+      - INBOX_DOMAIN=${INBOX_DOMAIN:-inbox.factorylm.com}
     networks:
       - mira-net
       - cmms-ext


### PR DESCRIPTION
## Summary

Hotfix for PR #541 + #543 — both shipped new Doppler env vars but missed updating `docker-compose.saas.yml` so containers couldn't see them. Symptoms in prod after #541 + #543 deploy: `POST /api/v1/inbox/postmark` returned 500 `{"error":"Webhook not configured"}` because `process.env.POSTMARK_INBOUND_TOKEN` was undefined inside mira-web even though the secret was set in Doppler.

## Changes

- **mira-web env block**: adds `POSTMARK_INBOUND_TOKEN`, `MIRA_INGEST_URL` (defaults to the SaaS service name `mira-ingest-saas:8001`), `INBOX_DOMAIN`
- **mira-ingest env block**: adds `RELEVANCE_GATE_ENABLED` and `GROQ_API_KEY`

7 lines added, 0 removed. Defaults match the env-vars.md docs.

## Test plan

- [x] yaml validity (no indentation drift; same `${VAR:-}` pattern as the rest of the block)
- [ ] **After merge + deploy**: probe `POST /api/v1/inbox/postmark` with a wrong `X-Auth-Token` from inside the container → expect HTTP 401 (not 500). Public probe → still 405 until nginx location block is added separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)