### PR TITLE
feat(web): tokenize dark theme + apply to /cmms — funnel palette unified (v0.4.0)

### DIFF
--- a/mira-web/CHANGELOG.md
+++ b/mira-web/CHANGELOG.md
@@ -7,6 +7,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 to the component (`mira-web/vX.Y.Z`) so they don't collide with the MIRA
 monorepo's top-level tag progression.
 
+## [0.4.0] — 2026-05-03
+
+### Added
+- **Shared dark-theme stylesheet** at `mira-web/public/_dark-theme.css`
+  carrying the FactoryLM design-token overrides (page bg, card surface,
+  ink, amber accent) plus the dark-tinted `.fl-col-bad` /
+  `.fl-col-good` overrides used by the ChatGPT-vs-MIRA compare blocks.
+  Any view that wants to opt into the dark palette now includes a
+  single `<link rel="stylesheet" href="/_dark-theme.css">` in its
+  `<head>` — no per-component refactor needed because existing
+  selectors reference the tokens via `var()`.
+
+### Changed
+- **`/cmms` and `/sample` adopt the dark palette.** This is the P0 fix
+  from the 2026-05-03 style audit (`tools/web-review-runs/
+  2026-05-03-style-audit/AUDIT.md`): `/cmms` is the conversion landing
+  page every "Start Free — magic link" click on home led to, and the
+  light-theme break in the funnel was the most visible inconsistency
+  on the site after v0.3.1 shipped the dark hero. (`views/cmms.ts`)
+- **`home.ts` no longer carries the dark-token block inline.** The
+  duplicated CSS moved to `_dark-theme.css`; `home.ts` keeps only
+  layout/typography styles unique to the home view. (`views/home.ts`)
+- **`/_dark-theme.css` registered as a static route** alongside
+  `_tokens.css` and `_components.css` in `src/server.ts`.
+
+### Notes
+- This intentionally does *not* touch `/limitations`, `/security`,
+  `/pricing`, `/blog`, the legal stack, or `/activated` (which has its
+  own bespoke dark theme via static HTML). Those are tracked in the
+  audit as P1/P2 with separate fixes coming.
+
 ## [0.3.1] — 2026-05-03
 
 ### Fixed

