### PR TITLE
fix(telegram-bot): /new command + fresh-question bypass for stale WO state

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -119,12 +119,37 @@ _PLACEHOLDER_OPTION_RE = re.compile(r"^[\"']?\d+[.):\-]?[\"']?$")
 # WO confirmation, denial, or edit instruction. Anything outside this vocab AND
 # longer than the threshold is treated as a fresh question that should NOT be
 # routed into the WO confirmation flow.
-_WO_RESPONSE_VOCAB = frozenset({
-    "yes", "yeah", "yep", "yup", "y", "sure", "ok", "okay", "log", "long",
-    "create", "submit", "confirm", "do it", "log it", "create it", "go ahead",
-    "please", "1", "no", "nope", "n", "skip", "cancel", "abort",
-    "never mind", "nevermind",
-})
+_WO_RESPONSE_VOCAB = frozenset(
+    {
+        "yes",
+        "yeah",
+        "yep",
+        "yup",
+        "y",
+        "sure",
+        "ok",
+        "okay",
+        "log",
+        "long",
+        "create",
+        "submit",
+        "confirm",
+        "do it",
+        "log it",
+        "create it",
+        "go ahead",
+        "please",
+        "1",
+        "no",
+        "nope",
+        "n",
+        "skip",
+        "cancel",
+        "abort",
+        "never mind",
+        "nevermind",
+    }
+)
 
 _WO_EDIT_RE = re.compile(
     r"\b("
@@ -754,9 +779,7 @@ class Supervisor:
                         tenant_id=resolved_tenant,
                         honest_prefix=_honest_prefix,
                     )
