### PR TITLE
fix(hub): detect __Secure- cookie name for HTTPS — really closes #686

### DIFF
--- a/mira-hub/src/lib/session.ts
+++ b/mira-hub/src/lib/session.ts
@@ -21,8 +21,17 @@ export class UnauthorizedError extends Error {
 // null in App Router Route Handlers on Next.js 16, causing false 401s for
 // authenticated users.  getToken with the raw cookie store is the same
 // mechanism the middleware already uses reliably.
+//
+// Cookie name: next-auth v4 uses __Secure- prefix on HTTPS. Detect which
+// cookie is actually present rather than relying on NEXTAUTH_URL or req.url
+// (both absent when constructing a fake req from next/headers cookies).
 export async function requireSession(): Promise<SessionContext> {
   const cookieStore = await cookies();
+
+  const SECURE_NAME = "__Secure-next-auth.session-token";
+  const REGULAR_NAME = "next-auth.session-token";
+  const cookieName = cookieStore.get(SECURE_NAME) ? SECURE_NAME : REGULAR_NAME;
+
   const cookieHeader = cookieStore.getAll()
     .map(c => `${c.name}=${c.value}`)
     .join("; ");
@@ -30,6 +39,7 @@ export async function requireSession(): Promise<SessionContext> {
   const token = await getToken({
     req: { headers: { cookie: cookieHeader } } as Parameters<typeof getToken>[0]["req"],
     secret: process.env.AUTH_SECRET || process.env.NEXTAUTH_SECRET || "",
+    cookieName,
   });
 
   if (!token?.uid || !token?.tid) {


### PR DESCRIPTION
## Root cause

PR #739 switched `requireSession()` from `getServerSession` to `getToken` — correct approach. But `getToken` defaults `secureCookie=false` when the synthetic `req` has no `url`. In production (HTTPS), next-auth v4 stores the JWT as `__Secure-next-auth.session-token`. With `secureCookie=false`, `getToken` reads `next-auth.session-token` which doesn't exist on HTTPS → still returns null → still 401.

## Fix

Detect which cookie is actually present in the store and pass it as `cookieName` explicitly. Works for both dev (HTTP, plain name) and prod (HTTPS, `__Secure-` prefix).

## Test plan
- [ ] Deploy to VPS
- [ ] Playwright: login → navigate to /hub/assets → confirm stays on assets page (no login redirect)
- [ ] Screenshot proof saved to test-results/

🤖 Generated with [Claude Code](https://claude.com/claude-code)