### PR TITLE
fix(deploy): --force-recreate so env-only changes propagate

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -49,12 +49,12 @@ jobs:
           if [ -n "${SERVICES:-}" ]; then
             echo "Selective rebuild: $SERVICES"
             DOCKER_BUILDKIT=1 doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml build $SERVICES
-            doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml up -d --no-deps $SERVICES
+            doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml up -d --no-deps --force-recreate $SERVICES
           else
             echo "Full rebuild (mira-pipeline-saas, mira-bots)"
             DOCKER_BUILDKIT=1 doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml build \
               mira-pipeline mira-ingest mira-mcp
-            doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml up -d --no-deps \
+            doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml up -d --no-deps --force-recreate \
               mira-pipeline mira-ingest mira-mcp
           fi
 


### PR DESCRIPTION
## Why
`docker compose up -d` only recreates containers when the image/spec changes. Doppler-value-only changes don't trigger recreate — the old container keeps running with the stale env.

Hit today when swapping OLLAMA_BASE_URL for mira-ingest: Doppler updated, workflow dispatched, 'Selective rebuild: mira-ingest' logged, but `mira-ingest-saas Up 17 minutes` at end — old container still running with stale URL.

## Fix
Add `--force-recreate` to every compose up call in the workflow. Containers now always restart with the current Doppler snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)