### PR TITLE
test(hub): logo-nav Playwright suite + visual-qa selector fixes

### DIFF
--- a/mira-hub/tests/e2e/logo-nav.spec.ts
+++ b/mira-hub/tests/e2e/logo-nav.spec.ts
@@ -1,0 +1,112 @@
+/**
+ * Logo navigation — verifies clicking the FactoryLM logo from every hub page
+ * always lands on /hub/feed (the hub homepage).
+ */
+
+import { test, expect, Page } from "@playwright/test";
+import * as path from "path";
+
+const HUB = "https://app.factorylm.com/hub";
+const OUT = path.join("test-results", "visual-qa");
+
+async function login(page: Page) {
+  await page.goto(`${HUB}/login`, { waitUntil: "networkidle" });
+  await page.fill('input[type="email"]', "playwright@factorylm.com");
+  await page.fill('input[type="password"]', "TestPass123");
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/hub\/feed\/?/, { timeout: 20_000 });
+}
+
+// Pages to test logo click from (desktop — sidebar logo)
+const DESKTOP_PAGES = [
+  { name: "assets",     path: "/assets" },
+  { name: "channels",   path: "/channels" },
+  { name: "workorders", path: "/workorders" },
+  { name: "knowledge",  path: "/knowledge" },
+  { name: "event-log",  path: "/event-log" },
+  { name: "more",       path: "/more" },
+];
+
+// ---------------------------------------------------------------------------
+// Create test user before suite, delete after
+// ---------------------------------------------------------------------------
+test.beforeAll(async ({ request }) => {
+  const res = await request.post(`${HUB}/api/auth/register`, {
+    data: { email: "playwright@factorylm.com", password: "TestPass123", name: "Playwright" },
+  });
+  // 200 = created, 409 = already exists — both fine
+  console.log(`test user setup: ${res.status()}`);
+});
+
+test.afterAll(async ({ request }) => {
+  // Best-effort cleanup; ignore errors
+  await request.delete(`${HUB}/api/auth/account`, {
+    headers: { "Content-Type": "application/json" },
+  }).catch(() => {});
+});
+
+// ---------------------------------------------------------------------------
+// Desktop sidebar logo test for each page
+// ---------------------------------------------------------------------------
+for (const pg of DESKTOP_PAGES) {
+  test(`logo click from ${pg.name} → /hub/feed (desktop)`, async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await login(page);
+
+    // Navigate to the target page
+    await page.goto(`${HUB}${pg.path}`, { waitUntil: "networkidle" });
+    await page.waitForTimeout(500);
+
+    // Desktop sidebar logo — visible link (mobile topbar is md:hidden so hidden at this viewport)
+    const logo = page.locator('a[href*="/feed"]').filter({ visible: true }).first();
+    await expect(logo).toBeVisible({ timeout: 5_000 });
+    await logo.click();
+
+    // Should land on /hub/feed
+    await page.waitForURL(/\/hub\/feed\/?/, { timeout: 10_000 });
+    expect(page.url()).toMatch(/\/hub\/feed/);
+
+    // Screenshot proof for first page only
+    if (pg.name === "assets") {
+      await page.screenshot({ path: `${OUT}/logo-click-from-assets.png` });
+      console.log("📸 logo-click-from-assets.png");
+    }
+    console.log(`✅ Logo from /${pg.name} → ${page.url()}`);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mobile topbar logo test
+// ---------------------------------------------------------------------------
+test("logo click mobile topbar → /hub/feed", async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
+  const page = await ctx.newPage();
+
+  await page.goto(`${HUB}/login`, { waitUntil: "networkidle" });
+  await page.fill('input[type="email"]', "playwright@factorylm.com");
+  await page.fill('input[type="password"]', "TestPass123");
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/hub\/feed\/?/, { timeout: 20_000 });
+
+  // Navigate away
+  await page.goto(`${HUB}/assets`, { waitUntil: "networkidle" });
+  await page.waitForTimeout(500);
+
+  // Screenshot showing logo in mobile topbar
+  await page.screenshot({ path: `${OUT}/mobile-logo-before-click.png` });
+  console.log("📸 mobile-logo-before-click.png");
+
+  // Mobile topbar logo — Link wrapping the Factory icon + FactoryLM text
+  const mobileLogo = page.locator('header a[href*="/feed"]');
+  await expect(mobileLogo).toBeVisible({ timeout: 5_000 });
+  await mobileLogo.click();
+
+  await page.waitForURL(/\/hub\/feed\/?/, { timeout: 10_000 });
+  expect(page.url()).toMatch(/\/hub\/feed/);
+
+  await page.screenshot({ path: `${OUT}/mobile-logo-after-click.png` });
+  console.log("📸 mobile-logo-after-click.png");
+  console.log(`✅ Mobile logo → ${page.url()}`);
+
+  await ctx.close();
+});

