### PR TITLE
feat(web): Unit 9a — three named features above fold

### DIFF
--- a/docs/plans/2026-04-19-mira-90-day-mvp.md
+++ b/docs/plans/2026-04-19-mira-90-day-mvp.md
@@ -12,7 +12,7 @@
 
 | Unit / Task | Owner | Branch | Started | Notes |
 |---|---|---|---|---|
-| Unit 6 (hybrid retrieval) | agent-claude | feat/mvp-unit-6-hybrid-retrieval | 2026-04-20 06:56 UTC | BM25 + pgvector via RRF; touches `neon_recall.py` + new migration 006 (renumbered after collision with PR #421) |
+| Unit 9a (landing page rewrite) | agent-claude | feat/mvp-unit-9a-landing | 2026-04-25 20:30 UTC | Three named features above fold: Photo-to-Asset, Magic Manual Inbox, Source-Cited Answers. Last first-dollar gate (Units 2 + 6 already merged). Scope: edit `mira-web/public/index.html` only — minimal disruption to existing polish. |
 
 (Format: `Unit N (short name)` | `mike` or `agent-claude` or `agent-multica` | `feat/mvp-unit-N-...` | `YYYY-MM-DD HH:MM UTC` | optional)
 

--- a/mira-web/public/index.html
+++ b/mira-web/public/index.html
@@ -528,6 +528,70 @@
       50%       { opacity: 0; }
     }
 
+    /* ── Named Features (above-fold trust strip) ── */
+    .named-features {
+      padding: 56px 0 0;
+      position: relative;
+      z-index: 1;
+    }
+
+    @media (max-width: 768px) { .named-features { padding: 40px 0 0; } }
+
+    .named-features-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 20px;
+    }
+
+    @media (max-width: 768px) {
+      .named-features-grid { grid-template-columns: 1fr; gap: 14px; }
+    }
+
+    .named-feature {
+      display: block;
+      padding: 22px 22px 24px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--surface);
+      text-decoration: none;
+      color: var(--text);
+      transition: border-color 240ms var(--ease-out), transform 240ms var(--ease-out), background 240ms var(--ease-out);
+    }
+
+    .named-feature:hover {
+      border-color: var(--border-hi);
+      transform: translateY(-2px);
+      background: #16171e;
+    }
+
+    .named-feature-name {
+      font-size: 14px;
+      font-weight: 500;
+      letter-spacing: -0.005em;
+      margin-bottom: 10px;
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .named-feature-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--amber);
+      display: inline-block;
+      flex-shrink: 0;
+    }
+
+    .named-feature-blurb {
+      font-size: 13.5px;
+      color: var(--text-dim);
+      line-height: 1.55;
+      font-weight: 300;
+      margin: 0;
+    }
+
     /* ── Feature sections ── */
     .features {
       padding: 120px 0;
@@ -1113,6 +1177,26 @@
             </div>
           </div>
         </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ── Named features (3-pillar trust strip) ── -->
+  <section class="named-features" aria-label="Three core capabilities">
+    <div class="inner">
+      <div class="named-features-grid">
+        <a class="named-feature fade-in" href="/feature/voice-vision">
+          <div class="named-feature-name"><span class="named-feature-dot" aria-hidden="true"></span>Photo-to-Asset</div>
+          <p class="named-feature-blurb">Snap a nameplate. MIRA pulls the right manual and repair history before you finish typing.</p>
+        </a>
+        <a class="named-feature fade-in" href="#how-it-works">
+          <div class="named-feature-name"><span class="named-feature-dot" aria-hidden="true"></span>Magic Manual Inbox</div>
+          <p class="named-feature-blurb">Forward an OEM PDF to your inbox. Searchable in chat within 90 seconds &mdash; no upload tool.</p>
+        </a>
+        <a class="named-feature fade-in" href="/feature/fault-diagnosis">
+          <div class="named-feature-name"><span class="named-feature-dot" aria-hidden="true"></span>Source-Cited Answers</div>
+          <p class="named-feature-blurb">Every answer cites the manual, model, and section. No hallucinations &mdash; verifiable in seconds.</p>
+        </a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
Closes Unit 9a per [docs/plans/2026-04-19-mira-90-day-mvp.md](docs/plans/2026-04-19-mira-90-day-mvp.md). Adds an above-fold 3-pillar trust strip with the plan's prescribed names: **Photo-to-Asset**, **Magic Manual Inbox**, **Source-Cited Answers**.

This is the **last remaining first-dollar gate** — Units 2 (citations) and 6 (hybrid retrieval) are already merged. Unit 9a was on Harper's W1-W2 lane; landing this lets her start outbound on May 4 with three concrete, shippable claims.

## Scope (additive only)
- New `<section class="named-features">` between hero and existing `.features` block
- Self-contained CSS using existing tokens (`--surface`, `--border`, `--amber`, `--ease-out`)
- Three card links: `/feature/voice-vision`, `#how-it-works` (placeholder), `/feature/fault-diagnosis`
- **Hero, $97/mo CTA, and `/cmms` Stripe Checkout link untouched**
- Single file, +84 lines, 0 deletions

## Why these three names
All three are demoable today, not vaporware:
- **Photo-to-Asset** — existing photo pipeline
- **Magic Manual Inbox** — Unit 3, merged today (PRs #541/#543/#545/#560/#583/#585)
- **Source-Cited Answers** — Unit 2, merged 2026-04-20 (PR #428)

## Test plan
- [ ] Visual review on staging — strip reads as 3-up trust pillars, not 4th feature card
- [ ] Lighthouse mobile ≥90 (DoD; deferred to post-merge deploy)
- [ ] Stripe \$97 test charge end-to-end via `/cmms` (CTA wiring untouched; should pass unchanged)
- [ ] Mobile breakpoint <768px collapses to single column
- [ ] Hover transition on cards (`transform: translateY(-2px)` + border highlight)

## Coordination
- Plan in-flight table updated (`bf68961`) to claim Unit 9a before edits
- Pre-flight check on 2026-04-25 ~20:30 UTC: no other branch / PR touched `mira-web/public/index.html` since last main sync
- Branched from latest `origin/main` (`83912d9`, post-PR #636 lucide self-host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)