### PR TITLE
feat(hub): logo links to /hub/feed from every page

### DIFF
--- a/mira-hub/src/components/layout/mobile-topbar.tsx
+++ b/mira-hub/src/components/layout/mobile-topbar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Sun, Moon, Factory } from "lucide-react";
 import { useTheme } from "@/providers/theme-provider";
 import { useTranslations } from "next-intl";
@@ -19,7 +20,7 @@ export function MobileTopBar() {
       }}
     >
       {/* Logo */}
-      <div className="flex items-center gap-2">
+      <Link href="/feed" className="flex items-center gap-2">
         <div
           className="w-6 h-6 rounded-md flex items-center justify-center"
           style={{ background: "linear-gradient(135deg, #2563EB, #0891B2)" }}
@@ -29,7 +30,7 @@ export function MobileTopBar() {
         <span className="text-sm font-bold tracking-tight" style={{ color: "#F8FAFC" }}>
           FactoryLM
         </span>
-      </div>
+      </Link>
 
       {/* Right controls */}
       <div className="flex items-center gap-1">

--- a/mira-hub/src/components/layout/sidebar.tsx
+++ b/mira-hub/src/components/layout/sidebar.tsx
@@ -60,23 +60,25 @@ export function Sidebar({ role = "admin" }: { role?: string }) {
       {/* Logo */}
       <div className="flex items-center justify-between px-4 py-4"
         style={{ borderBottom: "1px solid var(--sidebar-border)", minHeight: 56 }}>
-        {!collapsed && (
-          <div className="flex items-center gap-2.5">
-            <div className="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0"
+        <Link href="/feed" className="flex items-center gap-2.5 min-w-0">
+          {!collapsed && (
+            <>
+              <div className="w-7 h-7 rounded-lg flex items-center justify-center flex-shrink-0"
+                style={{ background: "linear-gradient(135deg, #2563EB, #0891B2)" }}>
+                <Factory className="w-4 h-4 text-white" />
+              </div>
+              <span className="font-bold text-sm tracking-tight" style={{ color: "var(--sidebar-fg)" }}>
+                FactoryLM
+              </span>
+            </>
+          )}
+          {collapsed && (
+            <div className="w-7 h-7 rounded-lg flex items-center justify-center mx-auto"
               style={{ background: "linear-gradient(135deg, #2563EB, #0891B2)" }}>
               <Factory className="w-4 h-4 text-white" />
             </div>
-            <span className="font-bold text-sm tracking-tight" style={{ color: "var(--sidebar-fg)" }}>
-              FactoryLM
-            </span>
-          </div>
-        )}
-        {collapsed && (
-          <div className="w-7 h-7 rounded-lg flex items-center justify-center mx-auto"
-            style={{ background: "linear-gradient(135deg, #2563EB, #0891B2)" }}>
-            <Factory className="w-4 h-4 text-white" />
-          </div>
-        )}
+          )}
+        </Link>
         <button
           onClick={() => setCollapsed(c => !c)}
           className="w-6 h-6 rounded-md flex items-center justify-center transition-colors ml-auto"


### PR DESCRIPTION
## Summary
- Sidebar logo (desktop): wrapped in `<Link href="/feed">` — both expanded and collapsed states
- Mobile topbar logo: added `Link` import, wrapped logo div

With `basePath: "/hub"`, `href="/feed"` resolves to `/hub/feed` in the browser, so clicking the logo from any page (assets, channels, workorders, etc.) always returns to the hub feed.

## Verified
- All existing internal nav links already use `Link` with correct relative paths
- Breadcrumbs on detail pages (`/assets/[id]`, `/workorders/[id]`) already link back to correct parent lists
- More page items all use correct `Link` hrefs
- TypeScript clean (only pre-existing bcryptjs type-only errors unrelated to this change)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)