### PR TITLE
fix(hub): force-dynamic on root page so redirect() fires at request time (closes /hub down)

### DIFF
--- a/mira-hub/src/app/page.tsx
+++ b/mira-hub/src/app/page.tsx
@@ -1,5 +1,14 @@
 import { redirect } from "next/navigation";
 
+// Without this, Next.js 16 prerenders this page as a static /index.html at
+// build time. The build catches the redirect() throw, serializes the intent
+// as an RSC payload (`NEXT_REDIRECT;replace;/feed;307;`), and ships the
+// "error" template HTML — but at runtime the standalone server doesn't
+// honor that buried payload, so /hub/ comes back 200 with empty <body>.
+// Forcing dynamic rendering runs redirect() at request time where it
+// actually produces an HTTP 307. (See feedback_nextjs_dynamic_for_auth_middleware.)
+export const dynamic = "force-dynamic";
+
 export default function RootPage() {
   redirect("/feed");
 }

--- a/mira-hub/tests/e2e/hub-down-diagnostic.spec.ts
+++ b/mira-hub/tests/e2e/hub-down-diagnostic.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+
+// Diagnostic test for the /hub-is-down investigation. Probes the live
+// production endpoint and reports what a real Chromium navigation sees,
+// since curl alone has been showing 200 + empty body but not telling us
+// what (if anything) renders. Safe: read-only, no mutations.
+
+test("diagnose /hub root response and rendering", async ({ page, request }) => {
+  console.log("\n=== DIRECT REQUEST (no JS) ===");
+  const res = await request.get("/hub/", { maxRedirects: 0 });
+  console.log(`HTTP ${res.status()}`);
+  console.log(`Headers:`, JSON.stringify(res.headers(), null, 2));
+  const body = await res.text();
+  console.log(`Body length: ${body.length}`);
+  if (body.length > 0) {
+    console.log(`First 300 chars:\n${body.slice(0, 300)}`);
+  } else {
+    console.log("Body is EMPTY");
+  }
+
+  console.log("\n=== FOLLOWED REDIRECTS ===");
+  const followed = await request.get("/hub/");
+  console.log(`Final URL: ${followed.url()}`);
+  console.log(`Final status: ${followed.status()}`);
+  console.log(`Final body length: ${(await followed.text()).length}`);
+
+  console.log("\n=== BROWSER NAVIGATION (with JS, follows everything) ===");
+  const consoleLogs: string[] = [];
+  const pageErrors: string[] = [];
+  page.on("console", (msg) => consoleLogs.push(`[${msg.type()}] ${msg.text()}`));
+  page.on("pageerror", (err) => pageErrors.push(err.message));
+
+  const response = await page.goto("/hub/", { waitUntil: "domcontentloaded", timeout: 15000 });
+  console.log(`Initial response status: ${response?.status()}`);
+  console.log(`Final URL after navigation: ${page.url()}`);
+
+  const title = await page.title();
+  console.log(`Page title: "${title}"`);
+
+  const bodyHTML = await page.evaluate(() => document.body?.outerHTML?.slice(0, 500) ?? "<no body>");
+  console.log(`Body HTML (first 500):\n${bodyHTML}`);
+
+  const visibleText = await page.evaluate(() => document.body?.innerText?.slice(0, 300) ?? "<no innerText>");
+  console.log(`Visible text:\n${visibleText}`);
+
+  if (consoleLogs.length > 0) {
+    console.log(`\n=== CONSOLE LOGS (${consoleLogs.length}) ===`);
+    consoleLogs.forEach((l) => console.log(l));
+  }
+  if (pageErrors.length > 0) {
+    console.log(`\n=== PAGE ERRORS (${pageErrors.length}) ===`);
+    pageErrors.forEach((e) => console.log(e));
+  }
+
+  // Don't fail the test — this is diagnostic. We just want the output.
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
## Real root cause — confirmed via SSH inspection

Three middleware fixes (#645, #647, #648) all deployed cleanly and **none changed the symptom**: \`/hub/\` returns 200 with 0-byte body.

Root cause is upstream of middleware. Live container inspection:

\`\`\`
$ docker exec mira-hub cat /app/.next/server/app/index.html | head -c 200
<!DOCTYPE html><html id="__next_error__">...
\`\`\`

The build **prerendered** \`app/page.tsx\` as static \`index.html\` (9.2KB). Inside the RSC payload:

\`\`\`
"8:E{\"digest\":\"NEXT_REDIRECT;replace;/feed;307;\"}"
\`\`\`

The build caught the \`redirect("/feed")\` throw and serialized the redirect *intent* into the static HTML, then shipped the \`<html id="__next_error__">\` error template. At runtime the standalone server serves that HTML directly; Next.js 16 doesn't translate the buried RSC payload into an HTTP 307. The user gets the empty \`<body></body>\` you see in Playwright.

This is why every middleware fix was a no-op — the static HTML was already what the runtime was serving for \`/hub/\`.

## Fix

\`export const dynamic = "force-dynamic"\` on \`app/page.tsx\`. With dynamic rendering forced, the page is rendered at request time, \`redirect()\` runs server-side per request, and Next.js converts the throw into a real HTTP 307. Same pattern Mike documented in \`feedback_nextjs_dynamic_for_auth_middleware\` for a different but related symptom.

Two-line change:
\`\`\`tsx
import { redirect } from "next/navigation";
export const dynamic = "force-dynamic";   // ← added
export default function RootPage() {
  redirect("/feed");
}
\`\`\`

Also includes \`tests/e2e/hub-down-diagnostic.spec.ts\` — a Playwright probe that hits the prod endpoint and reports HTTP status, body, title, console errors, page errors. Re-runnable as a regression check.

## What about the middleware refactors from #645/#647/#648?

They were unnecessary for /hub/ root, but they're left in place because they're harmless and slightly improve resilience (the basePath-root branch in middleware is dead code now, but it's a pure if-check). I can remove it in a cleanup PR if preferred.

## Test plan
- [ ] CI green
- [ ] After deploy: \`curl -sI https://app.factorylm.com/hub/\` returns **HTTP 307** with \`Location: /hub/feed/\` (or 302 to /hub/login/ once AUTH_SECRET fully gates)
- [ ] Body length on followed request > 0
- [ ] Playwright diagnostic spec re-run shows non-empty body and a real title

🤖 Generated with [Claude Code](https://claude.com/claude-code)