### PR TITLE
security(hub+ingest): path-traversal sanitization on asset_tag

### DIFF
--- a/mira-core/mira-ingest/asset_tag.py
+++ b/mira-core/mira-ingest/asset_tag.py
@@ -1,0 +1,46 @@
+"""asset_tag sanitization for mira-ingest.
+
+`asset_tag` is user-controlled and used as a filesystem path component
+(`PHOTOS_DIR / asset_tag`) in `/ingest/photo`. The hub validates strictly
+at the UI boundary (`mira-hub/src/lib/asset-tag.ts`); this module is the
+belt-and-suspenders safety net for non-UI callers (Telegram bot, mira-pipeline,
+test runners) where captions may contain spaces, unicode, or punctuation.
+
+The whitelist matches the hub side: `^[A-Za-z0-9_-]{1,64}$`. We coerce
+unsafe input rather than rejecting it so the bot flows keep working.
+"""
+
+import logging
+import os
+import re
+
+from fastapi import HTTPException
+
+logger = logging.getLogger("mira-ingest")
+
+ASSET_TAG_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_INVALID_RE = re.compile(r"[^A-Za-z0-9_-]")
+
+
+def sanitize_asset_tag(asset_tag: str) -> str:
+    """Coerce asset_tag into a safe filesystem path component.
+
+    Replaces any character outside [A-Za-z0-9_-] with an underscore,
+    truncates to 64, and rejects only the case where nothing usable
+    remains (raises 400). The result always matches ASSET_TAG_RE, so
+    `PHOTOS_DIR / result` can never traverse out of PHOTOS_DIR.
+    """
+    candidate = (asset_tag or "").strip()
+    safe = _INVALID_RE.sub("_", candidate)[:64].strip("_-") or ""
+    if not safe:
+        raise HTTPException(
+            status_code=400,
+            detail="asset_tag must contain at least one of [A-Za-z0-9_-]",
+        )
+    if safe != candidate:
+        logger.info("asset_tag coerced: %r -> %r", candidate, safe)
+    if os.path.basename(safe) != safe:
+        # Defence in depth — the regex already excludes `/` and `\`, but the
+        # check makes the intent explicit and survives future regex edits.
+        raise HTTPException(status_code=400, detail="asset_tag contains path component")
+    return safe

--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -16,6 +16,7 @@ from pathlib import Path
 
 import httpx
 import pdfplumber
