### PR TITLE
security(hub): SSRF guard + manual-redirect re-validation on streamFromSignedUrl

### DIFF
--- a/mira-hub/src/lib/fetch-adapters.ts
+++ b/mira-hub/src/lib/fetch-adapters.ts
@@ -1,5 +1,8 @@
 // mira-hub/src/lib/fetch-adapters.ts
 import { composeTimeout, isAbortError } from "./abort-helpers";
+import { assertSafeUrl } from "./ssrf-guard";
+
+const MAX_REDIRECTS = 3;
 
 /**
  * Returns a Response object whose body is the file stream, plus parsed
@@ -49,12 +52,37 @@ export async function streamFromSignedUrl(
   url: string,
   signal?: AbortSignal,
 ): Promise<FetchedFile> {
-  let res: Response;
-  try {
-    res = await fetch(url, { signal: composeTimeout(signal, SIGNED_URL_TIMEOUT_MS) });
-  } catch (err) {
-    if (isAbortError(err)) throw new Error(`timeout: signed url fetch (${SIGNED_URL_TIMEOUT_MS}ms)`);
-    throw err;
+  // Validate the user-controlled URL before any network I/O — protocol,
+  // hostname allowlist, no IP literals. Throws SsrfBlockedError on
+  // rejection (caller catches and surfaces as upload failure).
+  let target = assertSafeUrl(url);
+
+  // Manual redirect handling: every Location must re-pass the SSRF check
+  // so a 302 from dropboxusercontent.com to 169.254.169.254 is rejected.
+  const composedSignal = composeTimeout(signal, SIGNED_URL_TIMEOUT_MS);
+  let res: Response | null = null;
+  for (let i = 0; i <= MAX_REDIRECTS; i++) {
+    try {
+      res = await fetch(target.toString(), {
+        signal: composedSignal,
+        redirect: "manual",
+      });
+    } catch (err) {
+      if (isAbortError(err)) throw new Error(`timeout: signed url fetch (${SIGNED_URL_TIMEOUT_MS}ms)`);
+      throw err;
+    }
+    if (res.status >= 300 && res.status < 400) {
+      const location = res.headers.get("location");
+      if (!location) throw new Error(`signed url ${res.status} with no location`);
+      // Resolve relative redirects against the previous target
+      target = assertSafeUrl(new URL(location, target).toString());
+      continue;
+    }
+    break;
+  }
+  if (!res) throw new Error("signed url: redirect loop");
+  if (res.status >= 300 && res.status < 400) {
+    throw new Error(`signed url: too many redirects (>${MAX_REDIRECTS})`);
   }
   if (!res.ok) {
     throw new Error(`signed url fetch ${res.status}`);

--- a/mira-hub/src/lib/ssrf-guard.ts
+++ b/mira-hub/src/lib/ssrf-guard.ts
@@ -1,0 +1,117 @@
+// mira-hub/src/lib/ssrf-guard.ts
+//
+// streamFromSignedUrl() takes a user-controlled URL from the Dropbox flow.
+// Without restrictions, an attacker could submit
+//   externalDownloadUrl: "http://100.86.236.11:9099/..."
+// and probe internal Tailscale services (mira-pipeline, atlas-api, ollama)
+// or AWS metadata endpoints (169.254.169.254).
+//
+// Defense:
+//   1. https only — no http, no file:, no ftp:
+//   2. Hostname must end with an allowlisted suffix (Dropbox / Google)
+//   3. Hostname must NOT be an IP literal (defense against IP-literal probes)
+//   4. If hostname IS an IP literal somehow, it must NOT be in private ranges
+//   5. On redirect, re-validate the Location URL (caller wraps with redirect: "manual")
+import { isIP } from "node:net";
+
+// Suffixes — leading "." ensures we match subdomains AND the apex.
+// e.g. ".dropbox.com" matches "uc.dropbox.com" but NOT "evildropbox.com".
+const ALLOWED_HOST_SUFFIXES = [
+  ".dropbox.com",
+  ".dropboxusercontent.com",
+  ".googleusercontent.com",
+];
+
+export class SsrfBlockedError extends Error {
+  url: string;
+  reason: string;
+  constructor(url: string, reason: string) {
+    super(`ssrf_blocked: ${reason} (url=${url})`);
+    this.name = "SsrfBlockedError";
+    this.url = url;
+    this.reason = reason;
+  }
+}
+
+function hostMatchesAllowlist(host: string): boolean {
+  const normalized = host.toLowerCase();
+  return ALLOWED_HOST_SUFFIXES.some((suffix) => {
+    // suffix is ".dropbox.com" — match "X.dropbox.com" or "dropbox.com" exactly.
+    const apex = suffix.slice(1);
+    return normalized === apex || normalized.endsWith(suffix);
+  });
+}
+
+function isPrivateIPv4(ip: string): boolean {
+  const parts = ip.split(".").map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((p) => Number.isNaN(p))) return false;
+  const [a, b] = parts;
+  // 10/8
+  if (a === 10) return true;
+  // 172.16/12
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168/16
+  if (a === 192 && b === 168) return true;
+  // 127/8 loopback
+  if (a === 127) return true;
+  // 169.254/16 link-local (covers AWS metadata 169.254.169.254)
+  if (a === 169 && b === 254) return true;
+  // 100.64/10 CGNAT (Tailscale)
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  // 0/8
+  if (a === 0) return true;
+  return false;
+}
+
+function isPrivateIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  // ::1 loopback (after dropping brackets / leading zeros)
+  if (lower === "::1" || lower === "0:0:0:0:0:0:0:1") return true;
+  // fc00::/7 ULA — first hex char is f, second is c or d
+  if (/^f[cd]/.test(lower)) return true;
+  // fe80::/10 link-local
+  if (/^fe[89ab]/.test(lower)) return true;
+  return false;
+}
+
+/**
+ * Validate a URL is safe to fetch from a server-side handler.
+ *
+ * Throws SsrfBlockedError on rejection. Returns the parsed URL on success.
+ */
+export function assertSafeUrl(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new SsrfBlockedError(rawUrl, "invalid_url");
+  }
+  if (parsed.protocol !== "https:") {
+    throw new SsrfBlockedError(rawUrl, `non_https_protocol: ${parsed.protocol}`);
+  }
+  // hostname includes brackets stripped for IPv6 — check with isIP first
+  const host = parsed.hostname;
+  const ipFamily = isIP(host);
+  if (ipFamily !== 0) {
+    // Hostname IS an ip literal. Even if not private, it bypasses the
+    // allowlist by design — reject all IP literals.
+    if (ipFamily === 4 && isPrivateIPv4(host)) {
+      throw new SsrfBlockedError(rawUrl, `private_ipv4: ${host}`);
+    }
+    if (ipFamily === 6 && isPrivateIPv6(host)) {
+      throw new SsrfBlockedError(rawUrl, `private_ipv6: ${host}`);
+    }
+    throw new SsrfBlockedError(rawUrl, `ip_literal_host_not_allowed: ${host}`);
+  }
+  if (!hostMatchesAllowlist(host)) {
+    throw new SsrfBlockedError(rawUrl, `host_not_allowlisted: ${host}`);
+  }
+  return parsed;
+}
+
+// Exported for unit tests
+export const _internals = {
+  hostMatchesAllowlist,
+  isPrivateIPv4,
+  isPrivateIPv6,
+};


