### PR TITLE
fix(synthetic): P0.8 — Rico dry-run gate (default ON; require RICO_LIVE=1 to mutate prod)

### DIFF
--- a/mira-bots/shared/chat/types.py
+++ b/mira-bots/shared/chat/types.py
@@ -31,7 +31,9 @@ class NormalizedChatEvent:
     """One inbound message from any platform, normalized."""
 
     event_id: str
-    platform: Literal["telegram", "slack", "teams", "gchat", "webui", "email", "whatsapp", "webchat"]
+    platform: Literal[
+        "telegram", "slack", "teams", "gchat", "webui", "email", "whatsapp", "webchat"
+    ]
     tenant_id: str
     user_id: str  # canonical MIRA user ID (after identity resolution)
     external_user_id: str  # platform-specific user ID

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -620,9 +620,7 @@ class Supervisor:
             # Procedural how-to questions: answer from knowledge, skip doc crawl.
             # Keyword "instructional" also routes here via the fallback mapping above.
             if _router_intent == "answer_question" or _keyword_intent == "instructional":
-                return await self._handle_instructional_question(
-                    chat_id, message, state, trace_id
-                )
+                return await self._handle_instructional_question(chat_id, message, state, trace_id)
 
             # find_documentation: let the existing specificity-gate block handle it below
             if _router_intent == "find_documentation":
