### PR TITLE
security(hub): tenant_id filter on updateUploadStatus

### DIFF
--- a/mira-hub/src/app/api/uploads/[id]/route.ts
+++ b/mira-hub/src/app/api/uploads/[id]/route.ts
@@ -17,7 +17,7 @@ export async function DELETE(
   if (!row) return NextResponse.json({ error: "not_found" }, { status: 404 });
 
   if (!TERMINAL.includes(row.status)) {
-    await updateUploadStatus(id, "cancelled", "user cancelled");
+    await updateUploadStatus(id, ctx.tenantId, "cancelled", "user cancelled");
     return NextResponse.json({ ok: true, action: "cancelled" });
   }
 

--- a/mira-hub/src/app/api/uploads/local/route.ts
+++ b/mira-hub/src/app/api/uploads/local/route.ts
@@ -85,19 +85,19 @@ export async function POST(req: NextRequest) {
         const result = await forwardToPhotoIngest(stream(), file.name, mime, {
           assetTag,
         });
-        await updateUploadStatus(upload.id, "parsed", result.description ?? null, {
+        await updateUploadStatus(upload.id, ctx.tenantId, "parsed", result.description ?? null, {
           kbFileId: result.photoId != null ? String(result.photoId) : undefined,
         });
       } else {
         const result = await forwardToIngest(stream(), file.name, mime);
-        await updateUploadStatus(upload.id, "parsed", null, {
+        await updateUploadStatus(upload.id, ctx.tenantId, "parsed", null, {
           kbFileId: result.fileId ?? undefined,
           kbChunkCount: result.chunkCount ?? undefined,
         });
       }
     } catch (err) {
       console.error(`[uploads/local/${upload.id}] failed`, err);
-      await updateUploadStatus(upload.id, "failed", (err as Error).message).catch(
+      await updateUploadStatus(upload.id, ctx.tenantId, "failed", (err as Error).message).catch(
         (statusErr) => console.error(`[uploads/local/${upload.id}] also failed to mark failed`, statusErr),
       );
     }

--- a/mira-hub/src/app/api/uploads/route.ts
+++ b/mira-hub/src/app/api/uploads/route.ts
@@ -118,7 +118,7 @@ async function runIngestPipeline(
   tenantId: string,
 ): Promise<void> {
   try {
-    await updateUploadStatus(uploadId, "fetching");
+    await updateUploadStatus(uploadId, tenantId, "fetching");
     let fetched;
     if (payload.provider === "google") {
       const { accessToken } = await ensureFreshAccessToken("google", tenantId);
@@ -127,25 +127,25 @@ async function runIngestPipeline(
       fetched = await streamFromSignedUrl(payload.externalDownloadUrl!);
     }
 
-    await updateUploadStatus(uploadId, "parsing");
+    await updateUploadStatus(uploadId, tenantId, "parsing");
     const mime = payload.mimeType ?? fetched.contentType;
 
     if (kind === "photo") {
       const result = await forwardToPhotoIngest(fetched.stream, payload.filename, mime, {
         assetTag: payload.assetTag ?? null,
       });
-      await updateUploadStatus(uploadId, "parsed", result.description ?? null, {
+      await updateUploadStatus(uploadId, tenantId, "parsed", result.description ?? null, {
         kbFileId: result.photoId != null ? String(result.photoId) : undefined,
       });
     } else {
       const result = await forwardToIngest(fetched.stream, payload.filename, mime);
-      await updateUploadStatus(uploadId, "parsed", null, {
+      await updateUploadStatus(uploadId, tenantId, "parsed", null, {
         kbFileId: result.fileId ?? undefined,
         kbChunkCount: result.chunkCount ?? undefined,
       });
     }
   } catch (err) {
     console.error(`[uploads/${uploadId}] pipeline failed`, err);
-    await updateUploadStatus(uploadId, "failed", (err as Error).message);
+    await updateUploadStatus(uploadId, tenantId, "failed", (err as Error).message);
   }
 }

--- a/mira-hub/src/lib/uploads.ts
+++ b/mira-hub/src/lib/uploads.ts
@@ -176,6 +176,7 @@ export async function getUpload(
 
 export async function updateUploadStatus(
   id: string,
+  tenantId: string,
   status: UploadStatus,
   detail?: string | null,
   extras?: { kbFileId?: string; kbChunkCount?: number },
@@ -183,14 +184,15 @@ export async function updateUploadStatus(
   await pool.query(
     `
     UPDATE hub_uploads
-       SET status = $2,
-           status_detail = COALESCE($3, status_detail),
-           kb_file_id = COALESCE($4, kb_file_id),
-           kb_chunk_count = COALESCE($5, kb_chunk_count),
+       SET status = $3,
+           status_detail = COALESCE($4, status_detail),
+           kb_file_id = COALESCE($5, kb_file_id),
+           kb_chunk_count = COALESCE($6, kb_chunk_count),
            updated_at = NOW()
      WHERE id = $1
+       AND tenant_id = $2
   `,
-    [id, status, detail ?? null, extras?.kbFileId ?? null, extras?.kbChunkCount ?? null],
+    [id, tenantId, status, detail ?? null, extras?.kbFileId ?? null, extras?.kbChunkCount ?? null],
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds required \`tenantId\` parameter to \`updateUploadStatus\` and scopes the UPDATE to \`AND tenant_id = \$2\`
- Threads \`ctx.tenantId\` through all 9 call sites across the 3 upload route files
- Closes #693 — first item from the senior backend hardening review

## Why
Every other query against \`hub_uploads\` (\`getUpload\`, \`listUploads\`, \`deleteUpload\`) is correctly scoped \`AND tenant_id = \$N\`. \`updateUploadStatus\` was the lone hole — UPDATE-by-id-only. A future bug with id collision or a swapped variable in a caller could silently overwrite another tenant's row. With the filter, mismatched \`(id, tenantId)\` pairs become no-ops — no row revealed, no row mutated.

This is the smallest, highest-priority item from today's review of the upload pipeline (after PR #664 unblocked actual ingest).

## Test plan
- [x] \`tsc --noEmit\` clean (only the unrelated stale \`.next/types/validator.ts\` Next.js generated file)
- [x] grep verified all 9 call sites pass \`tenantId\` in correct position
- [ ] Manual: re-upload a PDF on factorylm.com/hub/upload, confirm status row still updates parsed
- [ ] Manual: cancel a parsing upload via DELETE, confirm row flips to cancelled

## Out of scope (separate PRs)
- #694 stuck-upload reaper, #695 structured logs, #696 SSRF guard, #697 path-traversal, #698 magic-byte sniffing, #699 abort timeouts, #700 idempotency, #701 retry, #702 rate limit, #703 versioned migrations, #704 manual retry endpoint, #705 versioning catch-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)