### PR TITLE
fix(ingest): include asset_tag.py in Dockerfile COPY (hotfix #726)

### DIFF
--- a/mira-core/mira-ingest/Dockerfile
+++ b/mira-core/mira-ingest/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-COPY main.py crawl_verifier.py route_fallback.py crawl_routes.yaml ./
+COPY main.py crawl_verifier.py route_fallback.py asset_tag.py crawl_routes.yaml ./
 COPY db/ db/
 
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
Hotfix for #726 — `mira-ingest-saas` is crash-looping in production with:

```
File "/app/main.py", line 19, in <module>
    from asset_tag import sanitize_asset_tag
ModuleNotFoundError: No module named 'asset_tag'
```

The Dockerfile uses an explicit allow-list COPY (`COPY main.py crawl_verifier.py ... ./`) and `asset_tag.py` (added in #726) wasn't on the list. Adding it fixes the boot crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)