### PR TITLE
feat(web): shared topbar partial — kills 4 of 6 nav variants (mira-web v0.5.0)

### DIFF
--- a/mira-web/CHANGELOG.md
+++ b/mira-web/CHANGELOG.md
@@ -7,6 +7,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 to the component (`mira-web/vX.Y.Z`) so they don't collide with the MIRA
 monorepo's top-level tag progression.
 
+## [0.5.0] — 2026-05-03
+
+### Added
+- **Shared topbar partial** at `mira-web/src/views/_topbar.ts` exporting
+  `navbar({ currentPath, ctaPrefix })` and `footer({ ctaPrefix })`. Single
+  source of truth for the four TS-rendered marketing views (home, cmms,
+  limitations, security/sample). Per-page differences are limited to
+  `aria-current="page"` and the `data-cta` analytics prefix.
+- **23-test contract suite** (`src/views/__tests__/topbar.test.ts`)
+  locking down link set, ordering, CTA copy, and per-page
+  `aria-current` placement so the four views cannot drift apart again.
+
+### Changed
+- **`/limitations` and `/security` adopt the dark palette** by linking
+  the v0.4.0 `_dark-theme.css` stylesheet — same single-line opt-in
+  pattern used by `/cmms` and `/sample`. Closes the P1 row in the
+  2026-05-03 style audit.
+- **`/cmms` topbar gains the standard nav and CTA.** Previously
+  `/cmms` had its own four-link nav (Home / Pricing / Limitations /
+  Security) with no CTA; it now matches the home topbar exactly,
+  with `aria-current="page"` on the CMMS link.
+
+### Notes
+- This release fixes 4 of the 6 topbar variants flagged in the
+  2026-05-03 style audit. The remaining two — the M-icon-era topbar
+  shared by the static HTML pages (`pricing.html`, `privacy.html`,
+  `terms.html`, `trust.html`, `legal/dpa.html`) and the blog renderer
+  (`blog-renderer.ts`) — require either converting the static pages
+  to TS views or a build-time string-injection pass. Tracked as
+  Phase 2 in the audit.
+
 ## [0.4.0] — 2026-05-03
 
 ### Added

