### PR TITLE
docs(hub): integration research — PRD v1.1 + 11 API reference files

### DIFF
--- a/docs/INTEGRATION_IMPLEMENTATION_GUIDE.md
+++ b/docs/INTEGRATION_IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,355 @@
+# MIRA Hub Integrations — Implementation Guide
+
+**Version:** v1.0 | **Date:** 2026-04-28 | **Companion PRD:** `docs/PRD_Hub_Integrations_v1.md`
+
+---
+
+## 1. What Already Exists (Don't Rebuild)
+
+Before writing a line of code, understand the infrastructure already in place.
+
+### OAuth Framework (Production)
+
+The Hub ships a complete OAuth 2.0 framework:
+
+| File | Purpose |
+|------|---------|
+| `src/lib/oauth-state.ts` | State token generation (24-byte random, base64) + constant-time validation |
+| `src/lib/connections.ts` | Client-side `localStorage` wrapper (`mira_connections_v2`) |
+| `src/lib/bindings.ts` | Server-side NeonDB CRUD via `hub_channel_bindings` table |
+| `src/app/api/auth/[provider]/route.ts` | OAuth initiation — sets secure httpOnly cookie, redirects to provider |
+| `src/app/api/auth/[provider]/callback/route.ts` | OAuth callback — validates state, exchanges code for token, calls `upsertBinding()` |
+
+**Live providers:** Slack, Google, Microsoft, Dropbox, Confluence, Telegram (token-based), OpenWebUI (URL-based).
+
+Adding a new OAuth provider means: (a) add a `route.ts` initiation handler, (b) add a `callback/route.ts` handler, (c) register it in `ConnectorCard` on the channels page. No framework changes needed.
+
+### Token Storage (`hub_channel_bindings`)
+
+NeonDB table created at runtime by `ensureSchema()` in `bindings.ts`:
+
+```sql
+CREATE TABLE IF NOT EXISTS hub_channel_bindings (
+    id                SERIAL PRIMARY KEY,
+    tenant_id         TEXT NOT NULL,
+    provider          TEXT NOT NULL,
+    external_id       TEXT,
+    access_token_enc  TEXT,          -- encrypted at rest
+    refresh_token_enc TEXT,          -- encrypted at rest
+    token_expires_at  TIMESTAMPTZ,
+    scopes            TEXT[],
+    meta              JSONB,
+    status            TEXT NOT NULL DEFAULT 'active',
+    connected_at      TIMESTAMPTZ DEFAULT now(),
+    updated_at        TIMESTAMPTZ DEFAULT now(),
+    UNIQUE (tenant_id, provider)
+);
+```
+
+Key properties:
+- One row per `(tenant_id, provider)` — upsert semantics on reconnect
+- Tokens encrypted in `access_token_enc` / `refresh_token_enc` (AES, key in Doppler)
+- RLS enabled — queries always scoped to the calling tenant
+- `status` field: `active | disconnected | error` — drives Hub UI badge color
+
+### ConnectorCard Component
+
+`src/app/(hub)/channels/page.tsx:41` — the single reusable card:
+
+```typescript
+interface CardProps {
+    emoji: string;
+    name: string;
+    description: string;
+    conn: ConnectionMeta;          // from localStorage / bindings API
+    onConnect: () => void;
+    onDisconnect: () => void;
+    disabled?: boolean;
+    comingSoon?: boolean;          // grays out + shows "Coming Soon" badge
+    infoOnly?: boolean;            // shows info panel instead of connect button
+}
+```
+
+To add a new channel card: add an entry to the channels array in `page.tsx` with `comingSoon: true` initially — it renders without wiring. Remove `comingSoon` when the backend is live.
+
+---
+
+## 2. Shared Infrastructure Still Needed
+
+These are the three cross-cutting pieces that must be built before most integrations can go live.
+
+### 2.1 Webhook Ingress Endpoint
+
+**What it is:** A single authenticated POST endpoint that receives inbound events from external platforms and routes them to the MIRA engine.
+
+**Gap:** No `/api/webhook/` route exists. The integrations page has a `WebhookTarget` UI concept but no receiver.
+
+**Implementation:**
+
+```
+src/app/api/webhook/[provider]/route.ts
+```
+
+Pattern for each provider:
+1. Verify inbound signature (HMAC-SHA256 for Slack/GitHub, Bearer token for others)
+2. Parse event → `NormalizedChatEvent` using the provider's `ChatAdapter.normalize_incoming()`
+3. Forward to MIRA pipeline (`POST http://mira-pipeline:9099/chat`)
+4. Return 200 immediately (async processing — never block the webhook response)
+
+**Signature verification library:** Use Node.js `crypto.timingSafeEqual()` — same pattern as `oauth-state.ts`.
+
+**Providers needing webhook ingress (priority order):**
+1. Slack Events API (event_callback, url_verification challenge)
+2. Microsoft Teams (activity from Bot Framework)
+3. WhatsApp / Twilio (Twilio form POST)
+4. Google Chat (JSON POST from Google)
+5. GitHub (repo events for KB update triggers)
+
+### 2.2 OAuth Token Refresh
+
+**Gap:** `hub_channel_bindings` stores `token_expires_at` and `refresh_token_enc` but no refresh loop runs.
+
+**Implementation:** Add a server-side route `src/app/api/connections/refresh/route.ts`:
+
+```typescript
+// Called by a Vercel cron or explicit trigger
+// 1. SELECT all bindings WHERE token_expires_at < now() + interval '10 minutes'
+// 2. For each: call provider's token refresh endpoint
+// 3. upsertBinding() with new tokens
+```
+
+For the MVP: call refresh on-demand in `getBinding()` when `token_expires_at` is near. Add a background Vercel Cron (`vercel.json`) for scheduled refresh after GA.
+
+### 2.3 CMMS Adapter Server-Side Routing
+
+**Gap:** The integrations page CMMS tab shows Atlas (live via MCP), Limble, MaintainX, UpKeep, Fiix (all mock). There's no server-side routing layer that takes a work-order event and dispatches to the right CMMS based on the tenant's active connection.
+
+**Implementation:**
+
+```
+src/app/api/cmms/work-orders/route.ts   -- POST to create WO in connected CMMS
+src/app/api/cmms/assets/route.ts        -- GET asset list from connected CMMS
+src/app/api/cmms/sync/route.ts          -- Trigger full sync for a tenant
+```
+
+Each route:
+1. Load tenant's active CMMS binding from `hub_channel_bindings` (provider = "atlas" | "limble" | ...)
+2. Instantiate the matching `CMMSAdapter` from `mira-mcp/cmms/`
+3. Call the adapter's typed method
+4. Return normalized response
+
+---
+
+## 3. Sprint Plan
+
+### Sprint 1 — Foundation (Week 1–2)
+*Prerequisite for everything else. Ship before touching any new connector.*
+
+| Task | File(s) | Effort | Owner |
+|------|---------|--------|-------|
+| Webhook ingress endpoint | `api/webhook/[provider]/route.ts` | 1d | Backend |
+| Slack webhook verification (HMAC) | `api/webhook/slack/route.ts` | 0.5d | Backend |
+| Token refresh on-demand | `api/connections/refresh/route.ts` | 0.5d | Backend |
+| Wire `integrations/page.tsx` CMMS tab to real binding data | `integrations/page.tsx` | 0.5d | Frontend |
+| Replace mock webhook targets with NeonDB CRUD | `integrations/page.tsx` + new API route | 1d | Full-stack |
+
+**Exit criteria:** Slack can send an event to `/api/webhook/slack`, MIRA responds in Slack thread, webhook target shows real status in Hub.
+
+---
+
+### Sprint 2 — Communication Channels (Week 3–4)
+*High-leverage: each channel multiplies the user surface.*
+
+| Connector | What's needed | Effort |
+|-----------|--------------|--------|
+| **Slack** (full) | Webhook ingress wired + `hub_channel_bindings` token used for posting | 1d |
+| **WhatsApp via Twilio** | Add Twilio OAuth entry to channels page + webhook ingress route | 2d |
+| **Microsoft Teams** | Bot Framework registration + webhook ingress | 2d |
+| **Email (SMTP)** | `Nodemailer` outbound + IMAP polling inbound (or SendGrid inbound parse) | 2d |
+
+**Exit criteria:** 4 channels can receive a message and MIRA replies through the same channel.
+
+---
+
+### Sprint 3 — Productivity Suites (Week 5–6)
+*Google and Microsoft already have OAuth. These wire the tokens to real API calls.*
+
+| Connector | What's needed | Effort |
+|-----------|--------------|--------|
+| **Google Drive KB sync** | Cron job: poll Drive folder → `mira-crawler` ingest | 2d |
+| **Confluence KB sync** | Confluence Cloud REST API → `mira-crawler` ingest | 2d |
+| **Dropbox KB sync** | Dropbox webhooks → `mira-crawler` ingest | 1d |
+| **SharePoint KB sync** | Microsoft Graph → `mira-crawler` ingest | 2d |
+| **Outlook calendar** | Graph API read maintenance windows | 1d |
+
+**Exit criteria:** Connecting Google Drive triggers a KB ingest run; new documents appear in MIRA RAG results.
+
+---
+
+### Sprint 4 — CMMS Connectors (Week 7–8)
+*Atlas is live via MCP. Remaining four need adapter + OAuth.*
+
+| Connector | What's needed | Effort |
+|-----------|--------------|--------|
+| **Limble CMMS** | OAuth 2.0 + `LimbleCMMSAdapter` implementing `CMMSAdapter` base | 3d |
+| **MaintainX** | API key auth + `MaintainXAdapter` | 2d |
+| **UpKeep** | API key auth + `UpKeepAdapter` | 2d |
+| **Fiix** | SOAP/REST + `FiixAdapter` (complex auth) | 3d |
+
+**CMMS adapter pattern** (follow `mira-mcp/cmms/` existing structure):
+
+```python
+class LimbleCMMSAdapter(CMMSAdapter):
+    async def create_work_order(self, title, asset_id, description, priority) -> WorkOrder: ...
+    async def list_assets(self, site_id=None) -> list[Asset]: ...
+    async def get_work_order(self, wo_id) -> WorkOrder: ...
+    async def update_work_order(self, wo_id, **kwargs) -> WorkOrder: ...
+```
+
+---
+
+### Sprint 5 — Operational Tools (Week 9–10)
+
+| Connector | What's needed | Effort |
+|-----------|--------------|--------|
+| **GitHub** | Webhook for doc changes → KB re-ingest | 1d |
+| **Jira** | OAuth + create issue from MIRA WO recommendation | 2d |
+| **PagerDuty** | Webhook receive alert → MIRA diagnosis | 1.5d |
+| **Datadog** | Webhook receive anomaly → MIRA analysis | 1.5d |
+
+---
+
+### Sprint 6 — IoT / Sensor (Week 11–12)
+*Hardware-gated. Defer until at least 3 CMMS connectors are GA.*
+
+| Connector | What's needed | Effort |
+|-----------|--------------|--------|
+| **Ignition** | `mira-relay` already built — wire Hub UI to show tag stream status | 1d |
+| **MQTT broker** | `mira-connect` module (deferred "Config 4") — new service | 5d |
+| **Modbus TCP** | `mira-connect` expansion | 3d |
+| **OSIsoft PI** | PI Web API + polling | 4d |
+
+---
+
+## 4. Hub UI Patterns
+
+### Adding a New Connector Card
+
+1. **Add to channels array** in `src/app/(hub)/channels/page.tsx`:
+
+```typescript
+{
+    emoji: "🔧",
+    name: "Limble CMMS",
+    description: "Sync work orders and assets with Limble.",
+    provider: "limble",
+    comingSoon: false,          // set true until backend is live
+}
+```
+
+2. **Add OAuth initiation route:** `src/app/api/auth/limble/route.ts`
+3. **Add OAuth callback route:** `src/app/api/auth/limble/callback/route.ts`
+4. **Add provider to `ConnectionMeta` type** in `src/lib/connections.ts`
+
+That's it. `ConnectorCard` handles the rest: connected/disconnected state badge, connect/disconnect buttons, error display.
+
+### Connect / Disconnect Flow
+
+```
+User clicks Connect
+  → channels/page.tsx onConnect()
+  → redirect to /api/auth/[provider]
+  → provider sets secure cookie with CSRF state
+  → provider redirects to OAuth consent page
+
+User approves
+  → provider redirects to /api/auth/[provider]/callback
+  → callback validates CSRF state (timingSafeEqual)
+  → callback exchanges code for token pair
+  → upsertBinding() writes to hub_channel_bindings
+  → redirect to /channels with ?connected=provider
+  → page reads binding → updates localStorage ConnectionMeta
+  → ConnectorCard shows "Connected" badge
+
+User clicks Disconnect
+  → DELETE /api/connections/[provider]
+  → hub_channel_bindings row: status = 'disconnected', tokens nulled
+  → localStorage entry removed
+  → ConnectorCard shows "Connect" button
+```
+
+### Status Monitoring Panel
+
+The integrations page (`src/app/(hub)/integrations/page.tsx`) currently shows mock `WebhookTarget[]` data. Replace with a real-time panel:
+
+```typescript
+// Replace static WEBHOOK_TARGETS with:
+const { data: webhooks } = useSWR('/api/connections/webhooks', fetcher, { refreshInterval: 30000 })
+```
+
+Backend route `GET /api/connections/webhooks`:
+- Query `hub_channel_bindings` WHERE `meta->>'type' = 'webhook'`
+- Join `agent_events` for last-fired timestamp
+- Return `[{ provider, status, last_call, error_count }]`
+
+Status badge colors follow existing pattern: `active` → green, `error` → red, `disconnected` → gray.
+
+---
+
+## 5. Credential Vault Conventions
+
+All new integration credentials follow this pattern:
+
+| Credential type | Where stored | Format |
+|----------------|-------------|--------|
+| OAuth access token | `hub_channel_bindings.access_token_enc` | AES-256 encrypted, key = `HUB_TOKEN_ENCRYPTION_KEY` in Doppler |
+| OAuth refresh token | `hub_channel_bindings.refresh_token_enc` | Same |
+| API key (non-OAuth) | `hub_channel_bindings.meta->>'api_key_enc'` | Same encryption |
+| Webhook signing secret | `hub_channel_bindings.meta->>'signing_secret_enc'` | Same encryption |
+| Short-lived UI state | `localStorage` via `connections.ts` | Unencrypted — status only, never tokens |
+
+**Never** store raw tokens in `meta` JSONB, `localStorage`, or environment variables. If a provider uses a static API key (no OAuth), store it encrypted in the `meta` JSONB column using the same `encrypt()` / `decrypt()` helpers.
+
+Add `HUB_TOKEN_ENCRYPTION_KEY` to Doppler `factorylm/prd` before Sprint 1 ships.
+
+---
+
+## 6. Testing Each Connector
+
+### Unit Tests
+Each new adapter gets a test file at `mira-mcp/cmms/tests/test_[provider]_adapter.py`:
+- Mock the provider's HTTP responses
+- Assert `WorkOrder` fields are correctly mapped
+- Assert error states return typed exceptions (not raw HTTP errors)
+
+### Integration Tests (Sprint gate)
+Before a sprint is "done", run the connector e2e:
+1. Connect via Hub UI — verify `hub_channel_bindings` row appears in NeonDB
+2. Send a test message on the channel — verify MIRA replies in the same thread
+3. Trigger a WO creation — verify it appears in the CMMS UI
+4. Disconnect — verify `status = 'disconnected'` in NeonDB and Hub shows gray badge
+
+### Benchmark Impact
+After each new channel ships, re-run `python benchmarks/benchmark_suite.py --version X.Y.Z` from inside the `mira-bots` container. The benchmark's Technical and WO Quality dimensions will surface regressions introduced by routing changes.
+
+---
+
+## 7. File Checklist per New Connector
+
+```
+□ src/app/api/auth/[provider]/route.ts         -- OAuth initiation
+□ src/app/api/auth/[provider]/callback/route.ts -- OAuth callback + upsertBinding
+□ src/app/api/webhook/[provider]/route.ts       -- Inbound event receiver
+□ src/app/(hub)/channels/page.tsx               -- Add ConnectorCard entry
+□ mira-mcp/cmms/[provider]_adapter.py           -- (CMMS only) CMMSAdapter impl
+□ mira-mcp/cmms/tests/test_[provider]_adapter.py -- (CMMS only) unit tests
+□ docs/env-vars.md                              -- Document any new env vars
+□ .env.template                                 -- Add placeholder (no real values)
+```
+
+**Definition of done per connector:**
+- ConnectorCard shows real connected/disconnected state
+- Inbound message reaches MIRA engine and reply is delivered
+- Token is stored encrypted in `hub_channel_bindings` (verify with `SELECT access_token_enc FROM hub_channel_bindings WHERE provider = '...'`)
+- `ruff check` passes on any new Python
+- `tsc --noEmit` passes on any new TypeScript

