### PR TITLE
fix(hub): usage page crash + blank chart — closes #687 #717

### DIFF
--- a/mira-hub/src/app/(hub)/usage/page.tsx
+++ b/mira-hub/src/app/(hub)/usage/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { BarChart2, Zap, MessageSquare, Users, TrendingUp, Calendar } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { Zap, MessageSquare, Users, TrendingUp, Calendar } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
   BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer,
@@ -23,6 +24,11 @@ function initials(name: string) {
 
 export default function UsagePage() {
   const t = useTranslations("usage");
+  const router = useRouter();
+  // mounted guard: recharts ResponsiveContainer accesses DOM APIs (ResizeObserver,
+  // getBoundingClientRect) that don't exist during server pre-render. Rendering
+  // charts before mount causes hydration mismatches and blank boxes on hard reload.
+  const [mounted, setMounted] = useState(false);
   const [data, setData] = useState<{
     thisMonth: { totalActions: number; uniqueTechs: number; activeChannels: number; diagnostics: number; safetyAlerts: number };
     daily: { day: string; count: number }[];
@@ -31,9 +37,17 @@ export default function UsagePage() {
     allTime: { totalWorkOrders: number; totalKbChunks: number };
   } | null>(null);
 
+  useEffect(() => { setMounted(true); }, []);
+
   useEffect(() => {
-    fetch("/hub/api/usage").then(r => r.json()).then(setData).catch(console.error);
-  }, []);
+    fetch("/hub/api/usage")
+      .then(r => {
+        if (r.status === 401) { router.push("/login?callbackUrl=/hub/usage"); return null; }
+        return r.json();
+      })
+      .then(d => { if (d) setData(d); })
+      .catch(console.error);
+  }, [router]);
 
   const month = data?.thisMonth;
   const usedThisMonth = month?.totalActions ?? 0;
@@ -96,7 +110,7 @@ export default function UsagePage() {
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
           {[
             { label: t("kpi.totalActions"),   value: usedThisMonth.toString(),  Icon: Zap,          color: "#2563EB" },
-            { label: t("kpi.conversations"),  value: (data?.allTime.totalWorkOrders ?? 0).toString(), Icon: MessageSquare, color: "#7C3AED" },
+            { label: t("kpi.conversations"),  value: (data?.allTime?.totalWorkOrders ?? 0).toString(), Icon: MessageSquare, color: "#7C3AED" },
             { label: t("kpi.activeTechs"),    value: (month?.uniqueTechs ?? 0).toString(),    Icon: Users,         color: "#16A34A" },
             { label: t("kpi.avgPerDay"),      value: dailyChartData.length ? Math.round(dailyChartData.reduce((s,d) => s+d.actions, 0) / dailyChartData.length).toString() : "0", Icon: TrendingUp, color: "#0891B2" },
           ].map(kpi => (
@@ -116,18 +130,29 @@ export default function UsagePage() {
             <Calendar className="w-4 h-4" style={{ color: "var(--brand-blue)" }} />
             <p className="text-sm font-semibold" style={{ color: "var(--foreground)" }}>{t("dailyActions")}</p>
           </div>
-          <ResponsiveContainer width="100%" height={160}>
-            <BarChart data={dailyChartData} barSize={24}>
-              <XAxis dataKey="day" tick={{ fontSize: 11, fill: "var(--foreground-subtle)" }} axisLine={false} tickLine={false} />
-              <YAxis hide />
-              <Tooltip
-                contentStyle={{ backgroundColor: "var(--surface-1)", border: "1px solid var(--border)", borderRadius: 8, fontSize: 12 }}
-                labelStyle={{ color: "var(--foreground)" }}
-                itemStyle={{ color: "var(--brand-blue)" }}
-              />
-              <Bar dataKey="actions" fill="var(--brand-blue)" radius={[4, 4, 0, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
+          {/* Guard: recharts ResponsiveContainer uses ResizeObserver/getBoundingClientRect
+              which are browser-only. Rendering before mount causes hydration mismatches
+              and blank charts on hard reload. Show a placeholder until mounted. */}
+          {!mounted ? (
+            <div style={{ height: 160, backgroundColor: "var(--surface-1)" }} className="rounded-lg animate-pulse" />
+          ) : dailyChartData.length === 0 ? (
+            <div className="flex items-center justify-center" style={{ height: 160 }}>
+              <p className="text-xs" style={{ color: "var(--foreground-subtle)" }}>No activity in the last 7 days</p>
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height={160}>
+              <BarChart data={dailyChartData} barSize={24}>
+                <XAxis dataKey="day" tick={{ fontSize: 11, fill: "var(--foreground-subtle)" }} axisLine={false} tickLine={false} />
+                <YAxis hide />
+                <Tooltip
+                  contentStyle={{ backgroundColor: "var(--surface-1)", border: "1px solid var(--border)", borderRadius: 8, fontSize: 12 }}
+                  labelStyle={{ color: "var(--foreground)" }}
+                  itemStyle={{ color: "var(--brand-blue)" }}
+                />
+                <Bar dataKey="actions" fill="var(--brand-blue)" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          )}
         </div>
 
         {/* By type + by channel */}
@@ -138,9 +163,9 @@ export default function UsagePage() {
               <div className="space-y-2 pt-2">
                 {[
                   { name: "Diagnostics",   value: month.diagnostics,    color: "#EAB308" },
-                  { name: "Work Orders",   value: data?.allTime.totalWorkOrders ?? 0, color: "#2563EB" },
+                  { name: "Work Orders",   value: data?.allTime?.totalWorkOrders ?? 0, color: "#2563EB" },
                   { name: "Safety Alerts", value: month.safetyAlerts,   color: "#DC2626" },
-                  { name: "KB Chunks",     value: data?.allTime.totalKbChunks ?? 0,  color: "#0891B2" },
+                  { name: "KB Chunks",     value: data?.allTime?.totalKbChunks ?? 0,  color: "#0891B2" },
                 ].map(item => (
                   <div key={item.name} className="flex items-center gap-2">
                     <span className="w-2.5 h-2.5 rounded-full flex-shrink-0" style={{ backgroundColor: item.color }} />
@@ -158,6 +183,7 @@ export default function UsagePage() {
             <p className="text-sm font-semibold mb-3" style={{ color: "var(--foreground)" }}>{t("byChannel")}</p>
             {byChannelData.length > 0 ? (
               <>
+                {mounted && (
                 <ResponsiveContainer width="100%" height={140}>
                   <PieChart>
                     <Pie data={byChannelData} dataKey="value" cx="50%" cy="50%" innerRadius={40} outerRadius={60}>
@@ -170,6 +196,7 @@ export default function UsagePage() {
                     />
                   </PieChart>
                 </ResponsiveContainer>
+                )}
                 <div className="space-y-1.5 mt-2">
                   {byChannelData.map(item => (
                     <div key={item.name} className="flex items-center gap-2">

--- a/mira-hub/tests/e2e/repro-687.spec.ts
+++ b/mira-hub/tests/e2e/repro-687.spec.ts
@@ -1,0 +1,32 @@
+import { test } from "@playwright/test";
+import path from "path";
+import fs from "fs";
+
+const HUB = "https://app.factorylm.com/hub";
+const CREDS = { email: "playwright@factorylm.com", password: "TestPass123" };
+
+test("repro #687/#717 — /usage hard reload + chart blank", async ({ page }) => {
+  const errors: string[] = [];
+  const apiCalls: { url: string; status: number }[] = [];
+  page.on("pageerror", e => errors.push(e.message));
+  page.on("console", m => { if (m.type() === "error") errors.push(`[console] ${m.text()}`); });
+  page.on("response", r => { if (r.url().includes("/api/")) apiCalls.push({ url: r.url(), status: r.status() }); });
+
+  await page.goto(`${HUB}/login`, { waitUntil: "domcontentloaded" });
+  await page.fill('input[type="email"]', CREDS.email);
+  await page.fill('input[type="password"]', CREDS.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/hub\/feed\/?/, { timeout: 25_000 });
+  console.log("Logged in:", page.url());
+
+  // Navigate to usage (simulates hard reload — goto is a fresh navigation)
+  await page.goto(`${HUB}/usage`, { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(4000);
+
+  console.log("URL:", page.url());
+  console.log("Errors:", JSON.stringify(errors, null, 2));
+  console.log("API:", JSON.stringify(apiCalls, null, 2));
+
+  fs.mkdirSync(path.join(__dirname, "../../test-results/repro-687"), { recursive: true });
+  await page.screenshot({ path: path.join(__dirname, "../../test-results/repro-687/usage-before-fix.png"), fullPage: true });
+});


### PR DESCRIPTION
## Fixes #687 and #717

### #687 — crash on hard reload

`data?.allTime.totalWorkOrders` was missing the second `?.`. When the API returned an error payload (e.g. `{error: "Unauthorized"}` from a pre-session-fix 401), `data?.allTime` was `undefined` and `.totalWorkOrders` threw a TypeError, crashing the component.

- Fixed all three occurrences: `data?.allTime?.totalWorkOrders`, `data?.allTime?.totalKbChunks`
- Added 401 redirect (`router.push("/login?callbackUrl=/hub/usage")`) so unauthenticated users are redirected cleanly instead of getting a broken state

### #717 — Daily Actions chart blank white box

`ResponsiveContainer` from recharts uses `ResizeObserver` and `getBoundingClientRect` to measure its container. These are browser-only. Next.js App Router pre-renders client components on the server — recharts renders with `width=0`. On hydration the real width kicks in, causing a server/client mismatch that leaves the chart blank.

- Added `mounted` state guard (`useState(false)` + `useEffect(() => setMounted(true), [])`) — charts only render after hydration. A skeleton placeholder with the correct height shows during SSR to prevent layout shift.
- When `dailyChartData` is empty (new tenants with no MIRA activity), shows "No activity in the last 7 days" instead of a blank recharts SVG
- Same `mounted` guard applied to PieChart for consistency

## Test plan
- [ ] Deploy to VPS
- [ ] Playwright: hard-reload /hub/usage → page loads, no crash, chart shows data or "No activity" message
- [ ] Screenshot proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)