### PR TITLE
feat(cmms): WO completion validation + PM multi-trigger scheduling (#897 #898)

### DIFF
--- a/mira-bots/shared/pm_scheduler.py
+++ b/mira-bots/shared/pm_scheduler.py
@@ -20,7 +20,7 @@ import logging
 import os
 import uuid
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Optional
 
 import httpx
 
@@ -165,8 +165,13 @@ def _build_suggested_actions(pm: dict[str, Any]) -> list[str]:
     return actions
 
 
-def get_due_pms(tenant_id: str | None = None) -> list[dict[str, Any]]:
-    """Return all pm_schedules that are due (next_due_at <= NOW() or IS NULL)."""
+def get_due_pms(tenant_id: Optional[str] = None) -> list[dict[str, Any]]:
+    """Return all pm_schedules that are due.
+
+    Checks BOTH trigger conditions (#898):
+      - calendar / calendar_or_meter: next_due_at <= NOW() or IS NULL
+      - meter / calendar_or_meter:    meter_current >= meter_threshold
+    """
     from sqlalchemy import text
 
     engine = _get_neon_engine()
@@ -185,9 +190,21 @@ def get_due_pms(tenant_id: str | None = None) -> list[dict[str, Any]]:
                            task, interval_value, interval_unit, interval_type,
                            parts_needed, tools_needed, estimated_duration_minutes,
                            safety_requirements, criticality, source_citation, confidence,
-                           next_due_at
+                           next_due_at,
+                           COALESCE(trigger_type, 'calendar') AS trigger_type,
+                           meter_threshold,
+                           COALESCE(meter_current, 0)          AS meter_current
                     FROM pm_schedules
-                    WHERE (next_due_at IS NULL OR next_due_at <= NOW())
+                    WHERE (
+                        -- Calendar trigger
+                        (COALESCE(trigger_type, 'calendar') IN ('calendar', 'calendar_or_meter')
+                         AND (next_due_at IS NULL OR next_due_at <= NOW()))
+                        OR
+                        -- Meter trigger
+                        (COALESCE(trigger_type, 'calendar') IN ('meter', 'calendar_or_meter')
+                         AND meter_threshold IS NOT NULL
+                         AND COALESCE(meter_current, 0) >= meter_threshold)
+                    )
                     {tenant_filter}
                     ORDER BY criticality DESC, next_due_at ASC NULLS FIRST
                     LIMIT 500
@@ -220,19 +237,36 @@ def get_due_pms(tenant_id: str | None = None) -> list[dict[str, Any]]:
             "source_citation": r[14],
             "confidence": float(r[15]) if r[15] else None,
             "next_due_at": r[16].isoformat() if r[16] else None,
+            "trigger_type": str(r[17]),
+            "meter_threshold": float(r[18]) if r[18] is not None else None,
+            "meter_current": float(r[19]),
         }
         for r in rows
     ]
 
 
-def _advance_next_due(pm_id: str, interval_value: int, interval_unit: str) -> None:
-    """Advance next_due_at by the PM interval from NOW()."""
+def _advance_next_due(
+    pm_id: str,
+    interval_value: int,
+    interval_unit: str,
+    trigger_type: str = "calendar",
+) -> None:
+    """Advance next_due_at by the PM interval from NOW().
+
+    For meter / calendar_or_meter PMs also resets meter_current to 0 and
+    stamps meter_last_reset_at so the next reading cycle starts clean (#898).
+    """
     days = _UNIT_DAYS.get(interval_unit, 0)
     if days <= 0:
         logger.info("_advance_next_due: skipping cycle-based PM %s", pm_id)
         return
 
     total_days = interval_value * days
+    meter_reset_clause = (
+        ", meter_current = 0, meter_last_reset_at = NOW()"
+        if trigger_type in ("meter", "calendar_or_meter")
+        else ""
+    )
     from sqlalchemy import text
 
     engine = _get_neon_engine()
@@ -244,12 +278,16 @@ def _advance_next_due(pm_id: str, interval_value: int, interval_unit: str) -> No
                     UPDATE pm_schedules
                     SET next_due_at = NOW() + INTERVAL '{total_days} days',
                         last_completed_at = NOW()
