### PR TITLE
feat(hub+ingest): structured JSON logs + X-Request-Id propagation

### DIFF
--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -132,6 +132,28 @@ def _parse_structured_description(raw: str) -> dict:
 app = FastAPI(title="mira-ingest")
 
 
+@app.middleware("http")
+async def log_request_id(request, call_next):  # type: ignore[no-untyped-def]
+    """Log X-Request-Id on every request so hub uploads correlate end-to-end.
+
+    The hub generates a request id at upload entry and forwards it as
+    X-Request-Id on every fetch to mira-ingest. We log it (alongside method
+    + path) at INFO so a single grep can recover the full pipeline timeline.
+    """
+    request_id = request.headers.get("x-request-id", "")
+    if request_id and request.url.path not in ("/health", "/health/db"):
+        logger.info(
+            "request_received method=%s path=%s request_id=%s",
+            request.method,
+            request.url.path,
+            request_id,
+        )
+    response = await call_next(request)
+    if request_id:
+        response.headers["X-Request-Id"] = request_id
+    return response
+
+
 # ---------------------------------------------------------------------------
 # DB helpers
 # ---------------------------------------------------------------------------

--- a/mira-hub/src/app/api/uploads/[id]/route.ts
+++ b/mira-hub/src/app/api/uploads/[id]/route.ts
@@ -1,13 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
 import { getUpload, updateUploadStatus, deleteUpload } from "@/lib/uploads";
 import { sessionOr401 } from "@/lib/session";
+import { makeUploadLogger } from "@/lib/upload-log";
 
 export const dynamic = "force-dynamic";
 
 const TERMINAL: ReadonlyArray<string> = ["parsed", "failed", "cancelled"];
 
 export async function DELETE(
-  _req: NextRequest,
+  req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const ctx = await sessionOr401();
@@ -16,21 +18,26 @@ export async function DELETE(
   const row = await getUpload(id, ctx.tenantId);
   if (!row) return NextResponse.json({ error: "not_found" }, { status: 404 });
 
+  const requestId = req.headers.get("x-request-id") ?? randomUUID();
+  const log = makeUploadLogger({ requestId, uploadId: id, tenantId: ctx.tenantId });
+
   if (!TERMINAL.includes(row.status)) {
     await updateUploadStatus(id, ctx.tenantId, "cancelled", "user cancelled");
-    return NextResponse.json({ ok: true, action: "cancelled" });
+    log.log("cancelled", { previousStatus: row.status });
+    return NextResponse.json({ ok: true, action: "cancelled" }, { headers: { "X-Request-Id": requestId } });
   }
 
   if (row.status === "parsed" && row.kbFileId) {
     try {
       await deleteFromOpenWebUi(row.kbFileId);
     } catch (err) {
-      console.error(`[uploads/${id}] OpenWebUI delete failed`, err);
+      log.error("openwebui_delete_failed", err, { kbFileId: row.kbFileId });
     }
   }
 
   await deleteUpload(id, ctx.tenantId);
-  return NextResponse.json({ ok: true, action: "deleted" });
+  log.log("deleted", { previousStatus: row.status });
+  return NextResponse.json({ ok: true, action: "deleted" }, { headers: { "X-Request-Id": requestId } });
 }
 
 async function deleteFromOpenWebUi(fileId: string): Promise<void> {

--- a/mira-hub/src/app/api/uploads/local/route.ts
+++ b/mira-hub/src/app/api/uploads/local/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
 import { createUpload, updateUploadStatus } from "@/lib/uploads";
 import {
   forwardToIngest,
@@ -7,6 +8,7 @@ import {
   SUPPORTED_MIMES,
 } from "@/lib/mira-ingest-client";
 import { sessionOr401 } from "@/lib/session";
+import { makeUploadLogger } from "@/lib/upload-log";
 
 export const dynamic = "force-dynamic";
 
@@ -66,6 +68,16 @@ export async function POST(req: NextRequest) {
     assetTag,
   });
 
+  const requestId = req.headers.get("x-request-id") ?? randomUUID();
+  const log = makeUploadLogger({ requestId, uploadId: upload.id, tenantId: ctx.tenantId });
+  log.log("parsing", {
+    provider: "local",
+    kind,
+    filename: file.name,
+    mimeType: mime,
+    sizeBytes: file.size,
+  });
+
   // Background ingest. Used to be wrapped in `after()` from "next/server",
   // but Next.js 16 standalone throws `Error: ENVIRONMENT_FALLBACK` and the
   // callback never runs — so the upload row stayed at status="parsing"
@@ -84,24 +96,27 @@ export async function POST(req: NextRequest) {
       if (kind === "photo") {
         const result = await forwardToPhotoIngest(stream(), file.name, mime, {
           assetTag,
+          requestId,
         });
         await updateUploadStatus(upload.id, ctx.tenantId, "parsed", result.description ?? null, {
           kbFileId: result.photoId != null ? String(result.photoId) : undefined,
         });
+        log.log("parsed", { photoId: result.photoId, kind });
       } else {
-        const result = await forwardToIngest(stream(), file.name, mime);
+        const result = await forwardToIngest(stream(), file.name, mime, { requestId });
         await updateUploadStatus(upload.id, ctx.tenantId, "parsed", null, {
           kbFileId: result.fileId ?? undefined,
           kbChunkCount: result.chunkCount ?? undefined,
         });
+        log.log("parsed", { kind, kbFileId: result.fileId, kbChunkCount: result.chunkCount });
       }
     } catch (err) {
-      console.error(`[uploads/local/${upload.id}] failed`, err);
+      log.error("failed", err);
       await updateUploadStatus(upload.id, ctx.tenantId, "failed", (err as Error).message).catch(
-        (statusErr) => console.error(`[uploads/local/${upload.id}] also failed to mark failed`, statusErr),
+        (statusErr) => log.error("status_update_failed", statusErr),
       );
     }
   })();
 
