### PR TITLE
fix(hub): NEXTAUTH_URL must include /api/auth so OAuth callback resolves correctly

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -315,10 +315,21 @@ services:
       - OAUTH_TOKEN_ENC_KEY=${OAUTH_TOKEN_ENC_KEY:-}
       # NextAuth (Auth.js) — sign-in for the post-paywall hub
       # AUTH_SECRET: 32-byte random hex used to sign session JWTs
-      # NEXTAUTH_URL: must include the /hub basePath so callbacks land at /hub/api/auth/callback/google
+      # NEXTAUTH_URL: NextAuth v4 builds OAuth callback URLs as
+      #   `${NEXTAUTH_URL}/callback/{provider}` — the path portion of
+      #   NEXTAUTH_URL becomes the auth-API base, NOT the app base. With
+      #   `/hub` only, callback resolves to /hub/callback/google which doesn't
+      #   match the actual handler at /hub/api/auth/callback/google → Google
+      #   returns redirect_uri_mismatch. Including `/api/auth` makes the
+      #   callback resolve to /hub/api/auth/callback/google. Verified via
+      #   live probe of the OAuth flow.
+      # If updating: Doppler factorylm/prd NEXTAUTH_URL must match this value
+      # (or be unset to use this default). GCP authorized redirect URI for
+      # client_id 246891599587-* must include
+      # https://app.factorylm.com/hub/api/auth/callback/google.
       - AUTH_SECRET=${AUTH_SECRET:-}
-      - NEXTAUTH_URL=${NEXTAUTH_URL:-https://app.factorylm.com/hub}
-      - NEXTAUTH_URL_INTERNAL=${NEXTAUTH_URL_INTERNAL:-https://app.factorylm.com/hub}
+      - NEXTAUTH_URL=${NEXTAUTH_URL:-https://app.factorylm.com/hub/api/auth}
+      - NEXTAUTH_URL_INTERNAL=${NEXTAUTH_URL_INTERNAL:-https://app.factorylm.com/hub/api/auth}
       # Sign-in OAuth client. Named HUB_AUTH_GOOGLE_* to avoid collision with
       # the existing GOOGLE_OAUTH_CLIENT_ID (Apps Script magic-inbox) and
       # GOOGLE_CLIENT_ID (Drive integration). Different scopes than both.


### PR DESCRIPTION
## Sign-in-with-Google fails with Error 400 redirect_uri_mismatch

Mike clicks "Sign in with Google" on \`/hub/login\`, gets sent to Google, sees:
> Access blocked: This app's request is invalid
> Error 400: redirect_uri_mismatch

## Root cause — captured via live probe

Drove the OAuth flow with curl + Playwright. NextAuth's redirect to Google contains:

\`\`\`
location: https://accounts.google.com/o/oauth2/v2/auth?
  client_id=246891599587-usbnoa7g6agveginmbb62rvi2p3rmb83.apps.googleusercontent.com
  &redirect_uri=https%3A%2F%2Fapp.factorylm.com%2Fhub%2Fcallback%2Fgoogle
                                                  ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑
                                                  missing /api/auth/
\`\`\`

URL-decoded redirect_uri: \`https://app.factorylm.com/hub/callback/google\`. **The actual NextAuth callback handler lives at \`/hub/api/auth/callback/google\`** (per the \`[...nextauth]/route.ts\` file). The \`/api/auth/\` segment is missing from what NextAuth sends Google.

## Why

NextAuth v4 builds OAuth callback URLs as \`\${NEXTAUTH_URL}/callback/{provider}\`. The path portion of NEXTAUTH_URL is treated as the **auth-API base**, NOT as the **app base**. With \`NEXTAUTH_URL=https://app.factorylm.com/hub\`:
- NextAuth thinks the auth API lives at \`/hub/*\`
- Callback URL = \`/hub/callback/google\` ← what we observe Google receiving
- Actual handler URL = \`/hub/api/auth/callback/google\` (because the file is at \`app/api/auth/[...nextauth]\`)

The original compose comment claimed "NEXTAUTH_URL must include the /hub basePath so callbacks land at /hub/api/auth/callback/google" — but empirically they don't. The comment was an assumption that doesn't match NextAuth v4's behavior.

## Fix

Include \`/api/auth\` in the NEXTAUTH_URL default:
\`\`\`yaml
- NEXTAUTH_URL=\${NEXTAUTH_URL:-https://app.factorylm.com/hub/api/auth}
- NEXTAUTH_URL_INTERNAL=\${NEXTAUTH_URL_INTERNAL:-https://app.factorylm.com/hub/api/auth}
\`\`\`

After this:
- NextAuth treats \`/hub/api/auth\` as the auth-API base
- Callback URL = \`/hub/api/auth/callback/google\` ✓
- Matches the actual handler route ✓

Net diff: 1 file changed, +14 / -3 (mostly an explanatory comment block).

## Required follow-up actions (NOT in this PR)

1. **Doppler**: \`factorylm/prd\` — if \`NEXTAUTH_URL\` and \`NEXTAUTH_URL_INTERNAL\` are explicitly set to \`/hub\` there, update them to \`/hub/api/auth\`. If unset, this compose default takes effect on next deploy.
2. **GCP**: OAuth client \`246891599587-usbnoa7g6agveginmbb62rvi2p3rmb83\` — verify Authorized redirect URIs includes \`https://app.factorylm.com/hub/api/auth/callback/google\`. Likely already there if the original setup followed standard NextAuth setup.

## Verification

After deploy:
\`\`\`
curl -s "https://app.factorylm.com/hub/api/auth/csrf/" -c /tmp/c.txt | jq -r .csrfToken
# then POST signin/google/ and inspect Location header — should show
# redirect_uri=https%3A%2F%2Fapp.factorylm.com%2Fhub%2Fapi%2Fauth%2Fcallback%2Fgoogle
\`\`\`

Or via Playwright (the spec already exists at \`mira-hub/tests/e2e/probe-google-login.spec.ts\`):
\`\`\`
cd mira-hub && npx playwright test tests/e2e/probe-google-login.spec.ts
# expect: redirect_uri now includes /api/auth/
\`\`\`

## Risk: 1/10

Pure env-default change. If Doppler explicitly sets NEXTAUTH_URL to \`/hub\` (overriding this default), nothing changes — Mike just updates Doppler. If Doppler is unset, the new default takes effect on next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)