--- a/mira-hub/tests/e2e/visual-qa.spec.ts
+++ b/mira-hub/tests/e2e/visual-qa.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * Visual QA — Design system PRs #691 / #708 / #706 deployment verification
+ * Runs against live factorylm.com + app.factorylm.com
+ */
+
+import { test, expect, Page, Browser } from "@playwright/test";
+import * as path from "path";
+
+const MARKETING = "https://factorylm.com";
+const HUB = "https://app.factorylm.com/hub";
+const OUT = path.join("test-results", "visual-qa");
+
+async function shot(page: Page, name: string, fullPage = true) {
+  await page.screenshot({ path: `${OUT}/${name}.png`, fullPage });
+  console.log(`📸 ${name}.png`);
+}
+
+async function loginHub(page: Page) {
+  await page.goto(`${HUB}/login`, { waitUntil: "networkidle" });
+  await page.fill('input[type="email"]', "playwright@factorylm.com");
+  await page.fill('input[type="password"]', "TestPass123");
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/hub\/feed\/?/, { timeout: 20_000 });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Homepage — desktop
+// ---------------------------------------------------------------------------
+test("homepage desktop — trust-band visible (#708)", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(`${MARKETING}/`, { waitUntil: "networkidle" });
+  await shot(page, "homepage-desktop");
+
+  const html = await page.content();
+  expect(html).toContain("trust-band");
+  console.log("✅ trust-band present in homepage HTML");
+});
+
+// ---------------------------------------------------------------------------
+// 2. Homepage — mobile
+// ---------------------------------------------------------------------------
+test("homepage mobile 375px", async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
+  const page = await ctx.newPage();
+  await page.goto(`${MARKETING}/`, { waitUntil: "networkidle" });
+  await shot(page, "homepage-mobile");
+  await ctx.close();
+});
+
+// ---------------------------------------------------------------------------
+// 3. CMMS page — magic-link form (#706)
+// ---------------------------------------------------------------------------
+test("cmms page — magic-link form visible (#706)", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(`${MARKETING}/cmms`, { waitUntil: "networkidle" });
+  await shot(page, "cmms-desktop");
+
+  const html = await page.content();
+  expect(html.toLowerCase()).toMatch(/magic.?link|enter your email|sign in with email/i);
+  console.log("✅ Magic-link content confirmed on /cmms");
+
+  // Email input should be visible
+  const emailInput = page.locator('input[type="email"], input[type="text"]').first();
+  if (await emailInput.isVisible()) {
+    console.log("✅ Email input field visible");
+  } else {
+    console.log("⚠️  No email input found — check renderCmms output");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. CMMS page — mobile
+// ---------------------------------------------------------------------------
+test("cmms page mobile 375px", async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
+  const page = await ctx.newPage();
+  await page.goto(`${MARKETING}/cmms`, { waitUntil: "networkidle" });
+  await shot(page, "cmms-mobile");
+  await ctx.close();
+});
+
+// ---------------------------------------------------------------------------
+// 5. Sample page (#706 AC4)
+// ---------------------------------------------------------------------------
+test("sample page loads", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  const res = await page.goto(`${MARKETING}/sample`, { waitUntil: "networkidle" });
+  expect(res?.status()).toBe(200);
+  await shot(page, "sample-desktop");
+  console.log(`✅ /sample HTTP ${res?.status()}`);
+});
+
+// ---------------------------------------------------------------------------
+// 6. Tokens CSS (#691)
+// ---------------------------------------------------------------------------
+test("_tokens.css returns 200 with CSS variables", async ({ page }) => {
+  const res = await page.goto(`${MARKETING}/_tokens.css`);
+  expect(res?.status()).toBe(200);
+  const body = await res?.text() ?? "";
+  expect(body).toMatch(/--/); // CSS custom properties
+  console.log(`✅ /_tokens.css HTTP ${res?.status()}, length=${body.length}`);
+  // First 200 chars as proof
+  console.log(body.substring(0, 200));
+});
+
+// ---------------------------------------------------------------------------
+// 7. Hub login page
+// ---------------------------------------------------------------------------
+test("hub login page", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(`${HUB}/login`, { waitUntil: "networkidle" });
+  await shot(page, "hub-login-desktop");
+  await expect(page.locator('input[type="email"]')).toBeVisible();
+  console.log("✅ Hub login email input visible");
+});
+
+// ---------------------------------------------------------------------------
+// 8. Hub login mobile
+// ---------------------------------------------------------------------------
+test("hub login mobile 375px", async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
+  const page = await ctx.newPage();
+  await page.goto(`${HUB}/login`, { waitUntil: "networkidle" });
+  await shot(page, "hub-login-mobile");
+  await ctx.close();
+});
+
+// ---------------------------------------------------------------------------
+// 9. Hub feed (authenticated)
+// ---------------------------------------------------------------------------
+test("hub feed — authenticated", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await loginHub(page);
+  await page.waitForLoadState("networkidle");
+  await shot(page, "hub-feed-desktop");
+  console.log("✅ Hub feed loaded");
+});
+
+// ---------------------------------------------------------------------------
+// 10. Hub assets — blue + New Asset button (#create-asset)
+// ---------------------------------------------------------------------------
+test("hub assets — New Asset button visible", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await loginHub(page);
+  await page.goto(`${HUB}/assets`, { waitUntil: "networkidle" });
+  await page.waitForLoadState("networkidle");
+
+  // Wait for assets to load
+  await page.waitForTimeout(2000);
+  await shot(page, "hub-assets-desktop");
+
+  const newAssetBtn = page.locator('button:has-text("New Asset")');
+  const visible = await newAssetBtn.isVisible();
+  if (visible) {
+    console.log("✅ 'New Asset' button visible");
+  } else {
+    console.log("⚠️  'New Asset' button not found in desktop view");
+  }
+
+  const assetLinks = await page.locator('a[href*="/assets/"]').count();
+  console.log(`✅ ${assetLinks} asset links rendered`);
+});
+
+// ---------------------------------------------------------------------------
+// 11. Hub assets mobile — FAB
+// ---------------------------------------------------------------------------
+test("hub assets mobile — FAB visible", async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 375, height: 812 } });
+  const page = await ctx.newPage();
+  // Login first
+  await page.goto(`${HUB}/login`, { waitUntil: "networkidle" });
+  await page.fill('input[type="email"]', "playwright@factorylm.com");
+  await page.fill('input[type="password"]', "TestPass123");
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/hub\/feed\/?/, { timeout: 20_000 });
+
+  await page.goto(`${HUB}/assets`, { waitUntil: "networkidle" });
+  await page.waitForTimeout(1500);
+  await page.screenshot({ path: `${OUT}/hub-assets-mobile.png`, fullPage: true });
+  console.log("📸 hub-assets-mobile.png");
+
+  const fab = page.locator('button[aria-label="Create new asset"]');
+  const fabVisible = await fab.isVisible();
+  console.log(fabVisible ? "✅ Mobile FAB visible" : "⚠️  Mobile FAB not found");
+  await ctx.close();
+});
+
+// ---------------------------------------------------------------------------
+// 12. Hub channels
+// ---------------------------------------------------------------------------
+test("hub channels", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await loginHub(page);
+  await page.goto(`${HUB}/channels`, { waitUntil: "networkidle" });
+  await page.waitForTimeout(1500);
+  await shot(page, "hub-channels-desktop");
+  console.log("✅ Hub channels loaded");
+});


### PR DESCRIPTION
## Summary
- Logo nav test: 7 Playwright tests verifying the FactoryLM logo links to `/hub/feed` from every hub page (assets, channels, workorders, knowledge, event-log, more) on both desktop and mobile topbar
- visual-qa.spec.ts: fix `button:has-text("Sign In")` → `button[type="submit"]` (was matching Google OAuth button), fix `waitForURL` to handle nginx trailing-slash redirect

All 7 logo-nav tests pass on live site.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)