### PR TITLE
chore(gitignore): also ignore audio render outputs in marketing/videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,10 @@ tools/web-review-runs/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/
 marketing/videos/**/*.mp4
 marketing/videos/**/*.mov
 marketing/videos/**/*.webm
+marketing/videos/**/*.mp3
+marketing/videos/**/*.wav
+marketing/videos/**/*.ogg
+marketing/videos/**/*.m4a
 
 # Obsidian per-machine state (track plugin config under .obsidian/, not these)
 wiki/.obsidian/workspace*


### PR DESCRIPTION
## Summary
Adds \`.mp3\` / \`.wav\` / \`.ogg\` / \`.m4a\` to the existing \`marketing/videos/**\` ignore block so promo-director voiceover audio stays out of git like the video binaries already do.

## Why
Each promo-director run emits both \`<demo>.mp4\` and \`voiceover.mp3\` into \`marketing/videos/<demo-name>/\`. The video extensions were already ignored; the audio extensions slipped through, leaving stray voiceover files showing up as untracked across sessions:

\`\`\`
marketing/videos/ux-demo-full-2026-04-27/voiceover.mp3   (1.2 MB)
marketing/videos/ux-demo-pilot-2026-04-27/voiceover.mp3  (193 KB)
marketing/videos/ux-demo-v2-2026-04-27/voiceover.mp3     (668 KB)
\`\`\`

Same rationale as the existing \`*.mp4\` rule: render output is large and regenerable from the pipeline; \`spend.json\` and any source manifests stay tracked.

## What
\`\`\`diff
 marketing/videos/**/*.mp4
 marketing/videos/**/*.mov
 marketing/videos/**/*.webm
+marketing/videos/**/*.mp3
+marketing/videos/**/*.wav
+marketing/videos/**/*.ogg
+marketing/videos/**/*.m4a
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)