@@ -663,7 +661,11 @@ class Supervisor:
                 if "," in asset_id:
                     fallback_mfr = mfr or asset_id.split(",", 1)[0].strip()
                     return await self._do_documentation_lookup(
-                        chat_id, message, state, trace_id, resolved_tenant,
+                        chat_id,
+                        message,
+                        state,
+                        trace_id,
+                        resolved_tenant,
                         vendor_override=fallback_mfr,
                     )
                 return await self._enter_manual_lookup_gathering(
@@ -2146,7 +2148,7 @@ class Supervisor:
             if sep not in msg:
                 continue
             idx = msg.index(sep)
-            pre, fault = msg[:idx], msg[idx + len(sep):].strip()
+            pre, fault = msg[:idx], msg[idx + len(sep) :].strip()
             m = re.search(r"\bfor\s+(.{3,}?)$", pre, re.IGNORECASE)
             if m:
                 asset = m.group(1).strip()
@@ -2276,12 +2278,14 @@ class Supervisor:
             if "," in asset_id:
                 fallback_mfr = mfr or asset_id.split(",", 1)[0].strip()
                 return await self._do_documentation_lookup(
-                    chat_id, message, state, trace_id, resolved_tenant,
+                    chat_id,
+                    message,
+                    state,
+                    trace_id,
+                    resolved_tenant,
                     vendor_override=fallback_mfr,
                 )
-            return await self._enter_manual_lookup_gathering(
-                chat_id, message, state, trace_id, mfr
-            )
+            return await self._enter_manual_lookup_gathering(chat_id, message, state, trace_id, mfr)
         return await self._do_documentation_lookup(
             chat_id, message, state, trace_id, resolved_tenant, vendor_override=mfr
         )

--- a/mira-bots/shared/models/work_order.py
+++ b/mira-bots/shared/models/work_order.py
@@ -176,7 +176,10 @@ _EDIT_PATTERNS: list[tuple[str, str]] = [
     (r"\barea\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "area"),
     (r"\bline\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "line"),
     (r"\b(?:resolution|fix|solution)\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "resolution"),
-    (r"\b(?:fault(?:\s+description)?|problem|issue|description)\s+(?:is|:)\s*(.+?)(?:\s*\.|$)", "fault_description"),
+    (
+        r"\b(?:fault(?:\s+description)?|problem|issue|description)\s+(?:is|:)\s*(.+?)(?:\s*\.|$)",
+        "fault_description",
+    ),
 ]
 
 

--- a/mira-bots/shared/pm_extractor.py
+++ b/mira-bots/shared/pm_extractor.py
@@ -298,13 +298,16 @@ async def extract_pm_schedules(
     Returns validated list of PM schedule dicts ready for storage.
     """
     if not chunks:
-        logger.info("extract_pm_schedules: no PM-relevant chunks for %s %s", manufacturer, model_number)
+        logger.info(
+            "extract_pm_schedules: no PM-relevant chunks for %s %s", manufacturer, model_number
+        )
         return []
 
     # Import here — path differs between mira-bots context and mira-pipeline (where
     # shared/ is mounted directly into the container root).
     import importlib
     import importlib.util
+
     _spec = importlib.util.find_spec("shared")
     _mod = importlib.import_module("shared.inference.router" if _spec else "inference.router")
     InferenceRouter = _mod.InferenceRouter  # type: ignore[attr-defined]
@@ -421,8 +424,7 @@ def ensure_pm_table() -> None:
             # Indexes for common queries
             conn.execute(
                 text(
-                    "CREATE INDEX IF NOT EXISTS idx_pm_schedules_tenant "
-                    "ON pm_schedules (tenant_id)"
+                    "CREATE INDEX IF NOT EXISTS idx_pm_schedules_tenant ON pm_schedules (tenant_id)"
                 )
             )
             conn.execute(
@@ -488,9 +490,7 @@ def store_pm_schedules(
         with engine.begin() as conn:
             for item in schedules:
                 days_str = _interval_to_next_due(item["interval_value"], item["interval_unit"])
-                next_due_sql = (
-                    f"NOW() + INTERVAL '{days_str}'" if days_str else "NULL"
-                )
+                next_due_sql = f"NOW() + INTERVAL '{days_str}'" if days_str else "NULL"
 
                 conn.execute(
                     text(

--- a/mira-bots/shared/pm_scheduler.py
+++ b/mira-bots/shared/pm_scheduler.py
@@ -60,7 +60,11 @@ def _resolve_equipment_id(
         return hint
     from sqlalchemy import text
 
-    new_id = str(uuid.uuid5(_EQUIPMENT_NAMESPACE, f"{tenant_id}:{manufacturer.lower()}:{model_number.lower()}"))
+    new_id = str(
+        uuid.uuid5(
+            _EQUIPMENT_NAMESPACE, f"{tenant_id}:{manufacturer.lower()}:{model_number.lower()}"
+        )
+    )
     engine = _get_neon_engine()
     try:
         with engine.begin() as conn:
@@ -101,7 +105,9 @@ def _resolve_equipment_id(
             )
             logger.info(
                 "_resolve_equipment_id: created cmms_equipment id=%s %s %s",
-                new_id, manufacturer, model_number,
+                new_id,
+                manufacturer,
+                model_number,
             )
         return new_id
     except Exception as exc:
@@ -131,23 +137,23 @@ def _wo_number() -> str:
 
 def _build_description(pm: dict[str, Any]) -> str:
     lines = [
-        f"Auto-generated PM work order from manual extraction.",
-        f"",
+        "Auto-generated PM work order from manual extraction.",
+        "",
         f"Equipment: {pm['manufacturer']} {pm['model_number']}",
         f"Interval: Every {pm['interval_value']} {pm['interval_unit']}",
     ]
     if pm.get("source_citation"):
         lines.append(f"Manual reference: {pm['source_citation']}")
     if pm.get("parts_needed"):
-        lines.append(f"\nParts needed:")
+        lines.append("\nParts needed:")
         for p in pm["parts_needed"]:
             lines.append(f"  • {p}")
     if pm.get("tools_needed"):
-        lines.append(f"\nTools needed:")
+        lines.append("\nTools needed:")
         for t in pm["tools_needed"]:
             lines.append(f"  • {t}")
     if pm.get("safety_requirements"):
-        lines.append(f"\nSafety requirements:")
+        lines.append("\nSafety requirements:")
         for s in pm["safety_requirements"]:
             lines.append(f"  ⚠ {s}")
     confidence = pm.get("confidence")
@@ -367,9 +373,7 @@ async def generate_due_work_orders(tenant_id: str | None = None) -> dict[str, An
     Returns summary dict with counts and created WO IDs.
     """
     due_pms = get_due_pms(tenant_id=tenant_id)
-    logger.info(
-        "generate_due_work_orders: %d due PMs found (tenant=%s)", len(due_pms), tenant_id
-    )
+    logger.info("generate_due_work_orders: %d due PMs found (tenant=%s)", len(due_pms), tenant_id)
 
     created_wos: list[dict[str, str]] = []
     skipped = 0

--- a/mira-bots/synthetic/rico.py
+++ b/mira-bots/synthetic/rico.py
@@ -232,12 +232,24 @@ class NeonRecorder:
 
 # ── Telegram notify (stdlib-only, no httpx needed) ────────────────────────────
 
+def is_live() -> bool:
+    """
+    Rico defaults to dry-run everywhere (P0.8 — site-hardening 2026-04-30).
+    Real Atlas writes, real LLM token spend, and real WO creation only happen
+    when RICO_LIVE=1 is explicitly set in the environment. Telegram still fires
+    in dry-run (Mike wants the heartbeat) but is prefixed with [DRY RUN] so
+    it's obvious which mode the shift was in.
+    """
+    return os.environ.get("RICO_LIVE", "").strip() in ("1", "true", "yes")
+
+
 def _tg_send(text: str) -> bool:
     token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
     chat_id = os.environ.get("TELEGRAM_CHAT_ID", "8445149012")
     if not token:
         return False
-    payload = json.dumps({"chat_id": chat_id, "text": text, "parse_mode": "Markdown"}).encode()
+    body = text if is_live() else f"🧪 [DRY RUN] {text}"
+    payload = json.dumps({"chat_id": chat_id, "text": body, "parse_mode": "Markdown"}).encode()
     req = urllib.request.Request(
         f"https://api.telegram.org/bot{token}/sendMessage",
         data=payload,
@@ -430,12 +442,22 @@ class Rico:
         fault_codes = scenario.get("fault_codes", [])
         fault_str = fault_codes[0] if fault_codes else "unknown fault"
 
+        # Mode banner (P0.8) — make it obvious whether the shift mutated prod
+        # or just simulated. Default is dry-run; require RICO_LIVE=1 to enable
+        # real Atlas writes + real LLM token spend.
+        live = is_live()
+        mode_label = "LIVE" if live else "DRY RUN"
+        logger.info("=" * 60)
+        logger.info("Rico shift starting — mode: %s", mode_label)
+        logger.info("  RICO_LIVE=%r → %s", os.environ.get("RICO_LIVE", ""), mode_label)
+        logger.info("=" * 60)
         logger.info("Rico clocking in — scenario: %s %s", equipment, fault_str)
 
         # ── 1. Check PM schedule ──────────────────────────────────────────────
+        # Read-only Atlas call; safe in either mode.
         pms = self.hub.get_pm_schedules(status="due")
         _tg_send(
-            f"🔧 *Rico Mendez* — Clocking in\n"
+            f"🔧 *Rico Mendez* — Clocking in ({mode_label})\n"
             f"Session: `{self.session_id}`\n"
             f"{len(pms)} PM(s) due tonight · Scenario: {equipment} {fault_str}"
         )
@@ -446,13 +468,18 @@ class Rico:
             pm_id = pm.get("id", "")
             pm_title = pm.get("title", "scheduled PM")
             if pm_id:
-                self.hub.update_pm(pm_id, "in_progress")
-                time.sleep(1)
-                ok = self.hub.update_pm(pm_id, "completed")
-                if ok:
-                    result.pm_completed = True
-                    self._record("pm_complete", pm_title, "completed", success=True)
-                    logger.info("Rico completed PM: %s", pm_title)
+                if live:
+                    self.hub.update_pm(pm_id, "in_progress")
+                    time.sleep(1)
+                    ok = self.hub.update_pm(pm_id, "completed")
+                    if ok:
+                        result.pm_completed = True
+                        self._record("pm_complete", pm_title, "completed", success=True)
+                        logger.info("Rico completed PM: %s", pm_title)
+                else:
+                    logger.info("[DRY RUN] would update PM %s → in_progress → completed", pm_id)
+                    self._record("pm_complete", pm_title, "[dry-run] would complete",
+                                 success=True, quality={"dry_run": True})
         else:
             logger.info("No PMs due — Rico goes straight to fault scenario")
 
@@ -465,7 +492,12 @@ class Rico:
         logger.info("Rico asks MIRA: %s", rico_msg)
 
         # ── 4. First MIRA turn ────────────────────────────────────────────────
-        resp = self.mira.chat(rico_msg)
+        if live:
+            resp = self.mira.chat(rico_msg)
+        else:
+            logger.info("[DRY RUN] would chat with MIRA: %s", rico_msg)
+            resp = {"reply": "[dry-run] no chat performed", "latency_ms": 0,
+                    "success": True, "raw": {}}
         result.messages.append({"from": "rico", "text": rico_msg})
         result.messages.append({"from": "mira", "text": resp.get("reply", ""), "latency_ms": resp.get("latency_ms", 0)})
 
@@ -487,7 +519,15 @@ class Rico:
 
             follow_up = self._generate_follow_up(current_reply, scenario)
             logger.info("Rico follow-up %d: %s", turn + 1, follow_up)
-            resp = self.mira.chat(follow_up)
+            if live:
+                resp = self.mira.chat(follow_up)
+            else:
+                logger.info("[DRY RUN] would follow-up: %s", follow_up)
+                # Stop the followup loop in dry-run — without a real MIRA
+                # reply we can't usefully simulate further turns.
+                resp = {"reply": "", "latency_ms": 0, "success": True, "raw": {}}
+                current_reply = ""
+                break
 
             result.messages.append({"from": "rico", "text": follow_up})
             result.messages.append({"from": "mira", "text": resp.get("reply", ""), "latency_ms": resp.get("latency_ms", 0)})
@@ -511,26 +551,39 @@ class Rico:
         # ── 7. Work order creation ────────────────────────────────────────────
         if "work order" in final_reply.lower() or random.random() < 0.4:
             wo_msg = "yes log it"
-            resp = self.mira.chat(wo_msg)
-            result.messages.append({"from": "rico", "text": wo_msg})
-            result.messages.append({"from": "mira", "text": resp.get("reply", "")})
+            if live:
+                resp = self.mira.chat(wo_msg)
+                result.messages.append({"from": "rico", "text": wo_msg})
+                result.messages.append({"from": "mira", "text": resp.get("reply", "")})
 
-            self._record(
-                "wo_request", wo_msg, resp.get("reply", ""),
-                latency_ms=resp.get("latency_ms", 0),
-                success=resp.get("success", False),
-                quality={"wo_trigger": "voice"},
-            )
+                self._record(
+                    "wo_request", wo_msg, resp.get("reply", ""),
+                    latency_ms=resp.get("latency_ms", 0),
+                    success=resp.get("success", False),
+                    quality={"wo_trigger": "voice"},
+                )
 
-            # Also hit the Hub API directly
-            wo = self.hub.create_work_order(
-                title=f"{equipment.title()} fault — {fault_str}",
-                description=rico_msg,
-                priority="medium",
-            )
-            if wo:
-                result.wo_created = True
-                self._record("hub_wo_create", rico_msg, json.dumps(wo), success=True)
+                # Also hit the Hub API directly — REAL Atlas write.
+                wo = self.hub.create_work_order(
+                    title=f"{equipment.title()} fault — {fault_str}",
+                    description=rico_msg,
+                    priority="medium",
+                )
+                if wo:
+                    result.wo_created = True
+                    self._record("hub_wo_create", rico_msg, json.dumps(wo), success=True)
+            else:
+                logger.info("[DRY RUN] would request WO: %s", wo_msg)
+                logger.info("[DRY RUN] would create Atlas WO: %s fault — %s", equipment, fault_str)
+                self._record(
+                    "wo_request", wo_msg, "[dry-run] no chat performed",
+                    success=True, quality={"dry_run": True, "wo_trigger": "voice"},
+                )
+                self._record(
+                    "hub_wo_create", rico_msg,
+                    json.dumps({"dry_run": True, "would_create": True}),
+                    success=True, quality={"dry_run": True},
+                )
 
         # ── 8. Count observations ─────────────────────────────────────────────
         result.observations_recorded = len(result.messages) // 2
@@ -544,7 +597,7 @@ class Rico:
         )
 
         report = (
-            f"🔧 *Rico Mendez — Shift Complete*\n\n"
+            f"🔧 *Rico Mendez — Shift Complete* ({mode_label})\n\n"
             f"*Scenario:* {equipment} — `{fault_str}`\n"
             f"*Turns:* {turns} messages sent\n"
             f"*MIRA responded:* {'✅' if result.mira_responded else '❌'}\n"

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -13,7 +13,6 @@ from shared import tts
 from shared.chat.dispatcher import ChatDispatcher
 from shared.engine import Supervisor
 from telegram import Update
-from voice_transcription import transcribe_voice
 from telegram.constants import ChatAction
 from telegram.error import Conflict
 from telegram.ext import (
@@ -24,6 +23,7 @@ from telegram.ext import (
     MessageHandler,
     filters,
 )
+from voice_transcription import transcribe_voice
 
 logging.basicConfig(
     level=logging.INFO,

--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -747,7 +747,11 @@ def _maybe_trigger_pm_extraction(equipment_type: str, fname: str, tenant_id: str
 
     parsed = _parse_manufacturer_model(equipment_type, fname)
     if not parsed:
-        logger.debug("PM extraction skipped: cannot parse manufacturer+model from %r / %r", equipment_type, fname)
+        logger.debug(
+            "PM extraction skipped: cannot parse manufacturer+model from %r / %r",
+            equipment_type,
+            fname,
+        )
         return
 
     manufacturer, model_number = parsed


### PR DESCRIPTION
## Summary — P0.8 Rico dry-run gate

Today's behavior: every `python3 mira-bots/synthetic/run_rico.py` makes real LLM calls against `mira-pipeline` (real cascade tokens) and, on a 40% random roll, creates a real Atlas work order. That was fine when Rico was a smoke-test against a staging tenant — but **Rico runs against the production tenant + production NeonDB + production Atlas**. Synthetic shifts mix into prod analytics; "test" WOs land in Mike's CMMS.

Verified live in `outputs/site-hardening-2026-04-30/rico-shift-2026-04-30T1034.md` — Rico made 4 real chat calls + would have written a real WO if the random roll had hit.

## Fix

- **Default to dry-run.** Require `RICO_LIVE=1` (or `true` / `yes`) in the environment to make a real shift.
- **New helper `is_live()`** at module level. Cheap to check, easy to grep.
- **Mode banner at the top of every shift** so a misconfigured rollout shows up in the log immediately:
  ```
  ============================================================
  Rico shift starting — mode: DRY RUN
    RICO_LIVE='' → DRY RUN
  ============================================================
  ```
- **Side-effect gates** at every prod-mutating call site:
  - `hub.update_pm()` → `[DRY RUN] would update PM …`
  - `mira.chat()` (LLM token spend) → `[DRY RUN] would chat: …`
  - `hub.create_work_order()` → `[DRY RUN] would create WO: …`
- **Telegram still fires** in dry-run (Mike wants the heartbeat) but the body is prefixed with `🧪 [DRY RUN]` and the shift-complete report header includes the mode label.
- **`synthetic_observations` rows in dry-run mode** get `quality_signals.dry_run = true` so analytics queries can filter them out cleanly.
- **Read paths untouched** — PM list query, scenario load, etc. still happen so the simulation is realistic.

## How to run after merge

```bash
# Default — dry-run. No prod side effects. Telegram fires with [DRY RUN] tag.
cd /opt/mira && doppler run -p factorylm -c prd -- \
    python3 mira-bots/synthetic/run_rico.py

# Live — real LLM calls + real Atlas writes possible.
cd /opt/mira && doppler run -p factorylm -c prd -- \
    env RICO_LIVE=1 python3 mira-bots/synthetic/run_rico.py
```

## Test plan

- [x] `python3 -c "import ast; ast.parse(open(...).read())"` on the patched rico.py — clean
- [x] Manual diff review: live-path code is identical to before — only NEW `if live: …` branches added; no existing behavior removed in live mode
- [ ] After merge + VPS pull: dry-run shift on VPS — expect zero Atlas WO written, zero `mira-pipeline` chat-completion calls, Telegram message prefixed `🧪 [DRY RUN]`, `synthetic_observations` rows have `quality_signals.dry_run = true`
- [ ] After dry-run is verified: one `RICO_LIVE=1` shift to confirm live mode still works end-to-end

## Branch base

Branched from `feat/synthetic-rico` (PR #879). **Merge order matters: #879 first, then this.** If #879 merges first to main, rebase this onto main; if #879 hasn't merged yet, merge this into `feat/synthetic-rico` then merge that to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
