### PR TITLE
feat(assets): Unit 5 — UNS-style asset model + /asset command

### DIFF
--- a/docs/plans/2026-04-19-mira-90-day-mvp.md
+++ b/docs/plans/2026-04-19-mira-90-day-mvp.md
@@ -12,7 +12,7 @@
 
 | Unit / Task | Owner | Branch | Started | Notes |
 |---|---|---|---|---|
-| Unit 9a (landing page rewrite) | agent-claude | feat/mvp-unit-9a-landing | 2026-04-25 20:30 UTC | Three named features above fold: Photo-to-Asset, Magic Manual Inbox, Source-Cited Answers. Last first-dollar gate (Units 2 + 6 already merged). Scope: edit `mira-web/public/index.html` only — minimal disruption to existing polish. |
+| Unit 5 (UNS asset model) | agent-claude | feat/mvp-unit-5-uns | 2026-04-25 21:25 UTC | New migration 011_assets_uns.sql (005 was taken; 006-010 too); ltree extension + assets table; new /asset Telegram command; backfill script. Reuses asset_qr_tags join. |
 
 (Format: `Unit N (short name)` | `mike` or `agent-claude` or `agent-multica` | `feat/mvp-unit-N-...` | `YYYY-MM-DD HH:MM UTC` | optional)
 

