### PR TITLE
fix(bots): clean up pre-existing ruff lint errors (F541, I001)

### DIFF
--- a/mira-bots/shared/pm_scheduler.py
+++ b/mira-bots/shared/pm_scheduler.py
@@ -131,23 +131,23 @@ def _wo_number() -> str:
 
 def _build_description(pm: dict[str, Any]) -> str:
     lines = [
-        f"Auto-generated PM work order from manual extraction.",
-        f"",
+        "Auto-generated PM work order from manual extraction.",
+        "",
         f"Equipment: {pm['manufacturer']} {pm['model_number']}",
         f"Interval: Every {pm['interval_value']} {pm['interval_unit']}",
     ]
     if pm.get("source_citation"):
         lines.append(f"Manual reference: {pm['source_citation']}")
     if pm.get("parts_needed"):
-        lines.append(f"\nParts needed:")
+        lines.append("\nParts needed:")
         for p in pm["parts_needed"]:
             lines.append(f"  • {p}")
     if pm.get("tools_needed"):
-        lines.append(f"\nTools needed:")
+        lines.append("\nTools needed:")
         for t in pm["tools_needed"]:
             lines.append(f"  • {t}")
     if pm.get("safety_requirements"):
-        lines.append(f"\nSafety requirements:")
+        lines.append("\nSafety requirements:")
         for s in pm["safety_requirements"]:
             lines.append(f"  ⚠ {s}")
     confidence = pm.get("confidence")

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -13,7 +13,6 @@ from shared import tts
 from shared.chat.dispatcher import ChatDispatcher
 from shared.engine import Supervisor
 from telegram import Update
-from voice_transcription import transcribe_voice
 from telegram.constants import ChatAction
 from telegram.error import Conflict
 from telegram.ext import (
@@ -24,6 +23,7 @@ from telegram.ext import (
     MessageHandler,
     filters,
 )
+from voice_transcription import transcribe_voice
 
 logging.basicConfig(
     level=logging.INFO,


### PR DESCRIPTION
## Summary
- Strips `f` prefix from 5 f-strings that have no placeholders in `mira-bots/shared/pm_scheduler.py` (F541).
- Sorts `voice_transcription` import into the alphabetical third-party block in `mira-bots/telegram/bot.py` (I001).
- Unblocks the **Lint & Format** check on every PR to `main` (currently red on every PR including #917).

## Why
Both errors were pre-existing on `origin/main`. The `Lint & Format` workflow runs `ruff check .` repo-wide, so any PR — even a 3-line copy-only change like #917 — gets blocked by these unrelated issues:

```
mira-bots/shared/pm_scheduler.py:134:9: F541 [*] f-string without any placeholders
mira-bots/shared/pm_scheduler.py:135:9: F541 [*] f-string without any placeholders
mira-bots/shared/pm_scheduler.py:142:22: F541 [*] f-string without any placeholders
mira-bots/shared/pm_scheduler.py:146:22: F541 [*] f-string without any placeholders
mira-bots/shared/pm_scheduler.py:150:22: F541 [*] f-string without any placeholders
mira-bots/telegram/bot.py:3:1: I001 [*] Import block is un-sorted or un-formatted
```

## What
- Pure mechanical fixes from `ruff check --fix`. No behavior change — `f` prefix on a string with no `{}` is a no-op at runtime, and import order doesn't change runtime behavior.
- Verified clean: `ruff check` on both files reports `All checks passed!`

## Test plan
- [ ] `Lint & Format` job goes green on this PR
- [ ] Re-run CI on PR #917 after merge — confirm `Lint & Format` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)