+                        {meter_reset_clause}
                     WHERE id = :pm_id
                     """
                 ),
                 {"pm_id": pm_id},
             )
-        logger.debug("_advance_next_due: pm_id=%s advanced by %g days", pm_id, total_days)
+        logger.debug(
+            "_advance_next_due: pm_id=%s advanced by %g days trigger_type=%s",
+            pm_id, total_days, trigger_type,
+        )
     except Exception as exc:
         logger.error("_advance_next_due failed for pm_id=%s: %s", pm_id, exc)
     finally:
@@ -380,7 +418,7 @@ async def generate_due_work_orders(tenant_id: str | None = None) -> dict[str, An
             skipped += 1
             continue
 
-        _advance_next_due(pm["id"], pm["interval_value"], pm["interval_unit"])
+        _advance_next_due(pm["id"], pm["interval_value"], pm["interval_unit"], pm.get("trigger_type", "calendar"))
 
         # Fire-and-forget to Atlas — import asyncio here to avoid issues at module load
         import asyncio

--- a/mira-hub/db/migrations/005_wo_pm_enhancements.sql
+++ b/mira-hub/db/migrations/005_wo_pm_enhancements.sql
@@ -1,0 +1,57 @@
+-- Migration 005: WO completion validation (#897) + PM multi-trigger scheduling (#898)
+
+-- ─── #897: Work order completion fields ──────────────────────────────────────
+
+-- Separate fault_description from the blob description field, add resolution,
+-- and closed_at timestamp for audit trail.
+ALTER TABLE work_orders
+  ADD COLUMN IF NOT EXISTS fault_description TEXT,
+  ADD COLUMN IF NOT EXISTS resolution        TEXT,
+  ADD COLUMN IF NOT EXISTS closed_at         TIMESTAMPTZ;
+
+-- Add needs_completion to the workorderstatus enum so stale WOs can be flagged
+-- without being auto-closed. Safe no-op if the value already exists.
+DO $$ BEGIN
+  ALTER TYPE workorderstatus ADD VALUE IF NOT EXISTS 'needs_completion';
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Backfill fault_description from description for existing WOs (best-effort).
+-- WOs whose description contains "Fault: " already have structured content.
+UPDATE work_orders
+SET fault_description = TRIM(REGEXP_REPLACE(description, E'^Fault:\\s*', ''))
+WHERE fault_description IS NULL
+  AND description IS NOT NULL
+  AND description != ''
+  AND description NOT LIKE 'Resolution:%';  -- don't stomp pure-resolution rows
+
+-- ─── #898: PM multi-trigger scheduling ───────────────────────────────────────
+
+-- trigger_type controls which condition(s) fire the PM:
+--   'calendar'          — next_due_at <= NOW() (existing behaviour)
+--   'meter'             — meter_current >= meter_threshold
+--   'calendar_or_meter' — EITHER condition triggers
+ALTER TABLE pm_schedules
+  ADD COLUMN IF NOT EXISTS trigger_type        TEXT    NOT NULL DEFAULT 'calendar',
+  ADD COLUMN IF NOT EXISTS meter_type         TEXT,            -- 'run_hours'|'cycles'|'miles'|'custom'
+  ADD COLUMN IF NOT EXISTS meter_threshold    NUMERIC,         -- e.g. 500 (hours)
+  ADD COLUMN IF NOT EXISTS meter_current      NUMERIC NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS meter_last_reset_at TIMESTAMPTZ;
+
+-- CHECK constraint keeps trigger_type to known values (non-blocking ADD)
+DO $$ BEGIN
+  ALTER TABLE pm_schedules
+    ADD CONSTRAINT pm_trigger_type_check
+    CHECK (trigger_type IN ('calendar', 'meter', 'calendar_or_meter'));
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Index for meter-triggered PM queries
+CREATE INDEX IF NOT EXISTS idx_pm_meter_due
+  ON pm_schedules (tenant_id, meter_current, meter_threshold)
+  WHERE trigger_type IN ('meter', 'calendar_or_meter');
+
+-- ─── Rollback notes ───────────────────────────────────────────────────────────
+-- ALTER TABLE work_orders DROP COLUMN IF EXISTS fault_description, resolution, closed_at;
+-- ALTER TABLE pm_schedules DROP COLUMN IF EXISTS trigger_type, meter_type, meter_threshold, meter_current, meter_last_reset_at;
+-- DROP INDEX IF EXISTS idx_pm_meter_due;

--- a/mira-hub/src/app/(hub)/schedule/page.tsx
+++ b/mira-hub/src/app/(hub)/schedule/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Calendar, List, ChevronLeft, ChevronRight, Clock, User, RotateCcw, AlertCircle, X, Sparkles, Package, Wrench, ShieldAlert, BookOpen } from "lucide-react";
+import { Calendar, List, ChevronLeft, ChevronRight, Clock, User, RotateCcw, AlertCircle, X, Sparkles, Package, Wrench, ShieldAlert, BookOpen, Gauge } from "lucide-react";
 import { useToast } from "@/providers/toast-provider";
 import { Badge } from "@/components/ui/badge";
 import { API_BASE } from "@/lib/config";
@@ -24,6 +24,11 @@ type PM = {
   safety_requirements?: string[];
   manufacturer?: string | null;
   model_number?: string | null;
+  // Multi-trigger fields (#898)
+  trigger_type?: string;
+  meter_type?: string | null;
+  meter_threshold?: number | null;
+  meter_current?: number;
 };
 
 // Fallback shown while loading or when no extracted PMs exist
@@ -437,6 +442,68 @@ function PMSheet({ pm, onClose, onComplete }: { pm: PM; onClose: () => void; onC
             </div>
           </div>
         )}
+
+        {/* Trigger settings (#898) */}
+        <div className="rounded-xl p-3 space-y-2" style={{ backgroundColor: "var(--surface-1)" }}>
+          <div className="flex items-center gap-1.5 mb-1">
+            <Gauge className="w-3.5 h-3.5" style={{ color: "var(--foreground-subtle)" }} />
+            <span className="text-[11px] font-semibold uppercase tracking-wide" style={{ color: "var(--foreground-subtle)" }}>Trigger</span>
+          </div>
+          <div className="flex gap-1 flex-wrap">
+            {(["calendar", "meter", "calendar_or_meter"] as const).map((tt) => {
+              const labels = { calendar: "Calendar only", meter: "Meter / Hours", calendar_or_meter: "Whichever comes first" };
+              const active = (pm.trigger_type ?? "calendar") === tt;
+              return (
+                <button key={tt}
+                  onClick={async () => {
+                    await fetch(`/hub/api/pm-schedules/${pm.id}`, {
+                      method: "PATCH",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ trigger_type: tt }),
+                    });
+                  }}
+                  className="px-2.5 py-1 rounded-full text-[11px] font-medium border transition-colors"
+                  style={{
+                    backgroundColor: active ? "var(--brand-blue)" : "var(--surface-0)",
+                    borderColor: active ? "var(--brand-blue)" : "var(--border)",
+                    color: active ? "#fff" : "var(--foreground-muted)",
+                  }}>
+                  {labels[tt]}
+                </button>
+              );
+            })}
+          </div>
+          {(pm.trigger_type === "meter" || pm.trigger_type === "calendar_or_meter") && (
+            <div className="flex items-center gap-3 pt-1">
+              <div className="flex-1">
+                <p className="text-[10px] uppercase tracking-wide mb-0.5" style={{ color: "var(--foreground-subtle)" }}>Current reading</p>
+                <p className="text-sm font-semibold" style={{ color: "var(--foreground)" }}>
+                  {pm.meter_current ?? 0}
+                  {pm.meter_type ? ` ${pm.meter_type.replace("_", " ")}` : ""}
+                </p>
+              </div>
+              <div className="flex-1">
+                <p className="text-[10px] uppercase tracking-wide mb-0.5" style={{ color: "var(--foreground-subtle)" }}>Threshold</p>
+                <p className="text-sm font-semibold" style={{ color: "var(--foreground)" }}>
+                  {pm.meter_threshold != null ? pm.meter_threshold : "—"}
+                  {pm.meter_type ? ` ${pm.meter_type.replace("_", " ")}` : ""}
+                </p>
+              </div>
+              {pm.meter_threshold != null && (
+                <div className="flex-1">
+                  <p className="text-[10px] uppercase tracking-wide mb-0.5" style={{ color: "var(--foreground-subtle)" }}>Progress</p>
+                  <div className="h-2 rounded-full overflow-hidden" style={{ backgroundColor: "var(--border)" }}>
+                    <div className="h-full rounded-full transition-all"
+                      style={{
+                        width: `${Math.min(100, ((pm.meter_current ?? 0) / pm.meter_threshold) * 100).toFixed(1)}%`,
+                        backgroundColor: (pm.meter_current ?? 0) >= pm.meter_threshold ? "#DC2626" : "var(--brand-blue)",
+                      }} />
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
 
         <div className="flex gap-2">
           <button onClick={onComplete} className="flex-1 py-2.5 rounded-xl text-sm font-semibold text-white"

--- a/mira-hub/src/app/(hub)/workorders/[id]/page.tsx
+++ b/mira-hub/src/app/(hub)/workorders/[id]/page.tsx
@@ -84,6 +84,13 @@ export default function WorkOrderDetailPage({ params }: { params: Promise<{ id: 
   const t = useTranslations("workorders");
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // Completion form state (#897)
+  const [showCompleteForm, setShowCompleteForm] = useState(false);
+  const [compFaultDesc, setCompFaultDesc] = useState("");
+  const [compResolution, setCompResolution] = useState("");
+  const [compSubmitting, setCompSubmitting] = useState(false);
+  const [compMissingFields, setCompMissingFields] = useState<string[]>([]);
+
   useEffect(() => {
     fetch(`/hub/api/work-orders/${id}`)
       .then(r => r.json())
@@ -108,7 +115,42 @@ export default function WorkOrderDetailPage({ params }: { params: Promise<{ id: 
 
   function startWork() { setStatus("inprogress"); setTimerRunning(true); toast(t("started")); }
   function stopTimer() { setTimerRunning(false); toast(t("paused", { time: formatTimer(elapsed) })); }
-  function completeWO() { setTimerRunning(false); setStatus("completed"); toast(t("markedComplete")); }
+
+  function openCompleteForm() {
+    setTimerRunning(false);
+    setCompFaultDesc(wo?.description ?? "");
+    setCompMissingFields([]);
+    setShowCompleteForm(true);
+  }
+
+  async function submitComplete() {
+    if (!wo) return;
+    setCompSubmitting(true);
+    setCompMissingFields([]);
+    try {
+      const res = await fetch(`/hub/api/work-orders/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          status: "completed",
+          fault_description: compFaultDesc,
+          resolution: compResolution,
+        }),
+      });
+      if (res.ok) {
+        setStatus("completed");
+        setShowCompleteForm(false);
+        toast(t("markedComplete"));
+      } else {
+        const data = (await res.json()) as { missing_fields?: string[] };
+        setCompMissingFields(data.missing_fields ?? []);
+      }
+    } catch {
+      toast("Network error — please try again");
+    } finally {
+      setCompSubmitting(false);
+    }
+  }
 
   function addComment() {
     if (!commentText.trim()) return;
@@ -412,7 +454,7 @@ export default function WorkOrderDetailPage({ params }: { params: Promise<{ id: 
         {status !== "completed" && (
           <div className="space-y-2">
             {status === "inprogress" && (
-              <Button onClick={completeWO} className="w-full h-11 gap-2 font-semibold"
+              <Button onClick={openCompleteForm} className="w-full h-11 gap-2 font-semibold"
                 style={{ backgroundColor: "#16A34A" }}>
                 <CheckCircle2 className="w-4 h-4" />{t("markComplete")}
               </Button>
@@ -437,6 +479,85 @@ export default function WorkOrderDetailPage({ params }: { params: Promise<{ id: 
           </div>
         )}
       </div>
+
+      {/* Completion form modal (#897) — validates fault_description + resolution before closing */}
+      {showCompleteForm && (
+        <div className="fixed inset-0 z-50 flex items-end justify-center"
+          style={{ backgroundColor: "rgba(0,0,0,0.5)" }}>
+          <div className="w-full max-w-lg rounded-t-2xl p-5 space-y-4"
+            style={{ backgroundColor: "var(--surface-0)", borderTop: "1px solid var(--border)" }}>
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold" style={{ color: "var(--foreground)" }}>
+                Close work order
+              </h2>
+              <button onClick={() => setShowCompleteForm(false)}
+                className="text-xs" style={{ color: "var(--foreground-muted)" }}>Cancel</button>
+            </div>
+
+            {compMissingFields.length > 0 && (
+              <div className="p-3 rounded-xl border" style={{ borderColor: "#DC2626", backgroundColor: "#FEF2F2" }}>
+                <p className="text-xs font-semibold mb-1" style={{ color: "#DC2626" }}>Required before closing:</p>
+                <ul className="text-xs list-disc list-inside space-y-0.5" style={{ color: "#DC2626" }}>
+                  {compMissingFields.map(f => (
+                    <li key={f}>{f === "fault_description" ? "Fault description" : f === "resolution" ? "Resolution / fix applied" : f}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            <div>
+              <label className="block text-xs font-medium mb-1" style={{
+                color: compMissingFields.includes("fault_description") ? "#DC2626" : "var(--foreground-muted)"
+              }}>
+                Fault description *
+              </label>
+              <textarea
+                value={compFaultDesc}
+                onChange={e => setCompFaultDesc(e.target.value)}
+                rows={3}
+                placeholder="Describe what failed and how it was found"
+                className="w-full text-sm px-3 py-2 rounded-xl border resize-none"
+                style={{
+                  borderColor: compMissingFields.includes("fault_description") ? "#DC2626" : "var(--border)",
+                  backgroundColor: "var(--surface-1)",
+                  color: "var(--foreground)",
+                }}
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium mb-1" style={{
+                color: compMissingFields.includes("resolution") ? "#DC2626" : "var(--foreground-muted)"
+              }}>
+                Resolution / fix applied *
+              </label>
+              <textarea
+                value={compResolution}
+                onChange={e => setCompResolution(e.target.value)}
+                rows={3}
+                placeholder="What was done to resolve the issue?"
+                className="w-full text-sm px-3 py-2 rounded-xl border resize-none"
+                style={{
+                  borderColor: compMissingFields.includes("resolution") ? "#DC2626" : "var(--border)",
+                  backgroundColor: "var(--surface-1)",
+                  color: "var(--foreground)",
+                }}
+              />
+            </div>
+
+            <Button
+              onClick={submitComplete}
+              disabled={compSubmitting}
+              className="w-full h-11 gap-2 font-semibold"
+              style={{ backgroundColor: "#16A34A" }}>
+              {compSubmitting
+                ? <Loader2 className="w-4 h-4 animate-spin" />
+                : <CheckCircle2 className="w-4 h-4" />}
+              {compSubmitting ? "Saving…" : "Mark complete"}
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/mira-hub/src/app/api/pm-schedules/[id]/meter/route.ts
+++ b/mira-hub/src/app/api/pm-schedules/[id]/meter/route.ts
@@ -1,0 +1,137 @@
+/**
+ * PATCH /api/pm-schedules/[id]/meter
+ *
+ * Update the current meter reading for a PM schedule. If the reading meets or
+ * exceeds meter_threshold (for 'meter' or 'calendar_or_meter' trigger types),
+ * the PM is triggered: meter_current resets to 0, meter_last_reset_at is
+ * stamped, and next_due_at recalculates from now using interval_value/interval_unit.
+ *
+ * This endpoint is the integration point for IoT/Ignition runtime-hours feeds.
+ * Expected body: { reading: number }
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+function addInterval(base: Date, value: number, unit: string): Date {
+  const d = new Date(base);
+  switch (unit) {
+    case "hours":  d.setHours(d.getHours() + value); break;
+    case "days":   d.setDate(d.getDate() + value); break;
+    case "weeks":  d.setDate(d.getDate() + value * 7); break;
+    case "months": d.setMonth(d.getMonth() + value); break;
+    case "years":  d.setFullYear(d.getFullYear() + value); break;
+    default:       d.setDate(d.getDate() + value); break;
+  }
+  return d;
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+
+  let body: { reading?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const reading = Number(body.reading);
+  if (isNaN(reading) || reading < 0) {
+    return NextResponse.json({ error: "reading must be a non-negative number" }, { status: 400 });
+  }
+
+  try {
+    const schedule = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query<{
+          id: string;
+          trigger_type: string;
+          meter_threshold: number | null;
+          interval_value: number;
+          interval_unit: string;
+        }>(
+          `SELECT id, trigger_type, meter_threshold, interval_value, interval_unit
+           FROM pm_schedules
+           WHERE id = $1 AND tenant_id = $2 LIMIT 1`,
+          [id, ctx.tenantId],
+        )
+        .then((r) => r.rows[0] ?? null),
+    );
+
+    if (!schedule) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const isMeterEnabled =
+      schedule.trigger_type === "meter" ||
+      schedule.trigger_type === "calendar_or_meter";
+
+    if (!isMeterEnabled) {
+      return NextResponse.json(
+        { error: "This PM schedule does not use meter triggers. Set trigger_type to 'meter' or 'calendar_or_meter' first." },
+        { status: 400 },
+      );
+    }
+
+    const threshold = schedule.meter_threshold ?? 0;
+    const triggered = reading >= threshold && threshold > 0;
+
+    let updated: Record<string, unknown>;
+
+    if (triggered) {
+      const nextDue = addInterval(new Date(), schedule.interval_value, schedule.interval_unit);
+      updated = await withTenantContext(ctx.tenantId, (c) =>
+        c
+          .query(
+            `UPDATE pm_schedules
+             SET meter_current      = 0,
+                 meter_last_reset_at = NOW(),
+                 last_completed_at   = NOW(),
+                 next_due_at         = $3
+             WHERE id = $1 AND tenant_id = $2
+             RETURNING id, meter_current, meter_threshold, meter_last_reset_at, next_due_at, trigger_type`,
+            [id, ctx.tenantId, nextDue.toISOString()],
+          )
+          .then((r) => r.rows[0]),
+      );
+    } else {
+      updated = await withTenantContext(ctx.tenantId, (c) =>
+        c
+          .query(
+            `UPDATE pm_schedules
+             SET meter_current = $3
+             WHERE id = $1 AND tenant_id = $2
+             RETURNING id, meter_current, meter_threshold, meter_last_reset_at, next_due_at, trigger_type`,
+            [id, ctx.tenantId, reading],
+          )
+          .then((r) => r.rows[0]),
+      );
+    }
+
+    return NextResponse.json({
+      schedule: updated,
+      triggered,
+      reading,
+      message: triggered
+        ? `PM triggered at ${reading} ${schedule.interval_unit}. Meter reset to 0. Next due recalculated.`
+        : `Meter updated to ${reading}. Threshold is ${threshold}.`,
+    });
+  } catch (err) {
+    console.error("[api/pm-schedules/[id]/meter PATCH]", err);
+    return NextResponse.json({ error: "Update failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/pm-schedules/[id]/route.ts
+++ b/mira-hub/src/app/api/pm-schedules/[id]/route.ts
@@ -1,0 +1,103 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const {
+    trigger_type,
+    meter_type,
+    meter_threshold,
+    meter_current,
+    interval_value,
+    interval_unit,
+    next_due_at,
+  } = body as {
+    trigger_type?: string;
+    meter_type?: string;
+    meter_threshold?: number;
+    meter_current?: number;
+    interval_value?: number;
+    interval_unit?: string;
+    next_due_at?: string;
+  };
+
+  const validTriggerTypes = ["calendar", "meter", "calendar_or_meter"];
+  if (trigger_type !== undefined && !validTriggerTypes.includes(trigger_type)) {
+    return NextResponse.json(
+      { error: `trigger_type must be one of: ${validTriggerTypes.join(", ")}` },
+      { status: 400 },
+    );
+  }
+
+  if ((trigger_type === "meter" || trigger_type === "calendar_or_meter") && meter_threshold === undefined) {
+    return NextResponse.json(
+      { error: "meter_threshold is required when trigger_type includes 'meter'" },
+      { status: 400 },
+    );
+  }
+
+  const setParts: string[] = [];
+  const values: unknown[] = [id, ctx.tenantId];
+
+  function param(v: unknown) {
+    values.push(v);
+    return `$${values.length}`;
+  }
+
+  if (trigger_type !== undefined) setParts.push(`trigger_type = ${param(trigger_type)}`);
+  if (meter_type !== undefined)    setParts.push(`meter_type = ${param(meter_type)}`);
+  if (meter_threshold !== undefined) setParts.push(`meter_threshold = ${param(meter_threshold)}`);
+  if (meter_current !== undefined)  setParts.push(`meter_current = ${param(meter_current)}`);
+  if (interval_value !== undefined) setParts.push(`interval_value = ${param(interval_value)}`);
+  if (interval_unit !== undefined)  setParts.push(`interval_unit = ${param(interval_unit)}`);
+  if (next_due_at !== undefined)    setParts.push(`next_due_at = ${param(next_due_at)}`);
+
+  if (setParts.length === 0) {
+    return NextResponse.json({ error: "No fields to update" }, { status: 400 });
+  }
+
+  try {
+    const updated = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query(
+          `UPDATE pm_schedules
+           SET ${setParts.join(", ")}
+           WHERE id = $1 AND tenant_id = $2
+           RETURNING id, trigger_type, meter_type, meter_threshold, meter_current,
+                     interval_value, interval_unit, next_due_at, task`,
+          values,
+        )
+        .then((r) => r.rows[0] ?? null),
+    );
+
+    if (!updated) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ schedule: updated });
+  } catch (err) {
+    console.error("[api/pm-schedules/[id] PATCH]", err);
+    return NextResponse.json({ error: "Update failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/pm-schedules/route.ts
+++ b/mira-hub/src/app/api/pm-schedules/route.ts
@@ -74,6 +74,11 @@ function rowToPM(r: Record<string, unknown>) {
     interval_value: r.interval_value,
     interval_unit: r.interval_unit,
     auto_extracted: r.auto_extracted ?? true,
+    // Multi-trigger fields (#898)
+    trigger_type: String(r.trigger_type ?? "calendar"),
+    meter_type: r.meter_type ? String(r.meter_type) : null,
+    meter_threshold: r.meter_threshold != null ? Number(r.meter_threshold) : null,
+    meter_current: r.meter_current != null ? Number(r.meter_current) : 0,
   };
 }
 
@@ -116,7 +121,9 @@ export async function GET(req: NextRequest) {
           task, interval_value, interval_unit, interval_type,
           parts_needed, tools_needed, estimated_duration_minutes,
           safety_requirements, criticality, source_citation, confidence,
-          next_due_at, last_completed_at, auto_extracted, created_at
+          next_due_at, last_completed_at, auto_extracted, created_at,
+          COALESCE(trigger_type, 'calendar') AS trigger_type,
+          meter_type, meter_threshold, COALESCE(meter_current, 0) AS meter_current
         FROM pm_schedules
         WHERE ${where}
         ORDER BY

--- a/mira-hub/src/app/api/work-orders/[id]/route.ts
+++ b/mira-hub/src/app/api/work-orders/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { sessionOr401 } from "@/lib/session";
 import { withTenantContext } from "@/lib/tenant-context";
+import { CLOSING_STATUSES, validateWOCompletion } from "@/lib/wo-completion-validation";
 
 export const dynamic = "force-dynamic";
 
@@ -108,5 +109,109 @@ export async function GET(
   } catch (err) {
     console.error("[api/work-orders/[id] GET]", err);
     return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { status, title, fault_description, resolution, priority } = body as {
+    status?: string;
+    title?: string;
+    fault_description?: string;
+    resolution?: string;
+    priority?: string;
+  };
+
+  // When closing, validate required fields against current + incoming values.
+  if (status && CLOSING_STATUSES.has(status)) {
+    const current = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query<{ title: string; description: string | null; fault_description: string | null; resolution: string | null }>(
+          `SELECT title, description, fault_description, resolution
+           FROM work_orders WHERE id = $1 AND tenant_id = $2 LIMIT 1`,
+          [id, ctx.tenantId],
+        )
+        .then((r) => r.rows[0] ?? null),
+    );
+
+    if (!current) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const { valid, missing_fields } = validateWOCompletion({
+      title: title ?? current.title,
+      description: current.description,
+      fault_description: fault_description ?? current.fault_description,
+      resolution: resolution ?? current.resolution,
+    });
+
+    if (!valid) {
+      return NextResponse.json(
+        { error: "Cannot close work order — missing required fields", missing_fields },
+        { status: 400 },
+      );
+    }
+  }
+
+  // Build the SET clause dynamically.
+  const setParts: string[] = ["updated_at = NOW()"];
+  const values: unknown[] = [id, ctx.tenantId];
+
+  function param(v: unknown) {
+    values.push(v);
+    return `$${values.length}`;
+  }
+
+  if (status !== undefined) {
+    // Cast to text so needs_completion (may not be in enum yet) still works.
+    setParts.push(`status = ${param(status)}::text::workorderstatus`);
+    if (CLOSING_STATUSES.has(status)) {
+      setParts.push("closed_at = NOW()");
+    }
+  }
+  if (title !== undefined) setParts.push(`title = ${param(title)}`);
+  if (fault_description !== undefined) setParts.push(`fault_description = ${param(fault_description)}`);
+  if (resolution !== undefined) setParts.push(`resolution = ${param(resolution)}`);
+  if (priority !== undefined) setParts.push(`priority = ${param(priority)}::prioritylevel`);
+
+  try {
+    const updated = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query(
+          `UPDATE work_orders
+           SET ${setParts.join(", ")}
+           WHERE id = $1 AND tenant_id = $2
+           RETURNING id, work_order_number, status, resolution, fault_description, closed_at, updated_at`,
+          values,
+        )
+        .then((r) => r.rows[0] ?? null),
+    );
+
+    if (!updated) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ work_order: updated });
+  } catch (err) {
+    console.error("[api/work-orders/[id] PATCH]", err);
+    return NextResponse.json({ error: "Update failed" }, { status: 500 });
   }
 }

--- a/mira-hub/src/lib/agents/wo-lifecycle.ts
+++ b/mira-hub/src/lib/agents/wo-lifecycle.ts
@@ -1,0 +1,125 @@
+/**
+ * WO Lifecycle agent (#897).
+ *
+ * checkStaleWorkOrders(tenantId) → StaleWOResult[]
+ *   Finds open/in_progress WOs older than 72 hours.
+ *   - If all completion fields are present  → candidate for auto-close (caller decides).
+ *   - If any field is missing               → flags the WO as "needs_completion"
+ *                                            and returns an alert payload for the
+ *                                            assigned tech.
+ *
+ * This function is designed to be called by a cron/Celery task. It does NOT
+ * auto-close any work order — it surfaces what needs human attention.
+ */
+
+import { withTenantContext } from "@/lib/tenant-context";
+import { validateWOCompletion } from "@/lib/wo-completion-validation";
+
+export interface StaleWOResult {
+  id: string;
+  workOrderNumber: string;
+  title: string;
+  asset: string;
+  assignedTo: string | null;
+  ageHours: number;
+  canAutoClose: boolean;
+  missing_fields: string[];
+  flaggedAsNeedsCompletion: boolean;
+  telegramAlert: string | null;
+}
+
+export async function checkStaleWorkOrders(tenantId: string): Promise<StaleWOResult[]> {
+  const cutoff = new Date(Date.now() - 72 * 60 * 60 * 1000).toISOString();
+
+  const rows = await withTenantContext(tenantId, (client) =>
+    client
+      .query<{
+        id: string;
+        work_order_number: string;
+        title: string;
+        description: string | null;
+        fault_description: string | null;
+        resolution: string | null;
+        assigned_to: string | null;
+        manufacturer: string | null;
+        model_number: string | null;
+        created_at: string;
+      }>(
+        `SELECT id, work_order_number, title, description,
+                fault_description, resolution, assigned_to,
+                manufacturer, model_number, created_at
+         FROM work_orders
+         WHERE tenant_id = $1
+           AND status IN ('open', 'in_progress')
+           AND created_at < $2
+         ORDER BY created_at ASC`,
+        [tenantId, cutoff],
+      )
+      .then((r) => r.rows),
+  );
+
+  const flagUpdates: Promise<void>[] = [];
+
+  const results: StaleWOResult[] = rows.map((r) => {
+    const validation = validateWOCompletion({
+      title: r.title,
+      description: r.description,
+      fault_description: r.fault_description,
+      resolution: r.resolution,
+    });
+
+    const ageHours = Math.floor(
+      (Date.now() - new Date(r.created_at).getTime()) / (1000 * 60 * 60),
+    );
+    const asset =
+      [r.manufacturer, r.model_number].filter(Boolean).join(" ") || "Unknown asset";
+
+    const needsFlag = !validation.valid;
+
+    if (needsFlag) {
+      flagUpdates.push(
+        withTenantContext(tenantId, (client) =>
+          client
+            .query(
+              `UPDATE work_orders
+               SET status = 'needs_completion', updated_at = NOW()
+               WHERE id = $1 AND tenant_id = $2
+                 AND status IN ('open', 'in_progress')`,
+              [r.id, tenantId],
+            )
+            .then(() => undefined),
+        ),
+      );
+    }
+
+    const telegramAlert = needsFlag
+      ? [
+          `⚠️ *Work order needs completion* — ${r.work_order_number}`,
+          `*Task:* ${r.title}`,
+          `*Asset:* ${asset}`,
+          `*Age:* ${ageHours}h`,
+          `*Missing fields:* ${validation.missing_fields.join(", ")}`,
+          "",
+          "Please add the missing details before this WO can be closed.",
+          "_MIRA WO Lifecycle · FactoryLM_",
+        ].join("\n")
+      : null;
+
+    return {
+      id: r.id,
+      workOrderNumber: r.work_order_number,
+      title: r.title,
+      asset,
+      assignedTo: r.assigned_to,
+      ageHours,
+      canAutoClose: validation.valid,
+      missing_fields: validation.missing_fields,
+      flaggedAsNeedsCompletion: needsFlag,
+      telegramAlert,
+    };
+  });
+
+  await Promise.allSettled(flagUpdates);
+
+  return results;
+}

--- a/mira-hub/src/lib/wo-completion-validation.ts
+++ b/mira-hub/src/lib/wo-completion-validation.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared validation for closing/completing work orders (#897).
+ *
+ * A WO can move to "completed" or "closed" only when all three fields are
+ * non-empty: title, fault_description, and resolution.
+ *
+ * fault_description falls back to the WO's description column so legacy WOs
+ * created before the column existed still pass validation if description is set.
+ */
+
+export const CLOSING_STATUSES = new Set(["completed", "closed"]);
+
+export interface WOFields {
+  title?: string | null;
+  description?: string | null;
+  fault_description?: string | null;
+  resolution?: string | null;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  missing_fields: string[];
+}
+
+export function validateWOCompletion(fields: WOFields): ValidationResult {
+  const effectiveTitle = (fields.title ?? "").trim();
+  const effectiveFault = (fields.fault_description ?? fields.description ?? "").trim();
+  const effectiveResolution = (fields.resolution ?? "").trim();
+
+  const missing: string[] = [];
+  if (!effectiveTitle) missing.push("title");
+  if (!effectiveFault) missing.push("fault_description");
+  if (!effectiveResolution) missing.push("resolution");
+
+  return { valid: missing.length === 0, missing_fields: missing };
+}


### PR DESCRIPTION
## Summary

**#897 — Mandatory WO field validation before closing**
- `PATCH /api/work-orders/[id]` validates `title`, `fault_description`, and `resolution` before accepting `status=completed|closed`. Returns `400 { error, missing_fields[] }` when any are empty. `fault_description` falls back to the existing `description` column for pre-migration WOs.
- `src/lib/wo-completion-validation.ts` — shared validation logic, importable by any agent or route
- `src/lib/agents/wo-lifecycle.ts` — `checkStaleWorkOrders(tenantId)`: finds open/in_progress WOs >72h old; flags ones with missing fields as `needs_completion` (DB update) and returns Telegram alert payloads for the assigned tech; leaves complete WOs for the caller to auto-close
- Hub UI (`workorders/[id]/page.tsx`): "Mark complete" button now opens a completion form modal. Fault description and resolution textareas are highlighted red on 400; users can't close until both are filled

**#898 — Multi-trigger PM scheduling**
- `db/migrations/005_wo_pm_enhancements.sql`: adds `fault_description`, `resolution`, `closed_at` to `work_orders`; adds `trigger_type` (calendar / meter / calendar_or_meter), `meter_type`, `meter_threshold`, `meter_current`, `meter_last_reset_at` to `pm_schedules`; adds `needs_completion` to `workorderstatus` enum
- `PATCH /api/pm-schedules/[id]` — update trigger type, meter fields, interval
- `PATCH /api/pm-schedules/[id]/meter` — IoT/Ignition meter reading ingest; auto-triggers PM + resets `meter_current=0` when `reading >= threshold`
- `pm_scheduler.py`: `get_due_pms()` WHERE clause now checks both calendar (`next_due_at <= NOW()`) and meter (`meter_current >= meter_threshold`) conditions; `_advance_next_due()` resets meter on meter-triggered PMs
- Schedule UI (`schedule/page.tsx`): PM detail panel shows a trigger type selector (Calendar only / Meter / Whichever comes first) + meter progress bar with current vs threshold

## Files
| File | Change |
|---|---|
| `mira-hub/db/migrations/005_wo_pm_enhancements.sql` | New migration |
| `mira-hub/src/lib/wo-completion-validation.ts` | New shared validator |
| `mira-hub/src/lib/agents/wo-lifecycle.ts` | New stale-WO lifecycle agent |
| `mira-hub/src/app/api/work-orders/[id]/route.ts` | +PATCH with validation |
| `mira-hub/src/app/api/pm-schedules/route.ts` | +meter fields in SELECT/rowToPM |
| `mira-hub/src/app/api/pm-schedules/[id]/route.ts` | New PATCH |
| `mira-hub/src/app/api/pm-schedules/[id]/meter/route.ts` | New meter endpoint |
| `mira-hub/src/app/(hub)/workorders/[id]/page.tsx` | Completion form modal |
| `mira-hub/src/app/(hub)/schedule/page.tsx` | Trigger type UI + meter bar |
| `mira-bots/shared/pm_scheduler.py` | Dual-trigger WHERE + meter reset |

## Test plan
- [ ] `PATCH /api/work-orders/[id]` with `status=completed` + empty resolution → `400 { missing_fields: ["resolution"] }`
- [ ] Same with all 3 fields populated → `200` + `closed_at` stamped
- [ ] Hub UI: "Mark complete" button opens modal; submit without resolution shows red field label
- [ ] `PATCH /api/pm-schedules/[id]` `{ trigger_type: "meter", meter_threshold: 500 }` → `200`
- [ ] `PATCH /api/pm-schedules/[id]/meter` `{ reading: 499 }` → `triggered: false`, meter_current=499
- [ ] `PATCH /api/pm-schedules/[id]/meter` `{ reading: 500 }` → `triggered: true`, meter_current=0, next_due_at recalculated
- [ ] Schedule page: PM detail panel shows trigger type pills; selecting "Meter/Hours" saves via PATCH and shows meter progress bar
- [ ] Run migration 005 on staging NeonDB — verify no errors
- [ ] `next build` passes ✓ (verified locally)

Closes #897, #898

🤖 Generated with [Claude Code](https://claude.com/claude-code)