--- a/mira-bots/shared/assets.py
+++ b/mira-bots/shared/assets.py
@@ -1,0 +1,185 @@
+"""UNS-style asset hierarchy queries (Unit 5 of 90-day MVP).
+
+Schema lives in mira-core/mira-ingest/db/migrations/011_assets_uns.sql.
+
+These helpers back the Telegram /asset command and (later) the QR
+pre-load context flow (Unit 7). They never raise on infra error — same
+contract as neon_recall.py: missing NEON_DATABASE_URL or sqlalchemy
+returns [] / None and logs a warning. The bot must keep running.
+
+Connection pattern follows neon_recall.py: NullPool + sslmode=require.
+NeonDB's PgBouncer handles pooling; we never pool application-side.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+
+logger = logging.getLogger("mira-gsd")
+
+# ltree label rules: [A-Za-z0-9_], at least 1 char, max 256.
+# Reject anything else BEFORE building SQL — defense in depth on top of
+# parameterized queries.
+_LTREE_LABEL_RE = re.compile(r"^[A-Za-z0-9_]{1,256}$")
+_LTREE_PATH_RE = re.compile(r"^[A-Za-z0-9_]{1,256}(\.[A-Za-z0-9_]{1,256})*$")
+
+
+def _validate_ltree_path(path: str) -> bool:
+    """Return True iff path is a syntactically valid ltree path."""
+    if not path:
+        return False
+    return bool(_LTREE_PATH_RE.fullmatch(path))
+
+
+def _connect():
+    """Return (engine, text) or (None, None) if NeonDB unavailable.
+
+    Mirrors neon_recall._connect pattern. Lazy-imports sqlalchemy so the
+    bot still boots in test environments without it.
+    """
+    url = os.environ.get("NEON_DATABASE_URL")
+    if not url:
+        return None, None
+    try:
+        from sqlalchemy import create_engine, text  # noqa: PLC0415
+        from sqlalchemy.pool import NullPool  # noqa: PLC0415
+    except ImportError:
+        return None, None
+    engine = create_engine(
+        url,
+        poolclass=NullPool,
+        connect_args={"sslmode": "require"},
+        pool_pre_ping=True,
+    )
+    return engine, text
+
+
+def list_top_levels(tenant_id: str, depth: int = 2) -> list[dict]:
+    """Return distinct ltree prefixes up to `depth` levels.
+
+    Used by `/asset` (no-arg) to show the customer's top-level hierarchy
+    so they can drill in. Empty list on infra error or no matches.
+    """
+    if not tenant_id or depth < 1:
+        return []
+    engine, text = _connect()
+    if engine is None:
+        return []
+    try:
+        sql = """
+            SELECT DISTINCT
+              subltree(uns_path, 0, LEAST(nlevel(uns_path), :depth))::text AS path,
+              MAX(name) FILTER (
+                WHERE nlevel(uns_path) = LEAST(nlevel(uns_path), :depth)
+              ) AS name
+            FROM assets
+            WHERE tenant_id = :tid
+            GROUP BY subltree(uns_path, 0, LEAST(nlevel(uns_path), :depth))
+            ORDER BY path
+            LIMIT 50
+        """
+        with engine.connect() as conn:
+            rows = conn.execute(text(sql), {"tid": tenant_id, "depth": depth}).mappings().fetchall()
+        return [dict(r) for r in rows]
+    except Exception as e:
+        logger.warning("assets.list_top_levels failed: %s", e)
+        return []
+
+
+def list_children(tenant_id: str, parent_path: str) -> list[dict]:
+    """Return assets exactly one level below `parent_path`.
+
+    Uses ltree lquery `parent.*{1}` for "one level deeper". Empty list on
+    invalid path, infra error, or no matches.
+    """
+    if not tenant_id or not _validate_ltree_path(parent_path):
+        return []
+    engine, text = _connect()
+    if engine is None:
+        return []
+    try:
+        # ltree's `~` operator with `parent.*{1}` matches paths that are
+        # exactly one level below `parent`. Cast to lquery via explicit
+        # bind variable concatenation done server-side.
+        sql = """
+            SELECT
+              id::text AS id,
+              name,
+              uns_path::text AS path,
+              asset_tag,
+              atlas_asset_id
+            FROM assets
+            WHERE tenant_id = :tid
+              AND uns_path ~ (:parent || '.*{1}')::lquery
+            ORDER BY uns_path
+            LIMIT 50
+        """
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text(sql),
+                {"tid": tenant_id, "parent": parent_path},
+            ).mappings().fetchall()
+        return [dict(r) for r in rows]
+    except Exception as e:
+        logger.warning("assets.list_children failed parent=%s: %s", parent_path, e)
+        return []
+
+
+def get_asset(tenant_id: str, full_path: str) -> dict | None:
+    """Return single asset record by exact uns_path. None if missing."""
+    if not tenant_id or not _validate_ltree_path(full_path):
+        return None
+    engine, text = _connect()
+    if engine is None:
+        return None
+    try:
+        sql = """
+            SELECT
+              id::text AS id,
+              name,
+              uns_path::text AS path,
+              asset_tag,
+              atlas_asset_id,
+              created_at
+            FROM assets
+            WHERE tenant_id = :tid
+              AND uns_path = :path::ltree
+            LIMIT 1
+        """
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(sql),
+                {"tid": tenant_id, "path": full_path},
+            ).mappings().fetchone()
+        return dict(row) if row else None
+    except Exception as e:
+        logger.warning("assets.get_asset failed path=%s: %s", full_path, e)
+        return None
+
+
+def format_asset_card(asset: dict) -> str:
+    """One-asset Markdown summary for Telegram. Plain text fallback safe."""
+    lines = [f"*{asset.get('name') or asset['path']}*"]
+    lines.append(f"`{asset['path']}`")
+    if asset.get("asset_tag"):
+        lines.append(f"QR tag: `{asset['asset_tag']}`")
+    if asset.get("atlas_asset_id"):
+        lines.append(f"Atlas ID: {asset['atlas_asset_id']}")
+    return "\n".join(lines)
+
+
+def format_hierarchy_list(rows: list[dict], parent_label: str | None = None) -> str:
+    """Multi-line listing of children/top-levels for Telegram."""
+    if not rows:
+        if parent_label:
+            return f"No assets under `{parent_label}`."
+        return "No assets registered yet."
+    header = f"Children of `{parent_label}`:" if parent_label else "Top-level assets:"
+    lines = [header]
+    for r in rows:
+        label = r.get("name") or r["path"].split(".")[-1]
+        lines.append(f"  • `{r['path']}` — {label}")
+    lines.append("\nUse `/asset <path>` to descend.")
+    return "\n".join(lines)

--- a/mira-bots/shared/assets.py
+++ b/mira-bots/shared/assets.py
@@ -117,10 +117,14 @@ def list_children(tenant_id: str, parent_path: str) -> list[dict]:
             LIMIT 50
         """
         with engine.connect() as conn:
