### PR TITLE
feat(lead-hunter): close hardening gaps — clean rebase of #600

### DIFF
--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -45,3 +45,7 @@ Full reference. Top 10 are in `CLAUDE.md`; this file has all of them.
 | `INBOX_DOMAIN`       | mira-web — domain shown in `/api/me` for the per-tenant address `kb+<slug>@<INBOX_DOMAIN>`. Default `factorylm.com` (uses Gmail plus-addressing on the apex; no subdomain MX needed). |
 | `RELEVANCE_GATE_ENABLED` | mira-ingest — set `"true"` to run the LLM relevance check on PDFs ingested via the inbox path (Unit 3.5). Default off (backward-compat for web upload + nightly cron callers, which leave the gate's `relevance_gate=on` form field unset). Cost ~$0.00005/file via Groq. Fail-open on any Groq error. |
 | `GROQ_API_KEY`       | mira-bots, mira-pipeline (existing); also mira-ingest when `RELEVANCE_GATE_ENABLED=true` for the magic-inbox relevance classifier. |
+| `LEAD_HUNTER_TIMEOUT_SECS` | tools/lead-hunter — hard timeout for hourly run; default 1500 (25 min) |
+| `HARDENING_LOCK_DIR` | tools/lead-hunter — directory for singleton lock file; default `/tmp` |
+| `HARDENING_ALERT_LOG` | tools/lead-hunter — JSONL alert log path; default `marketing/prospects/hardening-alerts.jsonl` |
+| `DISCORD_ALERT_WEBHOOK` | tools/lead-hunter — optional Discord webhook URL for degraded/failed runs |

--- a/docs/superpowers/plans/2026-04-25-lead-hunter-hardening-gaps.md
+++ b/docs/superpowers/plans/2026-04-25-lead-hunter-hardening-gaps.md
@@ -1,0 +1,1196 @@
+# Lead-Hunter Hardening Gaps Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the reliability gaps that the 2026-04-24 lead-hunter hardening (`2a7d68b`) exposed but did not fix — full test coverage on `hardening.py`, retry coverage on the discovery HTTP loop, partial-failure detection, Celery-path uniformity, and alerting that survives a reboot.
+
+**Architecture:** Two layers of change. First, characterization tests for `tools/lead-hunter/hardening.py` so we can refactor with confidence (currently zero tests). Second, behavioral fixes in `celery_tasks.py` and `run_hourly.py` to extend the hardening's reach: discovery HTTP retries, partial-failure surface, single-conn DB lifecycle, Celery-path delegation to `run_hourly.main()`, persistent alert log, and a new env-var docs row.
+
+**Tech Stack:** Python 3.12, pytest, httpx, psycopg2, Celery (mira-crawler app), launchd / Celery Beat scheduler.
+
+**Out of scope (separate PRs):** psycopg2 connection pooling, splitting the mega-branch into smaller PRs, Discord webhook unit tests requiring live network.
+
+---
+
+## File Structure
+
+| File | Role | Status |
+|---|---|---|
+| `tests/lead_hunter/test_hardening.py` | Unit tests for all hardening primitives | **Create** |
+| `tests/lead_hunter/test_run_hourly.py` | Tests for silent-zero detectors and exit codes | **Create** |
+| `tools/lead-hunter/hardening.py` | Default alert log path; minor doc | Modify (small) |
+| `tools/lead-hunter/celery_tasks.py` | Discovery retries, partial-failure surface, conn lifecycle, schema as step, Celery → `main()` | Modify (substantial) |
+| `tools/lead-hunter/run_hourly.py` | Wire schema-step + partial-failure detector | Modify |
+| `docs/env-vars.md` | Document `DISCORD_ALERT_WEBHOOK`, `HARDENING_ALERT_LOG`, `HARDENING_LOCK_DIR`, `LEAD_HUNTER_TIMEOUT_SECS` | Modify |
+
+Each task ends with a `git commit` step. Every commit is independently green (tests pass at HEAD).
+
+---
+
+## Task 1: Bootstrap test file + singleton_lock characterization tests
+
+**Files:**
+- Create: `tests/lead_hunter/test_hardening.py`
+
+- [ ] **Step 1: Write the test file scaffold + singleton_lock tests**
+
+```python
+# tests/lead_hunter/test_hardening.py
+"""Characterization tests for tools/lead-hunter/hardening.py.
+
+The module already ships in production; these tests pin its current behavior
+so subsequent refactors are safe.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+# ---------------- singleton_lock ----------------
+
+def test_singleton_lock_first_acquires(tmp_path):
+    from hardening import singleton_lock
+    with singleton_lock("test-lh-1", lock_dir=tmp_path):
+        assert (tmp_path / ".test-lh-1.lock").exists()
+    # Lock file removed on exit
+    assert not (tmp_path / ".test-lh-1.lock").exists()
+
+
+def test_singleton_lock_second_invocation_exits_zero(tmp_path):
+    """A second process holding the same lock must exit cleanly with code 0."""
+    from hardening import singleton_lock
+
+    # Hold the lock in this process; spawn a child that tries to acquire it.
+    with singleton_lock("test-lh-2", lock_dir=tmp_path):
+        helper = tmp_path / "child.py"
+        helper.write_text(
+            "import sys\n"
+            f"sys.path.insert(0, {str(Path(__file__).resolve().parents[2] / 'tools' / 'lead-hunter')!r})\n"
+            "from hardening import singleton_lock\n"
+            f"with singleton_lock('test-lh-2', lock_dir={str(tmp_path)!r}):\n"
+            "    pass\n"
+        )
+        result = subprocess.run([sys.executable, str(helper)], capture_output=True, timeout=10)
+        assert result.returncode == 0, result.stderr.decode()
+
+
+def test_singleton_lock_releases_on_exception(tmp_path):
+    from hardening import singleton_lock
+    with pytest.raises(RuntimeError):
+        with singleton_lock("test-lh-3", lock_dir=tmp_path):
+            raise RuntimeError("boom")
+    # Lock file gone even after exception
+    assert not (tmp_path / ".test-lh-3.lock").exists()
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cd /Users/bravonode/Mira && python3.12 -m pytest tests/lead_hunter/test_hardening.py -v`
+Expected: 3 PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/lead_hunter/test_hardening.py
+git commit -m "test(lead-hunter): characterization tests for singleton_lock"
+```
+
+---
+
+## Task 2: with_retries characterization tests
+
+**Files:**
+- Modify: `tests/lead_hunter/test_hardening.py`
+
+- [ ] **Step 1: Append with_retries tests**
+
+```python
+# Append to tests/lead_hunter/test_hardening.py
+
+# ---------------- with_retries ----------------
+
+def test_with_retries_returns_value_on_first_success():
+    from hardening import with_retries
+    calls = []
+    def fn():
+        calls.append(1)
+        return "ok"
+    assert with_retries(fn, name="t", retries=3) == "ok"
+    assert calls == [1]
+
+
+def test_with_retries_retries_then_succeeds(monkeypatch):
+    from hardening import with_retries
+    monkeypatch.setattr("hardening.time.sleep", lambda s: None)
+    monkeypatch.setattr("hardening.random.uniform", lambda a, b: 1.0)
+    calls = {"n": 0}
+    def fn():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionError("transient")
+        return "ok"
+    assert with_retries(fn, name="t", retries=3, retry_on=(ConnectionError,)) == "ok"
+    assert calls["n"] == 3
+
+
+def test_with_retries_exhausts_and_raises_last(monkeypatch):
+    from hardening import with_retries
+    monkeypatch.setattr("hardening.time.sleep", lambda s: None)
+    monkeypatch.setattr("hardening.random.uniform", lambda a, b: 1.0)
+    def fn():
+        raise ConnectionError("always fails")
+    with pytest.raises(ConnectionError, match="always fails"):
+        with_retries(fn, name="t", retries=2, retry_on=(ConnectionError,))
+
+
+def test_with_retries_does_not_retry_give_up_class(monkeypatch):
+    from hardening import with_retries
+    monkeypatch.setattr("hardening.time.sleep", lambda s: None)
+    calls = {"n": 0}
+    def fn():
+        calls["n"] += 1
+        raise KeyboardInterrupt()
+    with pytest.raises(KeyboardInterrupt):
+        with_retries(fn, name="t", retries=5)
+    assert calls["n"] == 1  # No retry on KeyboardInterrupt
+
+
+def test_with_retries_does_not_retry_unlisted_exception(monkeypatch):
+    from hardening import with_retries
+    calls = {"n": 0}
+    def fn():
+        calls["n"] += 1
+        raise ValueError("not in retry_on")
+    with pytest.raises(ValueError):
+        with_retries(fn, name="t", retries=3, retry_on=(ConnectionError,))
+    assert calls["n"] == 1
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `python3.12 -m pytest tests/lead_hunter/test_hardening.py -v`
+Expected: 8 PASS (3 from Task 1 + 5 new)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/lead_hunter/test_hardening.py
+git commit -m "test(lead-hunter): with_retries retry/give-up semantics"
+```
+
+---
+
+## Task 3: hard_timeout + preflight_secrets tests
+
+**Files:**
+- Modify: `tests/lead_hunter/test_hardening.py`
+
+- [ ] **Step 1: Append tests**
+
+```python
+# Append to tests/lead_hunter/test_hardening.py
+import signal as _signal
+
+# ---------------- hard_timeout ----------------
+
+@pytest.mark.skipif(not hasattr(_signal, "SIGALRM"), reason="SIGALRM unavailable on this platform")
+def test_hard_timeout_raises_after_expiry():
+    from hardening import hard_timeout
+    with pytest.raises(TimeoutError):
+        with hard_timeout(1):
+            time.sleep(2)
+
+
+def test_hard_timeout_clears_on_normal_exit():
+    from hardening import hard_timeout
+    with hard_timeout(5):
+        pass
+    # Subsequent sleep must not get interrupted
+    time.sleep(0.05)
+
+
+# ---------------- preflight_secrets ----------------
+
+def test_preflight_secrets_returns_map(monkeypatch):
+    from hardening import preflight_secrets
+    monkeypatch.setenv("PRESENT_REQ", "value")
+    monkeypatch.setenv("PRESENT_OPT", "value")
+    monkeypatch.delenv("MISSING_OPT", raising=False)
+    m = preflight_secrets(["PRESENT_REQ"], ["PRESENT_OPT", "MISSING_OPT"])
+    assert m == {"PRESENT_REQ": True, "PRESENT_OPT": True, "MISSING_OPT": False}
+
+
+def test_preflight_secrets_exits_2_on_missing_required(monkeypatch):
+    from hardening import preflight_secrets
+    monkeypatch.delenv("REQUIRED_X", raising=False)
+    with pytest.raises(SystemExit) as exc_info:
+        preflight_secrets(["REQUIRED_X"])
+    assert exc_info.value.code == 2
+
+
+def test_preflight_secrets_treats_blank_as_missing(monkeypatch):
+    from hardening import preflight_secrets
+    monkeypatch.setenv("BLANK_REQ", "   ")
+    with pytest.raises(SystemExit) as exc_info:
+        preflight_secrets(["BLANK_REQ"])
+    assert exc_info.value.code == 2
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `python3.12 -m pytest tests/lead_hunter/test_hardening.py -v`
+Expected: 13 PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/lead_hunter/test_hardening.py
+git commit -m "test(lead-hunter): hard_timeout + preflight_secrets coverage"
+```
+
+---
+
+## Task 4: RunReport + alert tests
+
+**Files:**
+- Modify: `tests/lead_hunter/test_hardening.py`
+
+- [ ] **Step 1: Append tests**
+
+```python
+# Append to tests/lead_hunter/test_hardening.py
+
+# ---------------- RunReport ----------------
+
+def test_runreport_step_ok_path():
+    from hardening import RunReport
+    r = RunReport(routine="t")
+    with r.step("a") as step:
+        step.detail["x"] = 1
+    r.finalize()
+    assert r.steps[0].status == "ok"
+    assert r.steps[0].detail == {"x": 1}
+    assert r.overall == "ok"
+    assert r.is_healthy()
+
+
+def test_runreport_step_fail_swallows_exception_and_marks_overall():
+    from hardening import RunReport
+    r = RunReport(routine="t")
+    with r.step("a"):
+        raise ValueError("kaboom")
+    r.finalize()
+    assert r.steps[0].status == "fail"
+    assert "ValueError: kaboom" in r.steps[0].error
+    assert r.overall == "fail"
+    assert not r.is_healthy()
+
+
+def test_runreport_skip_marks_degraded():
+    from hardening import RunReport
+    r = RunReport(routine="t")
+    with r.step("a") as step:
+        step.status = "skip"
+        step.detail["reason"] = "no data"
+    r.finalize()
+    assert r.overall == "degraded"
+
+
+def test_runreport_alert_marks_degraded():
+    from hardening import RunReport
+    r = RunReport(routine="t")
+    with r.step("a"):
+        pass
+    r.add_alert("something is sus")
+    r.finalize()
+    assert r.overall == "degraded"
+    assert r.alerts == ["something is sus"]
+
+
+def test_runreport_to_json_is_valid():
+    from hardening import RunReport
+    r = RunReport(routine="t")
+    with r.step("a"):
+        pass
+    r.finalize()
+    parsed = json.loads(r.to_json())
+    assert parsed["routine"] == "t"
+    assert parsed["overall"] == "ok"
+    assert len(parsed["steps"]) == 1
+
+
+# ---------------- alert() ----------------
+
+def test_alert_noop_on_healthy(tmp_path, monkeypatch):
+    from hardening import RunReport, alert
+    monkeypatch.delenv("DISCORD_ALERT_WEBHOOK", raising=False)
+    r = RunReport(routine="t")
+    with r.step("a"):
+        pass
+    r.finalize()
+    log_path = tmp_path / "alerts.jsonl"
+    alert(r, alert_log=log_path)
+    assert not log_path.exists()
+
+
+def test_alert_appends_jsonl_on_failure(tmp_path, monkeypatch):
+    from hardening import RunReport, alert
+    monkeypatch.delenv("DISCORD_ALERT_WEBHOOK", raising=False)
+    r = RunReport(routine="t")
+    with r.step("a"):
+        raise RuntimeError("nope")
+    r.finalize()
+    log_path = tmp_path / "alerts.jsonl"
+    alert(r, alert_log=log_path)
+    line = log_path.read_text().strip()
+    parsed = json.loads(line)
+    assert parsed["routine"] == "t"
+    assert parsed["overall"] == "fail"
+
+
+def test_alert_appends_jsonl_on_degraded(tmp_path, monkeypatch):
+    from hardening import RunReport, alert
+    monkeypatch.delenv("DISCORD_ALERT_WEBHOOK", raising=False)
+    r = RunReport(routine="t")
+    with r.step("a"):
+        pass
+    r.add_alert("partial failure")
+    r.finalize()
+    log_path = tmp_path / "alerts.jsonl"
+    alert(r, alert_log=log_path)
+    assert log_path.exists()
+    parsed = json.loads(log_path.read_text().strip())
+    assert parsed["overall"] == "degraded"
+    assert parsed["alerts"] == ["partial failure"]
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `python3.12 -m pytest tests/lead_hunter/test_hardening.py -v`
+Expected: 21 PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/lead_hunter/test_hardening.py
+git commit -m "test(lead-hunter): RunReport + alert() coverage"
+```
+
+---
+
+## Task 5: Wrap discovery HTTP loop in with_retries
+
+The discovery loop in `celery_tasks.py:114-156` makes ~120 HTTPS requests with no retry — a transient blip kills the run. Only DB and HubSpot got retries. Discovery is the *biggest* request volume so it's where retries help most.
+
+**Files:**
+- Modify: `tools/lead-hunter/celery_tasks.py:114-156`
+- Test: `tests/lead_hunter/test_celery_tasks.py` (Create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/lead_hunter/test_celery_tasks.py`:
+
+```python
+"""Tests that retries cover the discovery HTTP loop, not just DB/HubSpot."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+
+def test_discovery_msca_call_uses_with_retries(monkeypatch):
+    """scrape_msca should be invoked through hardening.with_retries.
+
+    Implementation detail: we patch hardening.with_retries and assert
+    the discovery code calls it with name='scrape_msca'.
+    """
+    import celery_tasks
+
+    calls = []
+
+    def fake_with_retries(fn, *, name, **kw):
+        calls.append(name)
+        # Don't actually run fn — we're only checking the call shape
+        return []
+
+    monkeypatch.setattr("celery_tasks.with_retries", fake_with_retries, raising=False)
+    # Patch out everything else so the function returns quickly
+    monkeypatch.setattr("celery_tasks._load_state", lambda: {
+        "city_index": 0, "requests_today": 0, "last_date": "", "total_discovered": 0,
+    })
+    monkeypatch.setattr("celery_tasks._save_state", lambda s: None)
+    monkeypatch.setattr("celery_tasks._check_daily_budget", lambda s: True)
+    monkeypatch.setenv("NEON_DATABASE_URL", "")
+    monkeypatch.setenv("HUNTER_API_KEY", "")
+    monkeypatch.setenv("HUBSPOT_ACCESS_TOKEN", "")
+
+    import hunt as hunt_mod
+    monkeypatch.setattr(hunt_mod, "CITIES", [("TestCity", 0.0, 0.0, 10)])
+    monkeypatch.setattr(hunt_mod, "QUERY_TEMPLATES", [])
+    monkeypatch.setattr(hunt_mod, "apply_schema", lambda *a, **k: None)
+    monkeypatch.setattr(hunt_mod, "RATE_LIMIT_SECS", 0)
+
+    import discover as discover_mod
+    monkeypatch.setattr(discover_mod, "MEDIUM_BIZ_QUERIES", [])
+    monkeypatch.setattr(discover_mod, "search_ddg_medium",
+                        lambda *a, **k: ([], None))
+
+    celery_tasks.run_discover_and_enrich()
+    assert "scrape_msca" in calls, f"Expected scrape_msca to be wrapped; got {calls}"
+```
+
+- [ ] **Step 2: Run test, verify FAIL**
+
+Run: `python3.12 -m pytest tests/lead_hunter/test_celery_tasks.py::test_discovery_msca_call_uses_with_retries -v`
+Expected: FAIL — scrape_msca is not currently wrapped in with_retries.
+
+- [ ] **Step 3: Add the wrapper at top of celery_tasks.py**
+
+In `tools/lead-hunter/celery_tasks.py`, add after the existing imports (around line 32):
+
+```python
+import httpx
+from hardening import with_retries
+
+# Exception classes that justify retrying a discovery HTTP call
+_HTTP_RETRY = (
+    httpx.TransportError,   # connect / read timeouts, network errors
+    httpx.HTTPStatusError,  # 5xx if .raise_for_status() is called
+    ConnectionError,
+    TimeoutError,
+)
+```
+
+Then change line ~114 (the MSCA block) from:
+
+```python
+    if city_idx == 0:
+        log.info("Running MSCA directory scrape...")
+        with httpx.Client(timeout=20) as client:
+            msca_facs = discover.scrape_msca(client)
+            requests_used += 1
+```
+
+to:
+
+```python
+    if city_idx == 0:
+        log.info("Running MSCA directory scrape...")
+        with httpx.Client(timeout=20) as client:
+            try:
+                msca_facs = with_retries(
+                    lambda: discover.scrape_msca(client),
+                    name="scrape_msca",
+                    retries=2,
+                    backoff=3.0,
+                    retry_on=_HTTP_RETRY,
+                )
+            except Exception as e:
+                log.warning("scrape_msca failed after retries: %s", e)
+                msca_facs = []
+            requests_used += 1
+```
+
+- [ ] **Step 4: Run test, verify PASS**
+
+Run: `python3.12 -m pytest tests/lead_hunter/test_celery_tasks.py::test_discovery_msca_call_uses_with_retries -v`
+Expected: PASS
+
+- [ ] **Step 5: Add a similar wrapper around the standard DDG loop**
+
+In `celery_tasks.py`, find `for qt in hunt.QUERY_TEMPLATES:` block (around line 138) and replace `results = discover._ddg_search(query, client)` with:
+
+```python
+                try:
+                    results = with_retries(
+                        lambda: discover._ddg_search(query, client),
+                        name=f"ddg_search:{qt[:20]}",
+                        retries=1,  # discovery loop already absorbs single fails via ddg_fails
+                        backoff=2.0,
+                        retry_on=_HTTP_RETRY,
+                    )
+                except Exception as e:
+                    log.warning("ddg_search retry exhausted (%s): %s", qt[:30], e)
+                    results = None
+```
+
+(`_ddg_search` already returns `None` on failure today; this just adds 1 retry on transient errors before falling through to the existing `ddg_fails` counter.)
+
+- [ ] **Step 6: Add test for the DDG loop wrapper**
+
+Append to `tests/lead_hunter/test_celery_tasks.py`:
+
+```python
+def test_discovery_ddg_search_uses_with_retries(monkeypatch):
+    import celery_tasks
+    import hunt as hunt_mod
+    import discover as discover_mod
+
+    calls = []
+    def fake_with_retries(fn, *, name, **kw):
+        calls.append(name)
+        return None
+
+    monkeypatch.setattr("celery_tasks.with_retries", fake_with_retries, raising=False)
+    monkeypatch.setattr("celery_tasks._load_state", lambda: {
+        "city_index": 1, "requests_today": 0, "last_date": "", "total_discovered": 0,
+    })
+    monkeypatch.setattr("celery_tasks._save_state", lambda s: None)
+    monkeypatch.setattr("celery_tasks._check_daily_budget", lambda s: True)
+    monkeypatch.setenv("NEON_DATABASE_URL", "")
+    monkeypatch.setenv("HUNTER_API_KEY", "")
+    monkeypatch.setenv("HUBSPOT_ACCESS_TOKEN", "")
+
+    monkeypatch.setattr(hunt_mod, "CITIES", [("CityA", 0.0, 0.0, 10), ("CityB", 1.0, 1.0, 10)])
+    monkeypatch.setattr(hunt_mod, "QUERY_TEMPLATES", ["machine shop {city}"])
+    monkeypatch.setattr(hunt_mod, "apply_schema", lambda *a, **k: None)
+    monkeypatch.setattr(hunt_mod, "RATE_LIMIT_SECS", 0)
+    monkeypatch.setattr(hunt_mod, "extract_facilities_from_results",
+                        lambda *a, **k: [])
+    monkeypatch.setattr(discover_mod, "MEDIUM_BIZ_QUERIES", [])
+    monkeypatch.setattr(discover_mod, "search_ddg_medium",
+                        lambda *a, **k: ([], None))
+
+    celery_tasks.run_discover_and_enrich()
+    assert any(n.startswith("ddg_search:") for n in calls), \
+        f"Expected ddg_search:* to be wrapped; got {calls}"
+```
+
+- [ ] **Step 7: Run all tests**
+
+Run: `python3.12 -m pytest tests/lead_hunter/ -v`
+Expected: all PASS (21 hardening + 2 celery_tasks)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add tools/lead-hunter/celery_tasks.py tests/lead_hunter/test_celery_tasks.py
+git commit -m "feat(lead-hunter): wrap discovery HTTP loop in with_retries"
+```
+
+---
+
+## Task 6: Surface partial enrichment failures
+
+`_enrich_unenriched` swallows exceptions at `log.debug` (silent below INFO). Today's silent-zero detector only catches *zero* enriched, not *partial* (18/20 failing).
+
+**Files:**
+- Modify: `tools/lead-hunter/celery_tasks.py:228-300` (`_enrich_unenriched`)
+- Modify: `tools/lead-hunter/run_hourly.py:99-117` (health_assertions step)
+- Test: `tests/lead_hunter/test_celery_tasks.py`
+
+- [ ] **Step 1: Change `_enrich_unenriched` return type**
+
+Modify the function signature + return:
+
+```python
+def _enrich_unenriched(db_url: str, hunter_key: str, limit: int) -> tuple[int, int]:
+    """Enrich facilities that have a website but no contacts yet.
+
+    Returns (succeeded, attempted). attempted == 0 means nothing eligible —
+    not a partial failure.
+    """
+    # ... same body, but:
+    enriched = 0
+    failed = 0
+    # ... in the loop:
+    try:
+        # ...existing enrichment code...
+        enriched += 1
+    except Exception as e:
+        log.warning("Enrich failed %s: %s", name, e)  # WAS: log.debug
+        failed += 1
+    # ... return:
+    return enriched, len(rows)
+```
+
+Update the call site (line 164 area):
+
+```python
+    if db_url:
+        enriched_count, enriched_attempted = _enrich_unenriched(
+            db_url, hunter_key, DISCOVERY_RATE["max_enrichments_per_run"]
+        )
+    else:
+        enriched_count, enriched_attempted = 0, 0
+```
+
+And add to the `run_result` dict:
+
+```python
+        "enriched_attempted": enriched_attempted,
+```
+
+- [ ] **Step 2: Wire partial-failure detector in `run_hourly._run`**
+
+In `tools/lead-hunter/run_hourly.py`, in the `_run()` function, capture the new field:
+
+```python
+            enriched = result.get("enriched", 0)
+            enriched_attempted = result.get("enriched_attempted", 0)
+            inserted = result.get("inserted", 0)
+            hs_pushed = result.get("hs_pushed", 0)
+            step.detail.update({
+                "discovered": discovered,
+                "enriched": enriched,
+                "enriched_attempted": enriched_attempted,
+                "inserted": inserted,
+                "hs_pushed": hs_pushed,
+                "city": result.get("city", "?"),
+            })
+```
+
+Then in the `health_assertions` step, add (after the existing detectors):
+
+```python
+        # Partial enrichment failure — most attempts failed but we got some
+        if enriched_attempted >= 4 and enriched / max(enriched_attempted, 1) < 0.5:
+            report.add_alert(
+                f"Enrichment partial failure: {enriched}/{enriched_attempted} succeeded "
+                "(<50%) — Firecrawl/Hunter degraded or many sites blocking scrapers"
+            )
+```
+
+(Threshold of 4 attempts avoids tripping on tiny batches like 1/2.)
+
+- [ ] **Step 3: Add tests**
+
+Create `tests/lead_hunter/test_run_hourly.py`:
+
+```python
+"""Tests for run_hourly._run silent-failure detectors and exit codes."""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+def _stub_required_env(monkeypatch):
+    monkeypatch.setenv("NEON_DATABASE_URL", "postgres://stub")
+
+
+def test_run_alerts_on_discovered_but_zero_enriched(monkeypatch):
+    import run_hourly
+    _stub_required_env(monkeypatch)
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "stub")
+
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 5, "enriched": 0, "enriched_attempted": 5,
+        "inserted": 0, "hs_pushed": 0,
+    })
+    rc = run_hourly._run()
+    # Degraded -> exit 1
+    assert rc == 1
+
+
+def test_run_alerts_on_inserted_but_zero_pushed(monkeypatch):
+    import run_hourly
+    _stub_required_env(monkeypatch)
+    monkeypatch.setenv("HUBSPOT_API_KEY", "stub")
+
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 5, "enriched": 5, "enriched_attempted": 5,
+        "inserted": 3, "hs_pushed": 0,
+    })
+    rc = run_hourly._run()
+    assert rc == 1  # degraded
+
+
+def test_run_alerts_on_partial_enrichment_failure(monkeypatch):
+    import run_hourly
+    _stub_required_env(monkeypatch)
+
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 5, "enriched": 1, "enriched_attempted": 5,
+        "inserted": 1, "hs_pushed": 0,
+    })
+    rc = run_hourly._run()
+    # 1/5 < 50% -> partial failure alert -> degraded
+    assert rc == 1
+
+
+def test_run_returns_zero_on_clean_run(monkeypatch):
+    import run_hourly
+    _stub_required_env(monkeypatch)
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "stub")
+    monkeypatch.setenv("HUBSPOT_API_KEY", "stub")
+
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 5, "enriched": 5, "enriched_attempted": 5,
+        "inserted": 5, "hs_pushed": 5,
+    })
+    rc = run_hourly._run()
+    assert rc == 0
+
+
+def test_run_skip_marks_degraded(monkeypatch):
+    import run_hourly
+    _stub_required_env(monkeypatch)
+
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "skipped": True, "reason": "daily_budget",
+    })
+    rc = run_hourly._run()
+    # skip without other failures: degraded -> exit 1
+    assert rc == 1
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `python3.12 -m pytest tests/lead_hunter/ -v`
+Expected: all PASS (21 hardening + 2 celery_tasks + 5 run_hourly = 28)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/lead-hunter/celery_tasks.py tools/lead-hunter/run_hourly.py tests/lead_hunter/test_run_hourly.py
+git commit -m "feat(lead-hunter): partial enrichment failure detector + tests"
+```
+
+---
+
+## Task 7: Move `apply_schema` into a `report.step()`
+
+Currently `celery_tasks.py:96-98` swallows schema errors with a warning. If schema migrations fail, every downstream SQL fails silently with no alert.
+
+**Files:**
+- Modify: `tools/lead-hunter/celery_tasks.py` — extract schema-apply call out
+- Modify: `tools/lead-hunter/run_hourly.py` — wrap in `report.step("apply_schema")`
+
+The cleanest split: `_run()` in `run_hourly.py` runs the schema step *before* `discover_and_enrich`. Schema failure marks the step as failed but the routine continues (downstream queries fail visibly with their own SQL errors).
+
+- [ ] **Step 1: Remove schema apply from `run_discover_and_enrich`**
+
+In `tools/lead-hunter/celery_tasks.py`, delete lines 94-98:
+
+```python
+    # Apply schema if DB available
+    if db_url:
+        try:
+            hunt.apply_schema(db_url)
+        except Exception as e:
+            log.warning("Schema apply (non-fatal): %s", e)
+```
+
+- [ ] **Step 2: Add a schema step in `run_hourly._run`**
+
+Insert in `_run()` after the preflight step, before `discover_and_enrich`:
+
+```python
+    # 1b. Apply DB schema (idempotent)
+    db_url = os.environ.get("NEON_DATABASE_URL", "")
+    with report.step("apply_schema") as step:
+        if not db_url:
+            step.status = "skip"
+            step.detail["reason"] = "no NEON_DATABASE_URL"
+        else:
+            sys.path.insert(0, str(Path(__file__).parent))
+            import hunt as hunt_mod
+            hunt_mod.apply_schema(db_url)
+            step.detail["applied"] = True
+```
+
+(If `apply_schema` raises, the `_StepCtx.__exit__` records `status=fail` and continues — `report.overall` becomes `fail` at finalize.)
+
+- [ ] **Step 3: Add a test**
+
+Append to `tests/lead_hunter/test_run_hourly.py`:
+
+```python
+def test_run_marks_schema_step_as_skip_when_no_db(monkeypatch):
+    import run_hourly
+    monkeypatch.setenv("NEON_DATABASE_URL", "")
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 0, "enriched": 0, "enriched_attempted": 0,
+        "inserted": 0, "hs_pushed": 0,
+    })
+    # NEON_DATABASE_URL blank => preflight exits 2 (since it's required).
+    # We must populate it.
+    monkeypatch.setenv("NEON_DATABASE_URL", "postgres://stub")
+    # But for the schema step itself we re-blank inside _run via env? No --
+    # the schema step reads at function entry, so we test the populated path:
+    import hunt as hunt_mod
+    monkeypatch.setattr(hunt_mod, "apply_schema", lambda url: None)
+    rc = run_hourly._run()
+    # Clean run path -> exit 0
+    assert rc == 0
+
+
+def test_run_step_records_schema_failure(monkeypatch):
+    import run_hourly
+    monkeypatch.setenv("NEON_DATABASE_URL", "postgres://stub")
+
+    def boom(url):
+        raise RuntimeError("migration broke")
+
+    import hunt as hunt_mod
+    monkeypatch.setattr(hunt_mod, "apply_schema", boom)
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 0, "enriched": 0, "enriched_attempted": 0,
+        "inserted": 0, "hs_pushed": 0,
+    })
+    rc = run_hourly._run()
+    # Schema failure -> step fails -> overall fail -> exit 1
+    assert rc == 1
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3.12 -m pytest tests/lead_hunter/ -v`
+Expected: all PASS (now ~30 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/lead-hunter/celery_tasks.py tools/lead-hunter/run_hourly.py tests/lead_hunter/test_run_hourly.py
+git commit -m "fix(lead-hunter): apply_schema runs as a tracked report step"
+```
+
+---
+
+## Task 8: Make Celery task delegate to `run_hourly.main()`
+
+Current Celery `discover_and_enrich` calls `run_discover_and_enrich()` directly — bypassing the lock, hard timeout, preflight, *and* alerting. If launchd + Celery beat both fire, we get duplicate runs.
+
+**Files:**
+- Modify: `tools/lead-hunter/celery_tasks.py:307-321`
+
+- [ ] **Step 1: Replace the Celery task body**
+
+In `tools/lead-hunter/celery_tasks.py`, replace lines 307-321 with:
+
+```python
+try:
+    from celery import shared_task
+
+    @shared_task(name="lead_hunter.discover_and_enrich", bind=True, max_retries=0)
+    def discover_and_enrich(self):
+        """Celery task: hourly lead discovery + enrichment.
+
+        Delegates to run_hourly.main() so the singleton lock, hard timeout,
+        preflight checks, and alert sink ALL apply (parity with launchd path).
+        Celery's own retry is disabled (max_retries=0) — run_hourly's
+        with_retries layer handles transient failures internally and the
+        next hour will re-run anyway.
+        """
+        sys.path.insert(0, str(Path(__file__).parent))
+        from run_hourly import main as run_main
+        rc = run_main()
+        # Celery treats non-zero return as success too (only exceptions retry).
+        # We log the rc so it shows up in flower/redis-insight.
+        log.info("lead_hunter.discover_and_enrich rc=%d", rc)
+        return {"exit_code": rc}
+
+except ImportError:
+    pass
+```
+
+- [ ] **Step 2: Add a test**
+
+Append to `tests/lead_hunter/test_celery_tasks.py`:
+
+```python
+def test_celery_task_delegates_to_run_hourly_main(monkeypatch):
+    """The @shared_task body must call run_hourly.main(), not run_discover_and_enrich()."""
+    import celery_tasks
+    import run_hourly
+
+    called = {"main": 0, "direct": 0}
+    monkeypatch.setattr(run_hourly, "main", lambda: (called.__setitem__("main", called["main"] + 1) or 0))
+    monkeypatch.setattr(celery_tasks, "run_discover_and_enrich",
+                        lambda: called.__setitem__("direct", called["direct"] + 1) or {})
+
+    # Find the unwrapped function — Celery wraps with bind=True so we call .run
+    task = celery_tasks.discover_and_enrich
+    if hasattr(task, "run"):
+        # Real celery task object has .run for the underlying function (bind=True signature)
+        task.run(task)
+    else:
+        task(None)  # Stub fallback if Celery not installed
+
+    assert called["main"] == 1, "Celery task must call run_hourly.main()"
+    assert called["direct"] == 0, "Celery task must NOT call run_discover_and_enrich() directly"
+```
+
+If Celery isn't installed in the test env, the test will skip via the `ImportError` block — so guard:
+
+```python
+def test_celery_task_delegates_to_run_hourly_main(monkeypatch):
+    pytest.importorskip("celery")
+    # ... rest unchanged
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `python3.12 -m pytest tests/lead_hunter/ -v`
+Expected: all PASS (or skip on machines without Celery)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/lead-hunter/celery_tasks.py tests/lead_hunter/test_celery_tasks.py
+git commit -m "fix(lead-hunter): Celery path goes through run_hourly.main() for full hardening"
+```
+
+---
+
+## Task 9: Refactor `_enrich_unenriched` connection lifecycle
+
+Current code: opens `conn` at line 235, never closes it. Opens new `conn2` per row inside the loop. On exception (line 297), `conn2` leaks.
+
+**Files:**
+- Modify: `tools/lead-hunter/celery_tasks.py:228-300`
+
+- [ ] **Step 1: Rewrite `_enrich_unenriched` body**
+
+Replace the function body with a single connection + context-managed cursors:
+
+```python
+def _enrich_unenriched(db_url: str, hunter_key: str, limit: int) -> tuple[int, int]:
+    """Enrich facilities that have a website but no contacts yet.
+
+    Returns (succeeded, attempted). Uses a single connection across all rows.
+    """
+    import psycopg2
+    import httpx
+    import hunt
+    import enrich
+
+    enriched = 0
+    attempted = 0
+
+    with psycopg2.connect(db_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT f.id, f.name, f.city, f.website, f.phone, f.icp_score, f.notes
+                FROM prospect_facilities f
+                LEFT JOIN prospect_contacts c ON c.facility_id = f.id
+                WHERE f.website IS NOT NULL AND f.website != ''
+                  AND c.id IS NULL
+                  AND f.icp_score >= 6
+                ORDER BY f.icp_score DESC
+                LIMIT %s
+                """,
+                (limit,),
+            )
+            rows = cur.fetchall()
+
+        if not rows:
+            return 0, 0
+
+        attempted = len(rows)
+        with httpx.Client(timeout=15) as client:
+            for row in rows:
+                fid, name, city, website, phone, icp_score, notes = row
+                f = hunt.Facility(
+                    name=name, city=city, website=website or "",
+                    phone=phone or "", icp_score=icp_score or 0, notes=notes or "",
+                )
+                try:
+                    log.info("Enriching: %s (%s)", name[:50], (website or "")[:40])
+                    result = enrich.scrape_facility_deep(f, client)
+                    enrich.apply_enrichment(f, result, hunter_key, client)
+                    f.icp_score = hunt.score_facility(f)
+
+                    with conn.cursor() as cur2:
+                        if f.phone:
+                            cur2.execute(
+                                "UPDATE prospect_facilities SET phone=%s, updated_at=NOW() WHERE id=%s",
+                                (f.phone, fid),
+                            )
+                        if "vfd_keywords_found" in f.notes:
+                            cur2.execute(
+                                "UPDATE prospect_facilities SET notes=%s, icp_score=%s, updated_at=NOW() WHERE id=%s",
+                                (f.notes, f.icp_score, fid),
+                            )
+                        if f.contacts:
+                            for c in f.contacts:
+                                cur2.execute(
+                                    """
+                                    INSERT INTO prospect_contacts (facility_id, name, title, email, phone, source, confidence)
+                                    VALUES (%s, %s, %s, %s, %s, %s, %s)
+                                    ON CONFLICT DO NOTHING
+                                    """,
+                                    (fid, c.get("name"), c.get("title"), c.get("email"),
+                                     c.get("phone"), c.get("source", "website"), c.get("confidence", "low")),
+                                )
+                    conn.commit()
+                    enriched += 1
+                except Exception as e:
+                    log.warning("Enrich failed %s: %s", name, e)
+                    conn.rollback()  # release transaction state on this connection
+
+    return enriched, attempted
+```
+
+(Note: `psycopg2`'s `connect()` context manager commits on clean exit and closes on exit; cursor `with` blocks always close. `conn.rollback()` after a per-row exception keeps the connection usable for the next row.)
+
+- [ ] **Step 2: Run tests (no behavior change for green path)**
+
+Run: `python3.12 -m pytest tests/lead_hunter/ -v`
+Expected: all PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/lead-hunter/celery_tasks.py
+git commit -m "refactor(lead-hunter): single-connection enrichment with context-managed cursors"
+```
+
+---
+
+## Task 10: Persistent default alert log + env-var docs
+
+Default alert log is `/tmp/hardening-alerts.jsonl` — wiped on macOS reboot. Move to a persistent path. Document `DISCORD_ALERT_WEBHOOK`, `HARDENING_ALERT_LOG`, `HARDENING_LOCK_DIR`, `LEAD_HUNTER_TIMEOUT_SECS`.
+
+**Files:**
+- Modify: `tools/lead-hunter/hardening.py:248`
+- Modify: `docs/env-vars.md` — add 4 rows
+
+- [ ] **Step 1: Change default in `hardening.py`**
+
+In `tools/lead-hunter/hardening.py`, line 248, replace:
+
+```python
+    alert_log = Path(alert_log or os.getenv("HARDENING_ALERT_LOG", "/tmp/hardening-alerts.jsonl"))
+```
+
+with:
+
+```python
+    # Default to a persistent path under marketing/prospects so /tmp wipe on reboot
+    # doesn't lose alert history. Override with HARDENING_ALERT_LOG.
+    default_log = Path(__file__).parent.parent.parent / "marketing" / "prospects" / "hardening-alerts.jsonl"
+    alert_log = Path(alert_log or os.getenv("HARDENING_ALERT_LOG", str(default_log)))
+```
+
+- [ ] **Step 2: Update tests that asserted /tmp**
+
+(Task 4 tests use `tmp_path` explicitly — they pass.) No test changes needed.
+
+- [ ] **Step 3: Document new env vars**
+
+In `docs/env-vars.md`, append after the last row of the main table:
+
+```markdown
+| `LEAD_HUNTER_TIMEOUT_SECS` | tools/lead-hunter — hard timeout for hourly run; default 1500 (25 min) |
+| `HARDENING_LOCK_DIR`     | tools/lead-hunter — directory for singleton lock file; default `/tmp` |
+| `HARDENING_ALERT_LOG`    | tools/lead-hunter — JSONL alert log path; default `marketing/prospects/hardening-alerts.jsonl` |
+| `DISCORD_ALERT_WEBHOOK`  | tools/lead-hunter — optional Discord webhook URL for degraded/failed runs |
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python3.12 -m pytest tests/lead_hunter/ -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tools/lead-hunter/hardening.py docs/env-vars.md
+git commit -m "fix(lead-hunter): persistent alert log default + document env vars"
+```
+
+---
+
+## Task 11: Final verification + push + open PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run full lead-hunter test suite**
+
+Run: `cd /Users/bravonode/Mira && python3.12 -m pytest tests/lead_hunter/ -v`
+Expected: ~32 tests, all PASS.
+
+- [ ] **Step 2: Smoke run `run_hourly.py` standalone (no DB write)**
+
+```bash
+NEON_DATABASE_URL="postgres://stub@localhost/none" \
+LEAD_HUNTER_TIMEOUT_SECS=10 \
+HARDENING_ALERT_LOG=/tmp/test-alerts.jsonl \
+python3.12 tools/lead-hunter/run_hourly.py
+echo "exit=$?"
+```
+
+Expected: exit code 1 (degraded — DB unreachable triggers schema step failure). Verify `/tmp/test-alerts.jsonl` was written with a JSON line containing `"overall": "fail"` (or `"degraded"`).
+
+- [ ] **Step 3: Lint**
+
+Run: `ruff check tools/lead-hunter/ tests/lead_hunter/`
+Expected: clean (or fix-pass with `ruff check --fix`).
+
+- [ ] **Step 4: Push**
+
+```bash
+git push -u origin feat/lead-hunter-firecrawl-enrichment
+```
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create --base main --title "feat(lead-hunter): close hardening gaps — tests + retry coverage + Celery parity" --body "$(cat <<'EOF'
+## Summary
+
+Closes the gaps the 2026-04-24 hardening (`2a7d68b`) exposed but didn't fix:
+
+- **Tests for `hardening.py`** — 21 unit tests across `singleton_lock`, `with_retries`, `hard_timeout`, `preflight_secrets`, `RunReport`, and `alert()` (was zero coverage)
+- **Discovery HTTP retries** — MSCA scrape and DDG search loop now wrapped in `with_retries` (previously only DB upsert + HubSpot push had retries)
+- **Partial enrichment failures surface** — `_enrich_unenriched` returns `(succeeded, attempted)`; `run_hourly` alerts on <50% success with ≥4 attempts
+- **Schema apply as tracked step** — moved from silent `log.warning` into a `report.step("apply_schema")` so failures escalate
+- **Celery path parity** — `@shared_task discover_and_enrich` now delegates to `run_hourly.main()`, so the singleton lock + hard timeout + preflight + alert sink apply on the Celery beat path (previously only launchd path got them)
+- **Connection lifecycle** — `_enrich_unenriched` uses one `psycopg2.connect()` with context-managed cursors instead of opening a new connection per row
+- **Persistent alert log** — default moved off `/tmp` (wiped on reboot) to `marketing/prospects/hardening-alerts.jsonl`
+- **Env-var docs** — 4 new rows in `docs/env-vars.md` for `LEAD_HUNTER_TIMEOUT_SECS`, `HARDENING_LOCK_DIR`, `HARDENING_ALERT_LOG`, `DISCORD_ALERT_WEBHOOK`
+
+## Test plan
+
+- [ ] `pytest tests/lead_hunter/ -v` — all green
+- [ ] Manual `run_hourly.py` smoke run with stub DB — exits 1, writes alert JSONL
+- [ ] `ruff check tools/lead-hunter/ tests/lead_hunter/` clean
+- [ ] Verify Celery worker picks up the new task body (compare `inspect registered` before/after)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Confirm PR opened**
+
+Run: `gh pr view --json url,number,title`
+Expected: PR URL printed.
+
+---
+
+## Self-Review Checklist (post-write)
+
+Spec coverage — every gap from the kickoff message has a task:
+
+| Gap | Task |
+|---|---|
+| `hardening.py` zero tests | Tasks 1–4 |
+| Discovery HTTP loop has no retries | Task 5 |
+| Per-facility enrichment errors swallowed silently | Task 6 |
+| Silent-zero detector misses partial failure | Task 6 |
+| `apply_schema` swallows errors | Task 7 |
+| Celery path bypasses lock/timeout/preflight/alert | Task 8 |
+| `_enrich_unenriched` opens conn per row, leaks on exception | Task 9 |
+| Alert log defaults to `/tmp` (wiped on reboot) | Task 10 |
+| New env vars undocumented | Task 10 |
+| No tests for silent-zero detectors | Task 6 |
+| Final verification + PR | Task 11 |
+
+Type consistency — `_enrich_unenriched` returns `tuple[int, int]` consistently across Tasks 6 and 9. `run_discover_and_enrich` adds `enriched_attempted` key in Task 6 and tests reference it in Tasks 6 and 7.
+
+Placeholders — none ("TBD", "TODO", "etc."). All code blocks are concrete.

--- a/mira-crawler/tasks/ingest.py
+++ b/mira-crawler/tasks/ingest.py
@@ -5,12 +5,20 @@ Reuses existing mira-crawler pipeline modules:
 - chunker.py for semantic chunking
 - embedder.py for Ollama embedding
 - store.py for NeonDB insert + dedup
+
+Reliability:
+  - HEAD pre-flight + post-download size check, default 50MB cap (env-tunable)
+  - Streams to tempfile instead of loading body into memory
+  - autoretry only on transient errors (httpx, OS, conn) — MemoryError bubbles
+  - acks_late=False so OOM kills don't trigger redelivery loop
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import tempfile
+from pathlib import Path
 
 import httpx
 
@@ -22,10 +30,31 @@ except ImportError:
 logger = logging.getLogger("mira-crawler.tasks.ingest")
 
 DOWNLOAD_TIMEOUT = int(os.getenv("INGEST_DOWNLOAD_TIMEOUT", "60"))
-MAX_PDF_BYTES = int(os.getenv("INGEST_MAX_PDF_BYTES", str(150 * 1024 * 1024)))  # 150 MB
+# Default lowered from 150MB to 50MB — Docling's PDF parser uses 5-10× the file
+# size during extraction (image OCR pass), so 50MB ≈ 250–500MB working set.
+MAX_PDF_BYTES = int(os.getenv("INGEST_MAX_PDF_BYTES", str(50 * 1024 * 1024)))
+
+_TRANSIENT = (
+    httpx.HTTPError,
+    httpx.TimeoutException,
+    ConnectionError,
+    TimeoutError,
+    OSError,
+)
 
 
-@app.task(bind=True, max_retries=3, default_retry_delay=30)
+@app.task(
+    bind=True,
+    max_retries=3,
+    soft_time_limit=600,
+    time_limit=900,
+    acks_late=False,
+    reject_on_worker_lost=False,
+    autoretry_for=_TRANSIENT,
+    retry_backoff=True,
+    retry_backoff_max=300,
+    retry_jitter=True,
+)
 def ingest_url(self, url: str, manufacturer: str = "",
                model: str = "", source_type: str = "equipment_manual"):
     """Download, extract, chunk, embed, and store one document.
@@ -88,25 +117,43 @@ def ingest_url(self, url: str, manufacturer: str = "",
             except Exception:
                 pass
 
+        # Stream download to a tempfile so a misbehaving server (no
+        # Content-Length, chunked-encoding bomb, etc.) can't OOM the worker.
+        # Abort mid-stream if we cross the size cap.
+        tmp = tempfile.NamedTemporaryFile(prefix="mira-ingest-", suffix=".bin", delete=False)
+        tmp_path = Path(tmp.name)
+        downloaded = 0
         try:
-            resp = httpx.get(
-                url,
+            with httpx.Client(
                 timeout=DOWNLOAD_TIMEOUT,
                 follow_redirects=True,
                 headers={"User-Agent": "MIRA-IngestBot/1.0 (KB builder)"},
-            )
-            resp.raise_for_status()
-            data = resp.content
-            content_type = resp.headers.get("content-type", "")
-            if len(data) > MAX_PDF_BYTES and ("application/pdf" in content_type or is_pdf_url):
-                logger.warning(
-                    "Skipping %s — downloaded %d MB exceeds limit",
-                    url[:80], len(data) // 1024 // 1024,
-                )
-                return {"url": url, "inserted": 0, "error": "file_too_large"}
-        except Exception as exc:
-            logger.warning("Download failed for %s: %s — retrying", url[:80], exc)
-            raise self.retry(exc=exc)
+            ) as client:
+                with client.stream("GET", url) as resp:
+                    resp.raise_for_status()
+                    content_type = resp.headers.get("content-type", "")
+                    for chunk in resp.iter_bytes(chunk_size=64 * 1024):
+                        downloaded += len(chunk)
+                        if downloaded > MAX_PDF_BYTES and (
+                            "application/pdf" in content_type or is_pdf_url
+                        ):
+                            tmp.close()
+                            tmp_path.unlink(missing_ok=True)
+                            logger.warning(
+                                "Aborted streaming download of %s — exceeded %d MB cap mid-stream",
+                                url[:80], MAX_PDF_BYTES // 1024 // 1024,
+                            )
+                            return {"url": url, "inserted": 0, "error": "file_too_large"}
+                        tmp.write(chunk)
+            tmp.close()
+            data = tmp_path.read_bytes()
+        except _TRANSIENT as exc:
+            tmp.close()
+            tmp_path.unlink(missing_ok=True)
+            logger.warning("Download failed for %s: %s — Celery will retry", url[:80], exc)
+            raise  # autoretry_for handles the retry
+        finally:
+            tmp_path.unlink(missing_ok=True)
 
     # 3. Extract text blocks
     is_pdf = url.lower().endswith(".pdf") or "application/pdf" in content_type

--- a/tests/lead_hunter/conftest.py
+++ b/tests/lead_hunter/conftest.py
@@ -1,0 +1,8 @@
+"""Make tools/lead-hunter importable as a module for tests."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "tools" / "lead-hunter"))

--- a/tests/lead_hunter/test_celery_tasks.py
+++ b/tests/lead_hunter/test_celery_tasks.py
@@ -1,0 +1,83 @@
+"""Tests that retries cover the discovery HTTP loop, not just DB/HubSpot."""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+
+def test_discovery_msca_call_uses_with_retries(monkeypatch):
+    """scrape_msca should be invoked through hardening.with_retries.
+
+    Implementation detail: we patch hardening.with_retries and assert
+    the discovery code calls it with name='scrape_msca'.
+    """
+    import celery_tasks
+
+    calls = []
+
+    def fake_with_retries(fn, *, name, **kw):
+        calls.append(name)
+        # Don't actually run fn — we're only checking the call shape
+        return []
+
+    monkeypatch.setattr("celery_tasks.with_retries", fake_with_retries, raising=False)
+    # Patch out everything else so the function returns quickly
+    monkeypatch.setattr("celery_tasks._load_state", lambda: {
+        "city_index": 0, "requests_today": 0, "last_date": "", "total_discovered": 0,
+    })
+    monkeypatch.setattr("celery_tasks._save_state", lambda s: None)
+    monkeypatch.setattr("celery_tasks._check_daily_budget", lambda s: True)
+    monkeypatch.setenv("NEON_DATABASE_URL", "")
+    monkeypatch.setenv("HUNTER_API_KEY", "")
+    monkeypatch.setenv("HUBSPOT_ACCESS_TOKEN", "")
+
+    import hunt as hunt_mod
+    monkeypatch.setattr(hunt_mod, "CITIES", [("TestCity", 0.0, 0.0, 10)])
+    monkeypatch.setattr(hunt_mod, "QUERY_TEMPLATES", [])
+    monkeypatch.setattr(hunt_mod, "apply_schema", lambda *a, **k: None)
+    monkeypatch.setattr(hunt_mod, "RATE_LIMIT_SECS", 0)
+
+    import discover as discover_mod
+    monkeypatch.setattr(discover_mod, "MEDIUM_BIZ_QUERIES", [])
+    monkeypatch.setattr(discover_mod, "search_ddg_medium",
+                        lambda *a, **k: ([], None))
+
+    celery_tasks.run_discover_and_enrich()
+    assert "scrape_msca" in calls, f"Expected scrape_msca to be wrapped; got {calls}"
+
+
+def test_discovery_ddg_search_uses_with_retries(monkeypatch):
+    import celery_tasks
+    import hunt as hunt_mod
+    import discover as discover_mod
+
+    calls = []
+    def fake_with_retries(fn, *, name, **kw):
+        calls.append(name)
+        return None
+
+    monkeypatch.setattr("celery_tasks.with_retries", fake_with_retries, raising=False)
+    monkeypatch.setattr("celery_tasks._load_state", lambda: {
+        "city_index": 1, "requests_today": 0, "last_date": "", "total_discovered": 0,
+    })
+    monkeypatch.setattr("celery_tasks._save_state", lambda s: None)
+    monkeypatch.setattr("celery_tasks._check_daily_budget", lambda s: True)
+    monkeypatch.setenv("NEON_DATABASE_URL", "")
+    monkeypatch.setenv("HUNTER_API_KEY", "")
+    monkeypatch.setenv("HUBSPOT_ACCESS_TOKEN", "")
+
+    monkeypatch.setattr(hunt_mod, "CITIES", [("CityA", 0.0, 0.0, 10), ("CityB", 1.0, 1.0, 10)])
+    monkeypatch.setattr(hunt_mod, "QUERY_TEMPLATES", ["machine shop {city}"])
+    monkeypatch.setattr(hunt_mod, "apply_schema", lambda *a, **k: None)
+    monkeypatch.setattr(hunt_mod, "RATE_LIMIT_SECS", 0)
+    monkeypatch.setattr(hunt_mod, "extract_facilities_from_results",
+                        lambda *a, **k: [])
+    monkeypatch.setattr(discover_mod, "MEDIUM_BIZ_QUERIES", [])
+    monkeypatch.setattr(discover_mod, "search_ddg_medium",
+                        lambda *a, **k: ([], None))
+
+    celery_tasks.run_discover_and_enrich()
+    assert any(n.startswith("ddg_search:") for n in calls), \
+        f"Expected ddg_search:* to be wrapped; got {calls}"

--- a/tests/lead_hunter/test_celery_tasks.py
+++ b/tests/lead_hunter/test_celery_tasks.py
@@ -81,3 +81,20 @@ def test_discovery_ddg_search_uses_with_retries(monkeypatch):
     celery_tasks.run_discover_and_enrich()
     assert any(n.startswith("ddg_search:") for n in calls), \
         f"Expected ddg_search:* to be wrapped; got {calls}"
+
+
+def test_celery_task_delegates_to_run_hourly_main(monkeypatch):
+    """The @shared_task body must call run_hourly.main(), not run_discover_and_enrich().
+
+    Use source inspection: verify that the Celery task delegates to run_hourly.main()
+    and does not call run_discover_and_enrich() directly.
+    """
+    pytest.importorskip("celery")
+    import inspect
+    import celery_tasks
+
+    src = inspect.getsource(celery_tasks.discover_and_enrich)
+    assert "from run_hourly import main" in src or "run_hourly.main" in src, \
+        "Celery task must import and call run_hourly.main()"
+    assert "run_discover_and_enrich()" not in src, \
+        "Celery task must NOT call run_discover_and_enrich() directly"

--- a/tests/lead_hunter/test_celery_tasks.py
+++ b/tests/lead_hunter/test_celery_tasks.py
@@ -1,9 +1,6 @@
 """Tests that retries cover the discovery HTTP loop, not just DB/HubSpot."""
 from __future__ import annotations
 
-from unittest.mock import patch
-
-import httpx
 import pytest
 
 
@@ -50,8 +47,8 @@ def test_discovery_msca_call_uses_with_retries(monkeypatch):
 
 def test_discovery_ddg_search_uses_with_retries(monkeypatch):
     import celery_tasks
-    import hunt as hunt_mod
     import discover as discover_mod
+    import hunt as hunt_mod
 
     calls = []
     def fake_with_retries(fn, *, name, **kw):
@@ -91,6 +88,7 @@ def test_celery_task_delegates_to_run_hourly_main(monkeypatch):
     """
     pytest.importorskip("celery")
     import inspect
+
     import celery_tasks
 
     src = inspect.getsource(celery_tasks.discover_and_enrich)

--- a/tests/lead_hunter/test_hardening.py
+++ b/tests/lead_hunter/test_hardening.py
@@ -53,3 +53,62 @@ def test_singleton_lock_releases_on_exception(tmp_path):
             raise RuntimeError("boom")
     # Lock file gone even after exception
     assert not (tmp_path / ".test-lh-3.lock").exists()
+
+
+# ---------------- with_retries ----------------
+
+def test_with_retries_returns_value_on_first_success():
+    from hardening import with_retries
+    calls = []
+    def fn():
+        calls.append(1)
+        return "ok"
+    assert with_retries(fn, name="t", retries=3) == "ok"
+    assert calls == [1]
+
+
+def test_with_retries_retries_then_succeeds(monkeypatch):
+    from hardening import with_retries
+    monkeypatch.setattr("hardening.time.sleep", lambda s: None)
+    monkeypatch.setattr("hardening.random.uniform", lambda a, b: 1.0)
+    calls = {"n": 0}
+    def fn():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionError("transient")
+        return "ok"
+    assert with_retries(fn, name="t", retries=3, retry_on=(ConnectionError,)) == "ok"
+    assert calls["n"] == 3
+
+
+def test_with_retries_exhausts_and_raises_last(monkeypatch):
+    from hardening import with_retries
+    monkeypatch.setattr("hardening.time.sleep", lambda s: None)
+    monkeypatch.setattr("hardening.random.uniform", lambda a, b: 1.0)
+    def fn():
+        raise ConnectionError("always fails")
+    with pytest.raises(ConnectionError, match="always fails"):
+        with_retries(fn, name="t", retries=2, retry_on=(ConnectionError,))
+
+
+def test_with_retries_does_not_retry_give_up_class(monkeypatch):
+    from hardening import with_retries
+    monkeypatch.setattr("hardening.time.sleep", lambda s: None)
+    calls = {"n": 0}
+    def fn():
+        calls["n"] += 1
+        raise KeyboardInterrupt()
+    with pytest.raises(KeyboardInterrupt):
+        with_retries(fn, name="t", retries=5)
+    assert calls["n"] == 1  # No retry on KeyboardInterrupt
+
+
+def test_with_retries_does_not_retry_unlisted_exception(monkeypatch):
+    from hardening import with_retries
+    calls = {"n": 0}
+    def fn():
+        calls["n"] += 1
+        raise ValueError("not in retry_on")
+    with pytest.raises(ValueError):
+        with_retries(fn, name="t", retries=3, retry_on=(ConnectionError,))
+    assert calls["n"] == 1

--- a/tests/lead_hunter/test_hardening.py
+++ b/tests/lead_hunter/test_hardening.py
@@ -6,14 +6,13 @@ so subsequent refactors are safe.
 from __future__ import annotations
 
 import json
-import os
+import signal as _signal
 import subprocess
 import sys
 import time
 from pathlib import Path
 
 import pytest
-
 
 # ---------------- singleton_lock ----------------
 
@@ -113,8 +112,6 @@ def test_with_retries_does_not_retry_unlisted_exception(monkeypatch):
         with_retries(fn, name="t", retries=3, retry_on=(ConnectionError,))
     assert calls["n"] == 1
 
-
-import signal as _signal
 
 # ---------------- hard_timeout ----------------
 

--- a/tests/lead_hunter/test_hardening.py
+++ b/tests/lead_hunter/test_hardening.py
@@ -159,3 +159,107 @@ def test_preflight_secrets_treats_blank_as_missing(monkeypatch):
     with pytest.raises(SystemExit) as exc_info:
         preflight_secrets(["BLANK_REQ"])
     assert exc_info.value.code == 2
+
+
+# ---------------- RunReport ----------------
+
+def test_runreport_step_ok_path():
+    from hardening import RunReport
+    r = RunReport(routine="t")
+    with r.step("a") as step:
+        step.detail["x"] = 1
+    r.finalize()
+    assert r.steps[0].status == "ok"
+    assert r.steps[0].detail == {"x": 1}
+    assert r.overall == "ok"
+    assert r.is_healthy()
+
+
+def test_runreport_step_fail_swallows_exception_and_marks_overall():
+    from hardening import RunReport
+    r = RunReport(routine="t")
+    with r.step("a"):
+        raise ValueError("kaboom")
+    r.finalize()
+    assert r.steps[0].status == "fail"
+    assert "ValueError: kaboom" in r.steps[0].error
+    assert r.overall == "fail"
+    assert not r.is_healthy()
+
+
+def test_runreport_skip_marks_degraded():
+    from hardening import RunReport
+    r = RunReport(routine="t")
+    with r.step("a") as step:
+        step.status = "skip"
+        step.detail["reason"] = "no data"
+    r.finalize()
+    assert r.overall == "degraded"
+
+
+def test_runreport_alert_marks_degraded():
+    from hardening import RunReport
+    r = RunReport(routine="t")
+    with r.step("a"):
+        pass
+    r.add_alert("something is sus")
+    r.finalize()
+    assert r.overall == "degraded"
+    assert r.alerts == ["something is sus"]
+
+
+def test_runreport_to_json_is_valid():
+    from hardening import RunReport
+    r = RunReport(routine="t")
+    with r.step("a"):
+        pass
+    r.finalize()
+    parsed = json.loads(r.to_json())
+    assert parsed["routine"] == "t"
+    assert parsed["overall"] == "ok"
+    assert len(parsed["steps"]) == 1
+
+
+# ---------------- alert() ----------------
+
+def test_alert_noop_on_healthy(tmp_path, monkeypatch):
+    from hardening import RunReport, alert
+    monkeypatch.delenv("DISCORD_ALERT_WEBHOOK", raising=False)
+    r = RunReport(routine="t")
+    with r.step("a"):
+        pass
+    r.finalize()
+    log_path = tmp_path / "alerts.jsonl"
+    alert(r, alert_log=log_path)
+    assert not log_path.exists()
+
+
+def test_alert_appends_jsonl_on_failure(tmp_path, monkeypatch):
+    from hardening import RunReport, alert
+    monkeypatch.delenv("DISCORD_ALERT_WEBHOOK", raising=False)
+    r = RunReport(routine="t")
+    with r.step("a"):
+        raise RuntimeError("nope")
+    r.finalize()
+    log_path = tmp_path / "alerts.jsonl"
+    alert(r, alert_log=log_path)
+    line = log_path.read_text().strip()
+    parsed = json.loads(line)
+    assert parsed["routine"] == "t"
+    assert parsed["overall"] == "fail"
+
+
+def test_alert_appends_jsonl_on_degraded(tmp_path, monkeypatch):
+    from hardening import RunReport, alert
+    monkeypatch.delenv("DISCORD_ALERT_WEBHOOK", raising=False)
+    r = RunReport(routine="t")
+    with r.step("a"):
+        pass
+    r.add_alert("partial failure")
+    r.finalize()
+    log_path = tmp_path / "alerts.jsonl"
+    alert(r, alert_log=log_path)
+    assert log_path.exists()
+    parsed = json.loads(log_path.read_text().strip())
+    assert parsed["overall"] == "degraded"
+    assert parsed["alerts"] == ["partial failure"]

--- a/tests/lead_hunter/test_hardening.py
+++ b/tests/lead_hunter/test_hardening.py
@@ -1,0 +1,55 @@
+"""Characterization tests for tools/lead-hunter/hardening.py.
+
+The module already ships in production; these tests pin its current behavior
+so subsequent refactors are safe.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+# ---------------- singleton_lock ----------------
+
+def test_singleton_lock_first_acquires(tmp_path):
+    from hardening import singleton_lock
+    with singleton_lock("test-lh-1", lock_dir=tmp_path):
+        assert (tmp_path / ".test-lh-1.lock").exists()
+    # Lock file removed on exit
+    assert not (tmp_path / ".test-lh-1.lock").exists()
+
+
+def test_singleton_lock_second_invocation_exits_zero(tmp_path):
+    """A second process holding the same lock must exit cleanly with code 0."""
+    from hardening import singleton_lock
+
+    # Compute the actual path to lead-hunter module in the repo
+    lh_dir = Path(__file__).resolve().parents[2] / "tools" / "lead-hunter"
+
+    # Hold the lock in this process; spawn a child that tries to acquire it.
+    with singleton_lock("test-lh-2", lock_dir=tmp_path):
+        helper = tmp_path / "child.py"
+        helper.write_text(
+            "import sys\n"
+            f"sys.path.insert(0, {str(lh_dir)!r})\n"
+            "from hardening import singleton_lock\n"
+            f"with singleton_lock('test-lh-2', lock_dir={str(tmp_path)!r}):\n"
+            "    pass\n"
+        )
+        result = subprocess.run([sys.executable, str(helper)], capture_output=True, timeout=10)
+        assert result.returncode == 0, result.stderr.decode()
+
+
+def test_singleton_lock_releases_on_exception(tmp_path):
+    from hardening import singleton_lock
+    with pytest.raises(RuntimeError):
+        with singleton_lock("test-lh-3", lock_dir=tmp_path):
+            raise RuntimeError("boom")
+    # Lock file gone even after exception
+    assert not (tmp_path / ".test-lh-3.lock").exists()

--- a/tests/lead_hunter/test_hardening.py
+++ b/tests/lead_hunter/test_hardening.py
@@ -112,3 +112,50 @@ def test_with_retries_does_not_retry_unlisted_exception(monkeypatch):
     with pytest.raises(ValueError):
         with_retries(fn, name="t", retries=3, retry_on=(ConnectionError,))
     assert calls["n"] == 1
+
+
+import signal as _signal
+
+# ---------------- hard_timeout ----------------
+
+@pytest.mark.skipif(not hasattr(_signal, "SIGALRM"), reason="SIGALRM unavailable on this platform")
+def test_hard_timeout_raises_after_expiry():
+    from hardening import hard_timeout
+    with pytest.raises(TimeoutError):
+        with hard_timeout(1):
+            time.sleep(2)
+
+
+def test_hard_timeout_clears_on_normal_exit():
+    from hardening import hard_timeout
+    with hard_timeout(5):
+        pass
+    # Subsequent sleep must not get interrupted
+    time.sleep(0.05)
+
+
+# ---------------- preflight_secrets ----------------
+
+def test_preflight_secrets_returns_map(monkeypatch):
+    from hardening import preflight_secrets
+    monkeypatch.setenv("PRESENT_REQ", "value")
+    monkeypatch.setenv("PRESENT_OPT", "value")
+    monkeypatch.delenv("MISSING_OPT", raising=False)
+    m = preflight_secrets(["PRESENT_REQ"], ["PRESENT_OPT", "MISSING_OPT"])
+    assert m == {"PRESENT_REQ": True, "PRESENT_OPT": True, "MISSING_OPT": False}
+
+
+def test_preflight_secrets_exits_2_on_missing_required(monkeypatch):
+    from hardening import preflight_secrets
+    monkeypatch.delenv("REQUIRED_X", raising=False)
+    with pytest.raises(SystemExit) as exc_info:
+        preflight_secrets(["REQUIRED_X"])
+    assert exc_info.value.code == 2
+
+
+def test_preflight_secrets_treats_blank_as_missing(monkeypatch):
+    from hardening import preflight_secrets
+    monkeypatch.setenv("BLANK_REQ", "   ")
+    with pytest.raises(SystemExit) as exc_info:
+        preflight_secrets(["BLANK_REQ"])
+    assert exc_info.value.code == 2

--- a/tests/lead_hunter/test_run_hourly.py
+++ b/tests/lead_hunter/test_run_hourly.py
@@ -61,6 +61,8 @@ def test_run_returns_zero_on_clean_run(monkeypatch):
         "city": "X", "discovered": 5, "enriched": 5, "enriched_attempted": 5,
         "inserted": 5, "hs_pushed": 5,
     })
+    import hunt as hunt_mod
+    monkeypatch.setattr(hunt_mod, "apply_schema", lambda url: None)
     rc = run_hourly._run()
     assert rc == 0
 
@@ -74,4 +76,41 @@ def test_run_skip_marks_degraded(monkeypatch):
     })
     rc = run_hourly._run()
     # skip without other failures: degraded -> exit 1
+    assert rc == 1
+
+
+def test_run_marks_schema_step_as_skip_when_no_db(monkeypatch):
+    """When NEON_DATABASE_URL is set (required passes preflight) but apply_schema
+    succeeds, downstream clean run -> exit 0."""
+    import run_hourly
+    monkeypatch.setenv("NEON_DATABASE_URL", "postgres://stub")
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "stub")
+    monkeypatch.setenv("HUBSPOT_API_KEY", "stub")
+    monkeypatch.setenv("SERPER_API_KEY", "stub")
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 5, "enriched": 5, "enriched_attempted": 5,
+        "inserted": 5, "hs_pushed": 5,
+    })
+    import hunt as hunt_mod
+    monkeypatch.setattr(hunt_mod, "apply_schema", lambda url: None)
+    rc = run_hourly._run()
+    # Clean run path -> exit 0
+    assert rc == 0
+
+
+def test_run_step_records_schema_failure(monkeypatch):
+    import run_hourly
+    monkeypatch.setenv("NEON_DATABASE_URL", "postgres://stub")
+
+    def boom(url):
+        raise RuntimeError("migration broke")
+
+    import hunt as hunt_mod
+    monkeypatch.setattr(hunt_mod, "apply_schema", boom)
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 0, "enriched": 0, "enriched_attempted": 0,
+        "inserted": 0, "hs_pushed": 0,
+    })
+    rc = run_hourly._run()
+    # Schema failure -> step fails -> overall fail -> exit 1
     assert rc == 1

--- a/tests/lead_hunter/test_run_hourly.py
+++ b/tests/lead_hunter/test_run_hourly.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import patch
 
 import pytest
 

--- a/tests/lead_hunter/test_run_hourly.py
+++ b/tests/lead_hunter/test_run_hourly.py
@@ -1,0 +1,78 @@
+"""Tests for run_hourly._run silent-failure detectors and exit codes."""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+def _stub_required_env(monkeypatch):
+    monkeypatch.setenv("NEON_DATABASE_URL", "postgres://stub")
+
+
+def test_run_alerts_on_discovered_but_zero_enriched(monkeypatch):
+    import run_hourly
+    _stub_required_env(monkeypatch)
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "stub")
+
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 5, "enriched": 0, "enriched_attempted": 5,
+        "inserted": 0, "hs_pushed": 0,
+    })
+    rc = run_hourly._run()
+    # Degraded -> exit 1
+    assert rc == 1
+
+
+def test_run_alerts_on_inserted_but_zero_pushed(monkeypatch):
+    import run_hourly
+    _stub_required_env(monkeypatch)
+    monkeypatch.setenv("HUBSPOT_API_KEY", "stub")
+
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 5, "enriched": 5, "enriched_attempted": 5,
+        "inserted": 3, "hs_pushed": 0,
+    })
+    rc = run_hourly._run()
+    assert rc == 1  # degraded
+
+
+def test_run_alerts_on_partial_enrichment_failure(monkeypatch):
+    import run_hourly
+    _stub_required_env(monkeypatch)
+
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 5, "enriched": 1, "enriched_attempted": 5,
+        "inserted": 1, "hs_pushed": 0,
+    })
+    rc = run_hourly._run()
+    # 1/5 < 50% -> partial failure alert -> degraded
+    assert rc == 1
+
+
+def test_run_returns_zero_on_clean_run(monkeypatch):
+    import run_hourly
+    _stub_required_env(monkeypatch)
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "stub")
+    monkeypatch.setenv("HUBSPOT_API_KEY", "stub")
+    monkeypatch.setenv("SERPER_API_KEY", "stub")
+
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "city": "X", "discovered": 5, "enriched": 5, "enriched_attempted": 5,
+        "inserted": 5, "hs_pushed": 5,
+    })
+    rc = run_hourly._run()
+    assert rc == 0
+
+
+def test_run_skip_marks_degraded(monkeypatch):
+    import run_hourly
+    _stub_required_env(monkeypatch)
+
+    monkeypatch.setattr("celery_tasks.run_discover_and_enrich", lambda: {
+        "skipped": True, "reason": "daily_budget",
+    })
+    rc = run_hourly._run()
+    # skip without other failures: degraded -> exit 1
+    assert rc == 1

--- a/tests/lead_hunter/test_run_hourly.py
+++ b/tests/lead_hunter/test_run_hourly.py
@@ -1,10 +1,6 @@
 """Tests for run_hourly._run silent-failure detectors and exit codes."""
 from __future__ import annotations
 
-import os
-
-import pytest
-
 
 def _stub_required_env(monkeypatch):
     monkeypatch.setenv("NEON_DATABASE_URL", "postgres://stub")

--- a/tools/lead-hunter/celery_tasks.py
+++ b/tools/lead-hunter/celery_tasks.py
@@ -194,11 +194,11 @@ def run_discover_and_enrich() -> dict:
 
     # Phase 2: Enrich top un-enriched facilities
     if db_url:
-        enriched_count = _enrich_unenriched(
+        enriched_count, enriched_attempted = _enrich_unenriched(
             db_url, hunter_key, DISCOVERY_RATE["max_enrichments_per_run"]
         )
     else:
-        enriched_count = 0
+        enriched_count, enriched_attempted = 0, 0
 
     # Persist to DB — retry on transient NeonDB errors (cold start, network blip)
     inserted = 0
@@ -242,6 +242,7 @@ def run_discover_and_enrich() -> dict:
         "discovered": len(fac_list),
         "inserted": inserted,
         "enriched": enriched_count,
+        "enriched_attempted": enriched_attempted,
         "hs_qualified": hs_qualified if hs_token and fac_list else 0,
         "hs_pushed": hs_pushed,
         "requests_used": requests_used,
@@ -258,8 +259,12 @@ def run_discover_and_enrich() -> dict:
     return run_result
 
 
-def _enrich_unenriched(db_url: str, hunter_key: str, limit: int) -> int:
-    """Enrich facilities that have a website but no contacts yet."""
+def _enrich_unenriched(db_url: str, hunter_key: str, limit: int) -> tuple[int, int]:
+    """Enrich facilities that have a website but no contacts yet.
+
+    Returns (succeeded, attempted). attempted == 0 means nothing eligible —
+    not a partial failure.
+    """
     import enrich
     import httpx
     import hunt
@@ -284,7 +289,7 @@ def _enrich_unenriched(db_url: str, hunter_key: str, limit: int) -> int:
     conn.close()
 
     if not rows:
-        return 0
+        return 0, 0
 
     enriched = 0
     with httpx.Client(timeout=15) as client:
@@ -339,9 +344,9 @@ def _enrich_unenriched(db_url: str, hunter_key: str, limit: int) -> int:
                 conn2.close()
                 enriched += 1
             except Exception as e:
-                log.debug("Enrich failed %s: %s", name, e)
+                log.warning("Enrich failed %s: %s", name, e)
 
-    return enriched
+    return enriched, len(rows)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/lead-hunter/celery_tasks.py
+++ b/tools/lead-hunter/celery_tasks.py
@@ -30,7 +30,18 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
+import httpx
+from hardening import with_retries
+
 log = logging.getLogger("lead-hunter.celery")
+
+# Exception classes that justify retrying a discovery HTTP call
+_HTTP_RETRY = (
+    httpx.TransportError,   # connect / read timeouts, network errors
+    httpx.HTTPStatusError,  # 5xx if .raise_for_status() is called
+    ConnectionError,
+    TimeoutError,
+)
 
 # ---------------------------------------------------------------------------
 # State: rotate through cities each run
@@ -75,8 +86,6 @@ def _check_daily_budget(state: dict) -> bool:
 
 def run_discover_and_enrich() -> dict:
     """Execute one hourly discovery + enrichment cycle. Returns run stats."""
-    import httpx
-
     # Import here to allow running without Celery
     sys.path.insert(0, str(Path(__file__).parent))
     import discover
@@ -112,7 +121,17 @@ def run_discover_and_enrich() -> dict:
     if city_idx == 0:
         log.info("Running MSCA directory scrape...")
         with httpx.Client(timeout=20) as client:
-            msca_facs = discover.scrape_msca(client)
+            try:
+                msca_facs = with_retries(
+                    lambda: discover.scrape_msca(client),
+                    name="scrape_msca",
+                    retries=2,
+                    backoff=3.0,
+                    retry_on=_HTTP_RETRY,
+                )
+            except Exception as e:
+                log.warning("scrape_msca failed after retries: %s", e)
+                msca_facs = []
             requests_used += 1
             for f in msca_facs:
                 if f.key not in new_facilities:
@@ -144,7 +163,17 @@ def run_discover_and_enrich() -> dict:
                 if requests_used >= DISCOVERY_RATE["max_requests_per_run"]:
                     break
                 query = qt.format(city=city_name)
-                results = discover._ddg_search(query, client)
+                try:
+                    results = with_retries(
+                        lambda: discover._ddg_search(query, client),
+                        name=f"ddg_search:{qt[:20]}",
+                        retries=1,  # discovery loop already absorbs single fails via ddg_fails
+                        backoff=2.0,
+                        retry_on=_HTTP_RETRY,
+                    )
+                except Exception as e:
+                    log.warning("ddg_search retry exhausted (%s): %s", qt[:30], e)
+                    results = None
                 requests_used += 1
                 if results is None:
                     ddg_fails[0] += 1
@@ -172,8 +201,6 @@ def run_discover_and_enrich() -> dict:
         enriched_count = 0
 
     # Persist to DB — retry on transient NeonDB errors (cold start, network blip)
-    from hardening import with_retries
-
     inserted = 0
     if db_url and fac_list:
         try:

--- a/tools/lead-hunter/celery_tasks.py
+++ b/tools/lead-hunter/celery_tasks.py
@@ -263,83 +263,72 @@ def _enrich_unenriched(db_url: str, hunter_key: str, limit: int) -> tuple[int, i
     import hunt
     import psycopg2
 
-    conn = psycopg2.connect(db_url)
-    cur = conn.cursor()
-    cur.execute(
-        """
-        SELECT f.id, f.name, f.city, f.website, f.phone, f.icp_score, f.notes
-        FROM prospect_facilities f
-        LEFT JOIN prospect_contacts c ON c.facility_id = f.id
-        WHERE f.website IS NOT NULL AND f.website != ''
-          AND c.id IS NULL
-          AND f.icp_score >= 6
-        ORDER BY f.icp_score DESC
-        LIMIT %s
-        """,
-        (limit,),
-    )
-    rows = cur.fetchall()
-    conn.close()
-
-    if not rows:
-        return 0, 0
-
     enriched = 0
-    with httpx.Client(timeout=15) as client:
-        for row in rows:
-            fid, name, city, website, phone, icp_score, notes = row
-            f = hunt.Facility(
-                name=name,
-                city=city,
-                website=website or "",
-                phone=phone or "",
-                icp_score=icp_score or 0,
-                notes=notes or "",
+    attempted = 0
+
+    with psycopg2.connect(db_url) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT f.id, f.name, f.city, f.website, f.phone, f.icp_score, f.notes
+                FROM prospect_facilities f
+                LEFT JOIN prospect_contacts c ON c.facility_id = f.id
+                WHERE f.website IS NOT NULL AND f.website != ''
+                  AND c.id IS NULL
+                  AND f.icp_score >= 6
+                ORDER BY f.icp_score DESC
+                LIMIT %s
+                """,
+                (limit,),
             )
-            try:
-                log.info("Enriching: %s (%s)", name[:50], (website or "")[:40])
-                result = enrich.scrape_facility_deep(f, client)
-                enrich.apply_enrichment(f, result, hunter_key, client)
-                f.icp_score = hunt.score_facility(f)
+            rows = cur.fetchall()
 
-                # Save enrichment back to DB
-                conn2 = psycopg2.connect(db_url)
-                cur2 = conn2.cursor()
-                if f.phone:
-                    cur2.execute(
-                        "UPDATE prospect_facilities SET phone=%s, updated_at=NOW() WHERE id=%s",
-                        (f.phone, fid),
-                    )
-                if "vfd_keywords_found" in f.notes:
-                    cur2.execute(
-                        "UPDATE prospect_facilities SET notes=%s, icp_score=%s, updated_at=NOW() WHERE id=%s",
-                        (f.notes, f.icp_score, fid),
-                    )
-                if f.contacts:
-                    for c in f.contacts:
-                        cur2.execute(
-                            """
-                            INSERT INTO prospect_contacts (facility_id, name, title, email, phone, source, confidence)
-                            VALUES (%s, %s, %s, %s, %s, %s, %s)
-                            ON CONFLICT DO NOTHING
-                            """,
-                            (
-                                fid,
-                                c.get("name"),
-                                c.get("title"),
-                                c.get("email"),
-                                c.get("phone"),
-                                c.get("source", "website"),
-                                c.get("confidence", "low"),
-                            ),
-                        )
-                conn2.commit()
-                conn2.close()
-                enriched += 1
-            except Exception as e:
-                log.warning("Enrich failed %s: %s", name, e)
+        if not rows:
+            return 0, 0
 
-    return enriched, len(rows)
+        attempted = len(rows)
+        with httpx.Client(timeout=15) as client:
+            for row in rows:
+                fid, name, city, website, phone, icp_score, notes = row
+                f = hunt.Facility(
+                    name=name, city=city, website=website or "",
+                    phone=phone or "", icp_score=icp_score or 0, notes=notes or "",
+                )
+                try:
+                    log.info("Enriching: %s (%s)", name[:50], (website or "")[:40])
+                    result = enrich.scrape_facility_deep(f, client)
+                    enrich.apply_enrichment(f, result, hunter_key, client)
+                    f.icp_score = hunt.score_facility(f)
+
+                    with conn.cursor() as cur2:
+                        if f.phone:
+                            cur2.execute(
+                                "UPDATE prospect_facilities SET phone=%s, updated_at=NOW() WHERE id=%s",
+                                (f.phone, fid),
+                            )
+                        if "vfd_keywords_found" in f.notes:
+                            cur2.execute(
+                                "UPDATE prospect_facilities SET notes=%s, icp_score=%s, updated_at=NOW() WHERE id=%s",
+                                (f.notes, f.icp_score, fid),
+                            )
+                        if f.contacts:
+                            for c in f.contacts:
+                                cur2.execute(
+                                    """
+                                    INSERT INTO prospect_contacts (facility_id, name, title, email, phone, source, confidence)
+                                    VALUES (%s, %s, %s, %s, %s, %s, %s)
+                                    ON CONFLICT DO NOTHING
+                                    """,
+                                    (fid, c.get("name"), c.get("title"), c.get("email"),
+                                     c.get("phone"), c.get("source", "website"), c.get("confidence", "low")),
+                                )
+                    conn.commit()
+                    enriched += 1
+                except Exception as e:
+                    log.warning("Enrich failed %s: %s", name, e)
+                    conn.rollback()  # release transaction state on this connection
+
+    return enriched, attempted
 
 
 # ---------------------------------------------------------------------------

--- a/tools/lead-hunter/celery_tasks.py
+++ b/tools/lead-hunter/celery_tasks.py
@@ -171,22 +171,39 @@ def run_discover_and_enrich() -> dict:
     else:
         enriched_count = 0
 
-    # Persist to DB
+    # Persist to DB — retry on transient NeonDB errors (cold start, network blip)
+    from hardening import with_retries
+
     inserted = 0
     if db_url and fac_list:
         try:
-            inserted = hunt.upsert_facilities(fac_list, db_url)
+            inserted = with_retries(
+                lambda: hunt.upsert_facilities(fac_list, db_url),
+                name="upsert_facilities",
+                retries=3,
+                backoff=2.0,
+            )
             log.info("DB: %d new, %d updated", inserted, len(fac_list) - inserted)
         except Exception as e:
-            log.error("DB upsert failed: %s", e)
+            log.error("DB upsert failed after retries: %s", e)
 
-    # HubSpot push for qualified new facilities
+    # HubSpot push — bounded retries on transient 5xx / network
     hs_pushed = 0
+    hs_qualified = 0
     if hs_token and fac_list:
         qualified = [f for f in fac_list if f.icp_score >= 10]
+        hs_qualified = len(qualified)
         if qualified:
-            stats = hunt.push_to_hubspot(qualified, hs_token)
-            hs_pushed = stats.get("companies_created", 0) + stats.get("companies_updated", 0)
+            try:
+                stats = with_retries(
+                    lambda: hunt.push_to_hubspot(qualified, hs_token),
+                    name="push_to_hubspot",
+                    retries=2,
+                    backoff=3.0,
+                )
+                hs_pushed = stats.get("companies_created", 0) + stats.get("companies_updated", 0)
+            except Exception as e:
+                log.error("HubSpot push failed after retries: %s", e)
 
     # Update state
     state["requests_today"] = state.get("requests_today", 0) + requests_used
@@ -198,6 +215,7 @@ def run_discover_and_enrich() -> dict:
         "discovered": len(fac_list),
         "inserted": inserted,
         "enriched": enriched_count,
+        "hs_qualified": hs_qualified if hs_token and fac_list else 0,
         "hs_pushed": hs_pushed,
         "requests_used": requests_used,
         "requests_today": state["requests_today"],

--- a/tools/lead-hunter/celery_tasks.py
+++ b/tools/lead-hunter/celery_tasks.py
@@ -100,13 +100,6 @@ def run_discover_and_enrich() -> dict:
     hunter_key = os.environ.get("HUNTER_API_KEY", "")
     hs_token = os.environ.get("HUBSPOT_ACCESS_TOKEN") or os.environ.get("HUBSPOT_API_KEY", "")
 
-    # Apply schema if DB available
-    if db_url:
-        try:
-            hunt.apply_schema(db_url)
-        except Exception as e:
-            log.warning("Schema apply (non-fatal): %s", e)
-
     # Pick city for this run (rotate)
     cities = hunt.CITIES
     city_idx = state.get("city_index", 0) % len(cities)

--- a/tools/lead-hunter/celery_tasks.py
+++ b/tools/lead-hunter/celery_tasks.py
@@ -349,14 +349,21 @@ def _enrich_unenriched(db_url: str, hunter_key: str, limit: int) -> tuple[int, i
 try:
     from celery import shared_task
 
-    @shared_task(name="lead_hunter.discover_and_enrich", bind=True, max_retries=2)
+    @shared_task(name="lead_hunter.discover_and_enrich", bind=True, max_retries=0)
     def discover_and_enrich(self):
-        """Celery task: hourly lead discovery + enrichment."""
-        try:
-            return run_discover_and_enrich()
-        except Exception as exc:
-            log.error("Hourly task failed: %s", exc)
-            raise self.retry(exc=exc, countdown=300)
+        """Celery task: hourly lead discovery + enrichment.
+
+        Delegates to run_hourly.main() so the singleton lock, hard timeout,
+        preflight checks, and alert sink ALL apply (parity with launchd path).
+        Celery's own retry is disabled (max_retries=0) — run_hourly's
+        with_retries layer handles transient failures internally and the
+        next hour will re-run anyway.
+        """
+        sys.path.insert(0, str(Path(__file__).parent))
+        from run_hourly import main as run_main
+        rc = run_main()
+        log.info("lead_hunter.discover_and_enrich rc=%d", rc)
+        return {"exit_code": rc}
 
 except ImportError:
     # Celery not installed — task available only via run_hourly.py

--- a/tools/lead-hunter/hardening.py
+++ b/tools/lead-hunter/hardening.py
@@ -245,7 +245,10 @@ def alert(report: RunReport, alert_log: str | Path | None = None) -> None:
     """
     if report.is_healthy():
         return
-    alert_log = Path(alert_log or os.getenv("HARDENING_ALERT_LOG", "/tmp/hardening-alerts.jsonl"))
+    # Default to a persistent path under marketing/prospects so /tmp wipe on reboot
+    # doesn't lose alert history. Override with HARDENING_ALERT_LOG.
+    default_log = Path(__file__).parent.parent.parent / "marketing" / "prospects" / "hardening-alerts.jsonl"
+    alert_log = Path(alert_log or os.getenv("HARDENING_ALERT_LOG", str(default_log)))
     alert_log.parent.mkdir(parents=True, exist_ok=True)
     with open(alert_log, "a") as fh:
         fh.write(json.dumps(asdict(report), default=str) + "\n")

--- a/tools/lead-hunter/hardening.py
+++ b/tools/lead-hunter/hardening.py
@@ -1,0 +1,270 @@
+"""Reusable reliability primitives for lead-hunter and similar batch routines.
+
+Provides:
+  singleton_lock(name)          — file-based lock; second invocation exits cleanly
+  with_retries(fn, ...)          — exponential backoff with jitter, bounded retries
+  hard_timeout(seconds)          — SIGALRM-based deadline (Unix only; no-op on Windows)
+  preflight_secrets(required)    — fail fast with actionable error if env missing
+  RunReport                       — structured per-step pass/fail/skip + timings
+  alert(report, level)            — append JSON line to alert log + optional webhook
+
+Designed for routines that run unattended on cron / launchd / Celery beat where
+silent failures and runaway processes are the most damaging failure modes.
+"""
+from __future__ import annotations
+
+import errno
+import fcntl
+import json
+import logging
+import os
+import random
+import signal
+import sys
+import time
+import traceback
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+log = logging.getLogger("hardening")
+
+
+# ---------------------------------------------------------------------------
+# Singleton lock — prevents overlapping cron runs
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def singleton_lock(name: str, lock_dir: str | Path | None = None):
+    """File-based lock; raises SystemExit(0) if another instance holds it.
+
+    Example:
+        with singleton_lock("lead-hunter"):
+            run()
+    """
+    lock_dir = Path(lock_dir or os.getenv("HARDENING_LOCK_DIR", "/tmp"))
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / f".{name}.lock"
+    fp = open(lock_path, "w")
+    try:
+        try:
+            fcntl.flock(fp, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as e:
+            if e.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
+                log.warning("Another %s instance is running (lock=%s) — exiting cleanly", name, lock_path)
+                fp.close()
+                sys.exit(0)
+            raise
+        fp.write(f"pid={os.getpid()}\nstarted={datetime.now(timezone.utc).isoformat()}\n")
+        fp.flush()
+        yield
+    finally:
+        try:
+            fcntl.flock(fp, fcntl.LOCK_UN)
+        except Exception:
+            pass
+        fp.close()
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Retry with exponential backoff + jitter
+# ---------------------------------------------------------------------------
+
+def with_retries(
+    fn: Callable[[], Any],
+    *,
+    name: str = "step",
+    retries: int = 3,
+    backoff: float = 2.0,
+    jitter: bool = True,
+    retry_on: tuple[type[BaseException], ...] = (Exception,),
+    give_up_on: tuple[type[BaseException], ...] = (KeyboardInterrupt, SystemExit),
+) -> Any:
+    """Call fn() with bounded retries. Returns fn()'s value or raises last error.
+
+    Backoff schedule: backoff^0, backoff^1, … (with up to ±25% jitter).
+    """
+    last_exc: BaseException | None = None
+    for attempt in range(retries + 1):
+        try:
+            return fn()
+        except give_up_on:
+            raise
+        except retry_on as e:
+            last_exc = e
+            if attempt == retries:
+                log.error("%s exhausted %d retries: %s", name, retries, e)
+                raise
+            wait = backoff ** attempt
+            if jitter:
+                wait *= random.uniform(0.75, 1.25)
+            log.warning("%s attempt %d/%d failed (%s) — retrying in %.1fs",
+                        name, attempt + 1, retries + 1, e, wait)
+            time.sleep(wait)
+    if last_exc:
+        raise last_exc
+
+
+# ---------------------------------------------------------------------------
+# Hard timeout — kills the routine if it hangs
+# ---------------------------------------------------------------------------
+
+@contextmanager
+def hard_timeout(seconds: int):
+    """SIGALRM-based deadline. Raises TimeoutError on expiry. Unix only.
+
+    Example:
+        with hard_timeout(1500):  # 25 min
+            do_long_work()
+    """
+    if not hasattr(signal, "SIGALRM"):
+        yield
+        return
+
+    def _handler(signum, frame):
+        raise TimeoutError(f"hard_timeout({seconds}s) expired")
+
+    old = signal.signal(signal.SIGALRM, _handler)
+    signal.alarm(seconds)
+    try:
+        yield
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, old)
+
+
+# ---------------------------------------------------------------------------
+# Preflight — verify required secrets/state before starting work
+# ---------------------------------------------------------------------------
+
+def preflight_secrets(required: Iterable[str], optional: Iterable[str] = ()) -> dict[str, bool]:
+    """Verify all `required` env vars are set and non-empty. Exit(2) if any missing.
+
+    Returns a {name: present} map for both required + optional so callers can
+    decide what to do about optional gaps (typically: log and skip that path).
+    """
+    missing = [k for k in required if not os.environ.get(k, "").strip()]
+    present = {k: bool(os.environ.get(k, "").strip()) for k in (*required, *optional)}
+    if missing:
+        log.error("PREFLIGHT FAIL — missing required env: %s", ", ".join(missing))
+        log.error("Common causes: launchd lacks Doppler keychain access; "
+                  "doppler service token not exported; running with wrong --config")
+        sys.exit(2)
+    return present
+
+
+# ---------------------------------------------------------------------------
+# Structured run reports
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StepResult:
+    name: str
+    status: str  # "ok" | "fail" | "skip"
+    duration_s: float = 0.0
+    detail: dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+
+@dataclass
+class RunReport:
+    """Captures per-step results for a single routine invocation."""
+    routine: str
+    started_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+    finished_at: str | None = None
+    duration_s: float = 0.0
+    overall: str = "ok"  # "ok" | "degraded" | "fail"
+    steps: list[StepResult] = field(default_factory=list)
+    alerts: list[str] = field(default_factory=list)
+
+    def step(self, name: str):
+        return _StepCtx(self, name)
+
+    def add_alert(self, msg: str) -> None:
+        log.warning("ALERT %s: %s", self.routine, msg)
+        self.alerts.append(msg)
+
+    def finalize(self) -> None:
+        self.finished_at = datetime.now(timezone.utc).isoformat()
+        if self.steps:
+            self.duration_s = sum(s.duration_s for s in self.steps)
+        if any(s.status == "fail" for s in self.steps):
+            self.overall = "fail"
+        elif self.alerts or any(s.status == "skip" for s in self.steps):
+            self.overall = "degraded" if self.overall == "ok" else self.overall
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2, default=str)
+
+    def is_healthy(self) -> bool:
+        return self.overall == "ok"
+
+
+class _StepCtx:
+    def __init__(self, report: RunReport, name: str):
+        self.report = report
+        self.name = name
+        self.t0 = 0.0
+        self.result = StepResult(name=name, status="ok")
+
+    def __enter__(self):
+        self.t0 = time.monotonic()
+        return self.result
+
+    def __exit__(self, exc_type, exc, tb):
+        self.result.duration_s = time.monotonic() - self.t0
+        if exc is not None:
+            self.result.status = "fail"
+            self.result.error = f"{exc_type.__name__}: {exc}"
+            log.error("step=%s FAIL after %.1fs: %s", self.name, self.result.duration_s, exc)
+            log.debug("traceback: %s", "".join(traceback.format_tb(tb)))
+        else:
+            log.info("step=%s %s in %.1fs (%s)", self.name, self.result.status,
+                     self.result.duration_s,
+                     ", ".join(f"{k}={v}" for k, v in self.result.detail.items()) or "no detail")
+        self.report.steps.append(self.result)
+        # Swallow exception so the routine can continue to other steps;
+        # caller checks report.is_healthy() at the end.
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Alerting — append JSONL + optional Discord webhook
+# ---------------------------------------------------------------------------
+
+def alert(report: RunReport, alert_log: str | Path | None = None) -> None:
+    """Append the report as one JSON line to the alert log if it isn't healthy.
+
+    Discord webhook (optional): set DISCORD_ALERT_WEBHOOK to fire there too.
+    """
+    if report.is_healthy():
+        return
+    alert_log = Path(alert_log or os.getenv("HARDENING_ALERT_LOG", "/tmp/hardening-alerts.jsonl"))
+    alert_log.parent.mkdir(parents=True, exist_ok=True)
+    with open(alert_log, "a") as fh:
+        fh.write(json.dumps(asdict(report), default=str) + "\n")
+    log.warning("ALERT logged: routine=%s status=%s alerts=%d steps_failed=%d",
+                report.routine, report.overall, len(report.alerts),
+                sum(1 for s in report.steps if s.status == "fail"))
+
+    webhook = os.getenv("DISCORD_ALERT_WEBHOOK", "").strip()
+    if webhook:
+        try:
+            import httpx
+            failed = [s.name for s in report.steps if s.status == "fail"]
+            content = (
+                f"**{report.routine}** — `{report.overall}`\n"
+                f"failed: {failed or '—'}\n"
+                f"alerts: {report.alerts or '—'}\n"
+                f"duration: {report.duration_s:.1f}s"
+            )
+            with httpx.Client(timeout=5) as client:
+                client.post(webhook, json={"content": content[:1900]})
+        except Exception as e:
+            log.warning("Discord webhook send failed (non-fatal): %s", e)

--- a/tools/lead-hunter/run_hourly.py
+++ b/tools/lead-hunter/run_hourly.py
@@ -1,31 +1,158 @@
 #!/usr/bin/env python3
-"""Standalone entry point for launchd hourly execution.
+"""Hardened hourly entry point for lead-hunter.
 
-Called by: com.mira.lead-hunter.plist (launchd)
-Doppler injects secrets automatically via the plist EnvironmentVariables.
+Called by: launchd (com.mira.lead-hunter) or Celery beat.
+Doppler injects secrets via the wrapper command.
+
+Reliability layers (in order):
+  1. Singleton lock           — prevents overlapping runs
+  2. Preflight secret check   — fails fast with actionable error if missing
+  3. Hard 25-min timeout      — must finish before next hour
+  4. Per-step RunReport       — captures pass/fail/skip for every phase
+  5. Alert sink               — degraded/failed runs append to JSONL + optional webhook
+
+Exit codes:
+  0  healthy run (or skipped via singleton lock)
+  1  routine completed but degraded (e.g. enrichment ran zero contacts)
+  2  preflight failure (missing secrets) — fix env, will retry next hour
+  3  hard timeout exceeded
+  4  unhandled exception
 """
+from __future__ import annotations
 
 import logging
+import os
 import sys
+import traceback
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)-7s %(message)s",
-    datefmt="%H:%M:%S",
-    handlers=[
-        logging.StreamHandler(),
-        logging.FileHandler(
-            Path(__file__).parent.parent.parent / "marketing" / "prospects" / "lead-hunter.log",
-            mode="a",
-        ),
-    ],
+from hardening import (
+    RunReport,
+    alert,
+    hard_timeout,
+    preflight_secrets,
+    singleton_lock,
 )
 
-from celery_tasks import run_discover_and_enrich  # noqa: E402
+REPO_ROOT = Path(__file__).parent.parent.parent
+LOG_PATH = REPO_ROOT / "marketing" / "prospects" / "lead-hunter.log"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-7s %(name)s %(message)s",
+    datefmt="%H:%M:%S",
+    handlers=[logging.StreamHandler(), logging.FileHandler(LOG_PATH, mode="a")],
+)
+log = logging.getLogger("lead-hunter.runner")
+
+HARD_TIMEOUT_SECS = int(os.getenv("LEAD_HUNTER_TIMEOUT_SECS", "1500"))  # 25 min
+REQUIRED_SECRETS = ("NEON_DATABASE_URL",)
+OPTIONAL_SECRETS = (
+    "SERPER_API_KEY",
+    "FIRECRAWL_API_KEY",
+    "HUNTER_API_KEY",
+    "HUBSPOT_API_KEY",
+    "HUBSPOT_ACCESS_TOKEN",
+)
+
+
+def _run() -> int:
+    """Inner routine — returns exit code based on RunReport health."""
+    report = RunReport(routine="lead-hunter-hourly")
+
+    # 1. Preflight: required secrets must be set
+    with report.step("preflight") as step:
+        present = preflight_secrets(REQUIRED_SECRETS, OPTIONAL_SECRETS)
+        step.detail.update({k: v for k, v in present.items()})
+        # Note degraded paths
+        if not (present.get("HUBSPOT_API_KEY") or present.get("HUBSPOT_ACCESS_TOKEN")):
+            report.add_alert("HubSpot token missing — qualified leads will not be pushed")
+        if not present.get("FIRECRAWL_API_KEY"):
+            report.add_alert("FIRECRAWL_API_KEY missing — contact enrichment will be limited")
+        if not present.get("SERPER_API_KEY"):
+            report.add_alert("SERPER_API_KEY missing — discovery will fall back to DuckDuckGo")
+
+    # 2. Run discovery + enrichment with the hard timeout wrapping ONLY this work
+    discovered = enriched = inserted = hs_pushed = 0
+    with report.step("discover_and_enrich") as step:
+        from celery_tasks import run_discover_and_enrich
+        result = run_discover_and_enrich()
+        if result.get("skipped"):
+            step.status = "skip"
+            step.detail["reason"] = result.get("reason", "unknown")
+        else:
+            discovered = result.get("discovered", 0)
+            enriched = result.get("enriched", 0)
+            inserted = result.get("inserted", 0)
+            hs_pushed = result.get("hs_pushed", 0)
+            step.detail.update({
+                "discovered": discovered,
+                "enriched": enriched,
+                "inserted": inserted,
+                "hs_pushed": hs_pushed,
+                "city": result.get("city", "?"),
+            })
+
+    # 3. Silent-failure detectors — catch the bugs that hid yesterday's bad runs
+    with report.step("health_assertions") as step:
+        # Discovery worked but enrichment didn't — the Charlie failure pattern
+        if discovered > 0 and enriched == 0 and (
+            os.environ.get("FIRECRAWL_API_KEY") or os.environ.get("HUNTER_API_KEY")
+        ):
+            report.add_alert(
+                f"Discovery found {discovered} facilities but enrichment ran 0 — "
+                "Firecrawl/Hunter likely failing or all facilities below ICP gate"
+            )
+        # Inserted but nothing pushed despite HubSpot configured
+        if inserted > 0 and hs_pushed == 0 and (
+            os.environ.get("HUBSPOT_API_KEY") or os.environ.get("HUBSPOT_ACCESS_TOKEN")
+        ):
+            report.add_alert(
+                f"Inserted {inserted} new facilities but pushed 0 to HubSpot — "
+                "either no leads cleared ICP+real-name gate, or HubSpot auth failed"
+            )
+        step.detail["assertions_passed"] = len(report.alerts) == 0
+
+    report.finalize()
+    log.info("RUN_REPORT %s", report.to_json())
+    alert(report)
+
+    if report.overall == "fail":
+        return 1
+    if report.overall == "degraded":
+        return 1
+    return 0
+
+
+def main() -> int:
+    try:
+        with singleton_lock("lead-hunter"):
+            try:
+                with hard_timeout(HARD_TIMEOUT_SECS):
+                    return _run()
+            except TimeoutError as e:
+                log.error("HARD TIMEOUT: %s", e)
+                # Build a minimal report so the timeout is alerted, not silent
+                report = RunReport(routine="lead-hunter-hourly")
+                report.add_alert(f"Hard timeout exceeded ({HARD_TIMEOUT_SECS}s)")
+                report.finalize()
+                report.overall = "fail"
+                alert(report)
+                return 3
+    except SystemExit as e:
+        # preflight_secrets calls sys.exit(2); singleton_lock calls sys.exit(0)
+        return int(e.code) if isinstance(e.code, int) else 0
+    except Exception as e:
+        log.error("UNHANDLED EXCEPTION: %s\n%s", e, traceback.format_exc())
+        report = RunReport(routine="lead-hunter-hourly")
+        report.add_alert(f"Unhandled exception: {type(e).__name__}: {e}")
+        report.finalize()
+        report.overall = "fail"
+        alert(report)
+        return 4
+
 
 if __name__ == "__main__":
-    result = run_discover_and_enrich()
-    sys.exit(0 if result else 1)
+    sys.exit(main())

--- a/tools/lead-hunter/run_hourly.py
+++ b/tools/lead-hunter/run_hourly.py
@@ -74,6 +74,18 @@ def _run() -> int:
         if not present.get("SERPER_API_KEY"):
             report.add_alert("SERPER_API_KEY missing — discovery will fall back to DuckDuckGo")
 
+    # 1b. Apply DB schema (idempotent)
+    db_url = os.environ.get("NEON_DATABASE_URL", "")
+    with report.step("apply_schema") as step:
+        if not db_url:
+            step.status = "skip"
+            step.detail["reason"] = "no NEON_DATABASE_URL"
+        else:
+            sys.path.insert(0, str(Path(__file__).parent))
+            import hunt as hunt_mod
+            hunt_mod.apply_schema(db_url)
+            step.detail["applied"] = True
+
     # 2. Run discovery + enrichment with the hard timeout wrapping ONLY this work
     discovered = enriched = enriched_attempted = inserted = hs_pushed = 0
     with report.step("discover_and_enrich") as step:

--- a/tools/lead-hunter/run_hourly.py
+++ b/tools/lead-hunter/run_hourly.py
@@ -75,7 +75,7 @@ def _run() -> int:
             report.add_alert("SERPER_API_KEY missing — discovery will fall back to DuckDuckGo")
 
     # 2. Run discovery + enrichment with the hard timeout wrapping ONLY this work
-    discovered = enriched = inserted = hs_pushed = 0
+    discovered = enriched = enriched_attempted = inserted = hs_pushed = 0
     with report.step("discover_and_enrich") as step:
         from celery_tasks import run_discover_and_enrich
         result = run_discover_and_enrich()
@@ -85,11 +85,13 @@ def _run() -> int:
         else:
             discovered = result.get("discovered", 0)
             enriched = result.get("enriched", 0)
+            enriched_attempted = result.get("enriched_attempted", 0)
             inserted = result.get("inserted", 0)
             hs_pushed = result.get("hs_pushed", 0)
             step.detail.update({
                 "discovered": discovered,
                 "enriched": enriched,
+                "enriched_attempted": enriched_attempted,
                 "inserted": inserted,
                 "hs_pushed": hs_pushed,
                 "city": result.get("city", "?"),
@@ -112,6 +114,12 @@ def _run() -> int:
             report.add_alert(
                 f"Inserted {inserted} new facilities but pushed 0 to HubSpot — "
                 "either no leads cleared ICP+real-name gate, or HubSpot auth failed"
+            )
+        # Partial enrichment failure — most attempts failed but we got some
+        if enriched_attempted >= 4 and enriched / max(enriched_attempted, 1) < 0.5:
+            report.add_alert(
+                f"Enrichment partial failure: {enriched}/{enriched_attempted} succeeded "
+                "(<50%) — Firecrawl/Hunter degraded or many sites blocking scrapers"
             )
         step.detail["assertions_passed"] = len(report.alerts) == 0
 


### PR DESCRIPTION
**Replaces #600** — same code, fresh branch off `origin/main` to avoid 184-commit drift conflicts.

## Summary

Closes 9 reliability gaps the prior `2a7d68b` hardening commit introduced primitives for but didn't fully wire up:

- **Hardening primitives** (`tools/lead-hunter/hardening.py`) — `singleton_lock`, `with_retries`, `hard_timeout`, `preflight_secrets`, `RunReport`/`step()`, `alert()`. **Plus** `mira-crawler/tasks/ingest.py` size cap + streaming download (the OOM fix).
- **21 unit tests** for `hardening.py` (was zero coverage)
- **Discovery HTTP retries** — MSCA scrape + DDG search loop wrapped in `with_retries` (previously only DB upsert + HubSpot push had retries)
- **Partial enrichment failures surface** — `_enrich_unenriched` returns `(succeeded, attempted)`; `run_hourly` alerts on <50% success with ≥4 attempts
- **`apply_schema` as tracked step** — moved from silent `log.warning` into `report.step("apply_schema")` so failures escalate
- **Celery path parity** — `@shared_task discover_and_enrich` delegates to `run_hourly.main()` for singleton lock + hard timeout + preflight + alert sink (parity with launchd path)
- **Connection lifecycle** — `_enrich_unenriched` uses one `psycopg2.connect()` with context-managed cursors (was leaking conn2 per row)
- **Persistent alert log** — default off `/tmp` to `marketing/prospects/hardening-alerts.jsonl`
- **4 new env vars** documented: `LEAD_HUNTER_TIMEOUT_SECS`, `HARDENING_LOCK_DIR`, `HARDENING_ALERT_LOG`, `DISCORD_ALERT_WEBHOOK`

## Test plan

- [x] `pytest tests/lead_hunter/` — **57 passing** (21 hardening + 7 run_hourly + 3 celery_tasks + 26 snippet_parser)
- [x] `ruff check tools/lead-hunter/ tests/lead_hunter/` — clean (the 2 ruff errors in `probe_serper.py` are from PR #517 on main, not this PR)
- [x] Cherry-picked cleanly off `origin/main` HEAD; 3 conflicts resolved (Task 6 + Task 9 in `celery_tasks.py`, Task 10 in `env-vars.md` — both rows kept)
- [x] No changes outside `tools/lead-hunter/`, `mira-crawler/tasks/ingest.py` (size cap), `tests/lead_hunter/`, `docs/env-vars.md`, `docs/superpowers/plans/`

## Plan

`docs/superpowers/plans/2026-04-25-lead-hunter-hardening-gaps.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)