### PR TITLE
fix(inbox): P0.4 — per-IP rate limit on /api/v1/inbox/email (10 req/min)

### DIFF
--- a/mira-bots/shared/chat/types.py
+++ b/mira-bots/shared/chat/types.py
@@ -31,7 +31,9 @@ class NormalizedChatEvent:
     """One inbound message from any platform, normalized."""
 
     event_id: str
-    platform: Literal["telegram", "slack", "teams", "gchat", "webui", "email", "whatsapp", "webchat"]
+    platform: Literal[
+        "telegram", "slack", "teams", "gchat", "webui", "email", "whatsapp", "webchat"
+    ]
     tenant_id: str
     user_id: str  # canonical MIRA user ID (after identity resolution)
     external_user_id: str  # platform-specific user ID

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -620,9 +620,7 @@ class Supervisor:
             # Procedural how-to questions: answer from knowledge, skip doc crawl.
             # Keyword "instructional" also routes here via the fallback mapping above.
             if _router_intent == "answer_question" or _keyword_intent == "instructional":
-                return await self._handle_instructional_question(
-                    chat_id, message, state, trace_id
-                )
+                return await self._handle_instructional_question(chat_id, message, state, trace_id)
 
             # find_documentation: let the existing specificity-gate block handle it below
             if _router_intent == "find_documentation":
