### PR TITLE
feat(hub): apply FactoryLM design system — colors, typography, spacing, dark mode

### DIFF
--- a/mira-hub/package-lock.json
+++ b/mira-hub/package-lock.json
@@ -95,7 +95,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1668,7 +1667,6 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -3615,7 +3613,6 @@
       "resolved": "https://registry.npmjs.org/@refinedev/core/-/core-5.0.12.tgz",
       "integrity": "sha512-9y5Bi9Lb7XyJmM55b8rCeBTDRCBU41p47OymJldasLfrtpUm2EwI+27DjjNpHTOugymiZsIbLlPtHCPQIXBHcg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@refinedev/devtools-internal": "2.0.2",
         "@tanstack/react-query": "^5.81.5",
@@ -4436,7 +4433,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4446,7 +4442,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4502,7 +4497,6 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -5028,7 +5022,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5410,7 +5403,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -6181,7 +6173,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6367,7 +6358,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6779,7 +6769,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8261,7 +8250,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
       "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "16.2.4",
         "@swc/helpers": "0.5.15",
@@ -8777,7 +8765,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9011,7 +8998,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
       "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -9135,7 +9121,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9145,7 +9130,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9157,15 +9141,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -9287,8 +9269,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -10027,7 +10008,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10190,7 +10170,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10584,7 +10563,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/mira-hub/src/app/(hub)/feed/page.tsx
+++ b/mira-hub/src/app/(hub)/feed/page.tsx
@@ -187,8 +187,8 @@ export default function FeedPage() {
                   </div>
                   <TrendingUp className="w-3.5 h-3.5" style={{ color: "var(--foreground-subtle)" }} />
                 </div>
-                <div className="text-xl font-bold leading-none mt-1" style={{ color: "var(--foreground)" }}>{kpi.value}</div>
-                <div className="text-[11px] leading-tight" style={{ color: "var(--foreground-muted)" }}>{KPI_LABEL_MAP[kpi.label] ?? kpi.label}</div>
+                <div className="kpi-value mt-1" style={{ color: "var(--foreground)" }}>{kpi.value}</div>
+                <div className="kpi-label mt-0.5">{KPI_LABEL_MAP[kpi.label] ?? kpi.label}</div>
               </div>
             </Link>
           ))}

--- a/mira-hub/src/app/(hub)/reports/page.tsx
+++ b/mira-hub/src/app/(hub)/reports/page.tsx
@@ -80,8 +80,8 @@ export default function ReportsPage() {
                   {Math.abs(kpi.trend)}%
                 </div>
               </div>
-              <div className="text-2xl font-bold leading-none" style={{ color: kpi.color }}>{kpi.value}</div>
-              <div className="text-[11px] leading-tight" style={{ color: "var(--foreground-muted)" }}>{t(kpi.labelKey)}</div>
+              <div className="kpi-value" style={{ color: kpi.color }}>{kpi.value}</div>
+              <div className="kpi-label mt-0.5">{t(kpi.labelKey)}</div>
             </div>
           ))}
         </div>
@@ -163,8 +163,8 @@ export default function ReportsPage() {
               </ResponsiveContainer>
             </div>
             <div className="text-center -mt-4">
-              <p className="text-3xl font-bold" style={{ color: "#16A34A" }}>87%</p>
-              <p className="text-xs" style={{ color: "var(--foreground-muted)" }}>{t("overallCompliance")}</p>
+              <p className="kpi-value" style={{ color: "var(--status-green)" }}>87%</p>
+              <p className="kpi-label mt-0.5">{t("overallCompliance")}</p>
             </div>
           </ChartCard>
         </div>

--- a/mira-hub/src/app/(hub)/usage/page.tsx
+++ b/mira-hub/src/app/(hub)/usage/page.tsx
@@ -104,8 +104,8 @@ export default function UsagePage() {
               <div className="w-7 h-7 rounded-lg flex items-center justify-center mb-2" style={{ backgroundColor: `${kpi.color}15` }}>
                 <kpi.Icon className="w-3.5 h-3.5" style={{ color: kpi.color }} />
               </div>
-              <div className="text-xl font-bold" style={{ color: "var(--foreground)" }}>{kpi.value}</div>
-              <div className="text-[11px] leading-tight mt-0.5" style={{ color: "var(--foreground-muted)" }}>{kpi.label}</div>
+              <div className="kpi-value" style={{ color: "var(--foreground)" }}>{kpi.value}</div>
+              <div className="kpi-label mt-0.5">{kpi.label}</div>
             </div>
           ))}
         </div>

