### PR TITLE
test(hub): fix Playwright e2e — beforeAll user setup + trailing slash in register URL

### DIFF
--- a/mira-hub/tests/e2e/logo-nav.spec.ts
+++ b/mira-hub/tests/e2e/logo-nav.spec.ts
@@ -31,7 +31,7 @@ const DESKTOP_PAGES = [
 // Create test user before suite, delete after
 // ---------------------------------------------------------------------------
 test.beforeAll(async ({ request }) => {
-  const res = await request.post(`${HUB}/api/auth/register`, {
+  const res = await request.post(`${HUB}/api/auth/register/`, {
     data: { email: "playwright@factorylm.com", password: "TestPass123", name: "Playwright" },
   });
   // 200 = created, 409 = already exists — both fine

--- a/mira-hub/tests/e2e/visual-qa.spec.ts
+++ b/mira-hub/tests/e2e/visual-qa.spec.ts
@@ -23,6 +23,20 @@ async function loginHub(page: Page) {
   await page.waitForURL(/\/hub\/feed\/?/, { timeout: 20_000 });
 }
 
+// Create test user before suite, delete after
+test.beforeAll(async ({ request }) => {
+  const res = await request.post(`${HUB}/api/auth/register/`, {
+    data: { email: "playwright@factorylm.com", password: "TestPass123", name: "Playwright" },
+  });
+  console.log(`test user setup: ${res.status()}`);
+});
+
+test.afterAll(async ({ request }) => {
+  await request.delete(`${HUB}/api/auth/account/`, {
+    headers: { "Content-Type": "application/json" },
+  }).catch(() => {});
+});
+
 // ---------------------------------------------------------------------------
 // 1. Homepage — desktop
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Added `beforeAll`/`afterAll` test user lifecycle to `visual-qa.spec.ts` (was missing — caused CredentialsSignin on all login-dependent tests)
- Fixed trailing slash in `POST /hub/api/auth/register/` URL in both spec files — nginx 308 redirects without it, and Playwright's `APIRequest.post` doesn't follow POST redirects silently

## Root cause
`visual-qa.spec.ts` had no `beforeAll` hook, so `playwright@factorylm.com` didn't exist in NeonDB when login tests ran. `logo-nav.spec.ts` had the hook but used the wrong URL (missing trailing slash), causing a 308 that Playwright silently didn't follow.

## Test results
- visual-qa.spec.ts: 12/12 pass
- logo-nav.spec.ts: 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)