### PR TITLE
fix(hub): trailingSlash: true to break /hub redirect loop with nginx

### DIFF
--- a/mira-hub/next.config.ts
+++ b/mira-hub/next.config.ts
@@ -4,6 +4,11 @@ const nextConfig: NextConfig = {
   output: "standalone",
   basePath: "/hub",
   assetPrefix: "/hub",
+  // nginx-oracle.conf has `location /hub/` — that block fires nginx's auto-301
+  // from /hub → /hub/. Next.js's default `trailingSlash: false` then 308s
+  // /hub/ → /hub, producing an infinite redirect loop on the basePath root.
+  // Forcing trailingSlash: true keeps Next.js consistent with nginx.
+  trailingSlash: true,
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Production hotfix — \`app.factorylm.com/hub/\` is currently down

\`\`\`
$ curl -sI https://app.factorylm.com/hub/
HTTP/1.1 308 Permanent Redirect    ← Next.js strips trailing slash
location: /hub

$ curl -sI https://app.factorylm.com/hub
HTTP/1.1 301 Moved Permanently     ← nginx auto-adds slash to match \`location /hub/\`
Location: https://app.factorylm.com/hub/
\`\`\`

Browsers loop until they hit the redirect cap → page appears broken.

## Root cause

nginx-oracle.conf line 70 declares \`location /hub/ { ... }\` (with trailing slash). nginx auto-issues a 301 on \`/hub\` (no slash) to make it match. Next.js's default \`trailingSlash: false\` then 308s \`/hub/\` back to \`/hub\` to strip the slash. They fight forever.

The loop has been latent since \`basePath: "/hub"\` was set in \`992e50e\`, but only became reachable from the public domain after PR #612 (b76545f, today) added the \`location /hub/\` block to \`nginx-oracle.conf\`.

## Fix

One line: \`trailingSlash: true\` in \`mira-hub/next.config.ts\`. Next.js now preserves the slash nginx requires.

- \`/hub/\` → served directly (no Next.js redirect)
- \`/hub\` → nginx 301 → \`/hub/\` → served (one hop)
- Internal links like \`/hub/foo\` (no slash) → Next.js 308 → \`/hub/foo/\` (one hop, no loop)

## Test plan
- [ ] CI green
- [ ] After deploy: \`curl -sI https://app.factorylm.com/hub/\` returns 200 (or 302 to /login if unauthenticated, per the auth gate from PR #634)
- [ ] No more 308 with \`location: /hub\`
- [ ] Browser load of \`https://app.factorylm.com/hub/\` reaches the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)