### PR TITLE
fix(hub): /assets no longer redirects to login for authenticated users — closes #686

### DIFF
--- a/mira-hub/src/app/(hub)/assets/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, Suspense } from "react";
-import { useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import {
@@ -394,6 +394,7 @@ function AssetsPageInner() {
   const t = useTranslations("assets");
   const tCommon = useTranslations("common");
   const searchParams = useSearchParams();
+  const router = useRouter();
 
   const [assets, setAssets] = useState<Asset[]>([]);
   const [loading, setLoading] = useState(true);
@@ -412,7 +413,7 @@ function AssetsPageInner() {
     fetch("/hub/api/assets")
       .then(r => {
         if (r.status === 401) {
-          window.location.href = "/hub/login?callbackUrl=/hub/assets";
+          router.push("/login?callbackUrl=/hub/assets");
           return null;
         }
         return r.json();

--- a/mira-hub/src/lib/session.ts
+++ b/mira-hub/src/lib/session.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { getServerSession } from "next-auth/next";
-import { authOptions } from "@/auth";
+import { getToken } from "next-auth/jwt";
+import { cookies } from "next/headers";
 
 export interface SessionContext {
   userId: string;
@@ -15,15 +15,31 @@ export class UnauthorizedError extends Error {
   }
 }
 
+// Use getToken + next/headers cookies instead of getServerSession.
+// In Next.js 16+ the headers/cookies APIs are async; getServerSession from
+// next-auth v4 was written for synchronous headers() and can silently return
+// null in App Router Route Handlers on Next.js 16, causing false 401s for
+// authenticated users.  getToken with the raw cookie store is the same
+// mechanism the middleware already uses reliably.
 export async function requireSession(): Promise<SessionContext> {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.id || !session.user.tenantId) {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.getAll()
+    .map(c => `${c.name}=${c.value}`)
+    .join("; ");
+
+  const token = await getToken({
+    req: { headers: { cookie: cookieHeader } } as Parameters<typeof getToken>[0]["req"],
+    secret: process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET || "",
+  });
+
+  if (!token?.uid || !token?.tid) {
     throw new UnauthorizedError();
   }
+
   return {
-    userId: session.user.id,
-    tenantId: session.user.tenantId,
-    email: session.user.email,
+    userId: token.uid as string,
+    tenantId: token.tid as string,
+    email: (token.email as string) ?? "",
   };
 }
 
@@ -44,11 +60,9 @@ export async function sessionOr401(): Promise<SessionContext | NextResponse> {
 }
 
 export async function getSessionOrNull(): Promise<SessionContext | null> {
-  const session = await getServerSession(authOptions);
-  if (!session?.user?.id || !session.user.tenantId) return null;
-  return {
-    userId: session.user.id,
-    tenantId: session.user.tenantId,
-    email: session.user.email,
-  };
+  try {
+    return await requireSession();
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Root cause
`getServerSession()` from next-auth v4 uses the **synchronous** `headers()` API internally. Next.js 16 made `headers()` and `cookies()` **async**. In App Router Route Handlers this caused `getServerSession` to read empty cookies, return `null`, and emit a false 401 — even when the user had a perfectly valid JWT session. The middleware (`getToken`) worked fine because it has its own cookie-reading path.

## Fix

### `lib/session.ts`
- Replaces `getServerSession(authOptions)` with `getToken` from `next-auth/jwt`, feeding it cookies from the async `cookies()` API from `next/headers`
- Same mechanism the middleware uses — guaranteed correct in Next.js 16
- `getSessionOrNull` now delegates to `requireSession` (DRY, same logic)

### `assets/page.tsx`
- Replaces `window.location.href = "/hub/login?..."` (hard page reload, breaks Back button) with `router.push("/login?callbackUrl=/hub/assets")` — proper Next.js client-side navigation

## Test plan
- [ ] Build clean ✅
- [ ] Playwright: login → navigate to /hub/assets → API returns 200, page shows asset grid
- [ ] Playwright: no redirect to /login observed

Closes #686

🤖 Generated with [Claude Code](https://claude.ai/claude-code)