### PR TITLE
fix(auth): P0.1 + P0.2 + P0.3 — drop ?token= query, JWT 30d→7d, scope CORS to /api/*

### DIFF
--- a/mira-bots/shared/chat/types.py
+++ b/mira-bots/shared/chat/types.py
@@ -31,7 +31,9 @@ class NormalizedChatEvent:
     """One inbound message from any platform, normalized."""
 
     event_id: str
-    platform: Literal["telegram", "slack", "teams", "gchat", "webui", "email", "whatsapp", "webchat"]
+    platform: Literal[
+        "telegram", "slack", "teams", "gchat", "webui", "email", "whatsapp", "webchat"
+    ]
     tenant_id: str
     user_id: str  # canonical MIRA user ID (after identity resolution)
     external_user_id: str  # platform-specific user ID

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -620,9 +620,7 @@ class Supervisor:
             # Procedural how-to questions: answer from knowledge, skip doc crawl.
             # Keyword "instructional" also routes here via the fallback mapping above.
             if _router_intent == "answer_question" or _keyword_intent == "instructional":
-                return await self._handle_instructional_question(
-                    chat_id, message, state, trace_id
-                )
+                return await self._handle_instructional_question(chat_id, message, state, trace_id)
 
             # find_documentation: let the existing specificity-gate block handle it below
             if _router_intent == "find_documentation":
@@ -663,7 +661,11 @@ class Supervisor:
                 if "," in asset_id:
                     fallback_mfr = mfr or asset_id.split(",", 1)[0].strip()
                     return await self._do_documentation_lookup(
-                        chat_id, message, state, trace_id, resolved_tenant,
+                        chat_id,
+                        message,
+                        state,
+                        trace_id,
+                        resolved_tenant,
                         vendor_override=fallback_mfr,
                     )
                 return await self._enter_manual_lookup_gathering(
@@ -2146,7 +2148,7 @@ class Supervisor:
             if sep not in msg:
                 continue
             idx = msg.index(sep)
-            pre, fault = msg[:idx], msg[idx + len(sep):].strip()
+            pre, fault = msg[:idx], msg[idx + len(sep) :].strip()
             m = re.search(r"\bfor\s+(.{3,}?)$", pre, re.IGNORECASE)
             if m:
                 asset = m.group(1).strip()
@@ -2276,12 +2278,14 @@ class Supervisor:
             if "," in asset_id:
                 fallback_mfr = mfr or asset_id.split(",", 1)[0].strip()
                 return await self._do_documentation_lookup(
-                    chat_id, message, state, trace_id, resolved_tenant,
+                    chat_id,
+                    message,
+                    state,
+                    trace_id,
+                    resolved_tenant,
                     vendor_override=fallback_mfr,
                 )
-            return await self._enter_manual_lookup_gathering(
-                chat_id, message, state, trace_id, mfr
-            )
+            return await self._enter_manual_lookup_gathering(chat_id, message, state, trace_id, mfr)
         return await self._do_documentation_lookup(
             chat_id, message, state, trace_id, resolved_tenant, vendor_override=mfr
         )

--- a/mira-bots/shared/models/work_order.py
+++ b/mira-bots/shared/models/work_order.py
@@ -176,7 +176,10 @@ _EDIT_PATTERNS: list[tuple[str, str]] = [
     (r"\barea\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "area"),
     (r"\bline\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "line"),
     (r"\b(?:resolution|fix|solution)\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "resolution"),
-    (r"\b(?:fault(?:\s+description)?|problem|issue|description)\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "fault_description"),
+    (
+        r"\b(?:fault(?:\s+description)?|problem|issue|description)\s+(?:is|:)\s*(.+?)(?:\s*\.|$)",
+        "fault_description",
+    ),
 ]
 
 

--- a/mira-bots/shared/pm_extractor.py
+++ b/mira-bots/shared/pm_extractor.py
@@ -298,13 +298,16 @@ async def extract_pm_schedules(
     Returns validated list of PM schedule dicts ready for storage.
     """
     if not chunks:
-        logger.info("extract_pm_schedules: no PM-relevant chunks for %s %s", manufacturer, model_number)
+        logger.info(
+            "extract_pm_schedules: no PM-relevant chunks for %s %s", manufacturer, model_number
+        )
         return []
 
     # Import here — path differs between mira-bots context and mira-pipeline (where
     # shared/ is mounted directly into the container root).
     import importlib
     import importlib.util
+
     _spec = importlib.util.find_spec("shared")
     _mod = importlib.import_module("shared.inference.router" if _spec else "inference.router")
     InferenceRouter = _mod.InferenceRouter  # type: ignore[attr-defined]
@@ -421,8 +424,7 @@ def ensure_pm_table() -> None:
             # Indexes for common queries
             conn.execute(
                 text(
-                    "CREATE INDEX IF NOT EXISTS idx_pm_schedules_tenant "
-                    "ON pm_schedules (tenant_id)"
+                    "CREATE INDEX IF NOT EXISTS idx_pm_schedules_tenant ON pm_schedules (tenant_id)"
                 )
             )
             conn.execute(
@@ -488,9 +490,7 @@ def store_pm_schedules(
         with engine.begin() as conn:
             for item in schedules:
                 days_str = _interval_to_next_due(item["interval_value"], item["interval_unit"])
-                next_due_sql = (
-                    f"NOW() + INTERVAL '{days_str}'" if days_str else "NULL"
-                )
+                next_due_sql = f"NOW() + INTERVAL '{days_str}'" if days_str else "NULL"
 
                 conn.execute(
                     text(

--- a/mira-bots/shared/pm_scheduler.py
+++ b/mira-bots/shared/pm_scheduler.py
@@ -60,7 +60,11 @@ def _resolve_equipment_id(
         return hint
     from sqlalchemy import text
 
-    new_id = str(uuid.uuid5(_EQUIPMENT_NAMESPACE, f"{tenant_id}:{manufacturer.lower()}:{model_number.lower()}"))
+    new_id = str(
+        uuid.uuid5(
+            _EQUIPMENT_NAMESPACE, f"{tenant_id}:{manufacturer.lower()}:{model_number.lower()}"
+        )
+    )
     engine = _get_neon_engine()
     try:
         with engine.begin() as conn:
@@ -101,7 +105,9 @@ def _resolve_equipment_id(
             )
             logger.info(
                 "_resolve_equipment_id: created cmms_equipment id=%s %s %s",
-                new_id, manufacturer, model_number,
+                new_id,
+                manufacturer,
+                model_number,
             )
         return new_id
     except Exception as exc:
@@ -131,23 +137,23 @@ def _wo_number() -> str:
 
 def _build_description(pm: dict[str, Any]) -> str:
     lines = [
-        f"Auto-generated PM work order from manual extraction.",
-        f"",
+        "Auto-generated PM work order from manual extraction.",
+        "",
         f"Equipment: {pm['manufacturer']} {pm['model_number']}",
         f"Interval: Every {pm['interval_value']} {pm['interval_unit']}",
     ]
     if pm.get("source_citation"):
         lines.append(f"Manual reference: {pm['source_citation']}")
     if pm.get("parts_needed"):
-        lines.append(f"\nParts needed:")
+        lines.append("\nParts needed:")
         for p in pm["parts_needed"]:
             lines.append(f"  • {p}")
     if pm.get("tools_needed"):
-        lines.append(f"\nTools needed:")
+        lines.append("\nTools needed:")
         for t in pm["tools_needed"]:
             lines.append(f"  • {t}")
     if pm.get("safety_requirements"):
-        lines.append(f"\nSafety requirements:")
+        lines.append("\nSafety requirements:")
         for s in pm["safety_requirements"]:
             lines.append(f"  ⚠ {s}")
     confidence = pm.get("confidence")
@@ -367,9 +373,7 @@ async def generate_due_work_orders(tenant_id: str | None = None) -> dict[str, An
     Returns summary dict with counts and created WO IDs.
     """
     due_pms = get_due_pms(tenant_id=tenant_id)
-    logger.info(
-        "generate_due_work_orders: %d due PMs found (tenant=%s)", len(due_pms), tenant_id
-    )
+    logger.info("generate_due_work_orders: %d due PMs found (tenant=%s)", len(due_pms), tenant_id)
 
     created_wos: list[dict[str, str]] = []
     skipped = 0

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -13,7 +13,6 @@ from shared import tts
 from shared.chat.dispatcher import ChatDispatcher
 from shared.engine import Supervisor
 from telegram import Update
-from voice_transcription import transcribe_voice
 from telegram.constants import ChatAction
 from telegram.error import Conflict
 from telegram.ext import (
@@ -24,6 +23,7 @@ from telegram.ext import (
     MessageHandler,
     filters,
 )
+from voice_transcription import transcribe_voice
 
 logging.basicConfig(
     level=logging.INFO,

--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -747,7 +747,11 @@ def _maybe_trigger_pm_extraction(equipment_type: str, fname: str, tenant_id: str
 
     parsed = _parse_manufacturer_model(equipment_type, fname)
     if not parsed:
-        logger.debug("PM extraction skipped: cannot parse manufacturer+model from %r / %r", equipment_type, fname)
+        logger.debug(
+            "PM extraction skipped: cannot parse manufacturer+model from %r / %r",
+            equipment_type,
+            fname,
+        )
         return
 
     manufacturer, model_number = parsed

--- a/mira-web/src/lib/auth.ts
+++ b/mira-web/src/lib/auth.ts
@@ -19,7 +19,11 @@ export interface MiraTokenPayload extends JWTPayload {
   atlasRole: "ADMIN" | "USER"; // NEW
 }
 
-const JWT_EXPIRY = "30d";
+// 7 days — long enough that a customer doesn't bounce mid-week, short enough
+// that a stolen JWT has a finite blast radius. Magic-link reissue is one click
+// away (no refresh-token machinery needed). Was 30d before P0.2 — see
+// docs/site-hardening-plan-2026-04-30.md.
+const JWT_EXPIRY = "7d";
 
 function getSecret(): Uint8Array {
   const secret = process.env.PLG_JWT_SECRET;
@@ -61,16 +65,22 @@ export async function verifyToken(
 }
 
 /**
- * Hono middleware — reads JWT from Authorization header, ?token= query param,
- * or `mira_session` cookie (lowest precedence so programmatic integrations
- * aren't affected).
+ * Hono middleware — reads JWT from Authorization header or `mira_session`
+ * cookie. Header wins over cookie.
+ *
+ * The `?token=` query-param fallback was removed in P0.1 (2026-04-30). It
+ * leaked JWTs into nginx access logs, browser history, and Referer headers
+ * to any third-party (analytics, CDN, etc.). The activation/magic-link
+ * landing routes still read `?token=` for their one-click handoff and set
+ * a cookie — that's a different auth surface and not affected by this
+ * change.
+ *
  * Sets c.set("user", payload) on success, returns 401 on failure.
  */
 export async function requireAuth(c: Context, next: Next) {
   const header = c.req.header("Authorization");
-  const query = c.req.query("token");
   const cookie = parseCookies(c.req.header("cookie"))["mira_session"];
-  const raw = header ? header.replace("Bearer ", "") : query ?? cookie;
+  const raw = header ? header.replace("Bearer ", "") : cookie;
 
   if (!raw) {
     return c.json({ error: "Unauthorized" }, 401);
@@ -91,14 +101,14 @@ export async function requireAuth(c: Context, next: Next) {
  * Use requireAuth (not requireActive) for routes any authenticated user needs
  * (e.g., billing portal).
  *
- * Reads JWT from Authorization header, ?token= query, or `mira_session`
- * cookie (lowest precedence).
+ * Reads JWT from Authorization header or `mira_session` cookie. The
+ * `?token=` query-param fallback was removed in P0.1 (2026-04-30) — see
+ * requireAuth for the rationale.
  */
 export async function requireActive(c: Context, next: Next) {
   const header = c.req.header("Authorization");
-  const query = c.req.query("token");
   const cookie = parseCookies(c.req.header("cookie"))["mira_session"];
-  const raw = header ? header.replace("Bearer ", "") : query ?? cookie;
+  const raw = header ? header.replace("Bearer ", "") : cookie;
 
   if (!raw) {
     return c.json({ error: "Unauthorized" }, 401);
@@ -135,9 +145,8 @@ export async function requireActive(c: Context, next: Next) {
  */
 export async function requireAdmin(c: Context, next: Next) {
   const header = c.req.header("Authorization");
-  const query = c.req.query("token");
   const cookie = parseCookies(c.req.header("cookie"))["mira_session"];
-  const raw = header ? header.replace("Bearer ", "") : query ?? cookie;
+  const raw = header ? header.replace("Bearer ", "") : cookie;
 
   if (!raw) return c.json({ error: "Unauthorized" }, 401);
 

--- a/mira-web/src/routes/__tests__/cross-tenant.test.ts
+++ b/mira-web/src/routes/__tests__/cross-tenant.test.ts
@@ -266,17 +266,16 @@ describe("cross-tenant fail-closed (auth middleware + handler contract)", () => 
     expect(res.status).toBe(401);
   });
 
-  test("query-param token with A's signed JWT cannot be paired with B's tenant_id", async () => {
-    // The ?token= path is a supported auth mechanism. Verify the same
-    // JWT-wins-over-query rule applies: even when the token itself comes
-    // via query string, a sibling tenant_id query param can't override it.
+  test("query-param token is rejected — middleware reads header/cookie only (P0.1, 2026-04-30)", async () => {
+    // Was: `?token=` was a supported auth source. Removed because tokens in
+    // URLs leak into nginx logs, browser history, and Referer headers.
+    // The activation/magic-link landing routes still read `?token=` for
+    // their one-click cookie-set handoff — that's not exercised here.
     const app = buildApp();
     const tokA = await jwtFor(TENANT_A);
     const res = await app.request(
-      `/test/me?token=${encodeURIComponent(tokA)}&tenant_id=${TENANT_B.id}`,
+      `/test/me?token=${encodeURIComponent(tokA)}`,
     );
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.tenant_id).toBe(TENANT_A.id);
+    expect(res.status).toBe(401);
   });
 });

--- a/mira-web/src/server.ts
+++ b/mira-web/src/server.ts
@@ -161,7 +161,24 @@ setInterval(() => {
 export const app = new Hono();
 
 // Middleware
-app.use("*", cors());
+//
+// CORS — scope to /api/* only with an explicit origin allowlist. Was
+// `app.use("*", cors())` before P0.3 (2026-04-30), which set
+// Access-Control-Allow-Origin: * on every response including JSON APIs.
+// Marketing/HTML routes don't need CORS at all (browsers default to
+// same-origin); APIs are the surface that matters. PLG_API_ALLOWED_ORIGINS
+// can override in env (comma-separated) — see docs/env-vars.md.
+const API_ALLOWED_ORIGINS = (process.env.PLG_API_ALLOWED_ORIGINS ??
+  "https://factorylm.com,https://www.factorylm.com,https://app.factorylm.com,http://localhost:3000,http://localhost:3200")
+  .split(",").map(s => s.trim()).filter(Boolean);
+
+app.use("/api/*", cors({
+  origin: (origin) => (API_ALLOWED_ORIGINS.includes(origin) ? origin : null),
+  credentials: true,
+  allowMethods: ["GET", "POST", "PATCH", "PUT", "DELETE", "OPTIONS"],
+  allowHeaders: ["Content-Type", "Authorization", "X-Hmac-Signature", "X-Hmac-Timestamp"],
+  maxAge: 86400,
+}));
 
 // Ensure Content-Length is set on all non-streaming text responses.
 // Bun sends HTML/JSON with chunked transfer encoding; nginx cannot synthesize


### PR DESCRIPTION
## Summary — Wave 1 P0 stack

Three small middleware fixes from `docs/site-hardening-plan-2026-04-30.md`. Stacked into one PR because they touch the same surface and ship best together (no partial-state where some fixes are live and others aren't).

| # | What | File |
|---|---|---|
| **P0.1** | Drop `?token=` query-param JWT auth from `requireAuth` / `requireActive` / `requireAdmin` | `mira-web/src/lib/auth.ts` |
| **P0.2** | JWT expiry `30d` → `7d` | `mira-web/src/lib/auth.ts` |
| **P0.3** | Scope `cors()` to `/api/*` with explicit origin allowlist (was `app.use("*", cors())` = ACAO `*` everywhere) | `mira-web/src/server.ts` |

## What changed at the edge

- **API responses no longer set `Access-Control-Allow-Origin: *`.** Allowed origins now come from `PLG_API_ALLOWED_ORIGINS` env (defaults to `factorylm.com,www.factorylm.com,app.factorylm.com,localhost:3000,localhost:3200`). Marketing/HTML routes get no CORS header (browser same-origin default).
- **`?token=` JWT URLs return 401.** Activation/magic-link landing routes (`/activated`, `/api/cmms/login`, `/m/:tag`, `/m-register`) still read `?token=` for their one-click cookie-set handoff — those are different surfaces, not affected.
- **JWT lifetime is 7 days.** Existing 30-day tokens in the wild keep their original expiry; only newly-issued tokens are short-lived.

## Test plan

- [x] `bun test src/routes/__tests__/cross-tenant.test.ts` → **8 pass / 0 fail** (28 expect calls)
- [x] The previously-passing `query-param token can't be paired with B's tenant_id` test was inverted — now asserts `?token=` returns 401, locking the contract so a future re-add fails CI
- [ ] After merge: smoke-test the magic-link flow (cookie-set on `/api/cmms/login` still works), the activation page (`/activated?token=...` still sets cookie), and a CORS preflight from `factorylm.com` against `/api/me`

## Migration notes

- **Customers with existing 30-day JWTs:** unaffected (token already issued, lifetime preserved). Newly-issued tokens are 7-day.
- **Any external integration that passed `?token=`** (none known in repo, scanned all routes): they'll start getting 401. Switch to `Authorization: Bearer <jwt>` header.
- **Any cross-origin caller of `/api/*`** not in the allowlist: gets a CORS rejection. Add to `PLG_API_ALLOWED_ORIGINS` if legit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