--- a/mira-hub/src/app/globals.css
+++ b/mira-hub/src/app/globals.css
@@ -12,16 +12,22 @@
   --status-yellow: #EAB308;
   --status-red: #DC2626;
   --status-gray: #64748B;
+  --status-orange: #EA580C;
   --status-green-bg: #DCFCE7;
   --status-yellow-bg: #FEF9C3;
   --status-red-bg: #FEE2E2;
   --status-gray-bg: #F1F5F9;
+  --status-orange-bg: #FFF7ED;
 
   /* Light mode surfaces */
-  --background: #F8FAFC;
+  --background: #FAFAFA;
   --surface-0: #FFFFFF;
   --surface-1: #F1F5F9;
   --surface-2: #E2E8F0;
+
+  /* Border */
+  --border-default: #E2E8F0;
+  --border-strong: #CBD5E1;
 
   /* Foregrounds */
   --foreground: #0F172A;
@@ -37,26 +43,34 @@
   --sidebar-width: 260px;
   --sidebar-collapsed-width: 64px;
 
-  /* Spacing */
+  /* Spacing — 8px grid */
   --space-1: 8px;
   --space-2: 16px;
   --space-3: 24px;
   --space-4: 32px;
   --space-5: 40px;
   --space-6: 48px;
+  --page-padding: 24px;
+  --card-padding: 20px;
+  --card-gap: 16px;
+  --section-gap: 32px;
 
   /* Card */
   --radius-card: 8px;
-  --shadow-card: 0 1px 3px 0 rgb(0 0 0 / 0.08), 0 1px 2px -1px rgb(0 0 0 / 0.06);
+  --radius-lg: 12px;
+  --shadow-card: 0 1px 3px rgba(0,0,0,0.1), 0 1px 2px rgba(0,0,0,0.06);
   --shadow-card-hover: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.06);
   --shadow-fab: 0 4px 14px 0 rgb(37 99 235 / 0.35);
 
   /* Typography */
+  --font-size-display: 36px;
   --font-size-body: 14px;
+  --font-size-small: 13px;
   --font-size-label: 12px;
-  --font-size-h1: 24px;
-  --font-size-h2: 20px;
-  --font-size-h3: 16px;
+  --font-size-h1: 30px;
+  --font-size-h2: 24px;
+  --font-size-h3: 20px;
+  --font-size-h4: 18px;
 
   /* shadcn / Tailwind compat aliases */
   --card: var(--surface-0);
@@ -98,6 +112,10 @@
   --sidebar-hover: #1A1D23;
   --sidebar-border: #21252D;
 
+  --border-default: #2D333B;
+  --border-strong: #3D4451;
+  --status-orange-bg: #431407;
+
   --card: var(--surface-0);
   --card-foreground: var(--foreground);
   --popover: var(--surface-1);
@@ -129,6 +147,7 @@
   --color-status-yellow: var(--status-yellow);
   --color-status-red: var(--status-red);
   --color-status-gray: var(--status-gray);
+  --color-status-orange: var(--status-orange);
   --color-brand: var(--brand-blue);
   --color-brand-cyan: var(--brand-cyan);
   --color-surface-0: var(--surface-0);