-            rows = conn.execute(
-                text(sql),
-                {"tid": tenant_id, "parent": parent_path},
-            ).mappings().fetchall()
+            rows = (
+                conn.execute(
+                    text(sql),
+                    {"tid": tenant_id, "parent": parent_path},
+                )
+                .mappings()
+                .fetchall()
+            )
         return [dict(r) for r in rows]
     except Exception as e:
         logger.warning("assets.list_children failed parent=%s: %s", parent_path, e)
@@ -149,10 +153,14 @@ def get_asset(tenant_id: str, full_path: str) -> dict | None:
             LIMIT 1
         """
         with engine.connect() as conn:
-            row = conn.execute(
-                text(sql),
-                {"tid": tenant_id, "path": full_path},
-            ).mappings().fetchone()
+            row = (
+                conn.execute(
+                    text(sql),
+                    {"tid": tenant_id, "path": full_path},
+                )
+                .mappings()
+                .fetchone()
+            )
         return dict(row) if row else None
     except Exception as e:
         logger.warning("assets.get_asset failed path=%s: %s", full_path, e)

--- a/mira-bots/shared/assets.py
+++ b/mira-bots/shared/assets.py
@@ -65,7 +65,7 @@ def list_top_levels(tenant_id: str, depth: int = 2) -> list[dict]:
     if not tenant_id or depth < 1:
         return []
     engine, text = _connect()
-    if engine is None:
+    if engine is None or text is None:
         return []
     try:
         sql = """
@@ -97,7 +97,7 @@ def list_children(tenant_id: str, parent_path: str) -> list[dict]:
     if not tenant_id or not _validate_ltree_path(parent_path):
         return []
     engine, text = _connect()
-    if engine is None:
+    if engine is None or text is None:
         return []
     try:
         # ltree's `~` operator with `parent.*{1}` matches paths that are
@@ -136,7 +136,7 @@ def get_asset(tenant_id: str, full_path: str) -> dict | None:
     if not tenant_id or not _validate_ltree_path(full_path):
         return None
     engine, text = _connect()
-    if engine is None:
+    if engine is None or text is None:
         return None
     try:
         sql = """

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -9,7 +9,7 @@ import os
 import httpx
 from chat_adapter import TelegramChatAdapter
 from PIL import Image
-from shared import tts
+from shared import assets, tts
 from shared.chat.dispatcher import ChatDispatcher
 from shared.engine import Supervisor
 from telegram import Update
@@ -551,6 +551,59 @@ async def bad_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         )
 
 
+async def asset_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Walk the UNS asset hierarchy.
+
+    /asset            -> top 2 levels of the customer's hierarchy
+    /asset <path>     -> children of <path>; if no children, show asset card
+    """
+    tenant_id = os.environ.get("MIRA_TENANT_ID", "")
+    if not tenant_id:
+        await update.message.reply_text(
+            "Asset hierarchy not configured (MIRA_TENANT_ID unset)."
+        )
+        return
+
+    arg = context.args[0].strip() if context.args else ""
+
+    if not arg:
+        rows = assets.list_top_levels(tenant_id, depth=2)
+        await update.message.reply_text(
+            assets.format_hierarchy_list(rows),
+            parse_mode="Markdown",
+        )
+        return
+
+    if not assets._validate_ltree_path(arg):
+        await update.message.reply_text(
+            "Invalid path. Use letters, digits, underscore, separated by dots \u2014 "
+            "e.g. `enterprise.site_a.line_2`.",
+            parse_mode="Markdown",
+        )
+        return
+
+    children = assets.list_children(tenant_id, arg)
+    if children:
+        await update.message.reply_text(
+            assets.format_hierarchy_list(children, parent_label=arg),
+            parse_mode="Markdown",
+        )
+        return
+
+    asset = assets.get_asset(tenant_id, arg)
+    if asset:
+        await update.message.reply_text(
+            assets.format_asset_card(asset),
+            parse_mode="Markdown",
+        )
+        return
+
+    await update.message.reply_text(
+        f"No assets found under `{arg}`.",
+        parse_mode="Markdown",
+    )
+
+
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Return static command list."""
     await update.message.reply_text(
@@ -558,6 +611,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "/equipment [id] \u2014 Live equipment status (instant)\n"
         "/faults \u2014 Active fault list (instant)\n"
         "/status \u2014 AI equipment summary\n"
+        "/asset [path] \u2014 Walk the UNS asset hierarchy\n"
         "/voice on|off \u2014 Enable/disable spoken responses\n"
         "/bad [reason] \u2014 Flag this response as unhelpful\n"
         "/reset \u2014 Reset conversation state\n"
@@ -614,6 +668,7 @@ def main():
     app.add_handler(CommandHandler("reset", reset_command))
     app.add_handler(CommandHandler("voice", voice_command))
     app.add_handler(CommandHandler("bad", bad_command))
+    app.add_handler(CommandHandler("asset", asset_command))
     app.add_handler(CommandHandler("help", help_command))
     app.add_handler(MessageHandler(filters.Document.PDF, document_handler))
     app.add_handler(MessageHandler(filters.PHOTO, photo_handler))

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -559,9 +559,7 @@ async def asset_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """
     tenant_id = os.environ.get("MIRA_TENANT_ID", "")
     if not tenant_id:
