### PR TITLE
fix(eval-bot): whitelist paths — never commit outside tests/eval/**

### DIFF
--- a/tests/eval/celery_tasks.py
+++ b/tests/eval/celery_tasks.py
@@ -144,6 +144,43 @@ def _run_eval(ts: str, out_file: Path, judge_enabled: bool) -> dict:
 
     subprocess.run(["git", "add"] + files_to_stage, cwd=MIRA_DIR, check=True)
 
+    # Safety whitelist — the bot is only permitted to commit paths under
+    # tests/eval/**. On 2026-04-24 an eval run (00c34e6) somehow co-committed
+    # mira-hub/src/** changes alongside the scorecard, stripping the Upload
+    # picker wiring out of the Knowledge page. Root cause of the extra
+    # staging was never identified, so we defend here: refuse to commit
+    # anything off-path and unstage it before logging + bailing.
+    staged_r = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        cwd=MIRA_DIR, capture_output=True, text=True,
+    )
+    staged_paths = [p for p in staged_r.stdout.splitlines() if p.strip()]
+    off_path = [p for p in staged_paths if not p.startswith("tests/eval/")]
+    if off_path:
+        logger.error(
+            "MIRA eval refusing to commit — %d off-whitelist paths staged: %s",
+            len(off_path),
+            ", ".join(off_path[:10]),
+        )
+        # Unstage everything off-whitelist so the next iteration has a clean slate
+        subprocess.run(
+            ["git", "reset", "HEAD", "--"] + off_path,
+            cwd=MIRA_DIR, capture_output=True, text=True,
+        )
+        # Also throw away any working-tree changes to those paths so the source
+        # of truth (origin/main) wins on the next fetch — otherwise the same
+        # rogue modifications will re-stage on the next run.
+        subprocess.run(
+            ["git", "checkout", "HEAD", "--"] + off_path,
+            cwd=MIRA_DIR, capture_output=True, text=True,
+        )
+        return {
+            "status": "refused",
+            "reason": "off_whitelist_paths_staged",
+            "paths": off_path,
+            "ts": ts,
+        }
+
     tag_label = "with judge" if judge_enabled else "no judge"
     commit_msg = (
         f"chore: eval run {ts} UTC ({tag_label})\n\n"


### PR DESCRIPTION
## Why
Today's hourly eval-bot commit `00c34e6` co-staged unrelated `mira-hub/src/**` changes alongside the scorecard, wiping the UploadPicker wiring out of the Knowledge page and breaking the Upload button in prod. Restored via PR #549; this PR prevents recurrence.

The bot's `_run_eval` helper explicitly stages only the scorecard .md (+ optional -judge.jsonl). Something else on the VPS is staging hub paths — possibly a pre-running process, a git config quirk, or a call site we haven't found yet.

## Fix
Before `git commit`, list all staged paths (`git diff --cached --name-only`). If any path is outside `tests/eval/**`, the bot:
1. Logs an error with the offending paths
2. Runs `git reset HEAD` + `git checkout HEAD` on them to clean up
3. Returns `status='refused', reason='off_whitelist_paths_staged'` so Celery / telemetry surfaces the event

Scorecards still commit normally. If/when we track down the rogue-staging source, we can remove the guard; until then it's cheap insurance.

## Deployment note
This file is deployed to `/opt/master_of_puppets/workers/mira_eval_tasks.py` on the VPS per the file's docstring — merging to main doesn't auto-propagate. Someone needs to copy the new file there and restart the Celery worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)