### PR TITLE
fix(mira-web): CMMS nav — wire JWT through magic-link to /sample Open CMMS button

### DIFF
--- a/mira-web/src/server.ts
+++ b/mira-web/src/server.ts
@@ -895,7 +895,7 @@ app.get("/api/magic/login", async (c) => {
     }).catch(() => {});
 
     c.header("Set-Cookie", buildSessionCookie(sessionToken));
-    return c.redirect("/sample", 302);
+    return c.redirect(`/sample?token=${encodeURIComponent(sessionToken)}`, 302);
   } catch (err) {
     console.error("[magic-link/login] Error:", err);
     return c.html(magicLinkErrorPage("Something went wrong"), 500);

--- a/mira-web/src/views/cmms.ts
+++ b/mira-web/src/views/cmms.ts
@@ -386,6 +386,7 @@ export function renderSamplePlaceholder(): string {
       <h1>You're signed in.</h1>
       <p>Your sample workspace will appear here once Phase 1 ships. For now, the fastest way to feel the product is to upload your first manual — MIRA will OCR it, chunk it, and let you ask questions with citations.</p>
       <div class="fl-sample-cta">
+        <a id="cmms-btn" href="#" class="fl-btn fl-btn-primary" data-cta="sample-cmms" style="display:none">Open CMMS</a>
         ${btnPrimary("Upload your first manual", { href: "/activated", cta: "sample-upload" })}
         ${btnGhost("Back to home", { href: "/", cta: "sample-home" })}
       </div>
@@ -393,6 +394,25 @@ export function renderSamplePlaceholder(): string {
   </main>
   ${footer({ ctaPrefix: "sample" })}
   <script src="/sun-toggle.js"></script>
+  <script>
+    (function () {
+      var params = new URLSearchParams(location.search);
+      var token = params.get('token');
+      if (token) {
+        sessionStorage.setItem('flm_token', token);
+        history.replaceState(null, '', '/sample');
+      } else {
+        token = sessionStorage.getItem('flm_token');
+      }
+      if (token) {
+        var btn = document.getElementById('cmms-btn');
+        if (btn) {
+          btn.href = '/api/cmms/login?token=' + encodeURIComponent(token);
+          btn.style.display = '';
+        }
+      }
+    })();
+  </script>
 </body>
 </html>`;
 }


### PR DESCRIPTION
## Problem

Magic-link sign-in was broken for returning users trying to reach the CMMS:

1. User goes to `/cmms`, enters email, clicks magic link
2. Server sets `mira_session` cookie (HttpOnly) → redirects to `/sample` with **no token in URL**
3. `feature-renderer.ts` checks `sessionStorage.flm_token` for the "Open CMMS" CTA swap — never set → CTA stays "Sign in"
4. User clicks "Upload your first manual" → `/activated` → no token in URL or sessionStorage → **bounced back to `/cmms` (broken loop)**

## Fix

**`server.ts`:** Pass `sessionToken` in the redirect URL:
```
/sample?token=${encodeURIComponent(sessionToken)}
```

**`views/cmms.ts`:** Add to `/sample` page:
- Hidden "Open CMMS" `<a id="cmms-btn">` button
- Inline script that reads `?token=` from URL, stores in `sessionStorage.flm_token`, cleans URL, then wires up button href to `/api/cmms/login?token=…` and makes it visible

## Flow after fix

Magic link click → `/sample?token=<jwt>` → script stores token → "Open CMMS" button appears → click → `/api/cmms/login?token=<jwt>` → Atlas SSO → `cmms.factorylm.com`

`activated.html` "Upload your first manual" also picks up the token from sessionStorage (already wired there).

## Test plan

- [ ] Sign in via magic link at `/cmms` — land on `/sample` with "Open CMMS" visible
- [ ] Click "Open CMMS" → redirected to `cmms.factorylm.com` and logged in
- [ ] Hard refresh `/sample` — token persists from sessionStorage, button still visible
- [ ] `bun test` — 18/19 pass (1 pre-existing fail in `renderCmms` AC1)

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)