+from asset_tag import sanitize_asset_tag
 from crawl_verifier import (
     OUTCOME_SUCCESS,
     classify_historical,
@@ -506,6 +507,8 @@ async def ingest_photo(
             raise
         except Exception:
             pass  # fail open — never block on DB errors
+
+    asset_tag = sanitize_asset_tag(asset_tag)
 
     raw = await image.read()
     if not raw:

--- a/mira-core/mira-ingest/tests/test_asset_tag_sanitization.py
+++ b/mira-core/mira-ingest/tests/test_asset_tag_sanitization.py
@@ -1,0 +1,71 @@
+"""Tests for asset_tag path-traversal sanitization (issue #697)."""
+
+import os
+import sys
+
+import pytest
+from fastapi import HTTPException
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from asset_tag import ASSET_TAG_RE, sanitize_asset_tag  # noqa: E402
+
+
+def test_normal_value_passes_through():
+    assert sanitize_asset_tag("PUMP-001") == "PUMP-001"
+    assert sanitize_asset_tag("MOTOR_42") == "MOTOR_42"
+    assert sanitize_asset_tag("a") == "a"
+
+
+def test_trims_whitespace():
+    assert sanitize_asset_tag("  PUMP-001  ") == "PUMP-001"
+
+
+def test_traversal_attempts_are_neutralized():
+    # The result of every traversal attempt must equal its own basename and
+    # match the safe whitelist — so it can never escape PHOTOS_DIR.
+    for hostile in [
+        "../../etc",
+        "../etc/passwd",
+        "..\\..\\windows",
+        "/etc/passwd",
+        "C:\\Windows",
+        "asset/with/slashes",
+        "asset\\with\\back",
+        "asset.with.dots",
+        "asset with spaces",
+        "asset;rm -rf /",
+        "asset$(whoami)",
+        "asset\x00null",
+    ]:
+        result = sanitize_asset_tag(hostile)
+        assert os.path.basename(result) == result
+        assert ASSET_TAG_RE.match(result), f"unsafe result: {result!r} from {hostile!r}"
+
+
+def test_truncates_to_64():
+    long = "A" * 200
+    result = sanitize_asset_tag(long)
+    assert len(result) == 64
+    assert result == "A" * 64
+
+
+def test_empty_or_unsanitizable_rejected():
+    for bad in ["", "   ", "...", "///", "...///"]:
+        with pytest.raises(HTTPException) as exc:
+            sanitize_asset_tag(bad)
+        assert exc.value.status_code == 400
+
+
+def test_unicode_coerced_not_rejected():
+    # Bot adapters may forward unicode captions — we coerce, not reject,
+    # so ingest doesn't 400 a legitimate bot upload.
+    result = sanitize_asset_tag("Pumpé-001")
+    assert ASSET_TAG_RE.match(result)
+    assert "_" in result  # the é became _
+
+
+def test_unassigned_default_passes():
+    # mira-hub's mira-ingest-client.ts sends "unassigned" when the user
+    # didn't pick an asset. Make sure that still works.
+    assert sanitize_asset_tag("unassigned") == "unassigned"

--- a/mira-hub/src/app/api/uploads/local/route.ts
+++ b/mira-hub/src/app/api/uploads/local/route.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/mira-ingest-client";
 import { sessionOr401 } from "@/lib/session";
 import { makeUploadLogger } from "@/lib/upload-log";
+import { validateAssetTag } from "@/lib/asset-tag";
 
 export const dynamic = "force-dynamic";
 
@@ -49,10 +50,11 @@ export async function POST(req: NextRequest) {
   }
 
   const assetTagRaw = form.get("assetTag");
-  const assetTag =
-    typeof assetTagRaw === "string" && assetTagRaw.trim().length > 0
-      ? assetTagRaw.trim()
-      : null;
+  const assetTagCheck = validateAssetTag(assetTagRaw);
+  if (!assetTagCheck.ok) {
+    return NextResponse.json({ error: assetTagCheck.reason }, { status: 400 });
+  }
+  const assetTag = assetTagCheck.value;
   const kind = inferKindFromMime(mime);
   const buffer = new Uint8Array(await file.arrayBuffer());
 

--- a/mira-hub/src/app/api/uploads/route.ts
+++ b/mira-hub/src/app/api/uploads/route.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/mira-ingest-client";
 import { sessionOr401 } from "@/lib/session";
 import { makeUploadLogger } from "@/lib/upload-log";
+import { validateAssetTag } from "@/lib/asset-tag";
 
 export const dynamic = "force-dynamic";
 
@@ -80,6 +81,12 @@ export async function POST(req: NextRequest) {
     );
   }
 
+  const assetTagCheck = validateAssetTag(body.assetTag);
+  if (!assetTagCheck.ok) {
+    return NextResponse.json({ error: assetTagCheck.reason }, { status: 400 });
+  }
+  const assetTag = assetTagCheck.value;
+
   const kind = inferKindFromMime(mime);
   const requestId = req.headers.get("x-request-id") ?? randomUUID();
 
@@ -94,7 +101,7 @@ export async function POST(req: NextRequest) {
     sizeBytes: body.sizeBytes ?? null,
     externalCreatedAt: body.externalCreatedAt ?? null,
     initialStatus: "queued",
-    assetTag: body.assetTag ?? null,
+    assetTag,
   });
 
   const log = makeUploadLogger({ requestId, uploadId: upload.id, tenantId: ctx.tenantId });
@@ -111,7 +118,7 @@ export async function POST(req: NextRequest) {
   // callback never runs — uploads stayed at status="queued" forever. mira-hub
   // runs as a long-lived standalone server, so a plain fire-and-forget
   // Promise stays alive until it resolves.
-  void runIngestPipeline(upload.id, body, kind, ctx.tenantId, requestId);
+  void runIngestPipeline(upload.id, body, kind, ctx.tenantId, requestId, assetTag);
 
   return NextResponse.json(upload, { status: 201, headers: { "X-Request-Id": requestId } });
 }