--- a/mira-web/package.json
+++ b/mira-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-web",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "FactoryLM PLG funnel — CMMS acquisition & onboarding flow",
   "type": "module",
   "scripts": {

--- a/mira-web/src/views/__tests__/topbar.test.ts
+++ b/mira-web/src/views/__tests__/topbar.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Contract tests for the shared topbar partial.
+ *
+ * Background: tools/web-review-runs/2026-05-03-style-audit/AUDIT.md
+ * found six different topbars live in production. This test suite
+ * locks down the standard so the four TS-rendered marketing views
+ * (home, cmms, limitations, security/sample) cannot drift again.
+ *
+ * If a future change needs to add or remove a nav link, update
+ * NAV_LINKS in _topbar.ts AND update this expectation list — the
+ * test won't let one happen without the other.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { renderHome } from "../home.js";
+import { renderCmms, renderSamplePlaceholder } from "../cmms.js";
+import { renderLimitations } from "../limitations.js";
+import { renderSecurity } from "../security.js";
+import { navbar, footer } from "../_topbar.js";
+
+const STANDARD_LINKS: ReadonlyArray<{ href: string; label: string }> = [
+  { href: "/cmms", label: "CMMS" },
+  { href: "/pricing", label: "Pricing" },
+  { href: "/blog", label: "Blog" },
+  { href: "/limitations", label: "Limitations" },
+  { href: "/security", label: "Security" },
+];
+
+describe("shared topbar partial — contract", () => {
+  test("renders all five standard nav links in order", () => {
+    const html = navbar();
+    const positions = STANDARD_LINKS.map((l) => html.indexOf(`href="${l.href}"`));
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i]).toBeGreaterThan(positions[i - 1]);
+    }
+  });
+
+  test("each nav link contains its expected label", () => {
+    const html = navbar();
+    for (const link of STANDARD_LINKS) {
+      expect(html).toContain(`href="${link.href}"`);
+      expect(html).toContain(`>${link.label}</a>`);
+    }
+  });
+
+  test("primary CTA is 'Sign in' linking to /cmms", () => {
+    const html = navbar();
+    expect(html).toContain("Sign in");
+    expect(html).toMatch(/<a href="\/cmms"[^>]*class="fl-btn fl-btn-ghost"/);
+  });
+
+  test("aria-current='page' is set only on the matching link", () => {
+    const html = navbar({ currentPath: "/limitations" });
+    const currentMatches = html.match(/aria-current="page"/g) || [];
+    expect(currentMatches.length).toBe(1);
+    expect(html).toMatch(
+      /<a href="\/limitations"[^>]*aria-current="page"/
+    );
+  });
+
+  test("ctaPrefix scopes data-cta attributes for analytics", () => {
+    const html = navbar({ ctaPrefix: "lim" });
+    expect(html).toContain('data-cta="lim-nav-cmms"');
+    expect(html).toContain('data-cta="lim-nav-pricing"');
+    expect(html).toContain('data-cta="lim-nav-signin"');
+  });
+
+  test("default (no prefix) uses bare 'nav-' data-cta names", () => {
+    const html = navbar();
+    expect(html).toContain('data-cta="nav-cmms"');
+    expect(html).toContain('data-cta="nav-signin"');
+  });
+
+  test("footer renders four legal/policy links + sun-toggle", () => {
+    const html = footer();
+    expect(html).toContain('href="/limitations"');
+    expect(html).toContain('href="/trust"');
+    expect(html).toContain('href="/privacy"');
+    expect(html).toContain('href="/terms"');
+    expect(html).toContain('id="fl-sun-toggle"');
+  });
+});
+
+describe("topbar parity — all four TS views render identical link sets", () => {
+  const homeHtml = renderHome("https://factorylm.com/");
+  const cmmsHtml = renderCmms("https://factorylm.com/cmms");
+  const sampleHtml = renderSamplePlaceholder();
+  const limHtml = renderLimitations("https://factorylm.com/limitations");
+  const secHtml = renderSecurity("https://factorylm.com/security");
+
+  const pages = [
+    { name: "home", html: homeHtml },
+    { name: "cmms", html: cmmsHtml },
+    { name: "sample", html: sampleHtml },
+    { name: "limitations", html: limHtml },
+    { name: "security", html: secHtml },
+  ];
+
+  for (const page of pages) {
+    test(`${page.name}: contains all five standard nav links in topbar`, () => {
+      // Extract just the topbar region so footer/body links don't pollute.
+      const headerMatch = page.html.match(/<header[^>]*class="fl-topbar"[\s\S]*?<\/header>/);
+      expect(headerMatch).not.toBeNull();
+      const header = headerMatch![0];
+      for (const link of STANDARD_LINKS) {
+        expect(header).toContain(`href="${link.href}"`);
+        expect(header).toContain(`>${link.label}</a>`);
+      }
+    });
+
+    test(`${page.name}: shows 'Sign in' CTA in topbar`, () => {
+      const headerMatch = page.html.match(/<header[^>]*class="fl-topbar"[\s\S]*?<\/header>/);
+      expect(headerMatch).not.toBeNull();
+      expect(headerMatch![0]).toContain("Sign in");
+    });
+  }
+
+  test("home marks '/' (no nav link gets aria-current)", () => {
+    const headerMatch = homeHtml.match(/<header[^>]*class="fl-topbar"[\s\S]*?<\/header>/)!;
+    expect(headerMatch[0]).not.toContain('aria-current="page"');
+  });
+
+  test("limitations marks the Limitations link as current", () => {
+    const headerMatch = limHtml.match(/<header[^>]*class="fl-topbar"[\s\S]*?<\/header>/)!;
+    expect(headerMatch[0]).toMatch(
+      /<a href="\/limitations"[^>]*aria-current="page"/
+    );
+  });
+
+  test("security marks the Security link as current", () => {
+    const headerMatch = secHtml.match(/<header[^>]*class="fl-topbar"[\s\S]*?<\/header>/)!;
+    expect(headerMatch[0]).toMatch(
+      /<a href="\/security"[^>]*aria-current="page"/
+    );
+  });
+
+  test("cmms marks the CMMS link as current (not Home)", () => {
+    const headerMatch = cmmsHtml.match(/<header[^>]*class="fl-topbar"[\s\S]*?<\/header>/)!;
+    expect(headerMatch[0]).toMatch(
+      /<a href="\/cmms"[^>]*aria-current="page"/
+    );
+    // The pre-fix cmms.ts had a "Home" link; the standard topbar drops it.
+    expect(headerMatch[0]).not.toMatch(/<a href="\/"[^>]*data-cta="cmms-nav-home"/);
+  });
+});
+
+describe("dark theme stylesheet linked on /limitations and /security", () => {
+  test("/limitations links /_dark-theme.css", () => {
+    const html = renderLimitations("https://factorylm.com/limitations");
+    expect(html).toContain('href="/_dark-theme.css"');
+  });
+
+  test("/security links /_dark-theme.css", () => {
+    const html = renderSecurity("https://factorylm.com/security");
+    expect(html).toContain('href="/_dark-theme.css"');
+  });
+});