-        await update.message.reply_text(
-            "Asset hierarchy not configured (MIRA_TENANT_ID unset)."
-        )
+        await update.message.reply_text("Asset hierarchy not configured (MIRA_TENANT_ID unset).")
         return
 
     arg = context.args[0].strip() if context.args else ""

--- a/mira-bots/tests/test_assets.py
+++ b/mira-bots/tests/test_assets.py
@@ -1,0 +1,146 @@
+"""Unit 5 — offline tests for UNS asset query helpers.
+
+These tests do NOT touch NeonDB. They exercise:
+  * ltree path validation (label rules, separator rules)
+  * Format helpers (asset card + hierarchy listing)
+  * Public-api guards (no NEON_DATABASE_URL -> empty list, no raise)
+
+Live integration (real ltree queries against a seeded fixture tenant) is
+the DoD verification step for Unit 5 — see plan §Verification.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from shared import assets
+
+
+class TestLtreePathValidation:
+    """The regex is the first line of defense before SQL."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "enterprise",
+            "acme.site_a",
+            "acme.site_a.line_2",
+            "acme.site_a.line_2.cell_3",
+            "abc123",
+            "x_y_z.a_b_c",
+            "Site1.Line2.Cell3",
+        ],
+    )
+    def test_valid_paths(self, path):
+        assert assets._validate_ltree_path(path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "",
+            ".",
+            ".acme",
+            "acme.",
+            "acme..site_a",
+            "acme.site a",  # space rejected
+            "acme.site-a",  # hyphen rejected
+            "acme.site/a",  # slash rejected
+            "acme.site;DROP TABLE assets;--",
+            "acme..",
+        ],
+    )
+    def test_invalid_paths(self, path):
+        assert assets._validate_ltree_path(path) is False
+
+
+class TestFormatAssetCard:
+    def test_full_asset(self):
+        out = assets.format_asset_card(
+            {
+                "name": "VFD #1",
+                "path": "acme.site_a.line_2.cell_3",
+                "asset_tag": "AT-0001",
+                "atlas_asset_id": "1234",
+            }
+        )
+        assert "*VFD #1*" in out
+        assert "`acme.site_a.line_2.cell_3`" in out
+        assert "QR tag: `AT-0001`" in out
+        assert "Atlas ID: 1234" in out
+
+    def test_minimal_asset_no_optional_fields(self):
+        out = assets.format_asset_card(
+            {
+                "name": None,
+                "path": "acme.site_a",
+                "asset_tag": None,
+                "atlas_asset_id": None,
+            }
+        )
+        # Falls back to path when name is missing
+        assert "*acme.site_a*" in out
+        assert "QR tag" not in out
+        assert "Atlas ID" not in out
+
+
+class TestFormatHierarchyList:
+    def test_empty_top_level(self):
+        out = assets.format_hierarchy_list([])
+        assert "No assets registered yet." in out
+
+    def test_empty_with_parent(self):
+        out = assets.format_hierarchy_list([], parent_label="acme.site_a")
+        assert "No assets under `acme.site_a`." in out
+
+    def test_top_level_listing(self):
+        rows = [
+            {"path": "acme", "name": "Acme Corp"},
+            {"path": "globex", "name": "Globex"},
+        ]
+        out = assets.format_hierarchy_list(rows)
+        assert "Top-level assets:" in out
+        assert "`acme` — Acme Corp" in out
+        assert "`globex` — Globex" in out
+        assert "/asset <path>" in out
+
+    def test_children_listing_falls_back_to_last_label(self):
+        rows = [{"path": "acme.site_a.line_2", "name": None}]
+        out = assets.format_hierarchy_list(rows, parent_label="acme.site_a")
+        # No name: falls back to the last label in the path.
+        assert "`acme.site_a.line_2` — line_2" in out
+
+
+class TestPublicApiSafety:
+    """Helpers must never raise — return [] / None on any infra failure."""
+
+    def test_list_top_levels_without_db_returns_empty(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert assets.list_top_levels("00000000-0000-0000-0000-000000000001") == []
+
+    def test_list_children_without_db_returns_empty(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert assets.list_children("tid", "acme.site_a") == []
+
+    def test_get_asset_without_db_returns_none(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert assets.get_asset("tid", "acme.site_a") is None
+
+    def test_invalid_path_short_circuits_before_db(self):
+        # Even with NEON_DATABASE_URL set, malformed path must not reach SQL.
+        with patch.dict(os.environ, {"NEON_DATABASE_URL": "postgres://fake"}):
+            assert assets.list_children("tid", "acme..site_a") == []
+            assert assets.list_children("tid", "acme.site;DROP--") == []
+            assert assets.get_asset("tid", "acme..") is None
+
+    def test_empty_tenant_id_short_circuits(self):
+        with patch.dict(os.environ, {"NEON_DATABASE_URL": "postgres://fake"}):
+            assert assets.list_top_levels("") == []
+            assert assets.list_children("", "acme") == []
+            assert assets.get_asset("", "acme") is None
+
+    def test_zero_or_negative_depth_returns_empty(self):
+        with patch.dict(os.environ, {"NEON_DATABASE_URL": "postgres://fake"}):
+            assert assets.list_top_levels("tid", depth=0) == []
+            assert assets.list_top_levels("tid", depth=-1) == []

--- a/mira-core/mira-ingest/db/migrations/011_assets_uns.sql
+++ b/mira-core/mira-ingest/db/migrations/011_assets_uns.sql
@@ -1,0 +1,115 @@
+-- mira-core/mira-ingest/db/migrations/011_assets_uns.sql
+--
+-- Unit 5 (90-day MVP): UNS-style asset model.
+-- Adds ltree extension + an `assets` table with hierarchical uns_path
+-- (e.g. enterprise.site_a.line_2.cell_3) so the Telegram /asset command
+-- can walk the customer's plant hierarchy.
+--
+-- Numbered 011 (not 005 as in the original plan). The plan was drafted
+-- when 003 was the latest; 004-010 were merged in flight (channel
+-- config, guest reports, knowledge tsvector, ingested files, hub
+-- users/tenants, tenant_id backfills). 011 is the next free slot.
+--
+-- Companion path (read): mira-bots/shared/assets.py
+-- Companion path (backfill): mira-core/scripts/backfill_uns.py
+--
+-- Reuses asset_qr_tags (migration 003) for the QR scan path; the new
+-- `assets` table is additive and joined on (tenant_id, asset_tag).
+--
+-- Per CLAUDE.md NeonDB rules: use `IF NOT EXISTS` everywhere (idempotent
+-- replays); UUID for tenant_id matches asset_qr_tags (NOT the TEXT
+-- 'mike' default used by hub-readable tables in 009/010).
+
+BEGIN;
+
+-- ──────────────────────────────────────────────────────────────────────
+-- 1. ltree extension. Safe to call repeatedly; CREATE EXTENSION IF NOT
+--    EXISTS is a Postgres-native idempotent op.
+-- ──────────────────────────────────────────────────────────────────────
+CREATE EXTENSION IF NOT EXISTS ltree;
+
+-- ──────────────────────────────────────────────────────────────────────
+-- 2. assets table.
+--    uns_path examples:
+--      enterprise
+--      enterprise.site_a
+--      enterprise.site_a.line_2
+--      enterprise.site_a.line_2.cell_3
+--    ltree labels are [A-Za-z0-9_], max 256 chars per label, max 65535
+--    levels — plenty for 4-6 level UNS hierarchies.
+-- ──────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS assets (
+    id              UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id       UUID         NOT NULL,
+    atlas_asset_id  TEXT,
+    asset_tag       TEXT,
+    name            TEXT,
+    uns_path        LTREE        NOT NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- ──────────────────────────────────────────────────────────────────────
+-- 3. Indexes.
+--    GIST on uns_path is the canonical ltree index — supports ancestor
+--    (@>), descendant (<@), and lquery (~) operators in O(log n).
+--    BTREE on tenant_id keeps simple "all assets for tenant X" queries
+--    fast even when ltree isn't part of the predicate.
+--    UNIQUE on (tenant_id, uns_path) prevents duplicate rows for the
+--    same physical asset when backfill is replayed.
+-- ──────────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_assets_uns_path
+    ON assets USING GIST (uns_path);
+
+CREATE INDEX IF NOT EXISTS idx_assets_tenant
+    ON assets (tenant_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_assets_tenant_uns_path
+    ON assets (tenant_id, uns_path);
+
+-- ──────────────────────────────────────────────────────────────────────
+-- 4. Optional unique on (tenant_id, asset_tag) to keep the QR join sane.
+--    asset_tag may be NULL (top-level nodes don't have QR codes); the
+--    partial index excludes those.
+-- ──────────────────────────────────────────────────────────────────────
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_assets_tenant_tag
+    ON assets (tenant_id, asset_tag)
+    WHERE asset_tag IS NOT NULL;
+
+COMMIT;
+
+-- ──────────────────────────────────────────────────────────────────────
+-- Verification (run after applying):
+--
+--   SELECT extname FROM pg_extension WHERE extname = 'ltree';
+--                                                  -- 1 row
+--   \d+ assets                                    -- columns + indexes shown
+--   \di+ idx_assets_uns_path                      -- access method 'gist'
+--
+--   -- Smoke test: insert a 4-level hierarchy + walk it.
+--   INSERT INTO assets (tenant_id, name, uns_path) VALUES
+--     ('00000000-0000-0000-0000-000000000001'::uuid, 'Acme Corp',  'acme'),
+--     ('00000000-0000-0000-0000-000000000001'::uuid, 'Site A',     'acme.site_a'),
+--     ('00000000-0000-0000-0000-000000000001'::uuid, 'Line 2',     'acme.site_a.line_2'),
+--     ('00000000-0000-0000-0000-000000000001'::uuid, 'Cell 3',     'acme.site_a.line_2.cell_3');
+--
+--   -- Children one level below 'acme.site_a':
+--   SELECT name, uns_path FROM assets
+--     WHERE uns_path ~ 'acme.site_a.*{1}'
+--       AND tenant_id = '00000000-0000-0000-0000-000000000001'::uuid;
+--                                                  -- 1 row: Line 2
+--
+--   -- All descendants:
+--   SELECT name, uns_path FROM assets
+--     WHERE uns_path <@ 'acme.site_a'
+--       AND tenant_id = '00000000-0000-0000-0000-000000000001'::uuid;
+--                                                  -- 3 rows
+--
+-- Rollback (if required):
+--   DROP INDEX IF EXISTS uniq_assets_tenant_tag;
+--   DROP INDEX IF EXISTS uniq_assets_tenant_uns_path;
+--   DROP INDEX IF EXISTS idx_assets_tenant;
+--   DROP INDEX IF EXISTS idx_assets_uns_path;
+--   DROP TABLE IF EXISTS assets;
+--   -- ltree extension left in place — may be in use by other migrations.
+-- ──────────────────────────────────────────────────────────────────────

--- a/mira-core/scripts/backfill_uns.py
+++ b/mira-core/scripts/backfill_uns.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Backfill the UNS asset hierarchy from a tenant-supplied CSV.
+
+Schema target: `assets` (migration 011_assets_uns.sql).
+
+CSV format (header row required):
+    asset_tag,uns_path,name,atlas_asset_id
+    AT-0001,acme.site_a.line_2.cell_3,VFD #1,1234
+    AT-0002,acme.site_a.line_2.cell_4,VFD #2,1235
+    ,acme.site_a,Site A,
+    ,acme.site_a.line_2,Line 2,
+
+Rows without `asset_tag` are still inserted (they represent intermediate
+nodes in the hierarchy that don't carry QR codes — sites, lines, cells).
+
+Usage:
+    # Dry run — print what would be inserted
+    NEON_DATABASE_URL=... MIRA_TENANT_ID=... \
+        python3 backfill_uns.py --csv ./hierarchy.csv --dry-run
+
+    # Apply
+    NEON_DATABASE_URL=... MIRA_TENANT_ID=... \
+        python3 backfill_uns.py --csv ./hierarchy.csv
+
+The script is idempotent: it uses ON CONFLICT (tenant_id, uns_path) DO
+UPDATE so re-running with an updated CSV refreshes name / asset_tag /
+atlas_asset_id without producing duplicate rows.
+
+Per CLAUDE.md feedback_no_throwaway_scripts.md: this is a versioned
+pipeline command, not a throwaway. Use --dry-run to preview before
+applying.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger("backfill-uns")
+
+_LTREE_PATH_RE = re.compile(r"^[A-Za-z0-9_]{1,256}(\.[A-Za-z0-9_]{1,256})*$")
+
+
+def _load_csv(path: Path) -> list[dict]:
+    with open(path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    if not rows:
+        raise SystemExit(f"{path} is empty")
+    required = {"asset_tag", "uns_path", "name", "atlas_asset_id"}
+    missing = required - set(rows[0].keys())
+    if missing:
+        raise SystemExit(f"{path} missing required columns: {sorted(missing)}")
+    return rows
+
+
+def _validate(rows: list[dict]) -> list[dict]:
+    """Reject malformed paths early; return cleaned rows."""
+    cleaned = []
+    seen_paths: set[str] = set()
+    for i, r in enumerate(rows, start=2):  # row 1 is the header
+        path = (r.get("uns_path") or "").strip()
+        if not _LTREE_PATH_RE.fullmatch(path):
+            raise SystemExit(
+                f"row {i}: invalid uns_path {path!r} — labels must be "
+                "[A-Za-z0-9_], separated by dots"
+            )
+        if path in seen_paths:
+            raise SystemExit(f"row {i}: duplicate uns_path {path!r}")
+        seen_paths.add(path)
+        cleaned.append(
+            {
+                "uns_path": path,
+                "asset_tag": (r.get("asset_tag") or "").strip() or None,
+                "name": (r.get("name") or "").strip() or None,
+                "atlas_asset_id": (r.get("atlas_asset_id") or "").strip() or None,
+            }
+        )
+    return cleaned
+
+
+def _connect():
+    url = os.environ.get("NEON_DATABASE_URL")
+    if not url:
+        raise SystemExit("NEON_DATABASE_URL is not set")
+    from sqlalchemy import create_engine, text  # noqa: PLC0415
+    from sqlalchemy.pool import NullPool  # noqa: PLC0415
+
+    engine = create_engine(
+        url,
+        poolclass=NullPool,
+        connect_args={"sslmode": "require"},
+        pool_pre_ping=True,
+    )
+    return engine, text
+
+
+def _upsert(rows: list[dict], tenant_id: str, dry_run: bool) -> None:
+    if dry_run:
+        for r in rows:
+            logger.info(
+                "[dry-run] would upsert tenant=%s path=%s tag=%s name=%s atlas=%s",
+                tenant_id,
+                r["uns_path"],
+                r["asset_tag"],
+                r["name"],
+                r["atlas_asset_id"],
+            )
+        logger.info("[dry-run] %d rows would be upserted", len(rows))
+        return
+
+    engine, text = _connect()
+    sql = text(
+        """
+        INSERT INTO assets (tenant_id, uns_path, asset_tag, name, atlas_asset_id)
+        VALUES (:tid, :path::ltree, :tag, :name, :atlas)
+        ON CONFLICT (tenant_id, uns_path) DO UPDATE SET
+            asset_tag      = EXCLUDED.asset_tag,
+            name           = EXCLUDED.name,
+            atlas_asset_id = EXCLUDED.atlas_asset_id,
+            updated_at     = NOW()
+        """
+    )
+    inserted = 0
+    with engine.begin() as conn:
+        for r in rows:
+            conn.execute(
+                sql,
+                {
+                    "tid": tenant_id,
+                    "path": r["uns_path"],
+                    "tag": r["asset_tag"],
+                    "name": r["name"],
+                    "atlas": r["atlas_asset_id"],
+                },
+            )
+            inserted += 1
+    logger.info("Upserted %d rows for tenant=%s", inserted, tenant_id)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        required=True,
+        help="Path to hierarchy CSV (asset_tag,uns_path,name,atlas_asset_id)",
+    )
+    parser.add_argument(
+        "--tenant-id",
+        default=os.environ.get("MIRA_TENANT_ID", ""),
+        help="Tenant UUID. Defaults to $MIRA_TENANT_ID.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would happen without writing.",
+    )
+    args = parser.parse_args()
+
+    if not args.tenant_id:
+        logger.error("--tenant-id (or MIRA_TENANT_ID) required")
+        return 2
+
+    rows = _load_csv(args.csv)
+    cleaned = _validate(rows)
+    logger.info("Loaded %d rows from %s", len(cleaned), args.csv)
+    _upsert(cleaned, args.tenant_id, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes **Unit 5** per [docs/plans/2026-04-19-mira-90-day-mvp.md](docs/plans/2026-04-19-mira-90-day-mvp.md). Foundation for hierarchical asset queries; unblocks Unit 7 (QR pre-load uses the same asset metadata).

- **Migration `011_assets_uns.sql`** — ltree extension + `assets` table with `uns_path ltree NOT NULL`, GIST index, tenant unique constraint
- **Read path `mira-bots/shared/assets.py`** — `list_top_levels` / `list_children` / `get_asset` helpers; fail-closed on missing DB or malformed input (matches `neon_recall.py` contract)
- **Telegram `/asset` command** — no-arg shows top 2 levels; `<path>` descends or shows asset card
- **Backfill `mira-core/scripts/backfill_uns.py`** — CSV → assets, idempotent ON CONFLICT, `--dry-run` mode
- **29 unit tests, all green** — path validation incl. SQL-injection attempts, formatter rendering, safety guards

## Migration numbering note

Plan said `005_assets_uns.sql`. Bumped to **011** because 004-010 were taken in flight (channel config, guest reports, knowledge tsvector for Unit 6, ingested files, hub user/tenant tables, tenant_id backfills). 011 is purely additive; no ordering dependency on prior migrations.

## Coordination

- Plan in-flight table updated (`2472cea`) before edits
- Pre-flight: no other branch/PR touches `mira-bots/shared/`, `mira-bots/telegram/bot.py`, or `mira-core/mira-ingest/db/migrations/`
- Branched from latest `origin/main` (`3816af0`, post Unit 9a merge)

## Test plan
- [x] `pytest mira-bots/tests/test_assets.py -v` — 29 passed
- [x] `python -m ruff check` on all touched files — clean
- [x] AST parses on bot.py / assets.py / backfill_uns.py
- [ ] **Live migration apply on NeonDB** — deferred to Mike's hand-run (not in PR scope)
- [ ] **DoD live demo** — seed fixture tenant w/ 4-level hierarchy (15 assets), `/asset enterprise.site_a` returns level-3 children — runs after migration applied

## Out of scope (refuse mid-execution per plan)
- Atlas → assets sync (that's Unit 8 territory)
- Multi-tenant signup flow for asset CSV upload (n=1 default)
- Real customer hierarchy mappings (post-pilot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)