-                return await self._handle_instructional_question(
-                    chat_id, message, state, trace_id
-                )
+                return await self._handle_instructional_question(chat_id, message, state, trace_id)
 
             if _router_intent == "continue_current" and detect_session_followup(
                 message, sc, state["state"]
@@ -820,7 +843,11 @@ class Supervisor:
                     kb_covered, _ = kb_has_coverage(mfr, combined, resolved_tenant or "")
                     if kb_covered:
                         return await self._do_documentation_lookup(
-                            chat_id, message, state, trace_id, resolved_tenant,
+                            chat_id,
+                            message,
+                            state,
+                            trace_id,
+                            resolved_tenant,
                             vendor_override=mfr,
                         )
                 return await self._enter_manual_lookup_gathering(
@@ -2547,7 +2574,11 @@ class Supervisor:
         # Phase 2 — KB pre-check: skip crawl when we already have coverage.
         kb_covered, kb_reason = kb_has_coverage(mfr, combined, resolved_tenant or "")
         if kb_covered:
-            reply = f"I have {mfr} documentation indexed." if mfr else "I already have documentation indexed for that equipment."
+            reply = (
+                f"I have {mfr} documentation indexed."
+                if mfr
+                else "I already have documentation indexed for that equipment."
+            )
             if url:
                 reply += f" Official source: {url}"
             reply += " Ask about fault codes, specs, or wiring."

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -115,6 +115,60 @@ _PADDING_OPTION_RE = re.compile(
 )
 _PLACEHOLDER_OPTION_RE = re.compile(r"^[\"']?\d+[.):\-]?[\"']?$")
 
+# Vocabulary used by the cmms-pending bypass: short responses that are clearly a
+# WO confirmation, denial, or edit instruction. Anything outside this vocab AND
+# longer than the threshold is treated as a fresh question that should NOT be
+# routed into the WO confirmation flow.
+_WO_RESPONSE_VOCAB = frozenset({
+    "yes", "yeah", "yep", "yup", "y", "sure", "ok", "okay", "log", "long",
+    "create", "submit", "confirm", "do it", "log it", "create it", "go ahead",
+    "please", "1", "no", "nope", "n", "skip", "cancel", "abort",
+    "never mind", "nevermind",
+})
+
+_WO_EDIT_RE = re.compile(
+    r"\b("
+    r"priority\s+(?:is|to)\s+(?:LOW|MEDIUM|HIGH|CRITICAL)"
+    r"|(?:asset|equipment|site|area|line|fault|resolution)\s+(?:is|:)"
+    r"|change\s+(?:priority|asset|site|area|line)"
+    r")",
+    re.IGNORECASE,
+)
+
+# Cues that the message is a fresh question, not a WO confirmation/edit.
+_NEW_QUESTION_RE = re.compile(
+    r"\b(what|how|why|when|where|which|who|tell me|explain|describe|"
+    r"diagnose|troubleshoot|help me|i need|can you|cause(?:s|d)?|"
+    r"causes?\s+of|caused\s+by|trigger(?:s|ed)?)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_fresh_question_during_wo(message: str) -> bool:
+    """True if message is a brand-new question, not a response to the WO preview.
+
+    Fixes the regression where a follow-up diagnostic question gets misrouted into
+    the cmms_pending flow because cmms_pending was set during a prior session.
+    """
+    msg = (message or "").strip()
+    if not msg:
+        return False
+    msg_lower = msg.lower()
+    # Short message that matches WO yes/no vocab → it's a WO response.
+    if msg_lower in _WO_RESPONSE_VOCAB:
+        return False
+    # Recognised edit instruction → WO response.
+    if _WO_EDIT_RE.search(msg):
+        return False
+    # Long message OR question marker OR question word → fresh question.
+    if "?" in msg:
+        return True
+    if _NEW_QUESTION_RE.search(msg):
+        return True
+    if len(msg) > 40:
+        return True
+    return False
+
 
 def _clean_option_list(options: list) -> list:
     """Strip leading numbers and drop padding/placeholder options.
@@ -353,7 +407,11 @@ class Supervisor:
         clear_photo: bool = False,
         target_state: str | None = None,
     ) -> dict:
-        """Drop stale diagnostic baggage when the user pivots to a new ask."""
+        """Drop stale diagnostic baggage when the user pivots to a new ask.
+
+        Also drops any pending WO draft + symptom/diagnosis summaries so a stale
+        WO from a prior conversation doesn't bleed into the next one.
+        """
         ctx = state.get("context") or {}
         sc = ctx.get("session_context") or {}
 
@@ -364,6 +422,11 @@ class Supervisor:
                 "last_question": None,
                 "last_options": [],
             }
+
+        # Clear any pending WO from a prior session — otherwise the next RESOLVED
+        # diagnosis re-uses the stale draft and shows wrong asset/fault to the user.
+        ctx.pop("cmms_pending", None)
+        ctx.pop("cmms_wo_draft", None)
 
         state["fault_category"] = None
         state["final_state"] = None
@@ -553,8 +616,24 @@ class Supervisor:
 
         # CMMS pending: user is answering the work-order creation prompt — handle before
         # any option resolution, session-followup detection, or intent classification.
+        # Bypass guard: if the message is clearly a brand-new diagnostic question (not a
+        # yes/no/edit on the pending WO), drop the stale WO flag and fall through to
+        # normal routing. Without this, a fresh question after a prior RESOLVED session
+        # gets misrouted into _handle_cmms_pending and the user can't escape the WO flow.
         if (state.get("context") or {}).get("cmms_pending") and not photo_b64:
-            return await self._handle_cmms_pending(chat_id, message, state, trace_id)
+            if _is_fresh_question_during_wo(message):
+                ctx_clear = state.get("context") or {}
+                ctx_clear.pop("cmms_pending", None)
+                ctx_clear.pop("cmms_wo_draft", None)
+                state["context"] = ctx_clear
+                self._save_state(chat_id, state)
+                logger.info(
+                    "CMMS_PENDING_BYPASS chat_id=%s msg=%r — treating as fresh question",
+                    chat_id,
+                    message[:120],
+                )
+            else:
+                return await self._handle_cmms_pending(chat_id, message, state, trace_id)
 
         # PM suggestion pending: user is answering a follow-up PM proposal.
         if (state.get("context") or {}).get("pm_suggestion_pending") and not photo_b64:

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -726,38 +726,58 @@ def main():
     # Helper to bind admin command kwargs without subclassing PTB's CommandHandler.
     async def _wrap_invite(update, context):
         if _admin_db_engine is None:
-            await update.message.reply_text("Admin commands unavailable: NEON_DATABASE_URL not set.")
+            await update.message.reply_text(
+                "Admin commands unavailable: NEON_DATABASE_URL not set."
+            )
             return
         await invite_command(
-            update, context,
-            engine=_admin_db_engine, auth=_authorizer, tenant_id=DEFAULT_TENANT_ID,
+            update,
+            context,
+            engine=_admin_db_engine,
+            auth=_authorizer,
+            tenant_id=DEFAULT_TENANT_ID,
         )
 
     async def _wrap_team(update, context):
         if _admin_db_engine is None:
-            await update.message.reply_text("Admin commands unavailable: NEON_DATABASE_URL not set.")
+            await update.message.reply_text(
+                "Admin commands unavailable: NEON_DATABASE_URL not set."
+            )
             return
         await team_command(
-            update, context,
-            engine=_admin_db_engine, auth=_authorizer, tenant_id=DEFAULT_TENANT_ID,
+            update,
+            context,
+            engine=_admin_db_engine,
+            auth=_authorizer,
+            tenant_id=DEFAULT_TENANT_ID,
         )
 
     async def _wrap_revoke(update, context):
         if _admin_db_engine is None:
-            await update.message.reply_text("Admin commands unavailable: NEON_DATABASE_URL not set.")
+            await update.message.reply_text(
+                "Admin commands unavailable: NEON_DATABASE_URL not set."
+            )
             return
         await revoke_command(
-            update, context,
-            engine=_admin_db_engine, auth=_authorizer, tenant_id=DEFAULT_TENANT_ID,
+            update,
+            context,
+            engine=_admin_db_engine,
+            auth=_authorizer,
+            tenant_id=DEFAULT_TENANT_ID,
         )
 
     async def _wrap_invite_status(update, context):
         if _admin_db_engine is None:
-            await update.message.reply_text("Admin commands unavailable: NEON_DATABASE_URL not set.")
+            await update.message.reply_text(
+                "Admin commands unavailable: NEON_DATABASE_URL not set."
+            )
             return
         await invite_status_command(
-            update, context,
-            engine=_admin_db_engine, auth=_authorizer, tenant_id=DEFAULT_TENANT_ID,
+            update,
+            context,
+            engine=_admin_db_engine,
+            auth=_authorizer,
+            tenant_id=DEFAULT_TENANT_ID,
         )
 
     async def _wrap_start(update, context):
@@ -800,8 +820,9 @@ def main():
     app.add_error_handler(_conflict_error_handler)
     _ver_path = os.path.join(os.path.dirname(__file__), "VERSION")
     _ver = open(_ver_path).read().strip() if os.path.exists(_ver_path) else "unknown"
-    logger.info("MIRA Telegram bot starting (polling) version=%s admins=%d",
-                _ver, _authorizer.admin_count())
+    logger.info(
+        "MIRA Telegram bot starting (polling) version=%s admins=%d", _ver, _authorizer.admin_count()
+    )
     app.run_polling(allowed_updates=Update.ALL_TYPES)
 
 

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -544,6 +544,14 @@ async def reset_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text("Conversation reset.")
 
 
+async def new_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Hard-reset conversation state — no preview of WO, no carryover from prior sessions."""
+    chat_id = str(update.effective_chat.id)
+    engine.reset(chat_id)
+    logger.info("NEW_SESSION chat_id=%s user=%s", chat_id, update.effective_user.first_name)
+    await update.message.reply_text("🔄 Fresh start. What can I help with?")
+
+
 async def status_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Query Open WebUI for an equipment status summary."""
     headers = {"Content-Type": "application/json"}
@@ -665,7 +673,8 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
         "/status \u2014 AI equipment summary\n"
         "/voice on|off \u2014 Enable/disable spoken responses\n"
         "/bad [reason] \u2014 Flag this response as unhelpful\n"
-        "/reset \u2014 Reset conversation state\n"
+        "/new \u2014 Fresh start (clear conversation state)\n"
+        "/reset \u2014 Reset conversation state (alias for /new)\n"
         "/help \u2014 Show this help\n"
         "Or just type any maintenance question.\n"
         "Send a photo to identify equipment.\n"
@@ -755,10 +764,24 @@ def main():
         if _admin_db_engine is None:
             await update.message.reply_text("MIRA isn't fully configured. Ask your admin.")
             return
+        # No-args /start from an already-enrolled user → behave like /new.
+        # Args present → invite-token consumption flow (unchanged).
+        if not (context.args or []):
+            chat_id = str(update.effective_chat.id)
+            engine.reset(chat_id)
+            logger.info(
+                "START_RESET chat_id=%s user=%s",
+                chat_id,
+                update.effective_user.first_name if update.effective_user else "?",
+            )
+            await update.message.reply_text("🔄 Fresh start. What can I help with?")
+            return
         await start_command(update, context, engine=_admin_db_engine)
 
-    # IMPORTANT: register /start FIRST so it wins over the legacy welcome.
+    # IMPORTANT: register /start and /new FIRST so they win over the legacy welcome
+    # AND so they always run before the message handler regardless of FSM state.
     app.add_handler(CommandHandler("start", _wrap_start))
+    app.add_handler(CommandHandler("new", new_command))
     app.add_handler(CommandHandler("invite", _wrap_invite))
     app.add_handler(CommandHandler("team", _wrap_team))
     app.add_handler(CommandHandler("revoke", _wrap_revoke))

--- a/mira-bots/tests/test_engine.py
+++ b/mira-bots/tests/test_engine.py
@@ -761,3 +761,50 @@ class TestFaultInfoRegex:
 
     def test_danfoss_alarm4(self):
         assert _FAULT_INFO_RE.search("FC102 showing Alarm 4")
+
+
+class TestFreshQuestionDuringWO:
+    """Guard against regression where a fresh question during a stale cmms_pending
+    state gets misrouted into the WO confirmation flow (bot critical fix 2026-05-04)."""
+
+    def test_yes_is_wo_response(self):
+        from shared.engine import _is_fresh_question_during_wo as f
+        assert not f("yes")
+        assert not f("Yes")
+        assert not f("yeah")
+        assert not f("y")
+
+    def test_no_is_wo_response(self):
+        from shared.engine import _is_fresh_question_during_wo as f
+        assert not f("no")
+        assert not f("nope")
+        assert not f("skip")
+        assert not f("cancel")
+
+    def test_edits_are_wo_response(self):
+        from shared.engine import _is_fresh_question_during_wo as f
+        assert not f("change priority to HIGH")
+        assert not f("asset is Pump-A3")
+        assert not f("priority is HIGH")
+        assert not f("line is Line 1")
+
+    def test_question_marks_are_fresh(self):
+        from shared.engine import _is_fresh_question_during_wo as f
+        assert f("What causes a VFD overcurrent fault?")
+        assert f("How do I reset this drive?")
+        assert f("why is my pump leaking?")
+
+    def test_question_words_are_fresh(self):
+        from shared.engine import _is_fresh_question_during_wo as f
+        assert f("How do I diagnose this")
+        assert f("Tell me about cooling tower maintenance")
+        assert f("describe the fault category")
+
+    def test_long_statements_are_fresh(self):
+        from shared.engine import _is_fresh_question_during_wo as f
+        assert f("My motor is making a strange grinding noise during startup")
+
+    def test_empty_message_is_not_fresh(self):
+        from shared.engine import _is_fresh_question_during_wo as f
+        assert not f("")
+        assert not f("   ")

--- a/mira-bots/tests/test_engine.py
+++ b/mira-bots/tests/test_engine.py
@@ -457,12 +457,12 @@ class TestSessionPivotRouting:
                 ),
             ),
             patch("shared.engine.classify_intent", return_value="documentation"),
-            patch.object(supervisor, "_handle_session_followup", new_callable=AsyncMock) as followup,
+            patch.object(
+                supervisor, "_handle_session_followup", new_callable=AsyncMock
+            ) as followup,
             patch("shared.engine.kb_has_coverage", return_value=(True, "cached docs")),
         ):
-            result = asyncio.run(
-                supervisor.process_full(chat_id, "do they have a website")
-            )
+            result = asyncio.run(supervisor.process_full(chat_id, "do they have a website"))
 
         assert followup.await_count == 0
         assert result["next_state"] == "ASSET_IDENTIFIED"
@@ -769,6 +769,7 @@ class TestFreshQuestionDuringWO:
 
     def test_yes_is_wo_response(self):
         from shared.engine import _is_fresh_question_during_wo as f
+
         assert not f("yes")
         assert not f("Yes")
         assert not f("yeah")
@@ -776,6 +777,7 @@ class TestFreshQuestionDuringWO:
 
     def test_no_is_wo_response(self):
         from shared.engine import _is_fresh_question_during_wo as f
+
         assert not f("no")
         assert not f("nope")
         assert not f("skip")
@@ -783,6 +785,7 @@ class TestFreshQuestionDuringWO:
 
     def test_edits_are_wo_response(self):
         from shared.engine import _is_fresh_question_during_wo as f
+
         assert not f("change priority to HIGH")
         assert not f("asset is Pump-A3")
         assert not f("priority is HIGH")
@@ -790,21 +793,25 @@ class TestFreshQuestionDuringWO:
 
     def test_question_marks_are_fresh(self):
         from shared.engine import _is_fresh_question_during_wo as f
+
         assert f("What causes a VFD overcurrent fault?")
         assert f("How do I reset this drive?")
         assert f("why is my pump leaking?")
 
     def test_question_words_are_fresh(self):
         from shared.engine import _is_fresh_question_during_wo as f
+
         assert f("How do I diagnose this")
         assert f("Tell me about cooling tower maintenance")
         assert f("describe the fault category")
 
     def test_long_statements_are_fresh(self):
         from shared.engine import _is_fresh_question_during_wo as f
+
         assert f("My motor is making a strange grinding noise during startup")
 
     def test_empty_message_is_not_fresh(self):
         from shared.engine import _is_fresh_question_during_wo as f
+
         assert not f("")
         assert not f("   ")


### PR DESCRIPTION
## Summary

Four-fix bundle for Telegram bot regressions Mike spotted in production today:

1. **`/new` command** — hard-resets conversation state, sends "🔄 Fresh start. What can I help with?". Also `/start` with no args now does the same (preserves invite-token deep-linking when args are present).
2. **FSM bypass for fresh questions** — when `cmms_pending=True` from a prior session, the engine was intercepting every new message and routing it into `_handle_cmms_pending`. New `_is_fresh_question_during_wo()` heuristic detects question marks / question words / long statements and clears the stale draft so the message falls through to normal routing.
3. **WO builder stale context** — `_clear_diagnostic_carryover()` now also pops `cmms_pending` and `cmms_wo_draft` so any pivot (general question / instructional / asset switch) drops the stale draft before a new RESOLVED can build a fresh one.
4. **Citations (PR #976)** — merged separately into `main` ahead of this PR.

## Test plan

- [x] `pytest mira-bots/tests/test_engine.py mira-bots/tests/test_work_order.py mira-bots/tests/test_engine_tenant_kwargs.py` — 103/103 passing
- [x] New `TestFreshQuestionDuringWO` class — 7 assertions
  - `yes` / `no` / `skip` / `cancel` → still treated as WO response
  - `priority is HIGH` / `asset is Pump-A3` → still treated as WO edit
  - `What causes a VFD overcurrent fault?` → fresh question
  - `How do I diagnose this` / `Tell me about cooling tower` → fresh question
- [ ] After deploy, send `/new` then `What causes a VFD overcurrent fault and how do I troubleshoot it?` — expect diagnostic answer with `[Source:...]` citations, NOT a work order preview.

## Files

- `mira-bots/telegram/bot.py` — `/new` handler + `/start` (no-args) reset
- `mira-bots/shared/engine.py` — `_is_fresh_question_during_wo()` helper, cmms_pending bypass, `_clear_diagnostic_carryover()` clears WO draft
- `mira-bots/tests/test_engine.py` — `TestFreshQuestionDuringWO` (7 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)