### PR TITLE
feat(comic-pipeline): OpenAI panel generation + SEO/GEO metadata + YouTube upload

### DIFF
--- a/docs/adr/0013-openai-marketing-pipeline-carve-out.md
+++ b/docs/adr/0013-openai-marketing-pipeline-carve-out.md
@@ -1,0 +1,157 @@
+# ADR-0013: OpenAI Carve-Out for Marketing Pipelines (Images + TTS Only)
+
+## Status
+Accepted — 2026-04-25
+
+**Related:** CLAUDE.md Hard Constraint #2 ("No cloud except: Anthropic Claude API + NeonDB"), ADR-0011 (No LangGraph migration — Constraint #3 enforcement).
+
+---
+
+## Context
+
+`marketing/comic-pipeline/` (and its sibling `tools/seedance-video-gen.py`) generate
+short explainer videos for top-of-funnel: a comic-style narration over animated panels,
+output as YouTube-ready MP4. The pipeline already calls:
+
+- **OpenAI `gpt-image-1`** (`pipeline/generate_panels.py`, `pipeline/v2/panels.py` planned) for comic panel generation.
+- **OpenAI `tts-1-hd`** (`pipeline/v2/tts.py`) for narration voiceover.
+
+Hard Constraint #2 (CLAUDE.md) reads: "No cloud except: Anthropic Claude API + NeonDB
+(Doppler-managed secrets)." Read literally, calling OpenAI Images or OpenAI TTS
+violates this. The constraint exists to bound the runtime attack surface, the data-residency
+surface, and the vendor-lock-in surface for the *product* — the diagnostic platform that
+ships to industrial customers.
+
+That constraint is correct for the product. It is over-broad for marketing tooling.
+
+Two factual observations forced an explicit decision:
+
+**1. Anthropic does not ship an image generation model.** As of 2026-04, there is no
+Claude equivalent of gpt-image-1 / DALL-E 3. Replacements (Stable Diffusion via Replicate,
+Flux via fal.ai, Midjourney) are *also* cloud and *also* outside Constraint #2. There
+is no on-prem Apache/MIT image model that produces magazine-quality comic panels at
+1536×1024 in one call. The choice is "use a cloud image vendor" or "do not generate
+panels at all."
+
+**2. The comic-pipeline does not touch product runtime.** It is a build-time tool that
+produces an MP4. The MP4 is uploaded to YouTube. The pipeline never runs on the VPS,
+never appears in the chat path (`Open WebUI → mira-pipeline → GSDEngine → Anthropic`),
+never sees customer PII, and is not part of any service users connect to. The blast
+radius of an OpenAI outage on this code is "no new marketing video this week," not
+"customer diagnostics down."
+
+---
+
+## Decision
+
+**OpenAI is permitted in `marketing/` and `tools/` for image generation and TTS only.**
+**OpenAI remains forbidden in any product runtime path.**
+
+### What is allowed
+
+| Path | Purpose | Models |
+|------|---------|--------|
+| `marketing/comic-pipeline/` | Comic explainer videos | `gpt-image-1`, `tts-1-hd` |
+| `tools/seedance-video-gen.py` | Text-to-video marketing | (model TBD per Seedance ADR) |
+| `tools/linkedin_drafter/` | Marketing copy assist | (allowed if scoped) |
+| Future `marketing/*` pipelines | YouTube/LinkedIn/X content | image, audio, video models only |
+
+### What is not allowed
+
+| Path | Reason |
+|------|--------|
+| `mira-pipeline/` | Active VPS chat path; Anthropic-only per constraint |
+| `mira-bots/` | Customer-facing diagnostic adapters |
+| `mira-mcp/` | NeonDB recall + equipment tools |
+| `mira-web/` | PLG funnel; user-PII path |
+| `mira-core/` | Open WebUI host |
+| `mira-cmms/` | Atlas CMMS, work orders |
+| `mira-bridge/` | Node-RED orchestration |
+| `mira-ingest/` | Document ingest path |
+| Anything else under `mira-*/` | Product runtime — covered by Constraint #2 |
+
+### Boundary enforcement
+
+1. The marketing pipeline imports `from openai import OpenAI`. Any non-marketing module
+   that does the same is a constraint violation and should fail code review.
+2. Add a CI check (`scripts/check-openai-import.sh`) that greps non-marketing paths
+   for `import openai` / `from openai`. Fail the build on hits outside the allowlist.
+3. The marketing pipeline reads `OPENAI_API_KEY` from Doppler `factorylm/prd`. The
+   key is restricted by OpenAI's project-level usage limits to a marketing budget cap.
+
+### Data flow
+
+The marketing pipeline never receives:
+
+- Customer queries, fault data, or any data from `mira-pipeline` / `mira-bots`.
+- NeonDB rows.
+- Doppler secrets other than `OPENAI_API_KEY`.
+
+It reads from:
+
+- `marketing/comic-pipeline/scripts/storyboard_v2.yaml` (committed in repo, no PII).
+- `marketing/comic-pipeline/reference/*.png` (committed in repo, no PII).
+- `marketing/references/*.png` (cross-pipeline reference assets).
+
+It writes to:
+
+- `marketing/comic-pipeline/output/` (gitignored, build artefacts).
+- `marketing/videos/` (final MP4s, gitignored).
+- `marketing/videos/spend.json` (cost log).
+
+---
+
+## Rationale
+
+| Criterion | Allow OpenAI in marketing | Force on-prem image model |
+|-----------|---------------------------|---------------------------|
+| Quality at 1536×1024 comic panels | gpt-image-1 produces shippable output | SDXL / Flux: usable for stills, struggles on multi-character scenes with consistent style |
+| Engineering cost | Existing pipeline already integrates OpenAI; ~0 changes | Stand up GPU host, fine-tune LoRA, retrain when characters change |
+| Recurring run cost | ~$0.10 per panel at high quality, 5–10 panels per video | Fixed GPU host cost (~$200–500/mo) regardless of usage |
+| Throughput | Bottlenecked by OpenAI rate limit (≥50 RPM) | Bottlenecked by single GPU |
+| Aligns with Constraint #2 (literal) | ✗ requires this carve-out ADR | ✓ |
+| Aligns with Constraint #2 *intent* (product attack surface) | ✓ marketing is not the product | ✓ |
+| Reversibility | Swap module if Anthropic ships image model in 2026 | Hard reversal — model artefacts, training pipeline |
+
+The constraint's intent is to keep customer diagnostic data inside Anthropic + NeonDB.
+Marketing pipelines do not touch customer diagnostic data. The carve-out preserves
+intent while admitting the practical reality that no equivalent on-prem model exists
+in 2026 for the comic-panel use case.
+
+---
+
+## Consequences
+
+**Positive:**
+
+- Marketing pipeline ships without architectural contortion.
+- Constraint #2 is preserved for the runtime path, where it actually matters.
+- New marketing pipelines in `marketing/` inherit a clear, audited approval.
+
+**Negative / risks:**
+
+- Constraint #2 is now nuanced. New contributors may apply it inconsistently. Mitigation:
+  the CI grep check (item 2 above) makes the boundary mechanical, not judgmental.
+- OpenAI rate limits or API outages can stall a marketing release. Acceptable — marketing
+  is not on the customer critical path.
+- OpenAI usage cost can drift if storyboard length grows. Mitigation: existing dry-run
+  cost report in `run_pipeline.py --dry-run` already exposes the $ before each build.
+
+**Deferred:**
+
+- If Anthropic ships an image model in 2026, revisit this ADR — first action would be
+  swapping `pipeline/generate_panels.py` to a thin Anthropic adapter; same prompt schema.
+- Migration to Replicate / fal.ai (Flux, SDXL) is a fallback option if OpenAI raises
+  prices significantly. The carve-out covers any non-Anthropic image vendor; not
+  OpenAI-specific.
+
+---
+
+## References
+
+- CLAUDE.md Hard Constraint #2: cloud-vendor allowlist
+- CLAUDE.md Hard Constraint #3: no frameworks that abstract the Claude API call
+- `marketing/comic-pipeline/README.md` — pipeline overview
+- `marketing/comic-pipeline/pipeline/generate_panels.py` — current OpenAI integration
+- `marketing/comic-pipeline/pipeline/v2/tts.py` — current OpenAI TTS integration
+- ADR-0011 — precedent for explicit "no framework" decisions tied to Constraint #3

--- a/marketing/comic-pipeline/build_video_v2.py
+++ b/marketing/comic-pipeline/build_video_v2.py
@@ -33,6 +33,8 @@ PROJECT_ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from pipeline.v2 import audio as v2_audio
+from pipeline.v2 import metadata as v2_metadata
+from pipeline.v2 import panels as v2_panels
 from pipeline.v2 import render as v2_render
 from pipeline.v2 import tts as v2_tts
 from pipeline.v2 import verify as v2_verify
@@ -95,6 +97,10 @@ def main() -> int:
                         help="reuse cached beat clips (visual debug)")
     parser.add_argument("--skip-verify", action="store_true",
                         help="skip the post-build Playwright verification pass")
+    parser.add_argument("--regen-panels", action="store_true",
+                        help="force-regenerate shot source images via gpt-image-1 "
+                             "(otherwise cached output/v2/sources/ are reused; "
+                             "default falls back to legacy reference/<file>.png)")
     args = parser.parse_args()
 
     storyboard = yaml.safe_load(STORYBOARD_PATH.read_text())