-  return NextResponse.json(upload, { status: 201 });
+  return NextResponse.json(upload, { status: 201, headers: { "X-Request-Id": requestId } });
 }

--- a/mira-hub/src/app/api/uploads/route.ts
+++ b/mira-hub/src/app/api/uploads/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "node:crypto";
 import {
   createUpload,
   listUploads,
@@ -17,6 +18,7 @@ import {
   SUPPORTED_MIMES,
 } from "@/lib/mira-ingest-client";
 import { sessionOr401 } from "@/lib/session";
+import { makeUploadLogger } from "@/lib/upload-log";
 
 export const dynamic = "force-dynamic";
 
@@ -79,6 +81,7 @@ export async function POST(req: NextRequest) {
   }
 
   const kind = inferKindFromMime(mime);
+  const requestId = req.headers.get("x-request-id") ?? randomUUID();
 
   const upload = await createUpload({
     tenantId: ctx.tenantId,
@@ -94,14 +97,23 @@ export async function POST(req: NextRequest) {
     assetTag: body.assetTag ?? null,
   });
 
+  const log = makeUploadLogger({ requestId, uploadId: upload.id, tenantId: ctx.tenantId });
+  log.log("queued", {
+    provider: body.provider,
+    kind,
+    filename: body.filename,
+    mimeType: mime,
+    sizeBytes: body.sizeBytes ?? null,
+  });
+
   // Background ingest. Used to be wrapped in `after()` from "next/server",
   // but Next.js 16 standalone throws `Error: ENVIRONMENT_FALLBACK` and the
   // callback never runs — uploads stayed at status="queued" forever. mira-hub
   // runs as a long-lived standalone server, so a plain fire-and-forget
   // Promise stays alive until it resolves.
-  void runIngestPipeline(upload.id, body, kind, ctx.tenantId);
+  void runIngestPipeline(upload.id, body, kind, ctx.tenantId, requestId);
 
-  return NextResponse.json(upload, { status: 201 });
+  return NextResponse.json(upload, { status: 201, headers: { "X-Request-Id": requestId } });
 }
 
 export async function GET() {
@@ -116,9 +128,13 @@ async function runIngestPipeline(
   payload: CreatePayload,
   kind: "document" | "photo",
   tenantId: string,
+  requestId: string,
 ): Promise<void> {
+  const log = makeUploadLogger({ requestId, uploadId, tenantId });
   try {
     await updateUploadStatus(uploadId, tenantId, "fetching");
+    log.log("fetching", { provider: payload.provider });
+
     let fetched;
     if (payload.provider === "google") {
       const { accessToken } = await ensureFreshAccessToken("google", tenantId);
@@ -129,23 +145,31 @@ async function runIngestPipeline(
 
     await updateUploadStatus(uploadId, tenantId, "parsing");
     const mime = payload.mimeType ?? fetched.contentType;
+    log.log("parsing", { mimeType: mime });
 
     if (kind === "photo") {
       const result = await forwardToPhotoIngest(fetched.stream, payload.filename, mime, {
         assetTag: payload.assetTag ?? null,
+        requestId,
       });
       await updateUploadStatus(uploadId, tenantId, "parsed", result.description ?? null, {
         kbFileId: result.photoId != null ? String(result.photoId) : undefined,
       });
+      log.log("parsed", { photoId: result.photoId, kind });
     } else {
-      const result = await forwardToIngest(fetched.stream, payload.filename, mime);
+      const result = await forwardToIngest(fetched.stream, payload.filename, mime, { requestId });
       await updateUploadStatus(uploadId, tenantId, "parsed", null, {
         kbFileId: result.fileId ?? undefined,
         kbChunkCount: result.chunkCount ?? undefined,
       });
+      log.log("parsed", {
+        kind,
+        kbFileId: result.fileId,
+        kbChunkCount: result.chunkCount,
+      });
     }
   } catch (err) {
-    console.error(`[uploads/${uploadId}] pipeline failed`, err);
+    log.error("failed", err);
     await updateUploadStatus(uploadId, tenantId, "failed", (err as Error).message);
   }
 }

--- a/mira-hub/src/lib/mira-ingest-client.ts
+++ b/mira-hub/src/lib/mira-ingest-client.ts
@@ -37,12 +37,15 @@ async function streamToBlob(
 
 /**
  * PDF / document path — POSTs to mira-ingest `/ingest/document-kb`.
+ *
+ * `requestId` is propagated as `X-Request-Id` so mira-ingest logs the same
+ * id and the full upload can be correlated across hub → ingest → OpenWebUI.
  */
 export async function forwardToIngest(
   stream: ReadableStream<Uint8Array>,
   filename: string,
   mimeType: string,
-  signal?: AbortSignal,
+  opts: { requestId?: string; signal?: AbortSignal } = {},
 ): Promise<IngestResult> {
   const base = process.env.INGEST_URL;
   if (!base) throw new Error("INGEST_URL not set");
@@ -53,10 +56,14 @@ export async function forwardToIngest(
   form.append("file", blob, filename);
   form.append("filename", filename);
 
+  const headers: Record<string, string> = {};
+  if (opts.requestId) headers["X-Request-Id"] = opts.requestId;
+
   const res = await fetch(`${base}/ingest/document-kb`, {
     method: "POST",
     body: form,
-    signal,
+    headers,
+    signal: opts.signal,
   });
   const json = await res.json().catch(() => ({}));
   if (!res.ok) {
@@ -80,8 +87,13 @@ export async function forwardToPhotoIngest(
   stream: ReadableStream<Uint8Array>,
   filename: string,
   mimeType: string,
-  opts: { assetTag?: string | null; notes?: string; location?: string } = {},
-  signal?: AbortSignal,
+  opts: {
+    assetTag?: string | null;
+    notes?: string;
+    location?: string;
+    requestId?: string;
+    signal?: AbortSignal;
+  } = {},
 ): Promise<PhotoIngestResult> {
   const base = process.env.INGEST_URL;
   if (!base) throw new Error("INGEST_URL not set");
@@ -97,10 +109,14 @@ export async function forwardToPhotoIngest(
   form.append("location", opts.location ?? "");
   form.append("notes", opts.notes ?? "");
 
+  const headers: Record<string, string> = {};
+  if (opts.requestId) headers["X-Request-Id"] = opts.requestId;
+
   const res = await fetch(`${base}/ingest/photo`, {
     method: "POST",
     body: form,
-    signal,
+    headers,
+    signal: opts.signal,
   });
   const json = await res.json().catch(() => ({}));
   if (!res.ok) {

--- a/mira-hub/src/lib/upload-log.ts
+++ b/mira-hub/src/lib/upload-log.ts
@@ -1,0 +1,68 @@
+// mira-hub/src/lib/upload-log.ts
+//
+// Structured JSON logger for the upload pipeline. Every status transition
+// emits a single line of JSON with a stable shape:
+//
+//   {"ts":"2026-04-26T13:20:00.000Z","service":"mira-hub","component":"upload",
+//    "event":"parsing","requestId":"...","uploadId":"...","tenantId":"...",
+//    "durationMs":42,"...extra"}
+//
+// Stdlib console.log (Next.js standalone forwards stdout to the docker log
+// driver). No new dep, no transport — every line is grep-correlatable by
+// requestId across mira-hub, mira-ingest, and OpenWebUI.
+
+export interface UploadLogContext {
+  requestId: string;
+  uploadId: string;
+  tenantId: string;
+}
+
+export type UploadLogEvent =
+  | "received"
+  | "queued"
+  | "fetching"
+  | "parsing"
+  | "parsed"
+  | "failed"
+  | "cancelled";
+
+export interface UploadLogger {
+  ctx: UploadLogContext;
+  start: number;
+  log(event: UploadLogEvent | string, data?: Record<string, unknown>): void;
+  error(event: string, err: unknown, data?: Record<string, unknown>): void;
+}
+
+export function makeUploadLogger(ctx: UploadLogContext): UploadLogger {
+  const start = Date.now();
+  return {
+    ctx,
+    start,
+    log(event, data) {
+      const entry: Record<string, unknown> = {
+        ts: new Date().toISOString(),
+        service: "mira-hub",
+        component: "upload",
+        event,
+        durationMs: Date.now() - start,
+        ...ctx,
+        ...(data ?? {}),
+      };
+      console.log(JSON.stringify(entry));
+    },
+    error(event, err, data) {
+      const e = err instanceof Error ? err : new Error(String(err));
+      const entry: Record<string, unknown> = {
+        ts: new Date().toISOString(),
+        service: "mira-hub",
+        component: "upload",
+        event,
+        durationMs: Date.now() - start,
+        ...ctx,
+        error: { message: e.message, name: e.name, stack: e.stack?.split("\n").slice(0, 5).join("\n") },
+        ...(data ?? {}),
+      };
+      console.error(JSON.stringify(entry));
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds \`mira-hub/src/lib/upload-log.ts\` — small structured logger (stdlib console + JSON.stringify, no new dep)
- Generates \`requestId\` at every upload entry (\`/api/uploads\`, \`/api/uploads/local\`, DELETE \`/api/uploads/[id]\`) and threads it through the pipeline
- Forwards as \`X-Request-Id\` on every fetch to mira-ingest; mira-ingest middleware logs it at INFO and echoes it back on the response
- Closes #695 — second item from the senior backend hardening review

## Why
PR #664 unblocked actual ingest, but today's debug session required SSH-tailing 3 services and grep-correlating timestamps to see what one upload did across hub → mira-ingest → OpenWebUI. Structured logs + a single shared requestId fix that:

1. **\`>=4\` log lines per upload** — queued / fetching / parsing / parsed (or failed). All carry \`{requestId, uploadId, tenantId, durationMs, ...}\`.
2. **One grep recovers the full pipeline** — \`docker logs mira-hub mira-ingest-saas | grep <requestId>\` returns the entire timeline.
3. **Browser correlation** — 201/200 responses echo \`X-Request-Id\` so a customer can paste it from devtools when reporting "my upload didn't show up".

## What you'll see in logs

\`\`\`json
{"ts":"2026-04-26T13:30:00.000Z","service":"mira-hub","component":"upload","event":"queued","durationMs":12,"requestId":"...","uploadId":"...","tenantId":"...","provider":"google","kind":"document","filename":"X.pdf","mimeType":"application/pdf","sizeBytes":123456}
{"ts":"...","event":"fetching","durationMs":47,"...":"..."}
{"ts":"...","event":"parsing","durationMs":1450,"mimeType":"application/pdf"}
{"ts":"...","event":"parsed","durationMs":42130,"kbFileId":"6ab8fd78-...","kbChunkCount":17}
\`\`\`

mira-ingest side:
\`\`\`
2026-04-26 13:30:00 [INFO] request_received method=POST path=/ingest/document-kb request_id=<same-uuid>
\`\`\`

## Test plan
- [x] \`tsc --noEmit\` clean (only the unrelated stale \`.next/types/validator.ts\`)
- [x] \`ruff check\` clean on the mira-ingest middleware
- [ ] Verify on prod after deploy: upload a small PDF on /hub/upload, \`docker logs mira-hub | grep <requestId>\` returns ≥4 JSON lines, \`docker logs mira-ingest-saas | grep <requestId>\` returns ≥1 line

## Out of scope (separate PRs)
#694 reaper, #696 SSRF, #697 path-traversal, #698 magic-byte, #699 timeouts, #700 idempotency, #701 retry, #702 rate limit, #703 versioned migrations, #704 retry endpoint, #705 versioning catch-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)