### PR TITLE
plc(ccw): remote PLC programming via Tailscale + RDP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,6 @@ wiki/.smart-env/
 **/* 2.txt
 
 .claire/
+
+# Transcript log emitted by plc/ccw/scripts/plc_laptop_harden/apply.ps1
+plc/ccw/scripts/plc_laptop_harden/apply.last-run.log

--- a/plc/ccw/plans/2026-04-24-remote-plc-programming.md
+++ b/plc/ccw/plans/2026-04-24-remote-plc-programming.md
@@ -1,0 +1,546 @@
+# Remote PLC Programming Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Configure the PLC laptop so the travel laptop can RDP in over Tailscale and program the Micro 820 without a human at the PLC laptop.
+
+**Architecture:** The PLC laptop (LAPTOP-0KA3C70H) becomes a hardened Tailscale jump host. Travel laptop RDPs to its Tailscale IP (100.72.2.99) and drives CCW locally. The PLC stays on an isolated 192.168.1.0/24 point-to-point cable to the PLC laptop's Ethernet NIC, unreachable from anywhere else.
+
+**Tech Stack:** Tailscale for Windows, Windows RDP (Remote Desktop Services), Windows Firewall, Sysinternals Autologon, CCW 22, PowerShell.
+
+**Spec:** [specs/2026-04-24-remote-plc-programming-design.md](../specs/2026-04-24-remote-plc-programming-design.md)
+
+**Artifacts produced:**
+- `runbooks/remote-plc-programming.md` — operational runbook (edited as steps are executed, captures actual command output)
+- Optional: `scripts/travel_laptop/ping_plc_laptop.ps1` — reachability probe if the 7-day test is automated
+
+**Test philosophy for this plan:** there is no application code under test. "Test" = a verification command that confirms the intended system state, run before and after each change. Every step pair is (apply change) → (verify state). Roll back if verify fails; do not commit broken state.
+
+**Execution environment:** Most steps run on the PLC laptop (LAPTOP-0KA3C70H) in an elevated PowerShell. For Chunk 1, reach it physically, via existing RDP on the home LAN, or via the remoteme endpoint at http://100.72.2.99:8765/shell. From Chunk 2 Task 4 onward, RDP over Tailscale should also work — prefer that.
+
+**Rollback posture:** every config change in this plan is reversible with one command. Before moving on from any step, confirm the verify output matches expectations. If it doesn't, the spec's Break-glass procedure (Task 9) assumes physical access remains available.
+
+---
+
+## Chunk 1: Baseline verification + runbook scaffold
+
+Before changing anything, confirm the current path works and record the starting state so later steps can be compared against it.
+
+### Task 1: Create the runbook scaffold
+
+**Files:**
+- Create: `runbooks/remote-plc-programming.md`
+
+- [ ] **Step 1: Write the scaffold**
+
+```markdown
+# Remote PLC Programming Runbook
+
+**Spec:** [specs/2026-04-24-remote-plc-programming-design.md](../specs/2026-04-24-remote-plc-programming-design.md)
+**Plan:** [plans/2026-04-24-remote-plc-programming.md](../plans/2026-04-24-remote-plc-programming.md)
+**Status:** In progress
+
+## Baseline (starting state)
+_to be filled by Task 2_
+
+## Tailscale persistence
+_to be filled by Task 4_
+
+## Windows availability
+_to be filled by Task 5_
+
+## RDP lockdown
+_to be filled by Task 3 + Task 6_
+
+## PLC subnet isolation
+_to be filled by Task 7_
+
+## Cold-boot verification
+_to be filled by Task 8_
+
+## 7-day unattended test
+_to be filled by Task 10_
+
+## Break-glass recovery
+_to be filled by Task 9_
+```
+
+- [ ] **Step 2: Commit scaffold**
+
+```bash
+git add runbooks/remote-plc-programming.md
+git commit -m "docs(runbook): scaffold remote PLC programming runbook"
+```
+
+### Task 2: Capture baseline state
+
+**Files:**
+- Modify: `runbooks/remote-plc-programming.md` — fill the Baseline section
+
+- [ ] **Step 1: From travel laptop, confirm Tailscale reach**
+
+Run: `tailscale ping 100.72.2.99`
+Expected: pong within ~5 attempts, preferably `direct` not `derp`.
+
+- [ ] **Step 2: Capture tailnet view**
+
+Run: `tailscale status`
+Expected: a row for `laptop-0ka3c70h` / `100.72.2.99`, no `expired` or `offline` flag.
+
+- [ ] **Step 3: Attempt RDP**
+
+Run: `mstsc /v:100.72.2.99`
+Expected: credentials prompt → PLC laptop desktop. If it fails, record the failure mode in the runbook — Task 3 will enable RDP.
+
+- [ ] **Step 4: On the PLC laptop, capture current config (elevated PowerShell)**
+
+```powershell
+Get-Service Tailscale, TermService | Select-Object Name, StartType, Status
+Get-NetIPAddress -InterfaceAlias 'Ethernet' -AddressFamily IPv4 | Select-Object IPAddress, PrefixLength
+Get-NetIPInterface | Where-Object Forwarding -eq 'Enabled' | Select-Object InterfaceAlias, AddressFamily
+Get-NetFirewallRule -DisplayGroup 'Remote Desktop' | Select-Object DisplayName, Enabled, Direction, Profile, Action
+powercfg /getactivescheme
+Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power' -Name HiberbootEnabled
+```
+
+Paste all output verbatim into the runbook Baseline section.
+
+- [ ] **Step 5: Verify PLC reach from PLC laptop**
+
+```powershell
+Test-Connection -ComputerName 192.168.1.100 -Count 2
+Test-NetConnection -ComputerName 192.168.1.100 -Port 502
+Test-NetConnection -ComputerName 192.168.1.100 -Port 44818
+```
+
+Expected: ping answers, both ports `TcpTestSucceeded : True`. If this fails, STOP — the plan assumes the PLC is already reachable from the laptop (confirmed 2026-04-17 per `scripts/eip_list_identity.ps1`). Diagnose before continuing.
+
+- [ ] **Step 6: Commit baseline**
+
+```bash
+git add runbooks/remote-plc-programming.md
+git commit -m "docs(runbook): record baseline PLC laptop state"
+```
+
+**Chunk 1 exit criteria:**
+- Runbook scaffold committed.
+- Baseline section filled with actual command output.
+- PLC confirmed reachable from PLC laptop (ports 502 + 44818 open).
+- RDP status known (enabled or not).
+
+---
+
+## Chunk 2: Hardening
+
+Five passes in order. Each pass is one task, one commit. Each task records its commands and before/after output in the runbook.
+
+### Task 3: Enable RDP with NLA (skip if baseline Step 3 already connected)
+
+**Files:**
+- Modify: `runbooks/remote-plc-programming.md` — RDP lockdown section
+
+- [ ] **Step 1: Apply change (elevated PowerShell on PLC laptop)**
+
+```powershell
+Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name fDenyTSConnections -Value 0
+Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -Name UserAuthentication -Value 1
+Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'
+```
+
+- [ ] **Step 2: Verify from travel laptop**
+
+Run: `mstsc /v:100.72.2.99`
+Expected: credential prompt → desktop.
+
+If this fails: check `Get-Service TermService` is Running, inspect `Get-NetFirewallRule -DisplayGroup 'Remote Desktop' | Format-List`, do NOT proceed to Task 6 (firewall lockdown) until plain RDP works.
+
+- [ ] **Step 3: Record in runbook** — commands run, the `fDenyTSConnections` and `UserAuthentication` values after, and the RDP connect outcome.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add runbooks/remote-plc-programming.md
+git commit -m "ops(plc-laptop): enable RDP with NLA"
+```
+
+### Task 4: Tailscale persistence
+
+**Files:**
+- Modify: `runbooks/remote-plc-programming.md` — Tailscale persistence section
+
+- [ ] **Step 1: Enable Unattended Mode**
+
+Tailscale tray icon → Preferences → check "Run unattended". Accept the UAC prompt.
+
+Verify:
+```powershell
+& 'C:\Program Files\Tailscale\tailscale.exe' status --json | ConvertFrom-Json | Select-Object -ExpandProperty Self | Select-Object HostName, Online
+```
+Expected: `Online : True`.
+
+Confirmation test: sign out of Windows on the PLC laptop, wait ~30 seconds, then from the travel laptop run `tailscale status`. The `100.72.2.99` row should still be `active` or `idle` (not offline). Sign back in when done.
+
+- [ ] **Step 2: Disable key expiry**
+
+Browser → https://login.tailscale.com/admin/machines. Find `laptop-0ka3c70h`. `...` menu → **Disable key expiry**. Confirm.
+
+Verify: the machine row no longer shows an expiry date.
+
+- [ ] **Step 3: Generate and store break-glass pre-auth key**
+
+Admin console → Settings → Keys → **Generate auth key**. Options: Reusable ON, Ephemeral OFF, expiry as long as allowed (default 90d). Copy the key.
+
+Save in your password manager under a clearly-named entry (e.g. "PLC laptop Tailscale break-glass"). **Do NOT commit the key anywhere in the repo.** Record the expiry date in the runbook so you rotate it before it lapses.
+
+- [ ] **Step 4: Configure service auto-restart**
+
+On PLC laptop (elevated):
+```powershell
+sc.exe failure Tailscale reset= 86400 actions= restart/5000/restart/5000/restart/5000
+sc.exe qfailure Tailscale
+```
+
+Expected qfailure output: reset period 86400, 3 restart actions at 5000ms each.
+
+- [ ] **Step 5: Record in runbook** — Unattended mode confirmed (with sign-out test result), key expiry disabled confirmation, break-glass key location (password manager entry name only, not the key itself), the full `sc qfailure Tailscale` output, and the pre-auth key expiry date.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add runbooks/remote-plc-programming.md
+git commit -m "ops(plc-laptop): harden Tailscale for unattended operation"
+```
+
+### Task 5: Windows availability
+
+**Files:**
+- Modify: `runbooks/remote-plc-programming.md` — Windows availability section
+
+- [ ] **Step 1: Power plan (elevated)**
+
+```powershell
+powercfg /change standby-timeout-ac 0
+powercfg /change hibernate-timeout-ac 0
+powercfg /change monitor-timeout-ac 10
+powercfg /hibernate off
+powercfg /setacvalueindex SCHEME_CURRENT SUB_NONE CONSOLELOCK 0
+powercfg /setactive SCHEME_CURRENT
+```
+
+Verify:
+- `powercfg /query SCHEME_CURRENT SUB_SLEEP` — AC standby-timeout should be 0.
+- `powercfg /query SCHEME_CURRENT SUB_NONE CONSOLELOCK` — AC value should be 0 (no password prompt on wake).
+
+- [ ] **Step 2: Disable Fast Startup**
+
+```powershell
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power' -Name HiberbootEnabled -Value 0
+```
+
+Verify: `Get-ItemProperty ... HiberbootEnabled` returns 0.
+
+- [ ] **Step 3: Confirm service startup types**
+
+```powershell
+Set-Service -Name Tailscale -StartupType Automatic
+Set-Service -Name TermService -StartupType Automatic
+Get-Service Tailscale, TermService | Select-Object Name, StartType, Status
+```
+
+Expected: both Running, both Automatic.
+
+Note: on some Windows SKUs `Set-Service` on `TermService` fails with "Access is denied" because it's a protected service. If that happens, use the registry equivalent instead:
+```powershell
+Set-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Services\TermService' -Name Start -Value 2
+```
+Then re-run the `Get-Service` verify — `TermService` should still show `StartType Automatic`.
+
+- [ ] **Step 4: Configure Windows auto-login**
+
+Download Sysinternals Autologon from https://learn.microsoft.com/en-us/sysinternals/downloads/autologon to `C:\Tools\Autologon64.exe`. Launch, enter the local Windows account username + password (leave Domain blank for a local account), click **Enable**.
+
+The credential is stored encrypted in LSA Secrets. Do NOT paste it anywhere else.
+
+No immediate verify — actual reboot-to-desktop behavior is verified in Task 8 cold-boot test.
+
+- [ ] **Step 5: Record in runbook** — each applied change + verify output, and note auto-login is configured (without recording the credential).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add runbooks/remote-plc-programming.md
+git commit -m "ops(plc-laptop): Windows power and startup tuned for unattended operation"
+```
+
+### Task 6: RDP lockdown to Tailscale only
+
+Locks RDP so only Tailscale peers can reach 3389. Home-LAN RDP attempts will start to fail after this step — that is the point.
+
+**Files:**
+- Modify: `runbooks/remote-plc-programming.md` — RDP lockdown section (append to Task 3 content)
+
+- [ ] **Step 1: Confirm the Tailscale IP falls inside 100.64.0.0/10**
+
+```powershell
+& 'C:\Program Files\Tailscale\tailscale.exe' ip -4
+```
+
+Expected: `100.72.2.99` (or similar 100.64.x.x address). If the address is outside 100.64.0.0/10, STOP and flag — the Tailscale ACL / custom IP pool has been reconfigured and the firewall scope below must be adjusted.
+
+- [ ] **Step 2: Apply scope change**
+
+```powershell
+Get-NetFirewallRule -DisplayGroup 'Remote Desktop' | Where-Object Direction -eq 'Inbound' | ForEach-Object {
+    Set-NetFirewallRule -Name $_.Name -RemoteAddress '100.64.0.0/10'
+}
+```
+
+- [ ] **Step 3: Verify the scope is set**
+
+```powershell
+Get-NetFirewallRule -DisplayGroup 'Remote Desktop' | Where-Object Direction -eq 'Inbound' |
+    ForEach-Object { $_ | Select-Object DisplayName, @{N='RemoteAddress';E={($_ | Get-NetFirewallAddressFilter).RemoteAddress}} }
+```
+
+Expected: every inbound Remote Desktop rule shows `RemoteAddress = 100.64.0.0/10`.
+
+- [ ] **Step 4: Prove the lockdown behaves correctly**
+
+  - From travel laptop over Tailscale: `mstsc /v:100.72.2.99` — should still connect.
+  - From any home-LAN machine (e.g. a phone on the same Wi-Fi, or the travel laptop after disconnecting Tailscale and joining the home Wi-Fi): try `mstsc /v:192.168.4.103` — should FAIL (time out or refused).
+
+Record both outcomes in the runbook. If the home-LAN test succeeds, the firewall scope didn't stick — re-run Step 2 and re-verify.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add runbooks/remote-plc-programming.md
+git commit -m "ops(plc-laptop): restrict RDP to Tailscale CGNAT range"
+```
+
+### Task 7: PLC subnet isolation
+
+**Files:**
+- Modify: `runbooks/remote-plc-programming.md` — PLC subnet isolation section
+
+- [ ] **Step 1: Check for parasitic APIPA and remove any address found**
+
+```powershell
+Get-NetIPAddress -InterfaceAlias 'Ethernet' -AddressFamily IPv4 | Format-Table IPAddress, PrefixLength
+```
+
+If any `169.254.x.x` appears alongside `192.168.1.50`, capture the actual address (it's randomized per-adapter, not necessarily `.100.1`) and remove it:
+```powershell
+$apipa = (Get-NetIPAddress -InterfaceAlias 'Ethernet' -AddressFamily IPv4 |
+          Where-Object { $_.IPAddress -like '169.254.*' }).IPAddress
+if ($apipa) {
+    Write-Host "Removing parasitic APIPA: $apipa"
+    netsh interface ipv4 delete address 'Ethernet' addr=$apipa
+} else {
+    Write-Host 'No parasitic APIPA present.'
+}
+```
+
+Verify: re-run the initial `Get-NetIPAddress` command — only `192.168.1.50/24` should remain.
+
+- [ ] **Step 2: Disable APIPA persistence on the Ethernet NIC**
+
+```powershell
+$guid = (Get-NetAdapter -Name 'Ethernet').InterfaceGuid
+$path = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$guid"
+Set-ItemProperty -Path $path -Name IPAutoconfigurationEnabled -Type DWord -Value 0
+Get-ItemProperty -Path $path -Name IPAutoconfigurationEnabled
+```
+
+Expected: `IPAutoconfigurationEnabled : 0`.
+
+- [ ] **Step 3: Confirm no IP forwarding between NICs**
+
+```powershell
+Get-NetIPInterface | Where-Object Forwarding -eq 'Enabled'
+```
+
+Expected: no output. If any interface shows Enabled forwarding, disable it:
+```powershell
+Set-NetIPInterface -InterfaceAlias '<alias>' -Forwarding Disabled
+```
+and re-run the query to confirm.
+
+- [ ] **Step 4: Confirm PLC still reachable from PLC laptop (regression guard)**
+
+```powershell
+Test-NetConnection -ComputerName 192.168.1.100 -Port 44818
+Test-NetConnection -ComputerName 192.168.1.100 -Port 502
+```
+
+Expected: both `TcpTestSucceeded : True`. If either fails, revert Steps 1-3 — the APIPA removal or forwarding change broke the cable path.
+
+- [ ] **Step 5: Record in runbook** — commands + verify output for each substep.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add runbooks/remote-plc-programming.md
+git commit -m "ops(plc-laptop): isolate PLC subnet and disable APIPA persistence"
+```
+
+**Chunk 2 exit criteria:**
+- RDP over Tailscale works; RDP from home LAN does not.
+- Tailscale stays up across a Windows sign-out.
+- Laptop does not sleep on AC; auto-login configured.
+- PLC (192.168.1.100) still reachable from PLC laptop on ports 502 and 44818.
+- All five tasks committed with runbook entries.
+
+---
+
+## Chunk 3: End-to-end verification
+
+### Task 8: Cold-boot test
+
+**Files:**
+- Modify: `runbooks/remote-plc-programming.md` — Cold-boot verification section
+
+- [ ] **Step 1: Cold power-cycle the PLC laptop**
+
+Physical: hold the power button until the laptop is off, wait ~10 seconds, power on. Do NOT sign in; step away. Alternative if remote-only: `Restart-Computer -Force` from the existing RDP session (expect ~5 min before Step 2 will succeed).
+
+- [ ] **Step 2: Wait 2 minutes, then from travel laptop**
+
+```
+tailscale ping 100.72.2.99
+```
+
+Expected: responds within a few pings. If it doesn't after 3 minutes total:
+- Unattended mode may not be saved (check `Get-Service Tailscale` status and `tailscale status --json` once you're back in)
+- Auto-login may have failed (laptop stuck at sign-in screen — Tailscale service should still be up though, so this usually isn't the cause of ping failure unless the service itself didn't start)
+- Power is actually off (flip it back on physically)
+
+- [ ] **Step 3: From travel laptop, RDP in**
+
+`mstsc /v:100.72.2.99` → credential prompt → desktop.
+
+- [ ] **Step 4: From the RDP session, open CCW and connect to the Micro 820**
+
+Open the existing CCW solution (`MIRA_PLC.ccwsln`). Connection path `LAPTOP-0KA3C70H!AB_ETHIP-2\192.168.1.100` should still be valid. Go online, confirm no connection errors.
+
+- [ ] **Step 5: Push a harmless round-trip change**
+
+In CCW, modify a single rung comment in the existing program. Download to PLC. Go online, verify the changed comment is present. Revert the comment, download again. Trivial, reversible, but proves the full write path works from the travel laptop.
+
+- [ ] **Step 6: Record in runbook**
+
+- Time from power-on to RDP-ready (target: ≤2 minutes).
+- Any issues encountered and their workarounds.
+- CCW round-trip outcome (PASS/FAIL).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add runbooks/remote-plc-programming.md
+git commit -m "docs(runbook): cold-boot verification results"
+```
+
+### Task 9: Write the break-glass procedure
+
+**Files:**
+- Modify: `runbooks/remote-plc-programming.md` — Break-glass recovery section
+
+- [ ] **Step 1: Write the procedure**
+
+Content to paste:
+```
+When to use: Tailscale login state is lost on the PLC laptop (manually logged out,
+node removed from admin console, device reset). Remote access is gone; only physical
+access (or home-LAN RDP if it's still enabled) will work.
+
+Requires: Physical or home-LAN access to the PLC laptop + the pre-auth key from
+the password manager entry "PLC laptop Tailscale break-glass".
+
+Steps:
+  1. Sign in to Windows on the PLC laptop.
+  2. Retrieve the pre-auth key from the password manager.
+  3. Open elevated PowerShell and run:
+       & 'C:\Program Files\Tailscale\tailscale.exe' up --authkey=<KEY> --unattended
+  4. From the travel laptop, verify `tailscale status` shows laptop-0ka3c70h online.
+  5. Clear clipboard history / any temp file that held the key.
+  6. If the key is near expiry (check entry notes) or was single-use, generate a
+     new key in the Tailscale admin console and update the password manager entry.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add runbooks/remote-plc-programming.md
+git commit -m "docs(runbook): break-glass Tailscale recovery procedure"
+```
+
+### Task 10: Start the 7-day unattended test
+
+**Files:**
+- Modify: `runbooks/remote-plc-programming.md` — 7-day unattended test section
+- Optional Create: `scripts/travel_laptop/ping_plc_laptop.ps1`
+
+- [ ] **Step 1: Record start time in runbook**
+
+Note the exact timestamp you stop touching the PLC laptop — the 7-day window starts now.
+
+- [ ] **Step 2: Pick a probe strategy**
+
+  - **Option A (minimal):** once per day, manually run `tailscale ping 100.72.2.99` from the travel laptop and note the result in the runbook.
+  - **Option B (automated):** Windows scheduled task on the travel laptop runs the probe hourly and appends to a log.
+
+For Option A, skip to Step 4.
+
+- [ ] **Step 3: If Option B, create the probe script**
+
+**File:** `scripts/travel_laptop/ping_plc_laptop.ps1`
+```powershell
+$ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+$result = & 'C:\Program Files\Tailscale\tailscale.exe' ping --c 1 100.72.2.99 2>&1
+Add-Content -Path "$PSScriptRoot\plc_laptop_reachability.log" -Value "$ts $result"
+```
+
+Register it via `Register-ScheduledTask`. Substitute `$scriptPath` below with the absolute path where you cloned this repo's `scripts/travel_laptop/ping_plc_laptop.ps1` — it must be an absolute path, not a relative one, since Scheduled Tasks run with no working directory context:
+```powershell
+$scriptPath = 'C:\Users\hharp\Documents\CCW\MIRA_PLC\scripts\travel_laptop\ping_plc_laptop.ps1'  # adjust to your actual path
+$action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument "-NoProfile -File `"$scriptPath`""
+$trigger = New-ScheduledTaskTrigger -Once -At (Get-Date) -RepetitionInterval (New-TimeSpan -Hours 1)
+Register-ScheduledTask -TaskName 'PingPlcLaptop' -Action $action -Trigger $trigger
+```
+
+Commit the script:
+```bash
+git add scripts/travel_laptop/ping_plc_laptop.ps1
+git commit -m "ops(travel-laptop): hourly Tailscale reachability probe"
+```
+
+- [ ] **Step 4: After 7 days, record the outcome in the runbook**
+
+- Start timestamp, end timestamp.
+- Total probe count, success count (Option B) or daily result list (Option A).
+- Any visible gaps: duration and suspected cause.
+- Final status: PASS if ≥99% of probes succeeded with no gap longer than 10 minutes; otherwise INVESTIGATE and document.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add runbooks/remote-plc-programming.md
+git commit -m "docs(runbook): 7-day unattended test outcome"
+```
+
+**Chunk 3 exit criteria:**
+- Cold-boot test passed and documented.
+- Break-glass procedure written.
+- 7-day unattended test complete, outcome recorded.
+- All spec success criteria met:
+  - Cold-boot-to-reachable ≤2 minutes, no human at the PLC laptop.
+  - ≥7 consecutive days reachable with no intervention.
+  - End-to-end CCW program push + read-back succeeded from the travel laptop.
+
+---
+
+## Post-completion notes
+
+- Every command in Chunk 2 is idempotent and safe to re-run. The runbook is the install guide if the laptop is ever rebuilt.
+- If the same hardening needs to be applied to a second machine later, factor the Chunk 2 commands into a single `scripts/plc_laptop_harden/apply.ps1` at that point — not now (YAGNI; you have one laptop).
+- Break-glass key rotation is the only ongoing maintenance task. Calendar reminder for the key expiry date noted in Task 4 Step 3.

--- a/plc/ccw/runbooks/remote-plc-programming.md
+++ b/plc/ccw/runbooks/remote-plc-programming.md
@@ -1,0 +1,199 @@
+# Remote PLC Programming Runbook
+
+**Spec:** [specs/2026-04-24-remote-plc-programming-design.md](../specs/2026-04-24-remote-plc-programming-design.md)
+**Plan:** [plans/2026-04-24-remote-plc-programming.md](../plans/2026-04-24-remote-plc-programming.md)
+**Status:** Automated hardening applied 2026-04-24. Remaining verification + Task 4/5 manual steps tracked as GitHub issues Mikecranesync/MIRA #551–#559.
+
+## Baseline (starting state)
+
+**Captured:** 2026-04-24
+**Host:** LAPTOP-0KA3C70H
+
+### Tailscale
+- Self: `100.72.2.99` (v4), `fd7a:115c:a1e0::7237:263` (v6), hostname `laptop-0ka3c70h`
+- Service `Tailscale`: Running, StartType Automatic.
+- Peer `miguelomaniac` (100.83.251.23, travel laptop): reachable, `tailscale ping` 22ms via direct path (192.168.4.35:41641).
+
+### Incident discovered and fixed during baseline
+
+The peer `pi-factory` (100.109.92.62, offline 50+ days) is persistently advertising `192.168.1.0/24` as a subnet route. When `--accept-routes` was enabled on this laptop (implicitly from a recent Tailscale reconnect), the tailnet subnet route won routing priority (metric 0) over the local Ethernet NIC's route (metric 10), and all traffic to the PLC was being tunneled into Tailscale instead of going out the direct cable. Result: PLC unreachable via ICMP and TCP, even though EIP List Identity broadcast still found it.
+
+Fix applied:
+```
+"C:\Program Files\Tailscale\tailscale.exe" set --accept-routes=false
+```
+
+After fix: route for `192.168.1.0/24` goes via `Ethernet` (metric 10), ping returns in <1ms, TCP/502 and TCP/44818 both open.
+
+This preference is persistent. Keep `--accept-routes=false` on the PLC laptop indefinitely — it is a jump host, not a consumer of subnet routes advertised by other peers.
+
+### Services
+| Name | StartType | Status | Note |
+|------|-----------|--------|------|
+| Tailscale | Automatic | Running | — |
+| TermService | **Manual** | Running | Task 5 will set Automatic |
+
+### Ethernet NIC
+| IP | Prefix | PrefixOrigin | Note |
+|----|--------|--------------|------|
+| 192.168.1.50 | 24 | Manual | legit static for PLC subnet |
+| 169.254.100.1 | 16 | Manual | parasitic APIPA; Task 7 cleanup |
+
+Link: Up, 100 Mbps, Connected. MAC of PLC in ARP: `5c-88-16-d8-e4-d7` (matches memory).
+
+### IP forwarding
+No NIC has forwarding enabled. Good.
+
+### RDP status (current)
+- `fDenyTSConnections` = **1** → RDP connections currently **disabled**. Task 3 will enable.
+- `UserAuthentication` = 1 → NLA already required (config present even though RDP is off).
+- Firewall rules query returned Access Denied from non-elevated session — will verify in Task 3/6.
+
+### Power
+- Active power scheme: `b1bb486f-db87-4e9c-96aa-b85e8e2a5da4` ("My Custom Plan 1")
+- `HiberbootEnabled` = **1** → Fast Startup ON. Task 5 will disable.
+
+### PLC reachability from PLC laptop (after route fix)
+- `ping 192.168.1.100`: 3/3 replies, <1ms.
+- `Test-NetConnection ... -Port 502`: `TcpTestSucceeded : True`.
+- `Test-NetConnection ... -Port 44818`: `TcpTestSucceeded : True`.
+- `Find-NetRoute` shows source address `169.254.100.1` (the parasitic APIPA winning source-selection). Path still works, but Task 7's APIPA cleanup will also clean up source selection.
+
+## Tailscale persistence
+
+### accept-routes = false (applied during baseline)
+`tailscale set --accept-routes=false` applied 2026-04-24 to work around the `pi-factory` subnet-route hijack (see Baseline > Incident). Persistent preference; keep this off.
+
+### Service auto-restart on failure (Task 4 Step 4, applied via apply.ps1)
+```
+sc.exe failure Tailscale reset= 86400 actions= restart/5000/restart/5000/restart/5000
+```
+Verify output of `sc qfailure Tailscale`:
+```
+SERVICE_NAME: Tailscale
+    RESET_PERIOD (in seconds)    : 86400
+    FAILURE_ACTIONS              : RESTART -- Delay = 5000 milliseconds.
+                                   RESTART -- Delay = 5000 milliseconds.
+                                   RESTART -- Delay = 5000 milliseconds.
+```
+
+### Unattended Mode (Task 4 Step 1) — **manual, tracked in Mikecranesync/MIRA#551**
+Tailscale tray icon → Preferences → check "Run unattended". UAC prompt; accept.
+
+Verify after: sign out of Windows, wait ~30 seconds, from travel laptop run `tailscale status` — the `laptop-0ka3c70h` row should still be online (not offline). Sign back in.
+
+### Disable key expiry (Task 4 Step 2) — **manual, tracked in Mikecranesync/MIRA#552**
+Browser → https://login.tailscale.com/admin/machines → find `laptop-0ka3c70h` → `...` menu → Disable key expiry.
+
+Verify after: the machine row in the admin console no longer shows an expiry date.
+
+### Break-glass pre-auth key (Task 4 Step 3) — **manual, tracked in Mikecranesync/MIRA#553**
+Admin console → Settings → Keys → Generate auth key. Options: **Reusable ON, Ephemeral OFF, expiry 90 days**. Copy the key. Save in password manager under entry "PLC laptop Tailscale break-glass". Record the expiry date below when done.
+
+**Pre-auth key expiry recorded:** _(fill in after generating)_
+
+## Windows availability
+Applied 2026-04-24 via `scripts/plc_laptop_harden/apply.ps1`.
+
+### Power plan
+```
+powercfg /change standby-timeout-ac 0
+powercfg /change hibernate-timeout-ac 0
+powercfg /change monitor-timeout-ac 10
+powercfg /hibernate off
+powercfg /setacvalueindex SCHEME_CURRENT SUB_NONE CONSOLELOCK 0
+powercfg /setactive SCHEME_CURRENT
+```
+Result: never sleep / never hibernate on AC; monitor blanks after 10 min; no password prompt on wake.
+
+### Fast Startup
+`HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power\HiberbootEnabled` = **0** (off).
+
+### Service startup types
+| Service | StartType | Status |
+|---------|-----------|--------|
+| Tailscale | Automatic | Running |
+| TermService | Automatic | Running |
+
+(Baseline showed TermService Manual; script switched it to Automatic without needing the registry fallback.)
+
+### Windows auto-login (Task 5 Step 4 — optional, tracked in Mikecranesync/MIRA#554)
+Not applied. To set up: download Sysinternals Autologon from https://learn.microsoft.com/en-us/sysinternals/downloads/autologon, launch, enter local account credentials, click Enable. Until then, a reboot will land at the Windows sign-in screen — Tailscale unattended mode (when enabled via Task 4) still keeps the tunnel up, but no one can open a desktop session until someone signs in once.
+
+## RDP lockdown
+
+### Task 3: Enable RDP with NLA
+Applied 2026-04-24 via `scripts/plc_laptop_harden/apply.ps1` (elevated).
+
+Commands:
+```
+Set-ItemProperty 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name fDenyTSConnections -Value 0
+Set-ItemProperty 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -Name UserAuthentication -Value 1
+Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'
+```
+
+Verify (post-apply):
+- `fDenyTSConnections` = **0** (RDP allowed).
+- `UserAuthentication` = **1** (NLA required).
+- Port 3389 listening on `0.0.0.0` and `::` (both IPv4/IPv6), State = Listen.
+- End-to-end connect test from travel laptop (`mstsc /v:100.72.2.99`): tracked in Mikecranesync/MIRA#555.
+
+### Task 6: Scope RDP to Tailscale only
+Applied 2026-04-24 via `scripts/plc_laptop_harden/apply.ps1`.
+
+Pre-check: Tailscale self-IPv4 = `100.72.2.99`, inside `100.64.0.0/10` ✓.
+
+Three inbound rules scoped:
+| Rule | RemoteAddress |
+|------|---------------|
+| Remote Desktop - User Mode (TCP-In) | `100.64.0.0/255.192.0.0` |
+| Remote Desktop - User Mode (UDP-In) | `100.64.0.0/255.192.0.0` |
+| Remote Desktop - Shadow (TCP-In)    | `100.64.0.0/255.192.0.0` |
+
+Negative test (RDP from home LAN must fail): tracked in Mikecranesync/MIRA#556.
+
+## PLC subnet isolation
+Applied 2026-04-24 via `scripts/plc_laptop_harden/apply.ps1`.
+
+### APIPA cleanup
+- Parasitic `169.254.100.1/16` removed from Ethernet NIC via
+  `netsh interface ipv4 delete address Ethernet addr=169.254.100.1`.
+- Persistence disabled via registry:
+  `HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\{GUID}\IPAutoconfigurationEnabled = 0`
+  so Windows will not auto-assign 169.254.x.x on Ethernet after driver reloads or cable unplug events.
+
+Post-apply NIC state: only `192.168.1.50/24` on the Ethernet adapter.
+
+### IP forwarding
+`Get-NetIPInterface | Where-Object Forwarding -eq 'Enabled'` returned empty. No bridging between Tailscale, Wi-Fi, and the PLC subnet.
+
+### Regression guard — PLC still reachable
+- `Test-NetConnection -ComputerName 192.168.1.100 -Port 502`: `TcpTestSucceeded : True`.
+- `Test-NetConnection -ComputerName 192.168.1.100 -Port 44818`: `TcpTestSucceeded : True`.
+
+## Cold-boot verification
+Tracked in Mikecranesync/MIRA#557. Run after the three Task 4 manual steps are done.
+
+## 7-day unattended test
+Tracked in Mikecranesync/MIRA#558. Start after cold-boot verification passes.
+
+## Break-glass recovery
+
+**When to use:** Tailscale login state is lost on the PLC laptop (manually logged out, node removed from admin console, device reset). Remote access is gone; only physical access (or home-LAN RDP if it's still enabled — it is not, after Task 6) will work.
+
+**Requires:** Physical access to the PLC laptop + the pre-auth key from the password manager entry *"PLC laptop Tailscale break-glass"*.
+
+**Steps:**
+1. Sign in to Windows on the PLC laptop.
+2. Retrieve the pre-auth key from the password manager.
+3. Open elevated PowerShell and run:
+   ```
+   & 'C:\Program Files\Tailscale\tailscale.exe' up --authkey=<KEY> --unattended
+   ```
+4. From the travel laptop, verify `tailscale status` shows `laptop-0ka3c70h` online at `100.72.2.99`.
+5. Clear clipboard history / any temp file that held the key.
+6. If the key is near expiry (check password-manager entry notes) or was single-use, generate a new key in the Tailscale admin console and update the password-manager entry.
+
+**Collateral to check after recovery:**
+- `tailscale set --accept-routes=false` is still in effect (re-running `tailscale up --authkey=...` does not reset this pref, but verify with `Get-NetRoute -DestinationPrefix '192.168.1.0/24'` that no Tailscale route exists for the PLC subnet).
+- RDP from travel laptop works end-to-end.

--- a/plc/ccw/scripts/plc_laptop_harden/apply.ps1
+++ b/plc/ccw/scripts/plc_laptop_harden/apply.ps1
@@ -1,0 +1,157 @@
+<#
+.SYNOPSIS
+  Apply PLC-laptop hardening from plans/2026-04-24-remote-plc-programming.md
+
+.DESCRIPTION
+  Idempotent. Applies Tasks 3, 4 (sc-failure part), 5 (automatable parts),
+  6, and 7 of the remote-PLC-programming plan. Must be run as Administrator.
+
+  Safe to re-run. Each section prints what it did + a verify result.
+
+  MANUAL steps NOT covered by this script (run them yourself):
+    - Tailscale Unattended Mode (tray icon -> Preferences -> Run unattended)
+    - Tailscale admin console: disable key expiry for laptop-0ka3c70h
+    - Tailscale admin console: generate reusable pre-auth key; save to password manager
+    - Sysinternals Autologon (Task 5 Step 4) to set Windows auto-login
+#>
+
+#Requires -RunAsAdministrator
+
+$ErrorActionPreference = 'Stop'
+$InformationPreference = 'Continue'
+
+$transcriptPath = Join-Path $PSScriptRoot 'apply.last-run.log'
+Start-Transcript -Path $transcriptPath -Force | Out-Null
+
+function Section($title) {
+    Write-Host ''
+    Write-Host ('=' * 72)
+    Write-Host "  $title"
+    Write-Host ('=' * 72)
+}
+
+Section 'Pre-flight'
+Write-Host "Hostname:             $env:COMPUTERNAME"
+Write-Host "Tailscale IPv4:       $((& 'C:\Program Files\Tailscale\tailscale.exe' ip -4).Trim())"
+Write-Host "PLC ping reachable:   $((Test-Connection -ComputerName 192.168.1.100 -Count 1 -Quiet))"
+
+# -----------------------------------------------------------------------------
+Section 'Task 3: Enable RDP with NLA'
+
+Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' `
+    -Name fDenyTSConnections -Value 0
+Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' `
+    -Name UserAuthentication -Value 1
+Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'
+
+# Verify
+$fDeny = (Get-ItemProperty 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name fDenyTSConnections).fDenyTSConnections
+$nla   = (Get-ItemProperty 'HKLM:\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp' -Name UserAuthentication).UserAuthentication
+Write-Host "fDenyTSConnections    = $fDeny (expected 0)"
+Write-Host "UserAuthentication    = $nla (expected 1)"
+
+# -----------------------------------------------------------------------------
+Section 'Task 4 (sc-failure part): Tailscale service auto-restart'
+
+& sc.exe failure Tailscale reset= 86400 actions= restart/5000/restart/5000/restart/5000 | Out-Null
+& sc.exe qfailure Tailscale
+
+# -----------------------------------------------------------------------------
+Section 'Task 5: Windows availability (power / fast-startup / services)'
+
+# 5a: Power plan
+& powercfg /change standby-timeout-ac 0
+& powercfg /change hibernate-timeout-ac 0
+& powercfg /change monitor-timeout-ac 10
+& powercfg /hibernate off
+& powercfg /setacvalueindex SCHEME_CURRENT SUB_NONE CONSOLELOCK 0
+& powercfg /setactive SCHEME_CURRENT
+Write-Host '(power tuned: no sleep / no hibernate / no console-lock on wake on AC)'
+
+# 5b: Disable Fast Startup
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power' `
+    -Name HiberbootEnabled -Value 0
+$fs = (Get-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Power' -Name HiberbootEnabled).HiberbootEnabled
+Write-Host "HiberbootEnabled      = $fs (expected 0)"
+
+# 5c: Service startup types
+Set-Service -Name Tailscale -StartupType Automatic
+try {
+    Set-Service -Name TermService -StartupType Automatic -ErrorAction Stop
+} catch {
+    Write-Host "Set-Service TermService failed ($_). Falling back to registry..."
+    Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\TermService' -Name Start -Value 2
+}
+Get-Service Tailscale, TermService | Select-Object Name, StartType, Status | Format-Table -AutoSize
+
+# -----------------------------------------------------------------------------
+Section 'Task 6: RDP lockdown to Tailscale 100.64.0.0/10'
+
+# Sanity-check Tailscale IP is actually inside the CGNAT range before tightening
+$tsIp = (& 'C:\Program Files\Tailscale\tailscale.exe' ip -4).Trim()
+if (-not ($tsIp -match '^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.')) {
+    Write-Warning "Tailscale IP $tsIp is NOT inside 100.64.0.0/10. Skipping RDP lockdown to avoid locking you out."
+} else {
+    Get-NetFirewallRule -DisplayGroup 'Remote Desktop' |
+        Where-Object Direction -eq 'Inbound' |
+        ForEach-Object {
+            Set-NetFirewallRule -Name $_.Name -RemoteAddress '100.64.0.0/10'
+            Write-Host "Scoped rule: $($_.DisplayName)"
+        }
+
+    # Verify
+    Get-NetFirewallRule -DisplayGroup 'Remote Desktop' |
+        Where-Object Direction -eq 'Inbound' |
+        ForEach-Object {
+            $remote = ($_ | Get-NetFirewallAddressFilter).RemoteAddress
+            [PSCustomObject]@{ Rule = $_.DisplayName; RemoteAddress = $remote }
+        } | Format-Table -AutoSize
+}
+
+# -----------------------------------------------------------------------------
+Section 'Task 7: PLC subnet isolation'
+
+# 7a: Remove parasitic APIPA if present
+$apipa = (Get-NetIPAddress -InterfaceAlias 'Ethernet' -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+          Where-Object { $_.IPAddress -like '169.254.*' }).IPAddress
+if ($apipa) {
+    Write-Host "Removing parasitic APIPA $apipa from Ethernet"
+    & netsh interface ipv4 delete address 'Ethernet' addr=$apipa | Out-Null
+} else {
+    Write-Host 'No parasitic APIPA present.'
+}
+
+# 7b: Disable APIPA persistence on the Ethernet NIC
+$guid = (Get-NetAdapter -Name 'Ethernet').InterfaceGuid
+$nicPath = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\$guid"
+Set-ItemProperty -Path $nicPath -Name IPAutoconfigurationEnabled -Type DWord -Value 0
+$apipaOff = (Get-ItemProperty -Path $nicPath -Name IPAutoconfigurationEnabled).IPAutoconfigurationEnabled
+Write-Host "IPAutoconfigurationEnabled (Ethernet) = $apipaOff (expected 0)"
+
+# 7c: IP forwarding check (no changes unless enabled somewhere)
+$fwd = Get-NetIPInterface | Where-Object Forwarding -eq 'Enabled'
+if ($fwd) {
+    Write-Warning "IP forwarding enabled on the following interfaces. Disabling:"
+    $fwd | Format-Table InterfaceAlias, AddressFamily -AutoSize
+    $fwd | ForEach-Object { Set-NetIPInterface -InterfaceAlias $_.InterfaceAlias -AddressFamily $_.AddressFamily -Forwarding Disabled }
+} else {
+    Write-Host 'No IP forwarding enabled anywhere. Good.'
+}
+
+# -----------------------------------------------------------------------------
+Section 'Final: regression check'
+
+Write-Host 'Post-hardening state:'
+Get-NetIPAddress -InterfaceAlias 'Ethernet' -AddressFamily IPv4 | Format-Table IPAddress, PrefixLength -AutoSize
+(Test-NetConnection -ComputerName 192.168.1.100 -Port 502  -WarningAction SilentlyContinue) | Select-Object ComputerName, RemotePort, TcpTestSucceeded | Format-Table -AutoSize
+(Test-NetConnection -ComputerName 192.168.1.100 -Port 44818 -WarningAction SilentlyContinue) | Select-Object ComputerName, RemotePort, TcpTestSucceeded | Format-Table -AutoSize
+Get-Service Tailscale, TermService | Select-Object Name, StartType, Status | Format-Table -AutoSize
+
+Write-Host ''
+Write-Host 'Done. Now do the MANUAL steps:'
+Write-Host '  1. Tailscale tray icon -> Preferences -> check "Run unattended"'
+Write-Host '  2. https://login.tailscale.com/admin/machines -> laptop-0ka3c70h -> Disable key expiry'
+Write-Host '  3. Settings -> Keys -> generate reusable auth key; save to password manager'
+Write-Host '  4. (Optional) Sysinternals Autologon to configure Windows auto-login'
+
+Stop-Transcript | Out-Null

--- a/plc/ccw/specs/2026-04-24-remote-plc-programming-design.md
+++ b/plc/ccw/specs/2026-04-24-remote-plc-programming-design.md
@@ -1,0 +1,111 @@
+# Remote PLC Programming — Design
+
+**Date:** 2026-04-24
+**Status:** Approved (brainstorm)
+**Scope:** Enable remote programming of the Micro 820 PLC from the travel laptop over Tailscale, keeping the PLC on an isolated subnet.
+
+## Goal
+
+Program the Allen-Bradley Micro 820 (2080-LC20-20QBB, static IP 192.168.1.100) from the travel laptop wherever it has internet, without exposing the PLC to the home LAN or the public internet.
+
+## Non-goals
+
+- Access from arbitrary third-party machines.
+- Access for additional humans on the tailnet.
+- Wake-on-LAN, LTE backup, or any secondary network path.
+- Putting the PLC on the home LAN (option B in brainstorm). Rejected — PLC stays isolated.
+- Installing CCW on the travel laptop. RDP-based remote use only.
+- Mobile / phone-based CCW use.
+
+## Architecture
+
+```
+[Travel laptop]  ──Tailscale──▶  [PLC laptop]  ──Eth cable──▶  [Micro 820]
+ 100.83.251.23                    100.72.2.99                    192.168.1.100
+ mstsc (RDP client)               RDP host + CCW                 isolated /24,
+                                  (jump host)                     no other devices
+```
+
+- **PLC laptop** (LAPTOP-0KA3C70H) is the single bridge. CCW runs there.
+- **Travel laptop** needs only an RDP client and Tailscale — no CCW, no Rockwell software.
+- **Point-to-point 192.168.1.0/24** between PLC laptop Ethernet NIC (192.168.1.50) and the PLC. No switch, no router, no other endpoints.
+- **Home LAN** (192.168.4.0/24) and Tailscale tailnet (100.64.0.0/10) remain strictly separate from the PLC subnet. No IP forwarding between NICs.
+
+## Components
+
+### 1. Tailscale persistence on PLC laptop
+
+The laptop must stay reachable without any human at the keyboard.
+
+- **Unattended Mode** enabled (Tailscale tray → Preferences → Run unattended). Required so Tailscale runs without an interactive Windows session.
+- **Key expiry disabled** for the PLC-laptop node in the Tailscale admin console. Prevents forced re-auth every 180 days.
+- **Service auto-restart** on failure:
+  `sc failure Tailscale reset=86400 actions=restart/5000/restart/5000/restart/5000`
+- **Break-glass pre-auth key:** generate a reusable, non-expiring auth key; store encrypted in password manager. Used via `tailscale up --authkey=<key>` if auth state is ever lost and someone physically accesses the laptop.
+
+### 2. Windows availability config
+
+- Power plan: **never sleep / never hibernate on AC**, disable USB selective suspend.
+- **Fast Startup OFF** (it defers NIC/service initialization in ways that break post-reboot network bring-up).
+- Services `Tailscale` and `TermService` set to **Automatic**.
+- **Auto-login** via Sysinternals `Autologon` (stores credential encrypted in LSA). Eliminates the "stuck at Windows sign-in screen" failure mode after an unattended reboot.
+
+### 3. RDP enabled and locked down
+
+- Remote Desktop enabled, **NLA required**.
+- Windows Firewall inbound rule for TCP 3389: **allow only from 100.64.0.0/10** (Tailscale CGNAT range). Block from LAN and public scopes explicitly.
+- Before trusting the firewall rule, verify the assigned Tailscale IPv4 actually falls inside 100.64.0.0/10: `tailscale ip -4` on the PLC laptop. If Tailscale is ever reconfigured with a custom IP pool, update the firewall rule accordingly.
+- Strong password on the RDP user account.
+- Optional hardening: Tailscale ACL restricting which tailnet nodes can reach port 3389 (currently a single-user tailnet, so low marginal value).
+
+### 4. PLC subnet isolation preserved
+
+- Ethernet NIC stays at 192.168.1.50/24, cabled direct to PLC at 192.168.1.100.
+- Remove the parasitic APIPA: `netsh interface ipv4 delete address "Ethernet" addr=169.254.100.1`.
+- Disable APIPA persistence on the Ethernet NIC via registry (`IPAutoconfigurationEnabled=0` under the NIC's `Tcpip\Parameters\Interfaces\{GUID}` key). Windows otherwise re-adds 169.254.x.x after driver reloads or cable-unplug events.
+- Verify IP forwarding disabled across NICs: `Get-NetIPInterface | Where-Object Forwarding -eq Enabled` should return nothing relevant. Windows default is off; just confirm.
+
+### 5. Verification / recovery runbook
+
+Short operational doc covering:
+
+- **Cold-boot test:** hard-power the PLC laptop → wait → from travel laptop, `tailscale ping 100.72.2.99` answers → RDP connects → CCW opens → PLC 192.168.1.100 reachable from the RDP session.
+- **End-to-end programming test:** open CCW over RDP, change a rung comment, download to PLC, read back, verify.
+- **7-day unattended test:** leave untouched for ≥7 days, confirm still reachable without intervention.
+- **Break-glass procedure:** physical access + `tailscale up --authkey=<stored-key>`.
+
+## Data flow
+
+1. User on travel laptop launches `mstsc`, targets `100.72.2.99`.
+2. Tailscale on both ends establishes WireGuard tunnel (direct if NAT allows, DERP-relayed otherwise).
+3. Windows NLA authenticates user credentials; RDP session starts.
+4. User opens CCW on the PLC laptop desktop, selects the existing project pointing at `LAPTOP-0KA3C70H!AB_ETHIP-2\192.168.1.100`.
+5. CCW issues EtherNet/IP operations over the Ethernet NIC to 192.168.1.100. Traffic never touches Tailscale or Wi-Fi.
+6. Downloads, online edits, and monitoring render back to the travel laptop as RDP pixels.
+
+## Failure modes and mitigations
+
+| Failure | Mitigation in design | Residual risk |
+|---------|---------------------|---------------|
+| User Windows session logs out | Unattended mode keeps Tailscale up | None |
+| Tailscale key expires | Key expiry disabled on node | None (until node is manually removed) |
+| Laptop reboots (Windows update) | Service auto-start + auto-login | Small window during reboot |
+| Laptop sleeps / hibernates | Power plan disables both | None |
+| Tailscale service crash | SC failure actions restart it | None for transient crashes |
+| Home power outage | — | Accepted; kills any remote option |
+| Home ISP outage | — | Accepted; kills any remote option |
+| Laptop hardware failure | Break-glass via physical access | Accepted |
+| Auth state lost (manual logout, admin console removal) | Pre-auth key for non-interactive recovery | Requires physical access |
+
+## Success criteria
+
+- **Cold-boot-to-reachable:** laptop hard-rebooted and idle, RDP session usable from travel laptop within 2 minutes, with no human at the PLC laptop.
+- **Unattended duration:** laptop runs ≥7 consecutive days with no intervention, remaining RDP-reachable over Tailscale throughout.
+- **Programming round-trip:** via the RDP session, push a CCW change to the PLC, read it back, confirm value — all from the travel laptop's physical location.
+
+## Out of scope (future)
+
+- Add a Raspberry Pi or Tailscale-capable router on the home LAN as a second always-on bridge. Decouples remote access from the PLC laptop's uptime.
+- LTE or secondary-ISP failover for the home network.
+- Wake-on-LAN triggered from VPS (Jarvis, 100.68.120.99) so a powered-down laptop can be woken remotely.
+- Multi-user tailnet with ACLs restricting PLC-laptop access by identity.


### PR DESCRIPTION
## Summary

Imports the spec, implementation plan, runbook, and consolidated PowerShell hardening script for remote programming the Micro 820 PLC over Tailscale + RDP. Lands at `plc/ccw/{specs,plans,runbooks,scripts}/`. Pure additive PR — touches no existing files except a 3-line `.gitignore` append.

The hardening was actually applied to the PLC laptop (LAPTOP-0KA3C70H) on 2026-04-24 — this PR captures the artifacts produced. Manual followups (Tailscale Unattended Mode, key expiry, pre-auth key, cold-boot test, 7-day unattended test, etc.) are already filed as #551–#559.

## What's in here

- **`plc/ccw/specs/2026-04-24-remote-plc-programming-design.md`** — design doc (architecture, components, failure modes, success criteria).
- **`plc/ccw/plans/2026-04-24-remote-plc-programming.md`** — 10-task / 3-chunk implementation plan with exact PowerShell + verify steps.
- **`plc/ccw/runbooks/remote-plc-programming.md`** — operational runbook with baseline + applied state for each task. Notably documents the `pi-factory` subnet-route hijack discovered + fixed during baseline (#559).
- **`plc/ccw/scripts/plc_laptop_harden/apply.ps1`** — idempotent elevated PowerShell that applies Tasks 3, 4 (sc-failure part), 5, 6, 7 in one run. Logs to transcript.

## Sibling issues

| # | Item |
|---|------|
| #551 | Tailscale Unattended Mode |
| #552 | Disable key expiry |
| #553 | Generate break-glass pre-auth key |
| #554 | Windows auto-login (optional) |
| #555 | E2E RDP test from travel laptop |
| #556 | RDP negative test (home LAN must fail) |
| #557 | Cold-boot reachability + CCW round-trip |
| #558 | 7-day unattended test |
| #559 | Retire pi-factory subnet advertisement |

## Test Plan

- [ ] `plc/ccw/scripts/plc_laptop_harden/apply.ps1` already executed cleanly on LAPTOP-0KA3C70H — transcript at `apply.last-run.log` (gitignored). All sections verified pass.
- [ ] Verify the relative doc links resolve (runbook → plan → spec) when browsed on GitHub at the new paths.
- [ ] Followup verification tracked as #551–#559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)