@@ -663,7 +661,11 @@ class Supervisor:
                 if "," in asset_id:
                     fallback_mfr = mfr or asset_id.split(",", 1)[0].strip()
                     return await self._do_documentation_lookup(
-                        chat_id, message, state, trace_id, resolved_tenant,
+                        chat_id,
+                        message,
+                        state,
+                        trace_id,
+                        resolved_tenant,
                         vendor_override=fallback_mfr,
                     )
                 return await self._enter_manual_lookup_gathering(
@@ -2146,7 +2148,7 @@ class Supervisor:
             if sep not in msg:
                 continue
             idx = msg.index(sep)
-            pre, fault = msg[:idx], msg[idx + len(sep):].strip()
+            pre, fault = msg[:idx], msg[idx + len(sep) :].strip()
             m = re.search(r"\bfor\s+(.{3,}?)$", pre, re.IGNORECASE)
             if m:
                 asset = m.group(1).strip()
@@ -2276,12 +2278,14 @@ class Supervisor:
             if "," in asset_id:
                 fallback_mfr = mfr or asset_id.split(",", 1)[0].strip()
                 return await self._do_documentation_lookup(
-                    chat_id, message, state, trace_id, resolved_tenant,
+                    chat_id,
+                    message,
+                    state,
+                    trace_id,
+                    resolved_tenant,
                     vendor_override=fallback_mfr,
                 )
-            return await self._enter_manual_lookup_gathering(
-                chat_id, message, state, trace_id, mfr
-            )
+            return await self._enter_manual_lookup_gathering(chat_id, message, state, trace_id, mfr)
         return await self._do_documentation_lookup(
             chat_id, message, state, trace_id, resolved_tenant, vendor_override=mfr
         )

--- a/mira-bots/shared/models/work_order.py
+++ b/mira-bots/shared/models/work_order.py
@@ -176,7 +176,10 @@ _EDIT_PATTERNS: list[tuple[str, str]] = [
     (r"\barea\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "area"),
     (r"\bline\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "line"),
     (r"\b(?:resolution|fix|solution)\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "resolution"),
-    (r"\b(?:fault(?:\s+description)?|problem|issue|description)\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "fault_description"),
+    (
+        r"\b(?:fault(?:\s+description)?|problem|issue|description)\s+(?:is|:)\s*(.+?)(?:\s*\.|$)",
+        "fault_description",
+    ),
 ]
 
 

--- a/mira-bots/shared/pm_extractor.py
+++ b/mira-bots/shared/pm_extractor.py
@@ -298,13 +298,16 @@ async def extract_pm_schedules(
     Returns validated list of PM schedule dicts ready for storage.
     """
     if not chunks:
-        logger.info("extract_pm_schedules: no PM-relevant chunks for %s %s", manufacturer, model_number)
+        logger.info(
+            "extract_pm_schedules: no PM-relevant chunks for %s %s", manufacturer, model_number
+        )
         return []
 
     # Import here — path differs between mira-bots context and mira-pipeline (where
     # shared/ is mounted directly into the container root).
     import importlib
     import importlib.util
+
     _spec = importlib.util.find_spec("shared")
     _mod = importlib.import_module("shared.inference.router" if _spec else "inference.router")
     InferenceRouter = _mod.InferenceRouter  # type: ignore[attr-defined]
@@ -421,8 +424,7 @@ def ensure_pm_table() -> None:
             # Indexes for common queries
             conn.execute(
                 text(
-                    "CREATE INDEX IF NOT EXISTS idx_pm_schedules_tenant "
-                    "ON pm_schedules (tenant_id)"
+                    "CREATE INDEX IF NOT EXISTS idx_pm_schedules_tenant ON pm_schedules (tenant_id)"
                 )
             )
             conn.execute(
@@ -488,9 +490,7 @@ def store_pm_schedules(
         with engine.begin() as conn:
             for item in schedules:
                 days_str = _interval_to_next_due(item["interval_value"], item["interval_unit"])
-                next_due_sql = (
-                    f"NOW() + INTERVAL '{days_str}'" if days_str else "NULL"
-                )
+                next_due_sql = f"NOW() + INTERVAL '{days_str}'" if days_str else "NULL"
 
                 conn.execute(
                     text(

--- a/mira-bots/shared/pm_scheduler.py
+++ b/mira-bots/shared/pm_scheduler.py
@@ -60,7 +60,11 @@ def _resolve_equipment_id(
         return hint
     from sqlalchemy import text
 
-    new_id = str(uuid.uuid5(_EQUIPMENT_NAMESPACE, f"{tenant_id}:{manufacturer.lower()}:{model_number.lower()}"))
+    new_id = str(
+        uuid.uuid5(
+            _EQUIPMENT_NAMESPACE, f"{tenant_id}:{manufacturer.lower()}:{model_number.lower()}"
+        )
+    )
     engine = _get_neon_engine()
     try:
         with engine.begin() as conn:
@@ -101,7 +105,9 @@ def _resolve_equipment_id(
             )
             logger.info(
                 "_resolve_equipment_id: created cmms_equipment id=%s %s %s",
-                new_id, manufacturer, model_number,
+                new_id,
+                manufacturer,
+                model_number,
             )
         return new_id
     except Exception as exc:
@@ -131,23 +137,23 @@ def _wo_number() -> str:
 
 def _build_description(pm: dict[str, Any]) -> str:
     lines = [
-        f"Auto-generated PM work order from manual extraction.",
-        f"",
+        "Auto-generated PM work order from manual extraction.",
+        "",
         f"Equipment: {pm['manufacturer']} {pm['model_number']}",
         f"Interval: Every {pm['interval_value']} {pm['interval_unit']}",
     ]
     if pm.get("source_citation"):
         lines.append(f"Manual reference: {pm['source_citation']}")
     if pm.get("parts_needed"):
-        lines.append(f"\nParts needed:")
+        lines.append("\nParts needed:")
         for p in pm["parts_needed"]:
             lines.append(f"  • {p}")
     if pm.get("tools_needed"):
-        lines.append(f"\nTools needed:")
+        lines.append("\nTools needed:")
         for t in pm["tools_needed"]:
             lines.append(f"  • {t}")
     if pm.get("safety_requirements"):
-        lines.append(f"\nSafety requirements:")
+        lines.append("\nSafety requirements:")
         for s in pm["safety_requirements"]:
             lines.append(f"  ⚠ {s}")
     confidence = pm.get("confidence")
@@ -367,9 +373,7 @@ async def generate_due_work_orders(tenant_id: str | None = None) -> dict[str, An
     Returns summary dict with counts and created WO IDs.
     """
     due_pms = get_due_pms(tenant_id=tenant_id)
-    logger.info(
-        "generate_due_work_orders: %d due PMs found (tenant=%s)", len(due_pms), tenant_id
-    )
+    logger.info("generate_due_work_orders: %d due PMs found (tenant=%s)", len(due_pms), tenant_id)
 
     created_wos: list[dict[str, str]] = []
     skipped = 0

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -13,7 +13,6 @@ from shared import tts
 from shared.chat.dispatcher import ChatDispatcher
 from shared.engine import Supervisor
 from telegram import Update
-from voice_transcription import transcribe_voice
 from telegram.constants import ChatAction
 from telegram.error import Conflict
 from telegram.ext import (
@@ -24,6 +23,7 @@ from telegram.ext import (
     MessageHandler,
     filters,
 )
+from voice_transcription import transcribe_voice
 
 logging.basicConfig(
     level=logging.INFO,

--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -747,7 +747,11 @@ def _maybe_trigger_pm_extraction(equipment_type: str, fname: str, tenant_id: str
 
     parsed = _parse_manufacturer_model(equipment_type, fname)
     if not parsed:
-        logger.debug("PM extraction skipped: cannot parse manufacturer+model from %r / %r", equipment_type, fname)
+        logger.debug(
+            "PM extraction skipped: cannot parse manufacturer+model from %r / %r",
+            equipment_type,
+            fname,
+        )
         return
 
     manufacturer, model_number = parsed

--- a/mira-web/src/routes/__tests__/inbox-rate-limit.test.ts
+++ b/mira-web/src/routes/__tests__/inbox-rate-limit.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Inbox per-IP rate-limit unit tests (P0.4 — site-hardening 2026-04-30).
+ *
+ * The handler-side wiring (returns 429 + Retry-After ahead of HMAC compute)
+ * is covered indirectly by inbox.test.ts; this file isolates the pure
+ * sliding-window logic so a regression on the bucketing math is caught
+ * without booting the full route.
+ */
+import { describe, test, expect, beforeEach } from "bun:test";
+
+process.env.INBOUND_HMAC_SECRET = "test_value_for_module_load";
+
+const { _testing } = await import("../inbox.js");
+const { checkInboxRateLimit, getClientIp, reset, INBOX_LIMIT_PER_MINUTE } = _testing;
+
+describe("inbox per-IP rate limit", () => {
+  beforeEach(() => reset());
+
+  test("first request from an IP is allowed", () => {
+    const r = checkInboxRateLimit("1.1.1.1", 1_000_000);
+    expect(r.allowed).toBe(true);
+    expect(r.retryAfterSec).toBe(0);
+  });
+
+  test("up to the limit is allowed within a 60s window", () => {
+    const t0 = 1_000_000;
+    for (let i = 0; i < INBOX_LIMIT_PER_MINUTE; i++) {
+      const r = checkInboxRateLimit("1.1.1.1", t0 + i * 100);
+      expect(r.allowed).toBe(true);
+    }
+  });
+
+  test("the (limit+1)-th request in the window is blocked with Retry-After", () => {
+    const t0 = 1_000_000;
+    for (let i = 0; i < INBOX_LIMIT_PER_MINUTE; i++) {
+      checkInboxRateLimit("1.1.1.1", t0 + i * 100);
+    }
+    const r = checkInboxRateLimit("1.1.1.1", t0 + INBOX_LIMIT_PER_MINUTE * 100);
+    expect(r.allowed).toBe(false);
+    expect(r.retryAfterSec).toBeGreaterThan(0);
+    expect(r.retryAfterSec).toBeLessThanOrEqual(60);
+  });
+
+  test("limit resets after the window slides past the oldest hit", () => {
+    const t0 = 1_000_000;
+    for (let i = 0; i < INBOX_LIMIT_PER_MINUTE; i++) {
+      checkInboxRateLimit("1.1.1.1", t0 + i * 100);
+    }
+    // Next request, 61s after the first hit, should be allowed again.
+    const r = checkInboxRateLimit("1.1.1.1", t0 + 61_000);
+    expect(r.allowed).toBe(true);
+  });
+
+  test("different IPs don't share the bucket", () => {
+    const t0 = 1_000_000;
+    for (let i = 0; i < INBOX_LIMIT_PER_MINUTE; i++) {
+      checkInboxRateLimit("1.1.1.1", t0 + i * 100);
+    }
+    // 2.2.2.2 starts fresh
+    const r = checkInboxRateLimit("2.2.2.2", t0 + 100);
+    expect(r.allowed).toBe(true);
+  });
+});
+
+describe("getClientIp", () => {
+  test("prefers X-Forwarded-For first hop", () => {
+    const h = new Headers({ "x-forwarded-for": "203.0.113.5, 10.0.0.1" });
+    expect(getClientIp(h)).toBe("203.0.113.5");
+  });
+
+  test("falls back to X-Real-IP", () => {
+    const h = new Headers({ "x-real-ip": "198.51.100.7" });
+    expect(getClientIp(h)).toBe("198.51.100.7");
+  });
+
+  test("falls back to CF-Connecting-IP", () => {
+    const h = new Headers({ "cf-connecting-ip": "192.0.2.42" });
+    expect(getClientIp(h)).toBe("192.0.2.42");
+  });
+
+  test("returns fallback when no header is present", () => {
+    expect(getClientIp(new Headers(), "fb")).toBe("fb");
+  });
+});

--- a/mira-web/src/routes/__tests__/inbox.test.ts
+++ b/mira-web/src/routes/__tests__/inbox.test.ts
@@ -93,7 +93,7 @@ mock.module("../../lib/audit.js", () => ({
   requestMetadata: () => ({ ip: "127.0.0.1", userAgent: "bun-test" }),
 }));
 
-const { inbox, extractSlug } = await import("../inbox.js");
+const { inbox, extractSlug, _testing } = await import("../inbox.js");
 
 // --- helpers ---------------------------------------------------------------
 function pdfAttachment(name: string, sizeBytes?: number) {
@@ -165,6 +165,11 @@ async function postWebhook(
 beforeEach(() => {
   sentReceipts.length = 0;
   auditEvents.length = 0;
+  // Reset the per-IP rate-limit state so each test starts with a clean
+  // bucket — otherwise the suite blows past INBOX_LIMIT_PER_MINUTE since
+  // every request shares ip="unknown" via the in-process inbox.request().
+  // See P0.4 (site-hardening 2026-04-30).
+  _testing.reset();
 });
 
 // --- pure-function tests ---------------------------------------------------

--- a/mira-web/src/routes/inbox.ts
+++ b/mira-web/src/routes/inbox.ts
@@ -41,6 +41,50 @@ const HMAC_SECRET = () => process.env.INBOUND_HMAC_SECRET || "";
 const MAX_PDF_BYTES = 20 * 1024 * 1024; // matches mira-ingest enforcement
 const MAX_TIMESTAMP_SKEW_SECONDS = 300; // ±5 min replay window
 
+// ── Per-IP rate limit (P0.4, 2026-04-30) ─────────────────────────────────────
+// Each request runs HMAC-SHA256 over the raw body; junk traffic burns CPU and
+// floods logs. Token-bucket-ish: sliding 60-second window per IP, max
+// INBOX_LIMIT_PER_MINUTE requests. Apps Script fires once per email so a real
+// customer almost never exceeds 5/min; a flooder gets 429 + Retry-After.
+//
+// In-memory map is fine for n=1 mira-web container. If we scale horizontally
+// this needs to move to Redis (the existing infra_redis_1 container would do).
+
+const INBOX_LIMIT_PER_MINUTE = 10;
+const _inboxRequests = new Map<string, number[]>();
+
+function checkInboxRateLimit(ip: string, now: number = Date.now()): { allowed: boolean; retryAfterSec: number } {
+  const cutoff = now - 60_000;
+  const recent = (_inboxRequests.get(ip) ?? []).filter((t) => t > cutoff);
+  if (recent.length >= INBOX_LIMIT_PER_MINUTE) {
+    const oldest = recent[0]!;
+    return { allowed: false, retryAfterSec: Math.max(1, Math.ceil((oldest + 60_000 - now) / 1000)) };
+  }
+  recent.push(now);
+  _inboxRequests.set(ip, recent);
+  // Opportunistic GC — keeps the map bounded under sustained junk traffic.
+  if (_inboxRequests.size > 5_000) {
+    for (const [k, v] of _inboxRequests) {
+      if (v.every((t) => t <= cutoff)) _inboxRequests.delete(k);
+    }
+  }
+  return { allowed: true, retryAfterSec: 0 };
+}
+
+function getClientIp(headers: Headers, fallback = "unknown"): string {
+  const fwd = headers.get("x-forwarded-for");
+  if (fwd) return fwd.split(",")[0]!.trim();
+  return headers.get("x-real-ip") || headers.get("cf-connecting-ip") || fallback;
+}
+
+// Exported for tests only.
+export const _testing = {
+  checkInboxRateLimit,
+  getClientIp,
+  reset: () => _inboxRequests.clear(),
+  INBOX_LIMIT_PER_MINUTE,
+};
+
 // Webhook payload shape (Apps Script emits this — Postmark-style for ease)
 interface InboundAttachment {
   Name?: string;
@@ -220,6 +264,16 @@ async function forwardAttachment(
 }
 
 inbox.post("/email", async (c) => {
+  // 0. Per-IP rate limit (P0.4) — gate ahead of HMAC compute so a flood doesn't
+  //    burn CPU verifying signatures on junk traffic.
+  const ip = getClientIp(c.req.raw.headers);
+  const rl = checkInboxRateLimit(ip);
+  if (!rl.allowed) {
+    c.header("Retry-After", String(rl.retryAfterSec));
+    console.warn("[inbox] rate-limited ip=%s retry_after=%ds", ip, rl.retryAfterSec);
+    return c.json({ error: "Too many requests" }, 429);
+  }
+
   // 1. Auth — HMAC-SHA256 over raw body.
   const secret = HMAC_SECRET();
   if (!secret) {


### PR DESCRIPTION
## Summary — P0.4 inbox rate limit

Audit found 0 throttling on `/api/v1/inbox/email` — verified live with 10 parallel POSTs, all returning 401 with no rate-limit kicking in. Each request runs HMAC-SHA256 over the raw body; sustained junk traffic burns CPU and floods the audit log.

**Scope narrowed:** `/api/register` turned out to already have `checkRegisterRateLimit()` (verified live: 5 then 429). The original P0.4 was overscoped against a clean codebase scan. This PR is inbox-only.

## What changed

- `mira-web/src/routes/inbox.ts` — added in-memory sliding-window rate limit:
  - **10 requests per 60s per source IP**
  - Returns `429` + `Retry-After: <seconds>` header
  - Gate runs **before** HMAC compute so a flood doesn't burn signature work
  - IP from `X-Forwarded-For` first hop, falling back to `X-Real-IP` and `CF-Connecting-IP`
  - Opportunistic GC keeps the map bounded under sustained junk traffic
- `_testing` export added so the unit tests can reset state and exercise the bucket
- New test file `inbox-rate-limit.test.ts` (9 tests) covers sliding window, boundary, recovery, per-IP isolation, and the IP-extraction header precedence
- Existing `inbox.test.ts` got `beforeEach(_testing.reset())` so the suite doesn't blow past the bucket on `ip="unknown"` (shared across all in-process `inbox.request()` calls)

## Why in-memory

`mira-web` is currently n=1 container. Single source of truth, no extra dep. The file comment flags that horizontal scale would lift this to the existing `infra_redis_1` Redis container — should be a 30-min refactor at that point, not blocking now.

## Apps Script behavior unchanged

Apps Script fires once per email (max ~1/min in observed practice). 10/min headroom comfortably covers a customer who forwards 5 PDFs at once and any retries the script does.

## Test plan

- [x] `bun test inbox.test.ts inbox-rate-limit.test.ts` → **36/36 pass**
- [ ] After merge: `for i in {1..15}; do curl -X POST https://factorylm.com/api/v1/inbox/email -H "X-Hmac-Signature: 00" -d '{}'; done` — expect first 10 to return 401, the rest to return 429 with Retry-After

🤖 Generated with [Claude Code](https://claude.com/claude-code)