--- a/mira-web/src/views/_topbar.ts
+++ b/mira-web/src/views/_topbar.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared topbar + footer partials for FactoryLM marketing pages.
+ *
+ * Single source of truth for the four TS-rendered marketing views
+ * (home, cmms, limitations, security). Replaces four hand-rolled
+ * navbar() / footer() functions that drifted in link set and CTA copy
+ * — see tools/web-review-runs/2026-05-03-style-audit/AUDIT.md.
+ *
+ * Static HTML pages (pricing, privacy, terms, trust, dpa) and the
+ * blog renderer are still on the older M-icon nav. Bringing them onto
+ * this partial is tracked as Phase 2 in the audit; that work is
+ * larger because it requires moving HTML into TS views.
+ *
+ * The link set, ordering, and primary CTA are the home-page
+ * standard. Per-page differences are limited to:
+ *   - aria-current="page" on the matching link
+ *   - data-cta attribute prefix for analytics
+ */
+
+import { btnGhost } from "../lib/components.js";
+
+export interface TopbarOpts {
+  /** Path of the current page, used to set aria-current="page". */
+  currentPath?: string;
+  /** Prefix for data-cta analytics attributes (e.g., "lim", "sec"). */
+  ctaPrefix?: string;
+}
+
+interface NavLink {
+  href: string;
+  label: string;
+  ctaSlug: string;
+}
+
+const NAV_LINKS: NavLink[] = [
+  { href: "/cmms", label: "CMMS", ctaSlug: "cmms" },
+  { href: "/pricing", label: "Pricing", ctaSlug: "pricing" },
+  { href: "/blog", label: "Blog", ctaSlug: "blog" },
+  { href: "/limitations", label: "Limitations", ctaSlug: "limitations" },
+  { href: "/security", label: "Security", ctaSlug: "security" },
+];
+
+function ctaName(prefix: string | undefined, slug: string): string {
+  return prefix ? `${prefix}-nav-${slug}` : `nav-${slug}`;
+}
+
+function renderLink(link: NavLink, opts: TopbarOpts): string {
+  const current = opts.currentPath === link.href ? ` aria-current="page"` : "";
+  const cta = ctaName(opts.ctaPrefix, link.ctaSlug);
+  return `<a href="${link.href}" data-cta="${cta}"${current}>${link.label}</a>`;
+}
+
+export function navbar(opts: TopbarOpts = {}): string {
+  const links = NAV_LINKS.map((l) => renderLink(l, opts)).join("\n    ");
+  const signinCta = ctaName(opts.ctaPrefix, "signin");
+  return `<header class="fl-topbar" role="banner">
+  <a class="fl-topbar-brand" href="/" aria-label="FactoryLM home">FactoryLM</a>
+  <nav class="fl-topbar-nav" aria-label="Primary">
+    ${links}
+  </nav>
+  <div class="fl-topbar-cta">
+    ${btnGhost("Sign in", { href: "/cmms", cta: signinCta })}
+  </div>
+</header>`;
+}
+
+const FOOTER_LINKS = [
+  { href: "/limitations", label: "Limitations", slug: "limitations" },
+  { href: "/trust", label: "Trust", slug: "trust" },
+  { href: "/privacy", label: "Privacy", slug: "privacy" },
+  { href: "/terms", label: "Terms", slug: "terms" },
+];
+
+export function footer(opts: TopbarOpts = {}): string {
+  const items = FOOTER_LINKS.map((l) => {
+    const cta = opts.ctaPrefix
+      ? `${opts.ctaPrefix}-footer-${l.slug}`
+      : `footer-${l.slug}`;
+    return `      <li><a href="${l.href}" data-cta="${cta}">${l.label}</a></li>`;
+  }).join("\n");
+  return `<footer class="fl-footer" role="contentinfo">
+  <div class="fl-footer-inner">
+    <p class="fl-footer-brand">FactoryLM &middot; Built for industrial maintenance.</p>
+    <ul class="fl-footer-links">
+${items}
+    </ul>
+    <button type="button" id="fl-sun-toggle" class="fl-sun-toggle" aria-pressed="false" aria-label="Toggle high-contrast outdoor mode" data-cta="sun-toggle">&#9728; Sun-readable</button>
+  </div>
+</footer>`;
+}

