### PR TITLE
feat(web): site-wide topbar coherence (mira-web v0.6.0)

### DIFF
--- a/mira-web/CHANGELOG.md
+++ b/mira-web/CHANGELOG.md
@@ -7,6 +7,52 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 to the component (`mira-web/vX.Y.Z`) so they don't collide with the MIRA
 monorepo's top-level tag progression.
 
+## [0.6.0] — 2026-05-03
+
+### Changed
+- **Site-wide topbar coherence — Phase 2 done.** The static HTML pages
+  (`pricing.html`, `privacy.html`, `terms.html`, `trust.html`,
+  `legal/dpa.html`) and the blog renderer (`src/lib/blog-renderer.ts`)
+  now serve the same standardized topbar as the TS-rendered marketing
+  views: plain "FactoryLM" wordmark (M-icon SVG dropped), the standard
+  5-link nav (CMMS / Pricing / Blog / Limitations / Security), and
+  the "Sign in" CTA. Per-page differences are limited to
+  `aria-current="page"`. This closes all six topbar variants flagged
+  in the 2026-05-03 style audit.
+- **Static HTML footers standardized.** Each footer now uses the same
+  4-link set as the marketing pages (Limitations / Trust / Privacy /
+  Terms) and drops the M-icon SVG from the footer logo. Previous
+  footers had inconsistent link sets (some had Blog + Fault Codes +
+  Troubleshooter + Contact, others omitted some).
+- **Blog renderer nav drops the M-icon and Mira-FAB-only branding
+  collision.** The 4 blog routes (/blog, /blog/fault-codes,
+  /blog/:slug for posts, /blog/:slug for fault codes) all render the
+  standardized topbar via the refactored `nav()` helper in
+  `blog-renderer.ts`.
+
+### Added
+- **56-test site-wide coherence suite** at
+  `src/__tests__/site-wide-topbar.test.ts`. Reads each rendered or
+  static HTML page and asserts:
+  - No M-icon SVG (`fill="#f0a000"`) in the topbar
+  - "Sign in" CTA copy (rejects "Get Started" / "Try free" /
+    "Join the Beta")
+  - All five standard nav links present
+  - M-icon-era labels gone ("Troubleshooter", "Product",
+    "Fault Codes" link in topbar)
+
+### Notes
+- /activated retains its own bespoke single-purpose post-payment
+  design (no topbar to standardize).
+- The static HTML pages keep their existing dark CSS world (their
+  own `--bg`/`--surface`/`--text` tokens). Only the nav/footer
+  markup was touched. Future Phase 3 could fully unify the design
+  tokens across blog + static pages with the marketing site, but
+  that's not needed to close the 2026-05-03 audit.
+- SW `CACHE_NAME` does not need to bump for this release — sw.js is
+  network-first for HTML navigations, so the changed static HTML
+  pages will reach returning visitors immediately on next nav.
+
 ## [0.5.2] — 2026-05-03
 
 ### Fixed