@@ -179,6 +198,96 @@ body {
 .status-yellow { color: var(--status-yellow); background: var(--status-yellow-bg); }
 .status-red    { color: var(--status-red);    background: var(--status-red-bg); }
 .status-gray   { color: var(--status-gray);   background: var(--status-gray-bg); }
+.status-orange { color: var(--status-orange); background: var(--status-orange-bg); }
+
+/* ─── Badge / Pill ──────────────────────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  padding: 4px 12px;
+  border-radius: 9999px;
+  white-space: nowrap;
+}
+.badge-green  { color: var(--status-green);  background: var(--status-green-bg); }
+.badge-yellow { color: var(--status-yellow); background: var(--status-yellow-bg); }
+.badge-red    { color: var(--status-red);    background: var(--status-red-bg); }
+.badge-gray   { color: var(--status-gray);   background: var(--status-gray-bg); }
+.badge-orange { color: var(--status-orange); background: var(--status-orange-bg); }
+.badge-blue   { color: var(--brand-blue);    background: #EFF6FF; }
+
+/* ─── Status Dot ────────────────────────────────────────────────────── */
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.dot-green  { background: var(--status-green); }
+.dot-yellow { background: var(--status-yellow); }
+.dot-red    { background: var(--status-red); }
+.dot-gray   { background: var(--status-gray); }
+.dot-orange { background: var(--status-orange); }
+
+/* ─── Typography Scale ──────────────────────────────────────────────── */
+.text-display {
+  font-size: var(--font-size-display);
+  font-weight: 700;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+}
+.text-h1 { font-size: var(--font-size-h1); font-weight: 700; line-height: 1.2; }
+.text-h2 { font-size: var(--font-size-h2); font-weight: 600; line-height: 1.3; }
+.text-h3 { font-size: var(--font-size-h3); font-weight: 600; line-height: 1.4; }
+.text-h4 { font-size: var(--font-size-h4); font-weight: 600; line-height: 1.4; }
+.text-small  { font-size: var(--font-size-small); }
+.text-xsmall { font-size: var(--font-size-label); font-weight: 500; }
+
+/* ─── Table Utilities ───────────────────────────────────────────────── */
+.data-table { width: 100%; border-collapse: collapse; font-size: var(--font-size-body); }
+.data-table th {
+  padding: 10px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  text-align: left;
+  color: var(--foreground-muted);
+  border-bottom: 1px solid var(--border-default, var(--surface-2));
+  background: var(--surface-1);
+}
+.data-table td {
+  padding: 12px;
+  border-bottom: 1px solid var(--border-default, var(--surface-2));
+  color: var(--foreground);
+}
+.data-table tr:hover td { background: var(--surface-1); }
+
+/* ─── KPI Card ──────────────────────────────────────────────────────── */
+.kpi-value {
+  font-size: var(--font-size-display);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.kpi-label {
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--foreground-muted);
+}
+
+/* ─── Page Layout Helpers ───────────────────────────────────────────── */
+.page-header {
+  padding: 16px var(--page-padding);
+  border-bottom: 1px solid var(--border-default, var(--surface-2));
+  background: var(--surface-0);
+}
+.page-content { padding: var(--page-padding); }
 
 /* ─── Scrollbars ────────────────────────────────────────────────────── */
 ::-webkit-scrollbar { width: 6px; height: 6px; }


### PR DESCRIPTION
## Summary
Full design system pass on the hub to match the FactoryLM design spec.

### globals.css
- Background `#FAFAFA` (off-white per spec)
- Orange status color `#EA580C` with dark-mode bg variant
- Explicit `--border-default` / `--border-strong` tokens
- Heading scale updated: H1 30px/700, H2 24px/600, H3 20px/600, H4 18px/600
- Display font size 36px for KPI numbers
- Radius lg 12px for larger cards
- Spacing aliases: `--page-padding`, `--card-gap`, `--section-gap`
- Badge/pill utility (`.badge`, `.badge-green/yellow/red/gray/orange/blue`)
- Status dot utility (`.status-dot`, `.dot-green/yellow/red/gray/orange`)
- Typography utilities (`.text-display`, `.text-h1–h4`, `.text-small`)
- Table utilities (`.data-table` with header, row hover)
- KPI utilities (`.kpi-value` 36px/700, `.kpi-label` 12px caps)
- Page layout helpers (`.page-header`, `.page-content`)
- Dark mode border token `#2D333B`

### Pages
- `feed/page.tsx` KPI values → `.kpi-value` (36px)
- `reports/page.tsx` KPI values + 87% compliance → `.kpi-value`
- `usage/page.tsx` KPI values → `.kpi-value`

Build clean ✅

🤖 Generated with [Claude Code](https://claude.ai/claude-code)