--- a/mira-web/package.json
+++ b/mira-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-web",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "FactoryLM PLG funnel — CMMS acquisition & onboarding flow",
   "type": "module",
   "scripts": {

--- a/mira-web/public/_dark-theme.css
+++ b/mira-web/public/_dark-theme.css
@@ -1,0 +1,44 @@
+/* ─────────────────────────────────────────────────────────────────
+   Dark theme — token overrides matched to the cartoon panel palette.
+
+   Including this stylesheet on a page rebinds the FactoryLM design
+   tokens (--fl-bg-50, --fl-card-0, etc.) to dark values. Existing
+   selectors in _components.css and per-view <style> blocks that
+   reference the tokens via var() flip to dark automatically — no
+   per-component refactor required.
+
+   Kept tiny on purpose. Page-specific layout/typography styles still
+   live with their views; only the *palette* is shared here.
+
+   Pages opted in: /, /cmms (and post-checkout /activated routes that
+   render via the cmms view).
+   ─────────────────────────────────────────────────────────────────*/
+
+body {
+  --fl-bg-50:     #09090c;   /* page background — matches cartoon bg */
+  --fl-card-0:    #13141a;   /* cards / surfaces */
+  --fl-rule-200:  rgba(255,255,255,.08);
+  --fl-navy-900:  #ffffff;   /* primary headings / brand */
+  --fl-navy-700:  #e8eaf0;
+  --fl-ink-900:   #e8eaf0;   /* body text */
+  --fl-muted-600: rgba(232,234,240,.55); /* muted text */
+  --fl-orange-600:#f0a000;   /* primary accent — matches cartoon amber */
+  --fl-orange-500:#ffb547;
+  --fl-sky-100:   #0d1320;   /* hero gradient top — deep navy fade */
+  --fl-good:      #00d4aa;   /* lifted from FactoryLM green for dark contrast */
+  --fl-bad:       #ff7a5c;   /* lifted from FactoryLM red for dark contrast */
+  background: var(--fl-bg-50);
+  color: var(--fl-ink-900);
+}
+
+/* Compare columns hard-code light pink / green in _components.css for the
+   light marketing theme. Override with red/teal-tinted dark surfaces so the
+   ChatGPT-vs-MIRA contrast survives on the dark page. */
+.fl-col-bad {
+  background: rgba(255,122,92,0.07);
+  border-color: rgba(255,122,92,0.28);
+}
+.fl-col-good {
+  background: rgba(0,212,170,0.07);
+  border-color: rgba(0,212,170,0.28);
+}

--- a/mira-web/src/server.ts
+++ b/mira-web/src/server.ts
@@ -296,6 +296,7 @@ app.use("/og-image.png", serveStatic({ path: "./public/og-image.png" }));
 // without the /public/ prefix (matches the head() helper's <link> output).
 app.use("/_tokens.css", serveStatic({ path: "./public/_tokens.css" }));
 app.use("/_components.css", serveStatic({ path: "./public/_components.css" }));
+app.use("/_dark-theme.css", serveStatic({ path: "./public/_dark-theme.css" }));
 app.use("/sun-toggle.js", serveStatic({ path: "./public/sun-toggle.js" }));
 app.use("/feature-cartoons.js", serveStatic({ path: "./public/feature-cartoons.js" }));
 app.use("/posthog-init.js", serveStatic({ path: "./public/posthog-init.js" }));

--- a/mira-web/src/views/cmms.ts
+++ b/mira-web/src/views/cmms.ts
@@ -366,6 +366,7 @@ export function renderCmms(reqUrl?: string): string {
 <html lang="en">
 <head>
   ${headHtml}
+  <link rel="stylesheet" href="/_dark-theme.css">
   <style>${PAGE_STYLES}</style>
 </head>
 <body>
@@ -393,6 +394,7 @@ export function renderSamplePlaceholder(): string {
 <html lang="en">
 <head>
   ${headHtml}
+  <link rel="stylesheet" href="/_dark-theme.css">
   <style>${PAGE_STYLES}
 .fl-sample-card {
   max-width: 640px; margin: var(--fl-sp-10) auto;

--- a/mira-web/src/views/home.ts
+++ b/mira-web/src/views/home.ts
@@ -271,43 +271,9 @@ function footer(): string {
 }
 
 const PAGE_STYLES = `
-/* ─────────────────────────────────────────────────────────────────
-   Dark theme — scoped to the home page only by living inside the
-   inlined <style> block. Rebinds FactoryLM design tokens so existing
-   selectors (in _components.css too) flip to dark without any
-   per-component refactor. Other marketing pages (/pricing, /cmms,
-   /security, /limitations) keep their light theme.
-   Palette is matched to the embedded cartoon panels so the demos
-   feel native rather than pasted-in.
-   ─────────────────────────────────────────────────────────────────*/
-body {
-  --fl-bg-50:     #09090c;   /* page background — matches cartoon bg */
-  --fl-card-0:    #13141a;   /* cards / surfaces */
-  --fl-rule-200:  rgba(255,255,255,.08);
-  --fl-navy-900:  #ffffff;   /* primary headings / brand */
-  --fl-navy-700:  #e8eaf0;
-  --fl-ink-900:   #e8eaf0;   /* body text */
-  --fl-muted-600: rgba(232,234,240,.55); /* muted text */
-  --fl-orange-600:#f0a000;   /* primary accent — matches cartoon amber */
-  --fl-orange-500:#ffb547;
-  --fl-sky-100:   #0d1320;   /* hero gradient top — deep navy fade */
-  --fl-good:      #00d4aa;   /* lifted from FactoryLM green for dark contrast */
-  --fl-bad:       #ff7a5c;   /* lifted from FactoryLM red for dark contrast */
-  background: var(--fl-bg-50);
-  color: var(--fl-ink-900);
-}
-
-/* Compare columns hard-code light pink / green in _components.css for the
-   light marketing theme. Override with red/teal-tinted dark surfaces so the
-   ChatGPT-vs-MIRA contrast survives on the dark page. */
-.fl-col-bad {
-  background: rgba(255,122,92,0.07);
-  border-color: rgba(255,122,92,0.28);
-}
-.fl-col-good {
-  background: rgba(0,212,170,0.07);
-  border-color: rgba(0,212,170,0.28);
-}
+/* Page-specific styles for the home view. Dark theme tokens are
+   inherited from /_dark-theme.css (linked from <head>) so this block
+   only carries layout and typography rules unique to the home page. */
 
 .fl-topbar {
   display: flex; align-items: center; justify-content: space-between;
@@ -507,6 +473,7 @@ export function renderHome(reqUrl?: string): string {
 <html lang="en">
 <head>
   ${headHtml}
+  <link rel="stylesheet" href="/_dark-theme.css">
   <style>${PAGE_STYLES}</style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

P0 fix from the 2026-05-03 style audit (#938). v0.3.1 shipped the dark home + cartoon hero, but the conversion funnel still broke — clicking \`Start Free — magic link\` on home dropped visitors onto a light-themed \`/cmms\`. This PR closes that gap and sets up the structural piece (tokenized dark stylesheet) that unblocks the remaining P1/P2 pages.

## Changes

1. **New shared stylesheet** at \`mira-web/public/_dark-theme.css\` carrying the FactoryLM design-token overrides (page bg, card surface, ink, amber accent) plus the dark \`.fl-col-bad\` / \`.fl-col-good\` overrides. Any view opts in by adding \`<link rel=\"stylesheet\" href=\"/_dark-theme.css\">\` to its head.

2. **\`/cmms\` and \`/sample\` go dark.** Both views render via \`views/cmms.ts\`; one \`<link>\` tag in each \`renderCmms\` and \`renderSamplePlaceholder\` head flips them.

3. **\`home.ts\` deduplicated.** The dark token block + .fl-col-bad/.fl-col-good rules moved to the shared stylesheet; home keeps only its layout/typography styles.

4. **Static route registered** in \`src/server.ts\` next to \`_tokens.css\` and \`_components.css\`.

5. **v0.4.0 bump + CHANGELOG entry** per the customer-facing versioning rule.

## Out of scope (deliberately)

- /limitations, /security, /pricing, /blog, legal stack — covered by the audit as P1/P2; will be migrated by adding the same \`<link>\` to each view in follow-up PRs
- /activated — has its own bespoke dark theme via static HTML; separate reconciliation
- Topbar partial unification (six nav variants in production) — the audit's #2 cross-cutting fix; bigger refactor, separate PR

## Verification

- [x] \`bun test src/views/__tests__/home.test.ts\` → 18/18 pass
- [x] Local \`bun run dev\` + chrome --headless screenshot:
      - \`/\` renders identically to v0.3.1 (no regression)
      - \`/cmms\` renders dark with amber CTA, matching home palette
- [ ] Post-deploy: live verification of palette on \`/cmms\` and confirm \`/_dark-theme.css\` returns 200 with content-type \`text/css\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)