### PR TITLE
fix(saas): read OLLAMA_BASE_URL from env so Doppler controls it

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -21,7 +21,7 @@ services:
       - WEBUI_NAME=MIRA
       - WEBUI_ENABLE_TELEMETRY=false
       - WEBUI_CHECK_FOR_UPDATES=false
-      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       - OPENAI_API_BASE_URLS=http://mira-pipeline-saas:9099/v1
       - OPENAI_API_KEYS=${PIPELINE_API_KEY:-}
       - DEFAULT_MODELS=mira-diagnostic
@@ -61,7 +61,7 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - LLM_MODEL_ANTHROPIC=claude-sonnet-4-6
       - EMBEDDING_PROVIDER=ollama
-      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       - OLLAMA_EMBED_MODEL=nomic-embed-text
       - HOST=0.0.0.0
       - PORT=5000
@@ -93,7 +93,7 @@ services:
       - OPENWEBUI_BASE_URL=http://mira-core-saas:8080
       - OPENWEBUI_API_KEY=${OPENWEBUI_API_KEY}
       - KNOWLEDGE_COLLECTION_ID=${KNOWLEDGE_COLLECTION_ID}
-      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       - EMBED_TEXT_MODEL=nomic-embed-text
       - APIFY_API_KEY=${APIFY_API_KEY}
       # Unit 3.5 — magic-inbox safety gates
@@ -182,7 +182,7 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       - MIRA_DB_PATH=/mira-db/mira.db
-      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       - OPENWEBUI_BASE_URL=http://mira-core-saas:8080
       - OPENWEBUI_API_KEY=${OPENWEBUI_API_KEY:-}
       - KNOWLEDGE_COLLECTION_ID=${KNOWLEDGE_COLLECTION_ID:-}
@@ -243,7 +243,7 @@ services:
       - NEON_DATABASE_URL=${NEON_DATABASE_URL:-}
       - MIRA_TENANT_ID=${MIRA_TENANT_ID:-}
       - VISION_MODEL=qwen2.5vl:7b
-      - OLLAMA_BASE_URL=http://host.docker.internal:11434
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       - INFERENCE_BACKEND=cloud
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - GROQ_API_KEY=${GROQ_API_KEY:-}


### PR DESCRIPTION
Root cause of silent vision-caption failures in the v1.3.0 photo uploads.

5 services hardcoded `OLLAMA_BASE_URL=http://host.docker.internal:11434`. On the DO Linux VPS, that resolves to the VPS host — where Ollama doesn't run. Ollama is on BRAVO, reachable via Tailscale at `100.86.236.11:11434`, and Doppler had `OLLAMA_BASE_URL` pointing there for weeks. The compose just wasn't reading it.

Proven on factorylm-prod (via Tailscale SSH):
- Host `curl http://100.86.236.11:11434/api/tags` → 200 with model list (includes qwen2.5vl:7b)
- `docker exec mira-ingest-saas printenv OLLAMA_BASE_URL` → `http://host.docker.internal:11434` (Doppler value was `100.86.236.11:11434`, but compose ignored it because the value was literal)

Change: `\http://host.docker.internal:11434` — Doppler overrides, local-dev default preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)