### PR TITLE
feat(wiki): ~/MiraDrop → wiki/raw/<date>/ auto-ingest pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ bash install/smoke_test.sh
 - **ADRs:** `docs/adr/`
 - **Ops wiki:** `wiki/` — **Session start: read `wiki/hot.md`. Session end: update it.**
 - **Wiki schema:** `wiki/SCHEMA.md`
+- **Wiki sync across nodes + `~/MiraDrop/` auto-ingest:** `wiki/nodes/wiki-sync.md`
 - **Skills:** `.claude/skills/`
 - **Sprint state:** `.planning/STATE.md`
 - **Active 90-day MVP plan:** `docs/plans/2026-04-19-mira-90-day-mvp.md` — locked 2026-04-19 → 2026-07-19; **read its "Currently in-flight" section + run the 3-command coordination check before claiming any work**

--- a/tools/charlie-wiki-sync-setup-prompt.md
+++ b/tools/charlie-wiki-sync-setup-prompt.md
@@ -1,0 +1,67 @@
+# CHARLIE Wiki Sync Setup — Claude Code Prompt
+
+Paste the block below into a Claude Code session on CHARLIE (the `charlienode` user on `CharlieNodes-Mac-mini`). It mirrors the setup that BRAVO got on 2026-04-26: Obsidian opens `wiki/` as a vault, a launchd watcher auto-ingests `~/MiraDrop/*.md` into `wiki/raw/<date>/`, and an hourly cron pulls wiki updates from other nodes.
+
+---
+
+```
+You are running on CHARLIE node (CharlieNodes-Mac-mini, user `charlienode`, Tailscale 100.70.49.126). I want you to set up the same wiki auto-ingest pipeline that's already running on BRAVO.
+
+**Context:**
+- The MIRA repo is at /Users/charlienode/Mira (verify with `ls`; if it's elsewhere, use that path everywhere below).
+- The pipeline scripts live in `tools/` and are documented in `wiki/nodes/wiki-sync.md`. They were added on 2026-04-26 — make sure your checkout has them: `ls tools/install_wiki_raw_ingest.sh tools/install_wiki_pull_cron.sh tools/wiki_raw_ingest.py`. If those files are missing, fetch and checkout the branch they live on (ask the user; the BRAVO session left them on `codex/repo-sync-baseline` pending PR to main).
+- CHARLIE already runs the eval-fixer agent which commits `docs(wiki): eval-fixer run …` to main. Don't break that. The auto-ingest script commits separately and never auto-pushes, so they won't fight.
+- CHARLIE also runs the Telegram bot and Qdrant — leave those alone.
+
+**Steps:**
+
+1. **Confirm the wiki files exist locally.** If `tools/wiki_raw_ingest.py` is missing, stop and tell the user which branch to merge first.
+
+2. **Open the vault in Obsidian.** Tell the user to install Obsidian (if not already), then "Open folder as vault" → /Users/charlienode/Mira/wiki/. The repo `.gitignore` already excludes `wiki/.obsidian/` and `wiki/.smart-env/`, so opening the vault will not pollute git. Wait for the user to confirm before proceeding to step 3 — this is the only manual UI step.
+
+3. **Install the launchd auto-ingest watcher.** Run:
+   ```
+   bash tools/install_wiki_raw_ingest.sh
+   ```
+   Verify with `launchctl list | grep wiki-raw` — expect `com.mira.wiki-raw-ingest` listed. Then verify the plist content with `cat ~/Library/LaunchAgents/com.mira.wiki-raw-ingest.plist | grep WatchPaths -A1` — expect `<string>/Users/charlienode/MiraDrop</string>`.
+
+4. **Install the hourly pull cron.** Run:
+   ```
+   bash tools/install_wiki_pull_cron.sh
+   ```
+   Verify with `crontab -l | grep mira-wiki-pull` — expect one entry pulling /Users/charlienode/Mira hourly.
+
+5. **Smoke-verify the pipeline fires.** Run:
+   ```
+   echo "# charlie install verification $(date)" > ~/MiraDrop/charlie-verify-$(date +%s).md
+   sleep 6
+   cat ~/Library/Logs/wiki-raw-ingest.log
+   git -C ~/Mira status -s wiki/raw/
+   ```
+   Expected log line: `INFO moved charlie-verify-….md -> wiki/raw/2026-04-26/charlie-verify-….md` (or similar).
+   Expected git status: one new file under `wiki/raw/<today>/` and a new commit `chore(wiki): raw ingest charlie-verify-….md`.
+
+   **If the log says "branch X not in allowed=['main']":** that's the safety guard firing because your checkout isn't on `main`. The file stays in `~/MiraDrop/` for later. Either (a) `git checkout main` and re-test, or (b) run the smoke test in a temp repo: `bash tools/wiki_raw_ingest.test.sh` — should print 7 passes.
+
+6. **Do NOT push.** Per the operator doc, every node commits but only the human pushes. End of session: `git -C ~/Mira log origin/main..HEAD --oneline` to see what'll go up, then `git push` if the user approves.
+
+7. **Update wiki/nodes/wiki-sync.md.** In the per-node table, change CHARLIE's row from "scripted only" to "Obsidian + `~/MiraDrop/` auto-ingest + scripted (eval-fixer)." Commit as `docs(wiki): mark CHARLIE wiki-sync as installed`.
+
+8. **Report back.** Single message to the user: confirmation that all four checks passed (Obsidian opens, launchctl shows the agent, crontab shows the entry, smoke verification produced a commit), plus any deviations.
+
+**What this does NOT do:**
+- Does not install Syncthing or any cross-node filesystem replication. Wiki sync stays git-only.
+- Does not change CHARLIE's existing eval-fixer cron or Telegram poller.
+- Does not touch CHARLIE's Qdrant, Docker, or SSH config.
+
+**Footgun to avoid:**
+ALPHA's obsidian-git plugin auto-pushes on a timer and on 2026-04-25 stranded four wiki commits on `feat/comic-pipeline-v2` (see `wiki/nodes/wiki-sync.md`). On CHARLIE, if you install obsidian-git, set it to **commit-only, no auto-push**.
+```
+
+---
+
+## After CHARLIE finishes
+
+Update `wiki/nodes/wiki-sync.md` per-node table — CHARLIE row, "scripted only" → "Obsidian + auto-ingest + scripted." That marks the rollout as complete on the two macs you said you wanted in v1 scope.
+
+ALPHA / TRAVEL / PLC / PI can run the same two installer scripts later when you're ready; the prompt above is reusable with the path swapped (e.g., `/Users/factorylm/Documents/mira/` for ALPHA).