@@ -116,9 +122,27 @@ def main() -> int:
         f"(elapsed {time.time()-t0:.1f}s)"
     )
 
+    # ── Stage 1.5: generate (or cache) shot source images via gpt-image-1 ─
+    # Opt-in only: --regen-panels triggers OpenAI calls. Default path uses
+    # cached output/v2/sources/<id>.png if present, else legacy reference/<file>.
+    console.rule("[bold]1.5/6 Shot sources (gpt-image-1)")
+
+    def _panel_progress(shot_id, path, *, mode, skipped):
+        tag_color = {"cache": "yellow", "legacy": "blue", "generated": "green"}[mode]
+        tag = f"[{tag_color}]{mode}[/{tag_color}]"
+        console.print(f"  [shot {shot_id}] {tag} {path.name}")
+
+    sources_dir = WORK_ROOT / "sources"
+    source_images = v2_panels.generate_shot_sources(
+        storyboard=storyboard,
+        reference_dir=REF_DIR,
+        out_dir=sources_dir,
+        force_regen=args.regen_panels,
+        progress_cb=_panel_progress,
+    )
+
     # ── Stage 2: pre-render canvas PNGs (letterbox to 1920x1080) ─────────
     console.rule("[bold]2/6 Letterbox canvas")
-    source_images = {shot["id"]: REF_DIR / shot["file"] for shot in storyboard["shots"]}
     canvas_dir = WORK_ROOT / "canvas"
     canvases = v2_render.canvas_pre_render(source_images=source_images, out_dir=canvas_dir)
     console.print(f"  [green]ok[/green] {len(canvases)} canvases")
@@ -240,6 +264,21 @@ def main() -> int:
     table.add_row("pivot at", f"{pivot_seconds:.1f}s")
     table.add_row("elapsed", f"{time.time()-t0:.1f}s")
     console.print(table)
+
+    # ── Stage 6.5: Emit YouTube + GEO metadata bundle ────────────────────
+    # Pure transformation of the manifest + storyboard — no API calls.
+    # Produces transcript.srt, transcript.md, youtube_description.md,
+    # schema_video_object.jsonld, llms_entry.md.
+    console.rule("[bold]6.5/7 Metadata bundle (SEO + GEO)")
+    metadata_dir = WORK_ROOT / "metadata"
+    artifacts = v2_metadata.emit_metadata_bundle(
+        manifest_path=WORK_ROOT / "build_manifest.json",
+        storyboard=storyboard,
+        final_video_path=final_path,
+        out_dir=metadata_dir,
+    )
+    for name, path in artifacts.items():
+        console.print(f"  [green]ok[/green] {name} -> {path.name}")
 
     # ── Stage 7 (optional): Playwright-driven verification ───────────────
     if args.skip_verify:

