### PR TITLE
chore(gitignore): untrack mira-hub Playwright test-results + report dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,10 @@ htmlcov/
 # Playwright MCP session ephemera (per-session, regenerable)
 .playwright-mcp/
 
+# Playwright test runner artifacts — regenerated on every test run
+mira-hub/test-results/
+mira-hub/playwright-report/
+
 # Marketing video binaries — large, regenerable; keep spend.json tracked
 marketing/videos/**/*.mp4
 marketing/videos/**/*.mov

--- a/mira-hub/test-results/.last-run.json
+++ b/mira-hub/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
Untracks \`mira-hub/test-results/.last-run.json\` and adds the \`test-results/\` and \`playwright-report/\` dirs to \`.gitignore\`. These are regenerated on every Playwright run and were polluting \`git status\` with line-ending-only "modifications" between sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)