--- a/mira-web/package.json
+++ b/mira-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-web",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "FactoryLM PLG funnel — CMMS acquisition & onboarding flow",
   "type": "module",
   "scripts": {

--- a/mira-web/public/legal/dpa.html
+++ b/mira-web/public/legal/dpa.html
@@ -120,17 +120,15 @@
 
   <nav>
     <div class="nav-inner">
-      <a href="/" class="nav-logo">
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="24" height="24" rx="5" fill="#f0a000"/><path d="M6 17V8l3.5 5 2.5-3.5L14.5 13 18 8v9" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        FactoryLM
-      </a>
+      <a href="/" class="nav-logo" aria-label="FactoryLM home">FactoryLM</a>
       <ul class="nav-links">
-        <li><a href="/#features">Product</a></li>
+        <li><a href="/cmms">CMMS</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/blog">Blog</a></li>
-        <li><a href="/cmms">Troubleshooter</a></li>
+        <li><a href="/limitations">Limitations</a></li>
+        <li><a href="/security">Security</a></li>
       </ul>
-      <a href="/cmms" class="nav-cta">Join the Beta</a>
+      <a href="/cmms" class="nav-cta">Sign in</a>
     </div>
   </nav>
 
@@ -296,18 +294,12 @@
   <footer>
     <div class="inner">
       <div class="footer-inner">
-        <a href="/" class="nav-logo" style="font-size:13px;">
-          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" width="18" height="18"><rect width="24" height="24" rx="5" fill="#f0a000"/><path d="M6 17V8l3.5 5 2.5-3.5L14.5 13 18 8v9" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          FactoryLM
-        </a>
+        <a href="/" class="nav-logo" style="font-size:13px;" aria-label="FactoryLM home">FactoryLM</a>
         <ul class="footer-links">
-          <li><a href="/blog">Blog</a></li>
-          <li><a href="/cmms">Troubleshooter</a></li>
+          <li><a href="/limitations">Limitations</a></li>
           <li><a href="/trust">Trust</a></li>
           <li><a href="/privacy">Privacy</a></li>
           <li><a href="/terms">Terms</a></li>
-          <li><a href="/legal/dpa">DPA</a></li>
-          <li><a href="mailto:contact@factorylm.com">Contact</a></li>
         </ul>
       </div>
     </div>

--- a/mira-web/public/pricing.html
+++ b/mira-web/public/pricing.html
@@ -272,16 +272,15 @@
 
   <nav>
     <div class="nav-inner">
-      <a href="/" class="nav-logo">
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="24" height="24" rx="5" fill="#f0a000"/><path d="M6 17V8l3.5 5 2.5-3.5L14.5 13 18 8v9" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        FactoryLM
-      </a>
+      <a href="/" class="nav-logo" aria-label="FactoryLM home">FactoryLM</a>
       <ul class="nav-links">
-        <li><a href="/#features">Product</a></li>
+        <li><a href="/cmms">CMMS</a></li>
+        <li><a href="/pricing" aria-current="page">Pricing</a></li>
         <li><a href="/blog">Blog</a></li>
-        <li><a href="/cmms">Troubleshooter</a></li>
+        <li><a href="/limitations">Limitations</a></li>
+        <li><a href="/security">Security</a></li>
       </ul>
-      <a href="/cmms" class="nav-cta">Get Started</a>
+      <a href="/cmms" class="nav-cta">Sign in</a>
     </div>
   </nav>
 
@@ -408,15 +407,10 @@
   <footer>
     <div class="inner">
       <div class="footer-inner">
-        <a href="/" class="nav-logo" style="font-size:13px;">
-          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" width="18" height="18"><rect width="24" height="24" rx="5" fill="#f0a000"/><path d="M6 17V8l3.5 5 2.5-3.5L14.5 13 18 8v9" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          FactoryLM
-        </a>
+        <a href="/" class="nav-logo" style="font-size:13px;" aria-label="FactoryLM home">FactoryLM</a>
         <ul class="footer-links">
-          <li><a href="/blog">Blog</a></li>
-          <li><a href="/blog/fault-codes">Fault Codes</a></li>
-          <li><a href="/cmms">Troubleshooter</a></li>
-          <li><a href="mailto:contact@factorylm.com">Contact</a></li>
+          <li><a href="/limitations">Limitations</a></li>
+          <li><a href="/trust">Trust</a></li>
           <li><a href="/privacy">Privacy</a></li>
           <li><a href="/terms">Terms</a></li>
         </ul>

--- a/mira-web/public/privacy.html
+++ b/mira-web/public/privacy.html
@@ -107,17 +107,15 @@
 
   <nav>
     <div class="nav-inner">
-      <a href="/" class="nav-logo">
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="24" height="24" rx="5" fill="#f0a000"/><path d="M6 17V8l3.5 5 2.5-3.5L14.5 13 18 8v9" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        FactoryLM
-      </a>
+      <a href="/" class="nav-logo" aria-label="FactoryLM home">FactoryLM</a>
       <ul class="nav-links">
-        <li><a href="/#features">Product</a></li>
+        <li><a href="/cmms">CMMS</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/blog">Blog</a></li>
-        <li><a href="/cmms">Troubleshooter</a></li>
+        <li><a href="/limitations">Limitations</a></li>
+        <li><a href="/security">Security</a></li>
       </ul>
-      <a href="/cmms" class="nav-cta">Join the Beta</a>
+      <a href="/cmms" class="nav-cta">Sign in</a>
     </div>
   </nav>
 
@@ -241,18 +239,12 @@
   <footer>
     <div class="inner">
       <div class="footer-inner">
-        <a href="/" class="nav-logo" style="font-size:13px;">
-          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" width="18" height="18"><rect width="24" height="24" rx="5" fill="#f0a000"/><path d="M6 17V8l3.5 5 2.5-3.5L14.5 13 18 8v9" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          FactoryLM
-        </a>
+        <a href="/" class="nav-logo" style="font-size:13px;" aria-label="FactoryLM home">FactoryLM</a>
         <ul class="footer-links">
-          <li><a href="/blog">Blog</a></li>
-          <li><a href="/blog/fault-codes">Fault Codes</a></li>
-          <li><a href="/cmms">Troubleshooter</a></li>
+          <li><a href="/limitations">Limitations</a></li>
           <li><a href="/trust">Trust</a></li>
           <li><a href="/privacy">Privacy</a></li>
           <li><a href="/terms">Terms</a></li>
-          <li><a href="mailto:contact@factorylm.com">Contact</a></li>
         </ul>
       </div>
     </div>

--- a/mira-web/public/terms.html
+++ b/mira-web/public/terms.html
@@ -108,17 +108,15 @@
 
   <nav>
     <div class="nav-inner">
-      <a href="/" class="nav-logo">
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="24" height="24" rx="5" fill="#f0a000"/><path d="M6 17V8l3.5 5 2.5-3.5L14.5 13 18 8v9" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        FactoryLM
-      </a>
+      <a href="/" class="nav-logo" aria-label="FactoryLM home">FactoryLM</a>
       <ul class="nav-links">
-        <li><a href="/#features">Product</a></li>
+        <li><a href="/cmms">CMMS</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/blog">Blog</a></li>
-        <li><a href="/cmms">Troubleshooter</a></li>
+        <li><a href="/limitations">Limitations</a></li>
+        <li><a href="/security">Security</a></li>
       </ul>
-      <a href="/cmms" class="nav-cta">Join the Beta</a>
+      <a href="/cmms" class="nav-cta">Sign in</a>
     </div>
   </nav>
 
@@ -190,18 +188,12 @@
   <footer>
     <div class="inner">
       <div class="footer-inner">
-        <a href="/" class="nav-logo" style="font-size:13px;">
-          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" width="18" height="18"><rect width="24" height="24" rx="5" fill="#f0a000"/><path d="M6 17V8l3.5 5 2.5-3.5L14.5 13 18 8v9" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          FactoryLM
-        </a>
+        <a href="/" class="nav-logo" style="font-size:13px;" aria-label="FactoryLM home">FactoryLM</a>
         <ul class="footer-links">
-          <li><a href="/blog">Blog</a></li>
-          <li><a href="/blog/fault-codes">Fault Codes</a></li>
-          <li><a href="/cmms">Troubleshooter</a></li>
+          <li><a href="/limitations">Limitations</a></li>
           <li><a href="/trust">Trust</a></li>
           <li><a href="/privacy">Privacy</a></li>
           <li><a href="/terms">Terms</a></li>
-          <li><a href="mailto:contact@factorylm.com">Contact</a></li>
         </ul>
       </div>
     </div>

--- a/mira-web/public/trust.html
+++ b/mira-web/public/trust.html
@@ -117,17 +117,15 @@
 
   <nav>
     <div class="nav-inner">
-      <a href="/" class="nav-logo">
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="24" height="24" rx="5" fill="#f0a000"/><path d="M6 17V8l3.5 5 2.5-3.5L14.5 13 18 8v9" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        FactoryLM
-      </a>
+      <a href="/" class="nav-logo" aria-label="FactoryLM home">FactoryLM</a>
       <ul class="nav-links">
-        <li><a href="/#features">Product</a></li>
+        <li><a href="/cmms">CMMS</a></li>
         <li><a href="/pricing">Pricing</a></li>
         <li><a href="/blog">Blog</a></li>
-        <li><a href="/cmms">Troubleshooter</a></li>
+        <li><a href="/limitations">Limitations</a></li>
+        <li><a href="/security">Security</a></li>
       </ul>
-      <a href="/cmms" class="nav-cta">Join the Beta</a>
+      <a href="/cmms" class="nav-cta">Sign in</a>
     </div>
   </nav>
 
@@ -299,17 +297,12 @@
   <footer>
     <div class="inner">
       <div class="footer-inner">
-        <a href="/" class="nav-logo" style="font-size:13px;">
-          <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" width="18" height="18"><rect width="24" height="24" rx="5" fill="#f0a000"/><path d="M6 17V8l3.5 5 2.5-3.5L14.5 13 18 8v9" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>
-          FactoryLM
-        </a>
+        <a href="/" class="nav-logo" style="font-size:13px;" aria-label="FactoryLM home">FactoryLM</a>
         <ul class="footer-links">
-          <li><a href="/blog">Blog</a></li>
-          <li><a href="/cmms">Troubleshooter</a></li>
+          <li><a href="/limitations">Limitations</a></li>
           <li><a href="/trust">Trust</a></li>
           <li><a href="/privacy">Privacy</a></li>
           <li><a href="/terms">Terms</a></li>
-          <li><a href="mailto:contact@factorylm.com">Contact</a></li>
         </ul>
       </div>
     </div>

--- a/mira-web/src/__tests__/site-wide-topbar.test.ts
+++ b/mira-web/src/__tests__/site-wide-topbar.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Site-wide topbar coherence tests (v0.6.0).
+ *
+ * After the v0.5.0 audit found six different topbars live in production,
+ * v0.5.0 unified the four TS-rendered marketing views and v0.6.0 brings
+ * the static HTML pages and blog renderer onto the same standard.
+ *
+ * This suite reads each rendered/served page and asserts:
+ *   - No M-icon SVG in the topbar (wordmark only, per audit's recommended logo)
+ *   - The standard 5-link nav set (CMMS, Pricing, Blog, Limitations, Security)
+ *     OR — for blog renderer — the standard nav-link helper output
+ *   - The "Sign in" CTA copy (no "Get Started", "Try free", "Join the Beta")
+ *
+ * Static HTML pages are read from disk; TS view pages are rendered via
+ * their exported render functions; blog pages are rendered via the
+ * blog-renderer module.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { renderHome } from "../views/home.js";
+import { renderCmms, renderSamplePlaceholder } from "../views/cmms.js";
+import { renderLimitations } from "../views/limitations.js";
+import { renderSecurity } from "../views/security.js";
+import {
+  renderBlogIndex,
+  renderFaultCodeIndex,
+  renderBlogPost,
+  renderFaultCodePage,
+} from "../lib/blog-renderer.js";
+import { BLOG_POSTS } from "../data/blog-posts.js";
+import { FAULT_CODES } from "../data/fault-codes.js";
+
+const PUBLIC_DIR = join(process.cwd(), "public");
+
+function readStatic(file: string): string {
+  return readFileSync(join(PUBLIC_DIR, file), "utf-8");
+}
+
+interface PageCase {
+  name: string;
+  html: string;
+}
+
+const tsViewPages: PageCase[] = [
+  { name: "/", html: renderHome("https://factorylm.com/") },
+  { name: "/cmms", html: renderCmms("https://factorylm.com/cmms") },
+  { name: "/sample", html: renderSamplePlaceholder() },
+  { name: "/limitations", html: renderLimitations("https://factorylm.com/limitations") },
+  { name: "/security", html: renderSecurity("https://factorylm.com/security") },
+];
+
+const staticPages: PageCase[] = [
+  { name: "/pricing", html: readStatic("pricing.html") },
+  { name: "/privacy", html: readStatic("privacy.html") },
+  { name: "/terms", html: readStatic("terms.html") },
+  { name: "/trust", html: readStatic("trust.html") },
+  { name: "/legal/dpa", html: readStatic("legal/dpa.html") },
+];
+
+const blogPages: PageCase[] = [
+  { name: "/blog", html: renderBlogIndex(BLOG_POSTS) },
+  { name: "/blog/fault-codes", html: renderFaultCodeIndex(FAULT_CODES) },
+  ...(BLOG_POSTS[0]
+    ? [
+        {
+          name: `/blog/${BLOG_POSTS[0].slug}`,
+          html: renderBlogPost(BLOG_POSTS[0], BLOG_POSTS, FAULT_CODES),
+        },
+      ]
+    : []),
+  ...(FAULT_CODES[0]
+    ? [
+        {
+          name: `/blog/${FAULT_CODES[0].slug}`,
+          html: renderFaultCodePage(FAULT_CODES[0], BLOG_POSTS, FAULT_CODES),
+        },
+      ]
+    : []),
+];
+
+const allPages: PageCase[] = [...tsViewPages, ...staticPages, ...blogPages];
+
+// Extracts the topbar (header.fl-topbar OR <nav>) so footer/body links
+// don't pollute assertions.
+function extractTopbar(html: string): string {
+  const fl = html.match(/<header[^>]*class="fl-topbar"[\s\S]*?<\/header>/);
+  if (fl) return fl[0];
+  const nav = html.match(/<nav[\s\S]*?<\/nav>/);
+  if (nav) return nav[0];
+  return "";
+}
+
+describe("site-wide topbar coherence (v0.6.0)", () => {
+  for (const page of allPages) {
+    test(`${page.name}: topbar logo is wordmark only — no M-icon SVG`, () => {
+      const topbar = extractTopbar(page.html);
+      expect(topbar).not.toBe("");
+      // The M-icon SVG is identified by its distinctive amber rect fill.
+      expect(topbar).not.toMatch(/fill="#f0a000"/);
+    });
+
+    test(`${page.name}: topbar CTA reads "Sign in"`, () => {
+      const topbar = extractTopbar(page.html);
+      expect(topbar).toContain("Sign in");
+      // Killed CTAs from the M-icon era:
+      expect(topbar).not.toContain("Get Started");
+      expect(topbar).not.toContain("Try free");
+      expect(topbar).not.toContain("Join the Beta");
+    });
+
+    test(`${page.name}: topbar nav has the five standard links`, () => {
+      const topbar = extractTopbar(page.html);
+      expect(topbar).toContain('href="/cmms"');
+      expect(topbar).toContain('href="/pricing"');
+      expect(topbar).toContain('href="/blog"');
+      expect(topbar).toContain('href="/limitations"');
+      expect(topbar).toContain('href="/security"');
+    });
+
+    test(`${page.name}: topbar dropped the "Troubleshooter" / "Product" / "Fault Codes" labels`, () => {
+      const topbar = extractTopbar(page.html);
+      // M-icon-era nav labels:
+      expect(topbar).not.toContain("Troubleshooter");
+      expect(topbar).not.toContain(">Product<");
+      expect(topbar).not.toMatch(/href="\/blog\/fault-codes"[^>]*>Fault Codes</);
+    });
+  }
+});

--- a/mira-web/src/lib/blog-renderer.ts
+++ b/mira-web/src/lib/blog-renderer.ts
@@ -57,44 +57,49 @@ function htmlHead(opts: {
 </head>`;
 }
 
-// ── Shared nav (matches index.html structure exactly) ──
+// ── Shared nav + footer ──
+//
+// The blog uses its own CSS world (blog.css) but the topbar markup is now
+// the same standardized 5-link nav + "Sign in" CTA used by the marketing
+// pages. Drops the M-icon, uses the wordmark only — matches the post-v0.5.0
+// site standard. blog.css's `.nav-*` classes still provide the visual style.
 
-function nav(): string {
+interface BlogNavOpts {
+  /** Path of the current page, used for aria-current="page". */
+  currentPath?: string;
+}
+
+function navLink(href: string, label: string, currentPath?: string): string {
+  const current = currentPath === href ? ` aria-current="page"` : "";
+  return `<li><a href="${href}"${current}>${label}</a></li>`;
+}
+
+function nav(opts: BlogNavOpts = {}): string {
   return `<nav id="main-nav" role="navigation" aria-label="Main navigation">
   <div class="nav-inner">
-    <a href="/" class="nav-logo" aria-label="FactoryLM home">
-      ${LOGO_SVG}
-      FactoryLM
-    </a>
+    <a href="/" class="nav-logo" aria-label="FactoryLM home">FactoryLM</a>
     <ul class="nav-links" role="list">
-      <li><a href="/#features">Product</a></li>
-      <li><a href="/blog">Blog</a></li>
-      <li><a href="/blog/fault-codes">Fault Codes</a></li>
-      <li><a href="/cmms">CMMS</a></li>
+      ${navLink("/cmms", "CMMS", opts.currentPath)}
+      ${navLink("/pricing", "Pricing", opts.currentPath)}
+      ${navLink("/blog", "Blog", opts.currentPath)}
+      ${navLink("/limitations", "Limitations", opts.currentPath)}
+      ${navLink("/security", "Security", opts.currentPath)}
     </ul>
-    <a href="/cmms" class="nav-cta">Try free</a>
+    <a href="/cmms" class="nav-cta">Sign in</a>
   </div>
 </nav>`;
 }
-
-// ── Shared footer (matches index.html structure exactly) ──
 
 function siteFooter(): string {
   return `<footer role="contentinfo">
   <div class="inner">
     <div class="footer-inner">
-      <a href="/" class="footer-logo" aria-label="FactoryLM home">
-        <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" width="18" height="18">
-          <rect width="24" height="24" rx="5" fill="#f0a000"/>
-          <path d="M6 17V8l3.5 5 2.5-3.5L14.5 13 18 8v9" stroke="#000" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-        </svg>
-        FactoryLM
-      </a>
+      <a href="/" class="footer-logo" aria-label="FactoryLM home">FactoryLM</a>
       <ul class="footer-links" role="list">
-        <li><a href="/blog">Blog</a></li>
-        <li><a href="/blog/fault-codes">Fault Codes</a></li>
-        <li><a href="/cmms">CMMS</a></li>
-        <li><a href="mailto:contact@factorylm.com">Contact</a></li>
+        <li><a href="/limitations">Limitations</a></li>
+        <li><a href="/trust">Trust</a></li>
+        <li><a href="/privacy">Privacy</a></li>
+        <li><a href="/terms">Terms</a></li>
       </ul>
     </div>
   </div>
@@ -155,7 +160,7 @@ export function renderBlogPost(
 
   return `${htmlHead({ title: `${post.title} | FactoryLM`, description: post.description, canonical, jsonLd })}
 <body>
-${nav()}
+${nav({ currentPath: "/blog" })}
 
 <main>
 <article class="article-wrap">
@@ -285,7 +290,7 @@ ${related.map((r) => `      <li><a href="/blog/${r.slug}">${escHtml(r.title)}</a
 
   return `${htmlHead({ title: `${fc.title} | FactoryLM`, description: fc.metaDescription, canonical, jsonLd })}
 <body>
-${nav()}
+${nav({ currentPath: "/blog" })}
 
 <main>
 <article class="article-wrap">
@@ -374,7 +379,7 @@ export function renderBlogIndex(
     jsonLd,
   })}
 <body>
-${nav()}
+${nav({ currentPath: "/blog" })}
 
 <main>
 <div class="blog-hero">
@@ -472,7 +477,7 @@ ${codes
     jsonLd,
   })}
 <body>
-${nav()}
+${nav({ currentPath: "/blog" })}
 
 <main>
 <div class="blog-hero">


### PR DESCRIPTION
## Summary

Closes the 2026-05-03 style audit. After v0.5.0 unified the four TS-rendered marketing views (home, cmms, limitations, security/sample), the M-icon-era topbar still lived on every static HTML page (\`pricing\`, \`privacy\`, \`terms\`, \`trust\`, \`legal/dpa\`) and the blog renderer (\`/blog\`, \`/blog/fault-codes\`, individual posts). v0.6.0 brings them all onto the same standardized topbar.

**Per page now:**
- Plain "FactoryLM" wordmark — M-icon SVG dropped
- Standard 5-link nav: CMMS / Pricing / Blog / Limitations / Security
- "Sign in" CTA (was: "Get Started" / "Try free" / "Join the Beta" depending on page)
- \`aria-current="page"\` on the matching link

**Static HTML footers standardized too:** 4-link set (Limitations / Trust / Privacy / Terms), M-icon dropped from footer logo.

## Test plan

- [x] 56 new tests in \`src/__tests__/site-wide-topbar.test.ts\` — assert no M-icon SVG, "Sign in" copy, 5 standard links, M-icon-era labels gone. Reads each page (TS-rendered or static HTML).
- [x] All 79 topbar tests pass (23 from v0.5.0 + 56 new).
- [x] Zero new failures in full test suite (the 14 pre-existing failures in admin/qr-print, m-register, and the cmms AC1 hidden-input test are unchanged).
- [ ] Post-deploy: visit /, /cmms, /pricing, /privacy, /terms, /trust, /legal/dpa, /blog, /blog/fault-codes, /limitations, /security in a browser and confirm topbar parity (same wordmark + same nav + same "Sign in" CTA on all 11 routes).

## Files changed (9)

- \`src/lib/blog-renderer.ts\` — \`nav()\` and \`siteFooter()\` rewritten to standard markup
- \`public/pricing.html\`, \`public/privacy.html\`, \`public/terms.html\`, \`public/trust.html\`, \`public/legal/dpa.html\` — nav + footer markup standardized
- \`src/__tests__/site-wide-topbar.test.ts\` — new 56-test contract suite
- \`package.json\` — 0.5.2 → 0.6.0
- \`CHANGELOG.md\` — v0.6.0 entry

## Out of scope

- /activated — bespoke single-purpose post-payment design, no topbar to standardize
- Full design-system unification (static HTML pages still use their own \`--bg\`/\`--surface\`/\`--text\` tokens, close-but-not-identical to marketing's \`#09090c\` palette). Tracked as future Phase 3 if the next audit flags it.
- Floating Mira-FAB chat button on /blog (separate concern from topbar)

## Versioning

- mira-web 0.5.2 → 0.6.0 (minor — site-wide visual change affecting every public page)
- Tag \`mira-web/v0.6.0\` pushed
- CHANGELOG entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)