### PR TITLE
URGENT hotfix: admin telegram IDs bypass invite-only gate

### DIFF
--- a/mira-bots/shared/chat/dispatcher.py
+++ b/mira-bots/shared/chat/dispatcher.py
@@ -18,6 +18,12 @@ _RATE_LIMIT_MESSAGES = int(os.getenv("RATE_LIMIT_MESSAGES", "10"))
 _RATE_LIMIT_WINDOW = 60  # seconds
 
 
+def _admin_telegram_ids() -> frozenset[str]:
+    """Parse ADMIN_TELEGRAM_IDS env (CSV) — admins bypass the identity gate."""
+    raw = os.getenv("ADMIN_TELEGRAM_IDS", "")
+    return frozenset(tok.strip() for tok in raw.split(",") if tok.strip())
+
+
 class ChatDispatcher:
     """Takes normalized events from any adapter, runs them through MIRA's engine,
     returns normalized responses."""
@@ -99,18 +105,41 @@ class ChatDispatcher:
             )
 
         if mira_user is None:
-            logger.info(
-                "DISPATCH_BLOCKED platform=%s ext=%s reason=stranger",
-                event.platform,
-                event.external_user_id,
-            )
-            return NormalizedChatResponse(
-                text=(
-                    "Hi — I'm MIRA, your team's maintenance assistant. "
-                    "I'm invite-only. Ask your admin to send you an enrollment link."
-                ),
-                thread_id=event.external_thread_id,
-            )
+            # Admin bypass: ADMIN_TELEGRAM_IDS holders are the operators of the
+            # bot — they should never be gated by their own enrollment system.
+            # Synthesize a MiraUser with the default tenant_id from env so the
+            # rest of the pipeline (engine.process, ChatDispatcher logging) has
+            # the fields it expects.
+            admin_ids = _admin_telegram_ids()
+            if event.platform == "telegram" and str(event.external_user_id) in admin_ids:
+                from shared.identity.service import MiraUser as _MiraUser
+
+                tenant_id = os.getenv("MIRA_TENANT_ID", "")
+                mira_user = _MiraUser(
+                    id=f"admin:{event.external_user_id}",
+                    tenant_id=tenant_id,
+                    display_name="Admin",
+                    email="",
+                )
+                logger.info(
+                    "DISPATCH_ADMIN_BYPASS platform=%s ext=%s tenant=%s",
+                    event.platform,
+                    event.external_user_id,
+                    tenant_id,
+                )
+            else:
+                logger.info(
+                    "DISPATCH_BLOCKED platform=%s ext=%s reason=stranger",
+                    event.platform,
+                    event.external_user_id,
+                )
+                return NormalizedChatResponse(
+                    text=(
+                        "Hi — I'm MIRA, your team's maintenance assistant. "
+                        "I'm invite-only. Ask your admin to send you an enrollment link."
+                    ),
+                    thread_id=event.external_thread_id,
+                )
 
         # Extract pre-downloaded image bytes (set by adapter before dispatch)
         photo_b64 = None

--- a/mira-bots/tests/test_dispatcher_gate.py
+++ b/mira-bots/tests/test_dispatcher_gate.py
@@ -74,3 +74,34 @@ async def test_no_identity_service_blocks_all(fake_engine):
         or "not configured" in resp.text.lower()
     )
     fake_engine.process.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_admin_bypass_when_no_identity_link(fake_engine, monkeypatch):
+    """Admin telegram IDs (operators of the bot) bypass the enrollment gate
+    even without an identity_links row — they should never be locked out of
+    their own bot."""
+    monkeypatch.setenv("ADMIN_TELEGRAM_IDS", "8445149012")
+    monkeypatch.setenv("MIRA_TENANT_ID", "t_admin")
+    identity = MagicMock(spec=IdentityService)
+    identity.lookup_only = MagicMock(return_value=None)
+    disp = ChatDispatcher(fake_engine, identity_service=identity)
+    resp = await disp.dispatch(_event("8445149012", "diagnose this"))
+    assert resp.text == "OK reply"
+    fake_engine.process.assert_awaited_once()
+    # Engine should receive the admin bypass user with default tenant
+    call_kwargs = fake_engine.process.await_args.kwargs
+    assert call_kwargs.get("tenant_id") == "t_admin"
+    assert call_kwargs.get("mira_user_id") == "admin:8445149012"
+
+
+@pytest.mark.asyncio
+async def test_non_admin_still_blocked(fake_engine, monkeypatch):
+    """A non-admin telegram ID still hits the invite gate — bypass is admin-only."""
+    monkeypatch.setenv("ADMIN_TELEGRAM_IDS", "8445149012")
+    identity = MagicMock(spec=IdentityService)
+    identity.lookup_only = MagicMock(return_value=None)
+    disp = ChatDispatcher(fake_engine, identity_service=identity)
+    resp = await disp.dispatch(_event("999", "hi"))
+    assert "invite" in resp.text.lower()
+    fake_engine.process.assert_not_called()


### PR DESCRIPTION
## Why

Mike (the bot operator) was being blocked by his own enrollment gate because his Telegram ID has no row in `identity_links`. ADMIN_TELEGRAM_IDS holders should never be locked out of their own bot.

## Change

`shared/chat/dispatcher.py` — when `lookup_only` returns None, check `ADMIN_TELEGRAM_IDS` (CSV env var already used by `/invite` admin commands). If platform is telegram and `external_user_id` is in the admin set, synthesize a MiraUser with the default tenant_id from `MIRA_TENANT_ID` and let the engine process the message. Non-admin strangers are still blocked.

## Tests

5/5 `tests/test_dispatcher_gate.py` pass, including 2 new asserts:
- `test_admin_bypass_when_no_identity_link` — admin ID with no link gets through
- `test_non_admin_still_blocked` — non-admin still hits invite message

## Ops follow-up (required)

`ADMIN_TELEGRAM_IDS` must include Mike's ID `8445149012` in Doppler (`factorylm/prd`). Without that env var the bypass has nothing to allow. Apply via Doppler dashboard or:
```
doppler secrets set ADMIN_TELEGRAM_IDS=8445149012 --project factorylm --config prd
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)