### PR TITLE
fix(hub): replace after() with fire-and-forget Promise so uploads actually ingest

### DIFF
--- a/mira-hub/src/app/api/uploads/local/route.ts
+++ b/mira-hub/src/app/api/uploads/local/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { after } from "next/server";
 import { createUpload, updateUploadStatus } from "@/lib/uploads";
 import {
   forwardToIngest,
@@ -67,7 +66,13 @@ export async function POST(req: NextRequest) {
     assetTag,
   });
 
-  after(async () => {
+  // Background ingest. Used to be wrapped in `after()` from "next/server",
+  // but Next.js 16 standalone throws `Error: ENVIRONMENT_FALLBACK` and the
+  // callback never runs — so the upload row stayed at status="parsing"
+  // forever and the UI spun. mira-hub runs as a long-lived standalone
+  // server (worker isn't killed after each request), so a plain
+  // fire-and-forget Promise stays alive until it resolves.
+  void (async () => {
     try {
       const stream = () =>
         new ReadableStream<Uint8Array>({
@@ -92,9 +97,11 @@ export async function POST(req: NextRequest) {
       }
     } catch (err) {
       console.error(`[uploads/local/${upload.id}] failed`, err);
-      await updateUploadStatus(upload.id, "failed", (err as Error).message);
+      await updateUploadStatus(upload.id, "failed", (err as Error).message).catch(
+        (statusErr) => console.error(`[uploads/local/${upload.id}] also failed to mark failed`, statusErr),
+      );
     }
-  });
+  })();
 
   return NextResponse.json(upload, { status: 201 });
 }

--- a/mira-hub/src/app/api/uploads/route.ts
+++ b/mira-hub/src/app/api/uploads/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { after } from "next/server";
 import {
   createUpload,
   listUploads,
@@ -95,7 +94,12 @@ export async function POST(req: NextRequest) {
     assetTag: body.assetTag ?? null,
   });
 
-  after(() => runIngestPipeline(upload.id, body, kind, ctx.tenantId));
+  // Background ingest. Used to be wrapped in `after()` from "next/server",
+  // but Next.js 16 standalone throws `Error: ENVIRONMENT_FALLBACK` and the
+  // callback never runs — uploads stayed at status="queued" forever. mira-hub
+  // runs as a long-lived standalone server, so a plain fire-and-forget
+  // Promise stays alive until it resolves.
+  void runIngestPipeline(upload.id, body, kind, ctx.tenantId);
 
   return NextResponse.json(upload, { status: 201 });
 }


### PR DESCRIPTION
## PDF upload spins forever — Next.js 16 \`after()\` throws ENVIRONMENT_FALLBACK

Mike reports: clicked Upload, page spun, file never appeared in the KB. Diagnosed via SSH inside the running container.

## Evidence

\`\`\`
$ docker exec mira-hub env | grep INGEST_URL
INGEST_URL=http://mira-ingest-saas:8001                  ← env set correctly

$ docker exec mira-hub wget http://mira-ingest-saas:8001/health
{"status":"ok"}                                          ← service reachable

$ docker logs mira-ingest-saas --tail=50
GET /health 200 OK
GET /health 200 OK
...                                                       ← only health checks
(no /ingest/document-kb requests at all)

$ docker logs mira-hub --tail=80
Error: ENVIRONMENT_FALLBACK
    at <unknown> (.next/server/chunks/ssr/_0hsvpp4._.js:1:99)
    code: 'ENVIRONMENT_FALLBACK'
\`\`\`

## Root cause

The upload routes used \`after()\` from \`"next/server"\` to defer the ingest call until after the response was sent. In Next.js 16 standalone, that throws \`ENVIRONMENT_FALLBACK\` and the callback **never runs**:

1. \`POST /hub/api/uploads/local\` validates file, creates DB row with \`status="parsing"\`
2. Returns 201 to client
3. \`after(async () => { forwardToIngest(…) })\` schedules → throws ENVIRONMENT_FALLBACK
4. Status stays \`"parsing"\` forever
5. UI polls every 2s, sees \`"parsing"\`, keeps spinning

## Fix

Replace \`after()\` with a plain fire-and-forget Promise:

\`\`\`ts
// before
after(async () => { … });

// after
void (async () => { … })();
\`\`\`

mira-hub runs as a long-lived standalone Docker container — the worker isn't killed after each response, so the Promise stays alive until it resolves. \`after()\` was originally needed for Vercel-style serverless where the function gets terminated.

Diff: 2 files, +17/-6.

| File | Change |
|---|---|
| \`mira-hub/src/app/api/uploads/route.ts\` | cloud picks (Google/Dropbox) — drop \`after()\`, fire-and-forget |
| \`mira-hub/src/app/api/uploads/local/route.ts\` | local file upload — drop \`after()\`, fire-and-forget. Also tightened the catch handler so a failing \`updateUploadStatus\` log doesn't itself throw. |

## Verification plan

After merge + deploy:
1. Visit \`/hub/knowledge\`, upload a small PDF
2. Status should advance from \`parsing\` → \`parsed\` within seconds (not stuck on parsing)
3. \`docker logs mira-ingest-saas --tail=20\` should show a \`POST /ingest/document-kb\` 200 response
4. \`docker logs mira-hub --tail=80\` should NOT show any new \`Error: ENVIRONMENT_FALLBACK\`

## Related — Next.js 16 standalone bug roster (today)

This is the **3rd Next.js 16 standalone-only bug** found this session:
1. \`redirect()\` from Server Component or Route Handler → 200 + empty body (fixed via nginx in PR #653)
2. \`NEXTAUTH_URL\` parsing — must include \`/api/auth\` (PR #655)
3. \`after()\` callback throws \`ENVIRONMENT_FALLBACK\` (this PR)

Pattern: Next.js 16 standalone has multiple "looks like it works in dev / breaks in prod" runtime divergences. SSH-level diagnosis is the only reliable confirmation.

## Risk: 1/10

Pure mechanical change. The replacement keeps identical control flow — only the scheduler primitive changes. Both files compile cleanly (typescript only sees imports + Promise types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)