### PR TITLE
fix(web): bump SW CACHE_NAME so v0.5.x asset updates land (mira-web v0.5.2)

### DIFF
--- a/mira-web/CHANGELOG.md
+++ b/mira-web/CHANGELOG.md
@@ -7,6 +7,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 to the component (`mira-web/vX.Y.Z`) so they don't collide with the MIRA
 monorepo's top-level tag progression.
 
+## [0.5.2] — 2026-05-03
+
+### Fixed
+- **Service worker was masking the v0.5.0 + v0.5.1 deploys.** Returning
+  visitors saw the old topbar, white edges, and dead sun-toggle even
+  after both PRs landed in production because `sw.js` is cache-first
+  for static assets and `CACHE_NAME` had been pinned at `factorylm-v3`
+  since the SW was introduced. Bump to `factorylm-v4` triggers the
+  activate handler's `caches.delete()` for every key !== current name,
+  forcing all CSS/JS to re-fetch on next page load. Also adds
+  `_dark-theme.css` and `_components.css` companions `_dark-theme.css`
+  and `sun-toggle.js` to `PRECACHE_URLS` so future first-load visitors
+  get them up front instead of opportunistically.
+
+  CACHE_NAME bumps need to ship every time a CSS/JS asset under
+  `/public` changes — added a TODO comment in `sw.js` so future
+  edits don't repeat the trap.
+
 ## [0.5.1] — 2026-05-03
 
 ### Fixed

--- a/mira-web/package.json
+++ b/mira-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-web",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "FactoryLM PLG funnel — CMMS acquisition & onboarding flow",
   "type": "module",
   "scripts": {

--- a/mira-web/public/sw.js
+++ b/mira-web/public/sw.js
@@ -1,5 +1,17 @@
-const CACHE_NAME = 'factorylm-v3';
-const PRECACHE_URLS = ['/', '/cmms', '/pricing', '/manifest.json', '/_tokens.css', '/_components.css'];
+// Bump CACHE_NAME on every release that ships a new CSS/JS asset under /public
+// so returning visitors get fresh files instead of stale cache. The activate
+// handler below deletes any cache key that doesn't match this name.
+const CACHE_NAME = 'factorylm-v4';
+const PRECACHE_URLS = [
+  '/',
+  '/cmms',
+  '/pricing',
+  '/manifest.json',
+  '/_tokens.css',
+  '/_components.css',
+  '/_dark-theme.css',
+  '/sun-toggle.js',
+];
 const API_PREFIXES = ['/api/', '/demo/'];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Why

Mike reported that the v0.5.0 + v0.5.1 work \"all looks the same\" in his browser. Production was confirmed serving the new files (curl-verified: \`/_dark-theme.css\` has the html-bg fix, \`/sun-toggle.js\` has the click listener, \`/cmms\` HTML has the new shared topbar markup). But the **service worker was masking everything**.

\`sw.js\` is cache-first for CSS/JS and \`CACHE_NAME\` had been pinned at \`'factorylm-v3'\` since the SW was introduced. The activate handler only deletes caches whose key !== current CACHE_NAME — so without a name bump, the old cache lives forever and returning visitors get stale assets indefinitely.

## Fix

1. Bump \`CACHE_NAME\` \`'factorylm-v3'\` → \`'factorylm-v4'\`. Activate handler now deletes the v3 cache; assets re-fetch from network.
2. Add \`/_dark-theme.css\` and \`/sun-toggle.js\` to \`PRECACHE_URLS\` (companions to the already-precached \`/_tokens.css\` and \`/_components.css\`).
3. Add a comment to \`sw.js\` so the next person editing it remembers to bump on every asset change.

## Action for returning visitors

After deploy: refresh once to fetch the new \`sw.js\`, then refresh again so the new SW activates and serves fresh assets. Or open in an incognito window for an immediate clean check.

## Test plan
- [x] Local: \`bun test src/views/__tests__/topbar.test.ts\` — 23/23 still pass (no test impact, sw.js is static).
- [ ] Post-deploy: hard-refresh \`/\`, \`/cmms\`, \`/limitations\`, \`/security\` — confirm new topbar + dark bg + working sun-toggle land in a real browser.

## Versioning
- \`mira-web\` 0.5.1 → 0.5.2 (patch).
- Tag \`mira-web/v0.5.2\` pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)