### PR DESCRIPTION
## Summary
- New \`mira-hub/src/lib/ssrf-guard.ts\` — \`assertSafeUrl(url)\` rejects non-https, IP literals, all private IPv4/IPv6 ranges, and any host not on the allowlist
- \`streamFromSignedUrl\` now uses \`redirect: \"manual\"\` and re-validates every \`Location\` against \`assertSafeUrl\` (3-redirect cap)
- Allowlist: \`.dropbox.com\`, \`.dropboxusercontent.com\`, \`.googleusercontent.com\`
- Closes #696

## Why
\`streamFromSignedUrl\` takes user-controlled \`externalDownloadUrl\` from the Dropbox flow. Without restrictions, attacker submits \`http://100.86.236.11:9099/...\` (Tailscale IP for mira-pipeline) or \`http://169.254.169.254/latest/meta-data/...\` (AWS metadata) and the server-side fetch happily probes internal services on the attacker's behalf.

## Defense layers
1. **Protocol** — https only
2. **Hostname allowlist** — leading-dot suffix match (\`.dropbox.com\` matches \`uc.dropbox.com\` but NOT \`evildropbox.com\`)
3. **IP literal block** — any IPv4/IPv6 hostname is rejected (allowlist hosts never resolve to literals in URLs)
4. **Private range block** — 10/8, 172.16/12, 192.168/16, 127/8, 169.254/16, 100.64/10, 0/8, ::1, fc00::/7, fe80::/10
5. **Manual redirect** — 302 from \`dropboxusercontent.com\` → \`169.254.169.254\` re-validates and rejects

## What's NOT changed
\`streamFromGoogleDrive\` — its URL is hardcoded against \`googleapis.com\` and not user-controllable. Adding the same guard there would be belt-and-suspenders without value.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] CI green
- [ ] Manual: real Dropbox upload still works
- [ ] Manual: \`assertSafeUrl(\"http://100.86.236.11:9099/test\")\` throws \`ssrf_blocked: non_https_protocol\`
- [ ] Manual: \`assertSafeUrl(\"https://169.254.169.254/...\")\` throws \`ssrf_blocked: ip_literal_host_not_allowed\`
- [ ] Manual: \`assertSafeUrl(\"https://evildropbox.com/...\")\` throws \`ssrf_blocked: host_not_allowlisted\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)