@@ -129,6 +136,7 @@ async function runIngestPipeline(
   kind: "document" | "photo",
   tenantId: string,
   requestId: string,
+  assetTag: string | null,
 ): Promise<void> {
   const log = makeUploadLogger({ requestId, uploadId, tenantId });
   try {
@@ -149,7 +157,7 @@ async function runIngestPipeline(
 
     if (kind === "photo") {
       const result = await forwardToPhotoIngest(fetched.stream, payload.filename, mime, {
-        assetTag: payload.assetTag ?? null,
+        assetTag,
         requestId,
       });
       await updateUploadStatus(uploadId, tenantId, "parsed", result.description ?? null, {

--- a/mira-hub/src/lib/asset-tag.ts
+++ b/mira-hub/src/lib/asset-tag.ts
@@ -1,0 +1,45 @@
+// mira-hub/src/lib/asset-tag.ts
+//
+// `assetTag` is user-controlled and flows downstream into a filesystem path
+// in mira-ingest (`PHOTOS_DIR / asset_tag`). Without validation, a value like
+// "../../etc" traverses out of PHOTOS_DIR. The hub validates first; mira-ingest
+// belt-and-suspenders re-validates.
+//
+// Whitelist: 1–64 chars of letters, digits, underscore, dash. No dots (rules
+// out "." / ".." / hidden files), no slashes, no spaces, no Unicode.
+
+export const ASSET_TAG_REGEX = /^[A-Za-z0-9_-]{1,64}$/;
+
+export interface AssetTagValidation {
+  ok: boolean;
+  value: string | null;
+  reason?: string;
+}
+
+/**
+ * Normalize and validate an `assetTag` value from a request body.
+ *
+ * Returns `{ok: true, value: null}` for absent/empty/whitespace input —
+ * uploaders may legitimately omit it (mira-ingest stores those photos under
+ * "unassigned").
+ *
+ * Returns `{ok: true, value: <trimmed>}` for valid values.
+ *
+ * Returns `{ok: false, reason: ...}` for any value present but rejected.
+ */
+export function validateAssetTag(raw: unknown): AssetTagValidation {
+  if (raw === undefined || raw === null) return { ok: true, value: null };
+  if (typeof raw !== "string") {
+    return { ok: false, value: null, reason: "asset_tag_must_be_string" };
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return { ok: true, value: null };
+  if (!ASSET_TAG_REGEX.test(trimmed)) {
+    return {
+      ok: false,
+      value: null,
+      reason: "asset_tag_invalid: must match /^[A-Za-z0-9_-]{1,64}$/",
+    };
+  }
+  return { ok: true, value: trimmed };
+}


### PR DESCRIPTION
## Summary
- New \`mira-hub/src/lib/asset-tag.ts\` — strict whitelist validation \`/^[A-Za-z0-9_-]{1,64}\$/\`. Cloud + local upload routes 400 on invalid input.
- New \`mira-core/mira-ingest/asset_tag.py\` — coerce-and-truncate fallback at the filesystem boundary, refactored into its own module so tests skip pillow_heif.
- 7 unit tests covering normal values, 12 traversal/injection attempts, unicode, truncation, etc.
- Closes #697

## Why
\`asset_tag\` is user-controlled and used as a path component in mira-ingest (\`PHOTOS_DIR / asset_tag\`). Without validation, \`assetTag: "../../etc"\` would traverse out of \`PHOTOS_DIR\`. Defense in depth across two boundaries:

| Layer | Behavior | Why |
|-------|----------|-----|
| mira-hub UI | strict 400 reject | UI controls input — fail loud |
| mira-ingest filesystem | coerce + log | bot adapters (Telegram, mira-pipeline) forward \`caption.split()[0]\` — strict reject would regress those flows |

Both layers guarantee the final stored \`asset_tag\` matches \`/^[A-Za-z0-9_-]{1,64}\$/\`, so \`PHOTOS_DIR / asset_tag\` can never escape \`PHOTOS_DIR\`.

## Bot-flow regression check
Inspected callers of \`/ingest/photo\`: \`mira-bots/telegram/bot.py\`, \`mira-pipeline/main.py\`, \`mira-bots/v2_test_harness/runner.py\`. They forward arbitrary caption-derived tags. Coerce-not-reject keeps them working with an \`asset_tag coerced: 'X' -> 'Y'\` log line for ops visibility.

## Test plan
- [x] \`pytest tests/test_asset_tag_sanitization.py\` — 7/7 green
- [x] \`ruff check\` clean (auto-fixed import order)
- [x] \`tsc --noEmit\` clean
- [ ] CI green
- [ ] Manual: upload a PDF on /hub/upload with assetTag \"PUMP-001\" — succeeds
- [ ] Manual: POST to /api/uploads with assetTag \"../../etc\" — 400 with \`asset_tag_invalid\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)