### PR TITLE
fix(hub): prefix 7 missed /api/ fetches with /hub/ basePath

### DIFF
--- a/mira-hub/src/app/(hub)/assets/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/page.tsx
@@ -141,7 +141,7 @@ function CreateAssetModal({
     setSaving(true);
     setError(null);
     try {
-      const res = await fetch("/api/assets", {
+      const res = await fetch("/hub/api/assets", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(form),

--- a/mira-hub/src/app/(hub)/channels/page.tsx
+++ b/mira-hub/src/app/(hub)/channels/page.tsx
@@ -198,7 +198,7 @@ function ChannelsInner() {
 
     refresh();
 
-    fetch("/api/auth/status")
+    fetch("/hub/api/auth/status")
       .then(r => r.json())
       .then((d: AuthStatus) => setAuthStatus(d))
       .catch(() => {});
@@ -217,7 +217,7 @@ function ChannelsInner() {
     setTelegramLoading(true);
     setTelegramError(null);
     try {
-      const res = await fetch("/api/auth/telegram", {
+      const res = await fetch("/hub/api/auth/telegram", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ token: telegramToken.trim() }),

--- a/mira-hub/src/app/(hub)/event-log/page.tsx
+++ b/mira-hub/src/app/(hub)/event-log/page.tsx
@@ -156,7 +156,7 @@ export default function EventLogPage() {
 
   const loadEvents = useCallback(async () => {
     try {
-      const res = await fetch("/api/events");
+      const res = await fetch("/hub/api/events");
       if (res.ok) {
         const data = await res.json();
         setEvents(Array.isArray(data) ? data.map(apiRowToEvent) : []);

--- a/mira-hub/src/app/(hub)/knowledge/page.tsx
+++ b/mira-hub/src/app/(hub)/knowledge/page.tsx
@@ -51,7 +51,7 @@ export default function KnowledgePage() {
   const [pickerOpen, setPickerOpen] = useState(false);
 
   useEffect(() => {
-    fetch("/api/knowledge")
+    fetch("/hub/api/knowledge")
       .then((r) => r.json())
       .then((data) => {
         setDocs(data.docs ?? []);

--- a/mira-hub/src/app/(hub)/usage/page.tsx
+++ b/mira-hub/src/app/(hub)/usage/page.tsx
@@ -32,7 +32,7 @@ export default function UsagePage() {
   } | null>(null);
 
   useEffect(() => {
-    fetch("/api/usage").then(r => r.json()).then(setData).catch(console.error);
+    fetch("/hub/api/usage").then(r => r.json()).then(setData).catch(console.error);
   }, []);
 
   const month = data?.thisMonth;

--- a/mira-hub/src/components/UploadPicker.tsx
+++ b/mira-hub/src/components/UploadPicker.tsx
@@ -127,7 +127,7 @@ export function UploadPicker({
     fetch("/hub/api/picker/dropbox/key")
       .then((r) => setDropboxAvailable(r.ok))
       .catch(() => setDropboxAvailable(false));
-    fetch("/api/assets")
+    fetch("/hub/api/assets")
       .then((r) => (r.ok ? r.json() : []))
       .then((data: Asset[] | unknown) => {
         if (Array.isArray(data)) setAssets(data as Asset[]);


### PR DESCRIPTION
## Closes user-reported breakage on /hub/assets and /hub/usage

PR #612's basePath migration moved most internal fetches to \`/hub/api/...\` but **seven** were missed. With \`basePath: "/hub"\`, a bare \`/api/foo\` fetch from a page under \`/hub/\` resolves to \`https://app.factorylm.com/api/foo\` (apex) → nginx catch-all → mira-pipeline / Open WebUI, not mira-hub.

User-visible result on the two reported pages:
- **/hub/assets**: GET on mount uses correct \`/hub/api/assets\` (line 412). The page renders fine when logged in. The POST on line 144 used wrong path so creating an asset always 4xx'd. When session was missing, GET 401'd → page redirected to \`/hub/login\` → Mike clicked Sign-in-with-Google (his previous choice) → he saw \`accounts.google.com\` and reported "the asset page redirects to Google login"
- **/hub/usage**: GET on line 35 hit the wrong endpoint and silently failed; page rendered with \`data=null\` ("Loading..." forever)

## Diagnosis

Three parallel Explore agents + one Plan agent + direct file reads + SSH-confirmed runtime state all converged on the same root cause: client-side \`fetch()\` paths missing \`/hub/\` prefix. \`nginx-oracle.conf\`, middleware, basePath config, NextAuth — all working correctly. Pure client-side string-construction bug.

## Files changed

| # | File | Line | Was | Now |
|---|---|---|---|---|
| 1 | \`(hub)/assets/page.tsx\` | 144 | \`fetch("/api/assets",\` | \`fetch("/hub/api/assets",\` |
| 2 | \`(hub)/usage/page.tsx\` | 35 | \`fetch("/api/usage")\` | \`fetch("/hub/api/usage")\` |
| 3 | \`(hub)/knowledge/page.tsx\` | 54 | \`fetch("/api/knowledge")\` | \`fetch("/hub/api/knowledge")\` |
| 4 | \`(hub)/event-log/page.tsx\` | 159 | \`fetch("/api/events")\` | \`fetch("/hub/api/events")\` |
| 5 | \`(hub)/channels/page.tsx\` | 201 | \`fetch("/api/auth/status")\` | \`fetch("/hub/api/auth/status")\` |
| 6 | \`(hub)/channels/page.tsx\` | 220 | \`fetch("/api/auth/telegram",\` | \`fetch("/hub/api/auth/telegram",\` |
| 7 | \`components/UploadPicker.tsx\` | 130 | \`fetch("/api/assets")\` | \`fetch("/hub/api/assets")\` |

7 single-line string replacements. Net diff: 6 files, +7/-7. All seven backend endpoints already exist (\`mira-hub/src/app/api/{assets,usage,knowledge,events,auth/status,auth/telegram}/\`).

## Risk: 1/10

Pure string-prefix change, no logic touched, no API contracts moved. Identical syntax to the working GET on \`assets/page.tsx:412\` already in production. Worst case (typo in one of seven sites) breaks a page that's already broken — net regression impossible.

## Out of scope

- Adding 401-handling to /usage so it doesn't silently fail (UX polish)
- Replacing /assets's \`window.location.href = "/hub/login"\` with inline error UI (UX polish; would diverge from the consistent pattern used by every other auth-gated page)
- The Next.js 16 basePath-root \`redirect()\` bug — already worked around via nginx earlier this morning
- Reconciling repo \`nginx-oracle.conf\` drift vs deployed \`/etc/nginx/sites-enabled/mira\`

## Verification plan

After merge + deploy:
1. \`curl -sI -L -b 'next-auth.session-token=<token>' https://app.factorylm.com/hub/api/usage\` → 200 + JSON \`{thisMonth, daily, bySource, byTech, allTime}\`
2. Visit \`https://app.factorylm.com/hub/assets\` while logged in → list renders. Click "Add asset" → form submits → new row in list.
3. Visit \`https://app.factorylm.com/hub/usage\` while logged in → KPI cards populate (no longer "Loading...")
4. Visit \`/hub/knowledge\`, \`/hub/event-log\`, \`/hub/channels\` → no \`/api/\` 404s in DevTools network tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)