### PR TITLE
feat(hub): login gate + 7-day trial + magic link + pricing — closes #741, #747

### DIFF
--- a/mira-hub/src/app/(hub)/admin/users/page.tsx
+++ b/mira-hub/src/app/(hub)/admin/users/page.tsx
@@ -1,209 +1,175 @@
 "use client";
 
-import { useState } from "react";
-import Link from "next/link";
-import { UserPlus, Search, MoreHorizontal, CheckCircle2, XCircle, ShieldCheck } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { useState, useEffect } from "react";
+import { Search, CheckCircle2, XCircle, ShieldCheck, Clock, Loader2, Zap } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { useTranslations } from "next-intl";
 
-type User = {
+type ApiUser = {
   id: string;
-  name: string;
+  name: string | null;
   email: string;
-  role: "admin" | "manager" | "scheduler" | "technician" | "operator";
-  dept: string;
-  lastActive: string;
-  active: boolean;
+  status: string;
+  plan: string | null;
+  trialExpiresAt: string | null;
+  role: string;
 };
 
-const ROLE_BADGE: Record<User["role"], "red" | "inprogress" | "secondary" | "green" | "yellow"> = {
-  admin:      "red",
-  manager:    "inprogress",
-  scheduler:  "yellow",
-  technician: "green",
-  operator:   "secondary",
+const STATUS_CONFIG: Record<string, { label: string; color: string; bg: string; Icon: typeof CheckCircle2 }> = {
+  admin:    { label: "Admin",    color: "#EF4444", bg: "rgba(239,68,68,0.1)",    Icon: ShieldCheck },
+  approved: { label: "Approved", color: "#22C55E", bg: "rgba(34,197,94,0.1)",    Icon: CheckCircle2 },
+  trial:    { label: "Trial",    color: "#60A5FA", bg: "rgba(96,165,250,0.1)",    Icon: Zap },
+  pending:  { label: "Pending",  color: "#EAB308", bg: "rgba(234,179,8,0.1)",     Icon: Clock },
+  expired:  { label: "Expired",  color: "#94A3B8", bg: "rgba(148,163,184,0.1)",   Icon: XCircle },
 };
 
-const INITIAL_USERS: User[] = [
-  { id: "U-001", name: "Mike Harper",  email: "mike@factorylm.com",  role: "admin",      dept: "Maintenance", lastActive: "2026-04-22", active: true },
-  { id: "U-002", name: "John Smith",   email: "john@factorylm.com",  role: "technician", dept: "Mechanical",  lastActive: "2026-04-22", active: true },
-  { id: "U-003", name: "Sara Kim",     email: "sara@factorylm.com",  role: "operator",   dept: "Production",  lastActive: "2026-04-21", active: true },
-  { id: "U-004", name: "Dave Torres",  email: "dave@factorylm.com",  role: "scheduler",  dept: "Maintenance", lastActive: "2026-04-20", active: true },
-  { id: "U-005", name: "Lisa Wong",    email: "lisa@factorylm.com",  role: "manager",    dept: "Engineering", lastActive: "2026-04-19", active: true },
-  { id: "U-006", name: "Ray Patel",    email: "ray@factorylm.com",   role: "technician", dept: "Electrical",  lastActive: "2026-04-18", active: true },
-  { id: "U-007", name: "Tom Nguyen",   email: "tom@factorylm.com",   role: "technician", dept: "Mechanical",  lastActive: "2026-04-10", active: false },
-];
+function daysLeft(isoDate: string): number {
+  return Math.max(0, Math.ceil((new Date(isoDate).getTime() - Date.now()) / 86_400_000));
+}
 
 export default function AdminUsersPage() {
   const t = useTranslations("admin");
-  const tStatus = useTranslations("status");
-  const tCommon = useTranslations("common");
-
-  const [users, setUsers] = useState<User[]>(INITIAL_USERS);
+  const [users, setUsers] = useState<ApiUser[]>([]);
+  const [loading, setLoading] = useState(true);
   const [query, setQuery] = useState("");
-  const [showInvite, setShowInvite] = useState(false);
-  const [inviteEmail, setInviteEmail] = useState("");
-  const [inviteRole, setInviteRole] = useState<User["role"]>("technician");
-  const [menuOpen, setMenuOpen] = useState<string | null>(null);
+  const [updating, setUpdating] = useState<string | null>(null);
+
+  async function loadUsers() {
+    const res = await fetch("/hub/api/admin/users");
+    if (!res.ok) return;
+    const { users: data } = await res.json() as { users: ApiUser[] };
+    setUsers(data);
+    setLoading(false);
+  }
+
+  useEffect(() => { loadUsers(); }, []);
+
+  async function setStatus(id: string, status: string) {
+    setUpdating(id);
+    await fetch(`/hub/api/admin/users/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status }),
+    });
+    await loadUsers();
+    setUpdating(null);
+  }
 
   const visible = users.filter(u =>
-    !query || u.name.toLowerCase().includes(query.toLowerCase()) || u.email.toLowerCase().includes(query.toLowerCase())
+    !query || (u.name ?? u.email).toLowerCase().includes(query.toLowerCase()) || u.email.toLowerCase().includes(query.toLowerCase())
   );
 
-  function toggleActive(id: string) {
-    setUsers(prev => prev.map(u => u.id === id ? { ...u, active: !u.active } : u));
-    setMenuOpen(null);
-  }
-
-  function sendInvite() {
-    if (!inviteEmail) return;
-    const newUser: User = {
-      id: `U-${String(users.length + 1).padStart(3, "0")}`,
-      name: inviteEmail.split("@")[0],
-      email: inviteEmail,
-      role: inviteRole,
-      dept: "—",
-      lastActive: "Invited",
-      active: false,
-    };
-    setUsers(prev => [...prev, newUser]);
-    setInviteEmail("");
-    setShowInvite(false);
-  }
-
-  const activeCount = users.filter(u => u.active).length;
+  const pendingCount = users.filter(u => u.status === "pending").length;
 
   return (
     <div className="min-h-full" style={{ backgroundColor: "var(--background)" }}>
-      {/* Header */}
       <div className="sticky top-0 z-20 border-b" style={{ backgroundColor: "var(--surface-0)", borderColor: "var(--border)" }}>
-        <div className="px-4 md:px-6 pt-3 pb-3">
-          <div className="flex items-center justify-between mb-2">
-            <div>
-              <h1 className="text-base font-semibold" style={{ color: "var(--foreground)" }}>{t("usersTab")}</h1>
-              <div className="flex gap-3 mt-0.5">
-                <span className="text-[11px]" style={{ color: "var(--foreground-subtle)" }}>{activeCount} {tStatus("active")} · {users.length - activeCount} {tStatus("inactive")}</span>
-              </div>
-            </div>
-            <Button size="sm" className="h-8 gap-1.5 text-xs" onClick={() => setShowInvite(true)}>
-              <UserPlus className="w-3.5 h-3.5" />{t("inviteUser")}
-            </Button>
-          </div>
-
-          {/* Role sub-nav */}
-          <div className="flex gap-4 text-xs border-t pt-2" style={{ borderColor: "var(--border)" }}>
-            <Link href="/admin/users" className="font-semibold pb-1 border-b-2" style={{ color: "var(--brand-blue)", borderColor: "var(--brand-blue)" }}>{t("usersTab")}</Link>
-            <Link href="/admin/roles" className="pb-1 border-b-2 border-transparent" style={{ color: "var(--foreground-muted)" }}>{t("rolesTab")}</Link>
+        <div className="px-4 md:px-6 py-3 flex items-center justify-between">
+          <div>
+            <h1 className="text-base font-semibold" style={{ color: "var(--foreground)" }}>{t("users.title")}</h1>
+            <p className="text-xs mt-0.5" style={{ color: "var(--foreground-muted)" }}>
+              {users.length} total{pendingCount > 0 && ` · ${pendingCount} pending review`}
+            </p>
           </div>
         </div>
       </div>
 
-      <div className="px-4 md:px-6 py-4 space-y-4">
-        {/* Invite form */}
-        {showInvite && (
-          <div className="card p-4 space-y-3">
-            <h3 className="text-sm font-semibold" style={{ color: "var(--foreground)" }}>{t("inviteUser")}</h3>
-            <Input placeholder={t("emailPlaceholder")} value={inviteEmail} onChange={e => setInviteEmail(e.target.value)} />
-            <div className="flex gap-2">
-              <select value={inviteRole} onChange={e => setInviteRole(e.target.value as User["role"])}
-                className="flex-1 text-xs px-3 py-2 rounded-lg border"
-                style={{ borderColor: "var(--border)", backgroundColor: "var(--surface-0)", color: "var(--foreground)" }}>
-                {(["technician","operator","scheduler","manager","admin"] as User["role"][]).map(r => (
-                  <option key={r} value={r}>{t(`roles.${r}`)}</option>
-                ))}
-              </select>
-              <Button size="sm" className="h-9" onClick={sendInvite}>{t("inviteUser")}</Button>
-              <Button size="sm" variant="outline" className="h-9" onClick={() => setShowInvite(false)}>{tCommon("cancel")}</Button>
-            </div>
-          </div>
-        )}
-
-        {/* Search */}
-        <div className="relative">
+      <div className="px-4 md:px-6 py-4 max-w-4xl mx-auto">
+        <div className="relative mb-4">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4" style={{ color: "var(--foreground-subtle)" }} />
-          <Input placeholder={`${tCommon("search")}…`} value={query} onChange={e => setQuery(e.target.value)} className="pl-9" />
+          <Input
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search users…"
+            className="pl-9 h-9"
+          />
         </div>
 
-        {/* Desktop table */}
-        <div className="hidden md:block card overflow-hidden">
-          <table className="w-full text-sm">
-            <thead style={{ backgroundColor: "var(--surface-1)", borderBottom: "1px solid var(--border)" }}>
-              <tr>
-                {[t("tableHeaders.user"), t("tableHeaders.role"), t("tableHeaders.department"), t("tableHeaders.lastActive"), tCommon("status"), ""].map(h => (
-                  <th key={h} className="px-4 py-3 text-left text-xs font-semibold" style={{ color: "var(--foreground-muted)" }}>{h}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody className="divide-y" style={{ borderColor: "var(--border)" }}>
-              {visible.map(u => (
-                <tr key={u.id} className="hover:bg-[var(--surface-1)] transition-colors">
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2.5">
-                      <div className="w-8 h-8 rounded-full flex items-center justify-center text-xs font-bold text-white flex-shrink-0"
-                        style={{ background: "linear-gradient(135deg, #2563EB, #0891B2)" }}>
-                        {u.name.split(" ").map(n => n[0]).join("")}
-                      </div>
-                      <div>
-                        <p className="text-sm font-medium" style={{ color: "var(--foreground)" }}>{u.name}</p>
-                        <p className="text-xs" style={{ color: "var(--foreground-subtle)" }}>{u.email}</p>
-                      </div>
-                    </div>
-                  </td>
-                  <td className="px-4 py-3">
-                    <Badge variant={ROLE_BADGE[u.role]} className="text-[10px]">{t(`roles.${u.role}`)}</Badge>
-                  </td>
-                  <td className="px-4 py-3 text-xs" style={{ color: "var(--foreground-muted)" }}>{u.dept}</td>
-                  <td className="px-4 py-3 text-xs" style={{ color: "var(--foreground-muted)" }}>{u.lastActive}</td>
-                  <td className="px-4 py-3">
-                    {u.active
-                      ? <span className="flex items-center gap-1 text-xs" style={{ color: "#16A34A" }}><CheckCircle2 className="w-3.5 h-3.5" />{tStatus("active")}</span>
-                      : <span className="flex items-center gap-1 text-xs" style={{ color: "#94A3B8" }}><XCircle className="w-3.5 h-3.5" />{tStatus("inactive")}</span>
-                    }
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="relative">
-                      <button onClick={() => setMenuOpen(menuOpen === u.id ? null : u.id)}
-                        className="p-1 rounded" style={{ color: "var(--foreground-subtle)" }}>
-                        <MoreHorizontal className="w-4 h-4" />
-                      </button>
-                      {menuOpen === u.id && (
-                        <div className="absolute right-0 top-6 z-10 card py-1 w-36 shadow-lg">
-                          <button onClick={() => toggleActive(u.id)}
-                            className="w-full text-left px-3 py-1.5 text-xs hover:bg-[var(--surface-1)] transition-colors"
-                            style={{ color: u.active ? "#DC2626" : "#16A34A" }}>
-                            {u.active ? tStatus("inactive") : tStatus("active")}
-                          </button>
-                        </div>
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="w-6 h-6 animate-spin" style={{ color: "var(--brand-blue)" }} />
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {visible.map(user => {
+              const cfg = STATUS_CONFIG[user.status] ?? STATUS_CONFIG.pending;
+              const StatusIcon = cfg.Icon;
+              return (
+                <div key={user.id} className="card p-3 flex items-center gap-3">
+                  <div className="w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0"
+                    style={{ background: "linear-gradient(135deg,#2563EB,#0891B2)", color: "white" }}>
+                    {(user.name ?? user.email)[0].toUpperCase()}
+                  </div>
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-sm font-medium truncate" style={{ color: "var(--foreground)" }}>
+                        {user.name ?? user.email}
+                      </span>
+                      {user.name && (
+                        <span className="text-xs truncate" style={{ color: "var(--foreground-muted)" }}>{user.email}</span>
                       )}
                     </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                    <div className="flex items-center gap-2 mt-0.5 flex-wrap">
+                      <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded"
+                        style={{ backgroundColor: cfg.bg, color: cfg.color }}>
+                        <StatusIcon className="w-3 h-3" />
+                        {cfg.label}
+                      </span>
+                      {user.status === "trial" && user.trialExpiresAt && (
+                        <span className="text-xs" style={{ color: "var(--foreground-subtle)" }}>
+                          {daysLeft(user.trialExpiresAt)}d left
+                        </span>
+                      )}
+                      {user.plan && (
+                        <span className="text-xs capitalize" style={{ color: "var(--foreground-subtle)" }}>{user.plan}</span>
+                      )}
+                    </div>
+                  </div>
 
-        {/* Mobile cards */}
-        <div className="md:hidden space-y-2">
-          {visible.map(u => (
-            <div key={u.id} className="card p-3 flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full flex items-center justify-center text-xs font-bold text-white flex-shrink-0"
-                style={{ background: "linear-gradient(135deg, #2563EB, #0891B2)" }}>
-                {u.name.split(" ").map(n => n[0]).join("")}
-              </div>
-              <div className="flex-1 min-w-0">
-                <p className="text-sm font-medium truncate" style={{ color: "var(--foreground)" }}>{u.name}</p>
-                <p className="text-[11px] truncate" style={{ color: "var(--foreground-subtle)" }}>{u.email}</p>
-                <div className="flex items-center gap-2 mt-1">
-                  <Badge variant={ROLE_BADGE[u.role]} className="text-[10px]">{t(`roles.${u.role}`)}</Badge>
-                  {!u.active && <span className="text-[10px]" style={{ color: "#94A3B8" }}>{tStatus("inactive")}</span>}
+                  <div className="flex items-center gap-1.5 flex-shrink-0">
+                    {updating === user.id ? (
+                      <Loader2 className="w-4 h-4 animate-spin" style={{ color: "var(--brand-blue)" }} />
+                    ) : user.status !== "admin" && (
+                      <>
+                        {user.status !== "approved" && (
+                          <button
+                            onClick={() => setStatus(user.id, "approved")}
+                            className="px-2.5 py-1 text-xs font-medium rounded-md transition-colors"
+                            style={{ backgroundColor: "rgba(34,197,94,0.1)", color: "#22C55E" }}
+                          >
+                            Approve
+                          </button>
+                        )}
+                        {user.status === "approved" && (
+                          <button
+                            onClick={() => setStatus(user.id, "pending")}
+                            className="px-2.5 py-1 text-xs font-medium rounded-md transition-colors"
+                            style={{ backgroundColor: "rgba(234,179,8,0.1)", color: "#EAB308" }}
+                          >
+                            Revoke
+                          </button>
+                        )}
+                        {user.status === "trial" && (
+                          <button
+                            onClick={() => setStatus(user.id, "expired")}
+                            className="px-2.5 py-1 text-xs font-medium rounded-md transition-colors"
+                            style={{ backgroundColor: "rgba(148,163,184,0.1)", color: "#94A3B8" }}
+                          >
+                            Expire
+                          </button>
+                        )}
+                      </>
+                    )}
+                  </div>
                 </div>
-              </div>
-            </div>
-          ))}
-        </div>
+              );
+            })}
+            {visible.length === 0 && !loading && (
+              <p className="text-center py-8 text-sm" style={{ color: "var(--foreground-subtle)" }}>No users found</p>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/mira-hub/src/app/(hub)/api/admin/users/[id]/route.ts
+++ b/mira-hub/src/app/(hub)/api/admin/users/[id]/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { updateUserStatus, type UserStatus } from "@/lib/users";
+import { requireSession, UnauthorizedError } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+const VALID_STATUSES: UserStatus[] = ["pending", "trial", "approved", "expired", "admin"];
+
+export async function PATCH(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const session = await requireSession();
+    if (session.status !== "admin") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    const { id } = await params;
+    const body = await req.json() as { status?: unknown };
+    const { status } = body;
+    if (!status || !VALID_STATUSES.includes(status as UserStatus)) {
+      return NextResponse.json({ error: "invalid status" }, { status: 400 });
+    }
+    await updateUserStatus(id, status as UserStatus);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "server error" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/(hub)/api/admin/users/route.ts
+++ b/mira-hub/src/app/(hub)/api/admin/users/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { listAllUsers } from "@/lib/users";
+import { requireSession, UnauthorizedError } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const session = await requireSession();
+    if (session.status !== "admin") {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+    const users = await listAllUsers();
+    return NextResponse.json({ users: users.map(u => ({
+      id: u.id,
+      email: u.email,
+      name: u.name,
+      status: u.status,
+      plan: u.plan,
+      trialExpiresAt: u.trialExpiresAt?.toISOString() ?? null,
+      role: u.role,
+    }))});
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "server error" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/(hub)/api/auth/check-approval/route.ts
+++ b/mira-hub/src/app/(hub)/api/auth/check-approval/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { findUserById } from "@/lib/users";
+import { requireSession, UnauthorizedError } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    const session = await requireSession();
+    const user = await findUserById(session.userId);
+    if (!user) return NextResponse.json({ error: "user not found" }, { status: 404 });
+    return NextResponse.json({ status: user.status, trialExpiresAt: user.trialExpiresAt?.toISOString() ?? null });
+  } catch (err) {
+    if (err instanceof UnauthorizedError) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    return NextResponse.json({ error: "server error" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/(hub)/api/auth/magic-link/route.ts
+++ b/mira-hub/src/app/(hub)/api/auth/magic-link/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { createMagicToken } from "@/lib/users";
+
+export const dynamic = "force-dynamic";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+async function sendMagicLinkEmail(email: string, token: string): Promise<void> {
+  const baseUrl = process.env.NEXTAUTH_URL ?? "https://app.factorylm.com/hub";
+  const magicUrl = `${baseUrl}/magic?token=${token}`;
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.warn("[magic-link] RESEND_API_KEY not set — skipping email send");
+    console.log("[magic-link] Magic URL:", magicUrl);
+    return;
+  }
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      from: "FactoryLM <noreply@factorylm.com>",
+      to: [email],
+      subject: "Your FactoryLM sign-in link",
+      html: `
+        <div style="font-family:Inter,sans-serif;max-width:480px;margin:0 auto;padding:32px 24px;background:#0F172A;color:#F1F5F9;border-radius:12px;">
+          <div style="margin-bottom:24px;">
+            <span style="font-size:24px;font-weight:700;color:#2563EB;">FactoryLM</span>
+          </div>
+          <h2 style="font-size:20px;font-weight:600;margin-bottom:8px;">Sign in to FactoryLM</h2>
+          <p style="color:#94A3B8;margin-bottom:24px;">Click the button below to sign in. This link expires in 15 minutes and can only be used once.</p>
+          <a href="${magicUrl}"
+             style="display:inline-block;padding:12px 28px;background:linear-gradient(135deg,#2563EB,#0891B2);color:#fff;text-decoration:none;border-radius:8px;font-weight:600;font-size:15px;">
+            Sign in to FactoryLM
+          </a>
+          <p style="color:#64748B;font-size:12px;margin-top:24px;">If you didn't request this link, you can safely ignore this email.</p>
+        </div>
+      `,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    console.error("[magic-link] Resend error:", res.status, body);
+    throw new Error("Failed to send magic link email");
+  }
+}
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON" }, { status: 400 });
+  }
+  const { email } = body as { email?: unknown };
+  if (typeof email !== "string" || !EMAIL_RE.test(email.trim())) {
+    return NextResponse.json({ error: "valid email required" }, { status: 400 });
+  }
+  try {
+    const token = await createMagicToken(email.trim().toLowerCase());
+    await sendMagicLinkEmail(email.trim(), token);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[magic-link]", err);
+    return NextResponse.json({ error: "failed to send magic link" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/(hub)/layout.tsx
+++ b/mira-hub/src/app/(hub)/layout.tsx
@@ -1,6 +1,7 @@
 import { Sidebar } from "@/components/layout/sidebar";
 import { BottomTabs } from "@/components/layout/bottom-tabs";
 import { MobileTopBar } from "@/components/layout/mobile-topbar";
+import { TrialBanner } from "@/components/trial-banner";
 
 // Force dynamic rendering on all (hub)/* pages so the auth middleware
 // runs on every request. Without this, pages with no data fetching
@@ -13,6 +14,7 @@ export const dynamic = "force-dynamic";
 export default function HubLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex flex-col h-full min-h-screen" style={{ backgroundColor: "var(--background)" }}>
+      <TrialBanner />
       {/* Mobile-only sticky top bar */}
       <MobileTopBar />
 

--- a/mira-hub/src/app/(hub)/magic/page.tsx
+++ b/mira-hub/src/app/(hub)/magic/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { signIn } from "next-auth/react";
+import { Factory, Loader2, XCircle } from "lucide-react";
+import { Suspense } from "react";
+
+function MagicVerify() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get("token");
+  const [status, setStatus] = useState<"verifying" | "error">("verifying");
+
+  useEffect(() => {
+    if (!token) {
+      setStatus("error");
+      return;
+    }
+    signIn("magic-token", { token, redirect: false })
+      .then(result => {
+        if (result?.ok) {
+          router.push("/feed");
+        } else {
+          setStatus("error");
+        }
+      })
+      .catch(() => setStatus("error"));
+  }, [token, router]);
+
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center px-4"
+      style={{ background: "linear-gradient(135deg, #0F172A 0%, #1E293B 50%, #0F172A 100%)" }}
+    >
+      <div className="text-center">
+        <div
+          className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto mb-6"
+          style={{ background: "linear-gradient(135deg, #2563EB, #0891B2)", boxShadow: "0 0 32px rgba(37,99,235,0.4)" }}
+        >
+          <Factory className="w-8 h-8 text-white" />
+        </div>
+        {status === "verifying" ? (
+          <>
+            <Loader2 className="w-8 h-8 animate-spin text-blue-400 mx-auto mb-4" />
+            <p className="text-white text-lg font-semibold">Signing you in…</p>
+            <p className="text-slate-400 text-sm mt-2">Verifying your magic link</p>
+          </>
+        ) : (
+          <>
+            <XCircle className="w-8 h-8 text-red-400 mx-auto mb-4" />
+            <p className="text-white text-lg font-semibold">Link expired or already used</p>
+            <p className="text-slate-400 text-sm mt-2">Magic links expire after 15 minutes.</p>
+            <a
+              href="/login"
+              className="mt-6 inline-block px-6 py-2.5 rounded-lg text-sm font-semibold text-white"
+              style={{ background: "linear-gradient(135deg,#2563EB,#0891B2)" }}
+            >
+              Back to login
+            </a>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function MagicPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-slate-900">
+        <Loader2 className="w-8 h-8 animate-spin text-blue-400" />
+      </div>
+    }>
+      <MagicVerify />
+    </Suspense>
+  );
+}

--- a/mira-hub/src/app/(hub)/pending-approval/page.tsx
+++ b/mira-hub/src/app/(hub)/pending-approval/page.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { signOut } from "next-auth/react";
+import { Factory, Clock, CheckCircle2, Loader2, LogOut } from "lucide-react";
+
+export default function PendingApprovalPage() {
+  const [checking, setChecking] = useState(false);
+  const [approved, setApproved] = useState(false);
+
+  async function checkStatus() {
+    setChecking(true);
+    try {
+      const res = await fetch("/hub/api/auth/check-approval");
+      if (!res.ok) return;
+      const { status } = await res.json() as { status: string };
+      if (status === "approved" || status === "admin" || status === "trial") {
+        setApproved(true);
+        // Force re-login so new JWT contains updated status
+        setTimeout(() => {
+          signOut({ callbackUrl: "/login?callbackUrl=/hub/feed" });
+        }, 1500);
+      }
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center px-4"
+      style={{ background: "linear-gradient(135deg, #0F172A 0%, #1E293B 50%, #0F172A 100%)" }}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl border border-slate-700/50 p-8 text-center"
+        style={{ background: "rgba(26,29,35,0.95)", backdropFilter: "blur(12px)", boxShadow: "0 24px 64px rgba(0,0,0,0.4)" }}
+      >
+        <div
+          className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto mb-6"
+          style={{ background: "linear-gradient(135deg, #2563EB, #0891B2)", boxShadow: "0 0 32px rgba(37,99,235,0.3)" }}
+        >
+          <Factory className="w-8 h-8 text-white" />
+        </div>
+
+        {approved ? (
+          <>
+            <CheckCircle2 className="w-10 h-10 text-green-400 mx-auto mb-4" />
+            <h1 className="text-xl font-bold text-white mb-2">You&apos;re approved!</h1>
+            <p className="text-slate-400 text-sm">Signing you in now…</p>
+          </>
+        ) : (
+          <>
+            <div className="flex items-center justify-center gap-2 mb-4">
+              <Clock className="w-5 h-5 text-yellow-400" />
+              <span className="text-yellow-400 text-sm font-medium">Pending Approval</span>
+            </div>
+            <h1 className="text-xl font-bold text-white mb-3">Your account is under review</h1>
+            <p className="text-slate-400 text-sm leading-relaxed mb-6">
+              Thanks for signing up for FactoryLM. An admin will review your request shortly.
+              You&apos;ll get access to AI-powered maintenance diagnostics, work order management,
+              and the full CMMS suite once approved.
+            </p>
+
+            <div className="space-y-3 text-left mb-8 p-4 rounded-lg" style={{ backgroundColor: "rgba(37,99,235,0.08)", border: "1px solid rgba(37,99,235,0.2)" }}>
+              <p className="text-xs font-semibold text-blue-300 uppercase tracking-wide">What you&apos;ll get</p>
+              {["AI diagnostic assistant (15 sec vs 3 hours)", "Work order & PM scheduling", "Asset management & parts tracking", "Multi-channel tech support (Telegram, Slack)"].map(f => (
+                <div key={f} className="flex items-start gap-2">
+                  <CheckCircle2 className="w-4 h-4 text-blue-400 flex-shrink-0 mt-0.5" />
+                  <span className="text-sm text-slate-300">{f}</span>
+                </div>
+              ))}
+            </div>
+
+            <button
+              onClick={checkStatus}
+              disabled={checking}
+              className="w-full h-11 rounded-lg font-semibold text-white transition-opacity disabled:opacity-60 flex items-center justify-center gap-2 mb-3"
+              style={{ background: "linear-gradient(135deg,#2563EB,#0891B2)" }}
+            >
+              {checking ? <><Loader2 className="w-4 h-4 animate-spin" /> Checking…</> : "Check approval status"}
+            </button>
+
+            <button
+              onClick={() => signOut({ callbackUrl: "/login" })}
+              className="w-full h-10 rounded-lg text-sm text-slate-400 hover:text-white flex items-center justify-center gap-2 transition-colors"
+            >
+              <LogOut className="w-4 h-4" /> Sign out
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/mira-hub/src/app/(hub)/upgrade/page.tsx
+++ b/mira-hub/src/app/(hub)/upgrade/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { Factory, Zap, Users, Check, LogOut } from "lucide-react";
+import { signOut } from "next-auth/react";
+
+const PLANS = [
+  {
+    id: "individual",
+    name: "Individual",
+    price: "$20",
+    period: "/month",
+    description: "Perfect for solo maintenance techs and plant engineers",
+    highlight: "Most popular",
+    color: "#2563EB",
+    features: [
+      "AI diagnostic assistant",
+      "Work order & PM scheduling",
+      "Asset & parts management",
+      "1 user seat",
+      "All integrations (Telegram, Slack)",
+      "7-day free trial",
+    ],
+  },
+  {
+    id: "facility",
+    name: "Facility",
+    price: "$499",
+    period: "/month",
+    description: "For maintenance teams and full plant operations",
+    highlight: null,
+    color: "#0891B2",
+    features: [
+      "Everything in Individual",
+      "Unlimited user seats",
+      "Multi-site support",
+      "Custom KB ingestion",
+      "SLA support",
+      "Dedicated onboarding",
+    ],
+  },
+];
+
+export default function UpgradePage() {
+  function handleUpgrade(planId: string) {
+    // Stripe checkout — placeholder until Stripe is wired
+    window.open(`mailto:mike@factorylm.com?subject=FactoryLM%20${planId}%20plan%20signup`, "_blank");
+  }
+
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center px-4 py-12"
+      style={{ background: "linear-gradient(135deg, #0F172A 0%, #1E293B 50%, #0F172A 100%)" }}
+    >
+      <div className="w-full max-w-3xl">
+        <div className="text-center mb-10">
+          <div
+            className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto mb-6"
+            style={{ background: "linear-gradient(135deg, #2563EB, #0891B2)", boxShadow: "0 0 32px rgba(37,99,235,0.4)" }}
+          >
+            <Factory className="w-8 h-8 text-white" />
+          </div>
+          <h1 className="text-3xl font-bold text-white mb-3">Your trial has ended</h1>
+          <p className="text-slate-400 text-base max-w-md mx-auto">
+            Upgrade to continue using FactoryLM. We beat Factory AI at half the price.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-6 mb-8">
+          {PLANS.map(plan => (
+            <div
+              key={plan.id}
+              className="rounded-2xl border p-6 flex flex-col"
+              style={{
+                background: "rgba(26,29,35,0.95)",
+                borderColor: plan.highlight ? "#2563EB" : "rgba(148,163,184,0.15)",
+                boxShadow: plan.highlight ? "0 0 32px rgba(37,99,235,0.2)" : "none",
+              }}
+            >
+              {plan.highlight && (
+                <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold mb-4 self-start"
+                  style={{ backgroundColor: "rgba(37,99,235,0.15)", color: "#60A5FA" }}>
+                  <Zap className="w-3 h-3" /> {plan.highlight}
+                </div>
+              )}
+
+              <div className="flex items-center gap-2 mb-2">
+                {plan.id === "facility" ? (
+                  <Users className="w-5 h-5" style={{ color: plan.color }} />
+                ) : (
+                  <Zap className="w-5 h-5" style={{ color: plan.color }} />
+                )}
+                <span className="text-white font-semibold text-lg">{plan.name}</span>
+              </div>
+
+              <div className="flex items-baseline gap-1 mb-2">
+                <span className="text-4xl font-bold text-white">{plan.price}</span>
+                <span className="text-slate-400 text-sm">{plan.period}</span>
+              </div>
+              <p className="text-slate-400 text-sm mb-5">{plan.description}</p>
+
+              <ul className="space-y-2.5 mb-6 flex-1">
+                {plan.features.map(f => (
+                  <li key={f} className="flex items-start gap-2">
+                    <Check className="w-4 h-4 flex-shrink-0 mt-0.5" style={{ color: plan.color }} />
+                    <span className="text-sm text-slate-300">{f}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <button
+                onClick={() => handleUpgrade(plan.id)}
+                className="w-full h-11 rounded-lg font-semibold text-white transition-opacity hover:opacity-90"
+                style={{ background: `linear-gradient(135deg, ${plan.color}, ${plan.id === "individual" ? "#0891B2" : "#7C3AED"})` }}
+              >
+                Start {plan.name} Plan
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div className="text-center">
+          <p className="text-slate-500 text-sm mb-3">Questions? <a href="mailto:mike@factorylm.com" className="text-blue-400 hover:text-blue-300">Contact us</a></p>
+          <button
+            onClick={() => signOut({ callbackUrl: "/login" })}
+            className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-300 transition-colors"
+          >
+            <LogOut className="w-4 h-4" /> Sign out
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/mira-hub/src/app/api/auth/register/route.ts
+++ b/mira-hub/src/app/api/auth/register/route.ts
@@ -7,6 +7,38 @@ export const dynamic = "force-dynamic";
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MIN_PASSWORD = 8;
 
+async function captureHubSpotLead(email: string, name: string | undefined): Promise<void> {
+  const apiKey = process.env.HUBSPOT_API_KEY;
+  if (!apiKey) return;
+  try {
+    const properties: Record<string, string> = {
+      email,
+      hs_lead_status: "NEW",
+      lifecyclestage: "lead",
+    };
+    if (name) {
+      const parts = name.trim().split(" ");
+      properties.firstname = parts[0];
+      if (parts.length > 1) properties.lastname = parts.slice(1).join(" ");
+    }
+    const res = await fetch("https://api.hubapi.com/crm/v3/objects/contacts", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ properties }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      // 409 = contact already exists — not an error
+      if (res.status !== 409) console.warn("[hubspot] lead capture failed:", res.status, body);
+    }
+  } catch (err) {
+    console.warn("[hubspot] lead capture error:", err);
+  }
+}
+
 export async function POST(req: Request) {
   if (!process.env.NEON_DATABASE_URL) {
     return NextResponse.json({ error: "DB not configured" }, { status: 503 });
@@ -37,11 +69,10 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "account already exists" }, { status: 409 });
     }
     const passwordHash = await bcrypt.hash(password, 12);
-    const result = await ensureUserAndTenant({
-      email: trimmed,
-      passwordHash,
-      name: typeof name === "string" ? name.trim() || undefined : undefined,
-    });
+    const nameStr = typeof name === "string" ? name.trim() || undefined : undefined;
+    const result = await ensureUserAndTenant({ email: trimmed, passwordHash, name: nameStr });
+    // Fire HubSpot capture async — don't block the response
+    captureHubSpotLead(trimmed, nameStr).catch(() => {});
     return NextResponse.json({ ok: true, userId: result.id, tenantId: result.tenantId }, { status: 201 });
   } catch (err) {
     console.error("[api/auth/register]", err);

--- a/mira-hub/src/app/login/page.tsx
+++ b/mira-hub/src/app/login/page.tsx
@@ -4,7 +4,7 @@ import { useState, Suspense } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
-import { Factory, Loader2, Eye, EyeOff } from "lucide-react";
+import { Factory, Loader2, Eye, EyeOff, Mail, ChevronDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 
@@ -18,6 +18,10 @@ function LoginForm() {
   const [showPw, setShowPw] = useState(false);
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
+  const [magicEmail, setMagicEmail] = useState("");
+  const [magicLoading, setMagicLoading] = useState(false);
+  const [magicSent, setMagicSent] = useState(false);
+  const [showPasswordForm, setShowPasswordForm] = useState(false);
   const [error, setError] = useState(initialError ? "Sign in failed" : "");
 
   async function handleSubmit(e: React.FormEvent) {
@@ -42,6 +46,29 @@ function LoginForm() {
     setGoogleLoading(true);
     setError("");
     await signIn("google", { callbackUrl });
+  }
+
+  async function handleMagicLink(e: React.FormEvent) {
+    e.preventDefault();
+    if (!magicEmail) return;
+    setMagicLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/hub/api/auth/magic-link", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: magicEmail }),
+      });
+      if (res.ok) {
+        setMagicSent(true);
+      } else {
+        setError("Failed to send magic link. Try again.");
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setMagicLoading(false);
+    }
   }
 
   return (
@@ -80,6 +107,7 @@ function LoginForm() {
             boxShadow: "0 24px 64px rgba(0,0,0,0.4)",
           }}
         >
+          {/* Google */}
           <button
             type="button"
             onClick={handleGoogle}
@@ -96,77 +124,130 @@ function LoginForm() {
                 <path fill="#1976D2" d="M43.611 20.083H42V20H24v8h11.303c-.792 2.237-2.231 4.166-4.087 5.571l.003-.002 6.19 5.238C36.971 39.205 44 34 44 24c0-1.341-.138-2.65-.389-3.917z" />
               </svg>
             )}
-            <span>Sign in with Google</span>
+            <span>Continue with Google</span>
           </button>
 
-          <div className="flex items-center gap-3 my-4">
+          <div className="flex items-center gap-3 mb-4">
             <div className="flex-1 h-px bg-slate-700/50" />
             <span className="text-xs text-slate-500">or</span>
             <div className="flex-1 h-px bg-slate-700/50" />
           </div>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label className="block text-xs font-medium text-slate-400 mb-1.5">Email</label>
-              <Input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="you@company.com"
-                autoComplete="email"
-                required
-                className="h-11 bg-slate-800/60 border-slate-700 text-white placeholder:text-slate-500 focus:ring-blue-500"
-              />
+          {/* Magic link */}
+          {magicSent ? (
+            <div className="text-center py-2 mb-4">
+              <Mail className="w-8 h-8 text-blue-400 mx-auto mb-2" />
+              <p className="text-white font-semibold text-sm">Check your inbox</p>
+              <p className="text-slate-400 text-xs mt-1">We sent a sign-in link to <strong>{magicEmail}</strong></p>
+              <button onClick={() => setMagicSent(false)} className="text-blue-400 text-xs mt-2 hover:text-blue-300">
+                Send again
+              </button>
             </div>
-
-            <div>
-              <label className="block text-xs font-medium text-slate-400 mb-1.5">Password</label>
-              <div className="relative">
+          ) : (
+            <form onSubmit={handleMagicLink} className="mb-4">
+              <label className="block text-xs font-medium text-slate-400 mb-1.5">Email magic link</label>
+              <div className="flex gap-2">
                 <Input
-                  type={showPw ? "text" : "password"}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder="••••••••"
-                  autoComplete="current-password"
+                  type="email"
+                  value={magicEmail}
+                  onChange={(e) => setMagicEmail(e.target.value)}
+                  placeholder="you@company.com"
+                  autoComplete="email"
                   required
-                  className="h-11 pr-10 bg-slate-800/60 border-slate-700 text-white placeholder:text-slate-500 focus:ring-blue-500"
+                  className="flex-1 h-11 bg-slate-800/60 border-slate-700 text-white placeholder:text-slate-500 focus:ring-blue-500"
                 />
                 <button
-                  type="button"
-                  onClick={() => setShowPw((v) => !v)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200 transition-colors"
+                  type="submit"
+                  disabled={magicLoading || !magicEmail}
+                  className="px-4 h-11 rounded-md font-medium text-white text-sm disabled:opacity-50 flex items-center gap-1.5"
+                  style={{ background: "linear-gradient(135deg,#2563EB,#0891B2)" }}
                 >
-                  {showPw ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  {magicLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Mail className="w-4 h-4" />}
                 </button>
               </div>
-            </div>
+            </form>
+          )}
 
-            {error && (
-              <div className="rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2 text-sm text-red-400">
-                {error}
+          <div className="flex items-center gap-3 mb-4">
+            <div className="flex-1 h-px bg-slate-700/50" />
+            <span className="text-xs text-slate-500">or</span>
+            <div className="flex-1 h-px bg-slate-700/50" />
+          </div>
+
+          {/* Password — collapsible */}
+          <button
+            type="button"
+            onClick={() => setShowPasswordForm(v => !v)}
+            className="w-full flex items-center justify-between text-xs text-slate-400 hover:text-slate-200 transition-colors mb-3"
+          >
+            <span>Sign in with password</span>
+            <ChevronDown className={`w-4 h-4 transition-transform ${showPasswordForm ? "rotate-180" : ""}`} />
+          </button>
+
+          {showPasswordForm && (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-xs font-medium text-slate-400 mb-1.5">Email</label>
+                <Input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@company.com"
+                  autoComplete="email"
+                  required
+                  className="h-11 bg-slate-800/60 border-slate-700 text-white placeholder:text-slate-500 focus:ring-blue-500"
+                />
               </div>
-            )}
 
-            <Button
-              type="submit"
-              className="w-full h-11 text-base font-semibold mt-2"
-              disabled={loading}
-              style={{ background: loading ? undefined : "linear-gradient(135deg, #2563EB, #0891B2)" }}
-            >
-              {loading ? (
-                <>
-                  <Loader2 className="w-4 h-4 animate-spin" /> Signing in
-                </>
-              ) : (
-                "Sign in"
-              )}
-            </Button>
-          </form>
+              <div>
+                <label className="block text-xs font-medium text-slate-400 mb-1.5">Password</label>
+                <div className="relative">
+                  <Input
+                    type={showPw ? "text" : "password"}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    placeholder="••••••••"
+                    autoComplete="current-password"
+                    required
+                    className="h-11 pr-10 bg-slate-800/60 border-slate-700 text-white placeholder:text-slate-500 focus:ring-blue-500"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPw((v) => !v)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200 transition-colors"
+                  >
+                    {showPw ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  </button>
+                </div>
+              </div>
+
+              <Button
+                type="submit"
+                className="w-full h-11 text-base font-semibold"
+                disabled={loading}
+                style={{ background: loading ? undefined : "linear-gradient(135deg, #2563EB, #0891B2)" }}
+              >
+                {loading ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" /> Signing in
+                  </>
+                ) : (
+                  "Sign in"
+                )}
+              </Button>
+            </form>
+          )}
+
+          {error && (
+            <div className="rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2 text-sm text-red-400 mt-4">
+              {error}
+            </div>
+          )}
 
           <p className="text-center text-sm text-slate-400 mt-6">
             Don&apos;t have an account?{" "}
             <Link href="/signup" className="text-blue-400 hover:text-blue-300 font-medium">
-              Create one
+              Start free trial
             </Link>
           </p>
         </div>

--- a/mira-hub/src/auth.ts
+++ b/mira-hub/src/auth.ts
@@ -2,7 +2,7 @@ import type { NextAuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
 import bcrypt from "bcryptjs";
-import { ensureUserAndTenant, findUserByEmail } from "@/lib/users";
+import { ensureUserAndTenant, findUserByEmail, validateMagicToken } from "@/lib/users";
 
 declare module "next-auth" {
   interface Session {
@@ -12,12 +12,16 @@ declare module "next-auth" {
       name?: string | null;
       image?: string | null;
       tenantId: string;
+      status: string;
+      trialExpiresAt?: string | null;
     };
   }
   interface User {
     id: string;
     email?: string | null;
     tenantId?: string;
+    status?: string;
+    trialExpiresAt?: string | null;
   }
 }
 
@@ -25,6 +29,8 @@ declare module "next-auth/jwt" {
   interface JWT {
     uid?: string;
     tid?: string;
+    status?: string;
+    trialExpiresAt?: string | null;
   }
 }
 
@@ -46,7 +52,34 @@ const providers: NextAuthOptions["providers"] = [
       if (!user?.passwordHash) return null;
       const ok = await bcrypt.compare(password, user.passwordHash);
       if (!ok) return null;
-      return { id: user.id, email: user.email, name: user.name ?? null, tenantId: user.tenantId };
+      return {
+        id: user.id,
+        email: user.email,
+        name: user.name ?? null,
+        tenantId: user.tenantId,
+        status: user.status,
+        trialExpiresAt: user.trialExpiresAt?.toISOString() ?? null,
+      };
+    },
+  }),
+  CredentialsProvider({
+    id: "magic-token",
+    name: "Magic Link",
+    credentials: { token: { type: "text" } },
+    async authorize(credentials) {
+      if (!credentials?.token) return null;
+      const result = await validateMagicToken(credentials.token);
+      if (!result) return null;
+      const account = await ensureUserAndTenant({ email: result.email });
+      const user = await findUserByEmail(result.email);
+      return {
+        id: account.id,
+        email: account.email,
+        name: user?.name ?? null,
+        tenantId: account.tenantId,
+        status: user?.status ?? "trial",
+        trialExpiresAt: user?.trialExpiresAt?.toISOString() ?? null,
+      };
     },
   }),
 ];
@@ -74,9 +107,12 @@ export const authOptions: NextAuthOptions = {
           googleSub: account.providerAccountId,
           name: (profile as { name?: string }).name,
         });
+        const fullUser = await findUserByEmail(existing.email);
         user.id = existing.id;
         user.email = existing.email;
         user.tenantId = existing.tenantId;
+        user.status = fullUser?.status ?? "trial";
+        user.trialExpiresAt = fullUser?.trialExpiresAt?.toISOString() ?? null;
       }
       return true;
     },
@@ -84,6 +120,8 @@ export const authOptions: NextAuthOptions = {
       if (user) {
         token.uid = user.id;
         token.tid = user.tenantId;
+        token.status = user.status ?? "trial";
+        token.trialExpiresAt = user.trialExpiresAt ?? null;
       }
       return token;
     },
@@ -91,6 +129,8 @@ export const authOptions: NextAuthOptions = {
       if (session.user) {
         session.user.id = token.uid ?? "";
         session.user.tenantId = token.tid ?? "";
+        session.user.status = token.status ?? "trial";
+        session.user.trialExpiresAt = token.trialExpiresAt ?? null;
       }
       return session;
     },

--- a/mira-hub/src/components/trial-banner.tsx
+++ b/mira-hub/src/components/trial-banner.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import Link from "next/link";
+import { Zap, X } from "lucide-react";
+import { useState } from "react";
+
+function daysRemaining(isoDate: string): number {
+  const ms = new Date(isoDate).getTime() - Date.now();
+  return Math.max(0, Math.ceil(ms / (1000 * 60 * 60 * 24)));
+}
+
+export function TrialBanner() {
+  const { data: session } = useSession();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (dismissed) return null;
+
+  const status = session?.user?.status;
+  const trialExpiresAt = session?.user?.trialExpiresAt;
+
+  if (status !== "trial" || !trialExpiresAt) return null;
+
+  const days = daysRemaining(trialExpiresAt);
+  const urgent = days <= 4;
+
+  return (
+    <div
+      className="w-full px-4 py-2.5 flex items-center justify-between text-sm relative"
+      style={{
+        backgroundColor: urgent ? "#92400E" : "#1E3A5F",
+        borderBottom: `1px solid ${urgent ? "#B45309" : "#1D4ED8"}`,
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <Zap className="w-3.5 h-3.5 flex-shrink-0" style={{ color: urgent ? "#FCD34D" : "#60A5FA" }} />
+        <span style={{ color: urgent ? "#FDE68A" : "#BFDBFE" }}>
+          {days === 0
+            ? "Your free trial has ended."
+            : `Free trial: ${days} day${days === 1 ? "" : "s"} remaining`}
+        </span>
+        <Link
+          href="/upgrade"
+          className="ml-2 px-2.5 py-0.5 rounded text-xs font-semibold"
+          style={{ backgroundColor: urgent ? "#F59E0B" : "#2563EB", color: "#fff" }}
+        >
+          Upgrade
+        </Link>
+      </div>
+      <button
+        onClick={() => setDismissed(true)}
+        className="text-slate-400 hover:text-white transition-colors ml-4"
+        aria-label="Dismiss"
+      >
+        <X className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/mira-hub/src/lib/session.ts
+++ b/mira-hub/src/lib/session.ts
@@ -6,6 +6,8 @@ export interface SessionContext {
   userId: string;
   tenantId: string;
   email: string;
+  status: string;
+  trialExpiresAt: string | null;
 }
 
 export class UnauthorizedError extends Error {
@@ -55,6 +57,8 @@ export async function requireSession(): Promise<SessionContext> {
     userId: token.uid as string,
     tenantId: token.tid as string,
     email: (token.email as string) ?? "",
+    status: (token.status as string) ?? "trial",
+    trialExpiresAt: (token.trialExpiresAt as string) ?? null,
   };
 }
 

--- a/mira-hub/src/lib/users.ts
+++ b/mira-hub/src/lib/users.ts
@@ -1,5 +1,7 @@
 import pool from "@/lib/db";
 
+export type UserStatus = "pending" | "trial" | "approved" | "expired" | "admin";
+
 export interface HubUser {
   id: string;
   email: string;
@@ -8,6 +10,9 @@ export interface HubUser {
   tenantId: string;
   name: string | null;
   role: string;
+  status: UserStatus;
+  trialExpiresAt: Date | null;
+  plan: string | null;
 }
 
 let schemaReady: Promise<void> | null = null;
@@ -32,9 +37,12 @@ export function ensureSchema(): Promise<void> {
         google_sub     TEXT,
         tenant_id      TEXT NOT NULL REFERENCES hub_tenants(id),
         name           TEXT,
-        role           TEXT NOT NULL DEFAULT 'owner',
-        created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-        updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        role             TEXT NOT NULL DEFAULT 'owner',
+        status           TEXT NOT NULL DEFAULT 'trial',
+        trial_expires_at TIMESTAMPTZ,
+        plan             TEXT,
+        created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
       )
     `);
     await pool.query(`
@@ -49,6 +57,16 @@ export function ensureSchema(): Promise<void> {
       CREATE INDEX IF NOT EXISTS idx_hub_users_tenant
         ON hub_users (tenant_id)
     `);
+    // Idempotent migrations: add new columns to existing tables
+    await pool.query(`ALTER TABLE hub_users ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'trial'`);
+    await pool.query(`ALTER TABLE hub_users ADD COLUMN IF NOT EXISTS trial_expires_at TIMESTAMPTZ`);
+    await pool.query(`ALTER TABLE hub_users ADD COLUMN IF NOT EXISTS plan TEXT`);
+    // Promote admin and set trial expiry for existing trial users
+    await pool.query(`UPDATE hub_users SET status = 'admin' WHERE email_lower = 'mike@factorylm.com' AND status != 'admin'`);
+    await pool.query(`
+      UPDATE hub_users SET trial_expires_at = created_at + INTERVAL '7 days'
+      WHERE status = 'trial' AND trial_expires_at IS NULL
+    `);
   })();
   return schemaReady;
 }
@@ -62,14 +80,18 @@ function rowToUser(r: Record<string, unknown>): HubUser {
     tenantId: String(r.tenant_id),
     name: (r.name as string) ?? null,
     role: String(r.role ?? "owner"),
+    status: (r.status as UserStatus) ?? "trial",
+    trialExpiresAt: r.trial_expires_at ? new Date(r.trial_expires_at as string) : null,
+    plan: (r.plan as string) ?? null,
   };
 }
