### PR TITLE
feat(hub): photos upload — JPEG/PNG/WebP/HEIC + multi-select + asset linking (v1.3.0)

### DIFF
--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -26,8 +26,12 @@ from crawl_verifier import (
 )
 from fastapi import BackgroundTasks, FastAPI, File, Form, HTTPException, UploadFile
 from PIL import Image
+from pillow_heif import register_heif_opener
 from pydantic import BaseModel
 from route_fallback import RETRY_ON, run_fallback
+
+# Enable HEIC/HEIF decoding in Pillow so iPhone photos ingest without conversion
+register_heif_opener()
 
 logger = logging.getLogger("mira-ingest")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
@@ -463,7 +467,7 @@ async def health_db():
 @app.post("/ingest/photo")
 async def ingest_photo(
     image: UploadFile = File(...),
-    asset_tag: str = Form(...),
+    asset_tag: str = Form(default="unassigned"),
     location: str = Form(default=""),
     notes: str = Form(default=""),
 ):

--- a/mira-core/mira-ingest/requirements.txt
+++ b/mira-core/mira-ingest/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.136.*
 uvicorn[standard]==0.44.*
 httpx==0.28.*
 Pillow>=10.0
+pillow-heif>=0.18
 python-multipart==0.0.26
 pytest==9.*
 pytest-asyncio==1.3.*

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/app/(hub)/knowledge/page.tsx
+++ b/mira-hub/src/app/(hub)/knowledge/page.tsx
@@ -68,23 +68,27 @@ export default function KnowledgePage() {
       const rows = (await res.json()) as Array<{
         id: string;
         provider: "google" | "dropbox" | "local";
+        kind?: "document" | "photo";
         filename: string;
         sizeBytes: number | null;
         externalCreatedAt: string | null;
         status: UploadBlockData["status"];
         statusDetail: string | null;
         kbChunkCount: number | null;
+        assetTag: string | null;
       }>;
       setUploads(
         rows.map((r) => ({
           id: r.id,
           provider: r.provider,
+          kind: r.kind ?? "document",
           filename: r.filename,
           sizeBytes: r.sizeBytes,
           externalCreatedAt: r.externalCreatedAt,
           status: r.status,
           statusDetail: r.statusDetail,
           kbChunkCount: r.kbChunkCount,
+          assetTag: r.assetTag,
         })),
       );
     } catch {
@@ -103,28 +107,36 @@ export default function KnowledgePage() {
     return () => clearInterval(iv);
   }, [uploads, fetchUploads]);
 