--- a/tools/eval_watch.py
+++ b/tools/eval_watch.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import datetime as dt
 import os
 import sys
 import time
@@ -82,7 +83,37 @@ async def run_subset(fixture_filenames: list[str]) -> int:
 
     passed = sum(1 for g in grades if all(g.checkpoints.values()))
     print(f"\n{passed}/{len(grades)} passed in {total_seconds:.1f}s")
+
+    if os.environ.get("MIRA_WIKI_DROP"):
+        _drop_report(grades, passed, total_seconds)
+
     return 0 if passed == len(grades) else 1
+
+
+def _drop_report(grades: list, passed: int, total_seconds: float) -> None:
+    """Write a markdown summary into ~/MiraDrop/ for the wiki raw-ingest hook."""
+    drop = Path(os.environ.get("MIRA_DROP_DIR", str(Path.home() / "MiraDrop")))
+    try:
+        drop.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return
+    ts = dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+    lines = [
+        f"# eval-watch run {ts}",
+        "",
+        f"- result: **{passed}/{len(grades)}** passed in {total_seconds:.1f}s",
+        "",
+        "| fixture | passed |",
+        "|---|---|",
+    ]
+    for g in grades:
+        ok = all(g.checkpoints.values())
+        fid = getattr(g, "id", None) or getattr(g, "fixture_id", "?")
+        lines.append(f"| `{fid}` | {'YES' if ok else 'no'} |")
+    try:
+        (drop / f"eval-watch-{ts}.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    except OSError:
+        pass
 
 
 def is_watched(path: Path) -> bool:

--- a/tools/install_wiki_pull_cron.sh
+++ b/tools/install_wiki_pull_cron.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Install an hourly `git pull --rebase --autostash` for the MIRA repo on
+# this node. Catches wiki updates from other cluster nodes (ALPHA's
+# obsidian-git pushes, CHARLIE's eval-fixer commits) without manual pulls.
+# Idempotent — refuses to add a duplicate entry.
+#
+# Uninstall: crontab -l | grep -v '# mira-wiki-pull' | crontab -
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MARKER="# mira-wiki-pull"
+LOG="$HOME/Library/Logs/mira-wiki-pull.log"
+GIT_BIN="$(command -v git)"
+
+if [[ -z "$GIT_BIN" ]]; then
+  echo "ERROR: git not on PATH" >&2
+  exit 2
+fi
+
+mkdir -p "$(dirname "$LOG")"
+
+ENTRY="0 * * * * cd $REPO_ROOT && $GIT_BIN pull --rebase --autostash >> $LOG 2>&1 $MARKER"
+
+EXISTING="$(crontab -l 2>/dev/null || true)"
+
+if grep -Fq "$MARKER" <<<"$EXISTING"; then
+  CURRENT="$(grep -F "$MARKER" <<<"$EXISTING")"
+  if [[ "$CURRENT" == "$ENTRY" ]]; then
+    echo "cron entry already installed (unchanged)"
+    exit 0
+  fi
+  echo "updating existing cron entry"
+  printf '%s\n' "$EXISTING" | grep -vF "$MARKER" > /tmp/mira-cron.$$
+  printf '%s\n' "$ENTRY" >> /tmp/mira-cron.$$
+  crontab /tmp/mira-cron.$$
+  rm -f /tmp/mira-cron.$$
+else
+  echo "installing cron entry"
+  { [[ -n "$EXISTING" ]] && printf '%s\n' "$EXISTING"; printf '%s\n' "$ENTRY"; } | crontab -
+fi
+
+echo "Installed: $ENTRY"
+echo "Verify with: crontab -l | grep mira-wiki-pull"
+echo "Tail with:   tail -f $LOG"

--- a/tools/install_wiki_raw_ingest.sh
+++ b/tools/install_wiki_raw_ingest.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Install the launchd WatchPaths agent that ingests ~/MiraDrop/*.md
+# into wiki/raw/<date>/. Idempotent — re-running replaces the plist
+# only if its content changed and reloads the agent cleanly.
+#
+# Run on each node where you want auto-ingest.
+# Uninstall: launchctl bootout gui/$UID com.mira.wiki-raw-ingest
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LABEL="com.mira.wiki-raw-ingest"
+PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
+DROP="$HOME/MiraDrop"
+PYTHON_BIN="$(command -v python3)"
+GIT_BIN="$(command -v git)"
+
+if [[ -z "$PYTHON_BIN" || -z "$GIT_BIN" ]]; then
+  echo "ERROR: python3 and git must be on PATH" >&2
+  exit 2
+fi
+
+mkdir -p "$DROP"
+mkdir -p "$HOME/Library/Logs"
+mkdir -p "$(dirname "$PLIST")"
+
+# Inherit PATH so the script can find git when launchd invokes it
+PATH_VALUE="$(dirname "$GIT_BIN"):$(dirname "$PYTHON_BIN"):/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin"
+
+NEW_PLIST="$(mktemp)"
+trap 'rm -f "$NEW_PLIST"' EXIT
+
+cat > "$NEW_PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>$LABEL</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$PYTHON_BIN</string>
+    <string>$REPO_ROOT/tools/wiki_raw_ingest.py</string>
+  </array>
+  <key>WatchPaths</key>
+  <array><string>$DROP</string></array>
+  <key>RunAtLoad</key><false/>
+  <key>ThrottleInterval</key><integer>5</integer>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key><string>$PATH_VALUE</string>
+    <key>HOME</key><string>$HOME</string>
+    <key>REPO_ROOT</key><string>$REPO_ROOT</string>
+  </dict>
+  <key>StandardOutPath</key><string>$HOME/Library/Logs/wiki-raw-ingest.stdout.log</string>
+  <key>StandardErrorPath</key><string>$HOME/Library/Logs/wiki-raw-ingest.stderr.log</string>
+</dict>
+</plist>
+EOF
+
+plutil -lint "$NEW_PLIST" >/dev/null
+
+if [[ -f "$PLIST" ]] && cmp -s "$NEW_PLIST" "$PLIST"; then
+  echo "plist unchanged at $PLIST"
+else
+  install -m 0644 "$NEW_PLIST" "$PLIST"
+  echo "wrote $PLIST"
+fi
+
+# Reload — bootout is no-op if not loaded; ignore the error
+launchctl bootout "gui/$UID/$LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$UID" "$PLIST"
+launchctl enable "gui/$UID/$LABEL"
+
+echo
+echo "Installed. Drop a .md file into $DROP and check:"
+echo "  tail -f ~/Library/Logs/wiki-raw-ingest.log"
+echo "Uninstall: launchctl bootout gui/\$UID/$LABEL && rm $PLIST"

--- a/tools/wiki_raw_ingest.py
+++ b/tools/wiki_raw_ingest.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Move .md files from a drop folder into wiki/raw/<YYYY-MM-DD>/ and commit.
+
+Triggered by a launchd WatchPaths agent. SHA-256 dedupes against everything
+already under wiki/raw/. Refuses to run if the repo is not on an allowed
+branch (default: main) — defends against the obsidian-git wrong-branch
+footgun where auto-commits ended up on feat/comic-pipeline-v2 in 2026-04-25.
+
+Logs to ~/Library/Logs/wiki-raw-ingest.log; never auto-pushes.
+
+Usage:
+    python tools/wiki_raw_ingest.py
+    MIRA_DROP_DIR=/tmp/x REPO_ROOT=/tmp/repo python tools/wiki_raw_ingest.py
+
+Env:
+    MIRA_DROP_DIR              default ~/MiraDrop
+    REPO_ROOT                  default = git toplevel of this script's dir
+    MIRA_WIKI_ALLOWED_BRANCHES default "main"; comma-separated list
+    MIRA_WIKI_INGEST_LOG       default ~/Library/Logs/wiki-raw-ingest.log
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import fcntl
+import hashlib
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+LOCK_PATH = Path("/tmp/wiki-raw-ingest.lock")
+SKIP_PREFIXES = (".", "~")
+SKIP_SUFFIXES = (".swp", ".swo", ".tmp", ".part")
+
+
+def repo_root() -> Path:
+    if env := os.environ.get("REPO_ROOT"):
+        return Path(env).resolve()
+    here = Path(__file__).resolve().parent
+    out = subprocess.run(
+        ["git", "-C", str(here), "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=True,
+    )
+    return Path(out.stdout.strip())
+
+
+def setup_logging() -> logging.Logger:
+    log_path = Path(os.environ.get(
+        "MIRA_WIKI_INGEST_LOG",
+        str(Path.home() / "Library/Logs/wiki-raw-ingest.log"),
+    ))
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    logger = logging.getLogger("wiki-raw-ingest")
+    logger.setLevel(logging.INFO)
+    if not logger.handlers:
+        handler = logging.FileHandler(log_path)
+        handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+        logger.addHandler(handler)
+    return logger
+
+
+def current_branch(repo: Path) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, check=True,
+    )
+    return out.stdout.strip()
+
+
+def hash_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def existing_hashes(raw_root: Path) -> set[str]:
+    hashes = set()
+    if not raw_root.exists():
+        return hashes
+    for f in raw_root.rglob("*.md"):
+        if f.is_file():
+            hashes.add(hash_file(f))
+    return hashes
+
+
+def sanitize(name: str) -> str:
+    base = Path(name).name  # strip any path
+    base = re.sub(r"\s+", "-", base.strip())
+    base = re.sub(r"[^\w.\-]+", "_", base, flags=re.UNICODE)
+    base = base.lstrip(".") or "untitled.md"
+    if not base.endswith(".md"):
+        base += ".md"
+    return base
+
+
+def unique_dest(folder: Path, name: str) -> Path:
+    candidate = folder / name
+    if not candidate.exists():
+        return candidate
+    stem, suffix = candidate.stem, candidate.suffix
+    for n in range(1, 10000):
+        c = folder / f"{stem}-{n}{suffix}"
+        if not c.exists():
+            return c
+    raise RuntimeError(f"could not find unique name in {folder} for {name}")
+
+
+def git_commit(repo: Path, paths: list[Path], message: str, log: logging.Logger) -> None:
+    rel = [str(p.relative_to(repo)) for p in paths]
+    subprocess.run(["git", "-C", str(repo), "add", "--", *rel], check=True)
+    out = subprocess.run(
+        ["git", "-C", str(repo), "diff", "--cached", "--quiet"],
+    )
+    if out.returncode == 0:
+        log.info("git: nothing staged after add, skipping commit")
+        return
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", message],
+        check=True, capture_output=True,
+    )
+    log.info("git: committed %s", message)
+
+
+def candidate_files(drop: Path) -> list[Path]:
+    if not drop.exists():
+        return []
+    out = []
+    for p in sorted(drop.iterdir()):
+        if not p.is_file():
+            continue
+        if p.suffix.lower() != ".md":
+            continue
+        if p.name.startswith(SKIP_PREFIXES) or p.name.endswith(SKIP_SUFFIXES):
+            continue
+        out.append(p)
+    return out
+
+
+def main() -> int:
+    log = setup_logging()
+    LOCK_PATH.touch(exist_ok=True)
+    lock_fd = LOCK_PATH.open("w")
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        log.info("another ingest run is in progress; exiting")
+        return 0
+
+    drop = Path(os.environ.get("MIRA_DROP_DIR", str(Path.home() / "MiraDrop")))
+    files = candidate_files(drop)
+    if not files:
+        return 0
+
+    try:
+        repo = repo_root()
+    except subprocess.CalledProcessError:
+        log.error("could not resolve repo root from %s", Path(__file__).resolve())
+        return 2
+
+    branch = current_branch(repo)
+    allowed = {b.strip() for b in os.environ.get("MIRA_WIKI_ALLOWED_BRANCHES", "main").split(",") if b.strip()}
+    if branch not in allowed:
+        log.warning("branch %s not in allowed=%s; %d files left in %s", branch, sorted(allowed), len(files), drop)
+        return 0
+
+    raw_root = repo / "wiki" / "raw"
+    today = dt.datetime.now().strftime("%Y-%m-%d")
+    target_dir = raw_root / today
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    seen = existing_hashes(raw_root)
+    moved: list[Path] = []
+    for src in files:
+        try:
+            digest = hash_file(src)
+        except OSError as exc:
+            log.error("hash failed for %s: %s", src, exc)
+            continue
+        if digest in seen:
+            log.info("dedup-skipped %s sha=%s", src.name, digest[:12])
+            src.unlink(missing_ok=True)
+            continue
+        dest = unique_dest(target_dir, sanitize(src.name))
+        try:
+            shutil.move(str(src), str(dest))
+        except OSError as exc:
+            log.error("move failed %s -> %s: %s", src, dest, exc)
+            continue
+        log.info("moved %s -> %s", src.name, dest.relative_to(repo))
+        moved.append(dest)
+        seen.add(digest)
+
+    if not moved:
+        return 0
+
+    names = ", ".join(p.name for p in moved[:3])
+    extra = f" (+{len(moved) - 3} more)" if len(moved) > 3 else ""
+    message = f"chore(wiki): raw ingest {names}{extra}"
+    try:
+        git_commit(repo, moved, message, log)
+    except subprocess.CalledProcessError as exc:
+        log.error("git commit failed: %s", exc.stderr.decode() if exc.stderr else exc)
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/wiki_raw_ingest.test.sh
+++ b/tools/wiki_raw_ingest.test.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Smoke test for tools/wiki_raw_ingest.py.
+# Builds a throwaway git repo + drop folder, runs the ingest script
+# against it, asserts the expected files / commits / log lines.
+#
+# Run from anywhere: bash tools/wiki_raw_ingest.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INGEST="$SCRIPT_DIR/wiki_raw_ingest.py"
+
+WORK="$(mktemp -d -t wiki-raw-ingest.XXXXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+REPO="$WORK/repo"
+DROP="$WORK/drop"
+LOG="$WORK/ingest.log"
+TODAY="$(date +%F)"
+
+mkdir -p "$REPO" "$DROP"
+git -C "$REPO" -c init.defaultBranch=main init -q
+git -C "$REPO" config user.email "smoke@test.local"
+git -C "$REPO" config user.name "smoke-test"
+mkdir -p "$REPO/wiki/raw"
+touch "$REPO/wiki/raw/.gitkeep"
+git -C "$REPO" add wiki/raw/.gitkeep
+git -C "$REPO" commit -q -m "init"
+
+export MIRA_DROP_DIR="$DROP"
+export REPO_ROOT="$REPO"
+export MIRA_WIKI_INGEST_LOG="$LOG"
+export MIRA_WIKI_ALLOWED_BRANCHES="main"
+
+run_ingest() { python3 "$INGEST"; }
+
+fail() { echo "FAIL: $*" >&2; echo "--- log ---"; cat "$LOG" 2>/dev/null || true; exit 1; }
+pass() { echo "  pass: $*"; }
+
+# -- Test 1: happy path move + commit ----------------------------------------
+echo "[1] happy path"
+echo "# hello $(date +%s%N)" > "$DROP/note-1.md"
+run_ingest
+[ -f "$REPO/wiki/raw/$TODAY/note-1.md" ] || fail "note-1.md not in wiki/raw/$TODAY/"
+[ -f "$DROP/note-1.md" ] && fail "source not removed from drop"
+git -C "$REPO" log -1 --oneline | grep -q "raw ingest note-1.md" || fail "no raw-ingest commit"
+pass "moved + committed"
+
+# -- Test 2: dedupe identical content ----------------------------------------
+echo "[2] dedupe"
+existing="$(cat "$REPO/wiki/raw/$TODAY/note-1.md")"
+echo "$existing" > "$DROP/note-1-copy.md"
+before=$(git -C "$REPO" rev-list --count HEAD)
+run_ingest
+after=$(git -C "$REPO" rev-list --count HEAD)
+[ "$before" = "$after" ] || fail "duplicate content created a new commit (before=$before after=$after)"
+[ -f "$DROP/note-1-copy.md" ] && fail "duplicate left behind in drop"
+grep -q "dedup-skipped note-1-copy.md" "$LOG" || fail "no dedup-skipped log line"
+pass "duplicate skipped, no commit"
+
+# -- Test 3: branch guard refuses on non-main --------------------------------
+echo "[3] branch guard"
+git -C "$REPO" checkout -q -b junk
+echo "# guarded" > "$DROP/should-not-land.md"
+run_ingest
+[ -f "$DROP/should-not-land.md" ] || fail "branch guard removed the file anyway"
+[ -f "$REPO/wiki/raw/$TODAY/should-not-land.md" ] && fail "branch guard did not stop the move"
+grep -q "branch junk not in allowed" "$LOG" || fail "no branch-guard log line"
+pass "refused on junk branch, file preserved"
+
+# -- Test 4: returning to main processes the queued file ---------------------
+echo "[4] resume on main"
+git -C "$REPO" checkout -q main
+run_ingest
+[ -f "$REPO/wiki/raw/$TODAY/should-not-land.md" ] || fail "queued file did not land after switch"
+pass "queued file processed"
+
+# -- Test 5: sanitize spaces and odd chars in filenames ----------------------
+echo "[5] sanitize"
+echo "# weird" > "$DROP/Weird Name (v2)!.md"
+run_ingest
+find "$REPO/wiki/raw/$TODAY" -maxdepth 1 -name 'Weird-Name*' -print -quit | grep -q . \
+  || fail "sanitized name not produced"
+pass "sanitized basename"
+
+# -- Test 6: collision in same day picks unique name -------------------------
+echo "[6] collision"
+echo "# unique-A $RANDOM" > "$DROP/dup-name.md"
+run_ingest
+echo "# unique-B $RANDOM-$RANDOM" > "$DROP/dup-name.md"
+run_ingest
+count=$(find "$REPO/wiki/raw/$TODAY" -maxdepth 1 -name 'dup-name*.md' | wc -l | tr -d ' ')
+[ "$count" -ge 2 ] || fail "collision did not produce a -1 suffixed file (got $count)"
+pass "collision handled"
+
+# -- Test 7: empty drop is a no-op -------------------------------------------
+echo "[7] empty drop is no-op"
+before=$(git -C "$REPO" rev-list --count HEAD)
+run_ingest
+after=$(git -C "$REPO" rev-list --count HEAD)
+[ "$before" = "$after" ] || fail "empty drop produced a commit"
+pass "no-op when drop empty"
+
+echo "OK — wiki_raw_ingest smoke passed (workdir: $WORK)"

--- a/wiki/SCHEMA.md
+++ b/wiki/SCHEMA.md
@@ -57,6 +57,8 @@ When new operational knowledge arrives (incident resolved, deploy completed, con
 5. Append to `wiki/log.md`
 6. Cross-link: if a gotcha references a node, link to it. If a service runs on a node, link to it.
 
+**Drop-folder ingest into `raw/`:** drop generated `.md` files (eval reports, deploy outputs, transcripts) into `~/MiraDrop/` on whichever node you're working on. A launchd watcher (`tools/wiki_raw_ingest.py`) moves the file into `wiki/raw/<YYYY-MM-DD>/`, dedupes by SHA-256, and commits — no auto-push. See [[nodes/wiki-sync]].
+
 ### Query
 
 When the user asks an operational question:

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -12,6 +12,7 @@
 | [[nodes/vps]] | DigitalOcean VPS — factorylm.com, SaaS v1, Atlas CMMS |
 | [[nodes/plc-laptop]] | PLC programming laptop — CCW, RSLinx, Factory I/O |
 | [[nodes/windows-dev]] | Windows 11 primary dev box — main Claude Code sessions |
+| [[nodes/wiki-sync]] | How the vault is shared across nodes + `~/MiraDrop/` auto-ingest |
 
 ## Gotchas
 

--- a/wiki/nodes/wiki-sync.md
+++ b/wiki/nodes/wiki-sync.md
@@ -1,0 +1,83 @@
+---
+title: Wiki Sync — How the Vault Lives on 6 Nodes
+type: ops
+updated: 2026-04-26
+tags: [wiki, obsidian, sync, cluster, raw-ingest]
+---
+
+# Wiki Sync — How the Vault Lives on 6 Nodes
+
+The wiki at `/Users/.../Mira/wiki/` is a plain-Markdown Obsidian vault. There is no SMB share, Syncthing, or live filesystem replication between cluster nodes. **All sync goes through git on this repo.** Each node has the wiki because each node has the repo cloned.
+
+## Per-node setup
+
+| Node | Wiki path | Updates | Push |
+|---|---|---|---|
+| ALPHA (`Michaels-Mac-mini-2`) | `/Users/factorylm/Documents/mira/wiki/` | Obsidian + obsidian-git auto-commit | auto-pushes (see footgun below) |
+| BRAVO (`FactoryLM-Bravo`) | `/Users/bravonode/Mira/wiki/` | Obsidian (manual) + `~/MiraDrop/` auto-ingest into `wiki/raw/` | manual |
+| CHARLIE (`CharlieNodes-Mac-mini`) | scripted only | eval-fixer agent commits `docs(wiki): eval-fixer run …` | manual |
+| TRAVEL | scripted only | direct commits (`docs(wiki): capture travel-laptop session log …`) | manual |
+| PLC, PI | not active for wiki | — | — |
+
+`.gitignore` already excludes per-machine state:
+- `wiki/.obsidian/`, `wiki/.obsidian/workspace*`, `wiki/.obsidian/app.json`, `wiki/.obsidian/appearance.json`
+- `wiki/.smart-env/` (Smart Connections embeddings — local per-node)
+
+So opening the vault on a new node never pollutes the repo with editor state.
+
+## Auto-ingest from `~/MiraDrop/`
+
+Drop a `.md` file into `~/MiraDrop/` on any node where the launchd watcher is installed. Within ~5 seconds:
+
+1. The file moves to `wiki/raw/<YYYY-MM-DD>/<sanitized-name>.md`
+2. A `chore(wiki): raw ingest <name>` commit is made on `main` (no auto-push)
+3. The event is logged to `~/Library/Logs/wiki-raw-ingest.log`
+
+Duplicates (same SHA-256 as something already under `wiki/raw/`) are removed from the drop folder and logged as `dedup-skipped`. The watcher refuses to run unless the repo is on an allowed branch (default `main`) — see footgun below.
+
+**Install on a node:**
+```bash
+bash tools/install_wiki_raw_ingest.sh        # launchd watcher for ~/MiraDrop
+bash tools/install_wiki_pull_cron.sh         # hourly `git pull --rebase --autostash`
+```
+Both are idempotent. Uninstall instructions are inside each script.
+
+**Verify:**
+```bash
+echo "# test $(date)" > ~/MiraDrop/test-$(date +%s).md
+sleep 6
+git -C ~/Mira log -1 --oneline   # expect: chore(wiki): raw ingest test-...md
+tail ~/Library/Logs/wiki-raw-ingest.log
+```
+
+## Footgun: obsidian-git pushed to the wrong branch
+
+On 2026-04-25, ALPHA's obsidian-git plugin auto-committed and **auto-pushed** to whatever branch ALPHA's checkout happened to be on at the time — which was `feat/comic-pipeline-v2`, not `main`. Four wiki commits ended up stranded there and will never merge as-is.
+
+Stranded SHAs (on `origin/feat/comic-pipeline-v2`):
+- `22ac09a` — `wiki: session auto-commit 2026-04-25T02:27:07Z`
+- `16b8c4d` — `wiki: session auto-commit 2026-04-25T00:53:45Z`
+- `23595d3` — `wiki: session auto-commit 2026-04-25T00:48:51Z`
+- `41383d8` — `wiki: session auto-commit 2026-04-25T00:45:21Z`
+
+**Recovery (one-time, optional):**
+```bash
+git checkout main
+git checkout 22ac09a -- wiki/log.md         # cherry-pick just the log delta
+# (.smart-env/ blobs are now gitignored — they won't follow)
+git diff --cached
+git commit -m "docs(wiki): recover stranded log delta from 2026-04-25 ALPHA auto-commits"
+```
+
+**Prevention going forward:**
+- The `~/MiraDrop/` ingest watcher (`tools/wiki_raw_ingest.py`) refuses to run if the repo isn't on an allowed branch. Default allowlist is `main`; override via `MIRA_WIKI_ALLOWED_BRANCHES` env on the launchd plist.
+- ALPHA's obsidian-git should be reconfigured to **commit only**, not push. The user pushes manually at end of session — same way every other node already works.
+
+## Why git, not Syncthing or SMB
+
+- The repo is already on every node — zero new infrastructure.
+- Conflicts surface as standard git merge conflicts, not as silent file-overwrite-wins races.
+- Works offline (TRAVEL, PLC laptop on the factory floor) — commits queue locally, push when the node sees the network again.
+- `CLUSTER.md` describes a `/Users/Shared/cluster/` SMB share on ALPHA, but that share is not currently mounted on BRAVO and is out of scope for the wiki.
+
+If realtime sync between two nodes ever becomes necessary, point Syncthing at `~/MiraDrop/` only — never at the repo itself. The repo and Syncthing fight over file ownership.


### PR DESCRIPTION
## Summary

- Launchd watcher (`tools/wiki_raw_ingest.py` + `tools/install_wiki_raw_ingest.sh`) auto-ingests `~/MiraDrop/*.md` into `wiki/raw/<YYYY-MM-DD>/`, SHA-256 dedupes, commits but never auto-pushes.
- Branch guard refuses to commit unless on `main` (configurable via `MIRA_WIKI_ALLOWED_BRANCHES`) — defense against the obsidian-git wrong-branch footgun that stranded 4 ALPHA commits on `feat/comic-pipeline-v2` on 2026-04-25.
- Idempotent installer for hourly `git pull --rebase --autostash` so each node picks up wiki commits from peers without manual fetches.
- Operator doc at `wiki/nodes/wiki-sync.md` covers per-node setup, the obsidian-git footgun + recovery, and stranded SHAs to optionally cherry-pick.
- Setup prompt at `tools/charlie-wiki-sync-setup-prompt.md` — paste into a Claude Code session on CHARLIE to mirror the BRAVO install.
- Pilot drop in `tools/eval_watch.py` (env-gated `MIRA_WIKI_DROP=1`, default off) writes a markdown summary into `~/MiraDrop/` so eval runs flow into the wiki.

## Test plan

- [x] `bash tools/wiki_raw_ingest.test.sh` — 7-case smoke (happy path, dedupe, branch guard, resume on main, sanitize, collision, empty no-op) all green
- [x] `shellcheck tools/wiki_raw_ingest.test.sh tools/install_wiki_raw_ingest.sh tools/install_wiki_pull_cron.sh` — clean
- [x] `plutil -lint` on the generated launchd plist — OK
- [x] BRAVO install: launchd watcher loaded (`launchctl list | grep wiki-raw`), cron entry installed (`crontab -l | grep mira-wiki-pull`), drop event correctly triggered the script and was branch-guarded out (file preserved in `~/MiraDrop/`)
- [ ] Reviewer: confirm `.gitignore` already excludes `wiki/.obsidian/` and `wiki/.smart-env/` (it does — lines 116, 161-164 on main), no further gitignore changes needed
- [ ] Reviewer: confirm pre-commit hook tolerates the script's automated commits (shellcheck + rg credential scan only run on staged shell/credential-bearing files; a `wiki/raw/<date>/foo.md` commit triggers nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)