### PR TITLE
fix(ingest): make asset_tag required on /ingest/photo (closes #594)

### DIFF
--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -467,7 +467,7 @@ async def health_db():
 @app.post("/ingest/photo")
 async def ingest_photo(
     image: UploadFile = File(...),
-    asset_tag: str = Form(default="unassigned"),
+    asset_tag: str = Form(...),
     location: str = Form(default=""),
     notes: str = Form(default=""),
 ):


### PR DESCRIPTION
Closes #594.

## The fix

```diff
 @app.post("/ingest/photo")
 async def ingest_photo(
     image: UploadFile = File(...),
-    asset_tag: str = Form(default="unassigned"),
+    asset_tag: str = Form(...),
     location: str = Form(default=""),
     notes: str = Form(default=""),
 ):
```

`mira-core/mira-ingest/main.py:470`. Single character change in semantics: `default="unassigned"` makes the Form field optional → missing → defaults to `"unassigned"` → 200. `Form(...)` (Ellipsis) makes it required → missing → 422.

## Why this matters

- **Restores `test_missing_asset_tag_returns_422` to passing.** This test has been silently failing on every PR's Unit Tests check, which gated CI on #584, #586, and forced `--admin --squash` overrides on unrelated work.
- **Plugs a real production hazard.** The `default="unassigned"` fallback meant photos with no asset_tag landed at `PHOTOS_DIR / "unassigned"` — a magic catch-all that silently pooled unidentified photos and triggered downstream Vision / embed calls (visible in the test's DNS-error logs from CI). Reject at the boundary instead.
- **Maintainers preserve their CI signal.** With this merged, the next failing PR check is something that *actually broke in that PR*, not stale repo debt.

## Verification

Local smoke test with the new signature against a stripped-down FastAPI app:

```
missing asset_tag: 422 (expected 422) PASS
with asset_tag:    200 (expected 200) PASS
```

(Full `test_missing_asset_tag_returns_422` unit test wasn't runnable locally — mira-ingest pulls heavy deps: pdfplumber, qwen client, neon. CI will exercise it in container.)

## Risk

Tiny. Existing callers pass `asset_tag` per the documented endpoint spec; missing field was previously silently absorbed and is now surfaced as 422 — which is the correct behavior. No other code paths reference the `"unassigned"` literal as a default expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)