--- a/mira-web/src/views/cmms.ts
+++ b/mira-web/src/views/cmms.ts
@@ -5,6 +5,7 @@ import {
   stateBadge,
   compareBlock,
 } from "../lib/components.js";
+import { navbar, footer } from "./_topbar.js";
 
 const PAGE_STYLES = `
 .fl-topbar {
@@ -223,19 +224,6 @@ const FORM_SCRIPT = `
 })();
 `;
 
-function navbar(): string {
-  return `<header class="fl-topbar" role="banner">
-  <a class="fl-topbar-brand" href="/" aria-label="FactoryLM home">FactoryLM</a>
-  <nav class="fl-topbar-nav" aria-label="Primary">
-    <a href="/" data-cta="cmms-nav-home">Home</a>
-    <a href="/pricing" data-cta="cmms-nav-pricing">Pricing</a>
-    <a href="/limitations" data-cta="cmms-nav-limitations">Limitations</a>
-    <a href="/security" data-cta="cmms-nav-security">Security</a>
-  </nav>
-  <div></div>
-</header>`;
-}
-
 const PLAN_LABELS: Record<string, { eyebrow: string; h1: string; sub: string }> = {
   mira: {
     eyebrow: "MIRA Troubleshooter — $97/mo",
@@ -330,22 +318,6 @@ function compareSection(): string {
 </section>`;
 }
 
