### PR TITLE
fix(hub): redirect /hub root via middleware (Next.js 16 redirect-from-page bug)

### DIFF
--- a/mira-hub/src/middleware.ts
+++ b/mira-hub/src/middleware.ts
@@ -1,4 +1,5 @@
 import { withAuth } from "next-auth/middleware";
+import { NextResponse } from "next/server";
 
 // Explicit `secret` is required for the edge-runtime middleware to find
 // the JWT signing key. next-auth/middleware defaults to reading
@@ -6,12 +7,27 @@ import { withAuth } from "next-auth/middleware";
 // withAuth silently falls through and the request proceeds (resulting in
 // a 200 instead of a 302). We use AUTH_SECRET (Auth.js v5 convention)
 // throughout the rest of the stack, so plumb it explicitly here.
-export default withAuth({
-  pages: {
-    signIn: "/login",
+export default withAuth(
+  function middleware(req) {
+    // Root of the basePath (i.e. /hub/) — `redirect()` from a Server
+    // Component is silently swallowed in Next.js 16.2.4 standalone + basePath
+    // (response comes back 200 with empty body and no Location header).
+    // Doing the redirect here in middleware where NextResponse.redirect is
+    // a known-good primitive avoids that path entirely.
+    if (req.nextUrl.pathname === "/") {
+      const url = req.nextUrl.clone();
+      url.pathname = "/feed";
+      return NextResponse.redirect(url);
+    }
+    return NextResponse.next();
   },
-  secret: process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET,
-});
+  {
+    pages: {
+      signIn: "/login",
+    },
+    secret: process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET,
+  }
+);
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Production-down (continuation of PR #645)

PR #645 fixed the redirect loop. `/hub/` now returns **200 with empty body and no Location header** — the page appears blank, so still "down" from the user's view.

### Diagnosis

\`mira-hub/src/app/page.tsx\` does:
\`\`\`tsx
import { redirect } from "next/navigation";
export default function RootPage() {
  redirect("/feed");
}
\`\`\`

In Next.js 16.2.4 + \`output: standalone\` + \`basePath: /hub\`, this redirect signal from a Server Component is silently swallowed — the response is chunked, 0 bytes, no Location header.

Sibling routes confirm the bug is specific to \`redirect()\` from the basePath root Server Component:

| Route | Status | Body |
|---|---|---|
| \`/hub/\` (root, broken) | 200 | **empty** |
| \`/hub/feed/\` | 200 | 61KB ✓ |
| \`/hub/login/\` | 200 | 11KB ✓ |
| \`/hub/api/health/\` | 200 | \`{"status":"ok",...}\` ✓ |

### Fix

Do the redirect in middleware where \`NextResponse.redirect\` is the same primitive already in production use across every route handler in \`src/app/api/auth/**/*.ts\`. Edge runtime, well-tested path.

\`\`\`ts
export default withAuth(
  function middleware(req) {
    if (req.nextUrl.pathname === "/") {
      const url = req.nextUrl.clone();
      url.pathname = "/feed";
      return NextResponse.redirect(url);
    }
    return NextResponse.next();
  },
  { pages: { signIn: "/login" }, secret: process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET }
);
\`\`\`

The custom function runs *after* withAuth's auth check:
- Unauthenticated \`/hub/\` → withAuth → 302 \`/hub/login/\` (correct auth gate)
- Authenticated \`/hub/\` → custom middleware → 302 \`/hub/feed/\`

\`app/page.tsx\` is left as-is — middleware intercepts before it ever runs.

## Test plan
- [ ] CI green
- [ ] After deploy: \`curl -sI https://app.factorylm.com/hub/\` returns 302 with \`Location: /hub/login/\` (unauthenticated) or \`/hub/feed/\` (authenticated)
- [ ] Browser load of \`https://app.factorylm.com/hub/\` reaches a real page

🤖 Generated with [Claude Code](https://claude.com/claude-code)