-  async function handleLocalFile(file: File) {
-    const form = new FormData();
-    form.append("file", file);
-    const res = await fetch("/hub/api/uploads/local", { method: "POST", body: form });
-    if (res.ok) await fetchUploads();
+  async function handleLocalFiles(files: File[], assetTag: string | null) {
+    for (const file of files) {
+      const form = new FormData();
+      form.append("file", file);
+      if (assetTag) form.append("assetTag", assetTag);
+      await fetch("/hub/api/uploads/local", { method: "POST", body: form });
+    }
+    await fetchUploads();
   }
 
-  async function handleCloudPick(result: {
-    provider: "google" | "dropbox";
-    externalFileId?: string;
-    externalDownloadUrl?: string;
-    filename: string;
-    mimeType: string;
-    sizeBytes: number;
-    externalCreatedAt: string | null;
-  }) {
-    const res = await fetch("/hub/api/uploads", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(result),
-    });
-    if (res.ok) await fetchUploads();
+  async function handleCloudPicks(
+    results: Array<{
+      provider: "google" | "dropbox";
+      externalFileId?: string;
+      externalDownloadUrl?: string;
+      filename: string;
+      mimeType: string;
+      sizeBytes: number;
+      externalCreatedAt: string | null;
+    }>,
+    assetTag: string | null,
+  ) {
+    for (const result of results) {
+      await fetch("/hub/api/uploads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...result, assetTag: assetTag ?? undefined }),
+      });
+    }
+    await fetchUploads();
   }
 
   async function handleDeleteUpload(id: string) {
@@ -292,8 +304,8 @@ export default function KnowledgePage() {
       <UploadPicker
         open={pickerOpen}
         onClose={() => setPickerOpen(false)}
-        onLocalFile={handleLocalFile}
-        onCloudPick={handleCloudPick}
+        onLocalFiles={handleLocalFiles}
+        onCloudPicks={handleCloudPicks}
       />
     </div>
   );

--- a/mira-hub/src/app/api/uploads/local/route.ts
+++ b/mira-hub/src/app/api/uploads/local/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { after } from "next/server";
 import { createUpload, updateUploadStatus } from "@/lib/uploads";
-import { forwardToIngest } from "@/lib/mira-ingest-client";
+import {
+  forwardToIngest,
+  forwardToPhotoIngest,
+  inferKindFromMime,
+  SUPPORTED_MIMES,
+} from "@/lib/mira-ingest-client";
 
 export const dynamic = "force-dynamic";
 
@@ -18,35 +23,69 @@ export async function POST(req: NextRequest) {
   if (file.size > MAX) {
     return NextResponse.json({ error: "exceeds_20mb_limit", got: file.size }, { status: 400 });
   }
-  const mime = file.type || "application/pdf";
-  if (mime !== "application/pdf" && !file.name.toLowerCase().endsWith(".pdf")) {
-    return NextResponse.json({ error: "only_pdf_supported", got: mime }, { status: 400 });
+  const nameLower = file.name.toLowerCase();
+  const extGuess =
+    nameLower.endsWith(".pdf") ? "application/pdf" :
+    nameLower.endsWith(".jpg") || nameLower.endsWith(".jpeg") ? "image/jpeg" :
+    nameLower.endsWith(".png") ? "image/png" :
+    nameLower.endsWith(".webp") ? "image/webp" :
+    nameLower.endsWith(".heic") ? "image/heic" :
+    nameLower.endsWith(".heif") ? "image/heif" :
+    "";
+  const mime = file.type || extGuess || "application/octet-stream";
+  if (!SUPPORTED_MIMES.has(mime)) {
+    return NextResponse.json(
+      {
+        error: "unsupported_mime",
+        got: mime,
+        supported: Array.from(SUPPORTED_MIMES),
+      },
+      { status: 400 },
+    );
   }
 
+  const assetTagRaw = form.get("assetTag");
+  const assetTag =
+    typeof assetTagRaw === "string" && assetTagRaw.trim().length > 0
+      ? assetTagRaw.trim()
+      : null;
+  const kind = inferKindFromMime(mime);
   const buffer = new Uint8Array(await file.arrayBuffer());
 
   const upload = await createUpload({
     provider: "local",
+    kind,
     filename: file.name,
     mimeType: mime,
     sizeBytes: file.size,
     externalCreatedAt: new Date(file.lastModified),
     initialStatus: "parsing",
+    assetTag,
   });
 
   after(async () => {
     try {
-      const stream = new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(buffer);
-          controller.close();
-        },
-      });
-      const result = await forwardToIngest(stream, file.name, mime);
-      await updateUploadStatus(upload.id, "parsed", null, {
-        kbFileId: result.fileId ?? undefined,
-        kbChunkCount: result.chunkCount ?? undefined,
-      });
+      const stream = () =>
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(buffer);
+            controller.close();
+          },
+        });
+      if (kind === "photo") {
+        const result = await forwardToPhotoIngest(stream(), file.name, mime, {
+          assetTag,
+        });
+        await updateUploadStatus(upload.id, "parsed", result.description ?? null, {
+          kbFileId: result.photoId != null ? String(result.photoId) : undefined,
+        });
+      } else {
+        const result = await forwardToIngest(stream(), file.name, mime);
+        await updateUploadStatus(upload.id, "parsed", null, {
+          kbFileId: result.fileId ?? undefined,
+          kbChunkCount: result.chunkCount ?? undefined,
+        });
+      }
     } catch (err) {
       console.error(`[uploads/local/${upload.id}] failed`, err);
       await updateUploadStatus(upload.id, "failed", (err as Error).message);

--- a/mira-hub/src/app/api/uploads/route.ts
+++ b/mira-hub/src/app/api/uploads/route.ts
@@ -11,7 +11,12 @@ import {
   streamFromGoogleDrive,
   streamFromSignedUrl,
 } from "@/lib/fetch-adapters";
-import { forwardToIngest } from "@/lib/mira-ingest-client";
+import {
+  forwardToIngest,
+  forwardToPhotoIngest,
+  inferKindFromMime,
+  SUPPORTED_MIMES,
+} from "@/lib/mira-ingest-client";
 
 export const dynamic = "force-dynamic";
 
@@ -23,6 +28,7 @@ interface CreatePayload {
   mimeType?: string;
   sizeBytes?: number;
   externalCreatedAt?: string;
+  assetTag?: string;
 }
 
 export async function POST(req: NextRequest) {
@@ -42,9 +48,14 @@ export async function POST(req: NextRequest) {
   if (!body.filename) {
     return NextResponse.json({ error: "filename_required" }, { status: 400 });
   }
-  if (body.mimeType && body.mimeType !== "application/pdf") {
+  const mime = body.mimeType ?? "application/pdf";
+  if (!SUPPORTED_MIMES.has(mime)) {
     return NextResponse.json(
-      { error: "only_pdf_supported", got: body.mimeType },
+      {
+        error: "unsupported_mime",
+        got: mime,
+        supported: Array.from(SUPPORTED_MIMES),
+      },
       { status: 400 },
     );
   }
@@ -65,18 +76,22 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  const kind = inferKindFromMime(mime);
+
   const upload = await createUpload({
     provider: body.provider,
+    kind,
     externalFileId: body.externalFileId ?? null,
     externalDownloadUrl: body.externalDownloadUrl ?? null,
     filename: body.filename,
-    mimeType: body.mimeType ?? "application/pdf",
+    mimeType: mime,
     sizeBytes: body.sizeBytes ?? null,
     externalCreatedAt: body.externalCreatedAt ?? null,
     initialStatus: "queued",
+    assetTag: body.assetTag ?? null,
   });
 
-  after(() => runIngestPipeline(upload.id, body));
+  after(() => runIngestPipeline(upload.id, body, kind));
 
   return NextResponse.json(upload, { status: 201 });
 }
@@ -86,7 +101,11 @@ export async function GET() {
   return NextResponse.json(rows);
 }
 
-async function runIngestPipeline(uploadId: string, payload: CreatePayload): Promise<void> {
+async function runIngestPipeline(
+  uploadId: string,
+  payload: CreatePayload,
+  kind: "document" | "photo",
+): Promise<void> {
   try {
     await updateUploadStatus(uploadId, "fetching");
     let fetched;
@@ -98,15 +117,22 @@ async function runIngestPipeline(uploadId: string, payload: CreatePayload): Prom
     }
 
     await updateUploadStatus(uploadId, "parsing");
-    const result = await forwardToIngest(
-      fetched.stream,
-      payload.filename,
-      payload.mimeType ?? fetched.contentType,
-    );
-    await updateUploadStatus(uploadId, "parsed", null, {
-      kbFileId: result.fileId ?? undefined,
-      kbChunkCount: result.chunkCount ?? undefined,
-    });
+    const mime = payload.mimeType ?? fetched.contentType;
+
+    if (kind === "photo") {
+      const result = await forwardToPhotoIngest(fetched.stream, payload.filename, mime, {
+        assetTag: payload.assetTag ?? null,
+      });
+      await updateUploadStatus(uploadId, "parsed", result.description ?? null, {
+        kbFileId: result.photoId != null ? String(result.photoId) : undefined,
+      });
+    } else {
+      const result = await forwardToIngest(fetched.stream, payload.filename, mime);
+      await updateUploadStatus(uploadId, "parsed", null, {
+        kbFileId: result.fileId ?? undefined,
+        kbChunkCount: result.chunkCount ?? undefined,
+      });
+    }
   } catch (err) {
     console.error(`[uploads/${uploadId}] pipeline failed`, err);
     await updateUploadStatus(uploadId, "failed", (err as Error).message);

--- a/mira-hub/src/components/UploadBlock.tsx
+++ b/mira-hub/src/components/UploadBlock.tsx
@@ -1,17 +1,19 @@
 "use client";
 
 import { useState } from "react";
-import { X, Loader2, CheckCircle2, AlertCircle } from "lucide-react";
+import { X, Loader2, CheckCircle2, AlertCircle, Image as ImageIcon, FileText, Tag } from "lucide-react";
 
 export type UploadBlockData = {
   id: string;
   provider: "google" | "dropbox" | "local";
+  kind: "document" | "photo";
   filename: string;
   sizeBytes: number | null;
   externalCreatedAt: string | null;
   status: "queued" | "fetching" | "parsing" | "parsed" | "failed" | "cancelled";
   statusDetail: string | null;
   kbChunkCount: number | null;
+  assetTag: string | null;
 };
 
 const PROVIDER_LABEL: Record<UploadBlockData["provider"], string> = {
@@ -46,6 +48,7 @@ export function UploadBlock({
   const [deleting, setDeleting] = useState(false);
   const parsed = upload.status === "parsed";
   const failed = upload.status === "failed";
+  const isPhoto = upload.kind === "photo";
 
   const statusLine = (() => {
     switch (upload.status) {
@@ -54,11 +57,19 @@ export function UploadBlock({
       case "fetching":
         return { icon: <Loader2 className="w-3.5 h-3.5 animate-spin" />, text: `Fetching from ${PROVIDER_LABEL[upload.provider]}…`, color: "var(--foreground-muted)" };
       case "parsing":
-        return { icon: <Loader2 className="w-3.5 h-3.5 animate-spin" />, text: "Parsing to KB…", color: "var(--foreground-muted)" };
+        return {
+          icon: <Loader2 className="w-3.5 h-3.5 animate-spin" />,
+          text: isPhoto ? "Describing & indexing photo…" : "Parsing to KB…",
+          color: "var(--foreground-muted)",
+        };
       case "parsed":
         return {
           icon: <CheckCircle2 className="w-3.5 h-3.5" />,
-          text: `Parsed${upload.kbChunkCount != null ? ` · ${upload.kbChunkCount} chunks` : ""}`,
+          text: isPhoto
+            ? upload.statusDetail
+              ? `Indexed: ${upload.statusDetail.slice(0, 80)}${upload.statusDetail.length > 80 ? "…" : ""}`
+              : "Photo indexed"
+            : `Parsed${upload.kbChunkCount != null ? ` · ${upload.kbChunkCount} chunks` : ""}`,
           color: "#16A34A",
         };
       case "failed":
@@ -78,6 +89,17 @@ export function UploadBlock({
       style={parsed ? { opacity: 0.6 } : failed ? { borderColor: "#DC262650" } : undefined}
     >
       <div
+        className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 mt-0.5"
+        style={{ backgroundColor: "var(--surface-1)" }}
+      >
+        {isPhoto ? (
+          <ImageIcon className="w-4 h-4" style={{ color: "var(--brand-blue)" }} />
+        ) : (
+          <FileText className="w-4 h-4" style={{ color: "var(--brand-blue)" }} />
+        )}
+      </div>
+
+      <div
         className="flex-1 min-w-0"
         style={parsed ? { textDecoration: "line-through" } : undefined}
       >
@@ -87,6 +109,18 @@ export function UploadBlock({
         <p className="text-xs mt-0.5" style={{ color: "var(--foreground-muted)" }}>
           {PROVIDER_LABEL[upload.provider]} · {formatSize(upload.sizeBytes)} · {formatDate(upload.externalCreatedAt)}
         </p>
+        {upload.assetTag && (
+          <p
+            className="text-[11px] mt-1 inline-flex items-center gap-1 px-1.5 py-0.5 rounded"
+            style={{
+              backgroundColor: "var(--surface-1)",
+              color: "var(--foreground-muted)",
+            }}
+          >
+            <Tag className="w-3 h-3" />
+            {upload.assetTag}
+          </p>
+        )}
         <div className="flex items-center gap-1.5 mt-2">
           {statusLine.icon}
           <span className="text-[11px]" style={{ color: statusLine.color }}>

--- a/mira-hub/src/components/UploadPicker.tsx
+++ b/mira-hub/src/components/UploadPicker.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Script from "next/script";
-import { X, Upload as UploadIcon } from "lucide-react";
+import { X, Upload as UploadIcon, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
-type PickResult = {
+export type PickResult = {
   provider: "google" | "dropbox";
   externalFileId?: string;
   externalDownloadUrl?: string;
@@ -14,6 +14,8 @@ type PickResult = {
   sizeBytes: number;
   externalCreatedAt: string | null;
 };
+
+type Asset = { id: number | string; tag: string; name: string };
 
 declare global {
   interface Window {
@@ -71,16 +73,38 @@ interface GooglePickerBuilder {
   build: () => { setVisible: (v: boolean) => void };
 }
 
+const ACCEPTED_MIME = [
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+].join(",");
+
+const DROPBOX_EXTENSIONS = [".pdf", ".jpg", ".jpeg", ".png", ".webp", ".heic", ".heif"];
+
+function mimeFromExt(name: string): string {
+  const n = name.toLowerCase();
+  if (n.endsWith(".pdf")) return "application/pdf";
+  if (n.endsWith(".jpg") || n.endsWith(".jpeg")) return "image/jpeg";
+  if (n.endsWith(".png")) return "image/png";
+  if (n.endsWith(".webp")) return "image/webp";
+  if (n.endsWith(".heic")) return "image/heic";
+  if (n.endsWith(".heif")) return "image/heif";
+  return "application/octet-stream";
+}
+
 export function UploadPicker({
   open,
   onClose,
-  onLocalFile,
-  onCloudPick,
+  onLocalFiles,
+  onCloudPicks,
 }: {
   open: boolean;
   onClose: () => void;
-  onLocalFile: (file: File) => void | Promise<void>;
-  onCloudPick: (result: PickResult) => void | Promise<void>;
+  onLocalFiles: (files: File[], assetTag: string | null) => void | Promise<void>;
+  onCloudPicks: (results: PickResult[], assetTag: string | null) => void | Promise<void>;
 }) {
   const [googleReady, setGoogleReady] = useState(false);
   const [dropboxReady, setDropboxReady] = useState(false);
@@ -89,6 +113,10 @@ export function UploadPicker({
   const [dropboxAvailable, setDropboxAvailable] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [assetSearch, setAssetSearch] = useState("");
+  const [selectedAsset, setSelectedAsset] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -99,12 +127,31 @@ export function UploadPicker({
     fetch("/hub/api/picker/dropbox/key")
       .then((r) => setDropboxAvailable(r.ok))
       .catch(() => setDropboxAvailable(false));
+    fetch("/api/assets")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data: Asset[] | unknown) => {
+        if (Array.isArray(data)) setAssets(data as Asset[]);
+      })
+      .catch(() => setAssets([]));
   }, [open]);
 
   useEffect(() => {
     if (!googleReady || pickerLoaded) return;
     window.gapi?.load("picker", () => setPickerLoaded(true));
   }, [googleReady, pickerLoaded]);
+
+  const filteredAssets = useMemo(() => {
+    if (assets.length === 0) return [];
+    const q = assetSearch.toLowerCase().trim();
+    if (!q) return assets.slice(0, 8);
+    return assets
+      .filter(
+        (a) =>
+          a.tag.toLowerCase().includes(q) ||
+          (a.name ?? "").toLowerCase().includes(q),
+      )
+      .slice(0, 8);
+  }, [assets, assetSearch]);
 
   async function openGoogle() {
     setError(null);
@@ -116,7 +163,7 @@ export function UploadPicker({
         throw new Error("Google Picker not loaded yet — try again in a moment");
       }
       const view = new window.google.picker.DocsView()
-        .setMimeTypes("application/pdf")
+        .setMimeTypes("application/pdf,image/jpeg,image/png,image/webp,image/heic,image/heif")
         .setIncludeFolders(true)
         .setSelectFolderEnabled(false);
       const picker = new window.google.picker.PickerBuilder()
@@ -124,10 +171,10 @@ export function UploadPicker({
         .setOAuthToken(accessToken)
         .setDeveloperKey(apiKey)
         .setAppId(appId)
+        .enableFeature(window.google.picker.Feature.MULTISELECT_ENABLED)
         .setCallback((data) => {
-          if (data.action === window.google!.picker.Action.PICKED && data.docs?.[0]) {
-            const doc = data.docs[0];
-            void onCloudPick({
+          if (data.action === window.google!.picker.Action.PICKED && data.docs && data.docs.length > 0) {
+            const results: PickResult[] = data.docs.map((doc) => ({
               provider: "google",
               externalFileId: doc.id,
               filename: doc.name,
@@ -136,7 +183,8 @@ export function UploadPicker({
               externalCreatedAt: doc.lastEditedUtc
                 ? new Date(Number(doc.lastEditedUtc)).toISOString()
                 : null,
-            });
+            }));
+            void onCloudPicks(results, selectedAsset);
             onClose();
           }
         })
@@ -153,18 +201,18 @@ export function UploadPicker({
       if (!window.Dropbox) throw new Error("Dropbox Chooser not loaded yet");
       window.Dropbox.choose({
         linkType: "direct",
-        multiselect: false,
-        extensions: [".pdf"],
+        multiselect: true,
+        extensions: DROPBOX_EXTENSIONS,
         success: (files) => {
-          const f = files[0];
-          void onCloudPick({
+          const results: PickResult[] = files.map((f) => ({
             provider: "dropbox",
             externalDownloadUrl: f.link,
             filename: f.name,
-            mimeType: "application/pdf",
+            mimeType: mimeFromExt(f.name),
             sizeBytes: f.bytes,
             externalCreatedAt: f.client_modified ?? null,
-          });
+          }));
+          void onCloudPicks(results, selectedAsset);
           onClose();
         },
       });
@@ -187,6 +235,11 @@ export function UploadPicker({
   }, [open, dropboxKey]);
 
   if (!open) return null;
+
+  const selectedLabel =
+    selectedAsset != null
+      ? assets.find((a) => a.tag === selectedAsset)?.tag ?? selectedAsset
+      : null;
 
   return (
     <>
@@ -221,28 +274,89 @@ export function UploadPicker({
             </button>
           </div>
 
+          {assets.length > 0 && (
+            <div className="mb-3">
+              <label className="text-xs font-medium" style={{ color: "var(--foreground-muted)" }}>
+                Link to asset (optional)
+              </label>
+              <div className="relative mt-1">
+                <Search
+                  className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5"
+                  style={{ color: "var(--foreground-subtle)" }}
+                />
+                <input
+                  type="text"
+                  placeholder={selectedLabel ? `Linked: ${selectedLabel}` : "Search assets or leave blank…"}
+                  value={assetSearch}
+                  onChange={(e) => setAssetSearch(e.target.value)}
+                  className="w-full h-8 pl-8 pr-3 text-xs rounded-lg border"
+                  style={{
+                    backgroundColor: "var(--surface-1)",
+                    borderColor: "var(--border)",
+                    color: "var(--foreground)",
+                  }}
+                />
+              </div>
+              {assetSearch && filteredAssets.length > 0 && (
+                <div
+                  className="mt-1 max-h-36 overflow-y-auto rounded-lg border"
+                  style={{ backgroundColor: "var(--surface-1)", borderColor: "var(--border)" }}
+                >
+                  {filteredAssets.map((a) => (
+                    <button
+                      key={a.id}
+                      onClick={() => {
+                        setSelectedAsset(a.tag);
+                        setAssetSearch("");
+                      }}
+                      className="w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--surface-2)] transition-colors"
+                      style={{ color: "var(--foreground)" }}
+                    >
+                      <span className="font-medium">{a.tag}</span>
+                      {a.name && (
+                        <span className="ml-2" style={{ color: "var(--foreground-muted)" }}>
+                          {a.name}
+                        </span>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+              {selectedAsset && (
+                <button
+                  onClick={() => setSelectedAsset(null)}
+                  className="mt-1 text-[10px] underline"
+                  style={{ color: "var(--foreground-subtle)" }}
+                >
+                  Clear link
+                </button>
+              )}
+            </div>
+          )}
+
           <label
             className="flex flex-col items-center justify-center gap-2 border-2 border-dashed rounded-xl px-4 py-8 cursor-pointer transition-colors hover:bg-[var(--surface-1)]"
             style={{ borderColor: "var(--border)" }}
           >
             <UploadIcon className="w-6 h-6" style={{ color: "var(--foreground-muted)" }} />
             <span className="text-sm font-medium" style={{ color: "var(--foreground)" }}>
-              Drop a PDF here or click to browse
+              Drop PDFs or photos here — or click to browse
             </span>
             <span className="text-xs" style={{ color: "var(--foreground-subtle)" }}>
-              Up to 20 MB
+              PDF, JPEG, PNG, WebP, HEIC · Up to 20 MB each
             </span>
             <input
               ref={fileInputRef}
               type="file"
-              accept="application/pdf,.pdf"
+              accept={ACCEPTED_MIME}
+              multiple
               className="sr-only"
               onChange={async (e) => {
-                const f = e.target.files?.[0];
-                if (f) {
-                  await onLocalFile(f);
-                  onClose();
-                }
+                const list = e.target.files;
+                if (!list || list.length === 0) return;
+                const files = Array.from(list);
+                await onLocalFiles(files, selectedAsset);
+                onClose();
               }}
             />
           </label>

--- a/mira-hub/src/lib/mira-ingest-client.ts
+++ b/mira-hub/src/lib/mira-ingest-client.ts
@@ -6,6 +6,38 @@ export interface IngestResult {
   processingStatus: string | null;
 }
 
+export interface PhotoIngestResult {
+  status: string;
+  photoId: number | null;
+  description: string | null;
+  assetTag: string | null;
+  photoPath: string | null;
+}
+
+const MAX_BYTES = 20 * 1024 * 1024;
+
+async function streamToBlob(
+  stream: ReadableStream<Uint8Array>,
+  mimeType: string,
+): Promise<Blob> {
+  const chunks: Uint8Array[] = [];
+  const reader = stream.getReader();
+  let total = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > MAX_BYTES) {
+      throw new Error(`file exceeds 20 MB limit (${(total / 1024 / 1024).toFixed(1)} MB)`);
+    }
+    chunks.push(value);
+  }
+  return new Blob(chunks as BlobPart[], { type: mimeType });
+}
+
+/**
+ * PDF / document path — POSTs to mira-ingest `/ingest/document-kb`.
+ */
 export async function forwardToIngest(
   stream: ReadableStream<Uint8Array>,
   filename: string,
@@ -15,23 +47,7 @@ export async function forwardToIngest(
   const base = process.env.INGEST_URL;
   if (!base) throw new Error("INGEST_URL not set");
 
-  // Consume the stream into a Blob for multipart upload. mira-ingest's
-  // /ingest/document-kb endpoint expects multipart/form-data with a
-  // single `file` field (+ optional `filename`).
-  const chunks: Uint8Array[] = [];
-  const reader = stream.getReader();
-  let total = 0;
-  const MAX = 20 * 1024 * 1024;
-  while (true) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > MAX) {
-      throw new Error(`file exceeds 20 MB limit (${(total / 1024 / 1024).toFixed(1)} MB)`);
-    }
-    chunks.push(value);
-  }
-  const blob = new Blob(chunks as BlobPart[], { type: mimeType });
+  const blob = await streamToBlob(stream, mimeType);
 
   const form = new FormData();
   form.append("file", blob, filename);
@@ -53,3 +69,68 @@ export async function forwardToIngest(
     processingStatus: json.processing_status ?? null,
   };
 }
+
+/**
+ * Photo path — POSTs to mira-ingest `/ingest/photo`. Field name is `image`
+ * (not `file`), and `asset_tag` is required — when the user didn't pick an
+ * asset we send "unassigned" so the photo still gets sanitized, captioned,
+ * and embedded, and can be linked to an asset later from the asset page.
+ */
+export async function forwardToPhotoIngest(
+  stream: ReadableStream<Uint8Array>,
+  filename: string,
+  mimeType: string,
+  opts: { assetTag?: string | null; notes?: string; location?: string } = {},
+  signal?: AbortSignal,
+): Promise<PhotoIngestResult> {
+  const base = process.env.INGEST_URL;
+  if (!base) throw new Error("INGEST_URL not set");
+
+  const blob = await streamToBlob(stream, mimeType);
+
+  const form = new FormData();
+  form.append("image", blob, filename);
+  form.append(
+    "asset_tag",
+    opts.assetTag && opts.assetTag.length > 0 ? opts.assetTag : "unassigned",
+  );
+  form.append("location", opts.location ?? "");
+  form.append("notes", opts.notes ?? "");
+
+  const res = await fetch(`${base}/ingest/photo`, {
+    method: "POST",
+    body: form,
+    signal,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`photo ingest ${res.status}: ${json.detail ?? res.statusText}`);
+  }
+  return {
+    status: "ok",
+    photoId: typeof json.id === "number" ? json.id : null,
+    description: json.description ?? null,
+    assetTag: json.asset_tag ?? null,
+    photoPath: json.photo_path ?? null,
+  };
+}
+
+export function inferKindFromMime(mime: string | null | undefined): "document" | "photo" {
+  if (!mime) return "document";
+  if (mime.startsWith("image/")) return "photo";
+  return "document";
+}
+
+export const SUPPORTED_IMAGE_MIMES = new Set([
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+]);
+
+export const SUPPORTED_MIMES = new Set<string>([
+  "application/pdf",
+  ...SUPPORTED_IMAGE_MIMES,
+]);

--- a/mira-hub/src/lib/uploads.ts
+++ b/mira-hub/src/lib/uploads.ts
@@ -12,10 +12,13 @@ export type UploadStatus =
 
 export type UploadProvider = "google" | "dropbox" | "local";
 
+export type UploadKind = "document" | "photo";
+
 export interface Upload {
   id: string;
   tenantId: string;
   provider: UploadProvider;
+  kind: UploadKind;
   externalFileId: string | null;
   externalDownloadUrl: string | null;
   filename: string;
@@ -26,6 +29,7 @@ export interface Upload {
   statusDetail: string | null;
   kbFileId: string | null;
   kbChunkCount: number | null;
+  assetTag: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -54,6 +58,15 @@ export function ensureUploadsSchema(): Promise<void> {
         updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
       )
     `);
+    // In-place migrations for pre-existing deployments (idempotent)
+    await pool.query(`
+      ALTER TABLE hub_uploads
+        ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'document'
+    `);
+    await pool.query(`
+      ALTER TABLE hub_uploads
+        ADD COLUMN IF NOT EXISTS asset_tag TEXT
+    `);
     await pool.query(`
       CREATE INDEX IF NOT EXISTS idx_hub_uploads_tenant_status
         ON hub_uploads (tenant_id, status, created_at DESC)
@@ -65,6 +78,7 @@ export function ensureUploadsSchema(): Promise<void> {
 export interface CreateUploadInput {
   tenantId?: string;
   provider: UploadProvider;
+  kind?: UploadKind;
   externalFileId?: string | null;
   externalDownloadUrl?: string | null;
   filename: string;
@@ -72,6 +86,7 @@ export interface CreateUploadInput {
   sizeBytes?: number | null;
   externalCreatedAt?: string | Date | null;
   initialStatus?: UploadStatus;
+  assetTag?: string | null;
 }
 
 function rowToUpload(r: Record<string, unknown>): Upload {
@@ -79,6 +94,7 @@ function rowToUpload(r: Record<string, unknown>): Upload {
     id: r.id as string,
     tenantId: r.tenant_id as string,
     provider: r.provider as UploadProvider,
+    kind: ((r.kind as string) ?? "document") as UploadKind,
     externalFileId: (r.external_file_id as string | null) ?? null,
     externalDownloadUrl: (r.external_download_url as string | null) ?? null,
     filename: r.filename as string,
@@ -89,6 +105,7 @@ function rowToUpload(r: Record<string, unknown>): Upload {
     statusDetail: (r.status_detail as string | null) ?? null,
     kbFileId: (r.kb_file_id as string | null) ?? null,
     kbChunkCount: r.kb_chunk_count != null ? Number(r.kb_chunk_count) : null,
+    assetTag: (r.asset_tag as string | null) ?? null,
     createdAt: r.created_at as string,
     updatedAt: r.updated_at as string,
   };
@@ -98,6 +115,7 @@ export async function createUpload(input: CreateUploadInput): Promise<Upload> {
   await ensureUploadsSchema();
   const tenantId = input.tenantId ?? DEFAULT_TENANT_ID;
   const status = input.initialStatus ?? "queued";
+  const kind = input.kind ?? "document";
   const createdAt =
     input.externalCreatedAt instanceof Date
       ? input.externalCreatedAt.toISOString()
@@ -106,14 +124,15 @@ export async function createUpload(input: CreateUploadInput): Promise<Upload> {
   const { rows } = await pool.query(
     `
     INSERT INTO hub_uploads
-      (tenant_id, provider, external_file_id, external_download_url,
-       filename, mime_type, size_bytes, external_created_at, status)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      (tenant_id, provider, kind, external_file_id, external_download_url,
+       filename, mime_type, size_bytes, external_created_at, status, asset_tag)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
     RETURNING *
   `,
     [
       tenantId,
       input.provider,
+      kind,
       input.externalFileId ?? null,
       input.externalDownloadUrl ?? null,
       input.filename,
@@ -121,6 +140,7 @@ export async function createUpload(input: CreateUploadInput): Promise<Upload> {
       input.sizeBytes ?? null,
       createdAt,
       status,
+      input.assetTag ?? null,
     ],
   );
   return rowToUpload(rows[0]);

--- a/mira-hub/tests/e2e/photo-upload-probe.spec.ts
+++ b/mira-hub/tests/e2e/photo-upload-probe.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Photo upload probe — verifies the picker accepts images, local JPEG
+ * round-trips through /ingest/photo, and Google Drive photo pick works
+ * end-to-end. Assumes the hub is live at app.factorylm.com.
+ */
+import { test, expect } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+const HUB = "https://app.factorylm.com/hub";
+
+test.setTimeout(180_000);
+
+test("photo upload — local JPEG round-trip to /ingest/photo", async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await ctx.newPage();
+
+  await page.goto(`${HUB}/login`, { waitUntil: "networkidle" });
+  await page.fill('input[type="email"]', "mike@factorylm.com");
+  await page.fill('input[type="password"]', "admin123");
+  await page.click('button:has-text("Sign In")');
+  await page.waitForURL(/\/hub\/feed/, { timeout: 15_000 });
+
+  // Generate a tiny valid JPEG in-memory (1×1 white pixel). Pillow/Sharp
+  // can decode this; no external fixture needed.
+  const onePixelJpeg = Buffer.from(
+    "/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+iiigD//2Q==",
+    "base64",
+  );
+
+  const filename = `probe-local-photo-${Date.now()}.jpg`;
+  const uploadRes = await page.request.post(`${HUB}/api/uploads/local`, {
+    multipart: {
+      file: {
+        name: filename,
+        mimeType: "image/jpeg",
+        buffer: onePixelJpeg,
+      },
+    },
+  });
+  expect(uploadRes.ok(), `upload failed: ${uploadRes.status()}`).toBeTruthy();
+  const created = (await uploadRes.json()) as { id: string; kind?: string; status: string };
+  expect(created.kind).toBe("photo");
+
+  // Poll until terminal
+  let terminal: string | null = null;
+  let detail: string | null = null;
+  for (let i = 0; i < 40 && !terminal; i++) {
+    await new Promise((r) => setTimeout(r, 2000));
+    const list = await page.request.get(`${HUB}/api/uploads`);
+    const rows = (await list.json()) as Array<{
+      id: string;
+      status: string;
+      statusDetail: string | null;
+    }>;
+    const me = rows.find((r) => r.id === created.id);
+    if (me && ["parsed", "failed", "cancelled"].includes(me.status)) {
+      terminal = me.status;
+      detail = me.statusDetail ?? null;
+    }
+  }
+
+  console.log(`Local JPEG probe: id=${created.id}, terminal=${terminal}, detail=${detail}`);
+  expect(terminal).toBe("parsed");
+
+  await ctx.close();
+});
+
+test("photo upload — Google Drive JPEG round-trip to /ingest/photo", async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+  const page = await ctx.newPage();
+
+  await page.goto(`${HUB}/login`, { waitUntil: "networkidle" });
+  await page.fill('input[type="email"]', "mike@factorylm.com");
+  await page.fill('input[type="password"]', "admin123");
+  await page.click('button:has-text("Sign In")');
+  await page.waitForURL(/\/hub\/feed/, { timeout: 15_000 });
+
+  // 1. Drive access token
+  const tokenRes = await page.request.get(`${HUB}/api/picker/google/token`);
+  if (!tokenRes.ok()) {
+    console.log("Google Drive not connected — skipping cloud photo probe");
+    await ctx.close();
+    return;
+  }
+  const { accessToken } = (await tokenRes.json()) as { accessToken: string };
+
+  // 2. Find any image in Drive
+  const listRes = await page.request.get(
+    "https://www.googleapis.com/drive/v3/files?" +
+      new URLSearchParams({
+        q: "(mimeType='image/jpeg' or mimeType='image/png' or mimeType='image/webp') and trashed=false",
+        pageSize: "5",
+        fields: "files(id,name,size,mimeType,modifiedTime)",
+        orderBy: "modifiedTime desc",
+      }).toString(),
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+  const list = (await listRes.json()) as {
+    files?: Array<{
+      id: string;
+      name: string;
+      size: string;
+      mimeType: string;
+      modifiedTime: string;
+    }>;
+  };
+
+  if (!list.files || list.files.length === 0) {
+    console.log("No image in Drive — skipping cloud photo probe");
+    await ctx.close();
+    return;
+  }
+
+  const candidate =
+    list.files
+      .filter((f) => Number(f.size) < 10 * 1024 * 1024)
+      .sort((a, b) => Number(a.size) - Number(b.size))[0] ?? list.files[0];
+
+  console.log(`Picking Drive image: ${candidate.name} (${candidate.size} bytes, ${candidate.mimeType})`);
+
+  const postRes = await page.request.post(`${HUB}/api/uploads`, {
+    data: {
+      provider: "google",
+      externalFileId: candidate.id,
+      filename: candidate.name,
+      mimeType: candidate.mimeType,
+      sizeBytes: Number(candidate.size),
+      externalCreatedAt: candidate.modifiedTime,
+    },
+    headers: { "Content-Type": "application/json" },
+  });
+  expect(postRes.ok()).toBeTruthy();
+  const created = (await postRes.json()) as { id: string; kind?: string };
+  expect(created.kind).toBe("photo");
+
+  let terminal: string | null = null;
+  let detail: string | null = null;
+  for (let i = 0; i < 60 && !terminal; i++) {
+    await new Promise((r) => setTimeout(r, 2000));
+    const rows = (await (await page.request.get(`${HUB}/api/uploads`)).json()) as Array<{
+      id: string;
+      status: string;
+      statusDetail: string | null;
+    }>;
+    const me = rows.find((r) => r.id === created.id);
+    if (me && ["parsed", "failed", "cancelled"].includes(me.status)) {
+      terminal = me.status;
+      detail = me.statusDetail ?? null;
+    }
+  }
+
+  console.log(`Drive photo probe: id=${created.id}, terminal=${terminal}, detail=${detail}`);
+  expect(terminal).toBe("parsed");
+
+  await ctx.close();
+});


### PR DESCRIPTION
## Summary
Extends the Knowledge upload picker to accept photos alongside PDFs. Photos route through mira-ingest's existing `/ingest/photo` pipeline (sanitize + resize + qwen2.5vl caption + dual-embed), same service that powers the 3,694-photo corpus.

Mike's Q1/Q2/Q3 answers implemented as-spec: all 4 image formats, batch+single, optional non-blocking asset link.

## What changed
**Hub (`mira-hub`):**
- UploadPicker accepts PDF + JPEG + PNG + WebP + HEIC
- Google Picker + Dropbox Chooser both multi-select enabled
- Optional "Link to asset" typeahead (empty → 'unassigned' default, can be linked later)
- Schema: `kind` + `asset_tag` columns on `hub_uploads` (idempotent ALTERs)
- Pipeline branches on kind: photos → `forwardToPhotoIngest`, PDFs → existing `forwardToIngest`
- UploadBlock renders photo icon + asset tag pill for `kind=photo`, shows vision description as status detail
- package.json bumped to 1.3.0

**Ingest (`mira-core/mira-ingest`):**
- `register_heif_opener()` — iPhone HEIC decodes without conversion
- `/ingest/photo`: `asset_tag` now optional (defaults to 'unassigned'). Existing callers unaffected.
- Added `pillow-heif` to requirements

**Tests:**
- `tests/e2e/photo-upload-probe.spec.ts` — local JPEG + Drive image round-trip to `parsed`

## Test plan
- [ ] PR merge auto-deploys pipeline/ingest/mcp (triggers HEIC support)
- [ ] Manual `gh workflow run deploy-vps.yml -f services="mira-hub"` for hub rebuild
- [ ] Run `npx playwright test tests/e2e/photo-upload-probe.spec.ts` — both tests pass
- [ ] Upload a photo from phone (HEIC) via /hub/knowledge, verify parsed

🤖 Generated with [Claude Code](https://claude.com/claude-code)