### PR TITLE
fix(deploy-vps): hub health check accepts both basePath layouts (#928)

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -85,7 +85,12 @@ jobs:
           fi
 
           echo "=== mira-hub health check ==="
-          HUB_STATUS=$(curl -sf -o /dev/null -w "%{http_code}" http://127.0.0.1:3101/hub/api/health || echo "unreachable")
+          # Try empty-basePath path first (current Phase 2 deployment), fall back to /hub
+          # path so the check survives a future re-cutover. Mirrors the Dockerfile
+          # HEALTHCHECK fallback pattern. Closes #928.
+          HUB_STATUS=$(curl -sf -o /dev/null -w "%{http_code}" http://127.0.0.1:3101/api/health \
+            || curl -sf -o /dev/null -w "%{http_code}" http://127.0.0.1:3101/hub/api/health \
+            || echo "unreachable")
           echo "mira-hub health: $HUB_STATUS"
           if [ "$HUB_STATUS" != "200" ]; then
             echo "WARNING: mira-hub health returned $HUB_STATUS — check container logs"


### PR DESCRIPTION
## Summary
- Try `http://127.0.0.1:3101/api/health` first (current Phase 2 layout, `basePath=""`)
- Fall back to `/hub/api/health` for future-proofing if we ever re-cutover
- Mirrors the existing fallback in `Dockerfile` HEALTHCHECK (line 38)

## Why
After Phase 2 nginx cutover (2026-04-27), `mira-hub` builds with `NEXT_PUBLIC_BASE_PATH: ""`, so internal routes live at `/api/health`, not `/hub/api/health`. The deploy script kept probing the legacy `/hub` path and got 404 every time, printing a misleading WARNING in CI logs. Live verification (2026-05-03):

- `https://app.factorylm.com/api/health/` → 200 `{"status":"ok"}`
- `https://app.factorylm.com/hub/api/health/` → does not resolve (path stripped by nginx)

Container's own `Dockerfile` HEALTHCHECK was unaffected (already has both-paths fallback) — only the workflow's post-deploy probe was wrong.

## Test plan
- [ ] Wait for next deploy run (this PR + smoke green)
- [ ] Confirm log line shows `mira-hub health: 200` (not WARNING)
- [ ] Verify production unchanged: `curl -sSL https://app.factorylm.com/api/health` → 200

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)