### PR TITLE
feat(hub): cloud-source upload idempotency

### DIFF
--- a/mira-hub/src/app/api/uploads/route.ts
+++ b/mira-hub/src/app/api/uploads/route.ts
@@ -2,8 +2,10 @@ import { NextRequest, NextResponse } from "next/server";
 import { randomUUID } from "node:crypto";
 import {
   createUpload,
+  findUploadByExternalFileId,
   listUploads,
   updateUploadStatus,
+  type Upload,
   type UploadProvider,
 } from "@/lib/uploads";
 import { ensureFreshAccessToken } from "@/lib/token-refresh";
@@ -90,19 +92,49 @@ export async function POST(req: NextRequest) {
   const kind = inferKindFromMime(mime);
   const requestId = req.headers.get("x-request-id") ?? randomUUID();
 
-  const upload = await createUpload({
-    tenantId: ctx.tenantId,
-    provider: body.provider,
-    kind,
-    externalFileId: body.externalFileId ?? null,
-    externalDownloadUrl: body.externalDownloadUrl ?? null,
-    filename: body.filename,
-    mimeType: mime,
-    sizeBytes: body.sizeBytes ?? null,
-    externalCreatedAt: body.externalCreatedAt ?? null,
-    initialStatus: "queued",
-    assetTag,
-  });
+  // Idempotency: re-picking the same Drive/Dropbox file should return the
+  // existing row, not duplicate the entire fetch → forward → KB pipeline.
+  // body.externalFileId is required for both google + dropbox per the
+  // validation above.
+  if (body.externalFileId) {
+    const existing = await findUploadByExternalFileId(
+      ctx.tenantId,
+      body.provider,
+      body.externalFileId,
+    );
+    if (existing) {
+      return idempotentResponse(existing, requestId);
+    }
+  }
+
+  let upload: Upload;
+  try {
+    upload = await createUpload({
+      tenantId: ctx.tenantId,
+      provider: body.provider,
+      kind,
+      externalFileId: body.externalFileId ?? null,
+      externalDownloadUrl: body.externalDownloadUrl ?? null,
+      filename: body.filename,
+      mimeType: mime,
+      sizeBytes: body.sizeBytes ?? null,
+      externalCreatedAt: body.externalCreatedAt ?? null,
+      initialStatus: "queued",
+      assetTag,
+    });
+  } catch (err) {
+    // Race fallback: another request beat us to the unique index between
+    // the pre-flight findUploadByExternalFileId() and the INSERT.
+    if (isUniqueViolation(err) && body.externalFileId) {
+      const existing = await findUploadByExternalFileId(
+        ctx.tenantId,
+        body.provider,
+        body.externalFileId,
+      );
+      if (existing) return idempotentResponse(existing, requestId);
+    }
+    throw err;
+  }
 
   const log = makeUploadLogger({ requestId, uploadId: upload.id, tenantId: ctx.tenantId });
   log.log("queued", {
@@ -121,6 +153,43 @@ export async function POST(req: NextRequest) {
   void runIngestPipeline(upload.id, body, kind, ctx.tenantId, requestId, assetTag);
 
   return NextResponse.json(upload, { status: 201, headers: { "X-Request-Id": requestId } });
+}
+
+const IN_FLIGHT_STATUSES: ReadonlyArray<string> = ["queued", "fetching", "parsing"];
+
+function isUniqueViolation(err: unknown): boolean {
+  // pg's UniqueViolation has SQLSTATE 23505
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: string }).code === "23505"
+  );
+}
+
+function idempotentResponse(existing: Upload, requestId: string): NextResponse {
+  if (existing.status === "parsed") {
+    return NextResponse.json(
+      { ...existing, alreadyImported: true },
+      { status: 200, headers: { "X-Request-Id": requestId } },
+    );
+  }
+  if (IN_FLIGHT_STATUSES.includes(existing.status)) {
+    return NextResponse.json(
+      { ...existing, alreadyInProgress: true },
+      { status: 200, headers: { "X-Request-Id": requestId } },
+    );
+  }
+  // failed or cancelled — caller should DELETE first to retry
+  return NextResponse.json(
+    {
+      error: "previous_upload_terminal",
+      status: existing.status,
+      hint: "DELETE /hub/api/uploads/:id then re-upload",
+      existing,
+    },
+    { status: 409, headers: { "X-Request-Id": requestId } },
+  );
 }
 
 export async function GET() {

--- a/mira-hub/src/lib/uploads.ts
+++ b/mira-hub/src/lib/uploads.ts
@@ -71,6 +71,14 @@ export function ensureUploadsSchema(): Promise<void> {
       CREATE INDEX IF NOT EXISTS idx_hub_uploads_tenant_status
         ON hub_uploads (tenant_id, status, created_at DESC)
     `);
+    // Idempotency for cloud-source uploads (#700) — re-picking the same
+    // Drive/Dropbox file should return the existing row, not duplicate
+    // the entire fetch → forward → KB pipeline.
+    await pool.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_hub_uploads_dedup
+        ON hub_uploads (tenant_id, provider, external_file_id)
+        WHERE external_file_id IS NOT NULL
+    `);
   })();
   return schemaReady;
 }
