### PR TITLE
fix(web): register /images/* static route to unblock hero cartoon (v0.3.1)

### DIFF
--- a/mira-web/CHANGELOG.md
+++ b/mira-web/CHANGELOG.md
@@ -7,6 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 to the component (`mira-web/vX.Y.Z`) so they don't collide with the MIRA
 monorepo's top-level tag progression.
 
+## [0.3.1] — 2026-05-03
+
+### Fixed
+- **`/images/*` static route was missing.** v0.3.0 shipped the new hero
+  cartoon at `/images/hero-fault-lookup-cartoon.png`, but Hono's
+  `serveStatic` registrations in `src/server.ts` only covered `/public/*`
+  and a handful of explicit per-file paths — anything under `/images/`
+  404'd. Same root-cause as the pre-existing
+  `/images/app-screenshot-desktop.png` 404 flagged in PR #933. Adds
+  `app.use("/images/*", serveStatic({ root: "./public" }))` so the
+  conventional `/images/foo.png` path works without forcing a `/public/`
+  prefix in markup. (`mira-web/src/server.ts`)
+
 ## [0.3.0] — 2026-05-03
 
 ### Changed

--- a/mira-web/package.json
+++ b/mira-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "FactoryLM PLG funnel — CMMS acquisition & onboarding flow",
   "type": "module",
   "scripts": {

--- a/mira-web/src/server.ts
+++ b/mira-web/src/server.ts
@@ -281,6 +281,13 @@ if (process.env.NODE_ENV !== "test" && process.env.MIRA_DISABLE_PURGE_WORKER !==
 // ---------------------------------------------------------------------------
 
 app.use("/public/*", serveStatic({ root: "./" }));
+// Marketing/site imagery served at the conventional /images/* path so the
+// landing page can reference assets the way every other web app does
+// (without a /public/ prefix). Without this route, anything under
+// public/images/ 404s — that's the bug PR #933 flagged for
+// /images/app-screenshot-desktop.png and that the v0.3.0 hero swap
+// also tripped on. Fixed here for v0.3.1.
+app.use("/images/*", serveStatic({ root: "./public" }));
 app.use("/manifest.json", serveStatic({ path: "./public/manifest.json" }));
 app.use("/sw.js", serveStatic({ path: "./public/sw.js" }));
 app.use("/robots.txt", serveStatic({ path: "./public/robots.txt" }));


### PR DESCRIPTION
## Summary

v0.3.0 (#935) shipped the new hero cartoon HTML reference, but the asset itself 404s in production because Hono's \`serveStatic\` registrations in \`src/server.ts\` never covered \`/images/*\` — only \`/public/*\` and a handful of explicit per-file routes. Same root cause as the pre-existing \`/images/app-screenshot-desktop.png\` 404 PR #933 flagged.

One-line fix:

\`\`\`ts
app.use(\"/images/*\", serveStatic({ root: \"./public\" }))
\`\`\`

Plus v0.3.1 bump + CHANGELOG entry per the customer-facing versioning rule.

## Test plan
- [x] home.test.ts unchanged (route registration is invisible to rendered HTML)
- [ ] Post-deploy: \`curl -I https://factorylm.com/images/hero-fault-lookup-cartoon.png\` returns 200 + image/png

This branch is fresh from main (no merge conflicts). Replaces #936 which had conflicts from the prior squash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)