+
+const USER_COLS = "id, email, password_hash, google_sub, tenant_id, name, role, status, trial_expires_at, plan";
 
 export async function findUserByEmail(email: string): Promise<HubUser | null> {
   await ensureSchema();
   const { rows } = await pool.query(
-    `SELECT id, email, password_hash, google_sub, tenant_id, name, role
-       FROM hub_users WHERE email_lower = LOWER($1) LIMIT 1`,
+    `SELECT ${USER_COLS} FROM hub_users WHERE email_lower = LOWER($1) LIMIT 1`,
     [email],
   );
   return rows[0] ? rowToUser(rows[0]) : null;
@@ -78,11 +100,74 @@ export async function findUserByEmail(email: string): Promise<HubUser | null> {
 export async function findUserById(id: string): Promise<HubUser | null> {
   await ensureSchema();
   const { rows } = await pool.query(
-    `SELECT id, email, password_hash, google_sub, tenant_id, name, role
-       FROM hub_users WHERE id = $1 LIMIT 1`,
+    `SELECT ${USER_COLS} FROM hub_users WHERE id = $1 LIMIT 1`,
     [id],
   );
   return rows[0] ? rowToUser(rows[0]) : null;
+}
+
+export async function listAllUsers(): Promise<HubUser[]> {
+  await ensureSchema();
+  const { rows } = await pool.query(
+    `SELECT ${USER_COLS}, created_at FROM hub_users ORDER BY created_at DESC`,
+  );
+  return rows.map(rowToUser);
+}
+
+export async function updateUserStatus(id: string, status: UserStatus): Promise<void> {
+  await ensureSchema();
+  await pool.query(
+    `UPDATE hub_users SET status = $1, updated_at = NOW() WHERE id = $2`,
+    [status, id],
+  );
+}
+
+// ── Magic link tokens ──────────────────────────────────────────────────────────
+
+let magicSchemaReady: Promise<void> | null = null;
+
+function ensureMagicSchema(): Promise<void> {
+  if (magicSchemaReady) return magicSchemaReady;
+  magicSchemaReady = (async () => {
+    await ensureSchema();
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS hub_magic_tokens (
+        token      TEXT PRIMARY KEY,
+        email      TEXT NOT NULL,
+        expires_at TIMESTAMPTZ NOT NULL,
+        used_at    TIMESTAMPTZ
+      )
+    `);
+    await pool.query(`
+      CREATE INDEX IF NOT EXISTS idx_magic_tokens_email ON hub_magic_tokens (email)
+    `);
+  })();
+  return magicSchemaReady;
+}
+
+export async function createMagicToken(email: string): Promise<string> {
+  await ensureMagicSchema();
+  const { randomUUID } = await import("crypto");
+  const token = randomUUID();
+  await pool.query(
+    `INSERT INTO hub_magic_tokens (token, email, expires_at)
+     VALUES ($1, $2, NOW() + INTERVAL '15 minutes')
+     ON CONFLICT (token) DO NOTHING`,
+    [token, email.toLowerCase()],
+  );
+  return token;
+}
+
+export async function validateMagicToken(token: string): Promise<{ email: string } | null> {
+  await ensureMagicSchema();
+  const { rows } = await pool.query(
+    `UPDATE hub_magic_tokens
+     SET used_at = NOW()
+     WHERE token = $1 AND expires_at > NOW() AND used_at IS NULL
+     RETURNING email`,
+    [token],
+  );
+  return rows[0] ? { email: String(rows[0].email) } : null;
 }
 
 export interface EnsureUserAndTenantInput {
@@ -132,8 +217,8 @@ export async function ensureUserAndTenant(
     const {
       rows: [user],
     } = await client.query(
-      `INSERT INTO hub_users (email, password_hash, google_sub, tenant_id, name)
-       VALUES ($1, $2, $3, $4, $5)
+      `INSERT INTO hub_users (email, password_hash, google_sub, tenant_id, name, status, trial_expires_at)
+       VALUES ($1, $2, $3, $4, $5, 'trial', NOW() + INTERVAL '7 days')
        RETURNING id, email`,
       [input.email, input.passwordHash ?? null, input.googleSub ?? null, tenantId, input.name ?? null],
     );

--- a/mira-hub/src/middleware.ts
+++ b/mira-hub/src/middleware.ts
@@ -1,18 +1,49 @@
 import { withAuth, type NextRequestWithAuth } from "next-auth/middleware";
 import { NextResponse, type NextFetchEvent, type NextRequest } from "next/server";
 
-// withAuth's two-arg form runs the inner middleware ONLY when authorized.
-// When AUTH_SECRET is unset in the runtime env, getToken throws and withAuth
-// silently returns NextResponse.next() without invoking the inner function
-// at all (per PR #634's issue body). That means we can't put the basePath
-// root redirect inside withAuth — it has to fire before withAuth gets the
-// chance to fall through.
-const authMiddleware = withAuth({
-  pages: {
-    signIn: "/login",
+// Gate pages: authenticated users with non-approved status land here;
+// skip the status check when already on these pages to avoid redirect loops.
+const GATE_PATHS = ["/pending-approval", "/upgrade", "/magic"];
+
+// withAuth's two-arg form: inner function runs ONLY when authorized (token exists).
+// The outer middleware handles the basePath root redirect before withAuth runs.
+const authMiddleware = withAuth(
+  function onAuthorized(req: NextRequestWithAuth) {
+    const token = req.nextauth?.token;
+    if (!token) return NextResponse.next();
+
+    const pathname = req.nextUrl.pathname;
+    if (GATE_PATHS.some(p => pathname.startsWith(p))) return NextResponse.next();
+
+    const status = String(token.status ?? "trial");
+
+    if (status === "pending") {
+      const url = req.nextUrl.clone();
+      url.pathname = "/pending-approval";
+      return NextResponse.redirect(url);
+    }
+
+    if (status === "expired") {
+      const url = req.nextUrl.clone();
+      url.pathname = "/upgrade";
+      return NextResponse.redirect(url);
+    }
+
+    if (status === "trial" && token.trialExpiresAt) {
+      if (new Date() > new Date(token.trialExpiresAt as string)) {
+        const url = req.nextUrl.clone();
+        url.pathname = "/upgrade";
+        return NextResponse.redirect(url);
+      }
+    }
+
+    return NextResponse.next();
   },
-  secret: process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET,
-});
+  {
+    pages: { signIn: "/login" },
+    secret: process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET,
+  },
+);
 
 export default async function middleware(req: NextRequest, ev: NextFetchEvent) {
   // Basepath root → redirect to /feed. `redirect()` from a Server Component
@@ -30,6 +61,6 @@ export default async function middleware(req: NextRequest, ev: NextFetchEvent) {
 
 export const config = {
   matcher: [
-    "/((?!login|signup|api/auth|api/health|_next/static|_next/image|favicon\\.ico).*)",
+    "/((?!login|signup|magic|api/auth|api/health|_next/static|_next/image|favicon\\.ico).*)",
   ],
 };

--- a/mira-hub/tests/e2e/hub-validation.spec.ts
+++ b/mira-hub/tests/e2e/hub-validation.spec.ts
@@ -24,7 +24,7 @@ async function login(page: Page): Promise<void> {
   await page.fill('input[type="email"]', LOGIN_EMAIL);
   await page.fill('input[type="password"]', LOGIN_PASSWORD);
   await page.click('button[type="submit"]');
-  await page.waitForURL(`${HUB}/feed`, { timeout: 15_000 });
+  await page.waitForURL(/\/hub\/feed\/?$/, { timeout: 15_000 });
 }
 
 // ── Shared fixture: logged-in page ───────────────────────────────────────────

--- a/mira-hub/tests/e2e/proof-pr-740-assets-auth.spec.ts
+++ b/mira-hub/tests/e2e/proof-pr-740-assets-auth.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Proof spec for PR #740 — really closes #686
+ * Verifies that /hub/assets does NOT redirect to login when authenticated.
+ */
+
+import { test, expect } from "@playwright/test";
+import path from "path";
+import fs from "fs";
+
+const HUB = "https://app.factorylm.com/hub";
+const CREDS = { email: "playwright@factorylm.com", password: "TestPass123" };
+
+const outDir = path.join(__dirname, "../../test-results/proof-pr-740");
+
+test.beforeAll(async ({ request }) => {
+  fs.mkdirSync(outDir, { recursive: true });
+  const res = await request.post(`${HUB}/api/auth/register/`, {
+    data: { email: CREDS.email, password: CREDS.password, name: "Playwright 740" },
+  });
+  console.log(`test user: ${res.status()} (201=created, 409=exists)`);
+});
+
+test("authenticated user stays on /assets (no login redirect)", async ({ page }) => {
+  const apiStatuses: { url: string; status: number }[] = [];
+  page.on("response", (resp) => {
+    if (resp.url().includes("/api/assets")) {
+      apiStatuses.push({ url: resp.url(), status: resp.status() });
+    }
+  });
+
+  // Login
+  await page.goto(`${HUB}/login`, { waitUntil: "domcontentloaded" });
+  await page.fill('input[type="email"]', CREDS.email);
+  await page.fill('input[type="password"]', CREDS.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/hub\/feed\/?/, { timeout: 25_000 });
+  console.log("✅ Logged in:", page.url());
+
+  // Navigate to /assets
+  await page.goto(`${HUB}/assets`, { waitUntil: "domcontentloaded" });
+  // Wait for either the asset list or a redirect to finish
+  await page.waitForTimeout(5000);
+
+  const finalUrl = page.url();
+  console.log("Final URL:", finalUrl);
+  console.log("API calls:", JSON.stringify(apiStatuses));
+
+  await page.screenshot({ path: path.join(outDir, "assets-page.png"), fullPage: false });
+
+  // Must NOT be on login page
+  expect(finalUrl).not.toContain("/login");
+  // Final /api/assets/ call (after trailingSlash 308) must return 200
+  const successCall = apiStatuses.find(c => c.url.includes("/api/assets") && c.status === 200);
+  expect(successCall).toBeDefined();
+
+  console.log(`✅ /assets loaded without redirect. API calls: ${JSON.stringify(apiStatuses)}`);
+});

--- a/mira-hub/tests/e2e/proof-pr-746-usage.spec.ts
+++ b/mira-hub/tests/e2e/proof-pr-746-usage.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Proof spec for PR #746 — closes #687 and #717
+ * Verifies: hard reload of /hub/usage does not crash, chart renders (or shows
+ * "No activity" for tenants with no data), API returns 200.
+ */
+
+import { test, expect } from "@playwright/test";
+import path from "path";
+import fs from "fs";
+
+const HUB = "https://app.factorylm.com/hub";
+const CREDS = { email: "playwright@factorylm.com", password: "TestPass123" };
+const outDir = path.join(__dirname, "../../test-results/proof-pr-746");
+
+test.beforeAll(async ({ request }) => {
+  fs.mkdirSync(outDir, { recursive: true });
+  const res = await request.post(`${HUB}/api/auth/register/`, {
+    data: { email: CREDS.email, password: CREDS.password, name: "Playwright 746" },
+  });
+  console.log(`test user: ${res.status()} (201=created, 409=exists)`);
+});
+
+test("hard reload /usage — no crash, API 200, chart rendered or no-data message shown", async ({ page }) => {
+  const errors: string[] = [];
+  const apiStatuses: { url: string; status: number }[] = [];
+  page.on("pageerror", e => errors.push(e.message));
+  page.on("response", r => { if (r.url().includes("/api/usage")) apiStatuses.push({ url: r.url(), status: r.status() }); });
+
+  // Login
+  await page.goto(`${HUB}/login`, { waitUntil: "domcontentloaded" });
+  await page.fill('input[type="email"]', CREDS.email);
+  await page.fill('input[type="password"]', CREDS.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/hub\/feed\/?/, { timeout: 25_000 });
+  console.log("✅ Logged in:", page.url());
+
+  // Hard reload (fresh navigation, triggers full server pre-render then hydration)
+  await page.goto(`${HUB}/usage`, { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(4000);
+
+  const finalUrl = page.url();
+  console.log("Final URL:", finalUrl);
+  console.log("JS errors:", JSON.stringify(errors));
+  console.log("API calls:", JSON.stringify(apiStatuses));
+
+  await page.screenshot({ path: path.join(outDir, "usage-after-fix.png"), fullPage: true });
+
+  // Must not have crashed (redirected to login or blank)
+  expect(finalUrl).not.toContain("/login");
+  expect(errors).toHaveLength(0);
+
+  // API must return 200
+  const successCall = apiStatuses.find(c => c.status === 200);
+  expect(successCall).toBeDefined();
+
+  // Chart area must be present — either chart SVG or "No activity" message
+  const chartCard = page.locator(".card").filter({ hasText: /Daily Actions/i });
+  await expect(chartCard).toBeVisible({ timeout: 5000 });
+  const noActivityMsg = chartCard.getByText("No activity in the last 7 days");
+  const chartSvg = chartCard.locator("svg");
+  const hasNoActivity = await noActivityMsg.isVisible();
+  const hasSvg = await chartSvg.isVisible();
+  expect(hasNoActivity || hasSvg).toBe(true);
+
+  console.log(`✅ /usage loaded cleanly. Chart: ${hasSvg ? "SVG rendered" : "No activity message shown"}`);
+});

--- a/mira-hub/tests/e2e/repro-686.spec.ts
+++ b/mira-hub/tests/e2e/repro-686.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+
+const HUB = "https://app.factorylm.com/hub";
+const CREDS = { email: "playwright@factorylm.com", password: "TestPass123" };
+
+test.beforeAll(async ({ request }) => {
+  await request.post(`${HUB}/api/auth/register/`, {
+    data: { email: CREDS.email, password: CREDS.password, name: "Playwright 686" },
+  });
+});
+
+test("repro #686 — /assets redirects to login after login", async ({ page }) => {
+  // Capture all fetch requests + responses
+  const apiCalls: { url: string; status: number; body: string }[] = [];
+  page.on("response", async (resp) => {
+    if (resp.url().includes("/api/assets")) {
+      const body = await resp.text().catch(() => "");
+      apiCalls.push({ url: resp.url(), status: resp.status(), body: body.slice(0, 200) });
+    }
+  });
+
+  // Login
+  await page.goto(`${HUB}/login`, { waitUntil: "networkidle" });
+  await page.fill('input[type="email"]', CREDS.email);
+  await page.fill('input[type="password"]', CREDS.password);
+  await page.click('button[type="submit"]');
+  await page.waitForURL(/\/hub\/feed\/?/, { timeout: 25_000 });
+  console.log("✅ Logged in at:", page.url());
+
+  // Navigate to /assets
+  await page.goto(`${HUB}/assets`, { waitUntil: "networkidle" });
+  await page.waitForTimeout(3000);
+
+  const finalUrl = page.url();
+  console.log("Final URL:", finalUrl);
+  console.log("API calls intercepted:", JSON.stringify(apiCalls, null, 2));
+
+  await page.screenshot({ path: "test-results/repro-686/result.png" });
+
+  // Report result
+  if (finalUrl.includes("/login")) {
+    console.log("❌ REPRODUCED: redirected to login");
+  } else {
+    console.log("✅ NOT reproduced: stayed on assets page");
+  }
+});


### PR DESCRIPTION
## Summary

Full login gate implementation combining #741 (login gate / pending approval) and #747 (magic link + trial + pricing).

- **User status flow**: new signup → `trial` (7 days) → `expired` → `/hub/upgrade` → `approved` → full access; `admin` bypasses everything
- **Magic link login**: email field + "Send magic link" → Resend email → `/hub/magic?token=xxx` → auto sign-in
- **Trial banner**: countdown shown on every page during trial; turns orange at day 4
- **Login page**: 3 options (Google | Magic link | Password below fold)
- **Admin users page**: real DB data, Approve / Revoke / Expire buttons
- **HubSpot lead capture**: fires async on every new credential signup

## Files changed

| Area | Change |
|------|--------|
| `src/lib/users.ts` | status/trial_expires_at/plan columns; magic token table + helpers |
| `src/auth.ts` | magic-token CredentialsProvider; status+trialExpiresAt in JWT |
| `src/lib/session.ts` | expose status+trialExpiresAt from SessionContext |
| `src/middleware.ts` | gate pending→/pending-approval, expired→/upgrade |
| `src/app/(hub)/layout.tsx` | TrialBanner |
| `src/app/login/page.tsx` | 3 sign-in options |
| `src/app/(hub)/magic/page.tsx` | magic link verify + auto sign-in |
| `src/app/(hub)/pending-approval/page.tsx` | pending page with check-status polling |
| `src/app/(hub)/upgrade/page.tsx` | pricing: Individual $20, Facility $499 |
| `src/app/(hub)/api/auth/magic-link/route.ts` | POST → create token + Resend email |
| `src/app/(hub)/api/auth/check-approval/route.ts` | GET → live DB status |
| `src/app/(hub)/api/admin/users/route.ts` | GET → list all users (admin only) |
| `src/app/(hub)/api/admin/users/[id]/route.ts` | PATCH → update status (admin only) |
| `src/app/(hub)/admin/users/page.tsx` | real data + approve/revoke/expire |
| `src/app/api/auth/register/route.ts` | HubSpot lead capture on signup |
| `src/components/trial-banner.tsx` | trial countdown banner |

## Test plan

- [ ] Build clean ✓
- [ ] New signup → status=trial, trial_expires_at=now+7d
- [ ] Login page shows magic link input
- [ ] Magic link email arrives, clicking it signs user in
- [ ] Trial banner visible with correct countdown on all hub pages
- [ ] mike@factorylm.com → admin, no banner, no gate
- [ ] Pending user → /pending-approval, "Check Status" polls DB
- [ ] Expired/day-7 user → /upgrade with pricing cards
- [ ] Admin users page shows real users with status + approve/revoke buttons
- [ ] HubSpot contact created on new registration

Closes #741
Closes #747

🤖 Generated with [Claude Code](https://claude.ai/claude-code)