@@ -170,6 +178,29 @@ export async function getUpload(
   const { rows } = await pool.query(
     `SELECT * FROM hub_uploads WHERE id = $1 AND tenant_id = $2 LIMIT 1`,
     [id, tenantId],
+  );
+  return rows[0] ? rowToUpload(rows[0]) : null;
+}
+
+/**
+ * Look up an existing upload by its cloud-source identity (tenant + provider
+ * + external_file_id). Returns null when none exists. Used for idempotency
+ * (#700) — re-picking the same Drive/Dropbox file finds the prior row
+ * instead of duplicating the pipeline.
+ */
+export async function findUploadByExternalFileId(
+  tenantId: string,
+  provider: UploadProvider,
+  externalFileId: string,
+): Promise<Upload | null> {
+  await ensureUploadsSchema();
+  const { rows } = await pool.query(
+    `SELECT * FROM hub_uploads
+       WHERE tenant_id = $1
+         AND provider = $2
+         AND external_file_id = $3
+       LIMIT 1`,
+    [tenantId, provider, externalFileId],
   );
   return rows[0] ? rowToUpload(rows[0]) : null;
 }


### PR DESCRIPTION
## Summary
- New \`UNIQUE INDEX idx_hub_uploads_dedup ON (tenant_id, provider, external_file_id) WHERE external_file_id IS NOT NULL\` — additive, idempotent (CREATE INDEX IF NOT EXISTS)
- New \`findUploadByExternalFileId()\` helper in \`mira-hub/src/lib/uploads.ts\`
- Cloud upload route does pre-flight lookup; on hit returns existing row with status flag (\`alreadyImported\` / \`alreadyInProgress\`) or 409 (failed/cancelled — DELETE first to retry)
- Race fallback: catches SQLSTATE 23505 and returns the winner
- Closes #700

## Why
Re-picking the same Drive/Dropbox file used to run the whole \`fetch → forward → KB extract\` pipeline twice — wasted bandwidth, duplicate KB chunks, double the Doppler-tracked API quota burn. Worse: the user got \"successfully uploaded\" twice but only one of the chunks set was newly searchable, leading to confusing retrieval.

## Behavior matrix
| Existing status | Response |
|-----------------|----------|
| (no row) | normal 201 — pipeline runs |
| \`parsed\` | 200 + \`{alreadyImported: true}\` |
| \`queued\` / \`fetching\` / \`parsing\` | 200 + \`{alreadyInProgress: true}\` |
| \`failed\` / \`cancelled\` | 409 + \`{error: \"previous_upload_terminal\", hint: \"DELETE first to retry\"}\` |

Local uploads have no \`external_file_id\` and are unaffected.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] CI green
- [ ] Manual: upload same Drive file twice → second returns \`alreadyImported\`
- [ ] Manual: re-upload while first still parsing → second returns \`alreadyInProgress\`
- [ ] Manual: re-upload after first failed → 409 with hint
- [ ] Manual: DELETE then re-upload → succeeds (clean retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)