--- a/marketing/comic-pipeline/pipeline/v2/metadata.py
+++ b/marketing/comic-pipeline/pipeline/v2/metadata.py
@@ -1,0 +1,401 @@
+"""
+SEO + GEO metadata generation for comic-pipeline v2.
+
+After the final mp4 is built, this module emits the full bundle of artifacts
+that drive YouTube ranking AND LLM citation pickup:
+
+  output/v2/metadata/
+    transcript.srt              — sidecar caption file (upload to YouTube)
+    transcript.md               — human + LLM readable Markdown transcript
+    youtube_description.md      — title + description with timestamped chapters,
+                                  pinned-comment block, hashtag tail
+    schema_video_object.jsonld  — VideoObject + HowTo + FAQPage JSON-LD for the
+                                  /diagnostics/<slug>/ landing page on
+                                  factorylm.com
+    llms_entry.md               — paste-into-llms.txt block for the brand's
+                                  llms.txt root file
+
+Why these specific artifacts (per 2026 GEO research, Adweek/eMarketer):
+  - YouTube transcripts overtook Reddit as the #1 social citation source in
+    LLM answers in early 2026 (16% vs 10%).
+  - Clean, accurate transcripts are HOW LLMs read videos (auto-captions are
+    mediocre — we generate from the per-beat manifest which has perfect text).
+  - Schema markup (VideoObject + HowTo + FAQPage) drives 2.5× more AI
+    citations than prose alone.
+  - llms.txt at site root is Anthropic-endorsed (Nov 2024) and respected by
+    GPTBot/ClaudeBot/PerplexityBot during inference.
+
+This module reads only the build_manifest.json + storyboard. It does not call
+any LLM or external service — pure transformation.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("comic.v2.metadata")
+
+
+# ─── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _slugify(text: str) -> str:
+    s = re.sub(r"[^\w\s-]", "", text.lower()).strip()
+    return re.sub(r"[\s_-]+", "-", s)[:60]
+
+
+def _seconds_to_srt_time(seconds: float) -> str:
+    """0.0 → '00:00:00,000', 92.0 → '00:01:32,000'."""
+    if seconds < 0:
+        seconds = 0
+    h = int(seconds // 3600)
+    m = int((seconds % 3600) // 60)
+    s = int(seconds % 60)
+    ms = int(round((seconds - int(seconds)) * 1000))
+    if ms == 1000:
+        ms = 0
+        s += 1
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def _seconds_to_chapter_time(seconds: float) -> str:
+    """0.0 → '0:00', 92.0 → '1:32'."""
+    m = int(seconds // 60)
+    s = int(seconds % 60)
+    return f"{m}:{s:02d}"
+
+
+@dataclass
+class BeatTiming:
+    shot_id: int
+    beat_index: int
+    text: str
+    start: float
+    end: float
+    pause: float
+
+
+def _walk_beats(manifest: dict[str, Any]) -> list[BeatTiming]:
+    """Walk manifest['beats'] in storyboard order, computing absolute start/end."""
+    out: list[BeatTiming] = []
+    pauses = manifest.get("pauses", [])
+    cursor = 0.0
+    for i, b in enumerate(manifest["beats"]):
+        dur = float(b["duration"])
+        pause = float(pauses[i]) if i < len(pauses) else 0.0
+        out.append(BeatTiming(
+            shot_id=int(b["shot_id"]),
+            beat_index=int(b["beat_index"]),
+            text=str(b["text"]),
+            start=cursor,
+            end=cursor + dur,
+            pause=pause,
+        ))
+        cursor += dur + pause
+    return out
+
+
+# ─── transcript builders ──────────────────────────────────────────────────────
+
+
+def build_srt(timings: list[BeatTiming]) -> str:
+    """Emit standard SRT — one cue per beat, gap-free timing."""
+    lines: list[str] = []
+    for n, t in enumerate(timings, start=1):
+        lines.append(str(n))
+        lines.append(f"{_seconds_to_srt_time(t.start)} --> {_seconds_to_srt_time(t.end)}")
+        lines.append(t.text)
+        lines.append("")
+    return "\n".join(lines)
+
+
+def build_transcript_md(timings: list[BeatTiming], *, title: str) -> str:
+    """Emit a paragraph-style Markdown transcript with shot headers."""
+    lines = [f"# {title} — Transcript", ""]
+    current_shot: int | None = None
+    paragraph: list[str] = []
+    for t in timings:
+        if t.shot_id != current_shot:
+            if paragraph:
+                lines.append(" ".join(paragraph))
+                lines.append("")
+                paragraph = []
+            lines.append(f"## Shot {t.shot_id}")
+            lines.append("")
+            current_shot = t.shot_id
+        paragraph.append(t.text)
+    if paragraph:
+        lines.append(" ".join(paragraph))
+        lines.append("")
+    return "\n".join(lines)
+
+
+# ─── YouTube description ──────────────────────────────────────────────────────
+
+
+def build_youtube_description(
+    *,
+    storyboard: dict[str, Any],
+    timings: list[BeatTiming],
+    landing_url: str,
+    cta_short: str,
+) -> str:
+    """The first 100 chars are the SEO/GEO answer; chapters at shot starts."""
+    title = storyboard.get("title", "MIRA Explainer")
+    # The first paragraph IS the GEO answer — direct, fact-dense, &lt; 100 words.
+    tldr = (
+        "How modern industrial maintenance teams cut conveyor downtime from "
+        "21 minutes to 6 minutes using AI fault diagnosis. One shift tech, "
+        "one tablet, the whole org on the same page in under 90 seconds. "
+        f"Watch the workflow → {landing_url}"
+    )
+
+    # Chapters: one per shot start.
+    chapters: list[str] = ["00:00 Cold open"]
+    seen: set[int] = set()
+    for t in timings:
+        if t.shot_id in seen:
+            continue
+        seen.add(t.shot_id)
+        # Shot 1 already covered by 00:00. Skip the duplicate.
+        if t.start == 0.0:
+            continue
+        shot = next(s for s in storyboard["shots"] if int(s["id"]) == t.shot_id)
+        role = shot.get("role", f"Shot {t.shot_id}")
+        chapters.append(f"{_seconds_to_chapter_time(t.start)} {role}")
+
+    pinned_block = (
+        "📌 PINNED COMMENT — full script + diagnostic checklist:\n"
+        "(Pin this comment after publishing. It boosts engagement signal AND "
+        "gives LLMs structured text to cite — pinned-comment text is in "
+        "every LLM-citation-eligible YouTube transcript snapshot.)"
+    )
+
+    hashtags = "#MIRA #FactoryLM #IndustrialAI #PLC #VFD #CMMS #PredictiveMaintenance"
+
+    parts = [
+        title,
+        "",
+        tldr,
+        "",
+        "▶ CHAPTERS",
+        *chapters,
+        "",
+        cta_short,
+        "",
+        f"More: {landing_url}",
+        "",
+        "─" * 40,
+        "",
+        pinned_block,
+        "",
+        hashtags,
+    ]
+    return "\n".join(parts)
+
+
+# ─── Schema.org JSON-LD ───────────────────────────────────────────────────────
+
+
+def build_schema_jsonld(
+    *,
+    storyboard: dict[str, Any],
+    timings: list[BeatTiming],
+    transcript_md: str,
+    final_video_url: str,
+    landing_url: str,
+    duration_seconds: float,
+    upload_date_iso: str,
+) -> dict[str, Any]:
+    """VideoObject + HowTo + FAQPage as a @graph."""
+    title = storyboard.get("title", "MIRA Explainer")
+
+    # Build HowTo steps from shot roles.
+    steps = []
+    for shot in storyboard["shots"]:
+        role = shot.get("role", f"Shot {shot['id']}")
+        steps.append({
+            "@type": "HowToStep",
+            "name": f"Step {shot['id']}: {role}",
+            "text": role,
+        })
+
+    # FAQ: industrial-niche queries this video answers.
+    faqs = [
+        {
+            "@type": "Question",
+            "name": "How fast can a fault on a conveyor line be diagnosed?",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": (
+                    "Using AI-assisted diagnosis tied to fault history, a typical "
+                    "cryptic fault code can move from detection to recommended "
+                    "fix in under 90 seconds — versus a 20+ minute manual binder "
+                    "search shown in the comparison."
+                ),
+            },
+        },
+        {
+            "@type": "Question",
+            "name": "What does an AI maintenance assistant actually do?",
+            "acceptedAnswer": {
+                "@type": "Answer",
+                "text": (
+                    "It interprets the fault code, looks up that code's history "
+                    "across every prior occurrence, cites the relevant OEM "
+                    "documentation, and surfaces the recommended action — all "
+                    "in the technician's chat client, not a separate CMMS tab."
+                ),
+            },
+        },
+    ]
+
+    # ISO 8601 duration: PT1M32S
+    h = int(duration_seconds // 3600)
+    m = int((duration_seconds % 3600) // 60)
+    s = int(duration_seconds % 60)
+    iso_dur = "PT" + (f"{h}H" if h else "") + (f"{m}M" if m else "") + f"{s}S"
+
+    return {
+        "@context": "https://schema.org",
+        "@graph": [
+            {
+                "@type": "VideoObject",
+                "name": title,
+                "description": (
+                    "How modern industrial maintenance teams cut conveyor "
+                    "downtime from 21 minutes to 6 minutes using AI fault "
+                    "diagnosis."
+                ),
+                "thumbnailUrl": f"{landing_url}/thumbnail.jpg",
+                "uploadDate": upload_date_iso,
+                "duration": iso_dur,
+                "contentUrl": final_video_url,
+                "embedUrl": final_video_url,
+                "publisher": {
+                    "@type": "Organization",
+                    "name": "FactoryLM",
+                    "logo": {
+                        "@type": "ImageObject",
+                        "url": "https://factorylm.com/logo.png",
+                    },
+                },
+                "transcript": transcript_md,
+            },
+            {
+                "@type": "HowTo",
+                "name": f"How to: {title}",
+                "totalTime": iso_dur,
+                "step": steps,
+            },
+            {
+                "@type": "FAQPage",
+                "mainEntity": faqs,
+            },
+        ],
+    }
+
+
+# ─── llms.txt entry ───────────────────────────────────────────────────────────
+
+
+def build_llms_txt_entry(
+    *,
+    storyboard: dict[str, Any],
+    landing_url: str,
+    duration_seconds: float,
+) -> str:
+    """A paste-in block for the brand's site-root llms.txt file."""
+    title = storyboard.get("title", "MIRA Explainer")
+    m = int(duration_seconds // 60)
+    s = int(duration_seconds % 60)
+    return (
+        f"## {title} ({m}:{s:02d})\n"
+        f"- URL: {landing_url}\n"
+        f"- Type: explainer video + transcript\n"
+        f"- Audience: maintenance technicians, plant engineers, ops managers\n"
+        f"- Topic: AI-assisted industrial fault diagnosis, conveyor downtime\n"
+        f"- Key claim: 21-minute manual diagnosis → 6-minute AI-assisted "
+        f"diagnosis on the same fault code (1.SOC B16.2)\n"
+    )
+
+
+# ─── orchestration ────────────────────────────────────────────────────────────
+
+
+def emit_metadata_bundle(
+    *,
+    manifest_path: Path,
+    storyboard: dict[str, Any],
+    final_video_path: Path,
+    out_dir: Path,
+    landing_url: str = "https://factorylm.com/diagnostics/conveyor-fault-diagnosis",
+    final_video_url: str = "",
+    upload_date_iso: str = "",
+    cta_short: str = "Stop fighting your CMMS. Start knowing your plant. → factorylm.com",
+) -> dict[str, Path]:
+    """Read manifest + storyboard, emit every artifact under out_dir.
+
+    Returns {artifact_name: path}.
+    """
+    manifest = json.loads(manifest_path.read_text())
+    timings = _walk_beats(manifest)
+    duration = float(manifest.get("video_duration", 0.0))
+
+    if not final_video_url:
+        final_video_url = f"file://{final_video_path.resolve()}"
+    if not upload_date_iso:
+        from datetime import datetime, timezone
+        upload_date_iso = datetime.now(timezone.utc).date().isoformat()
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    artifacts: dict[str, Path] = {}
+
+    # 1. SRT transcript
+    srt_path = out_dir / "transcript.srt"
+    srt_path.write_text(build_srt(timings))
+    artifacts["transcript_srt"] = srt_path
+
+    # 2. Markdown transcript
+    md_path = out_dir / "transcript.md"
+    transcript_md = build_transcript_md(
+        timings, title=str(storyboard.get("title", "MIRA Explainer")),
+    )
+    md_path.write_text(transcript_md)
+    artifacts["transcript_md"] = md_path
+
+    # 3. YouTube description
+    desc_path = out_dir / "youtube_description.md"
+    desc_path.write_text(build_youtube_description(
+        storyboard=storyboard, timings=timings,
+        landing_url=landing_url, cta_short=cta_short,
+    ))
+    artifacts["youtube_description"] = desc_path
+
+    # 4. JSON-LD schema
+    schema_path = out_dir / "schema_video_object.jsonld"
+    schema = build_schema_jsonld(
+        storyboard=storyboard, timings=timings, transcript_md=transcript_md,
+        final_video_url=final_video_url, landing_url=landing_url,
+        duration_seconds=duration, upload_date_iso=upload_date_iso,
+    )
+    schema_path.write_text(json.dumps(schema, indent=2))
+    artifacts["schema_jsonld"] = schema_path
+
+    # 5. llms.txt entry
+    llms_path = out_dir / "llms_entry.md"
+    llms_path.write_text(build_llms_txt_entry(
+        storyboard=storyboard, landing_url=landing_url,
+        duration_seconds=duration,
+    ))
+    artifacts["llms_entry"] = llms_path
+
+    logger.info(
+        "[metadata] emitted %d artifacts to %s",
+        len(artifacts), out_dir.resolve(),
+    )
+    return artifacts

--- a/marketing/comic-pipeline/pipeline/v2/panel_score.py
+++ b/marketing/comic-pipeline/pipeline/v2/panel_score.py
@@ -1,0 +1,176 @@
+"""
+Panel-quality scoring for comic-pipeline v2.
+
+After `panels.generate_shot_sources()` produces n=2 candidates per shot, this
+module asks Claude (vision) to score each candidate against three criteria:
+    - character_match     : do named characters match anchor reference (1-10)
+    - style_match         : does style match the master_prompt (1-10)
+    - prompt_adherence    : does the panel actually depict what the prompt asks (1-10)
+
+The highest `overall` (= mean of the three) wins and is promoted to the
+canonical `shot_{id}.png` path. All candidate scores are persisted to
+`build_manifest.json` so a human can review without re-paying for scoring.
+
+Cost: claude-3-5-haiku-vision is ~$0.001 per candidate-image scored. For a
+full 5-shot × n=2 batch: ~$0.01. Negligible vs the ~$1.67 image-gen cost.
+
+We deliberately use Anthropic (not OpenAI gpt-4o-vision) for scoring to keep
+OpenAI usage in this pipeline narrowly scoped to image generation + TTS, per
+ADR-0013. Anthropic is the project's primary LLM provider regardless.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import anthropic
+
+logger = logging.getLogger("comic.v2.panel_score")
+
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"  # cheap, fast, vision-capable
+
+SCORE_RUBRIC = """\
+You are scoring a generated comic panel image against:
+  1. The supplied REFERENCE/ANCHOR image (which encodes the canonical
+     character likeness and visual style).
+  2. The supplied PROMPT (which describes what the panel should depict).
+
+Score each dimension 1-10 (10 = perfect, 5 = mediocre, 1 = unusable):
+
+  - character_match: Do named characters look like the anchor? (faces,
+    proportions, outfit, hair, glasses). Score 1 if anyone is unrecognizable
+    relative to the anchor; 10 if the same person is depicted in every panel
+    they appear in.
+  - style_match: Does line work, color palette, panel-border style match the
+    anchor's gritty-Vertigo-comic look?
+  - prompt_adherence: Does the image actually contain the elements the prompt
+    asked for (specific signs, screens, layouts, speech bubbles)?
+
+Return ONLY this JSON object, no preamble, no code fences:
+{"character_match": <int>, "style_match": <int>, "prompt_adherence": <int>, "notes": "<one sentence>"}\
+"""
+
+
+@dataclass
+class CandidateScore:
+    candidate_path: str
+    character_match: int
+    style_match: int
+    prompt_adherence: int
+    overall: float
+    notes: str
+
+
+def _b64_image(path: Path) -> dict[str, Any]:
+    """Encode an image file as a Claude vision content block."""
+    media_type = "image/png" if path.suffix.lower() == ".png" else "image/jpeg"
+    data = base64.standard_b64encode(path.read_bytes()).decode("ascii")
+    return {
+        "type": "image",
+        "source": {"type": "base64", "media_type": media_type, "data": data},
+    }
+
+
+def _parse_json_strict(raw: str) -> dict[str, Any]:
+    """Pull a single JSON object out of the response text, tolerating fences."""
+    # Tolerate ```json … ``` fences and surrounding chatter.
+    m = re.search(r"\{[^{}]*\}", raw, re.DOTALL)
+    if not m:
+        raise ValueError(f"no JSON object found in: {raw[:300]}")
+    return json.loads(m.group(0))
+
+
+def score_candidate(
+    client: anthropic.Anthropic,
+    *,
+    anchor_path: Path,
+    candidate_path: Path,
+    prompt: str,
+    model: str = DEFAULT_MODEL,
+) -> CandidateScore:
+    """Score one candidate image vs an anchor + prompt, return CandidateScore."""
+    content: list[dict[str, Any]] = [
+        {"type": "text", "text": "ANCHOR (reference style + characters):"},
+        _b64_image(anchor_path),
+        {"type": "text", "text": "CANDIDATE (the panel to score):"},
+        _b64_image(candidate_path),
+        {"type": "text", "text": f"PROMPT FOR THE PANEL:\n{prompt}"},
+        {"type": "text", "text": SCORE_RUBRIC},
+    ]
+    message = client.messages.create(
+        model=model,
+        max_tokens=300,
+        messages=[{"role": "user", "content": content}],
+    )
+    raw = "".join(b.text for b in message.content if getattr(b, "type", None) == "text")
+    parsed = _parse_json_strict(raw)
+    cm = int(parsed.get("character_match", 0))
+    sm = int(parsed.get("style_match", 0))
+    pa = int(parsed.get("prompt_adherence", 0))
+    return CandidateScore(
+        candidate_path=str(candidate_path),
+        character_match=cm,
+        style_match=sm,
+        prompt_adherence=pa,
+        overall=round((cm + sm + pa) / 3.0, 2),
+        notes=str(parsed.get("notes", ""))[:240],
+    )
+
+
+def score_and_pick_best(
+    *,
+    anchor_path: Path,
+    candidate_paths: list[Path],
+    prompt: str,
+    model: str = DEFAULT_MODEL,
+) -> tuple[Path, list[CandidateScore]]:
+    """Score every candidate, return (winner_path, all_scores).
+
+    Picks the candidate with the highest `overall`. Caller decides whether
+    `overall` is high enough to accept or whether to trigger a regen.
+    """
+    if not candidate_paths:
+        raise ValueError("score_and_pick_best needs at least one candidate")
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "ANTHROPIC_API_KEY not set — run under "
+            "`doppler run --project factorylm --config prd -- ...`"
+        )
+    client = anthropic.Anthropic(api_key=api_key)
+
+    scores: list[CandidateScore] = []
+    for cp in candidate_paths:
+        try:
+            s = score_candidate(
+                client, anchor_path=anchor_path, candidate_path=cp,
+                prompt=prompt, model=model,
+            )
+        except Exception as e:
+            logger.warning("scoring failed for %s: %s — assigning 0", cp.name, e)
+            s = CandidateScore(
+                candidate_path=str(cp),
+                character_match=0, style_match=0, prompt_adherence=0,
+                overall=0.0, notes=f"score error: {e}",
+            )
+        logger.info(
+            "[score] %s overall=%.2f (char=%d style=%d prompt=%d) %s",
+            cp.name, s.overall, s.character_match, s.style_match,
+            s.prompt_adherence, s.notes[:80],
+        )
+        scores.append(s)
+
+    winner_idx = max(range(len(scores)), key=lambda i: scores[i].overall)
+    return candidate_paths[winner_idx], scores
+
+
+def scores_as_jsonable(scores: list[CandidateScore]) -> list[dict[str, Any]]:
+    """For embedding in build_manifest.json."""
+    return [asdict(s) for s in scores]

--- a/marketing/comic-pipeline/pipeline/v2/panels.py
+++ b/marketing/comic-pipeline/pipeline/v2/panels.py
@@ -1,0 +1,288 @@
+"""
+Programmatic shot-source generation for comic-pipeline v2.
+
+Reads `storyboard_v2.yaml`'s `style_guide` + per-shot `generation.prompt` and
+calls OpenAI gpt-image-1 with the existing reference image(s) as anchors. The
+result is dropped into `output/v2/sources/shot_{id}.png` and downstream
+canvas/render stages keep working unchanged.
+
+If a shot has no `generation` block, falls back to the legacy
+`reference/<file>` path. This keeps the pipeline working for shots that
+haven't been migrated yet.
+
+Pattern follows OpenAI cookbook for character consistency:
+    1. Master style preamble restated verbatim every call.
+    2. Named-character invariants restated whenever a character appears.
+    3. images.edit() with reference anchor as the FIRST image in the array
+       (only the first input retains "extra richness in texture" per the
+       cookbook prompting guide).
+    4. input_fidelity="high" — single most important parameter for keeping
+       characters recognizable across panels.
+    5. n=2 — generate twice, downstream scorer (panel_score.py — TODO) picks
+       the best; for now we just write the first candidate to disk.
+
+Cost (gpt-image-1, 1536x1024, quality=high, n=2):
+    ~$0.30–0.40 per shot. Full 5-shot regen: ~$1.50–2.00.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import random
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from openai import APIError, OpenAI, RateLimitError
+
+logger = logging.getLogger("comic.v2.panels")
+
+
+def _sleep_backoff(attempt: int, base: float = 2.0) -> None:
+    delay = base * (2**attempt)
+    jitter = delay * random.uniform(-0.2, 0.2)
+    time.sleep(max(0.5, delay + jitter))
+
+
+def _detect_characters(prompt: str, characters: dict[str, str]) -> list[str]:
+    """Find which named characters are mentioned in the shot prompt."""
+    found: list[str] = []
+    for name in characters:
+        # word-boundary, case-insensitive match
+        if re.search(rf"\b{re.escape(name)}\b", prompt, re.IGNORECASE):
+            found.append(name)
+    return found
+
+
+def _compose_prompt(
+    *,
+    shot_prompt: str,
+    style_guide: dict[str, Any],
+) -> str:
+    """Build the full prompt: style preamble + character invariants + shot."""
+    parts: list[str] = [style_guide["master_prompt"].strip()]
+
+    characters = style_guide.get("characters", {})
+    used = _detect_characters(shot_prompt, characters)
+    if used:
+        parts.append("Character invariants — keep these EXACTLY consistent:")
+        for name in used:
+            parts.append(f"- {name.upper()}: {characters[name].strip()}")
+
+    parts.append("Scene:")
+    parts.append(shot_prompt.strip())
+    return "\n\n".join(parts)
+
+
+def _resolve_anchors(
+    *,
+    shot: dict[str, Any],
+    reference_dir: Path,
+) -> list[Path]:
+    """Resolve generation.reference_anchors to absolute paths that exist."""
+    gen = shot.get("generation") or {}
+    raw = gen.get("reference_anchors") or []
+    out: list[Path] = []
+    for rel in raw:
+        p = (reference_dir / rel).expanduser().resolve()
+        if p.exists():
+            out.append(p)
+        else:
+            logger.warning("Reference anchor missing, skipping: %s", p)
+    return out
+
+
+def _generate_one(
+    client: OpenAI,
+    *,
+    prompt: str,
+    anchors: list[Path],
+    model: str,
+    size: str,
+    quality: str,
+    n: int,
+    input_fidelity: str,
+    max_retries: int,
+) -> list[bytes]:
+    """Return raw PNG bytes for n candidate panels for one shot."""
+    last_err: Exception | None = None
+    for attempt in range(max_retries):
+        try:
+            kwargs: dict[str, Any] = dict(
+                model=model,
+                prompt=prompt,
+                size=size,
+                quality=quality,
+                n=n,
+                output_format="png",
+            )
+            # input_fidelity is only valid on edit endpoint and only when at
+            # least one reference image is supplied.
+            if anchors:
+                kwargs["input_fidelity"] = input_fidelity
+                handles = [open(p, "rb") for p in anchors]
+                try:
+                    response = client.images.edit(image=handles, **kwargs)
+                finally:
+                    for h in handles:
+                        h.close()
+            else:
+                response = client.images.generate(**kwargs)
+
+            out: list[bytes] = []
+            for item in response.data:
+                if not item.b64_json:
+                    raise RuntimeError("gpt-image returned empty b64_json")
+                out.append(base64.b64decode(item.b64_json))
+            return out
+        except RateLimitError as e:
+            last_err = e
+            logger.warning("Rate-limited (attempt %d/%d): %s", attempt + 1, max_retries, e)
+            _sleep_backoff(attempt)
+        except APIError as e:
+            last_err = e
+            logger.warning("APIError (attempt %d/%d): %s", attempt + 1, max_retries, e)
+            _sleep_backoff(attempt)
+    raise RuntimeError(f"shot generation failed after {max_retries} retries: {last_err}")
+
+
+def generate_shot_sources(
+    *,
+    storyboard: dict[str, Any],
+    reference_dir: Path,
+    out_dir: Path,
+    force_regen: bool = False,
+    progress_cb=None,
+) -> dict[int, Path]:
+    """For each shot, return the path to its source image.
+
+    - Shot has `generation.prompt`: regenerate (or use cache) via gpt-image-1.
+    - Shot has no `generation`: fall back to `reference_dir / shot["file"]`.
+
+    Returns {shot_id: Path}. Caller passes this dict downstream to
+    canvas_pre_render() in place of the old hardcoded {id: REF_DIR/file}.
+    """
+    style_guide = storyboard.get("style_guide") or {}
+    defaults = style_guide.get("generation_defaults") or {}
+    model = defaults.get("model", "gpt-image-1")
+    quality = defaults.get("quality", "high")
+    size = defaults.get("size", "1536x1024")
+    n = int(defaults.get("n", 2))
+    input_fidelity = defaults.get("input_fidelity", "high")
+    max_retries = int(defaults.get("max_retries", 5))
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # OpenAI client is lazy — only construct if we'll actually call the API.
+    client: OpenAI | None = None
+
+    sources: dict[int, Path] = {}
+    for shot in storyboard["shots"]:
+        shot_id = int(shot["id"])
+        gen = shot.get("generation")
+        cache_path = out_dir / f"shot_{shot_id}.png"
+
+        # Resolution rules (opt-in to API spend):
+        #   1. Cache hit → use it (regardless of force_regen … unless force_regen).
+        #   2. force_regen=True → call API, overwrite cache.
+        #   3. No cache, no force_regen → fall back to legacy `file:`.
+        # This means ordinary `--skip-render`/`--skip-tts` builds NEVER hit the
+        # OpenAI image API. Generation only fires when --regen-panels is set.
+
+        if cache_path.exists() and cache_path.stat().st_size > 0 and not force_regen:
+            sources[shot_id] = cache_path
+            logger.info("[panels] cache hit shot %d -> %s", shot_id, cache_path.name)
+            if progress_cb:
+                progress_cb(shot_id, cache_path, mode="cache", skipped=True)
+            continue
+
+        if not force_regen or not (gen and gen.get("prompt")):
+            # Either no generation prompt available, or user did not pass
+            # --regen-panels. Use whatever was on disk before.
+            legacy = (reference_dir / shot["file"]).expanduser().resolve()
+            if not legacy.exists():
+                raise RuntimeError(
+                    f"shot {shot_id}: no cached gen, no --regen-panels, and "
+                    f"legacy file is missing at {legacy}"
+                )
+            sources[shot_id] = legacy
+            if progress_cb:
+                progress_cb(shot_id, legacy, mode="legacy", skipped=True)
+            continue
+
+        if client is None:
+            api_key = os.environ.get("OPENAI_API_KEY")
+            if not api_key:
+                raise RuntimeError(
+                    "OPENAI_API_KEY not set — run under "
+                    "`doppler run --project factorylm --config prd -- ...`"
+                )
+            client = OpenAI(api_key=api_key)
+
+        full_prompt = _compose_prompt(
+            shot_prompt=gen["prompt"], style_guide=style_guide,
+        )
+        anchors = _resolve_anchors(shot=shot, reference_dir=reference_dir)
+
+        logger.info(
+            "[panels] generating shot %d (anchors=%d, n=%d, q=%s)",
+            shot_id, len(anchors), n, quality,
+        )
+        candidates = _generate_one(
+            client,
+            prompt=full_prompt,
+            anchors=anchors,
+            model=model,
+            size=size,
+            quality=quality,
+            n=n,
+            input_fidelity=input_fidelity,
+            max_retries=max_retries,
+        )
+
+        # Write all candidates to disk so a human can review them.
+        candidates_dir = out_dir / "candidates" / f"shot_{shot_id}"
+        candidates_dir.mkdir(parents=True, exist_ok=True)
+        candidate_paths: list[Path] = []
+        for i, png in enumerate(candidates):
+            cp = candidates_dir / f"candidate_{i}.png"
+            cp.write_bytes(png)
+            candidate_paths.append(cp)
+
+        # Score with Claude vision and promote the highest-scoring candidate
+        # to the canonical shot_{id}.png. Scoring failures are non-fatal —
+        # we just default to candidate 0.
+        winner_path = candidate_paths[0]
+        scores_jsonable: list[dict[str, Any]] = []
+        if len(candidate_paths) > 1 and anchors:
+            try:
+                # Lazy import: only pulls anthropic if we actually need it.
+                from . import panel_score as v2_score
+                winner_path, scores = v2_score.score_and_pick_best(
+                    anchor_path=anchors[0],
+                    candidate_paths=candidate_paths,
+                    prompt=full_prompt,
+                )
+                scores_jsonable = v2_score.scores_as_jsonable(scores)
+                logger.info(
+                    "[panels] shot %d winner: %s (overall=%.2f)",
+                    shot_id, winner_path.name,
+                    next(s["overall"] for s in scores_jsonable
+                         if s["candidate_path"] == str(winner_path)),
+                )
+            except Exception as e:
+                logger.warning("scoring failed for shot %d, using candidate 0: %s", shot_id, e)
+
+        cache_path.write_bytes(winner_path.read_bytes())
+        # Persist scores alongside the canonical PNG for review.
+        if scores_jsonable:
+            (out_dir / f"shot_{shot_id}_scores.json").write_text(
+                __import__("json").dumps(scores_jsonable, indent=2)
+            )
+        sources[shot_id] = cache_path
+        if progress_cb:
+            progress_cb(shot_id, cache_path, mode="generated", skipped=False)
+
+    return sources

--- a/marketing/comic-pipeline/requirements.txt
+++ b/marketing/comic-pipeline/requirements.txt
@@ -3,9 +3,13 @@
 # (Python 3.12, per mira repo standard — uses httpx/ruff, not requests/pylint.)
 
 openai>=1.50.0          # gpt-image-1 + tts-1-hd
+anthropic>=0.40.0       # Claude vision for panel-quality scoring (ADR-0013)
 ffmpeg-python>=0.2.0    # thin wrapper over ffmpeg CLI (subprocess still used)
 pyyaml>=6.0             # always call yaml.safe_load(), never yaml.load()
 rich>=13.7              # progress UI + cost tables
 httpx>=0.27             # mira standard HTTP client (not requests)
 pillow>=11.0            # source image dimension probing
 playwright>=1.40        # v2 verification: real-browser playback check
+google-api-python-client>=2.140  # YouTube Data API v3 upload
+google-auth-oauthlib>=1.2        # OAuth flow for YouTube upload
+google-auth-httplib2>=0.2        # transport for google-api-python-client

--- a/marketing/comic-pipeline/scripts/generate_anchors.py
+++ b/marketing/comic-pipeline/scripts/generate_anchors.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+Generate canonical character anchor turnaround sheets for the comic pipeline.
+
+Anchors are the foundation of cross-panel character consistency. Per OpenAI's
+gpt-image-1.5 cookbook (2026): generate ONE character anchor (front + side +
+back-3/4, neutral expression, full outfit, palette swatch). Then in every
+subsequent panel call, pass the anchor as the FIRST image in the array with
+`input_fidelity="high"`. That single trick is the difference between
+"kinda the same person" and "recognizably the same person across 20+ panels."
+
+This script reads the 5 named characters from `style_guide.characters` in
+storyboard_v2.yaml and emits one anchor PNG per character to:
+    reference/anchors/<name>.png
+
+Cost (gpt-image-1, 1024x1024 quality=high, n=1):
+    ~$0.17 per character × 5 characters ≈ $0.85 total.
+
+Usage:
+    doppler run --project factorylm --config prd -- \\
+        .venv/bin/python scripts/generate_anchors.py [--regen]
+
+  Without --regen, characters whose anchor PNG already exists are skipped.
+
+After generation, REVIEW each anchor by eye. If a character looks wrong, just
+delete that one anchor and re-run with --regen — the others won't be touched.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import logging
+import os
+import sys
+from pathlib import Path
+
+import yaml
+from openai import OpenAI
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+STORYBOARD_PATH = PROJECT_ROOT / "scripts" / "storyboard_v2.yaml"
+ANCHOR_DIR = PROJECT_ROOT / "reference" / "anchors"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("generate-anchors")
+
+
+ANCHOR_PROMPT_TEMPLATE = """\
+Character anchor / turnaround sheet for a serialized industrial comic book.
+SINGLE flat layout image showing ONE character three times across the frame:
+left third — front view (full body, neutral standing pose, neutral expression),
+center third — three-quarter side view (same character, same outfit, same
+proportions), right third — back-three-quarter view. Below the three views, a
+small horizontal palette swatch row of the character's primary colors.
+
+CHARACTER:
+{description}
+
+STYLE: gritty 1990s Vertigo-comic ink + flat color, dark steel blue + amber +
+high-contrast black palette, dramatic chiaroscuro lighting on face, NOT
+cartoon, NOT superhero. Plain mid-grey background, no scene, no props, no
+speech bubbles, no panel borders. The image should look like a model sheet a
+production artist would tape to the wall — clean, reference-quality.
+"""
+
+
+def _gen_anchor(client: OpenAI, *, character_name: str, description: str, out_path: Path) -> None:
+    prompt = ANCHOR_PROMPT_TEMPLATE.format(description=description.strip())
+    logger.info("[anchor] generating %s ...", character_name)
+    response = client.images.generate(
+        model="gpt-image-1",
+        prompt=prompt,
+        size="1024x1024",
+        quality="high",
+        n=1,
+        output_format="png",
+    )
+    b64 = response.data[0].b64_json
+    if not b64:
+        raise RuntimeError(f"empty b64_json for {character_name}")
+    out_path.write_bytes(base64.b64decode(b64))
+    logger.info("[anchor] wrote %s (%d bytes)", out_path, out_path.stat().st_size)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Generate character anchor PNGs")
+    p.add_argument("--regen", action="store_true",
+                   help="re-generate anchors that already exist on disk")
+    p.add_argument("--only", nargs="*",
+                   help="generate only these character names (default: all)")
+    p.add_argument("--dry-run", action="store_true",
+                   help="show what would be generated; no API calls")
+    args = p.parse_args()
+
+    storyboard = yaml.safe_load(STORYBOARD_PATH.read_text())
+    style_guide = storyboard.get("style_guide") or {}
+    characters: dict[str, str] = style_guide.get("characters") or {}
+    if not characters:
+        raise SystemExit("storyboard has no style_guide.characters block")
+
+    targets = [n for n in characters if not args.only or n in args.only]
+    if not targets:
+        raise SystemExit(f"no matching characters; available: {list(characters)}")
+
+    ANCHOR_DIR.mkdir(parents=True, exist_ok=True)
+
+    if args.dry_run:
+        print(f"[dry-run] would generate {len(targets)} anchors at {ANCHOR_DIR}:")
+        for name in targets:
+            out = ANCHOR_DIR / f"{name}.png"
+            status = "exists" if out.exists() else "missing"
+            print(f"  - {name}: {out.name} ({status})")
+        cost = 0.17 * sum(
+            1 for n in targets if args.regen or not (ANCHOR_DIR / f"{n}.png").exists()
+        )
+        print(f"  estimated cost: ${cost:.2f}")
+        return 0
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise SystemExit("OPENAI_API_KEY not set — run under `doppler run ...`")
+    client = OpenAI(api_key=api_key)
+
+    skipped = 0
+    generated = 0
+    for name in targets:
+        out_path = ANCHOR_DIR / f"{name}.png"
+        if out_path.exists() and not args.regen:
+            logger.info("[anchor] %s exists, skipping (pass --regen to overwrite)", name)
+            skipped += 1
+            continue
+        _gen_anchor(
+            client,
+            character_name=name,
+            description=characters[name],
+            out_path=out_path,
+        )
+        generated += 1
+
+    print(f"\n✅ Generated {generated}, skipped {skipped}, total {len(targets)} anchors")
+    print(f"   Inspect: open {ANCHOR_DIR}")
+    print(
+        "   To use anchors in shot generation, add their paths to each shot's\n"
+        "   `generation.reference_anchors:` list in scripts/storyboard_v2.yaml.\n"
+        "   The anchor for a named character should be the FIRST item — only\n"
+        "   the first ref image gets the high-fidelity treatment from the\n"
+        "   gpt-image-1 edit endpoint."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/marketing/comic-pipeline/scripts/storyboard_v2.yaml
+++ b/marketing/comic-pipeline/scripts/storyboard_v2.yaml
@@ -77,10 +77,62 @@ music:
     - shot_id: 4
       mood: resolution
 
+# Style + character invariants used by pipeline/v2/panels.py when generating
+# shot images programmatically via gpt-image-1.
+# When `generation.prompt` is set on a shot AND --regen-panels is passed,
+# panels.py renders that shot fresh. Otherwise (default), falls back to the
+# legacy `file:` reference image already on disk.
+# `master_prompt` is restated verbatim on every panel call (per OpenAI cookbook
+# pattern); `characters` is restated verbatim whenever a named character appears.
+style_guide:
+  master_prompt: |
+    Industrial comic book single-page layout. Gritty 1990s Vertigo aesthetic
+    — realistic characters, not cartoon, no superheroes. Dark steel blue +
+    amber + high-contrast black color palette with selective red warning
+    accents. Bold black comic panel borders. Documentary tone, dramatic
+    chiaroscuro lighting. Color and proportions consistent with the supplied
+    reference images.
+  characters:
+    rico: |
+      Floor tech, mid-30s, dark hair, glasses, navy blue coveralls with
+      white "RICO" name patch on chest. Slightly stocky build. Same face,
+      same outfit, same proportions across every panel he appears in.
+    deb: |
+      Shift supervisor, late-30s, short-cropped dark hair, glasses, slim
+      headset, plant-floor work jacket. Same face/proportions every panel.
+    marcus: |
+      Maintenance manager, 40s, dark complexion, thoughtful expression,
+      usually at a laptop in a maintenance office. Same face every panel.
+    elena: |
+      Engineering manager, 30s, remote — usually on a phone or laptop in an
+      office or home-office setting. Professional. Same face every panel.
+    holt: |
+      Director, senior, grey hair, dark suit jacket, calm authoritative
+      posture. Office or boardroom setting. Same face every panel.
+  generation_defaults:
+    model: gpt-image-1
+    quality: high                  # low | medium | high
+    size: 1536x1024                # landscape — best for comic pages
+    n: 2                           # generate 2, vision-score, pick best
+    input_fidelity: high           # critical for character consistency
+    output_format: png
+
 shots:
   - id: 1
     file: "ChatGPT Image Apr 24, 2026 at 02_05_37 PM.png"
     role: "Scene 1 title — fault detected on Line 5"
+    generation:
+      prompt: |
+        Wide overhead establishing shot of factory conveyor floor. Two parallel
+        conveyor lines visible: Line 4 still running on the left side, Line 5
+        stopped on the right. Top-right corner of the page: large red metal
+        warning sign reading "LINE 5 STOPPED" in bold sign-painter lettering.
+        Center-bottom: large industrial HMI control panel screen displaying
+        angry red text on black: "FAULT: 1.SOC B16.2 OCCUPIED TOO LONG".
+        Mid-foreground: Rico standing tense, looking up at the HMI. Workers
+        idle in background, arms crossed.
+      reference_anchors:
+        - "ChatGPT Image Apr 24, 2026 at 02_05_37 PM.png"
     beats:
       - text: "Day shift. Full house. Two conveyor lines."
         focal: {cx: 0.50, cy: 0.50, zoom: 1.0}     # wide establish (full image)
@@ -98,6 +150,22 @@ shots:
   - id: 2
     file: "ChatGPT Image Apr 24, 2026 at 02_11_45 PM.png"
     role: "Scene 1 frustration — Maximo is a graveyard"
+    generation:
+      prompt: |
+        Maintenance office interior, late afternoon, fluorescent overhead
+        lighting. Small window in the back wall showing the stopped Line 5
+        on the factory floor.
+        LEFT THIRD: Rico at a cluttered desk, head in hands, frustrated.
+        Coffee cup. Scattered papers. Same Rico as shot 1.
+        CENTER: legacy desktop monitor showing a Maximo CMMS interface —
+        corporate-blue 1990s UI, cramped dropdown menus, work-order list,
+        no useful information. Screen glow falling on Rico's face.
+        BOTTOM-LEFT: Battered paper binder on desk labeled "CONVEYOR MANUALS
+        2009", dog-eared pages, sticky notes, coffee stains, open to a faded
+        proximity-switch schematic.
+        Speech bubble from Rico: "The data is here. But it isn't."
+      reference_anchors:
+        - "ChatGPT Image Apr 24, 2026 at 02_11_45 PM.png"
     beats:
       - text: "Rico turns to Maximo. The CMMS that's supposed to have the answer."
         focal: {cx: 0.68, cy: 0.518, zoom: 1.6}    # Maximo screen
@@ -115,6 +183,27 @@ shots:
   - id: 3
     file: "ChatGPT Image Apr 24, 2026 at 02_22_55 PM.png"
     role: "Scene 1 pressure — clock running, leadership reacts"
+    generation:
+      prompt: |
+        Multi-panel comic page layout. Top banner + left wide panel + right
+        column of 4 character vignettes.
+        TOP BANNER (full page width, ~10% height): bold red sign-style text
+        "LINE 5 STOPPED — 21:03 ELAPSED" with a ticking analog wall clock
+        graphic to the right. Black background, red text.
+        LEFT 30% (vertical panel): Wide overhead of stopped conveyor floor,
+        Rico tiny in foreground, idle workers in background, time-pressure mood.
+        RIGHT 70%: 4 horizontal vignette panels stacked vertically, each
+        showing one character reacting:
+          - PANEL A (top): Deb on radio, brow furrowed, speech bubble:
+            "If this drags, they'll blame my shift."
+          - PANEL B: Marcus at laptop, downtime spreadsheet visible,
+            speech bubble: "Every minute is money. Every day, it's me."
+          - PANEL C: Elena on phone, looking offscreen frustrated,
+            speech bubble: "I can't see what my team can't see."
+          - PANEL D (bottom): Director Holt at office monitor, calmly serious,
+            speech bubble: "Customers don't care why. They care that we deliver."
+      reference_anchors:
+        - "ChatGPT Image Apr 24, 2026 at 02_22_55 PM.png"
     beats:
       - text: "Twenty-one minutes elapsed. The line is still down."
         focal: {cx: 0.394, cy: 0.05, zoom: 2.5}    # 21:03 ELAPSED sign
@@ -140,6 +229,25 @@ shots:
   - id: 4
     file: "ChatGPT Image Apr 24, 2026 at 11_53_02 AM.png"
     role: "Scene 2 pivot — Rico tries MIRA"
+    generation:
+      prompt: |
+        Multi-panel comic page, conveyor-floor setting. The mood pivots from
+        tension to focus.
+        TOP HALF (wide panel): Rico standing at a shift supervisor station,
+        confident posture, holding a tablet. Same Rico as earlier shots.
+        Conveyor visible behind him.
+        BOTTOM-LEFT panel: Close-up of MIRA app on the tablet — dark theme
+        UI with amber accents. Readable screen content:
+        "MIRA ALERT — Fault 1.SOC B16.2 — Proximity sensor Section B16
+        Station 2. History: 14 occurrences in 6 months. Recommended action:
+        Reset panel B16 — no parts required. Source: ENG-PL-4472 Rev C."
+        BOTTOM-RIGHT panel: Rico holding tablet at angle, expression shifting
+        from frustration to focus. Slack notification popping up on screen:
+        "Deb: Approved. Reset and log."
+        Style note: the MIRA app screens should be the only spots of clean
+        modern UI in an otherwise grimy industrial scene.
+      reference_anchors:
+        - "ChatGPT Image Apr 24, 2026 at 11_53_02 AM.png"
     beats:
       - text: "This time, Rico tries something different."
         focal: {cx: 0.50, cy: 0.25, zoom: 1.5}     # top wide establishing
@@ -161,6 +269,30 @@ shots:
   - id: 5
     file: "ChatGPT Image Apr 24, 2026 at 12_12_29 PM.png"
     role: "Scene 3 resolution — org aligns in under 90 seconds"
+    generation:
+      prompt: |
+        Multi-panel comic page, the resolution shot. Mood is confident,
+        forward-momentum, with WARMER tones than earlier pages — green
+        accent lights suggesting forward motion.
+        TOP ROW (2 panels side by side, larger):
+          - LEFT: Rico on the floor with tablet, posting to Slack
+            channel #plant-ops. Fault summary visible on screen, MIRA
+            recommendation chip attached as PDF. Speech bubble: "Posting
+            to plant-ops..."
+          - RIGHT: Deb at supervisor station, phone in hand, replying in
+            Slack: "Approved. Reset and log." Green APPROVED badge visible.
+            "Seen by 28" read receipt.
+        BOTTOM ROW (3 smaller reaction panels side by side):
+          - LEFT: Marcus at laptop, downtime chart on screen — old 21:14
+            average crossed out, new 6:03 in green. Speech bubble:
+            "Downtime is coming down."
+          - CENTER: Elena on remote phone, fault-history chart showing
+            14 occurrences, lightbulb expression. Speech bubble:
+            "Why has this happened 14 times?"
+          - RIGHT: Director Holt at office monitor, calm posture, speech
+            bubble: "This is how a plant runs."
+      reference_anchors:
+        - "ChatGPT Image Apr 24, 2026 at 12_12_29 PM.png"
     beats:
       - text: "One message to plant-ops."
         focal: {cx: 0.25, cy: 0.25, zoom: 2.0}     # PANEL 1 (Rico posting)

--- a/marketing/comic-pipeline/upload_youtube.py
+++ b/marketing/comic-pipeline/upload_youtube.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""
+Upload the most recent v2 build to YouTube.
+
+ONE-TIME SETUP:
+
+1. Create a Google Cloud project, enable the YouTube Data API v3.
+2. Create OAuth 2.0 credentials of type "Desktop app".
+3. Download the JSON file as `~/.config/mira/youtube_oauth_client.json`.
+   (Do NOT commit it to git. Path is gitignored at repo root.)
+4. First run will open a browser for you to authorize the upload scope and
+   write a refresh token to `~/.config/mira/youtube_token.json`.
+   Subsequent runs are non-interactive.
+
+USAGE:
+
+    doppler run --project factorylm --config prd -- \\
+        .venv/bin/python upload_youtube.py \\
+            --video-path output/v2/comic-v2/mira_explainer_v2.mp4 \\
+            --metadata-dir output/v2/metadata \\
+            [--privacy unlisted|public|private] \\
+            [--playlist-id <ID>] \\
+            [--dry-run]
+
+DEFAULTS:
+    --privacy unlisted        # safe default — never auto-publishes public
+    --video-path = ~/mira/marketing/videos/comic-v2/mira_explainer_v2.mp4
+    --metadata-dir = output/v2/metadata
+
+The title comes from the storyboard, the description from
+`metadata/youtube_description.md`, captions from `metadata/transcript.srt`,
+and the thumbnail from the first letterboxed canvas (or `--thumbnail PATH`).
+
+After upload, prints the YouTube URL and appends to spend.json with the
+upload details.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+OAUTH_CLIENT_PATH = Path.home() / ".config" / "mira" / "youtube_oauth_client.json"
+OAUTH_TOKEN_PATH = Path.home() / ".config" / "mira" / "youtube_token.json"
+OAUTH_SCOPES = ["https://www.googleapis.com/auth/youtube.upload"]
+
+DEFAULT_VIDEO = (PROJECT_ROOT / ".." / "videos" / "comic-v2" / "mira_explainer_v2.mp4").resolve()
+DEFAULT_METADATA = PROJECT_ROOT / "output" / "v2" / "metadata"
+SPEND_LOG = (PROJECT_ROOT / ".." / "videos" / "spend.json").resolve()
+STORYBOARD_PATH = PROJECT_ROOT / "scripts" / "storyboard_v2.yaml"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("upload-youtube")
+
+
+def _abort_with_setup_help() -> None:
+    print(
+        "\n[upload_youtube] OAuth client not found.\n\n"
+        f"Place the OAuth client JSON at:\n  {OAUTH_CLIENT_PATH}\n\n"
+        "How to get it:\n"
+        "  1. https://console.cloud.google.com/ → create project (or select existing).\n"
+        "  2. APIs & Services → Library → enable 'YouTube Data API v3'.\n"
+        "  3. APIs & Services → Credentials → Create credentials →\n"
+        "     OAuth client ID → Application type: Desktop app.\n"
+        "  4. Download the JSON, then:\n"
+        f"     mkdir -p {OAUTH_CLIENT_PATH.parent}\n"
+        f"     mv ~/Downloads/client_secret_*.json {OAUTH_CLIENT_PATH}\n"
+        "  5. Re-run this script. A browser will open for one-time authorization.\n",
+        file=sys.stderr,
+    )
+    raise SystemExit(2)
+
+
+def _build_youtube_client() -> Any:
+    """Return an authenticated `googleapiclient` resource for YouTube Data API."""
+    if not OAUTH_CLIENT_PATH.exists():
+        _abort_with_setup_help()
+
+    # Imported lazily so `--dry-run` works without google libs installed.
+    from google.auth.transport.requests import Request  # type: ignore
+    from google.oauth2.credentials import Credentials  # type: ignore
+    from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore
+    from googleapiclient.discovery import build  # type: ignore
+
+    creds: Credentials | None = None
+    if OAUTH_TOKEN_PATH.exists():
+        creds = Credentials.from_authorized_user_file(str(OAUTH_TOKEN_PATH), OAUTH_SCOPES)
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(
+                str(OAUTH_CLIENT_PATH), OAUTH_SCOPES,
+            )
+            creds = flow.run_local_server(port=0)
+        OAUTH_TOKEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+        OAUTH_TOKEN_PATH.write_text(creds.to_json())
+        logger.info("Stored fresh OAuth token at %s", OAUTH_TOKEN_PATH)
+
+    return build("youtube", "v3", credentials=creds)
+
+
+def _resumable_upload(yt: Any, video_path: Path, body: dict[str, Any]) -> str:
+    """Upload using a resumable transfer; return the new videoId."""
+    from googleapiclient.http import MediaFileUpload  # type: ignore
+
+    media = MediaFileUpload(str(video_path), chunksize=-1, resumable=True, mimetype="video/mp4")
+    req = yt.videos().insert(part=",".join(body.keys()), body=body, media_body=media)
+    response = None
+    while response is None:
+        status, response = req.next_chunk()
+        if status:
+            logger.info("upload %.0f%%", status.progress() * 100)
+    return response["id"]
+
+
+def _upload_caption(yt: Any, video_id: str, srt_path: Path) -> None:
+    from googleapiclient.http import MediaFileUpload  # type: ignore
+
+    media = MediaFileUpload(str(srt_path), mimetype="application/octet-stream", resumable=False)
+    yt.captions().insert(
+        part="snippet",
+        body={"snippet": {
+            "videoId": video_id,
+            "language": "en",
+            "name": "English (auto from manifest)",
+            "isDraft": False,
+        }},
+        media_body=media,
+    ).execute()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Upload v2 comic build to YouTube")
+    p.add_argument("--video-path", default=str(DEFAULT_VIDEO))
+    p.add_argument("--metadata-dir", default=str(DEFAULT_METADATA))
+    p.add_argument("--privacy", default="unlisted",
+                   choices=["unlisted", "public", "private"])
+    p.add_argument("--playlist-id")
+    p.add_argument("--thumbnail", help="optional path to a custom thumbnail image")
+    p.add_argument("--dry-run", action="store_true",
+                   help="show what would be uploaded; no API calls")
+    args = p.parse_args()
+
+    video_path = Path(args.video_path).expanduser().resolve()
+    metadata_dir = Path(args.metadata_dir).expanduser().resolve()
+
+    if not video_path.exists():
+        raise SystemExit(f"video file not found: {video_path}")
+    desc_path = metadata_dir / "youtube_description.md"
+    srt_path = metadata_dir / "transcript.srt"
+    if not desc_path.exists():
+        raise SystemExit(
+            f"metadata description not found: {desc_path}\n"
+            "  Run build_video_v2.py first to emit the metadata bundle."
+        )
+
+    storyboard = yaml.safe_load(STORYBOARD_PATH.read_text())
+    title = str(storyboard.get("title", "MIRA Explainer"))
+    description = desc_path.read_text()
+
+    # Derive YouTube tags from the hashtag tail of the description (one
+    # source of truth).
+    tags = [t.lstrip("#") for t in description.split() if t.startswith("#")]
+
+    body = {
+        "snippet": {
+            "title": title[:100],          # YouTube hard cap
+            "description": description[:5000],  # YouTube hard cap
+            "tags": tags[:30],             # YouTube allows up to ~500 chars total
+            "categoryId": "28",            # Science & Technology
+        },
+        "status": {
+            "privacyStatus": args.privacy,
+            "selfDeclaredMadeForKids": False,
+        },
+    }
+
+    if args.dry_run:
+        print("[dry-run] would upload:")
+        print(f"  video:       {video_path}")
+        print(f"  size:        {video_path.stat().st_size / (1024*1024):.2f} MB")
+        print(f"  privacy:     {args.privacy}")
+        print(f"  title:       {body['snippet']['title']}")
+        print(f"  tags:        {body['snippet']['tags']}")
+        print(f"  caption:     {srt_path if srt_path.exists() else '(none)'}")
+        if args.playlist_id:
+            print(f"  playlist:    {args.playlist_id}")
+        if args.thumbnail:
+            print(f"  thumbnail:   {args.thumbnail}")
+        return 0
+
+    yt = _build_youtube_client()
+    logger.info("Uploading %s (%.2f MB) ...", video_path.name,
+                video_path.stat().st_size / (1024 * 1024))
+    video_id = _resumable_upload(yt, video_path, body)
+    url = f"https://www.youtube.com/watch?v={video_id}"
+    logger.info("Uploaded: %s", url)
+
+    if srt_path.exists():
+        try:
+            _upload_caption(yt, video_id, srt_path)
+            logger.info("Caption uploaded.")
+        except Exception as e:
+            logger.warning("Caption upload failed (video still uploaded): %s", e)
+
+    if args.playlist_id:
+        try:
+            yt.playlistItems().insert(
+                part="snippet",
+                body={"snippet": {
+                    "playlistId": args.playlist_id,
+                    "resourceId": {"kind": "youtube#video", "videoId": video_id},
+                }},
+            ).execute()
+            logger.info("Added to playlist %s.", args.playlist_id)
+        except Exception as e:
+            logger.warning("Playlist add failed: %s", e)
+
+    if args.thumbnail and Path(args.thumbnail).exists():
+        from googleapiclient.http import MediaFileUpload  # type: ignore
+        try:
+            yt.thumbnails().set(
+                videoId=video_id,
+                media_body=MediaFileUpload(args.thumbnail, mimetype="image/jpeg"),
+            ).execute()
+            logger.info("Thumbnail set.")
+        except Exception as e:
+            logger.warning("Thumbnail set failed: %s", e)
+
+    # Append to spend log
+    log_entry = {
+        "pipeline": "comic",
+        "version": "v2",
+        "action": "youtube_upload",
+        "video_id": video_id,
+        "url": url,
+        "privacy": args.privacy,
+        "size_bytes": video_path.stat().st_size,
+    }
+    if SPEND_LOG.exists():
+        existing = json.loads(SPEND_LOG.read_text())
+    else:
+        existing = []
+    existing.append(log_entry)
+    SPEND_LOG.write_text(json.dumps(existing, indent=2))
+
+    print(f"\n✅ Uploaded: {url}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Follow-on to #586. Adds the second layer to the comic-pipeline:

- **`pipeline/v2/panels.py`** — opt-in OpenAI `gpt-image-1` generator. Uses `images.edit()` with reference anchors first in the array and `input_fidelity="high"`. Generates n=2 candidates per shot, idempotent on-disk cache.
- **`pipeline/v2/panel_score.py`** — Claude vision scorer (claude-haiku-4-5) picks the best candidate. ~\$0.01 per build.
- **`pipeline/v2/metadata.py`** — pure transformation, no API calls. Emits transcript.srt, transcript.md, youtube_description.md, schema_video_object.jsonld (VideoObject + HowTo + FAQPage), llms_entry.md from the build manifest.
- **`upload_youtube.py`** — YouTube Data API v3 uploader. OAuth, captions, playlist add. Privacy defaults to `unlisted`. `--dry-run` supported.
- **`scripts/generate_anchors.py`** — character anchor turnaround sheet generator (~\$0.85 to make all 5).
- **`storyboard_v2.yaml`** — adds top-level `style_guide` block (master prompt, 5 named characters, generation defaults) plus per-shot `generation.prompt` + `reference_anchors`.
- **`build_video_v2.py`** — wires Stage 1.5 (Shot sources, opt-in OpenAI) and Stage 6.5 (Metadata bundle) into the existing pipeline. `--regen-panels` flag activates real generation.
- **`docs/adr/0013-openai-marketing-pipeline-carve-out.md`** — documents the deliberate exception to CLAUDE.md Constraint #2: OpenAI permitted in `marketing/` for image gen + TTS only, never in product runtime.

## Cost surface

**Default path: \$0.** Without `--regen-panels`, every shot takes the legacy `reference/<file>.png` path. No OpenAI calls.

Opt-in costs (when explicitly requested):
| Operation | Trigger | Cost |
|---|---|---|
| Character anchors | `scripts/generate_anchors.py` | \$0.85 once |
| Full panel regen | `build_video_v2.py --regen-panels` | ~\$1.67 per build |
| Vision scoring | automatic when n>1 candidates | ~\$0.01 per build |
| YouTube upload | `upload_youtube.py` | free (API quota) |

## Smoke test (verified before this commit)

```bash
cd marketing/comic-pipeline
doppler run --project factorylm --config prd -- .venv/bin/python build_video_v2.py --skip-verify
# 2.6s elapsed, 0 API calls, all 5 shots took legacy fallback,
# final mp4 at ~/mira/marketing/videos/comic-v2/mira_explainer_v2.mp4 (17.97 MB, 92s),
# 5 metadata artifacts under output/v2/metadata/

.venv/bin/python upload_youtube.py --dry-run        # correct payload, no API calls
.venv/bin/python scripts/generate_anchors.py --dry-run  # lists 5 anchors, $0.85 estimate
```

## Test plan

- [ ] `cd marketing/comic-pipeline && uv pip install -r requirements.txt`
- [ ] Smoke (zero spend): `doppler run -- .venv/bin/python build_video_v2.py --skip-verify` — completes <5s, no API calls, final mp4 rebuilt
- [ ] Verify metadata: `ls output/v2/metadata/` — 5 artifacts present
- [ ] `python upload_youtube.py --dry-run` — prints title/tags/caption sidecar
- [ ] `python scripts/generate_anchors.py --dry-run` — shows 5 missing anchors, \$0.85 estimate
- [ ] (Optional) Generate anchors for real: `python scripts/generate_anchors.py` (~\$0.85)
- [ ] (Optional) Full regen: `python build_video_v2.py --regen-panels --skip-verify` (~\$1.67)

## Architecture references in repo

- `docs/adr/0013-openai-marketing-pipeline-carve-out.md` — vendor policy decision
- `marketing/comic-pipeline/pipeline/v2/panels.py:_compose_prompt` — prompt-assembly pattern (master preamble + character invariants + scene)
- `marketing/comic-pipeline/pipeline/v2/panel_score.py:SCORE_RUBRIC` — three-axis scoring (character, style, prompt adherence)

## Known limitations

- YouTube upload requires one-time OAuth setup (instructions in `upload_youtube.py` docstring; client JSON at `~/.config/mira/youtube_oauth_client.json`).
- Anchors are not yet generated; pipeline currently uses the legacy `reference/<file>.png` ChatGPT exports as anchors. Run `scripts/generate_anchors.py` to produce real Rico/Deb/Marcus/Elena/Holt turnarounds before doing a full `--regen-panels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)