### PR TITLE
feat(web): dark theme for the marketing landing page

### DIFF
--- a/mira-web/src/views/home.ts
+++ b/mira-web/src/views/home.ts
@@ -271,6 +271,44 @@ function footer(): string {
 }
 
 const PAGE_STYLES = `
+/* ─────────────────────────────────────────────────────────────────
+   Dark theme — scoped to the home page only by living inside the
+   inlined <style> block. Rebinds FactoryLM design tokens so existing
+   selectors (in _components.css too) flip to dark without any
+   per-component refactor. Other marketing pages (/pricing, /cmms,
+   /security, /limitations) keep their light theme.
+   Palette is matched to the embedded cartoon panels so the demos
+   feel native rather than pasted-in.
+   ─────────────────────────────────────────────────────────────────*/
+body {
+  --fl-bg-50:     #09090c;   /* page background — matches cartoon bg */
+  --fl-card-0:    #13141a;   /* cards / surfaces */
+  --fl-rule-200:  rgba(255,255,255,.08);
+  --fl-navy-900:  #ffffff;   /* primary headings / brand */
+  --fl-navy-700:  #e8eaf0;
+  --fl-ink-900:   #e8eaf0;   /* body text */
+  --fl-muted-600: rgba(232,234,240,.55); /* muted text */
+  --fl-orange-600:#f0a000;   /* primary accent — matches cartoon amber */
+  --fl-orange-500:#ffb547;
+  --fl-sky-100:   #0d1320;   /* hero gradient top — deep navy fade */
+  --fl-good:      #00d4aa;   /* lifted from FactoryLM green for dark contrast */
+  --fl-bad:       #ff7a5c;   /* lifted from FactoryLM red for dark contrast */
+  background: var(--fl-bg-50);
+  color: var(--fl-ink-900);
+}
+
+/* Compare columns hard-code light pink / green in _components.css for the
+   light marketing theme. Override with red/teal-tinted dark surfaces so the
+   ChatGPT-vs-MIRA contrast survives on the dark page. */
+.fl-col-bad {
+  background: rgba(255,122,92,0.07);
+  border-color: rgba(255,122,92,0.28);
+}
+.fl-col-good {
+  background: rgba(0,212,170,0.07);
+  border-color: rgba(0,212,170,0.28);
+}
+
 .fl-topbar {
   display: flex; align-items: center; justify-content: space-between;
   padding: var(--fl-sp-4) var(--fl-sp-6);


### PR DESCRIPTION
## What changed
factorylm.com home page flips from light to dark to match the embedded cartoons + the hub at app.factorylm.com. 38 lines of CSS in `home.ts`. No other marketing pages touched.

## Visual proof

Full-page screenshot, 1440 viewport, all sections (hero → OEMs → Projects → Compare → Cartoons → Built for the floor → Pricing → Footer):

`docs/promo-screenshots/2026-05-03_dark-after-v2_full.png` — committed alongside.

Section-by-section audit:
| Section | Status |
|---|---|
| Hero | ✓ Dark bg, white "FactoryLM" wordmark, amber "Meet MIRA" line |
| OEM trust band | ✓ White names on dark |
| Three Projects cards | ✓ Card surfaces flip via `--fl-card-0` rebind |
| MIRA vs ChatGPT compare | ✓ Red-tinted vs teal-tinted dark panels (the visual fail mode in v1 — fixed via explicit `.fl-col-bad/-good` overrides) |
| Cartoons | ✓ Embedded SVG demos now feel native, not pasted-in |
| Built for the floor | ✓ State pills + safety stop card pop on dark (safety = intentionally jarring) |
| Pricing teaser | ✓ Amber CTA, gray sub-copy |
| Footer | ✓ Sun-readable toggle still visible |

## Implementation
Token rebinding scoped to home only via the inlined `<style>${PAGE_STYLES}</style>` block. `_components.css` selectors flip automatically because they reference design tokens — no per-component refactor needed. Palette matches the cartoon panels (`#09090c` page, `#13141a` cards, `#f0a000` amber).

```
body { --fl-bg-50, --fl-card-0, --fl-navy-900, --fl-ink-900, ... }
.fl-col-bad / .fl-col-good { ...override hard-coded pinks/greens... }
```

## Test plan
- [x] `bun test src/views/__tests__/home.test.ts` — 18/18 pass
- [x] Local chrome-headless-shell full-page screenshot — clean
- [ ] Smoke (CI) — should pass; same selectors, no markup changes
- [ ] After merge: `gh workflow run deploy-vps.yml --ref main -f services=mira-web` to publish (per `feedback_deploy_vps_default_targets_excludes_mira_web.md` — auto-deploy targets don't include mira-web)

## Out of scope
- Other marketing pages (`/pricing`, `/cmms`, `/security`, `/limitations`) stay light. Easy follow-up: promote this token block to a `body.theme-dark` class in `_tokens.css` and add the class to those page renderers too.
- `/images/app-screenshot-desktop.png` returns 404 in prod. Pre-existing, separate issue.
- `feature-cartoons.js` logs a benign SVG console warning. Pre-existing typo, separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)