-function footer(): string {
-  return `<footer class="fl-footer" role="contentinfo">
-  <div class="fl-footer-inner">
-    <p class="fl-footer-brand">FactoryLM &middot; Built for industrial maintenance.</p>
-    <ul class="fl-footer-links">
-      <!-- TODO: /limitations page not yet built; link disabled until page exists -->
-      <li><a href="/limitations" data-cta="cmms-footer-limitations">Limitations</a></li>
-      <li><a href="/trust" data-cta="cmms-footer-trust">Trust</a></li>
-      <li><a href="/privacy" data-cta="cmms-footer-privacy">Privacy</a></li>
-      <li><a href="/terms" data-cta="cmms-footer-terms">Terms</a></li>
-    </ul>
-    <button type="button" id="fl-sun-toggle" class="fl-sun-toggle" aria-pressed="false" aria-label="Toggle high-contrast outdoor mode" data-cta="cmms-sun-toggle">☀ Sun-readable</button>
-  </div>
-</footer>`;
-}
-
 export function renderCmms(reqUrl?: string): string {
   const plan = reqUrl
     ? (new URL(reqUrl).searchParams.get("plan") ?? undefined)
@@ -370,13 +342,13 @@ export function renderCmms(reqUrl?: string): string {
   <style>${PAGE_STYLES}</style>
 </head>
 <body>
-  ${navbar()}
+  ${navbar({ currentPath: "/cmms", ctaPrefix: "cmms" })}
   <main>
     ${hero(validPlan)}
     ${whatHappensNext()}
     ${compareSection()}
   </main>
-  ${footer()}
+  ${footer({ ctaPrefix: "cmms" })}
   <script>${FORM_SCRIPT}</script>
   <script src="/sun-toggle.js"></script>
 </body>
@@ -408,7 +380,7 @@ export function renderSamplePlaceholder(): string {
 </style>
 </head>
 <body>
-  ${navbar()}
+  ${navbar({ currentPath: "/sample", ctaPrefix: "sample" })}
   <main>
     <div class="fl-sample-card">
       <h1>You're signed in.</h1>
@@ -419,7 +391,7 @@ export function renderSamplePlaceholder(): string {
       </div>
     </div>
   </main>
-  ${footer()}
+  ${footer({ ctaPrefix: "sample" })}
   <script src="/sun-toggle.js"></script>
 </body>
 </html>`;

--- a/mira-web/src/views/home.ts
+++ b/mira-web/src/views/home.ts
@@ -7,6 +7,7 @@ import {
   stateBadge,
   stopCard,
 } from "../lib/components.js";
+import { navbar, footer } from "./_topbar.js";
 
 const OEMS = [
   "Allen-Bradley",
@@ -239,37 +240,6 @@ function pricingTeaser(): string {
 </section>`;
 }
 
-function navbar(): string {
-  return `<header class="fl-topbar" role="banner">
-  <a class="fl-topbar-brand" href="/" aria-label="FactoryLM home">FactoryLM</a>
-  <nav class="fl-topbar-nav" aria-label="Primary">
-    <a href="/cmms" data-cta="nav-cmms">CMMS</a>
-    <a href="/pricing" data-cta="nav-pricing">Pricing</a>
-    <a href="/blog" data-cta="nav-blog">Blog</a>
-    <a href="/limitations" data-cta="nav-limitations">Limitations</a>
-    <a href="/security" data-cta="nav-security">Security</a>
-  </nav>
-  <div class="fl-topbar-cta">
-    ${btnGhost("Sign in", { href: "/cmms", cta: "nav-signin" })}
-  </div>
-</header>`;
-}
-
-function footer(): string {
-  return `<footer class="fl-footer" role="contentinfo">
-  <div class="fl-footer-inner">
-    <p class="fl-footer-brand">FactoryLM &middot; Built for industrial maintenance.</p>
-    <ul class="fl-footer-links">
-      <li><a href="/limitations" data-cta="footer-limitations">Limitations</a></li>
-      <li><a href="/trust" data-cta="footer-trust">Trust</a></li>
-      <li><a href="/privacy" data-cta="footer-privacy">Privacy</a></li>
-      <li><a href="/terms" data-cta="footer-terms">Terms</a></li>
-    </ul>
-    <button type="button" id="fl-sun-toggle" class="fl-sun-toggle" aria-pressed="false" aria-label="Toggle high-contrast outdoor mode" data-cta="sun-toggle">☀ Sun-readable</button>
-  </div>
-</footer>`;
-}
-
 const PAGE_STYLES = `
 /* Page-specific styles for the home view. Dark theme tokens are
    inherited from /_dark-theme.css (linked from <head>) so this block
@@ -477,7 +447,7 @@ export function renderHome(reqUrl?: string): string {
   <style>${PAGE_STYLES}</style>
 </head>
 <body>
-  ${navbar()}
+  ${navbar({ currentPath: "/" })}
   <main>
     ${hero()}
     ${trustBand("68,000+ chunks of OEM documentation indexed", OEMS)}

--- a/mira-web/src/views/limitations.ts
+++ b/mira-web/src/views/limitations.ts
@@ -1,5 +1,6 @@
 import { head } from "../lib/head.js";
 import { btnPrimary, btnGhost } from "../lib/components.js";
+import { navbar, footer } from "./_topbar.js";
 
 const PAGE_STYLES = `
 .fl-topbar {
@@ -139,37 +140,6 @@ const PAGE_STYLES = `
 }
 `;
 
-function navbar(): string {
-  return `<header class="fl-topbar" role="banner">
-  <a class="fl-topbar-brand" href="/" aria-label="FactoryLM home">FactoryLM</a>
-  <nav class="fl-topbar-nav" aria-label="Primary">
-    <a href="/cmms" data-cta="lim-nav-cmms">CMMS</a>
-    <a href="/pricing" data-cta="lim-nav-pricing">Pricing</a>
-    <a href="/blog" data-cta="lim-nav-blog">Blog</a>
-    <a href="/limitations" data-cta="lim-nav-limitations" aria-current="page">Limitations</a>
-    <a href="/security" data-cta="lim-nav-security">Security</a>
-  </nav>
-  <div class="fl-topbar-cta">
-    ${btnGhost("Sign in", { href: "/cmms", cta: "lim-nav-signin" })}
-  </div>
-</header>`;
-}
-
-function footer(): string {
-  return `<footer class="fl-footer" role="contentinfo">
-  <div class="fl-footer-inner">
-    <p class="fl-footer-brand">FactoryLM &middot; Built for industrial maintenance.</p>
-    <ul class="fl-footer-links">
-      <li><a href="/limitations" data-cta="lim-footer-limitations">Limitations</a></li>
-      <li><a href="/trust" data-cta="lim-footer-trust">Trust</a></li>
-      <li><a href="/privacy" data-cta="lim-footer-privacy">Privacy</a></li>
-      <li><a href="/terms" data-cta="lim-footer-terms">Terms</a></li>
-    </ul>
-    <button type="button" id="fl-sun-toggle" class="fl-sun-toggle" aria-pressed="false" aria-label="Toggle high-contrast outdoor mode" data-cta="sun-toggle">☀ Sun-readable</button>
-  </div>
-</footer>`;
-}
-
 const LIMITS = [
   {
     lead: "Not a CMMS replacement.",
@@ -259,10 +229,11 @@ export function renderLimitations(reqUrl?: string): string {
     },
     reqUrl,
   )}
+  <link rel="stylesheet" href="/_dark-theme.css">
   <style>${PAGE_STYLES}</style>
 </head>
 <body>
-  ${navbar()}
+  ${navbar({ currentPath: "/limitations", ctaPrefix: "lim" })}
 
   <section class="fl-lim-hero">
     <div class="fl-lim-hero-inner">
@@ -287,7 +258,7 @@ export function renderLimitations(reqUrl?: string): string {
     </p>
   </div>
 
-  ${footer()}
+  ${footer({ ctaPrefix: "lim" })}
   <script src="/sun-toggle.js"></script>
 </body>
 </html>`;

--- a/mira-web/src/views/security.ts
+++ b/mira-web/src/views/security.ts
@@ -1,5 +1,6 @@
 import { head } from "../lib/head.js";
 import { btnPrimary, btnGhost } from "../lib/components.js";
+import { navbar, footer } from "./_topbar.js";
 
 const PAGE_STYLES = `
 .fl-topbar {
@@ -152,37 +153,6 @@ const PAGE_STYLES = `
   .fl-sec-h1 { font-size: var(--fl-type-2xl); }
 }
 `;
-
-function navbar(): string {
-  return `<header class="fl-topbar" role="banner">
-  <a class="fl-topbar-brand" href="/" aria-label="FactoryLM home">FactoryLM</a>
-  <nav class="fl-topbar-nav" aria-label="Primary">
-    <a href="/cmms" data-cta="sec-nav-cmms">CMMS</a>
-    <a href="/pricing" data-cta="sec-nav-pricing">Pricing</a>
-    <a href="/blog" data-cta="sec-nav-blog">Blog</a>
-    <a href="/limitations" data-cta="sec-nav-limitations">Limitations</a>
-    <a href="/security" data-cta="sec-nav-security" aria-current="page">Security</a>
-  </nav>
-  <div class="fl-topbar-cta">
-    ${btnGhost("Sign in", { href: "/cmms", cta: "sec-nav-signin" })}
-  </div>
-</header>`;
-}
-
-function footer(): string {
-  return `<footer class="fl-footer" role="contentinfo">
-  <div class="fl-footer-inner">
-    <p class="fl-footer-brand">FactoryLM &middot; Built for industrial maintenance.</p>
-    <ul class="fl-footer-links">
-      <li><a href="/security" data-cta="sec-footer-security">Security</a></li>
-      <li><a href="/limitations" data-cta="sec-footer-limitations">Limitations</a></li>
-      <li><a href="/privacy" data-cta="sec-footer-privacy">Privacy</a></li>
-      <li><a href="/terms" data-cta="sec-footer-terms">Terms</a></li>
-    </ul>
-    <button type="button" id="fl-sun-toggle" class="fl-sun-toggle" aria-pressed="false" aria-label="Toggle high-contrast outdoor mode" data-cta="sun-toggle">&#9728; Sun-readable</button>
-  </div>
-</footer>`;
-}
 
 interface SecurityItem {
   lead: string;
@@ -341,10 +311,11 @@ export function renderSecurity(reqUrl?: string): string {
     },
     reqUrl,
   )}
+  <link rel="stylesheet" href="/_dark-theme.css">
   <style>${PAGE_STYLES}</style>
 </head>
 <body>
-  ${navbar()}
+  ${navbar({ currentPath: "/security", ctaPrefix: "sec" })}
 
   <section class="fl-sec-hero">
     <div class="fl-sec-hero-inner">
@@ -368,7 +339,7 @@ export function renderSecurity(reqUrl?: string): string {
     </p>
   </div>
 
-  ${footer()}
+  ${footer({ ctaPrefix: "sec" })}
   <script src="/sun-toggle.js"></script>
 </body>
 </html>`;


### PR DESCRIPTION
## Summary

- **Shared topbar partial** at \`mira-web/src/views/_topbar.ts\` exporting \`navbar({ currentPath, ctaPrefix })\` and \`footer({ ctaPrefix })\` — single source of truth for the four TS-rendered marketing views (home, cmms, limitations, security/sample). Per-page differences reduced to \`aria-current\` and the \`data-cta\` analytics prefix.
- **\`/limitations\` and \`/security\` adopt the v0.4.0 dark palette** by linking \`/_dark-theme.css\` — same one-line opt-in pattern used by \`/cmms\` and \`/sample\`.
- **\`/cmms\` topbar gains the standard nav and CTA.** Previously it had its own four-link nav (Home / Pricing / Limitations / Security) with no CTA.

## Why

The 2026-05-03 style audit (\`tools/web-review-runs/2026-05-03-style-audit/AUDIT.md\`) found six different topbars live in production with four different primary CTAs. A visitor clicking off the home page experienced a nav break, a logo break, and a CTA-language break in one click.

This PR fixes 4 of the 6 variants. The remaining two — the M-icon-era topbar shared by static HTML pages (\`pricing.html\`, \`privacy.html\`, \`terms.html\`, \`trust.html\`, \`legal/dpa.html\`) and the blog renderer (\`blog-renderer.ts\`) — are tracked as Phase 2 in the audit because they require either converting the static HTML to TS views or doing build-time string injection. That's a bigger lift; deliberately deferred.

## Net delta
\`\`\`
 mira-web/CHANGELOG.md                       |  +31
 mira-web/package.json                       |   v0.4.0 → v0.5.0
 mira-web/src/views/__tests__/topbar.test.ts | +157  (new)
 mira-web/src/views/_topbar.ts               |  +90  (new)
 mira-web/src/views/cmms.ts                  |  -38  (now uses partial)
 mira-web/src/views/home.ts                  |  -34  (now uses partial)
 mira-web/src/views/limitations.ts           |  -37  (now uses partial)
 mira-web/src/views/security.ts              |  -37  (now uses partial)
 8 files, +294 / -132  (net +162; 132 lines of duplicated nav/footer code removed)
\`\`\`

## Test plan
- [x] \`bun test src/views/__tests__/topbar.test.ts\` — 23/23 pass (new contract suite)
- [x] \`bun test src/views/__tests__/\` — 36/37 pass; the 1 failure is a pre-existing latent test (\`#SO-070 cmms AC1\`) that counts a hidden form input as visible. Confirmed failing on \`main\` before this branch existed. Out of scope for this PR.
- [x] No new failures introduced anywhere in the suite (other failures are in admin/qr-print and m-register routes — unrelated, also pre-existing).
- [ ] Post-merge: rebuild \`mira-web\` on VPS, then visit \`/\`, \`/cmms\`, \`/limitations\`, \`/security\` and confirm topbar parity + dark palette on the two newly-darkened pages.

## Versioning

- Bumped \`mira-web/package.json\` to \`0.5.0\` (minor — site-wide nav coherence affects every TS view).
- Tagged \`mira-web/v0.5.0\` on the merge commit; pushed with \`--follow-tags\`.
- CHANGELOG entry added.

## Out of scope (Phase 2 follow-up)

- Static HTML page topbar (pricing, privacy, terms, trust, dpa)
- \`blog-renderer.ts\` topbar (blog index + fault-codes)
- Topbar mobile-menu behavior (currently hidden \`<640px\` per existing media query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)