### PR TITLE
fix(deploy-vps): pre-clean stale containers before docker compose up

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -57,18 +57,22 @@ jobs:
           git fetch origin main
           git reset --hard origin/main
 
+          # Resolve the rebuild list once so cleanup + build + up all agree.
+          TARGETS="${SERVICES:-mira-pipeline mira-ingest mira-mcp mira-hub}"
+          echo "Rebuild targets: $TARGETS"
+
+          echo "=== Pre-deploy cleanup: remove any stale containers blocking recreate ==="
+          # `docker compose up --force-recreate` only removes containers it considers part
+          # of the project; if a previous deploy left a same-named container that compose
+          # has lost track of, we hit `Error: container name already in use` and the deploy
+          # bails out (exact failure mode of run 25264673954, 2026-05-02).
+          for svc in $TARGETS; do
+            docker rm -f "${svc}-saas" 2>/dev/null || true
+          done
+
           echo "=== Rebuild containers ==="
-          if [ -n "${SERVICES:-}" ]; then
-            echo "Selective rebuild: $SERVICES"
-            DOCKER_BUILDKIT=1 doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml build $SERVICES
-            doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml up -d --no-deps --force-recreate $SERVICES
-          else
-            echo "Full rebuild (mira-pipeline, mira-ingest, mira-mcp, mira-hub)"
-            DOCKER_BUILDKIT=1 doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml build \
-              mira-pipeline mira-ingest mira-mcp mira-hub
-            doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml up -d --no-deps --force-recreate \
-              mira-pipeline mira-ingest mira-mcp mira-hub
-          fi
+          DOCKER_BUILDKIT=1 doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml build $TARGETS
+          doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml up -d --no-deps --force-recreate $TARGETS
 
           echo "=== Health check ==="
           sleep 8


### PR DESCRIPTION
## Summary
- Adds a defensive \`docker rm -f <svc>-saas\` sweep right before \`docker compose up\` so a stale container from a prior partial-failure deploy can't block the recreate.
- Dedupes the \`SERVICES\` vs default-list branch into a single \`TARGETS\` variable used by cleanup + build + up.

## Why now
Run [25264673954](https://github.com/Mikecranesync/MIRA/actions/runs/25264673954) (auto-fired after #921 merged on 2026-05-02) failed mid-deploy with:

\`\`\`
Error response from daemon: Error when allocating new name: Conflict.
The container name "/mira-mcp-saas" is already in use by container "0ece9...".
You have to remove (or rename) that container to be able to reuse that name.
\`\`\`

\`docker compose up --force-recreate\` only removes containers compose considers part of its project. If a previous deploy crashed mid-\`up\` and left a same-named container compose lost track of, the recreate hits a name collision and the deploy aborts. **That happened today — production app.factorylm.com is currently half-deployed** (root redirects to \`/feed/\` instead of \`/login\`, hub health endpoint 301 instead of 200).

## What

\`\`\`diff
+ TARGETS="\${SERVICES:-mira-pipeline mira-ingest mira-mcp mira-hub}"
+
+ echo "=== Pre-deploy cleanup: remove any stale containers blocking recreate ==="
+ for svc in \$TARGETS; do
+   docker rm -f "\${svc}-saas" 2>/dev/null || true
+ done
+
  echo "=== Rebuild containers ==="
- if [ -n "\${SERVICES:-}" ]; then ...full vs selective branches... fi
+ DOCKER_BUILDKIT=1 ... build \$TARGETS
+ ... up -d --no-deps --force-recreate \$TARGETS
\`\`\`

The \`docker rm -f\` is safe in this context because:
1. The very next step is \`up -d --force-recreate\`, which would have removed and recreated these same containers anyway. The cleanup just guarantees the removal happens even when compose has lost track.
2. The downtime window is identical to the existing \`--force-recreate\` window — we're not introducing new visible-to-users downtime.
3. \`|| true\` keeps the script from failing if a target container doesn't exist (first-deploy case).

## Test plan
- [ ] Merge this PR.
- [ ] Trigger \`workflow_dispatch\` of \`deploy-vps.yml\` (or wait for the next push to main to fire it via smoke).
- [ ] Verify the cleanup step runs in the deploy log: \`docker rm -f mira-pipeline-saas mira-ingest-saas mira-mcp-saas mira-hub-saas\`.
- [ ] Verify deploy completes (compose ps shows all 4 \`-saas\` containers up).
- [ ] Verify \`https://app.factorylm.com/\` redirects to \`/login\` (currently goes to \`/feed/\`).
- [ ] Verify \`https://app.factorylm.com/hub/api/health\` returns 200 (currently 301).

🤖 Generated with [Claude Code](https://claude.com/claude-code)