### PR TITLE
security(hub): magic-byte file sniffing on PDF/image uploads

### DIFF
--- a/mira-hub/src/app/api/uploads/local/route.ts
+++ b/mira-hub/src/app/api/uploads/local/route.ts
@@ -10,6 +10,7 @@ import {
 import { sessionOr401 } from "@/lib/session";
 import { makeUploadLogger } from "@/lib/upload-log";
 import { validateAssetTag } from "@/lib/asset-tag";
+import { sniffMime, isMimeCompatible } from "@/lib/sniff-mime";
 
 export const dynamic = "force-dynamic";
 
@@ -57,6 +58,17 @@ export async function POST(req: NextRequest) {
   const assetTag = assetTagCheck.value;
   const kind = inferKindFromMime(mime);
   const buffer = new Uint8Array(await file.arrayBuffer());
+
+  // Magic-byte sniff: client-supplied File.type and extension are both
+  // controllable. Reject any payload whose first bytes don't match the
+  // declared MIME's general category.
+  const sniffed = sniffMime(buffer.subarray(0, 16));
+  if (!isMimeCompatible(mime, sniffed)) {
+    return NextResponse.json(
+      { error: "content_does_not_match_declared_mime", declared: mime, sniffed },
+      { status: 400 },
+    );
+  }
 
   const upload = await createUpload({
     tenantId: ctx.tenantId,

--- a/mira-hub/src/lib/mira-ingest-client.ts
+++ b/mira-hub/src/lib/mira-ingest-client.ts
@@ -1,4 +1,17 @@
 // mira-hub/src/lib/mira-ingest-client.ts
+import { sniffMime, isMimeCompatible } from "./sniff-mime";
+
+export class MimeMismatchError extends Error {
+  declared: string;
+  sniffed: string | null;
+  constructor(declared: string, sniffed: string | null) {
+    super(`content_does_not_match_declared_mime: declared=${declared} sniffed=${sniffed}`);
+    this.name = "MimeMismatchError";
+    this.declared = declared;
+    this.sniffed = sniffed;
+  }
+}
+
 export interface IngestResult {
   status: string;
   fileId: string | null;
@@ -36,6 +49,19 @@ async function streamToBlob(
 }
 
 /**
+ * Read the first bytes of a Blob and reject if they don't match the
+ * declared MIME's general category. Throws MimeMismatchError on rejection
+ * so the upload pipeline can mark the row failed with a clear reason.
+ */
+async function assertMimeMatchesBlob(blob: Blob, declared: string): Promise<void> {
+  const head = new Uint8Array(await blob.slice(0, 16).arrayBuffer());
+  const sniffed = sniffMime(head);
+  if (!isMimeCompatible(declared, sniffed)) {
+    throw new MimeMismatchError(declared, sniffed);
+  }
+}
+
+/**
  * PDF / document path — POSTs to mira-ingest `/ingest/document-kb`.
  *
  * `requestId` is propagated as `X-Request-Id` so mira-ingest logs the same
@@ -51,6 +77,7 @@ export async function forwardToIngest(
   if (!base) throw new Error("INGEST_URL not set");
 
   const blob = await streamToBlob(stream, mimeType);
+  await assertMimeMatchesBlob(blob, mimeType);
 
   const form = new FormData();
   form.append("file", blob, filename);
@@ -99,6 +126,7 @@ export async function forwardToPhotoIngest(
   if (!base) throw new Error("INGEST_URL not set");
 
   const blob = await streamToBlob(stream, mimeType);
+  await assertMimeMatchesBlob(blob, mimeType);
 
   const form = new FormData();
   form.append("image", blob, filename);

--- a/mira-hub/src/lib/sniff-mime.ts
+++ b/mira-hub/src/lib/sniff-mime.ts
@@ -1,0 +1,66 @@
+// mira-hub/src/lib/sniff-mime.ts
+//
+// Magic-byte file sniffing. Client-supplied `mimeType` (cloud path) and
+// browser-supplied `File.type` (local path) are both controllable — a
+// malicious client can set "application/pdf" with an executable payload.
+// Defense in depth: read the first ~16 bytes and reject anything that
+// doesn't match a known signature.
+//
+// References:
+//   PDF       %PDF-     25 50 44 46 2D
+//   JPEG      JFIF/EXIF FF D8 FF
+//   PNG                 89 50 4E 47 0D 0A 1A 0A
+//   WebP      RIFF…WEBP 52 49 46 46 _ _ _ _ 57 45 42 50  (offset 0,8)
+//   HEIC/HEIF ftyp box  ?? ?? ?? ?? 66 74 79 70           (offset 4)
+
+export type SniffedKind = "pdf" | "jpeg" | "png" | "webp" | "heic" | null;
+
+const PDF = [0x25, 0x50, 0x44, 0x46, 0x2d];
+const JPEG = [0xff, 0xd8, 0xff];
+const PNG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const RIFF = [0x52, 0x49, 0x46, 0x46];
+const WEBP = [0x57, 0x45, 0x42, 0x50];
+const FTYP = [0x66, 0x74, 0x79, 0x70];
+// HEIC/HEIF brand codes that follow `ftyp` — there are several.
+const HEIC_BRANDS = new Set(["heic", "heix", "hevc", "hevx", "heim", "heis", "heif", "mif1", "msf1"]);
+
+function startsWith(buf: Uint8Array, sig: number[], offset = 0): boolean {
+  if (buf.length < offset + sig.length) return false;
+  for (let i = 0; i < sig.length; i++) {
+    if (buf[offset + i] !== sig[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Sniff the first ~16 bytes of `buf` and return the detected file kind, or
+ * null if no known signature matches.
+ */
+export function sniffMime(buf: Uint8Array): SniffedKind {
+  if (startsWith(buf, PDF)) return "pdf";
+  if (startsWith(buf, JPEG)) return "jpeg";
+  if (startsWith(buf, PNG)) return "png";
+  if (startsWith(buf, RIFF) && startsWith(buf, WEBP, 8)) return "webp";
+  // HEIC/HEIF: ftyp box at byte 4, brand at byte 8 (4 ASCII chars)
+  if (startsWith(buf, FTYP, 4) && buf.length >= 12) {
+    const brand = String.fromCharCode(buf[8], buf[9], buf[10], buf[11]).toLowerCase();
+    if (HEIC_BRANDS.has(brand)) return "heic";
+  }
+  return null;
+}
+
+/**
+ * Return true if the sniffed kind is compatible with the declared MIME.
+ *
+ * "Compatible" means the MIME's general category matches: PDFs go to PDF,
+ * any image MIME accepts any sniffed image format. We intentionally don't
+ * require an exact match (e.g. someone uploads a JPEG with the wrong
+ * extension labeled as image/png) — that's a UX nuisance, not a security
+ * concern, since both end up in the same image-processing pipeline.
+ */
+export function isMimeCompatible(declared: string, sniffed: SniffedKind): boolean {
+  if (sniffed === null) return false;
+  if (sniffed === "pdf") return declared === "application/pdf";
+  // Any non-pdf sniff is an image; reject if declared isn't an image MIME.
+  return declared.startsWith("image/");
+}


### PR DESCRIPTION
## Summary
- New \`mira-hub/src/lib/sniff-mime.ts\` — \`sniffMime()\` checks first 16 bytes against PDF/JPEG/PNG/WebP/HEIC magic numbers
- \`/api/uploads/local\` rejects with 400 when sniffed kind doesn't match declared MIME
- \`forwardToIngest\` / \`forwardToPhotoIngest\` (cloud path) sniff after \`streamToBlob\` and throw \`MimeMismatchError\`, surfaced as \"failed\" status to the user
- Closes #698

## Why
Client-supplied \`mimeType\` (cloud) and \`File.type\` (local) are both controllable. A malicious client can declare \`application/pdf\` while sending an executable payload. mira-ingest already handles image format internally via Pillow, but PDFs go straight to OpenWebUI's parser — no defense before this.

## Compatibility check
\`isMimeCompatible(declared, sniffed)\` is intentionally loose for images:

| Declared | Sniffed | Result |
|----------|---------|--------|
| \`application/pdf\` | \`pdf\` | ✓ |
| \`application/pdf\` | \`jpeg\` | ✗ |
| \`image/png\` | \`jpeg\` | ✓ (same pipeline) |
| \`image/jpeg\` | \`pdf\` | ✗ |
| \`image/heic\` | \`null\` | ✗ |

JPEG-with-PNG-extension is a UX nuisance, not a security concern — both go to sanitize → describe → embed. PDF↔image mismatch is the actual attack vector and is rejected.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] CI green
- [ ] Manual: upload a real PDF on /hub/upload — succeeds
- [ ] Manual: rename a binary to \`.pdf\` and upload — 400 with \`content_does_not_match_declared_mime\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)