### PR TITLE
fix(web): paint html bg + wire sun-toggle click (mira-web v0.5.1)

### DIFF
--- a/mira-web/CHANGELOG.md
+++ b/mira-web/CHANGELOG.md
@@ -7,6 +7,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 to the component (`mira-web/vX.Y.Z`) so they don't collide with the MIRA
 monorepo's top-level tag progression.
 
+## [0.5.1] — 2026-05-03
+
+### Fixed
+- **White viewport edges around dark pages.** `_dark-theme.css` only
+  painted the `<body>` background; the `<html>` element kept its UA
+  default white. When body content was shorter than the viewport, the
+  unpainted html element bled through as a white strip on the right
+  and bottom edges (visible on `/cmms`, `/limitations`, `/security`
+  in the v0.5.0 production screenshots). Fix paints `<html>` with the
+  same `#09090c` and adds `min-height: 100vh; margin: 0` to body so
+  it always fills the viewport.
+- **Sun-readable toggle button did nothing.** `sun-toggle.js` defined
+  `window.flToggleSun` but never attached a click listener to the
+  `#fl-sun-toggle` button — it has been a dead button on every page
+  shipping it. Fix adds an `addEventListener("click", flToggleSun)`
+  in the existing `DOMContentLoaded` handler. Now toggles between the
+  dark cartoon palette and the high-contrast `body.sun` outdoor mode
+  (`#F0F0F0` bg, `#000` text, defined in `_tokens.css`).
+
 ## [0.5.0] — 2026-05-03
 
 ### Added

--- a/mira-web/package.json
+++ b/mira-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-web",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "FactoryLM PLG funnel — CMMS acquisition & onboarding flow",
   "type": "module",
   "scripts": {

--- a/mira-web/public/_dark-theme.css
+++ b/mira-web/public/_dark-theme.css
@@ -14,6 +14,9 @@
    render via the cmms view).
    ─────────────────────────────────────────────────────────────────*/
 
+html {
+  background: #09090c;   /* prevents viewport-edge white flash when body is shorter than viewport */
+}
 body {
   --fl-bg-50:     #09090c;   /* page background — matches cartoon bg */
   --fl-card-0:    #13141a;   /* cards / surfaces */
@@ -29,6 +32,8 @@ body {
   --fl-bad:       #ff7a5c;   /* lifted from FactoryLM red for dark contrast */
   background: var(--fl-bg-50);
   color: var(--fl-ink-900);
+  min-height: 100vh;
+  margin: 0;
 }
 
 /* Compare columns hard-code light pink / green in _components.css for the

--- a/mira-web/public/sun-toggle.js
+++ b/mira-web/public/sun-toggle.js
@@ -18,5 +18,9 @@
     try { localStorage.setItem(KEY, on ? "1" : "0"); } catch (e) { /* blocked */ }
   };
 
-  document.addEventListener("DOMContentLoaded", applyState);
+  document.addEventListener("DOMContentLoaded", function () {
+    applyState();
+    var btn = document.getElementById("fl-sun-toggle");
+    if (btn) btn.addEventListener("click", window.flToggleSun);
+  });
 })();


### PR DESCRIPTION
## Summary

Two bugs Mike caught in the v0.5.0 production screenshots:

1. **White strip on the right/bottom edges of dark pages** — visible on \`/cmms\`, \`/limitations\`, \`/security\` in the v0.5.0 proof shots. Caused by \`_dark-theme.css\` painting only \`<body>\`, leaving the UA-default-white \`<html>\` element to bleed through when content was shorter than the viewport.
2. **Sun-readable toggle button did nothing.** \`sun-toggle.js\` defined \`window.flToggleSun\` but never attached a click listener anywhere — the button has been dead on every page that's ever shipped it.

## Fixes (4 lines each)

\`\`\`css
/* mira-web/public/_dark-theme.css */
html { background: #09090c; }
body { ...; min-height: 100vh; margin: 0; }
\`\`\`

\`\`\`js
// mira-web/public/sun-toggle.js
document.addEventListener("DOMContentLoaded", function () {
  applyState();
  var btn = document.getElementById("fl-sun-toggle");
  if (btn) btn.addEventListener("click", window.flToggleSun);
});
\`\`\`

## Test plan
- [x] Local: existing 23-test topbar contract suite still passes (CSS/JS surface; no test impact).
- [ ] Post-deploy: verify white edges are gone on \`/cmms\`, \`/limitations\`, \`/security\` via re-screenshot. Click sun-toggle on \`/\` and confirm body flips to \`body.sun\` light high-contrast mode.

## Versioning
- \`mira-web\` 0.5.0 → 0.5.1 (patch — pure bug fix).
- Tag \`mira-web/v0.5.1\` pushed.
- CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)