--- a/docs/PRD_Hub_Integrations_v1.md
+++ b/docs/PRD_Hub_Integrations_v1.md
@@ -1,0 +1,671 @@
+# PRD: Hub Integrations v1
+**MIRA as the Intelligence Layer — "Bring Your Own Stack"**
+
+**Version:** 1.0  
+**Date:** 2026-04-28  
+**Owner:** Mike Harper  
+**Status:** Draft → Review
+
+---
+
+## 1. Problem Statement
+
+Industrial maintenance teams don't abandon their existing tools when they adopt MIRA. They have Slack for alerts, Teams for enterprise comms, MaintainX or Upkeep for work orders, Google Drive full of manuals, and PLC data in a historian. MIRA's value is being the intelligence layer that sits across all of it — not another silo to manage.
+
+Today, MIRA is deployed as a Telegram-first diagnostic bot. The Hub exists but integrations are either mock data or hardcoded. The opportunity is to turn the Hub into an integration marketplace: connect your comms, your CMMS, your docs, your IoT data, and MIRA threads through all of them.
+
+**"Twilio for maintenance intelligence" — MIRA is the plug-in, not the delivery system.**
+
+---
+
+## 2. Current State (grounded)
+
+### What actually works today
+| Integration | Status | Where |
+|---|---|---|
+| Telegram | ✅ Live — adapter + polling bot + Hub card | `mira-bots/telegram/` |
+| Atlas CMMS | ✅ Live — MCP adapter, dual-write to Hub NeonDB | `mira-mcp/cmms/atlas.py` |
+| Open WebUI | ✅ Live — Hub card with URL config modal | Hub channels page |
+| Google OAuth | ✅ OAuth flow exists | `/api/auth/google` |
+| Microsoft OAuth | ✅ OAuth flow exists | `/api/auth/microsoft` |
+| Dropbox OAuth | ✅ OAuth flow exists | `/api/auth/dropbox` |
+| Confluence OAuth | ✅ OAuth flow exists | `/api/auth/confluence` |
+| Slack adapter | ✅ Adapter built + Hub OAuth card | `mira-bots/slack/` — needs container deploy |
+| Teams adapter | ✅ Adapter built + Hub OAuth card | `mira-bots/teams/` — needs Azure creds |
+| GChat adapter | ✅ Adapter built | `mira-bots/gchat/` — not on Hub yet |
+| Email adapter | ✅ Adapter built | `mira-bots/email/` — shown as infoOnly |
+| WhatsApp adapter | 🔄 Just migrated to ChatAdapter pattern | PR #805 |
+| WebChat adapter | 🔄 Just built — needs bot.py + Dockerfile | PR #805 |
+
+### What's mock/stub (Hub UI shows it, backend doesn't exist)
+| Integration | Hub location | Reality |
+|---|---|---|
+| Limble CMMS | Integrations → CMMS tab | `viaMcp: true` static object |
+| MaintainX | Integrations → CMMS tab | `viaMcp: true` static object |
+| UpKeep | Integrations → CMMS tab | `viaMcp: true` static object |
+| Fiix/Rockwell | Integrations → CMMS tab | `viaMcp: true` static object |
+| Webhooks (Slack, Teams, Email) | Integrations → Webhooks tab | Hardcoded mock array |
+| API key + events | Integrations → API tab | Hardcoded mock key |
+
+### What doesn't exist anywhere
+IoT (MQTT, OPC-UA), PagerDuty, ServiceNow, Jira, Zapier/Make, Power BI, SAP PM, IBM Maximo, SMS/Twilio, Google Chat card on Hub.
+
+---
+
+## 3. Vision
+
+Every industrial maintenance operation has 3 layers of tools:
+
+```
+COMMS LAYER          |  WORKFLOW LAYER         |  DATA LAYER
+─────────────────────|─────────────────────────|──────────────────
+Telegram             |  Atlas / FactoryLM Works|  Equipment manuals
+Slack                |  MaintainX              |  OEM PDFs
+Teams                |  UpKeep                 |  PLC historians
+WhatsApp             |  Limble / Fiix          |  MQTT broker
+Email                |  SAP PM / IBM Maximo    |  OPC-UA tags
+Web widget           |  ServiceNow / Jira      |  IoT sensors
+                     |  PagerDuty              |
+```
+
+MIRA connects to all three layers. Techs interact through any comms channel. Diagnosis and work orders flow into the CMMS. Alerts push to PagerDuty. Evidence pulls from IoT data. Documents pull from Drive, SharePoint, Confluence.
+
+---
+
+## 4. Section 1: Communication Channels
+
+*Bring your team — they stay in the channel they already use.*
+
+### 4.1 Telegram ✅ LIVE
+
+**Flow:** Tech sends message/photo → Telegram polling bot → Supervisor engine → diagnostic reply  
+**Auth:** Bot token (already in Doppler `TELEGRAM_BOT_TOKEN`)  
+**Hub card:** Present, functional — shows bot username when configured  
+**What's missing:** Nothing for MVP. Post-launch: thread management for group chats, voice note transcription.
+
+---
+
+### 4.2 Slack
+
+**Current state:** `mira-bots/slack/chat_adapter.py` built (97 lines). Hub shows OAuth card with `/api/auth/slack`. No deployed container.
+
+**Flow:**  
+- Inbound: Slack Events API → `POST /webhook` → `SlackChatAdapter.normalize_incoming()` → dispatcher → engine → `render_outgoing()` → Block Kit message  
+- Outbound push: MIRA posts alerts to configured Slack channels via Incoming Webhooks  
+
+**Auth:** Slack OAuth 2.0 — `SLACK_BOT_TOKEN` + `SLACK_SIGNING_SECRET` (request verification)  
+**Hub:** ConnectorCard present, disabled flag if creds not configured  
+**Implementation:** Deploy `mira-bot-slack` container + wire `SLACK_BOT_TOKEN` and `SLACK_SIGNING_SECRET` to Doppler  
+**Effort:** 3 hours (container + secrets + Slack app creation in dashboard)  
+**Priority:** Ship now — adapter done, just needs deploy
+
+**Data flow:**
+| Direction | What | Format |
+|---|---|---|
+| In | Tech message (text, thread reply, file) | Slack Events API JSON |
+| In | `/mira` slash command | Slash command payload |
+| Out | Diagnostic reply | Block Kit (formatted with headers, bullets) |
+| Out | Safety alert | Block Kit `warning` block, @here mention |
+| Out | WO created notification | Block Kit card with WO number, asset, priority |
+
+---
+
+### 4.3 Microsoft Teams
+
+**Current state:** `mira-bots/teams/chat_adapter.py` built (154 lines). Hub shows OAuth card. No deployed container.
+
+**Flow:** Bot Framework Activity → `POST /webhook` → `TeamsChatAdapter.normalize_incoming()` → dispatcher → engine → Adaptive Card reply
+
+**Auth:** Azure AD app registration — `TEAMS_APP_ID` + `TEAMS_APP_PASSWORD` + `TEAMS_TENANT_ID`  
+**Hub:** ConnectorCard present, disabled if Azure creds not configured  
+**Implementation:** Azure App Registration + Bot Framework channel registration + deploy `mira-bot-teams`  
+**Effort:** 6 hours (Azure setup is the friction; adapter is done)  
+**Priority:** Ship this sprint — high enterprise value
+
+**Data flow:**
+| Direction | What | Format |
+|---|---|---|
+| In | Message (1:1 or channel mention) | Bot Framework Activity JSON |
+| In | File attachment (image, PDF) | Graph API download |
+| Out | Diagnostic reply | Adaptive Card (rich formatted) |
+| Out | Safety alert | Adaptive Card with red accent + escalation action |
+| Out | WO created | Adaptive Card with status, asset, WO# |
+
+---
+
+### 4.4 WhatsApp / Twilio
+
+**Current state:** `WhatsAppChatAdapter` built (PR #805). `whatsapp/bot.py` uses legacy adapter — needs wiring to new ChatAdapter. Hub shows `comingSoon`.
+
+**Flow:** Twilio webhook → `POST /webhook` → `WhatsAppChatAdapter.normalize_incoming()` → dispatcher → engine → Twilio Messages API reply
+
+**Auth:** `TWILIO_ACCOUNT_SID` + `TWILIO_AUTH_TOKEN` + `TWILIO_WHATSAPP_FROM` + Twilio signature validation  
+**Hub:** Update Hub card from `comingSoon` → functional connect flow (enter phone number sandbox config)  
+**Implementation:** Wire `whatsapp/bot.py` to new `WhatsAppChatAdapter`, deploy container, connect Twilio dashboard webhook  
+**Effort:** 4 hours  
+**Priority:** Next sprint (post-Slack/Teams)
+
+**Data flow:**
+| Direction | What | Format |
+|---|---|---|
+| In | Text message | Twilio webhook form POST |
+| In | Image (MMS) | Twilio media URL → download with Basic auth |
+| In | Voice note | Twilio media URL → (transcription TBD) |
+| Out | Diagnostic reply (≤1600 chars) | TwiML `<Response><Message>` or Twilio Messages API |
+| Out | Safety alert | Plain text (no formatting — WhatsApp strips it otherwise) |
+
+---
+
+### 4.5 Google Chat
+
+**Current state:** `mira-bots/gchat/chat_adapter.py` built (146 lines). Not on Hub channels page.
+
+**Flow:** Google Chat Event → HTTP push webhook → `GoogleChatAdapter.normalize_incoming()` → dispatcher → engine → Google Chat Cards v2 reply
+
+**Auth:** Google Cloud project + Chat API enabled + webhook URL registered  
+**Hub:** Add ConnectorCard to channels page  
+**Effort:** 3 hours (adapter done, needs Hub card + container deploy)  
+**Priority:** Next sprint
+
+---
+
+### 4.6 Email
+
+**Current state:** `mira-bots/email/chat_adapter.py` built (204 lines). Hub shows `infoOnly` card — enabled via Google or Microsoft connection.
+
+**Flow:** Inbound email → SES/SNS → `POST /webhook` → `EmailChatAdapter.normalize_incoming()` → dispatcher → engine → reply via SES/Resend
+
+**Auth:** AWS SES receiving + Resend for outbound (`RESEND_API_KEY` in Doppler, pending Resend domain verification per `docs/known-issues.md`)  
+**Hub:** Keep `infoOnly` pattern — email works when Google or Microsoft is connected  
+**Effort:** 2 hours (unblock after Resend domain verification)  
+**Priority:** Unblock now — just needs Resend domain verified
+
+---
+
+### 4.7 Web Widget
+
+**Current state:** `WebChatAdapter` built (PR #805). `webchat/bot.py` not yet built.
+
+**Flow:** Widget JS → `POST /chat` to webchat bot → `WebChatAdapter.normalize_incoming()` → dispatcher → engine → JSON reply → widget renders HTML
+
+**Auth:** Per-tenant widget key (`MIRA_WIDGET_KEY`) in Authorization header or query param  
+**Embed:** `<script src="https://app.factorylm.com/widget.js" data-tenant="..." data-key="..."></script>`  
+**Hub:** Add ConnectorCard to channels page with embed snippet modal + API key display  
+**Effort:** 6 hours (bot.py + Dockerfile + widget JS + Hub card)  
+**Priority:** Next sprint — high PLG value for web signups
+
+---
+
+### 4.8 SMS / Twilio
+
+**Current state:** Nothing built. WhatsApp adapter reuses ~80% of the Twilio pattern.
+
+**Flow:** Twilio SMS webhook → FastAPI → engine → TwiML reply  
+**Auth:** Same Twilio credentials as WhatsApp  
+**Constraint:** 1600-char limit, no media, no formatting — pure plain text  
+**Effort:** 2 hours (fork WhatsApp adapter, strip image/formatting handling)  
+**Priority:** Q2 — after WhatsApp ships
+
+---
+
+### 4.9 Open WebUI
+
+**Current state:** ✅ Live. Hub card functional with URL config modal.  
+**No implementation work needed for MVP.**
+
+---
+
+## 5. Section 2: Productivity Suites
+
+*Bring your tools — MIRA reads from and writes to your existing workflows.*
+
+### 5.1 Microsoft 365
+
+#### Outlook / Email alerts
+**Direction:** MIRA → Outlook  
+**Use case:** Send WO creation, PM reminders, and safety alert summaries to maintenance supervisors via email  
+**Auth:** Microsoft Graph API with `Mail.Send` scope — OAuth token already captured via existing Microsoft OAuth flow  
+**Implementation:** `POST /v1.0/me/sendMail` via Graph API using stored access token  
+**Effort:** 2 hours  
+**Priority:** Ship now — auth already done
+
+#### Calendar / PM sync
+**Direction:** MIRA → Outlook Calendar  
+**Use case:** When a PM schedule is created in MIRA, create a recurring Outlook Calendar event for the responsible tech  
+**Auth:** `Calendars.ReadWrite` scope (add to existing OAuth)  
+**API:** `POST /v1.0/me/events` or `POST /v1.0/users/{id}/events`  
+**Effort:** 4 hours  
+**Priority:** Next sprint
+
+#### SharePoint / Document storage
+**Direction:** SharePoint → MIRA (ingest)  
+**Use case:** MIRA crawls a SharePoint site/library for OEM manuals and maintenance procedures, indexes to Open WebUI KB  
+**Auth:** `Sites.Read.All` scope (add to existing OAuth)  
+**API:** Graph API `GET /v1.0/sites/{site-id}/drive/items/{item-id}/content`  
+**Effort:** 4 hours (use existing mira-crawler pipeline)  
+**Priority:** Next sprint
+
+#### OneNote
+**Direction:** MIRA → OneNote  
+**Use case:** MIRA appends diagnostic summaries and repair logs to a maintenance OneNote notebook  
+**Auth:** `Notes.ReadWrite` scope  
+**Effort:** 3 hours  
+**Priority:** Q2
+
+---
+
+### 5.2 Google Workspace
+
+#### Gmail / Email alerts
+**Direction:** MIRA → Gmail  
+**Use case:** WO notifications, PM reminders, safety summaries via email  
+**Auth:** `gmail.send` scope — OAuth already captured  
+**API:** Gmail API `POST /gmail/v1/users/me/messages/send`  
+**Effort:** 2 hours  
+**Priority:** Ship now (same timing as Outlook — auth done)
+
+#### Google Calendar / PM sync
+**Direction:** MIRA → Google Calendar  
+**Use case:** Create recurring calendar events for PM schedules  
+**Auth:** `calendar.events` scope (add to existing OAuth)  
+**API:** Calendar API `POST /calendars/{calendarId}/events`  
+**Effort:** 3 hours  
+**Priority:** Next sprint
+
+#### Google Drive / Document ingest
+**Direction:** Drive → MIRA (ingest)  
+**Use case:** Crawl Drive folder for OEM manuals, index to Open WebUI KB  
+**Auth:** `drive.readonly` scope — OAuth already captured  
+**API:** Drive API `GET /files/{fileId}?alt=media`  
+**Effort:** 2 hours (mira-crawler already has Google Drive ingest)  
+**Priority:** Ship now — ingest pipeline exists, just needs OAuth token wiring
+
+---
+
+## 6. Section 3: CMMS Connectors
+
+*Bring your system of record — MIRA writes work orders where they already live.*
+
+### Architecture: MCP adapter pattern
+
+Every CMMS connector follows the same pattern as Atlas:
+1. Extend `CMMSAdapter` base class in `mira-mcp/cmms/`
+2. Set `CMMS_PROVIDER={name}` in Doppler
+3. MIRA MCP server routes work order creation to the active provider
+4. Hub Integrations page shows connected/available status
+
+### 6.1 Atlas / FactoryLM Works ✅ LIVE
+
+**Auth:** JWT (`/auth/signin` with `type: "CLIENT"`)  
+**Operations:** `list_work_orders`, `create_work_order`, `complete_work_order`, `list_assets`, `get_asset`, `create_asset`, `list_pm_schedules`, `invite_users`  
+**Effort:** Done
+
+---
+
+### 6.2 MaintainX
+
+**API:** REST v2 — `https://api.getmaintainx.com/v2`  
+**Auth:** API key in `Authorization: Bearer {key}` header  
+**Operations needed:**
+- `POST /workorders` — create work order
+- `GET /workorders` — list with status filter
+- `PATCH /workorders/{id}` — update/complete
+- `GET /assets` — list assets for asset picker
+- `POST /assets` — create asset from nameplate scan
+
+**Mapping:**
+| MIRA field | MaintainX field |
+|---|---|
+| `title` | `title` |
+| `description` | `description` |
+| `priority` | `priority` (NONE/LOW/MEDIUM/HIGH) |
+| `asset` | `asset.id` |
+| `status` | `status` (OPEN/IN_PROGRESS/DONE) |
+
+**Effort:** 4 hours  
+**Priority:** Next sprint (highest install base in target ICP)
+
+---
+
+### 6.3 UpKeep
+
+**API:** REST v2 — `https://api.upkeep.com/api/v2`  
+**Auth:** API key in header `x-api-key: {key}`  
+**Operations needed:**
+- `POST /work-orders` — create
+- `GET /work-orders` — list
+- `PATCH /work-orders/{id}` — update/complete
+- `GET /assets` — list
+- `POST /assets` — create
+
+**Mapping:**
+| MIRA field | UpKeep field |
+|---|---|
+| `title` | `title` |
+| `description` | `description` |
+| `priority` | `priority` (1=Low, 2=Medium, 3=High, 4=Critical) |
+| `asset` | `asset_id` |
+| `status` | `status` (open/in_progress/complete) |
+
+**Effort:** 4 hours  
+**Priority:** Next sprint
+
+---
+
+### 6.4 Limble CMMS
+
+**API:** REST — `https://api.limblecmms.com/v1` (requires paid plan for API access)  
+**Auth:** API key header `Authorization: Bearer {key}`  
+**Operations needed:** Same CRUD pattern as MaintainX/UpKeep  
+**Effort:** 4 hours  
+**Priority:** Q2 (requires customer to have Limble API access)
+
+---
+
+### 6.5 Fiix / Rockwell Automation
+
+**API:** REST/JSON-RPC hybrid — `https://fiixsoftware.com/api/v3/cmmses/1`  
+**Auth:** API key + company ID — complex signature requirement  
+**Operations needed:** Work order CRUD + asset lookup  
+**Effort:** 8 hours (non-standard auth signature is the friction)  
+**Priority:** Q2 (Rockwell shops = high value but low volume for now)
+
+---
+
+### 6.6 IBM Maximo
+
+**API:** Maximo Application Framework REST API (OSLC) — `https://{host}/maximo/oslc/os/mxwo`  
+**Auth:** HTTP Basic or API key token  
+**Operations needed:** WO creation + asset lookup  
+**Notes:** Self-hosted installations vary wildly in version and config; need customer to provide base URL + credentials  
+**Effort:** 10 hours (OSLC is verbose; field mapping is complex)  
+**Priority:** Q3 — enterprise deal requirement
+
+---
+
+### 6.7 SAP Plant Maintenance (PM)
+
+**API:** SAP OData API or RFC calls (via SAP API Business Hub or direct)  
+**Auth:** OAuth 2.0 (SAP BTP) or basic auth with SAP API key  
+**Operations needed:** `POST /MaintenanceOrder`, `GET /FunctionalLocation`  
+**Notes:** Customer-specific config (S/4HANA vs ECC vs BTP); almost always requires SI partner  
+**Effort:** 20+ hours + SAP license/environment  
+**Priority:** Q3 — enterprise tier only; never ship without a live customer requirement
+
+---
+
+## 7. Section 4: Operational Tools
+
+*Bring your workflow — MIRA fires into your existing escalation and ticketing systems.*
+
+### 7.1 Outbound Webhooks (exists as mock → make real)
+
+**Current:** Hub Integrations → Webhooks tab shows hardcoded mock array  
+**Target:** Real webhook registry per tenant in NeonDB  
+**Events to support:**
+- `safety_alert` — immediate push (< 5 seconds)
+- `wo_created` — with WO number, asset, priority, diagnosis summary
+- `pm_overdue` — daily digest at 6 AM local
+- `diagnostic_complete` — with confidence score and citations
+- `asset_created` — from nameplate scan
+
+**Implementation:**
+1. NeonDB table: `webhooks(id, tenant_id, url, events[], secret, enabled, last_called_at, healthy)`
+2. `mira-mcp` fires webhooks on key events (Supervisor calls `fire_webhook()`)
+3. Hub UI: real CRUD for webhook targets (url, events, test ping)
+
+**Effort:** 6 hours  
+**Priority:** Ship now — powers all outbound integrations
+
+---
+
+### 7.2 PagerDuty
+
+**Direction:** MIRA → PagerDuty  
+**Trigger:** `safety_alert` event  
+**Use case:** Arc flash, LOTO, confined space, exposed energized wire → immediately page the on-call supervisor  
+**Auth:** PagerDuty Events API v2 — integration key (routing key)  
+**API:** `POST https://events.pagerduty.com/v2/enqueue`  
+**Payload:**
+```json
+{
+  "routing_key": "{integration_key}",
+  "event_action": "trigger",
+  "payload": {
+    "summary": "SAFETY ALERT: Arc flash reported on Panel P-3 — Line 2",
+    "severity": "critical",
+    "source": "MIRA",
+    "custom_details": {
+      "asset": "Panel P-3", "technician": "chat_id", "raw_message": "..."
+    }
+  }
+}
+```
+**Effort:** 3 hours  
+**Priority:** Next sprint — safety is table stakes for enterprise
+
+---
+
+### 7.3 Jira Service Management
+
+**Direction:** MIRA → Jira  
+**Use case:** Create Jira issues for work orders when the customer uses Jira as their ticketing system (no CMMS)  
+**Auth:** API token — `Authorization: Basic base64(email:token)`  
+**API:** `POST /rest/api/3/issue`  
+**Field mapping:**
+| MIRA field | Jira field |
+|---|---|
+| `title` | `summary` |
+| `description` | `description` (Atlassian Document Format) |
+| `priority` | `priority.name` (Low/Medium/High/Critical) |
+| `asset` | Custom field or labels |
+
+**Effort:** 5 hours  
+**Priority:** Q2
+
+---
+
+### 7.4 ServiceNow
+
+**Direction:** MIRA → ServiceNow  
+**Use case:** Create ServiceNow `incident` or `change_request` records from MIRA diagnoses  
+**Auth:** OAuth 2.0 or Basic auth  
+**API:** `POST /api/now/table/incident`  
+**Effort:** 6 hours  
+**Priority:** Q3 — enterprise deal requirement
+
+---
+
+### 7.5 Zapier / Make
+
+**Direction:** MIRA → Zapier webhook trigger → customer-defined automation  
+**Use case:** Customers who can't afford direct integrations use Zapier to bridge MIRA events to any other tool  
+**Implementation:** Expose the outbound webhook system (Section 7.1) — Zapier/Make both accept any webhook. No MIRA-specific work needed beyond real webhooks.  
+**Effort:** 0 hours (webhooks cover this)  
+**Priority:** Document in Hub as "works via webhooks"
+
+---
+
+### 7.6 Power BI
+
+**Direction:** MIRA NeonDB → Power BI  
+**Use case:** Maintenance KPI dashboards for operations managers  
+**Implementation:** Power BI DirectQuery or Import from NeonDB PostgreSQL. Customer uses Power BI Desktop to connect to NeonDB connection string.  
+**Effort:** 0 hours for MIRA (NeonDB is already standard PostgreSQL)  
+**Priority:** Document in Hub as self-service
+
+---
+
+## 8. Section 5: IoT / Sensor Data
+
+*Bring your data — MIRA reads real-time signals and reasons about them.*
+
+### 8.1 MQTT Broker
+
+**Direction:** MQTT → MIRA  
+**Use case:** Subscribe to equipment topics, detect anomalies, trigger diagnostic when a threshold is exceeded  
+**Protocol:** MQTT 3.1.1 / 5.0 via `paho-mqtt` or `aiomqtt`  
+**Flow:**
+```
+MQTT broker (e.g. EMQX, Mosquitto, HiveMQ)
+  → mira-bridge (Node-RED) subscribes to topics
+  → threshold exceeded → HTTP POST to mira-pipeline
+  → engine processes event with sensor context
+  → creates work order if confidence high
+```
+**Integration point:** `mira-bridge` (Node-RED) is already running — extend with MQTT in node  
+**Effort:** 4 hours (Node-RED MQTT node + threshold rules + mira-pipeline endpoint)  
+**Priority:** Next sprint — `mira-bridge` is purpose-built for this
+
+**Hub UI:** Add "MQTT Broker" section to Integrations page — enter broker host, port, username/password, and topic subscriptions
+
+---
+
+### 8.2 OPC-UA
+
+**Direction:** OPC-UA server → MIRA  
+**Use case:** Read live tag values from PLCs (SCADA-connected systems), attach to diagnostic context  
+**Protocol:** OPC-UA over TCP (`opc.tcp://`) via `asyncua` Python library  
+**Flow:**
+```
+OPC-UA server (PLC / SCADA)
+  → mira-connect (deferred "Config 4" module)
+  → poll tags at configurable interval
+  → anomaly detection → trigger diagnostic
+```
+**Current state:** `mira-connect` exists as a deferred module  
+**Effort:** 16 hours (deferred Config 4)  
+**Priority:** Q3 — needs `mira-connect` to ship first
+
+---
+
+### 8.3 REST Sensor APIs
+
+**Direction:** REST sensor API → MIRA  
+**Use case:** Periodic polling of sensor APIs (vibration monitors, temperature loggers, etc.) — trigger diagnostics when values breach thresholds  
+**Flow:** Cron job → `GET {sensor_api}/readings/latest` → compare to baseline → POST to mira-pipeline if anomaly  
+**Effort:** 3 hours per sensor API (generic polling client)  
+**Priority:** Q2
+
+---
+
+### 8.4 Unified Namespace (UNS)
+
+**Current state:** UNS work order schema (`UNSWorkOrder`) already defined in `mira-bots/shared/models/work_order.py`. `log_uns_event()` called on every WO creation. UNS topic format: `mira/{tenant}/{site}/{area}/{asset}/workorder`.
+
+**Direction:** MIRA → UNS (publish) + UNS → MIRA (subscribe to asset health events)  
+**Hub:** Add UNS namespace config to Integrations page — enter MQTT broker + topic prefix  
+**Effort:** 2 hours (schema exists; just need Hub config + broker wiring)  
+**Priority:** Next sprint — UNS events already firing, just need a real broker endpoint
+
+---
+
+## 9. Connection Storage Architecture
+
+**Current problem:** Connection state is stored in `localStorage` (`mira_connections_v2` key). This means:
+- State is lost when the user clears browser storage
+- Multi-device access doesn't work
+- No server-side visibility into which tenants have what connected
+
+**Target:** Server-side connection registry in NeonDB
+
+```sql
+CREATE TABLE tenant_connections (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id   UUID NOT NULL REFERENCES tenants(id),
+  provider    TEXT NOT NULL,               -- "telegram" | "slack" | "teams" | ...
+  connected   BOOLEAN NOT NULL DEFAULT true,
+  config      JSONB NOT NULL DEFAULT '{}', -- provider-specific: bot_token, workspace, etc.
+  oauth_token TEXT,                        -- encrypted at rest
+  connected_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_active  TIMESTAMPTZ,
+  created_by  UUID,
+  UNIQUE(tenant_id, provider)
+);
+```
+
+**Migration path:**
+1. Add `tenant_connections` table to Hub NeonDB schema
+2. Move `/api/connections/` routes from localStorage sync → DB reads/writes
+3. Add `provider` to the existing `Provider` type (already typed in `src/lib/connections.ts`)
+4. Encrypt OAuth tokens at rest using `PLG_JWT_SECRET` key
+
+**Effort:** 4 hours  
+**Priority:** Ship before any OAuth integrations go to production
+
+---
+
+## 10. Hub UI Requirements
+
+### ConnectorCard states
+Every connector needs four visible states:
+1. **Not configured** — provider creds missing in Doppler; `disabled` with explanation
+2. **Available** — creds configured, not connected by this tenant
+3. **Connected** — green dot, shows connected label (username, email, workspace)
+4. **Error** — red dot + error message, reconnect CTA
+
+### Integrations page upgrade
+The Integrations page (`/integrations`) needs:
+- **CMMS tab:** Replace mock `CMMS_SYSTEMS` array with real DB-backed list. Add "Connect" flow per system (API key input modal).
+- **Webhooks tab:** Replace mock array with real CRUD backed by `webhooks` NeonDB table.
+- **IoT tab:** New tab — MQTT broker config, OPC-UA endpoint, UNS namespace
+- **API tab:** Real API key generation/rotation (not mock `mlm_sk_prod_...`)
+
+---
+
+## 11. Prioritization Summary
+
+### Ship now (this sprint)
+| Item | Effort | Blocker |
+|---|---|---|
+| Slack container deploy | 3 hrs | Doppler secrets + Slack app |
+| Google Drive ingest wiring | 2 hrs | OAuth token already captured |
+| Gmail/Outlook email alerts | 2 hrs each | OAuth done; just call Graph/Gmail API |
+| Outbound webhook system (real) | 6 hrs | NeonDB table |
+| Server-side connection storage | 4 hrs | Schema migration |
+| Resend domain verification (email unblock) | 0 hrs dev | Mike action item |
+
+### Next sprint (May)
+| Item | Effort |
+|---|---|
+| Teams container deploy + Azure setup | 6 hrs |
+| WhatsApp bot.py wiring + container | 4 hrs |
+| MaintainX MCP adapter | 4 hrs |
+| UpKeep MCP adapter | 4 hrs |
+| PagerDuty safety alert integration | 3 hrs |
+| Google Calendar PM sync | 3 hrs |
+| Outlook Calendar PM sync | 4 hrs |
+| MQTT → mira-bridge integration | 4 hrs |
+| UNS broker wiring | 2 hrs |
+| Google Chat Hub card + container | 3 hrs |
+| WebChat bot.py + widget JS | 6 hrs |
+
+### Q2
+| Item | Effort |
+|---|---|
+| Limble MCP adapter | 4 hrs |
+| Fiix MCP adapter | 8 hrs |
+| Jira Service Management | 5 hrs |
+| SMS/Twilio | 2 hrs |
+| SharePoint manual ingest | 4 hrs |
+| REST sensor API polling | 3 hrs/connector |
+
+### Q3
+| Item | Effort |
+|---|---|
+| IBM Maximo | 10 hrs + customer env |
+| SAP PM | 20+ hrs + SI partner |
+| ServiceNow | 6 hrs + customer env |
+| OPC-UA via mira-connect | 16 hrs |
+
+---
+
+## 12. Success Metrics
+
+| Metric | Now | 30-day target | 90-day target |
+|---|---|---|---|
+| Communication channels live | 1 (Telegram) | 4 (+ Slack, Teams, WhatsApp) | 7 (+ GChat, Email, WebChat) |
+| CMMS connectors live | 1 (Atlas) | 3 (+ MaintainX, UpKeep) | 6 |
+| Tenants with ≥2 channels connected | 0 | 3 | 10 |
+| Work orders via non-Telegram channel | 0 | 10/week | 50/week |
+| Webhook events fired | 0 (mock) | 100/week | 500/week |

--- a/docs/PRD_Hub_Integrations_v1.md
+++ b/docs/PRD_Hub_Integrations_v1.md
@@ -72,6 +72,76 @@ MIRA connects to all three layers. Techs interact through any comms channel. Dia
 
 ---
 
+## 3.5 Priority 0: CSV Import — The Universal On-Ramp
+
+> **"No API key. No IT department. No integration project. Just upload your spreadsheet."**
+
+Every industrial business can export their CMMS, ERP, or maintenance database to CSV. This is the zero-friction entry point — it works before any OAuth is wired, before any API key is issued, before any integration partner is approved.
+
+### What CSV Import Covers
+
+| Column Category | Field Examples |
+|---|---|
+| Asset identity | Equipment name, asset tag, manufacturer, model, serial number |
+| Location | Site, area, line, machine group |
+| Fault history | Fault description, date, resolution, downtime hours |
+| PM schedules | Task name, interval (days/hours), last completed, next due |
+| Parts inventory | Part number, description, quantity on hand, reorder point |
+| Work orders | WO number, status, priority, assigned tech, open date, close date |
+
+### Smart Column Mapping
+
+Auto-detect common column names and let users confirm or override before import:
+
+```
+Uploaded columns          → MIRA fields
+─────────────────────────────────────────
+"Equipment"               → asset.name (auto-matched, high confidence)
+"Asset #" / "Asset No."   → asset.tag (auto-matched)
+"S/N" / "Serial"          → asset.serial (auto-matched)
+"Last PM" / "PM Date"     → pm_schedule.last_completed (auto-matched)
+"Description"             → [ambiguous — prompt: fault_history or asset.description?]
+"Custom_Field_47"         → [unmatched — skip or assign manually]
+```
+
+Rules:
+- Fuzzy-match column headers (edit distance ≤ 2, case-insensitive)
+- High-confidence matches auto-assign; low-confidence shown in yellow for user confirmation
+- Unmatched columns can be: (a) mapped manually, (b) imported as custom fields, (c) skipped
+- Preview first 10 rows before committing import
+- Dry-run mode: show what would be created/updated without writing
+
+### What Happens After Import
+
+1. Assets land in Atlas CMMS (or the tenant's connected CMMS)
+2. Fault history is chunked and indexed in the MIRA knowledge graph — MIRA immediately knows this asset's failure patterns
+3. PM schedules are loaded into the PM calendar
+4. Parts inventory loads into the parts module
+5. Work orders are imported as historical records (closed) or active tickets (open)
+
+### Import Formats Accepted
+
+- `.csv` (UTF-8 or UTF-16, comma or semicolon delimited)
+- `.xlsx` / `.xls` (first sheet imported, sheet selector coming)
+- `.tsv` (tab-delimited)
+- Column order does not matter — header row required
+
+### Recurring Imports
+
+After the initial import, customers can schedule recurring CSV drops:
+- Manual re-upload (always available)
+- SFTP polling (Enterprise tier) — drop files to a dedicated SFTP path, MIRA polls hourly
+- Email attachment ingestion (Pro tier) — forward the export email to `import@factorylm.com`
+
+### Priority and Location in Hub
+
+This feature lives at **Hub → Import** (new tab, alongside Channels / Integrations). It appears as the first card on the Integrations page for tenants with no connected CMMS, with the headline: *"Start here — no API key needed."*
+
+**Priority:** P0 — ships before any other integration. This is how the first 10 customers onboard before native CMMS connectors are live.  
+**Effort:** 3 days (UI: column mapper component + preview table; backend: Papa Parse / SheetJS → upsert assets + fault_history rows)
+
+---
+
 ## 4. Section 1: Communication Channels
 
 *Bring your team — they stay in the channel they already use.*
@@ -669,3 +739,125 @@ The Integrations page (`/integrations`) needs:
 | Tenants with ≥2 channels connected | 0 | 3 | 10 |
 | Work orders via non-Telegram channel | 0 | 10/week | 50/week |
 | Webhook events fired | 0 (mock) | 100/week | 500/week |
+| CSV imports completed by new tenants | 0 | 5 | 20 |
+| Assets onboarded via CSV | 0 | 200 | 1,000 |
+
+---
+
+## 13. Data Portability Guarantee
+
+> **FactoryLM never holds your data hostage. Every byte you put in can come back out.**
+
+### The Policy
+
+1. **Export anytime, no penalty.** Any tenant on any tier can download a full export of their data at any time — no support ticket required, no offboarding fee, no waiting period.
+
+2. **Open formats.** Exports are delivered as:
+   - CSV (assets, work orders, PM schedules, parts, fault history)
+   - JSON (full structured export including relationships and metadata)
+   - Via API (GET endpoints for all first-party data objects — see API reference)
+
+3. **The only proprietary element is the intelligence.** The knowledge graph reasoning, AI diagnostics, fault pattern models — that's FactoryLM's IP. The *data* that goes into it is yours.
+
+4. **Formats are documented.** Export schemas are versioned and published at `docs/export-schema/`. Any tool that reads CSV or JSON can ingest a FactoryLM export.
+
+5. **You can take your data to a competitor.** The export format is intentionally compatible with all major CMMS import formats (MaintainX, UpKeep, Limble, IBM Maximo). We will document the mapping.
+
+### What Is and Isn't Exported
+
+| Data type | Exported | Format |
+|---|---|---|
+| Assets (name, tag, serial, location) | ✅ | CSV + JSON |
+| Work order history | ✅ | CSV + JSON |
+| PM schedules | ✅ | CSV + JSON |
+| Parts inventory | ✅ | CSV + JSON |
+| Fault history records | ✅ | CSV + JSON |
+| Channel connection tokens | ❌ | Security — re-authenticate after migration |
+| AI-generated knowledge graph | ❌ | FactoryLM IP — not exported |
+| Diagnostic conversation history | ✅ (anonymized) | JSON |
+
+### Export Endpoint (API)
+
+```
+GET /api/v1/export/full          → ZIP archive: all data as CSV + manifest.json
+GET /api/v1/export/assets        → assets.csv
+GET /api/v1/export/work-orders   → work_orders.csv
+GET /api/v1/export/pm-schedules  → pm_schedules.csv
+GET /api/v1/export/parts         → parts.csv
+GET /api/v1/export/fault-history → fault_history.csv
+```
+
+All export endpoints:
+- Require tenant JWT (same as rest of API)
+- Return 202 for large datasets with a `job_id` for async polling
+- Include a `schema_version` header matching the published schema docs
+- Available to all tiers (Starter, Professional, Enterprise)
+
+### Legal Commitment
+
+This guarantee is written into the Terms of Service: *"Customer retains full ownership of all Customer Data. FactoryLM grants no rights to Customer Data beyond what is necessary to operate the service. Customer may export all Customer Data at any time."*
+
+---
+
+## 14. Data Sensitivity Options
+
+Different customers have different risk tolerances. We meet them where they are.
+
+### Tier-by-Tier Controls
+
+| Control | Starter | Professional | Enterprise |
+|---|---|---|---|
+| Knowledge Cooperative participation | ✅ On (anonymous, opt-out available) | Opt-out available | Off by default |
+| Live CMMS API connection | ✅ Available | ✅ Available | ✅ Available |
+| CSV-only mode (no live connection) | ✅ Available | ✅ Available | ✅ Available |
+| On-premises deployment | ❌ | ❌ | ✅ Available |
+| Data residency choice (US / EU / AU) | ❌ | ❌ | ✅ Available |
+| Private knowledge base (no federation) | ❌ | ✅ | ✅ |
+| Audit log export | ❌ | ✅ | ✅ |
+| SOC 2 Type II report | ❌ | On request | ✅ Included |
+
+### CSV-Only Mode
+
+For customers whose IT policy prohibits live API connections to their CMMS:
+
+- Turn off all live CMMS API polling (no API credentials required or stored)
+- MIRA operates from imported CSV data only
+- Manual re-import triggers a sync (scheduled or on-demand)
+- The Hub shows a "CSV mode" badge on the CMMS card instead of a "Connected" badge
+- Full diagnostic capability is preserved — only the real-time sync is disabled
+
+Enabled via Hub → Integrations → CMMS → [provider] → "Use CSV import only".
+
+### Knowledge Cooperative Opt-Out
+
+The Knowledge Cooperative pools anonymized fault patterns across the tenant base to improve MIRA's diagnostic accuracy. Opt-out means:
+- MIRA diagnostics are limited to that tenant's own KB + the public domain OEM corpus
+- No anonymized data from this tenant is included in shared training sets
+- Diagnostic accuracy may be lower on novel faults not in the tenant's own history
+- Opt-out is reversible — re-enabling retroactively includes the tenant's anonymized history
+
+Enabled via Hub → Settings → Privacy → "Opt out of Knowledge Cooperative".
+
+### On-Premises Deployment (Enterprise)
+
+Full MIRA stack deployable to customer infrastructure:
+- Docker Compose or Kubernetes (Helm chart, `mira-ops/helm/`)
+- No data leaves the customer's network
+- Customer manages all updates (or FactoryLM managed via VPN access — customer choice)
+- Air-gapped mode: local LLM inference via Ollama (Groq/Cerebras fallback disabled)
+- Pricing: Enterprise contract, minimum 12-month term
+
+### Data Residency (Enterprise)
+
+For customers with regulatory requirements (GDPR, Australian Privacy Act, etc.):
+- **US (default):** NeonDB us-east-2, Vercel US regions
+- **EU:** NeonDB eu-central-1 (Frankfurt), Vercel EU regions
+- **AU:** NeonDB ap-southeast-2 (Sydney), Vercel AU regions
+- Residency is set at tenant creation and cannot be changed post-onboarding (data migration on request)
+
+### What We Never Do
+
+- We never sell, license, or share customer data with third parties
+- We never train public-facing models on identifiable customer data
+- We never store CMMS credentials in plaintext — tokens are AES-256 encrypted at rest
+- We never retain data after account deletion (30-day grace period, then permanent deletion)

--- a/docs/integrations/google_workspace_api_reference.md
+++ b/docs/integrations/google_workspace_api_reference.md
@@ -1,0 +1,696 @@
+# Google Workspace APIs Reference
+
+**For:** MIRA Hub integration — KB document sync, email alerts, Calendar PM scheduling, Google Chat messaging
+**Researched:** 2026-04-28
+**Existing code:** `mira-hub/src/app/api/auth/google/` (OAuth flow), `mira-bots/gchat/workspace_client.py` (service account Chat+Drive)
+
+---
+
+## Auth Method (shared across all Google APIs)
+
+Google APIs use **OAuth 2.0**. MIRA uses two distinct flows depending on the use-case:
+
+### 1. User OAuth (3-Legged) — what mira-hub already does
+
+Flow: User → Google consent screen → authorization code → access+refresh tokens stored in `bindings` table.
+
+Key implementation files:
+- `mira-hub/src/app/api/auth/google/route.ts` — builds the auth URL, sets state cookie
+- `mira-hub/src/app/api/auth/google/callback/route.ts` — exchanges code for tokens, calls `upsertBinding()`
+- `mira-hub/src/lib/token-refresh.ts` — `ensureFreshAccessToken("google")` — refresh logic (5-min skew window)
+
+Auth URL: `https://accounts.google.com/o/oauth2/v2/auth`
+Token URL: `https://oauth2.googleapis.com/token`
+UserInfo URL: `https://www.googleapis.com/oauth2/v2/userinfo`
+
+Required params for auth URL:
+```
+response_type=code
+access_type=offline          # get refresh token
+prompt=consent               # force consent screen (needed to get refresh_token every time)
+scope=<space-separated list>
+```
+
+Env vars required (Doppler `factorylm/prd`):
+- `GOOGLE_CLIENT_ID` — used by the workspace integration OAuth flow
+- `GOOGLE_CLIENT_SECRET` — used by the workspace integration OAuth flow
+- `HUB_AUTH_GOOGLE_CLIENT_ID` — used by NextAuth (login with Google)
+- `HUB_AUTH_GOOGLE_CLIENT_SECRET` — used by NextAuth
+
+Note: these are **two separate OAuth clients** — one for login identity, one for workspace data access. Keep them separate.
+
+### 2. Service Account (2-Legged) — what mira-bots/gchat already does
+
+`mira-bots/gchat/workspace_client.py` implements a self-contained service account client using PyJWT RS256 assertion → token exchange. No user interaction. Used for Chat bot messaging and Drive file downloads.
+
+JWT assertion flow:
+```
+POST https://oauth2.googleapis.com/token
+  grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer
+  assertion=<RS256-signed JWT with iss, sub, aud, iat, exp, scope>
+```
+
+The service account JSON key (`private_key` + `client_email`) is stored in Doppler. `WorkspaceClient.__init__()` accepts the JSON as a dict, raw JSON string, or base64-encoded JSON.
+
+### Choosing the Right Auth Method
+
+| Use-case | Auth method | Reason |
+|---|---|---|
+| KB Drive sync — user's My Drive | User OAuth | Service accounts can't see users' personal files without DWD |
+| KB Drive sync — Shared Drive | Service account | SA can be added as a member of Shared Drives directly |
+| Gmail send (outbound alerts) | User OAuth | Service accounts need DWD + admin approval to send as a user |
+| Calendar PM event creation | User OAuth | Events need to appear on the user's own calendar |
+| Google Chat bot messaging | Service account | `chat.bot` scope works without user consent |
+| Google Chat webhook | Neither — use webhook URL | Simplest for one-way push to a space |
+
+### Domain-Wide Delegation (DWD)
+
+For Google Workspace (paid) orgs only. Lets the service account impersonate any user in the domain. Setup:
+1. Google Workspace Admin console → Security → API Controls → Domain-wide Delegation
+2. Add service account Client ID + scopes
+3. Can take up to 24h to propagate
+
+For MIRA MVP (individual users signing in via OAuth), DWD is not needed. Consider for enterprise multi-tenant deployments.
+
+---
+
+## Google Drive
+
+### Key Endpoints We Need
+
+Base URL: `https://www.googleapis.com/drive/v3`
+
+#### files.list — discover KB documents
+```
+GET /drive/v3/files
+```
+Key query parameters:
+- `q` — search filter string (see query syntax below)
+- `pageSize` — max results per page (default 100, max 1000)
+- `pageToken` — pagination cursor from previous response
+- `fields` — partial response mask, e.g. `files(id,name,mimeType,modifiedTime,webViewLink),nextPageToken`
+- `corpora` — `user` (My Drive) or `drive` (Shared Drive, requires `driveId`) or `allDrives`
+- `includeItemsFromAllDrives` — `true` to include Shared Drives
+- `driveId` — required when `corpora=drive`
+- `supportsAllDrives` — `true` required when accessing Shared Drives
+
+Query filter (`q` param) examples:
+```
+# All non-trashed PDFs modified in last 30 days
+mimeType = 'application/pdf' and trashed = false and modifiedTime > '2026-03-28T00:00:00'
+
+# All Google Docs in a specific folder
+'FOLDER_ID' in parents and mimeType = 'application/vnd.google-apps.document' and trashed = false
+
+# Files shared with the authenticated user
+sharedWithMe = true and trashed = false
+
+# Full-text search
+fullText contains 'conveyor maintenance'
+```
+
+Google Workspace MIME types:
+| Type | MIME |
+|------|------|
+| Google Doc | `application/vnd.google-apps.document` |
+| Google Sheet | `application/vnd.google-apps.spreadsheet` |
+| Google Slides | `application/vnd.google-apps.presentation` |
+| Folder | `application/vnd.google-apps.folder` |
+
+#### files.get — get metadata or download binary
+```
+GET /drive/v3/files/{fileId}
+GET /drive/v3/files/{fileId}?alt=media   # download binary content
+```
+- Use `alt=media` for binary files (PDF, images)
+- Use `files.export` for Google Workspace formats
+
+#### files.export — export Google Docs/Sheets as PDF or text
+```
+GET /drive/v3/files/{fileId}/export?mimeType=application/pdf
+GET /drive/v3/files/{fileId}/export?mimeType=text/plain
+```
+- Cannot use `alt=media` on Google Workspace docs — must export
+- Export to `text/plain` for cheap LLM ingestion
+- Export to `application/pdf` for full-fidelity KB chunks (then pass through mira-docling)
+
+#### changes.getStartPageToken — baseline for incremental sync
+```
+GET /drive/v3/changes/startPageToken
+```
+Returns a `startPageToken`. Store it; use for polling `changes.list`.
+
+#### changes.list — poll for changes since last sync
+```
+GET /drive/v3/changes?pageToken={token}&spaces=drive
+```
+Returns changed file IDs since the token. Update stored token after processing.
+
+#### files.watch — push notification on a single file
+```
+POST /drive/v3/files/{fileId}/watch
+{
+  "id": "unique-channel-uuid",
+  "type": "web_hook",
+  "address": "https://app.factorylm.com/api/integrations/google/drive/webhook",
+  "expiration": 1234567890000  // ms timestamp, max 86400s from now
+}
+```
+
+#### changes.watch — push notification on all Drive changes
+```
+POST /drive/v3/changes/watch?pageToken={token}
+{
+  "id": "unique-channel-uuid",
+  "type": "web_hook",
+  "address": "https://app.factorylm.com/api/integrations/google/drive/webhook",
+  "token": "tenant-123-verification-token"
+}
+```
+Use `changes.watch` (not `files.watch`) for KB sync — one channel covers all changes.
+
+### Webhook / Push Notifications (Drive changes)
+
+How it works: POST requests sent to your HTTPS endpoint whenever a watched resource changes.
+
+Notification headers:
+```
+X-Goog-Channel-ID: your-channel-uuid
+X-Goog-Resource-State: change | sync
+X-Goog-Resource-ID: stable opaque resource ID
+X-Goog-Message-Number: incrementing (not sequential, gaps OK)
+X-Goog-Channel-Token: your verification token
+```
+
+MIRA endpoint requirements:
+- Must be public HTTPS with valid TLS (self-signed rejected)
+- Respond with 200/201/202/204 to acknowledge
+- User-Agent will be `APIs-Google`
+- On `sync` state: a sync probe, not a real change — respond 200, ignore it
+
+Expiration:
+- Files channel: max 86,400 seconds (1 day)
+- Changes channel: max 604,800 seconds (1 week)
+- No auto-renewal — must re-call `watch` before expiry with a new channel UUID
+- Run a daily cron in mira-hub to renew expiring channels
+
+Alternative to webhooks: Poll `changes.list` on a schedule (hourly is fine for KB sync). Simpler to implement and sufficient for non-real-time use cases.
+
+### Rate Limits
+
+- **12,000 requests per 60 seconds** (global, per project)
+- **12,000 requests per 60 seconds per user**
+- No daily request limit (as long as per-minute limits are respected)
+- Upload limit: 750 GB/day, 5 TB max file size
+- Error 403 `userRateLimitExceeded` or 429 — implement exponential backoff (max 64s)
+
+### Scopes Required
+
+| Scope | Use-case |
+|---|---|
+| `https://www.googleapis.com/auth/drive.readonly` | Read files + metadata for KB sync (already in mira-hub route.ts) |
+| `https://www.googleapis.com/auth/drive` | Full access — only if MIRA needs to write files back |
+| `https://www.googleapis.com/auth/drive.activity.readonly` | View file activity log (optional, for audit trail) |
+
+**Use `drive.readonly` for KB sync** — it covers `files.list`, `files.get`, `files.export`, `changes.list`, and `files.watch`.
+
+---
+
+## Gmail
+
+### Key Endpoints We Need
+
+Base URL: `https://gmail.googleapis.com`
+All calls use `userId=me` (acts as the authenticated user).
+
+#### messages.send — outbound alert emails
+```
+POST /gmail/v1/users/me/messages/send
+Content-Type: application/json
+
+{
+  "raw": "<base64url-encoded RFC 2822 message>"
+}
+```
+Message encoding: build RFC 2822 string → `base64url` encode (replace `+` with `-`, `/` with `_`, strip `=` padding).
+
+Python example (using stdlib):
+```python
+import base64
+from email.mime.text import MIMEText
+
+msg = MIMEText("Work order WO-1234 is overdue. Asset: Conveyor Belt A.")
+msg["to"] = "mike@factorylm.com"
+msg["from"] = "mira@factorylm.com"
+msg["subject"] = "[MIRA Alert] Overdue PM: Conveyor Belt A"
+
+raw = base64.urlsafe_b64encode(msg.as_bytes()).decode().rstrip("=")
+# POST {"raw": raw} to /gmail/v1/users/me/messages/send
+```
+
+Attachments: use `email.mime.multipart.MIMEMultipart` with `MIMEBase` parts; same base64url encoding applies.
+
+Threading: set `References` and `In-Reply-To` headers matching existing thread's `Message-ID` to keep alerts grouped.
+
+#### messages.list — inbound parse (future: receive work orders via email)
+```
+GET /gmail/v1/users/me/messages?q=subject:"MIRA Work Order"&labelIds=INBOX
+```
+- `q` uses same Gmail search syntax as the web UI
+- Returns message IDs only; use `messages.get` to fetch content
+
+#### messages.get — fetch full message content
+```
+GET /gmail/v1/users/me/messages/{id}?format=full
+GET /gmail/v1/users/me/messages/{id}?format=metadata  # headers only (fast)
+```
+- Body is base64url encoded in `payload.body.data` (or multipart `payload.parts`)
+- Decode with `base64.urlsafe_b64decode(data + "==")`
+
+#### users.watch — push notifications via Cloud Pub/Sub
+```
+POST /gmail/v1/users/me/watch
+{
+  "topicName": "projects/my-project/topics/mira-gmail-notifications",
+  "labelIds": ["INBOX"],
+  "labelFilterBehavior": "INCLUDE"
+}
+```
+Setup steps:
+1. Create a Cloud Pub/Sub topic in your GCP project
+2. Grant `gmail-api-push@system.gserviceaccount.com` the `roles/pubsub.publisher` role on the topic
+3. Create a Pub/Sub push subscription pointing to your HTTPS endpoint
+4. Call `users.watch` with the topic name
+
+Notification payload (base64url-decoded):
+```json
+{"emailAddress": "user@example.com", "historyId": "9876543210"}
+```
+After receiving: call `users.history.list?startHistoryId={historyId}` to get the actual changes.
+
+Renewal: must call `watch` at least every **7 days** or notifications stop.
+
+### Rate Limits
+
+Gmail API uses **quota units** per call, not raw request counts. From Google's docs:
+- `messages.send`: 100 quota units per call
+- `messages.list`: 5 quota units per call
+- `messages.get`: 5 quota units per call
+- Default daily quota: **1,000,000,000 quota units/day** per project (effectively unlimited for MIRA-scale)
+- Per-user send limit: Gmail enforces a **500 recipient/day** limit on personal accounts; Google Workspace accounts get 2,000
+- Rate: **250 quota units/second per user**
+
+For alert-only use (one email per alert), quota is never a concern. If doing inbound parsing at scale, batch `messages.list` calls with pagination.
+
+### Scopes Required
+
+| Scope | Use-case |
+|---|---|
+| `https://www.googleapis.com/auth/gmail.send` | Send outbound alert emails only (minimal, recommended) |
+| `https://www.googleapis.com/auth/gmail.readonly` | Read inbox for inbound work order parsing (already in mira-hub route.ts) |
+| `https://www.googleapis.com/auth/gmail.modify` | Read + modify labels (mark parsed emails as processed) |
+| `https://www.googleapis.com/auth/gmail.metadata` | Headers only — for routing/dedup without reading body |
+
+**Start with `gmail.send` + `gmail.readonly`** — covers all current MIRA use-cases. The existing route.ts already requests `gmail.readonly`; add `gmail.send` when implementing outbound alerts.
+
+---
+
+## Google Calendar
+
+### Key Endpoints We Need
+
+Base URL: `https://www.googleapis.com/calendar/v3`
+
+#### calendarList.list — discover user's calendars
+```
+GET /calendar/v3/users/me/calendarList
+```
+Returns all calendars the user has access to. Use to let users pick which calendar MIRA should write PM events to.
+
+Key response fields per calendar: `id` (use as `calendarId`), `summary`, `primary`, `accessRole`.
+
+#### events.list — read existing PM events
+```
+GET /calendar/v3/calendars/{calendarId}/events
+  ?timeMin=2026-04-28T00:00:00Z
+  &timeMax=2026-07-28T00:00:00Z
+  &q=MIRA%20PM
+  &singleEvents=true
+  &orderBy=startTime
+```
+- `q` does full-text search on event fields
+- `singleEvents=true` expands recurring events into individual instances
+- `calendarId=primary` works as a shortcut for the user's default calendar
+
+#### events.insert — create a PM scheduled event
+```
+POST /calendar/v3/calendars/{calendarId}/events
+Content-Type: application/json
+
+{
+  "summary": "[MIRA PM] Conveyor Belt A — Lubrication",
+  "description": "Preventive maintenance task auto-scheduled by MIRA.\nWork Order: WO-456\nAsset: Conveyor Belt A\nProcedure: Check tension + lubricate pulleys",
+  "location": "Plant Floor, Station 3",
+  "start": { "dateTime": "2026-05-15T08:00:00-05:00" },
+  "end": { "dateTime": "2026-05-15T09:00:00-05:00" },
+  "attendees": [
+    { "email": "technician@factorylm.com" }
+  ],
+  "reminders": {
+    "useDefault": false,
+    "overrides": [
+      { "method": "email", "minutes": 1440 },
+      { "method": "popup", "minutes": 60 }
+    ]
+  },
+  "recurrence": ["RRULE:FREQ=MONTHLY;INTERVAL=1"],
+  "extendedProperties": {
+    "private": {
+      "mira_work_order_id": "WO-456",
+      "mira_asset_id": "asset-123",
+      "mira_pm_schedule_id": "pm-789"
+    }
+  }
+}
+```
+`extendedProperties.private` is per-calendar-user, invisible to other attendees — use for MIRA IDs to enable sync-back.
+
+Required fields: `start` and `end` only. Everything else is optional.
+
+#### events.patch — update existing PM event (e.g., reschedule)
+```
+PATCH /calendar/v3/calendars/{calendarId}/events/{eventId}
+Content-Type: application/json
+
+{ "start": { "dateTime": "..." }, "end": { "dateTime": "..." } }
+```
+Patch semantics: only send fields to change; omitted fields are preserved.
+
+#### events.get — check if MIRA-created event still exists
+```
+GET /calendar/v3/calendars/{calendarId}/events/{eventId}
+```
+
+### Webhook / Push Notifications
+
+Subscribe to calendar changes to detect when a user moves/deletes a MIRA PM event:
+
+```
+POST /calendar/v3/calendars/{calendarId}/events/watch
+{
+  "id": "unique-channel-uuid",
+  "type": "web_hook",
+  "address": "https://app.factorylm.com/api/integrations/google/calendar/webhook",
+  "token": "tenant-123-verification-token"
+}
+```
+
+Notification format — HTTP POST headers (no body for most events):
+```
+X-Goog-Channel-ID: your-channel-uuid
+X-Goog-Resource-State: exists | sync | not_exists
+X-Goog-Channel-Token: your verification token
+X-Goog-Resource-ID: stable resource identifier
+```
+On `exists`: fetch `events.list` with `updatedMin` to get the diff.
+
+Important: notifications are **not 100% reliable** — small percentage can be dropped. Always reconcile with a periodic `events.list` poll as a fallback.
+
+No auto-renewal — must watch for expiration and re-register.
+
+### Rate Limits
+
+Calendar API uses a sliding per-minute window:
+- **Per project per minute**: visible in Google Cloud Console → Calendar API → Quotas tab
+- **Per user per minute**: separate sub-limit
+- Returns 403 `usageLimits` or 429 on breach
+- Exact numbers are project-configurable in Cloud Console; default free tier is generous for PM scheduling at MIRA scale
+
+For PM scheduling: `events.insert` once per PM task created — at MIRA scale (dozens/day max) quota is never a concern.
+
+### Scopes Required
+
+| Scope | Use-case |
+|---|---|
+| `https://www.googleapis.com/auth/calendar.events` | Read + write events on all accessible calendars (recommended for MIRA) |
+| `https://www.googleapis.com/auth/calendar.events.owned` | Write events only to calendars the user owns |
+| `https://www.googleapis.com/auth/calendar.events.readonly` | Read-only (list existing PM events) |
+| `https://www.googleapis.com/auth/calendar.calendarlist.readonly` | List user's calendars (let them pick which one) |
+| `https://www.googleapis.com/auth/calendar.readonly` | Read all calendar data including settings |
+| `https://www.googleapis.com/auth/calendar` | Full access including sharing permissions (more than needed) |
+
+**Recommended minimum for MIRA:** `calendar.events` + `calendar.calendarlist.readonly`
+
+---
+
+## Google Chat
+
+### Key Endpoints We Need
+
+Base URL: `https://chat.googleapis.com/v1`
+
+#### messages.create — send a message to a Chat space
+```
+POST /v1/{parent=spaces/SPACE_ID}/messages
+Authorization: Bearer {service_account_token or user_token}
+Content-Type: application/json
+
+{
+  "text": "MIRA Alert: Work order WO-456 is due in 24 hours.\nAsset: Conveyor Belt A"
+}
+```
+Rich Cards v2 (structured messages):
+```json
+{
+  "cardsV2": [{
+    "cardId": "mira-alert-wo456",
+    "card": {
+      "header": { "title": "MIRA PM Alert", "subtitle": "Conveyor Belt A" },
+      "sections": [{
+        "widgets": [
+          { "textParagraph": { "text": "Work Order WO-456 is due in 24 hours." } },
+          { "buttonList": { "buttons": [{
+            "text": "View Work Order",
+            "onClick": { "openLink": { "url": "https://app.factorylm.com/work-orders/WO-456" }}
+          }]}}
+        ]
+      }]
+    }
+  }]
+}
+```
+The `WorkspaceClient.send_message()` in `mira-bots/gchat/workspace_client.py` already implements this with service account auth.
+
+#### messages.list — retrieve messages from a space
+```
+GET /v1/spaces/SPACE_ID/messages
+```
+
+#### spaces.list — discover spaces the bot is a member of
+```
+GET /v1/spaces
+```
+
+#### spaces.members.list — list members in a space
+```
+GET /v1/spaces/SPACE_ID/members
+```
+
+### Webhook vs Bot App
+
+| | Incoming Webhook | Bot App (service account) |
+|---|---|---|
+| Setup | Copy URL from Chat space settings | Deploy service account + register bot in GCP |
+| Auth | No auth — URL is the secret | Service account JWT → OAuth token |
+| Send messages | POST to webhook URL | POST to `/v1/spaces/{id}/messages` |
+| Receive messages | Not possible | Via event subscriptions or interactive cards |
+| Rate limit | 1 req/sec per space, shared across all webhooks | Standard API quotas |
+| Use-case | Simple one-way notifications | Two-way bot, interactive alerts |
+| MIRA use-case | Quick wins: alerts to a #mira-alerts space | Full bot integration |
+
+**Webhook setup** (simplest path for MIRA alerts):
+1. Open Chat in browser → target space → Apps & Integrations → Add webhooks
+2. Name it "MIRA Alerts", copy the webhook URL
+3. Store URL in Doppler as `GOOGLE_CHAT_WEBHOOK_URL`
+4. `POST {"text": "..."}` to the URL — no auth headers needed
+
+**Webhook message format:**
+```python
+import httpx
+
+async def send_chat_alert(webhook_url: str, text: str) -> None:
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.post(webhook_url, json={"text": text})
+        resp.raise_for_status()
+```
+
+Threading with webhooks:
+```
+POST {webhook_url}?messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD
+{"text": "Reply...", "thread": {"threadKey": "wo-456"}}
+```
+
+**Bot App** (already partially implemented in `mira-bots/gchat/workspace_client.py`) is needed if MIRA needs to receive messages from Chat (e.g., technician replies, slash commands).
+
+### Rate Limits
+
+- **Webhook:** 1 request/second per space (shared across all webhooks posting to that space)
+- **Chat API (bot):** Standard per-project per-minute quota; no published hard number — generous for notification use
+- Rate limit response: `google.rpc.Status` JSON with appropriate HTTP error code
+- Implement exponential backoff with jitter for 429/503 responses
+
+### Scopes Required
+
+**Service account (bot):**
+| Scope | Notes |
+|---|---|
+| `https://www.googleapis.com/auth/chat.bot` | Default scope, no admin approval needed. Bot can send messages to spaces where it is a member. |
+| `https://www.googleapis.com/auth/chat.app.*` | App-level scopes, require one-time Google Workspace admin approval. |
+
+**User OAuth:**
+| Scope | Use-case |
+|---|---|
+| `https://www.googleapis.com/auth/chat.messages.create` | Send messages on behalf of a user |
+| `https://www.googleapis.com/auth/chat.messages` | Full message access |
+| `https://www.googleapis.com/auth/chat.spaces.readonly` | List spaces the user is in |
+| `https://www.googleapis.com/auth/chat.memberships.readonly` | See space members |
+
+**For webhooks:** No OAuth scopes — the URL itself is the credential.
+
+**Bot membership requirement:** When using service account + `chat.bot`, the bot must be manually added to the target space, OR create the space via API (bot auto-joins). Bot cannot send to spaces it's not a member of.
+
+---
+
+## SDK Availability
+
+### Python (mira-bots, mira-pipeline)
+
+```bash
+# Low-level — use if you want httpx (already used in workspace_client.py)
+pip install google-auth google-auth-httpx PyJWT
+
+# High-level client library (wraps discovery API)
+pip install google-api-python-client google-auth-httplib2 google-auth-oauthlib
+
+# Chat-specific
+pip install google-apps-chat
+```
+
+MIRA already uses the manual httpx approach in `workspace_client.py` — consistent with the project's httpx-only HTTP policy. Stick with that pattern.
+
+Service account usage with google-auth:
+```python
+from google.oauth2 import service_account
+import google.auth.transport.requests
+
+creds = service_account.Credentials.from_service_account_info(
+    sa_dict,
+    scopes=["https://www.googleapis.com/auth/chat.bot"]
+)
+creds.refresh(google.auth.transport.requests.Request())
+token = creds.token
+```
+
+### TypeScript / Node.js (mira-hub)
+
+```bash
+# Official Google API client for Node
+npm install googleapis
+
+# Chat-specific
+npm install @googleapis/chat
+
+# Auth only
+npm install google-auth-library
+```
+
+Usage in mira-hub route handlers:
+```typescript
+import { google } from "googleapis";
+
+const auth = new google.auth.OAuth2(
+  process.env.GOOGLE_CLIENT_ID,
+  process.env.GOOGLE_CLIENT_SECRET
+);
+auth.setCredentials({ refresh_token: storedRefreshToken });
+
+const drive = google.drive({ version: "v3", auth });
+const files = await drive.files.list({ q: "trashed = false", fields: "files(id,name)" });
+```
+
+---
+
+## Implementation Notes for MIRA
+
+### Adding Scopes to the Existing OAuth Flow
+
+The current `mira-hub/src/app/api/auth/google/route.ts` requests:
+```
+drive.readonly, gmail.readonly, userinfo.email, userinfo.profile
+```
+
+To add Calendar and Chat user-auth scopes, append to the `SCOPES` array:
+```typescript
+const SCOPES = [
+  "https://www.googleapis.com/auth/drive.readonly",
+  "https://www.googleapis.com/auth/gmail.readonly",
+  "https://www.googleapis.com/auth/gmail.send",               // add: outbound alerts
+  "https://www.googleapis.com/auth/calendar.events",          // add: PM event create/update
+  "https://www.googleapis.com/auth/calendar.calendarlist.readonly",  // add: list their calendars
+  "https://www.googleapis.com/auth/userinfo.email",
+  "https://www.googleapis.com/auth/userinfo.profile",
+].join(" ");
+```
+
+Because `prompt=consent` and `access_type=offline` are already set, existing users will see the consent screen again when they re-authorize. Store all granted scopes in `bindings.scopes` (already done by callback route) and check before calling an API.
+
+### Service Account vs User Delegation — Decision Matrix
+
+For MIRA Hub's per-tenant architecture:
+- **Use user OAuth tokens** (stored in `bindings` table) for Drive, Gmail, Calendar — these act on the user's personal data
+- **Use service account** (Doppler key, project-wide) for Chat bot messages — bot identity, not user identity
+- **Use webhooks** (not service account, not user OAuth) for Chat alerts until bot interactions are needed
+
+### Shared Drive for Enterprise KB Sync
+
+If enterprise customers store OEM manuals in a Google Shared Drive:
+1. Customer Workspace admin adds the service account email as a Shared Drive member (Viewer or Content Manager)
+2. No user OAuth needed — service account can access the Shared Drive directly
+3. Call `files.list` with `corpora=drive&driveId=SHARED_DRIVE_ID&includeItemsFromAllDrives=true&supportsAllDrives=true`
+4. Export Docs to text/pdf via `files.export` for KB ingestion into Qdrant
+
+### Token Storage Pattern
+
+Tokens are stored in the `bindings` table per tenant. The `ensureFreshAccessToken("google", tenantId)` function in `token-refresh.ts` handles expiry detection and refresh automatically. Access tokens expire in 1 hour; refresh tokens are long-lived (until revoked or 6 months of non-use for test apps).
+
+Keep OAuth app in "Testing" status during dev (100-user limit). Submit for verification before production launch to remove the "unverified app" warning and the 100-user cap.
+
+### Key Gotchas
+
+1. **Drive webhooks expire after 1 day (files) or 1 week (changes)** — need a scheduler in mira-hub to renew. Store channel expiry in DB.
+2. **Gmail push requires Cloud Pub/Sub** — more infra than Drive webhooks. For MVP, poll `messages.list` hourly instead.
+3. **Chat service account must be a space member** — bot cannot post to a space until it's been added. Document this in the setup guide for customers.
+4. **Google Workspace Marketplace approval** required to publish a Chat bot publicly; not required for internal/webhook use.
+5. **`prompt=consent` always required** to reliably get a refresh_token — without it, Google only returns refresh_token on first authorization.
+6. **Sensitive scopes** (`gmail.send`, `calendar.events`) trigger Google's OAuth verification review — budget 1-4 weeks for approval before production.
+7. **Service account DWD** — works only for Google Workspace orgs (paid accounts). Regular Gmail users cannot enable DWD.
+8. **`files.export` size limit** — Google Docs exported as PDF are capped at 10MB. Very large documents must be handled in chunks or exported as plain text.
+9. **Calendar `extendedProperties.private`** — per-user, not shared with event attendees. Safe to store MIRA internal IDs there.
+
+---
+
+## Links
+
+- Drive API v3 reference: https://developers.google.com/drive/api/reference/rest/v3
+- Drive push notifications guide: https://developers.google.com/drive/api/guides/push
+- Drive search query syntax: https://developers.google.com/drive/api/guides/search-files
+- Gmail API reference: https://developers.google.com/gmail/api/reference/rest
+- Gmail push notifications (Pub/Sub): https://developers.google.com/gmail/api/guides/push
+- Calendar API v3 reference: https://developers.google.com/calendar/api/v3/reference
+- Calendar create events guide: https://developers.google.com/calendar/api/guides/create-events
+- Chat API reference: https://developers.google.com/workspace/chat/api/reference/rest
+- Chat incoming webhooks: https://developers.google.com/workspace/chat/quickstart/webhooks
+- Chat auth guide (service accounts): https://developers.google.com/workspace/chat/api/guides/auth/service-accounts
+- OAuth 2.0 scopes reference: https://developers.google.com/identity/protocols/oauth2/scopes
+- Service accounts + DWD: https://developers.google.com/identity/protocols/oauth2/service-account
+- google-api-python-client docs: https://googleapis.github.io/google-api-python-client/docs/dyn/

--- a/docs/integrations/jira_api_reference.md
+++ b/docs/integrations/jira_api_reference.md
@@ -1,0 +1,302 @@
+# Jira (Atlassian Cloud) API Reference
+**For:** MIRA Hub integration | **Researched:** 2026-04-28
+
+Jira Cloud REST API v3 is used to create and manage work order tickets for maintenance tasks identified by MIRA. Base URL pattern: `https://api.atlassian.com/ex/jira/{cloudId}/rest/api/3/` (OAuth 2.0) or `https://{your-domain}.atlassian.net/rest/api/3/` (API token).
+
+---
+
+## Auth Method
+
+### Option A: API Token + Basic Auth (simpler, recommended for MIRA backend)
+```
+Authorization: Basic <base64(email:api_token)>
+```
+- Obtain token at: https://id.atlassian.com/manage-profile/security/api-tokens
+- Encode as: `base64("user@example.com:ATATT3xFfGF0...")` 
+- Store in Doppler as `JIRA_EMAIL` and `JIRA_API_TOKEN`
+
+```python
+import httpx, base64
+
+credentials = base64.b64encode(f"{email}:{token}".encode()).decode()
+headers = {
+    "Authorization": f"Basic {credentials}",
+    "Accept": "application/json",
+    "Content-Type": "application/json"
+}
+```
+
+### Option B: OAuth 2.0 (3LO) — for user-delegated flows
+**Authorization URL:**
+```
+https://auth.atlassian.com/authorize
+  ?audience=api.atlassian.com
+  &client_id=<CLIENT_ID>
+  &scope=<SCOPES>
+  &redirect_uri=<CALLBACK_URL>
+  &state=<CSRF_TOKEN>
+  &response_type=code
+  &prompt=consent
+```
+
+**Token exchange:**
+```
+POST https://auth.atlassian.com/oauth/token
+Content-Type: application/json
+
+{
+  "grant_type": "authorization_code",
+  "client_id": "<CLIENT_ID>",
+  "client_secret": "<CLIENT_SECRET>",
+  "code": "<AUTH_CODE>",
+  "redirect_uri": "<CALLBACK_URL>"
+}
+```
+
+**OAuth scopes needed for MIRA:**
+| Scope | Purpose |
+|-------|---------|
+| `read:jira-work` | Read issues, projects |
+| `write:jira-work` | Create/update issues, add comments |
+| `read:jira-user` | Resolve user accounts |
+| `offline_access` | Refresh tokens (no re-auth needed) |
+
+**API call with OAuth:**
+```
+https://api.atlassian.com/ex/jira/{cloudId}/rest/api/3/{endpoint}
+Authorization: Bearer <access_token>
+```
+
+Get `cloudId` via: `GET https://api.atlassian.com/oauth/token/accessible-resources`
+
+---
+
+## Key Endpoints We Need
+
+Base URL (API token): `https://{domain}.atlassian.net/rest/api/3`
+
+| Endpoint | Method | What it does | Required fields |
+|----------|--------|--------------|-----------------|
+| `/project` | GET | List all projects | — |
+| `/issuetype` | GET | List issue types globally | — |
+| `/issue` | POST | Create issue | `fields.project.key`, `fields.issuetype.name`, `fields.summary` |
+| `/issue/bulk` | POST | Create up to 50 issues | `issueUpdates[]` array |
+| `/issue/{issueIdOrKey}` | GET | Get issue details | — |
+| `/issue/{issueIdOrKey}` | PUT | Update issue | `fields` or `update` object |
+| `/issue/{issueIdOrKey}/comment` | POST | Add comment | `body` (Atlassian Document Format) |
+| `/issue/{issueIdOrKey}/transitions` | POST | Transition status | `transition.id` |
+| `/issue/{issueIdOrKey}/assignee` | PUT | Assign issue | `accountId` |
+| `/myself` | GET | Get current user info | — (verifies auth) |
+
+### Create Issue — Full Request Example
+
+```
+POST /rest/api/3/issue
+Content-Type: application/json
+
+{
+  "fields": {
+    "project": { "key": "MAINT" },
+    "summary": "VFD-01 — Motor overtemperature fault (MIRA-sess_abc123)",
+    "issuetype": { "name": "Task" },
+    "description": {
+      "type": "doc",
+      "version": 1,
+      "content": [
+        {
+          "type": "paragraph",
+          "content": [
+            {
+              "type": "text",
+              "text": "MIRA detected overtemperature on VFD-01 at 87.4°C. Fault code OC-001. Inspect cooling system and check motor load."
+            }
+          ]
+        }
+      ]
+    },
+    "priority": { "name": "High" },
+    "assignee": { "accountId": "5b10ac8d82e05b22cc7d4ef5" },
+    "labels": ["mira-auto", "vfd", "overtemp"],
+    "duedate": "2026-04-29"
+  }
+}
+```
+
+Response: `{ "id": "10001", "key": "MAINT-42", "self": "https://..." }`
+
+### Add Comment — ADF Format
+
+```json
+{
+  "body": {
+    "type": "doc",
+    "version": 1,
+    "content": [
+      {
+        "type": "paragraph",
+        "content": [{ "type": "text", "text": "MIRA resolved: fault cleared after cooling fan replacement." }]
+      }
+    ]
+  }
+}
+```
+
+### Get Issue Types for a Project
+
+```
+GET /rest/api/3/issue/createmeta?projectKeys=MAINT&expand=projects.issuetypes.fields
+```
+Returns all valid `issuetype` names and their required fields for a given project.
+
+---
+
+## Webhook / Event Capabilities
+
+Jira Cloud can push events to MIRA when issues are created, updated, or transitioned.
+
+**Register webhook (requires admin scope):**
+```
+POST /rest/api/3/webhook
+Authorization: Basic <credentials>
+Content-Type: application/json
+
+{
+  "url": "https://mira.factorylm.com/webhooks/jira",
+  "webhooks": [
+    {
+      "events": [
+        "jira:issue_created",
+        "jira:issue_updated",
+        "jira:issue_deleted",
+        "comment_created",
+        "comment_updated"
+      ],
+      "filters": {
+        "issue-related-events-section": "project = MAINT"
+      }
+    }
+  ]
+}
+```
+
+**Supported events:** `jira:issue_created`, `jira:issue_updated`, `jira:issue_deleted`, `comment_created`, `comment_updated`, `worklog_updated`, `issuelink_created`
+
+**Payload structure:**
+```json
+{
+  "timestamp": 1714305000000,
+  "webhookEvent": "jira:issue_updated",
+  "issue": {
+    "id": "10001",
+    "key": "MAINT-42",
+    "fields": {
+      "summary": "VFD-01 — Motor overtemperature",
+      "status": { "name": "In Progress" },
+      "assignee": { "accountId": "...", "displayName": "Tech A" }
+    }
+  },
+  "user": { "accountId": "...", "displayName": "Mike Harper" }
+}
+```
+
+**Note:** Dynamic webhooks (registered via API) expire after 30 days. Use the Jira admin UI for permanent webhooks, or refresh programmatically before expiry.
+
+---
+
+## Rate Limits
+
+Jira Cloud uses a **points-based quota** plus burst limits. Numbers are adaptive and not published as fixed values.
+
+| Limit type | Detail |
+|------------|--------|
+| Points quota | ~65,000 points/hour (global pool); each request costs 1 base point + 1 per affected object |
+| GET burst | ~100 requests/second per endpoint |
+| POST/PUT burst | ~50–100 requests/second per endpoint |
+| Per-issue writes | 20 writes per 2 seconds; 100 writes per 30 seconds on a single issue |
+| Exceeded response | HTTP 429 |
+
+**Response headers on 429:**
+```
+Retry-After: <seconds>
+X-RateLimit-Limit: <capacity>
+X-RateLimit-Remaining: <available>
+X-RateLimit-Reset: <ISO8601 timestamp>
+RateLimit-Reason: quota-based | burst-based | per-issue-on-write
+```
+
+**Retry strategy:** Exponential backoff with jitter — start at 2s, double each attempt, add ±30% random jitter, cap at 30s, max 4 attempts.
+
+---
+
+## SDK Availability
+
+| SDK | Install | Notes |
+|-----|---------|-------|
+| `atlassian-python-api` (community, popular) | `pip install atlassian-python-api` | Supports Jira, Confluence, Bitbucket; `Jira` class wraps all endpoints |
+| `jira` (community) | `pip install jira` | Python 3 compatible; simpler interface for issue CRUD |
+| No official Atlassian Python SDK | — | Atlassian provides SDKs for Connect apps (Node.js), not REST API wrappers |
+
+**atlassian-python-api usage:**
+```python
+from atlassian import Jira
+
+jira = Jira(
+    url="https://yourcompany.atlassian.net",
+    username="user@example.com",
+    password="ATATT3x...",  # API token
+    cloud=True
+)
+
+# Create issue
+issue = jira.issue_create(fields={
+    "project": {"key": "MAINT"},
+    "summary": "VFD-01 overtemp",
+    "issuetype": {"name": "Task"}
+})
+
+# Add comment
+jira.issue_add_comment("MAINT-42", "Fault confirmed by tech.")
+
+# List projects
+projects = jira.projects()
+```
+
+---
+
+## Implementation Notes for MIRA
+
+### Project Key + Issue Type Requirements
+Before creating issues, MIRA must know:
+1. `project.key` — the Jira project key (e.g., `MAINT`, `OPS`). Store as `JIRA_DEFAULT_PROJECT_KEY` in Doppler.
+2. `issuetype.name` — must exactly match an issue type in that project. Call `GET /rest/api/3/issue/createmeta?projectKeys=MAINT` on startup to cache valid types.
+
+Recommended issue types for MIRA: `Task` (standard work order), `Bug` (urgent fault), `Story` (PM task).
+
+### Description: Use Atlassian Document Format (ADF)
+Jira Cloud v3 **requires ADF** for `description` fields — plain strings are rejected. The minimum valid structure is:
+```json
+{
+  "type": "doc",
+  "version": 1,
+  "content": [{ "type": "paragraph", "content": [{ "type": "text", "text": "..." }] }]
+}
+```
+
+### Linking MIRA Sessions to Jira Issues
+Store `MAINT-42` in the MIRA session/incident record so tech follow-up in Jira can be synced back. Use `labels: ["mira-auto"]` on all MIRA-created issues for easy JQL filtering: `project = MAINT AND labels = mira-auto ORDER BY created DESC`.
+
+### Base URL Selection
+- API token auth: use `https://{domain}.atlassian.net/rest/api/3/`
+- OAuth 2.0: use `https://api.atlassian.com/ex/jira/{cloudId}/rest/api/3/`
+
+Store the domain as `JIRA_DOMAIN` in Doppler (e.g., `yourcompany.atlassian.net`).
+
+---
+
+## Links
+
+- [Jira Cloud REST API v3 — Issues Group](https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/)
+- [Jira Cloud REST API v3 — Overview](https://developer.atlassian.com/cloud/jira/platform/rest/v3/)
+- [OAuth 2.0 (3LO) Apps](https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/)
+- [Rate Limiting](https://developer.atlassian.com/cloud/jira/platform/rate-limiting/)
+- [atlassian-python-api Jira docs](https://atlassian-python-api.readthedocs.io/jira.html)

--- a/docs/integrations/limble_api_reference.md
+++ b/docs/integrations/limble_api_reference.md
@@ -1,0 +1,142 @@
+# Limble CMMS API Reference
+**For:** MIRA Hub integration | **Researched:** 2026-04-28
+
+## Auth Method
+
+**Type:** HTTP Basic Authentication using Client ID + Client Secret
+
+Every API request must include:
+```
+Authorization: Basic <base64(clientId:clientSecret)>
+Content-Type: application/json
+```
+
+**To generate credentials:**
+1. Log into Limble → Settings → Configuration → API Keys (Super User access required)
+2. Click "Add" → assign a name (permanent — cannot be changed after creation)
+3. Copy both `ClientID` and `Client Secret` immediately — the secret is only shown once
+4. If secret is lost: use "Refresh Client ID/Secret" (invalidates old credentials)
+
+**Regional Base URLs** (use the one matching your customer's account):
+
+| Region | Base URL |
+|--------|----------|
+| Default (US) | `https://api.limblecmms.com` |
+| Canada | `https://ca-api.limblecmms.com` |
+| Australia | `https://au-api.limblecmms.com` |
+| Europe | `https://eu-api.limblecmms.com` |
+| 21 CFR (pharma) | `https://21cfr-api.limblecmms.com` |
+
+API version: v2. Full docs at `https://apidocs.limblecmms.com/`.
+
+## Key Endpoints We Need
+
+| Endpoint | Method | What it does | Required params |
+|----------|--------|--------------|-----------------|
+| `/tasks` | GET | List tasks (WOs, PMs, WRs) | `Authorization` header; optional: `taskType`, `assetID`, `locationID`, `taskID` |
+| `/tasks` | POST | Create a work order/task | `Authorization`, task body |
+| `/tasks/{id}` | GET | Get single task | `Authorization`, path `id` |
+| `/tasks/{id}` | PATCH | Update task (status, fields) | `Authorization`, body fields |
+| `/tasks/{id}` | DELETE | Delete task | `Authorization` |
+| `/assets` | GET | List assets with hierarchy, meters | `Authorization` |
+| `/assets/{id}` | GET | Get single asset | `Authorization` |
+| `/pm-schedules` | GET | List PM schedules + next due dates | `Authorization` |
+| `/locations` | GET | List locations | `Authorization` |
+| `/parts` | GET | List parts + current quantities | `Authorization` |
+| `/parts` | POST | Create part | `Authorization`, part body |
+| `/users` | GET | List users | `Authorization` |
+| `/vendors` | GET | List vendors | `Authorization` |
+| `/purchase-orders` | GET | List purchase orders | `Authorization` |
+| `/webhooks` | GET | List registered webhooks | `Authorization` |
+| `/webhooks` | POST | Register webhook | `Authorization`, webhook config |
+
+**Task type filter values for GET `/tasks`:**
+- `wo` — Work Orders
+- `pm` — Planned Maintenance
+- `wr` — Work Requests
+- `pwo` — Planned Work Orders
+
+**Task create body fields (confirmed available, exact schema in Swagger at apidocs.limblecmms.com):**
+- `title` / task name
+- `assetID` — target asset
+- `locationID` — location
+- `taskType` — `wo`, `pm`, `wr`, `pwo`
+- `priority` — Limble uses configurable priority levels (verified: customizable per account in Settings → Task Priority Levels)
+- `status` — configurable per account (Settings → Task Status Configuration)
+- `assignees` — user/team assignments
+- `dueDate` / scheduled date
+
+**Resources also accessible via API:** Roles, Teams, General Ledgers, Budgets, Tags, Statuses, Bills, Regions, Units of Measure (UOM).
+
+## Webhook / Event Capabilities
+
+Limble API v2 includes a `/webhooks` resource (confirmed in API resource list). Webhooks provide asynchronous delivery for events including:
+- PM generation
+- Work order status changes
+
+**Registration:** POST to `/webhooks` with endpoint URL and event type configuration.
+
+**Payload format:** JSON. Specific event schema not publicly documented in accessible sources — intercept a test delivery to capture the live format.
+
+**Note:** The Make.com integration confirms "watch task changes" is available as an event trigger, meaning the webhook system supports at minimum task create/update/delete events.
+
+## Rate Limits
+
+Not publicly documented. Limble describes their system as "tuned for enterprise throughput while honoring customer entitlements and usage controls" — specific numbers are not published.
+
+**Practical guidance:**
+- Implement standard exponential backoff on HTTP 429 responses
+- Do not parallelize more than 5–10 concurrent requests
+- Limble is REST over HTTPS with no documented per-second or per-minute cap in public docs — test against your tenant and observe
+
+## SDK Availability
+
+- **Official SDK:** None. No official Python or Node.js client published by Limble.
+- **Official Postman workspace:** `https://www.postman.com/limbleapiqa/limble-solutions-llc-s-public-workspace/documentation/zskh2o7/limble-api-v2` — use this to explore and test the full v2 API interactively.
+- **Integration platforms:** Make.com (`apps.make.com/limble-cmms`), Zapier — pre-built connectors with 16 actions (create/update/delete tasks, instructions, parts; list assets, teams, users).
+- **Unified API wrapper:** Makini (`makini.io/integrations/limble`) — commercial normalized layer across CMMS providers.
+- **MCP server:** Limble has published a Limble MCP (Model Context Protocol) server — see `help.limblecmms.com/en/articles/12902567-limble-mcp-user-setup-guide`. Could be useful for MIRA's LLM-driven maintenance queries.
+
+## Implementation Notes for MIRA
+
+**MIRA WorkOrder → Limble field mapping:**
+
+| MIRA field | Limble field | Notes |
+|-----------|--------------|-------|
+| `title` | `title` (task name) | |
+| `asset_id` | `assetID` | Integer |
+| `location_id` | `locationID` | Integer |
+| `priority` | `priority` | Account-specific values — must fetch priority list first |
+| `status` | `status` | Account-specific values — must fetch status list first |
+| `type` | `taskType` | Map MIRA `work_order` → `wo`, `pm` → `pm` |
+| `assigned_to` | `assignees` | |
+| `due_date` | `dueDate` | Confirm date format in Swagger (ISO 8601 expected) |
+
+**MIRA Asset → Limble field mapping:**
+
+| MIRA field | Limble field | Notes |
+|-----------|--------------|-------|
+| `asset_id` | `id` (from GET response) | |
+| `name` | asset name field | |
+| `location` | `locationID` | |
+| Meters/readings | `meters` | Limble assets include meter data in GET response |
+
+**API quirks to handle:**
+- **Account-specific priority and status values** — Limble allows full customization of both. Before creating tasks, always GET `/priorities` and `/statuses` (or the equivalent resource in v2) to map MIRA's standard values to the customer's configured IDs. Do not assume numeric 1/2/3 priorities.
+- **Regional endpoint routing** — MIRA must determine the customer's region during connection setup (ask or detect from their Limble account URL) and store the correct base URL per tenant. Using the wrong regional URL returns auth errors.
+- **Super User requirement for API keys** — customers must grant MIRA a Super User-level credential. Document this clearly in the MIRA connection setup flow.
+- **Secret is one-time visible** — MIRA must capture and store the Client Secret in Doppler at connection setup time; there is no way to retrieve it later from Limble.
+- **Pagination** — Limble uses consistent resource schemas with pagination across modules. Specific params (offset/limit vs cursor) confirmed as present but the exact parameter names must be verified in the Swagger UI at `apidocs.limblecmms.com`.
+- **Tasks are the unified type** — Limble does not have separate "work order" and "PM" endpoints; everything is a `/tasks` resource filtered by `taskType`. Map accordingly.
+- **Error format:** Standard HTTP status codes + JSON error body. Specific schema in Swagger.
+- **Limble MCP server** — if MIRA ever needs to expose Limble data to an LLM agent directly, the Limble MCP is the fastest path.
+
+## Links
+
+- Official Swagger/API docs: `https://apidocs.limblecmms.com/`
+- Official Postman workspace: `https://www.postman.com/limbleapiqa/limble-solutions-llc-s-public-workspace/documentation/zskh2o7/limble-api-v2`
+- API key management guide: `https://help.limblecmms.com/en/articles/11932574-managing-api-keys-in-limble`
+- Limble MCP setup: `https://help.limblecmms.com/en/articles/12902567-limble-mcp-user-setup-guide`
+- Make.com integration docs: `https://apps.make.com/limble-cmms`
+- Task status configuration: `https://help.limblecmms.com/en/articles/2993175-task-status-configuration`
+- Task priority configuration: `https://help.limblecmms.com/en/articles/8672978-task-priority-levels`

--- a/docs/integrations/maintainx_api_reference.md
+++ b/docs/integrations/maintainx_api_reference.md
@@ -1,0 +1,120 @@
+# MaintainX API Reference
+**For:** MIRA Hub integration | **Researched:** 2026-04-28
+
+## Auth Method
+
+**Type:** Bearer Token (API Key)
+
+All requests require:
+```
+Authorization: Bearer <api_key>
+Content-Type: application/json
+Accept: application/json
+```
+
+To obtain credentials: MaintainX account → Settings → Integrations → New Key → Generate Key. API keys are plan-gated (Business and above). Contact `api@getmaintainx.com` for access questions.
+
+**Base URL:** `https://api.getmaintainx.com/v1`
+
+## Key Endpoints We Need
+
+| Endpoint | Method | What it does | Required params |
+|----------|--------|--------------|-----------------|
+| `/workorders` | GET | List work orders (cursor-paginated) | `Authorization` header; optional: `cursor`, `limit` (max 100) |
+| `/workorders` | POST | Create work order | `title` (string) |
+| `/workorders/{id}` | GET | Get single work order | path: `id` |
+| `/workorders/{id}` | PATCH | Update work order | path: `id`, body fields to change |
+| `/assets` | GET | List all assets | `Authorization` header |
+| `/assets/{id}` | GET | Get single asset | path: `id` |
+| `/locations` | GET | List locations | `Authorization` header |
+| `/users` | GET | List users | `Authorization` header |
+| `/parts` | GET | List parts | `Authorization` header |
+| `/procedures` | GET | List procedures/checklists | `Authorization` header |
+| `/workrequests` | POST | Create work request | `title` (string) |
+
+**Work order create body fields:**
+```json
+{
+  "title": "string (required)",
+  "description": "string",
+  "assetId": "integer",
+  "locationId": "integer",
+  "priority": "NONE | LOW | MEDIUM | HIGH",
+  "status": "OPEN | IN_PROGRESS | ON_HOLD | COMPLETED | CLOSED",
+  "dueDate": "ISO 8601 datetime",
+  "assignees": [{"id": "integer", "type": "string"}],
+  "categories": ["string"],
+  "estimatedTime": "integer (seconds)",
+  "procedure": {"id": "integer", "title": "string", "fields": []},
+  "partsRequired": [],
+  "notifyAssignees": "boolean"
+}
+```
+
+**Work order status values:** `OPEN`, `IN_PROGRESS`, `ON_HOLD`, `COMPLETED`, `CLOSED`
+
+**Work order response includes:** `id`, `title`, `description`, `status`, `priority`, `dueDate`, `assetId`, `locationId`, `assignees`, `categories`, `createdAt`, `updatedAt`, `workOrderNo`, `procedure`
+
+## Webhook / Event Capabilities
+
+MaintainX supports webhooks via a dedicated API endpoint (confirmed via Zapier and Make integrations, details in official docs at `api.getmaintainx.com/v1/docs`). Events include new work orders, work order completions, and work order category changes. Configuration via the API or the MaintainX UI (Settings → Integrations → Webhooks).
+
+Rate limit headers `x-ratelimit-remaining` and `Retry-After` are returned in responses; honor them when processing webhook bursts.
+
+**Note:** Webhook payload schema not publicly documented — verify via the Swagger UI at `https://api.getmaintainx.com/v1/docs` after authenticating.
+
+## Rate Limits
+
+- **10 requests per second** observed limit (inferred from Claude Code community skill implementation)
+- **Max 5 concurrent requests** recommended
+- **Max page size:** 100 items per cursor page
+- **429 response** → read `Retry-After` header, apply exponential backoff (`baseDelay * 2^attempt + jitter`)
+- Headers: `x-ratelimit-remaining` tracks remaining quota in current window
+
+## SDK Availability
+
+- **Official SDK:** None. MaintainX publishes no official Python or Node.js SDK.
+- **Community ETL library (Python):** `https://github.com/pradeep-somasundaram/MaintainX` — extracts work orders, assets, locations, users, teams; handles cursor pagination and retries. Not a general-purpose client.
+- **Integration platform connectors:** Pipedream, Make (Integromat), Zapier, Ibexa Connect — pre-built actions for common operations.
+
+## Implementation Notes for MIRA
+
+**MIRA WorkOrder → MaintainX field mapping:**
+
+| MIRA field | MaintainX field | Notes |
+|-----------|-----------------|-------|
+| `title` | `title` | Required |
+| `description` | `description` | |
+| `asset_id` | `assetId` | integer |
+| `location_id` | `locationId` | integer |
+| `priority` | `priority` | Map `LOW/MED/HIGH` to `LOW/MEDIUM/HIGH`; MIRA has no "NONE" |
+| `status` | `status` | MIRA uses `open/in_progress/closed`; map accordingly |
+| `due_date` | `dueDate` | ISO 8601 |
+| `assigned_to` | `assignees[].id` | Requires pre-fetching user IDs |
+
+**MIRA Asset → MaintainX field mapping:**
+
+| MIRA field | MaintainX field | Notes |
+|-----------|-----------------|-------|
+| `asset_id` | `id` | Read-only on MaintainX side |
+| `name` | `name` | |
+| `location` | `locationId` | |
+
+**API quirks to handle:**
+- **Cursor pagination only** — no page-number style. Store `nextCursor` from each response; loop until `null`.
+- **Rate limit is per-second not per-minute** — unlike most APIs. Throttle aggressively with a request queue.
+- **API keys are account-scoped** — one key per MaintainX account; no per-tenant keys for SaaS multi-tenancy. Design the MIRA connector to store one key per connected MaintainX account.
+- **Procedures (checklists) are separate resources** — you must GET `/procedures` to find the right `id` before embedding in a work order.
+- **Error format:** HTTP status code + JSON `{ "message": "..." }`. No structured error codes documented.
+- **Official docs are behind a Redoc/Swagger UI** — interactive but not easily scraped. Use `https://api.getmaintainx.com/v1/docs#tag/Getting-Started` for live schema exploration.
+
+## Links
+
+- Official REST API docs (Swagger/Redoc): `https://api.getmaintainx.com/v1/docs`
+- Getting started tag: `https://api.getmaintainx.com/v1/docs#tag/Getting-Started`
+- Help center (redirects): `https://help.getmaintainx.com/` (most deep links redirect to root)
+- Ibexa Connect integration docs: `https://doc.ibexa.co/projects/connect/en/latest/apps/maintainx/`
+- Make.com integration docs: `https://apps.make.com/maintainx`
+- Community rate-limit skill reference: `https://eliteai.tools/agent-skills/maintainx-rate-limits`
+- Community Python ETL: `https://github.com/pradeep-somasundaram/MaintainX`
+- API key management UI: `https://app.getmaintainx.com/settings/apikeys`

--- a/docs/integrations/microsoft_graph_api_reference.md
+++ b/docs/integrations/microsoft_graph_api_reference.md
@@ -1,0 +1,239 @@
+# Microsoft Graph API Reference
+**For:** MIRA Hub integration | **Researched:** 2026-04-28
+
+---
+
+## Auth Method
+
+Microsoft Graph uses **OAuth 2.0 via Microsoft Entra ID** exclusively. All API calls require a bearer token in the `Authorization` header.
+
+### Two permission models
+
+**Delegated permissions** — the app acts on behalf of a signed-in user. The token represents both the app and the user. Requires an interactive login flow (Authorization Code or Device Code). Users can consent to lower-privilege scopes themselves; admins must consent to sensitive scopes.
+
+**Application permissions** — the app acts as itself with no user context (daemon/service). Uses **Client Credentials flow**: `client_id` + `client_secret` (or certificate) → token. No user required. Almost always requires **admin consent** from a tenant administrator.
+
+### Token endpoint
+```
+POST https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token
+```
+For multi-tenant apps use `common` or `organizations` in place of `{tenant_id}`.
+
+### Common scopes MIRA will need
+
+| Scope | Type | What it grants | Admin consent? |
+|---|---|---|---|
+| `Mail.Read` | Delegated / Application | Read email messages | Delegated: No / Application: Yes |
+| `Mail.Send` | Delegated / Application | Send email as user or app | Delegated: No / Application: Yes |
+| `Calendars.Read` | Delegated / Application | Read calendar events | Delegated: No / Application: Yes |
+| `Calendars.ReadWrite` | Delegated / Application | Create/edit calendar events | Delegated: No / Application: Yes |
+| `Files.Read.All` | Delegated / Application | Read all files (OneDrive, SharePoint) | Delegated: No / Application: Yes |
+| `Files.ReadWrite.All` | Delegated / Application | Read/write all files | Delegated: No / Application: Yes |
+| `Sites.Read.All` | Delegated / Application | Read SharePoint sites | Delegated: No / Application: Yes |
+| `User.Read` | Delegated | Read signed-in user's profile | No |
+| `User.Read.All` | Application | Read all user profiles in tenant | Yes |
+| `ChannelMessage.Read.All` | Application | Read Teams channel messages | Yes |
+| `Chat.Read` / `Chat.ReadWrite` | Delegated | Read/write Teams chats for signed-in user | No |
+
+**Rule of thumb for MIRA**: Background service workers reading mail/files/calendar without user interaction need **Application permissions** and require a one-time admin consent grant in the customer's tenant.
+
+---
+
+## Key Endpoints We Need
+
+**Base URL:** `https://graph.microsoft.com/v1.0/` (stable, production)
+Use `https://graph.microsoft.com/beta/` only for preview features — do not take production dependencies on beta.
+
+### Email (Outlook / Exchange Online)
+
+| Endpoint | Method | What it does | Required permission |
+|---|---|---|---|
+| `/me/messages` | GET | List messages in signed-in user's mailbox | `Mail.Read` (delegated) |
+| `/users/{userId}/messages` | GET | List messages for a specific user | `Mail.Read` (application) |
+| `/me/messages/{messageId}` | GET | Get a single message (all properties) | `Mail.Read` |
+| `/me/sendMail` | POST | Send an email immediately | `Mail.Send` |
+| `/me/messages` | POST | Create a draft message | `Mail.ReadWrite` |
+| `/me/messages/{messageId}/send` | POST | Send a previously created draft | `Mail.Send` |
+| `/me/messages/{messageId}/reply` | POST | Reply to a message | `Mail.Send` |
+| `/me/messages/{messageId}/forward` | POST | Forward a message | `Mail.Send` |
+| `/me/mailFolders/{folderId}/messages` | GET | List messages in a specific folder | `Mail.Read` |
+
+**Message object key properties:** `id`, `subject`, `body` (HTML or text), `from`, `toRecipients`, `ccRecipients`, `bccRecipients`, `receivedDateTime`, `sentDateTime`, `hasAttachments`, `isDraft`, `isRead`, `importance`, `conversationId`, `internetMessageId`
+
+**Recipient limit:** Maximum 500 total recipients (to + cc + bcc) per message from Exchange Online.
+
+### Calendar (Outlook / Exchange Online)
+
+| Endpoint | Method | What it does | Required permission |
+|---|---|---|---|
+| `/me/events` | GET | List calendar events | `Calendars.Read` |
+| `/me/events` | POST | Create a calendar event | `Calendars.ReadWrite` |
+| `/me/events/{eventId}` | PATCH | Update an event | `Calendars.ReadWrite` |
+| `/me/events/{eventId}` | DELETE | Delete an event | `Calendars.ReadWrite` |
+| `/me/calendarView?startDateTime=&endDateTime=` | GET | Get events in a time window | `Calendars.Read` |
+| `/me/findMeetingTimes` | POST | Suggest optimal meeting times for attendees | `Calendars.Read` |
+
+### OneDrive / Files
+
+| Endpoint | Method | What it does | Required permission |
+|---|---|---|---|
+| `/me/drive/root/children` | GET | List files in root of user's OneDrive | `Files.Read` |
+| `/me/drive/items/{itemId}` | GET | Get a file item by ID | `Files.Read` |
+| `/me/drive/root:/{path}` | GET | Get a file by path | `Files.Read` |
+| `/me/drive/items/{itemId}/content` | GET | Download file content | `Files.Read` |
+| `/me/drive/root/children` | POST | Upload a new file | `Files.ReadWrite` |
+| `/drives/{driveId}/items/{itemId}` | GET | Access a specific SharePoint drive item | `Files.Read.All` |
+
+### SharePoint
+
+| Endpoint | Method | What it does | Required permission |
+|---|---|---|---|
+| `/sites/{siteId}` | GET | Get a SharePoint site | `Sites.Read.All` |
+| `/sites/{siteId}/drives` | GET | List document libraries in a site | `Sites.Read.All` |
+| `/sites/{siteId}/lists` | GET | List SharePoint lists | `Sites.Read.All` |
+| `/sites/{siteId}/lists/{listId}/items` | GET | List items in a SharePoint list | `Sites.Read.All` |
+
+### Teams (via Graph)
+
+| Endpoint | Method | What it does | Required permission |
+|---|---|---|---|
+| `/users/{userId}/teamwork/installedApps` | POST | Proactively install a Teams app for a user | `TeamsAppInstallation.ReadWriteForUser.All` |
+| `/chats/{chatId}/messages` | GET | Read messages in a Teams chat | `Chat.Read` |
+| `/teams/{teamId}/channels/{channelId}/messages` | GET | Read channel messages | `ChannelMessage.Read.All` |
+| `/me/joinedTeams` | GET | List teams the user is a member of | `Team.ReadBasic.All` |
+
+---
+
+## Webhook / Event Capabilities
+
+Microsoft Graph uses **change notification subscriptions** — you register a webhook endpoint and Graph pushes notifications when resources change.
+
+**Create a subscription:**
+```
+POST https://graph.microsoft.com/v1.0/subscriptions
+{
+  "changeType": "created,updated",
+  "notificationUrl": "https://your-mira-host/graph/notifications",
+  "resource": "/me/messages",
+  "expirationDateTime": "2026-05-05T00:00:00Z",
+  "clientState": "your-secret-validation-string"
+}
+```
+
+**Key subscribable resources:**
+
+| Resource | Change types | Use case |
+|---|---|---|
+| `/me/messages` | created, updated, deleted | Incoming email monitoring |
+| `/me/events` | created, updated, deleted | Calendar change alerts |
+| `/me/drive/root` | updated | OneDrive file changes |
+| `/communications/calls` | — | Teams call state changes |
+| `/chats/{chatId}/messages` | created | New Teams chat messages |
+| `/teams/{teamId}/channels/{channelId}/messages` | created | New channel messages |
+
+**Subscription management:**
+- Subscriptions expire (max ~3 days for most resources, up to 4230 minutes)
+- Must renew via `PATCH /subscriptions/{id}` before expiry
+- Validation: Graph sends a POST with a `validationToken` query param to your endpoint on creation — respond with `200 OK` and the token as plain text within 10 seconds
+- Payload is a lightweight notification (resource URL + change type); you must call Graph separately to fetch the changed data
+
+**Prefer change tracking (delta queries)** over subscriptions for bulk polling — use `/me/messages/delta` to get incremental changes without per-item polling.
+
+---
+
+## Rate Limits
+
+Graph throttling is **service-specific** and does not publish fixed per-minute numbers in the main docs. The pattern is consistent:
+
+- Throttled request returns **HTTP 429 Too Many Requests**
+- Response includes a `Retry-After` header (seconds to wait)
+- If no `Retry-After` header: use exponential backoff
+- Throttling can be per-app, per-tenant, or per-user depending on the service
+
+**Key throttling rules:**
+- Throttling is evaluated per service (Outlook, SharePoint, OneDrive, Teams each have their own limits)
+- Both reads and writes are throttled, but high-volume writes are more likely to trigger throttling
+- Error codes 412, 502, and 504 should also be retried (not just 429)
+- **Bulk data access**: Use Microsoft Graph Data Connect (Azure Data Factory pipeline) instead of REST APIs for large-scale extractions — Data Connect bypasses throttling limits
+
+**Graph SDK retry behavior:** The official Graph SDKs include a built-in retry handler that respects `Retry-After` and implements exponential backoff automatically. Use the SDK rather than raw HTTP for robustness.
+
+**JSON batching**: Combine up to 20 requests in a single HTTP call using `POST /v1.0/$batch`. Each sub-request is evaluated individually against throttling; throttled sub-requests return 429 within the 200 batch response. Retry only the failed sub-requests.
+
+---
+
+## SDK Availability
+
+| SDK | Language | Package | Notes |
+|---|---|---|---|
+| Microsoft Graph Python SDK | Python | `msgraph-sdk` (v1+) | Async support; built-in auth, retry, pagination handlers |
+| Microsoft Graph JavaScript SDK | JavaScript/TypeScript | `@microsoft/microsoft-graph-client` | Browser + Node |
+| Microsoft Graph .NET SDK | C# | `Microsoft.Graph` | Fluent API |
+| MSAL (auth only) | Python | `msal` | Token acquisition; use alongside graph SDK |
+| MSAL (auth only) | JavaScript | `@azure/msal-node` | Token acquisition for Node services |
+| Azure Identity | Python | `azure-identity` | `ClientSecretCredential`, `DeviceCodeCredential`, `InteractiveBrowserCredential` — recommended auth layer |
+
+**Recommended Python pattern for MIRA:**
+```python
+from azure.identity import ClientSecretCredential
+from msgraph import GraphServiceClient
+
+credential = ClientSecretCredential(
+    tenant_id=os.getenv("AZURE_TENANT_ID"),
+    client_id=os.getenv("AZURE_CLIENT_ID"),
+    client_secret=os.getenv("AZURE_CLIENT_SECRET"),
+)
+client = GraphServiceClient(credentials=credential, scopes=["https://graph.microsoft.com/.default"])
+```
+
+**npm equivalent for Node services:**
+```
+npm install @microsoft/microsoft-graph-client @azure/identity
+```
+
+---
+
+## Implementation Notes for MIRA
+
+### Azure App Registration (one per customer tenant or MIRA's own tenant)
+1. Register in Azure Entra ID → note `tenant_id`, `client_id`
+2. Add a client secret → note `client_secret` (store in Doppler `factorylm/prd`)
+3. Under API Permissions, add the Microsoft Graph permissions MIRA needs
+4. For **Application permissions**: click "Grant admin consent for [tenant]" — a tenant admin must do this, or MIRA must redirect them through the admin consent URL:
+   ```
+   https://login.microsoftonline.com/{tenant_id}/adminconsent?client_id={client_id}
+   ```
+5. For **multi-tenant MIRA SaaS**: register as a multi-tenant app; each customer org's admin must grant consent separately
+
+### Delegated vs Application — MIRA Decision Guide
+- **Background diagnostic workers** (read maintenance logs, email alerts, OEM files from SharePoint): use **Application permissions** — no user session needed
+- **User-triggered actions** (send email on behalf of tech, create calendar event): use **Delegated permissions** — requires the technician to have signed in at least once
+- **Proactive Teams bot installs**: use **Application permissions** (`TeamsAppInstallation.ReadWriteForUser.All`) — admin consent required
+
+### Admin Consent Requirement — Customer Impact
+Most permissions MIRA needs for unattended operation require a customer's Microsoft 365 admin to grant consent. This is a **sales/onboarding friction point**: plan a guided admin consent flow in the MIRA Hub activation sequence (similar to how mira-relay handles Ignition activation).
+
+### Versioning
+- Always use `v1.0` endpoint in production — beta APIs break without notice
+- Check the [Graph changelog](https://developer.microsoft.com/graph/changelog) before upgrading SDK major versions
+
+### Gotchas
+- **Subscription `notificationUrl` must be HTTPS** and publicly reachable — local dev requires ngrok or tunnel; mira-relay is the right candidate for this endpoint in production
+- **Subscription expiry**: Outlook message subs expire in ~3 days; set up a background job to renew before expiry
+- **User vs `/me`**: Application-permission requests must use `/users/{userId}` not `/me` — `/me` only works with delegated tokens
+- **Immutable IDs**: Message IDs change when items are moved between folders; use `Prefer: IdType="ImmutableId"` header if you need stable IDs across moves
+- **Exchange Online recipient limit**: 500 recipients max per send call
+- **`clientState` validation on webhooks**: always validate the `clientState` on incoming notifications to prevent spoofed webhook calls
+
+---
+
+## Links
+
+- Graph overview: https://learn.microsoft.com/en-us/graph/overview
+- Graph API v1.0 reference: https://learn.microsoft.com/en-us/graph/api/overview?view=graph-rest-1.0
+- Message resource (email): https://learn.microsoft.com/en-us/graph/api/resources/message?view=graph-rest-1.0
+- Throttling guidance: https://learn.microsoft.com/en-us/graph/throttling
+- Service-specific throttling limits: https://learn.microsoft.com/en-us/graph/throttling-limits
+- Change notifications (webhooks): https://learn.microsoft.com/en-us/graph/change-notifications-overview
+- msgraph-sdk-python: https://github.com/microsoftgraph/msgraph-sdk-python
+- Graph Explorer (live API tester): https://developer.microsoft.com/graph/graph-explorer

--- a/docs/integrations/microsoft_teams_api_reference.md
+++ b/docs/integrations/microsoft_teams_api_reference.md
@@ -1,0 +1,158 @@
+# Microsoft Teams Bot Framework API Reference
+**For:** MIRA Hub integration | **Researched:** 2026-04-28
+
+---
+
+## Auth Method
+
+Teams bots use **OAuth 2.0 via Microsoft Entra ID (formerly Azure AD)** with two distinct flows:
+
+### Bot-to-Bot-Service Auth (always required)
+The bot authenticates to the Bot Connector Service using **client credentials flow** (app ID + client secret or certificate). This is the baseline auth that lets your bot send/receive messages via the Bot Framework relay.
+
+- Register an app in Azure Entra ID → get an **App ID** (client_id) and **Client Secret**
+- Bot Framework Token Service issues bearer tokens; these are sent on every outbound API call
+- Token endpoint: `https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token`
+- Scope: `https://api.botframework.com/.default`
+
+### SSO / User-Delegated Auth (optional, for Graph access on behalf of user)
+When the bot needs to act as the user (read their files, calendar, etc.):
+
+- Uses **OBO (On-Behalf-Of)** flow: Teams sends a token to the bot, the bot exchanges it at Entra ID for a Graph token
+- Requires configuring an **OAuth Connection** in the Bot Framework registration (Azure Portal → Bot resource → OAuth Connections)
+- SSO is supported in personal scope and group chat; **not** supported in channel scope
+- App users consent once; Bot Framework Token Store caches the token
+- Key scopes for SSO: `openid`, `profile`, `email` — then add Graph scopes as needed (`User.Read`, `Files.Read`, etc.)
+- Admin consent required for high-privilege scopes (e.g., `Sites.ReadWrite.All`)
+
+### App Manifest Requirement
+The `webApplicationInfo` section in the Teams app manifest must declare the Entra app ID and application ID URI (`api://botid-{bot-app-id}`) to enable token exchange.
+
+---
+
+## Key Endpoints We Need
+
+All bot messaging goes through the **Bot Connector Service**. The `serviceUrl` is provided in every incoming activity from Teams and must be used for replies. For proactive messages, use the global fallback URLs below.
+
+| Endpoint | Method | What it does | Required params |
+|---|---|---|---|
+| `{serviceUrl}/v3/conversations` | POST | Create a new conversation (1:1 or channel thread) | `bot.id`, `members[].id`, `channelData.tenant.id` |
+| `{serviceUrl}/v3/conversations/{conversationId}/activities` | POST | Send a message or Adaptive Card into a conversation | `conversationId`, activity payload (type, text or attachments) |
+| `{serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}` | PUT | Update an existing message in-place | `conversationId`, `activityId`, updated activity body |
+| `{serviceUrl}/v3/conversations/{conversationId}/activities/{activityId}` | DELETE | Delete an existing bot message | `conversationId`, `activityId` |
+| `{serviceUrl}/v3/conversations/{conversationId}/members` | GET | List members of a conversation/channel | `conversationId` |
+| `https://smba.trafficmanager.net/teams/` | — | Global public service URL for proactive messages (use when no incoming `serviceUrl` available) | — |
+
+**Adaptive Cards:** Sent as part of the activity payload under `attachments`, with `contentType: "application/vnd.microsoft.card.adaptive"`. Supported in Teams for interactive notifications, forms, and action buttons.
+
+**Proactive messages flow:**
+1. Store `conversationId`, `tenantId`, and `serviceUrl` from any incoming activity OR retrieve via Graph API
+2. Call `continueConversation(conversationReference, callback, appId)` via Bot Framework SDK
+3. Inside callback, call `turnContext.sendActivity(...)`
+
+---
+
+## Webhook / Event Capabilities
+
+Teams delivers events to the bot's **messaging endpoint** (a public HTTPS URL you register during bot setup) as HTTP POST requests. The bot must respond with HTTP 200 within a few seconds.
+
+**Key activity types received:**
+
+| Activity type | When it fires |
+|---|---|
+| `message` | User sends a message to the bot |
+| `conversationUpdate` | Bot added/removed from team or chat; members added/removed (`membersAdded`, `membersRemoved`) |
+| `messageReaction` | User reacts to a message with an emoji |
+| `invoke` | Action from an Adaptive Card button, message extension, or SSO token exchange |
+| `installationUpdate` | App installed or uninstalled in a team/chat |
+| `event` | Subscription-based notification events (e.g., meeting start/end) |
+
+There is no separate webhook subscription management for Teams bots — all events are pushed to your registered messaging endpoint automatically once the app is installed in a Team or chat.
+
+---
+
+## Rate Limits
+
+Limits are per-bot-per-thread (single conversation). The global app-wide cap is **50 Requests Per Second (RPS) per app per tenant**.
+
+| Scenario | Window | Max operations |
+|---|---|---|
+| Send to conversation (per bot) | 1 sec | 7 |
+| Send to conversation (per bot) | 2 sec | 8 |
+| Send to conversation (per bot) | 30 sec | 60 |
+| Send to conversation (per bot) | 3600 sec | 1800 |
+| Create conversation (per bot) | 1 sec | 7 |
+| Create conversation (per bot) | 3600 sec | 1800 |
+| Get conversation members (per bot) | 3600 sec | 3600 |
+| Send to conversation (all bots combined) | 1 sec | 14 |
+| Send to conversation (all bots combined) | 2 sec | 16 |
+
+- Throttled requests return HTTP **429 Too Many Requests**
+- Also retry on: 412, 502, 504
+- Recommended strategy: exponential backoff with random jitter (2s min, 20s max, ±20% delta)
+- Rate limits are subject to change; do not hardcode thresholds — implement adaptive backoff
+
+---
+
+## SDK Availability
+
+| SDK | Language | Package | Status |
+|---|---|---|---|
+| Teams SDK (recommended, formerly Teams AI Library) | JavaScript/TypeScript | `@microsoft/teams-ai` | GA |
+| Teams SDK | C# | `Microsoft.Teams.AI` | GA |
+| Teams SDK | Python | `teams-ai` | Developer preview |
+| Bot Framework SDK v4 | Python | `botbuilder-core`, `botbuilder-integration-aiohttp` | Active (legacy path) |
+| Bot Framework SDK v4 | JavaScript | `botbuilder` | Active (legacy path) |
+| Bot Framework SDK v4 | C# | `Microsoft.Bot.Builder` | Active (legacy path) |
+| Microsoft 365 Agents SDK | C#, JS, Python | `microsoft-agents` | New recommended framework |
+
+**Note:** The classic Bot Framework SDK GitHub repo has been archived and support ended December 31, 2025. Microsoft now recommends the **Microsoft 365 Agents SDK** for new projects targeting Teams, or the **Teams SDK** for Teams-specific builds. Existing botbuilder-python code still runs but should be migrated.
+
+**Python install (legacy path, still functional):**
+```
+pip install botbuilder-core botbuilder-integration-aiohttp botframework-connector
+```
+
+---
+
+## Implementation Notes for MIRA
+
+### Azure App Registration
+1. Create an app registration in Azure Entra ID (portal.azure.com → Entra ID → App registrations)
+2. Note the **Application (client) ID** — this is the bot's `MicrosoftAppId`
+3. Create a **Client Secret** under Certificates & secrets → this is `MicrosoftAppPassword`
+4. Set the Application ID URI to `api://botid-{MicrosoftAppId}` for SSO
+5. Under Expose an API, add the scope `access_as_user`
+6. Under Authorized client applications, add Teams client IDs: `1fec8e78-bce4-4aaf-ab1b-5451cc387264` (Teams desktop/mobile) and `5e3ce6c0-2b1f-4285-8d4b-75ee78787346` (Teams web)
+
+### Azure Bot Resource
+- Create an **Azure Bot** resource (not a Bot Channels Registration — that's being retired)
+- Set the messaging endpoint to your MIRA service URL: `https://<your-host>/api/messages`
+- Add the **Microsoft Teams** channel in the bot resource
+- Configure OAuth connections here if using SSO / Graph-on-behalf-of
+
+### Teams App Manifest
+- The manifest (`manifest.json`) must include a `bots` section with the bot's App ID
+- Set `supportsFiles`, `isNotificationOnly`, and `scopes` (personal, team, groupchat) as needed
+- For proactive installs, the app must be in your org's app catalog (Teams Admin Center upload)
+- Package as a `.zip` (manifest + two icon files) and sideload for dev; publish via Teams Admin Center for org-wide
+
+### MIRA-specific Gotchas
+- **Proactive messages require prior installation**: The bot cannot cold-message a user who has never installed the app; use Graph API (`/v1.0/users/{id}/teamwork/installedApps`) to proactively install first
+- **`serviceUrl` must not be hardcoded**: Capture it from the first incoming activity and persist it (per tenant, per conversation) — it can differ by region
+- **Channel scope SSO**: SSO token exchange is not supported in channel scope; fall back to OAuth card flow for channel bots needing user identity
+- **403 `MessageWritesBlocked`**: User has blocked or uninstalled the bot; log this per-user to avoid repeated attempts
+- **`aadObjectId` vs `userId`**: The `aadObjectId` (Entra user GUID) is portable across bots; `userId` is bot-specific. Use `aadObjectId` for Graph lookups and proactive message targeting
+- **Government cloud**: Use dedicated service URLs for GCC/GCC-High/DoD — do not use the public `smba.trafficmanager.net` endpoint
+
+---
+
+## Links
+
+- Teams bots overview: https://learn.microsoft.com/en-us/microsoftteams/platform/bots/overview
+- Send proactive messages: https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/conversations/send-proactive-messages
+- Rate limiting for bots: https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/rate-limit
+- Bot SSO overview: https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/authentication/bot-sso-overview
+- Teams SDK (formerly Teams AI Library): https://learn.microsoft.com/en-us/microsoftteams/platform/teams-ai-library/welcome
+- Microsoft 365 Agents SDK migration guide: https://aka.ms/bfmigrationguidance
+- Teams samples repo: https://github.com/OfficeDev/Microsoft-Teams-Samples

--- a/docs/integrations/pagerduty_api_reference.md
+++ b/docs/integrations/pagerduty_api_reference.md
@@ -1,0 +1,236 @@
+# PagerDuty API Reference
+**For:** MIRA Hub integration | **Researched:** 2026-04-28
+
+PagerDuty provides two separate APIs: the **Events API v2** (for sending alert events from monitoring systems) and the **REST API v2** (for managing incidents, services, users, and webhooks). MIRA uses both — Events API to trigger safety alerts, REST API to list/acknowledge/resolve.
+
+---
+
+## Auth Method
+
+### Events API v2
+Uses an **Integration Key** (also called `routing_key`), not a user API key. Obtained from a PagerDuty service's Integrations tab when adding an "Events API v2" integration.
+
+```
+POST https://events.pagerduty.com/v2/enqueue
+Content-Type: application/json
+
+Body: { "routing_key": "<32-char integration key>", ... }
+```
+
+No `Authorization` header required — auth is embedded in the `routing_key` field.
+
+### REST API v2
+Two options:
+
+| Method | Header | When to use |
+|--------|--------|-------------|
+| API Access Key | `Authorization: Token token=<key>` | Server-to-server (MIRA backend) |
+| OAuth 2.0 Bearer | `Authorization: Bearer <access_token>` | User-delegated flows |
+
+Additionally, all **write operations on incidents** (PUT) require:
+```
+From: <valid-pagerduty-user-email>
+```
+Set via `default_from` on the client or as a header on each request.
+
+**Obtaining an API key:** PagerDuty → User Icon → My Profile → API Access → Create New API Key (read/write scope).
+
+---
+
+## Key Endpoints We Need
+
+### Events API v2
+
+| Endpoint | Method | What it does | Required fields |
+|----------|--------|--------------|-----------------|
+| `https://events.pagerduty.com/v2/enqueue` | POST | Trigger alert | `routing_key`, `event_action: "trigger"`, `payload.summary`, `payload.source`, `payload.severity` |
+| `https://events.pagerduty.com/v2/enqueue` | POST | Acknowledge alert | `routing_key`, `event_action: "acknowledge"`, `dedup_key` |
+| `https://events.pagerduty.com/v2/enqueue` | POST | Resolve alert | `routing_key`, `event_action: "resolve"`, `dedup_key` |
+
+**Trigger payload structure:**
+```json
+{
+  "routing_key": "<integration_key>",
+  "event_action": "trigger",
+  "dedup_key": "mira-asset-{asset_id}-{fault_type}",
+  "payload": {
+    "summary": "Arc flash risk detected on Motor Drive VFD-01",
+    "source": "mira-diagnosis",
+    "severity": "critical",
+    "timestamp": "2026-04-28T14:30:00Z",
+    "component": "VFD-01",
+    "group": "Conveyor Line 3",
+    "class": "electrical",
+    "custom_details": {
+      "asset_id": "VFD-01",
+      "fault_code": "OC-001",
+      "temperature_c": 87.4,
+      "mira_session_id": "sess_abc123"
+    }
+  },
+  "images": [],
+  "links": [
+    {
+      "href": "https://mira.factorylm.com/incidents/abc123",
+      "text": "View in MIRA"
+    }
+  ]
+}
+```
+
+`severity` values: `critical` | `error` | `warning` | `info`
+
+### REST API v2 — Base URL: `https://api.pagerduty.com`
+
+| Endpoint | Method | What it does | Required fields / params |
+|----------|--------|--------------|--------------------------|
+| `/incidents` | GET | List incidents | `statuses[]`, `time_zone`, `limit` |
+| `/incidents/{id}` | GET | Get single incident | — |
+| `/incidents` | PUT | Bulk update incidents | `incidents[]` array with `id`, `type`, `status` |
+| `/incidents/{id}` | PUT | Update single incident | `incident.type`, `incident.status`; `From` header |
+| `/services` | GET | List services | — |
+| `/webhook_subscriptions` | POST | Register v3 webhook | `delivery_method`, `events[]`, `filter` |
+
+**List open incidents (Python):**
+```python
+import pagerduty
+client = pagerduty.RestApiV2Client(API_KEY)
+incidents = client.list_all('incidents',
+    params={'statuses': ['triggered', 'acknowledged']})
+```
+
+**Acknowledge / Resolve via SDK:**
+```python
+# Resolve
+client.rput(incident, json={
+    'type': 'incident_reference',
+    'status': 'resolved'
+})
+```
+
+---
+
+## Webhook / Event Capabilities
+
+PagerDuty **v3 webhooks** push events to a MIRA endpoint when incident state changes.
+
+**Register via REST API:**
+```
+POST https://api.pagerduty.com/webhook_subscriptions
+Authorization: Token token=<key>
+Content-Type: application/json
+
+{
+  "webhook_subscription": {
+    "delivery_method": {
+      "type": "http_delivery_method",
+      "url": "https://mira.factorylm.com/webhooks/pagerduty",
+      "custom_headers": [
+        {"name": "X-MIRA-Secret", "value": "<secret>"}
+      ]
+    },
+    "description": "MIRA incident state sync",
+    "events": [
+      "incident.triggered",
+      "incident.acknowledged",
+      "incident.resolved",
+      "incident.escalated",
+      "incident.priority_updated"
+    ],
+    "filter": {
+      "type": "account_reference"
+    },
+    "type": "webhook_subscription"
+  }
+}
+```
+
+**Limit:** 10 subscriptions per unique service+team ID.
+
+**Payload structure:**
+```json
+{
+  "event": {
+    "id": "evt_01ABC",
+    "event_type": "incident.triggered",
+    "resource_type": "incident",
+    "occurred_at": "2026-04-28T14:30:01Z",
+    "data": {
+      "id": "Q1KFL24LR3",
+      "title": "Arc flash risk detected",
+      "status": "triggered",
+      "urgency": "high",
+      "service": { "id": "SVC001", "name": "MIRA Diagnosis" },
+      "teams": [{ "id": "TEAM001" }]
+    }
+  }
+}
+```
+
+**Signature verification:** PagerDuty sends `X-PagerDuty-Signature` header (HMAC-SHA256). Verify against the subscription secret.
+
+---
+
+## Rate Limits
+
+REST API uses a **token-bucket** model. No fixed numbers are published; limits are adaptive.
+
+| Signal | Detail |
+|--------|--------|
+| Exceeded response | HTTP 429 |
+| `ratelimit-limit` header | Current bucket capacity |
+| `ratelimit-remaining` header | Remaining calls |
+| `ratelimit-reset` header | Seconds until reset |
+
+**Best practice:** Check `ratelimit-remaining` before each batch; back off on 429 with `ratelimit-reset` delay.
+
+Events API v2 has no published rate limit but is designed for high-volume monitoring traffic.
+
+---
+
+## SDK Availability
+
+| SDK | Install | Notes |
+|-----|---------|-------|
+| `python-pagerduty` (official) | `pip install pagerduty` | Replaces deprecated `pdpyras`; supports REST + Events API v2 |
+| `pdpyras` (deprecated) | `pip install pdpyras` | Still works but no new features |
+| `go-pagerduty` | `go get github.com/PagerDuty/go-pagerduty` | Official Go client |
+| Node.js | No official SDK; use `node-pagerduty` (community) | `npm install node-pagerduty` |
+
+---
+
+## Implementation Notes for MIRA
+
+### Safety Alert → PagerDuty Severity Mapping
+
+| MIRA severity | PagerDuty severity | Trigger condition |
+|---------------|--------------------|-------------------|
+| `CRITICAL` | `critical` | LOTO required, arc flash, confined space |
+| `HIGH` | `error` | Motor overtemp, VFD fault requiring shutdown |
+| `MEDIUM` | `warning` | Elevated vibration, trending fault |
+| `LOW` | `info` | PM overdue, minor anomaly |
+
+### dedup_key Strategy
+Use `mira-{asset_id}-{fault_category}` as the `dedup_key`. This ensures:
+- Re-triggers on the same asset/fault update the existing PagerDuty alert rather than creating duplicates
+- Resolving in MIRA auto-closes the PagerDuty alert via `event_action: "resolve"` + same `dedup_key`
+
+### Routing Key Management
+Each PagerDuty **service** maps to one integration key. Recommended service layout:
+- `MIRA Safety Alerts` service → safety escalation routing
+- `MIRA Equipment Faults` service → maintenance team routing
+
+Store routing keys in Doppler `factorylm/prd` as `PAGERDUTY_SAFETY_ROUTING_KEY` and `PAGERDUTY_FAULTS_ROUTING_KEY`.
+
+### From Header Requirement
+REST API PUT calls require `From: <email>`. Use a dedicated service-account email (e.g., `mira-bot@factorylm.com`) registered as a PagerDuty user. Set as `PAGERDUTY_FROM_EMAIL` in Doppler.
+
+---
+
+## Links
+
+- [Events API v2 — Send Alert Event](https://developer.pagerduty.com/docs/events-api-v2/trigger-events/index.html)
+- [REST API Reference](https://developer.pagerduty.com/api-reference/)
+- [REST API Rate Limits](https://support.pagerduty.com/main/docs/rest-api-rate-limits)
+- [V3 Webhooks Documentation](https://support.pagerduty.com/main/docs/webhooks)
+- [python-pagerduty SDK User Guide](https://pagerduty.github.io/python-pagerduty/user_guide.html)

--- a/docs/integrations/servicenow_api_reference.md
+++ b/docs/integrations/servicenow_api_reference.md
@@ -1,0 +1,322 @@
+# ServiceNow API Reference
+**For:** MIRA Hub integration | **Researched:** 2026-04-28
+
+ServiceNow's **Table API** is the primary REST interface for CRUD operations on any ServiceNow table. For MIRA, this means creating and updating incidents in the `incident` table, and optionally looking up CMDB Configuration Items (CIs) in `cmdb_ci_hardware`. Base URL: `https://{instance}.service-now.com/api/now/table/{table_name}`.
+
+---
+
+## Auth Method
+
+ServiceNow supports three authentication methods. **OAuth 2.0 is strongly recommended for production.**
+
+### Option A: Basic Authentication (simplest, dev/testing only)
+
+```
+Authorization: Basic <base64(username:password)>
+```
+
+Use a **dedicated service account** — not a personal user account. The service account must have roles: `itil` (for incident CRUD) and `snc_platform_rest_api_access`.
+
+```python
+import httpx
+
+resp = await client.post(
+    f"https://{instance}.service-now.com/api/now/table/incident",
+    auth=(username, password),
+    json=payload
+)
+```
+
+### Option B: OAuth 2.0 — Client Credentials (recommended for MIRA)
+
+1. In ServiceNow: **System OAuth → Application Registry** → create OAuth API endpoint for external clients
+2. Enable "Client Credentials" grant type
+3. Note the `client_id` and `client_secret`
+
+**Token endpoint:**
+```
+POST https://{instance}.service-now.com/oauth_token.do
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials
+&client_id=<client_id>
+&client_secret=<client_secret>
+```
+
+**API call with token:**
+```
+Authorization: Bearer <access_token>
+Accept: application/json
+Content-Type: application/json
+```
+
+**Token lifetime:** Configurable per OAuth application (default 1800s). Refresh before expiry or re-request on 401.
+
+Store in Doppler: `SERVICENOW_INSTANCE`, `SERVICENOW_CLIENT_ID`, `SERVICENOW_CLIENT_SECRET` (or `SERVICENOW_USERNAME` / `SERVICENOW_PASSWORD` for basic auth).
+
+### Option C: API Key (on-prem instances, some versions)
+Some ServiceNow instances support `X-UserToken` header auth. Check with the customer's ServiceNow admin.
+
+---
+
+## Key Endpoints We Need
+
+Base URL: `https://{instance}.service-now.com/api/now/table`
+
+### Incident Operations
+
+| Endpoint | Method | What it does | Required fields |
+|----------|--------|--------------|-----------------|
+| `/incident` | POST | Create incident | `short_description` |
+| `/incident/{sys_id}` | GET | Get single incident | — |
+| `/incident` | GET | List incidents | `sysparm_query`, `sysparm_limit` |
+| `/incident/{sys_id}` | PUT | Full update | fields to overwrite |
+| `/incident/{sys_id}` | PATCH | Partial update | fields to change |
+
+### CMDB Operations
+
+| Endpoint | Method | What it does |
+|----------|--------|--------------|
+| `/cmdb_ci_hardware` | GET | Look up hardware CI by name/serial |
+| `/cmdb_ci` | GET | Generic CI lookup |
+| `/cmdb_relationship` | GET | Get CI relationships |
+
+### Create Incident — Full Request Example
+
+```
+POST https://{instance}.service-now.com/api/now/table/incident
+Authorization: Bearer <token>
+Accept: application/json
+Content-Type: application/json
+
+{
+  "short_description": "VFD-01 Motor overtemperature — MIRA alert",
+  "description": "MIRA diagnostic session sess_abc123 detected overtemperature at 87.4°C on VFD-01. Fault code OC-001. Recommend inspection of cooling system and motor load.",
+  "category": "hardware",
+  "subcategory": "motor",
+  "impact": "2",
+  "urgency": "2",
+  "priority": "2",
+  "state": "1",
+  "caller_id": "mira.bot",
+  "assignment_group": "Maintenance Team",
+  "cmdb_ci": "VFD-01",
+  "u_mira_session_id": "sess_abc123",
+  "work_notes": "Auto-created by MIRA AI diagnostics."
+}
+```
+
+**Response wraps result in `result` key:**
+```json
+{
+  "result": {
+    "sys_id": "1a2b3c4d5e6f7g8h9i0j",
+    "number": "INC0010042",
+    "short_description": "VFD-01 Motor overtemperature — MIRA alert",
+    "state": { "value": "1", "display_value": "New" },
+    "priority": { "value": "2", "display_value": "High" }
+  }
+}
+```
+
+Store the `sys_id` and `number` for subsequent updates and linking.
+
+### Key Incident Fields
+
+| Field | Type | Values / Notes |
+|-------|------|----------------|
+| `short_description` | string | Required. Max 160 chars. |
+| `description` | string | Full description, multiline |
+| `state` | integer | 1=New, 2=In Progress, 3=On Hold, 6=Resolved, 7=Closed |
+| `impact` | integer | 1=High, 2=Medium, 3=Low |
+| `urgency` | integer | 1=High, 2=Medium, 3=Low |
+| `priority` | integer | Auto-calculated from impact+urgency, or override: 1=Critical, 2=High, 3=Moderate, 4=Low |
+| `category` | string | `hardware`, `software`, `network`, `inquiry` |
+| `cmdb_ci` | string | CI name or sys_id — links to CMDB asset |
+| `caller_id` | string | Username of requester |
+| `assignment_group` | string | Group name or sys_id |
+| `assigned_to` | string | Username or sys_id of technician |
+| `work_notes` | string | Internal notes (not visible to caller) |
+| `comments` | string | Public comments (visible to caller) |
+| `resolved_at` | datetime | ISO 8601 — set when resolving |
+| `resolution_code` | string | e.g., `Solved (Permanently)` |
+| `close_notes` | string | Required when closing |
+
+### List Incidents with Query
+
+```
+GET /api/now/table/incident
+  ?sysparm_query=state=1^ORstate=2^assigned_to=mira.bot
+  &sysparm_limit=50
+  &sysparm_offset=0
+  &sysparm_fields=sys_id,number,short_description,state,priority,cmdb_ci
+  &sysparm_display_value=true
+```
+
+`sysparm_display_value=true` returns human-readable values (e.g., `"New"`) alongside raw values.
+
+### Update Incident (resolve)
+
+```
+PATCH https://{instance}.service-now.com/api/now/table/incident/{sys_id}
+Content-Type: application/json
+
+{
+  "state": "6",
+  "resolved_at": "2026-04-28T15:00:00Z",
+  "resolution_code": "Solved (Permanently)",
+  "close_notes": "Cooling fan replaced. Motor temperature normalized."
+}
+```
+
+### CMDB CI Lookup
+
+```
+GET /api/now/table/cmdb_ci_hardware
+  ?sysparm_query=name=VFD-01
+  &sysparm_fields=sys_id,name,serial_number,model_id,location
+  &sysparm_limit=1
+```
+
+---
+
+## Webhook / Event Capabilities
+
+ServiceNow does not expose traditional inbound webhooks. Instead it uses **outbound REST messages** triggered by **Business Rules** to push events to external systems.
+
+### Setting Up Outbound Notifications to MIRA
+
+**Step 1 — Create REST Message** (System Web Services → Outbound → REST Message):
+- Name: `MIRA Incident Sync`
+- Endpoint: `https://mira.factorylm.com/webhooks/servicenow`
+- HTTP method: POST
+- Authentication: Basic or OAuth
+- HTTP Request headers: `Content-Type: application/json`, `X-MIRA-Secret: <secret>`
+
+**Step 2 — Create Business Rule** (System Definition → Business Rules):
+```javascript
+// Business Rule: "Notify MIRA on incident state change"
+// Table: incident | When: after | Insert: false | Update: true
+// Condition: state changed
+
+(function executeRule(current, previous) {
+    var r = new sn_ws.RESTMessageV2('MIRA Incident Sync', 'notify');
+    r.setStringParameterNoEscape('sys_id', current.sys_id);
+    r.setStringParameterNoEscape('number', current.number);
+    r.setStringParameterNoEscape('state', current.state.toString());
+    r.setStringParameterNoEscape('assigned_to', current.assigned_to.toString());
+    try {
+        var response = r.execute();
+    } catch(ex) {
+        gs.error('MIRA Sync failed: ' + ex.message);
+    }
+})(current, previous);
+```
+
+**Events MIRA should receive:**
+- Incident state change (New → In Progress → Resolved)
+- Assignment changes
+- Work notes added
+
+**MIRA webhook endpoint** (`/webhooks/servicenow`) verifies the `X-MIRA-Secret` header and maps incoming `sys_id` to the MIRA session that created the incident.
+
+---
+
+## Rate Limits
+
+ServiceNow rate limits are **instance-configurable** — there is no universal published limit. Defaults vary by ServiceNow version and license tier.
+
+| Behavior | Detail |
+|----------|--------|
+| Default limit (common) | ~1,000 requests/hour per user/service account |
+| Exceeded response | HTTP 429 |
+| Response headers | `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `X-RateLimit-Rule` |
+| Config location | ServiceNow admin: System Properties → REST API → Rate Limiting |
+| Config activation delay | Up to 30 seconds after changing limits |
+| On-prem vs SaaS | On-prem instances: no default limit unless configured; SaaS: may have tenant limits |
+
+**Ask the customer's ServiceNow admin** for the actual limit on their instance before integration. Set `sysparm_limit` appropriately on list calls and implement exponential backoff on 429.
+
+---
+
+## SDK Availability
+
+| SDK | Install | Notes |
+|-----|---------|-------|
+| `pysnow` (community, stable) | `pip install pysnow` | Python; stable maintenance mode; covers Table API well |
+| `aiosnow` (community, async) | `pip install aiosnow` | Async successor to pysnow; use for MIRA's async stack |
+| `servicenow-sdk` (community) | `pip install servicenow-sdk` | Newer option; less adoption |
+| No official Python SDK | — | ServiceNow does not publish an official Python client |
+
+**aiosnow usage (async, recommended for MIRA):**
+```python
+import aiosnow
+
+async with aiosnow.Client(
+    "https://{instance}.service-now.com",
+    basic_auth=(username, password)
+) as client:
+    incident_model = await client.get_model(aiosnow.models.TableModel, "incident")
+    
+    # Create
+    result = await incident_model.create({
+        "short_description": "VFD-01 overtemp — MIRA",
+        "impact": "2",
+        "urgency": "2"
+    })
+    sys_id = result["sys_id"]
+    
+    # Update
+    await incident_model.update({"sys_id": sys_id}, {"state": "6"})
+```
+
+**Direct httpx (no SDK, explicit control):**
+```python
+import httpx
+
+async with httpx.AsyncClient(
+    base_url=f"https://{instance}.service-now.com/api/now/table",
+    auth=(username, password),
+    headers={"Accept": "application/json", "Content-Type": "application/json"},
+    timeout=30
+) as client:
+    resp = await client.post("/incident", json=payload)
+    resp.raise_for_status()
+    sys_id = resp.json()["result"]["sys_id"]
+```
+
+---
+
+## Implementation Notes for MIRA
+
+### Table Name for Incidents
+Always `incident` — this is the standard ServiceNow ITSM incident table. Never use `task` (parent table, too broad) or `u_incident` (custom table some orgs create).
+
+### Authentication Gotchas (On-Prem Instances)
+- **Basic auth may be disabled** on some hardened on-prem instances. Always attempt OAuth first.
+- **On-prem behind VPN:** MIRA must have network access to the ServiceNow instance. May require Tailscale or customer VPN peering.
+- **SSL cert issues:** On-prem instances often use self-signed or internal CA certs. Set `verify=False` only in dev; in production, provide the customer's CA bundle via `verify=/path/to/ca.pem`.
+- **`channel_binding` errors on Windows hosts** — not applicable to MIRA (macOS/Linux), but noted in gotchas.
+
+### CMDB CI Linking
+When MIRA knows the asset (e.g., `VFD-01`), set `cmdb_ci` in the incident payload. This links the incident to the CMDB record and enables asset history reporting in ServiceNow. Resolve the CI's `sys_id` first via a CMDB lookup, or use the display name if the instance accepts it.
+
+### Custom Fields
+Enterprise customers often have custom fields (prefixed `u_`). Common ones:
+- `u_external_id` — store MIRA session ID here
+- `u_source_system` — set to `"MIRA"` for filtering
+
+Ask the customer's ServiceNow admin for the field list on their instance.
+
+### Bidirectional Sync Loop Prevention
+If MIRA creates an incident and ServiceNow Business Rules fire back to MIRA, implement idempotency: tag MIRA-created incidents with `work_notes: "mira_created"` and skip webhook processing for updates where `u_source_system = MIRA` to prevent infinite loops.
+
+---
+
+## Links
+
+- [ServiceNow REST API Reference (Washington DC)](https://docs.servicenow.com/bundle/washingtondc-api-reference/page/integrate/inbound-rest/concept/c_RESTAPI.html)
+- [Table API Overview — Hevo Data guide](https://hevodata.com/learn/servicenow-rest-apis/)
+- [ServiceNow Rate Limit Community Article](https://www.servicenow.com/community/developer-articles/understanding-servicenow-rest-api-rate-limits-key-concepts-amp/ta-p/3407367)
+- [aiosnow GitHub](https://github.com/rbw/aiosnow)
+- [pysnow Documentation](https://pysnow.readthedocs.io/en/latest/)

--- a/docs/integrations/slack_api_reference.md
+++ b/docs/integrations/slack_api_reference.md
@@ -1,0 +1,213 @@
+# Slack API Reference
+**For:** MIRA Hub integration | **Researched:** 2026-04-28
+
+---
+
+## Auth Method
+
+**OAuth 2.0 (three-step flow)**
+
+1. **Request scopes** — Redirect users to:
+   ```
+   https://slack.com/oauth/v2/authorize?client_id=YOUR_ID&scope=SCOPES&redirect_uri=HTTPS_CALLBACK
+   ```
+   - `scope` = bot token scopes (comma-separated), e.g. `chat:write,channels:read,channels:history,app_mentions:read`
+   - `user_scope` = optional user token scopes (separate param)
+   - Include a `state` param and validate it on return to prevent CSRF
+
+2. **User approves** — Slack redirects back to your `redirect_uri` with a temporary `code` (valid 10 minutes)
+
+3. **Exchange code for token** — POST to:
+   ```
+   https://slack.com/api/oauth.v2.access
+   ```
+   Params: `code`, `client_id`, `client_secret`, `redirect_uri`
+
+   Response includes:
+   - `access_token` — Bot token (`xoxb-...`), used for all API calls
+   - `bot_user_id` — Bot's Slack user ID
+   - `scope` — Granted scopes
+   - `authed_user.access_token` — User token (`xoxp-...`) if user scopes were requested
+
+**Token usage:** All Web API calls use `Authorization: Bearer xoxb-YOUR-BOT-TOKEN` header.
+
+Tokens do not expire but can be revoked via `auth.revoke`. Store securely (Doppler `factorylm/prd`).
+
+---
+
+## Key Endpoints We Need
+
+All methods POST to `https://slack.com/api/<method>` with `Authorization: Bearer xoxb-...`.
+
+| Method | HTTP | What it does | Required params | Rate tier |
+|--------|------|--------------|-----------------|-----------|
+| `chat.postMessage` | POST | Send a message to a channel or DM | `channel`, one of: `text` or `blocks` | Special: 1 msg/sec/channel |
+| `chat.postEphemeral` | POST | Send a message visible only to one user | `channel`, `user`, `text` | Tier 4 |
+| `conversations.list` | POST | List all channels the bot can see | — (paginate with `cursor`) | Tier 2 (20+/min) |
+| `conversations.history` | POST | Fetch message history for a channel | `channel` | Tier 3 (50+/min) |
+| `conversations.replies` | POST | Fetch a message thread | `channel`, `ts` (parent msg timestamp) | Tier 3 |
+| `conversations.members` | POST | List members of a channel | `channel` | Tier 4 |
+| `users.list` | POST | List all users in workspace | — (paginate with `cursor`) | Tier 2 |
+| `users.info` | POST | Get profile for one user | `user` | Tier 4 |
+| `reactions.add` | POST | Add emoji reaction to a message | `channel`, `name` (emoji name), `timestamp` | Tier 3 |
+| `auth.test` | POST | Verify token and get bot identity | — | Tier 4 |
+
+**Sending a threaded reply:** Include `thread_ts` (the `ts` of the parent message) in `chat.postMessage`. Add `reply_broadcast: true` to also surface it in the main channel.
+
+**Blocks vs text:** Use `text` as a fallback. Rich messages use the `blocks` array (Block Kit format). Always include `text` even when using `blocks` — it's used for notifications and accessibility.
+
+---
+
+## Webhook / Event Capabilities
+
+**Delivery methods (choose one per app):**
+- **HTTP (Events API)** — Slack POSTs events to your public HTTPS endpoint
+- **Socket Mode** — Persistent WebSocket; no public endpoint needed (good for dev/internal tools)
+
+**Setup:** Enable Event Subscriptions in app settings → provide your Request URL → subscribe to event types.
+
+**URL Verification (one-time, on endpoint registration):**
+Slack sends:
+```json
+{ "type": "url_verification", "challenge": "abc123xyz", "token": "legacy_token" }
+```
+Respond immediately with: `{ "challenge": "abc123xyz" }` (HTTP 200, `Content-Type: application/json`)
+
+**Event payload format** (all subscribed events):
+```json
+{
+  "type": "event_callback",
+  "team_id": "T12345",
+  "api_app_id": "A12345",
+  "event_id": "Ev12345",
+  "event_time": 1700000000,
+  "event": {
+    "type": "app_mention",
+    "user": "U12345",
+    "text": "<@BOTID> help with pump 4",
+    "ts": "1700000000.000100",
+    "channel": "C12345",
+    "event_ts": "1700000000.000100"
+  },
+  "authorizations": [{ "enterprise_id": null, "team_id": "T12345", "user_id": "U12345", "is_bot": true }]
+}
+```
+
+**Signature verification (REQUIRED — verify every request):**
+```python
+import hmac, hashlib, time
+
+def verify_slack_signature(signing_secret: str, body: bytes, timestamp: str, signature: str) -> bool:
+    # Reject requests older than 5 minutes (replay attack prevention)
+    if abs(time.time() - float(timestamp)) > 300:
+        return False
+    basestring = f"v0:{timestamp}:{body.decode('utf-8')}".encode()
+    computed = "v0=" + hmac.new(signing_secret.encode(), basestring, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(computed, signature)
+
+# Headers to read: X-Slack-Signature, X-Slack-Request-Timestamp
+```
+Use `hmac.compare_digest` — never `==` — to prevent timing attacks.
+
+**Key event types for MIRA:**
+
+| Event type | Scope required | Trigger |
+|-----------|---------------|---------|
+| `app_mention` | `app_mentions:read` | Bot is @-mentioned in any channel |
+| `message.channels` | `channels:history` | Message posted in public channel bot is in |
+| `message.groups` | `groups:history` | Message in private channel bot is in |
+| `message.im` | `im:history` | Direct message to the bot |
+| `message.mpim` | `mpim:history` | Group DM including the bot |
+| `reaction_added` | `reactions:read` | User adds emoji to a message |
+| `member_joined_channel` | `channels:read` | User joins a channel |
+
+**Retry behavior:** Slack retries up to 3 times with exponential backoff (~1 min, then ~5 min). Retry headers: `x-slack-retry-num` (attempt number), `x-slack-retry-reason`. To suppress retries for a known-good event: respond with `x-slack-no-retry: 1`. Must respond HTTP 2xx within **3 seconds**.
+
+**Event rate cap:** 30,000 events per workspace per app per 60 minutes. Exceeding this triggers `app_rate_limited` events.
+
+---
+
+## Rate Limits
+
+Web API rate limits are per method, per workspace, evaluated per minute:
+
+| Tier | Limit | Example methods |
+|------|-------|----------------|
+| Tier 1 | 1+ req/min | Rarely-used admin methods |
+| Tier 2 | 20+ req/min | `conversations.list`, `users.list` |
+| Tier 3 | 50+ req/min | `conversations.history`, `conversations.replies`, `reactions.add` |
+| Tier 4 | 100+ req/min | `chat.postEphemeral`, `users.info`, `auth.test` |
+| Special | 1 msg/sec/channel | `chat.postMessage` |
+
+When exceeded: `HTTP 429 Too Many Requests` with `Retry-After: <seconds>` header. Design for 1 req/sec baseline; Slack tolerates occasional bursts.
+
+---
+
+## SDK Availability
+
+**Python — two packages, use both:**
+
+| Package | Install | Purpose |
+|---------|---------|---------|
+| `slack_sdk` | `pip install slack-sdk` | Low-level: WebClient, AsyncWebClient, OAuth, Socket Mode |
+| `slack_bolt` | `pip install slack-bolt` | High-level framework: event routing, middleware, OAuth flow |
+
+```python
+# Low-level send (slack_sdk)
+from slack_sdk import WebClient
+client = WebClient(token="xoxb-...")
+client.chat_postMessage(channel="#mira-alerts", text="Pump 4 anomaly detected")
+
+# Async (AsyncWebClient)
+from slack_sdk.web.async_client import AsyncWebClient
+client = AsyncWebClient(token="xoxb-...")
+await client.chat_postMessage(channel="C12345", text="...")
+
+# Event handling (slack_bolt)
+from slack_bolt import App
+app = App(token="xoxb-...", signing_secret="...")
+@app.event("app_mention")
+def handle_mention(event, say):
+    say(f"On it! Diagnosing {event['text']}")
+```
+
+**Node.js:**
+- `@slack/web-api` — `npm install @slack/web-api` — WebClient
+- `@slack/bolt` — `npm install @slack/bolt` — Full framework
+
+---
+
+## Implementation Notes for MIRA
+
+1. **Bot token scopes to request at install time:**
+   `chat:write`, `app_mentions:read`, `channels:read`, `channels:history`, `groups:history`, `im:history`, `mpim:history`, `users:read`, `reactions:read`
+
+2. **The `ts` field is the message ID** — it's a string timestamp like `"1700000000.000100"`. You need it to reply in a thread (`thread_ts`) or add a reaction (`timestamp`).
+
+3. **Bot only receives DMs if explicitly added** — `im:history` scope alone isn't enough; the user must open a DM with the bot. Use `message.im` event.
+
+4. **`app_mention` fires even in DMs** — but only in channels. For DMs, use `message.im`. For full coverage, subscribe to both.
+
+5. **Respond to Slack events within 3 seconds** — if your LLM cascade takes longer (it will), immediately return HTTP 200 and process asynchronously. Use the response URL or `chat.postMessage` to send the reply once ready. Slack will retry if you don't respond in time.
+
+6. **Channel IDs vs names** — Always use channel IDs (`C12345`) in API calls, not display names. IDs are stable; names change. `conversations.list` gives you the mapping.
+
+7. **Rate limit guard for MIRA:** At 1 msg/sec/channel cap on `chat.postMessage`, if MIRA sends bulk alerts to the same channel queue them with a 1-second delay.
+
+8. **Competing event consumers** — Only one Slack app can consume each event stream. Unlike Telegram, there's no multi-consumer issue, but make sure Socket Mode and HTTP mode aren't both enabled for the same app.
+
+9. **Block Kit for rich diagnostics** — Use blocks to send structured fault reports with sections, fields, and action buttons. Text-only messages are fine for MVP.
+
+10. **`WaId` field equivalent** — In Slack, the unique user identifier is the `user` field in the event (e.g., `"U12345"`). Combined with `team_id` it's globally unique.
+
+---
+
+## Links
+
+- Slack app management console: https://api.slack.com/apps
+- OAuth v2 install flow: https://docs.slack.dev/authentication/installing-with-oauth
+- Events API guide: https://docs.slack.dev/apis/events-api/
+- Signature verification: https://docs.slack.dev/authentication/verifying-requests-from-slack
+- Python SDK (slack_sdk): https://docs.slack.dev/tools/python-slack-sdk
+- chat.postMessage reference: https://docs.slack.dev/reference/methods/chat.postMessage
+- Block Kit Builder (interactive UI designer): https://app.slack.com/block-kit-builder

--- a/docs/integrations/upkeep_api_reference.md
+++ b/docs/integrations/upkeep_api_reference.md
@@ -1,0 +1,154 @@
+# UpKeep API Reference
+**For:** MIRA Hub integration | **Researched:** 2026-04-28
+
+## Auth Method
+
+**Type:** Session Token (login-first flow — NOT a static API key)
+
+**Auth flow:**
+1. POST credentials to auth endpoint → receive `sessionToken` + `expiresAt`
+2. Include token in every subsequent request header: `Session-Token: <sessionToken>`
+3. DELETE `/auth` to logout / invalidate token
+
+```
+POST https://api.onupkeep.com/api/v2/auth
+Body: { "email": "...", "password": "..." }
+Response: { "sessionToken": "r:ee091a894626a62d9dc09073884d91ba", "expiresAt": "..." }
+```
+
+All subsequent requests:
+```
+Session-Token: <sessionToken>
+Content-Type: application/json
+upkeep-version: 2022-09-14   # optional but recommended to pin version
+```
+
+To obtain credentials: UpKeep account → Settings → integrations, or use any account user's email/password. Note: the **API is Enterprise plan only**.
+
+**Base URL:** `https://api.onupkeep.com/api/v2/`
+
+There is also a legacy v1 base (`https://api.onupkeep.com/api/public/`) — still documented but v2 is preferred.
+
+## Key Endpoints We Need
+
+| Endpoint | Method | What it does | Required params |
+|----------|--------|--------------|-----------------|
+| `/auth` | POST | Login, get session token | `email`, `password` |
+| `/auth` | DELETE | Logout / invalidate token | `Session-Token` header |
+| `/work-orders` | POST | Create work order | `Session-Token`, `title` |
+| `/work-orders` | GET | List all work orders | `Session-Token`; optional: `offset`, `limit`, `status` filter |
+| `/work-orders/<ID>` | GET | Get single work order | `Session-Token`, path `ID` |
+| `/work-orders/<ID>` | PATCH | Update work order | `Session-Token`, body fields |
+| `/work-orders/<ID>` | DELETE | Delete work order | `Session-Token` |
+| `/work-orders/<ID>/workers/<userID>` | POST | Assign worker to WO | `Session-Token` |
+| `/work-orders/<ID>/teams/<teamID>` | POST | Assign team to WO | `Session-Token` |
+| `/assets` | POST | Create asset | `Session-Token`, `name` |
+| `/assets` | GET | List all assets | `Session-Token`; optional: `offset`, `limit` |
+| `/assets/<ID>` | GET | Get single asset | `Session-Token` |
+| `/assets/<ID>` | PATCH | Update asset | `Session-Token`, body fields |
+| `/assets/<ID>` | DELETE | Delete asset | `Session-Token` |
+| `/assets/downtime` | POST | Record downtime event (bulk) | `Session-Token`, downtime data |
+| `/preventive-maintenance` | POST/GET/PATCH/DELETE | CRUD PM triggers | `Session-Token` |
+| `/files` | POST | Upload file attachment | `Session-Token`, multipart/form-data |
+| `/webhooks` | POST | Register webhook | `Session-Token`, URL, events |
+| `/webhooks` | GET | List registered webhooks | `Session-Token` |
+| `/webhooks/<ID>` | PATCH | Update webhook | `Session-Token` |
+| `/webhooks/<ID>` | DELETE | Delete webhook | `Session-Token` |
+
+**Work order create body fields:**
+```json
+{
+  "title": "string (required)",
+  "additionalInfo": "string",
+  "priority": 0,
+  "dueDate": 1714300800000,
+  "assetId": "string",
+  "locationId": "string",
+  "userAssignedId": "string"
+}
+```
+
+**Priority values:** `0` = None (default), `1` = Low, `2` = Medium, `3` = High
+
+**Status values:** `open`, `complete`, `onHold`, `inProgress`
+
+**Work order response fields:** `id`, `status`, `title`, `description`, `dueDate`, `endDueDate`, `dateCompleted`, `completedBy`, `completedById`, `createdAt`, `workOrderNo`, `category`, `time`, `cost`, `assignedBy`, `assignedById`, `assignedTo`, `assignedToId`, `asset`, `assetId`, `location`, `locationId`, `team`, `teamId`, `requestedBy`, `requestedById`, `formItems`
+
+**Asset response fields:** `id`, `location` (object: `id`, `name`, `address`, `longitude`, `latitude`), `name`, `model`, `barcodeSerial`, `parentAssetId`, `description`, `isActive`, `additionalInformation`
+
+## Webhook / Event Capabilities
+
+**Plan gate:** Enterprise only.
+
+**Setup:** Settings → Webhooks → "+ Add Webhook" → provide title, endpoint URL, and select event triggers.
+
+**Known event types:**
+- `Reactive Work Order Created` — fires when a new reactive work order is submitted
+- Work order closure events (e.g., triggers cost sync to QuickBooks integration)
+
+**Registration via API:** Full CRUD at `/webhooks` endpoint (POST to register, GET to list, PATCH to update, DELETE to remove).
+
+**Payload format:** JSON. Specific schema not publicly documented — intercept via a test endpoint to capture live payloads.
+
+**Alternative to polling:** Webhooks are the recommended approach for real-time integration; the REST API does not offer server-sent events or GraphQL subscriptions.
+
+## Rate Limits
+
+- **HTTP 429** returned when throttled; no published per-plan request/minute numbers in public docs.
+- Use `offset` + `limit` query params for pagination; no cursor style.
+- Recommended: implement exponential backoff on 429 responses.
+- The `upkeep-version` header pins API behavior to a dated version — avoids surprises on breaking changes.
+
+**API versioning model:** Breaking changes create new dated versions (current: `2022-09-14`). Non-breaking additions (new fields, optional params) are added in-place without version bump.
+
+## SDK Availability
+
+- **Official SDK:** None published by UpKeep.
+- **No official Python or Node.js library** found in npm or PyPI.
+- **Integration platforms:** Pipedream, Zapier, Make.com — pre-built connectors.
+- **UpKeep Studio** (`run.upkeep.com`) — a low-code app platform built on UpKeep data; not an API client library.
+- Community REST wrappers exist but are unmaintained; prefer direct httpx calls for MIRA.
+
+## Implementation Notes for MIRA
+
+**MIRA WorkOrder → UpKeep field mapping:**
+
+| MIRA field | UpKeep field | Notes |
+|-----------|--------------|-------|
+| `title` | `title` | Required |
+| `description` | `additionalInfo` | Different field name |
+| `priority` | `priority` | 0–3 integer, not string enum |
+| `due_date` | `dueDate` | Unix milliseconds (not seconds, not ISO 8601) |
+| `asset_id` | `assetId` | String ID |
+| `location_id` | `locationId` | String ID |
+| `assigned_to` | `userAssignedId` | Single user only on create; use `/workers/<id>` POST to add more |
+| `status` | call `/work-orders/<ID>` PATCH | PATCH the status field directly |
+
+**MIRA Asset → UpKeep field mapping:**
+
+| MIRA field | UpKeep field | Notes |
+|-----------|--------------|-------|
+| `name` | `name` | |
+| `serial_number` | `barcodeSerial` | |
+| `description` | `description` | |
+| `parent_asset` | `parentAssetId` | Hierarchical assets supported |
+| `location` | `locationId` | |
+| `active` | `isActive` | Boolean |
+
+**API quirks to handle:**
+- **Session token expiry** — tokens are short-lived. MIRA must re-authenticate when a 401 is returned mid-session. Store `expiresAt` and proactively refresh before expiry.
+- **Date format is Unix milliseconds** — `dueDate` takes integer milliseconds since epoch, not ISO 8601 strings. Convert with `int(datetime.timestamp() * 1000)`.
+- **Status update** — there is no dedicated status-change endpoint in v2; PATCH the work order with `{ "status": "inProgress" }`.
+- **v1 legacy endpoints** use POST for list operations (e.g., `POST /api/public/workorders` to list) — avoid v1 for new integrations.
+- **Work order status filter** — the list endpoint only supports filtering by `status` field (not by asset, date range, etc.). For filtered queries by asset, fetch all and filter client-side.
+- **Expandable responses** — use `includes` query param (array or comma-separated) to embed related objects (e.g., `includes=asset,location`) and avoid N+1 fetches.
+- **Enterprise gate** — if a customer is not on Enterprise, API calls return 401/403. Surface this clearly in MIRA's connection setup UI.
+- **Error format:** `{ "message": "field cannot be null" }` with appropriate HTTP status code.
+
+## Links
+
+- Official developer reference: `https://developers.onupkeep.com/`
+- Legacy/community-maintained docs: `https://upkeepinfo.github.io/upkeep/`
+- REST API product page: `https://upkeep.com/integrations/rest-api/`
+- Help center — API & webhooks collection: `https://help.onupkeep.com/en/collections/1791249-using-upkeep-s-apis-and-webhooks`
+- API tracker profile: `https://apitracker.io/a/onupkeep`

--- a/docs/integrations/whatsapp_twilio_api_reference.md
+++ b/docs/integrations/whatsapp_twilio_api_reference.md
@@ -1,0 +1,208 @@
+# WhatsApp (via Twilio) API Reference
+**For:** MIRA Hub integration | **Researched:** 2026-04-28
+
+---
+
+## Auth Method
+
+**HTTP Basic Authentication** using Twilio Account credentials.
+
+Every API request authenticates with:
+- **Username:** `TWILIO_ACCOUNT_SID` (looks like `ACxxxxxxxxxxxxxxxxx`)
+- **Password:** `TWILIO_AUTH_TOKEN`
+
+Store both in Doppler `factorylm/prd`. The official Python SDK (`twilio`) handles this automatically when initialized:
+
+```python
+from twilio.rest import Client
+client = Client(account_sid, auth_token)
+```
+
+No OAuth flow required for server-to-server API calls. For inbound webhooks (Twilio → your server), Twilio signs each request — verify with the `twilio` library's `RequestValidator`.
+
+---
+
+## Key Endpoints We Need
+
+**Base URL:** `https://api.twilio.com/2010-04-01/Accounts/{AccountSid}/`
+
+All WhatsApp addresses use E.164 format prefixed with `whatsapp:` — e.g. `whatsapp:+14155238886`.
+
+| Operation | HTTP | Endpoint | Required params | Notes |
+|-----------|------|----------|-----------------|-------|
+| Send message (text) | POST | `/Messages.json` | `From`, `To`, `Body` | Both From/To must use `whatsapp:+...` format |
+| Send message (media) | POST | `/Messages.json` | `From`, `To`, `MediaUrl` | Up to 16 MB per file; JPEG/PNG/PDF/audio |
+| Send template | POST | `/Messages.json` | `From`, `To`, `ContentSid`, `ContentVariables` | Pre-approved template required for business-initiated messages |
+| Get message status | GET | `/Messages/{MessageSid}.json` | — | Returns delivery status |
+| List messages | GET | `/Messages.json` | — | Paginated; supports date filters |
+| Status callback | — | Your URL (configured in console) | — | Twilio POSTs delivery events to this URL |
+
+**Python SDK send example:**
+```python
+from twilio.rest import Client
+import os
+
+client = Client(os.environ["TWILIO_ACCOUNT_SID"], os.environ["TWILIO_AUTH_TOKEN"])
+
+# Freeform message (within 24h session window)
+message = client.messages.create(
+    from_="whatsapp:+14155238886",
+    to="whatsapp:+16285550100",
+    body="Pump 4 fault detected — vibration exceeds threshold. Assign a work order?"
+)
+print(message.sid)  # e.g. SM1234567890abcdef
+
+# Template message (business-initiated, outside 24h window)
+message = client.messages.create(
+    from_="whatsapp:+14155238886",
+    to="whatsapp:+16285550100",
+    content_sid="HXb5b62575e6e4ff6129ad7c8efe1f983e",
+    content_variables='{"1": "Pump 4", "2": "vibration fault"}'
+)
+```
+
+---
+
+## Webhook / Event Capabilities
+
+**Inbound messages (user → MIRA):**
+Configure a webhook URL in Twilio Console under the WhatsApp Sender settings ("When a message comes in"). Twilio POSTs to this URL on every inbound message.
+
+**Inbound webhook payload fields (POST form-encoded):**
+
+| Field | Example | Description |
+|-------|---------|-------------|
+| `AccountSid` | `ACxxxxxxxxx` | Your Twilio account ID |
+| `MessageSid` | `SMxxxxxxxxx` | Unique message ID |
+| `From` | `whatsapp:+16285550100` | Sender's WhatsApp number |
+| `To` | `whatsapp:+14155238886` | Your MIRA WhatsApp number |
+| `Body` | `Pump 4 is leaking` | Message text content |
+| `NumMedia` | `0` | Count of attached media files |
+| `MediaUrl0` | `https://api.twilio.com/...` | First media file URL (if NumMedia > 0) |
+| `MediaContentType0` | `image/jpeg` | MIME type of first media file |
+| `WaId` | `16285550100` | Sender's WhatsApp ID (no `whatsapp:` prefix, no `+`) |
+| `ProfileName` | `Mike Harper` | Sender's WhatsApp display name |
+
+Additional media files use `MediaUrl1`, `MediaUrl2`, etc. up to the value of `NumMedia`.
+
+**Signature verification (REQUIRED — verify every inbound webhook):**
+```python
+from twilio.request_validator import RequestValidator
+import os
+
+validator = RequestValidator(os.environ["TWILIO_AUTH_TOKEN"])
+
+def verify_twilio_request(url: str, post_params: dict, signature: str) -> bool:
+    return validator.validate(url, post_params, signature)
+
+# The signature is in the X-Twilio-Signature header
+# url must be the exact URL Twilio POSTed to (including query string if any)
+# post_params is the parsed form body as a dict
+```
+
+**Status callbacks (outbound delivery tracking):**
+Configure a `StatusCallback` URL when sending, or set a default in console. Twilio POSTs when status changes to: `queued`, `sent`, `delivered`, `read`, `failed`, `undelivered`.
+
+```python
+message = client.messages.create(
+    from_="whatsapp:+14155238886",
+    to="whatsapp:+16285550100",
+    body="Work order WO-4421 created",
+    status_callback="https://mira.example.com/webhooks/twilio/status"
+)
+```
+
+**Respond to inbound messages with TwiML:**
+```python
+from twilio.twiml.messaging_response import MessagingResponse
+from fastapi import Request, Response
+
+@app.post("/webhooks/whatsapp")
+async def whatsapp_webhook(request: Request):
+    form_data = await request.form()
+    # ... process message, call MIRA diagnostic engine ...
+    resp = MessagingResponse()
+    resp.message("Analyzing fault. Will respond in <30 seconds.")
+    return Response(content=str(resp), media_type="text/xml")
+```
+
+---
+
+## Rate Limits
+
+Twilio does not publish a single WhatsApp rate limit figure publicly — it depends on your WhatsApp Business Account tier and Meta's messaging limits. Verified numbers from Twilio docs and sandbox behavior:
+
+| Context | Limit |
+|---------|-------|
+| Sandbox (development) | 1 message every 3 seconds; max 50 messages/day on free trial |
+| Production — inbound | No hard limit documented; design for concurrent processing |
+| Production — outbound | Verify current limits in Twilio Console and Meta Business Manager |
+| Message size | 16 MB per media file |
+| Phone numbers per unverified Meta Business | 2 |
+| Phone numbers per verified Meta Business | Up to 20 (50 via support) |
+
+For production, check your specific messaging tier limits in the Twilio Console under "WhatsApp Senders." Meta imposes per-phone-number daily limits that increase as you build quality scores.
+
+---
+
+## SDK Availability
+
+**Python (official):**
+```bash
+pip install twilio
+```
+- Package: `twilio` (version 9.10.5 as of 2026-04-14)
+- Supports Python 3.7–3.13
+- Async: yes — `AsyncTwilioHttpClient` + `*_async` methods
+- Covers: Messages, Voice, TwiML, RequestValidator, Content API
+
+**Node.js (official):**
+```bash
+npm install twilio
+```
+- Package: `twilio`
+- Supports TypeScript out of the box
+
+**No Twilio-specific Bolt/framework** — it's a REST client library. You handle webhook routing yourself (FastAPI recommended for MIRA).
+
+---
+
+## Implementation Notes for MIRA
+
+1. **The 24-hour session window is critical.** WhatsApp only allows freeform (unstructured) messages within 24 hours of the user's last message to you. Outside that window, you MUST use a pre-approved Content Template (`ContentSid`). Templates must be submitted to Meta via Twilio Console and approved before use. Plan for a "re-engagement template" for dormant users.
+
+2. **Explicit opt-in is mandatory.** WhatsApp requires users to explicitly opt in before receiving messages from your business number. Collect and store opt-in records. Twilio can be fined/banned for violations. For MIRA: add an opt-in step during onboarding (e.g., "Reply YES to receive MIRA alerts").
+
+3. **`WaId` is your stable user identifier.** The `WaId` field in inbound webhooks (e.g., `16285550100`) is the user's WhatsApp ID without country code prefix. Combined with your WABA, it uniquely identifies the user. Use this as the key in NeonDB for session/conversation state.
+
+4. **One WABA per Twilio account (currently).** Twilio enforces one WhatsApp Business Account per Twilio account. Plan your production number accordingly.
+
+5. **Media download requires auth.** `MediaUrl0` URLs are Twilio-hosted and require Basic Auth to download. Use the Twilio Python client or pass credentials:
+   ```python
+   import httpx, base64
+   creds = base64.b64encode(f"{account_sid}:{auth_token}".encode()).decode()
+   async with httpx.AsyncClient() as c:
+       r = await c.get(media_url, headers={"Authorization": f"Basic {creds}"})
+   ```
+
+6. **Sandbox vs production number.** The sandbox number (`+14155238886`) is shared — all Twilio sandbox users use it. For production, provision a dedicated WhatsApp-enabled Twilio number. Users must join the sandbox by sending `join <your-code>` — this is not scalable for production.
+
+7. **Respond quickly but process async.** Twilio expects a response to the inbound webhook within a few seconds. Return TwiML immediately (even an empty `<Response/>`) and process the MIRA diagnostic engine asynchronously, then send the result via `client.messages.create`. This avoids webhook timeouts.
+
+8. **Status: `read` requires user's WhatsApp read receipts to be on.** Don't rely on `read` status for delivery confirmation — use `delivered` as your success signal.
+
+9. **Profile name in `ProfileName` field** — use this as the display name for MIRA's user context, since WhatsApp doesn't expose email. Map `WaId` → `ProfileName` in your user registry.
+
+10. **No channel concept.** Unlike Slack, WhatsApp has no concept of channels. Every conversation is 1:1 between MIRA and a user, or within a WhatsApp group. Group messaging via Twilio's API has separate requirements — scope MIRA to 1:1 DMs for MVP.
+
+---
+
+## Links
+
+- Twilio WhatsApp API overview: https://www.twilio.com/docs/whatsapp/api
+- WhatsApp quickstart (Python): https://www.twilio.com/docs/whatsapp/quickstart
+- WhatsApp Sandbox setup: https://www.twilio.com/docs/whatsapp/sandbox
+- Twilio Python library (GitHub): https://github.com/twilio/twilio-python
+- Twilio Console (manage numbers + webhooks): https://console.twilio.com/
+- Request validation (signature verification): https://www.twilio.com/docs/usage/security
+- WhatsApp Content Templates: https://www.twilio.com/docs/content-api


### PR DESCRIPTION
## Summary

- **PRD v1.1 additions** (3 new sections in `docs/PRD_Hub_Integrations_v1.md`):
  - **Section 3.5 — CSV Import (Priority 0):** The universal on-ramp. Smart column mapping with fuzzy auto-detect, dry-run preview, 4 accepted formats, recurring imports via SFTP/email. Ships before any native CMMS connector.
  - **Section 13 — Data Portability Guarantee:** Export everything anytime (CSV + JSON + API), open documented schemas, legal commitment language for ToS.
  - **Section 14 — Data Sensitivity Options:** Knowledge Cooperative opt-out, CSV-only mode (no live API credentials), on-prem deployment (Enterprise), data residency US/EU/AU.

- **11 API reference files** in `docs/integrations/` (2,790 lines, all grounded in fetched docs):

| File | Key discovery |
|------|--------------|
| `slack_api_reference.md` | Docs moved to `docs.slack.dev`; 3-second webhook response window; HMAC-SHA256 sig verification |
| `whatsapp_twilio_api_reference.md` | 24h session window — messages after that require pre-approved Templates; explicit opt-in legally required |
| `microsoft_teams_api_reference.md` | **`botbuilder-python` archived Dec 2025** — migrate to M365 Agents SDK; SSO broken in channel scope |
| `microsoft_graph_api_reference.md` | Most useful permissions are Application-type → require customer tenant admin consent; Outlook webhooks expire in 3 days |
| `google_workspace_api_reference.md` | Drive push channels expire in 7 days; Gmail inbound parse requires Cloud Pub/Sub (use polling for MVP); Chat bot must be manually added to each Space |
| `maintainx_api_reference.md` | Cursor-based pagination; API keys are account-scoped (not per-tenant) |
| `upkeep_api_reference.md` | Session-token auth (must re-auth on expiry); `dueDate` is Unix ms not ISO 8601; Enterprise only |
| `limble_api_reference.md` | 5 regional base URLs (US/CA/AU/EU/21CFR); priority/status values are account-configurable — must fetch dynamically |
| `pagerduty_api_reference.md` | Events v2 uses `routing_key` not auth header; PUT on incidents requires `From: <email>` header |
| `jira_api_reference.md` | `description` must be Atlassian Document Format (ADF) — plain strings rejected; dynamic webhooks expire in 30 days |
| `servicenow_api_reference.md` | Rate limits are instance-configurable with no universal default; outbound webhooks use Business Rules, not a REST endpoint |

## Test plan
- [ ] All 11 files render cleanly in GitHub markdown
- [ ] No secrets or credentials in any file
- [ ] PRD section numbers are consistent (3.5 inserted correctly before 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)