### PR TITLE
hotfix(citations): clean up garbled filename-stem citation labels

### DIFF
--- a/mira-bots/shared/response_formatter.py
+++ b/mira-bots/shared/response_formatter.py
@@ -179,6 +179,103 @@ def parse_response(raw: str) -> dict:
 # ── Reply formatting ──────────────────────────────────────────────────────────
 
 
+# Rockwell / Allen-Bradley document-type codes that show up in PDF filenames.
+# When a model_number arrives looking like "193 um011 en p" we map "um" → "User Manual"
+# and recognise the bulletin number so the user sees a readable label instead of the stem.
+_DOC_TYPE_CODES = {
+    "um": "User Manual",
+    "in": "Installation Instructions",
+    "sg": "Selection Guide",
+    "qs": "Quick Start",
+    "td": "Technical Data",
+    "rm": "Reference Manual",
+    "pp": "Product Profile",
+    "ds": "Data Sheet",
+    "wd": "Wiring Diagram",
+    "fl": "Family Listing",
+    "at": "Application Technique",
+    "rn": "Release Notes",
+    "ap": "Application Note",
+}
+
+# Bulletin / product-family hints we recognise from common Rockwell numbers.
+# Conservative — only the codes we've actually ingested. Add as KB grows.
+_BULLETIN_FAMILY = {
+    "193": "Bulletin 193 E1 Plus Overload Relay",
+    "1756": "ControlLogix 1756",
+    "1769": "CompactLogix 1769",
+    "1734": "POINT I/O 1734",
+    "150": "SMC Flex Soft Starter",
+    "pflex": "PowerFlex Drive",
+    "powerflex": "PowerFlex Drive",
+    "kinetix": "Kinetix Servo Drive",
+    "stratix": "Stratix Switch",
+}
+
+# Pattern: a bulletin/series number, optional space, doc-type letters + digits,
+# optional language code, optional trailing single letter. Matches "193 um011 en p",
+# "193-um011-en-p", "pflex_um001_en_p", and similar filename stems.
+_FILENAME_STEM_RE = re.compile(
+    r"^\s*"
+    r"(?P<series>[a-z0-9]+)"  # 193, pflex, 1756, etc.
+    r"[\s_\-]+"
+    r"(?P<doctype>[a-z]{2})"  # um, in, sg, etc.
+    r"(?P<docnum>\d{2,4})"  # document number (011, 001, etc.)
+    r"(?:[\s_\-]+(?:en|fr|de|es|it|jp|zh)\w?)?"  # optional language code
+    r"(?:[\s_\-]+[a-z])?"  # optional trailing single letter (p = print)
+    r"\s*$",
+    re.IGNORECASE,
+)
+
+
+def _format_citation_label(c: dict) -> str:
+    """Build a readable citation label from a chunk dict.
+
+    Strategy:
+    1. If manufacturer + model_number both look human, use them as-is.
+    2. If model_number looks like a filename stem (e.g. "193 um011 en p"),
+       parse out the series + doc-type code and expand to a real label.
+    3. Otherwise, fall back to whatever non-empty pieces we have.
+    Always optionally append the section if present.
+    """
+    mfr = (c.get("manufacturer") or "").strip()
+    mdl = (c.get("model_number") or "").strip()
+    section = (c.get("section") or "").strip()
+    src_url = (c.get("source_url") or "").strip()
+
+    # Detect filename-stem pattern in model_number; clean if matched.
+    label = ""
+    if mdl:
+        m = _FILENAME_STEM_RE.match(mdl)
+        if m:
+            series = m.group("series").lower()
+            doctype = m.group("doctype").lower()
+            docnum = m.group("docnum")
+            family = _BULLETIN_FAMILY.get(series, series.upper())
+            doc_label = _DOC_TYPE_CODES.get(doctype, doctype.upper())
+            cleaned = f"{family} — {doc_label} {docnum}".strip()
+            label = cleaned
+        else:
+            # Model is human-readable already (e.g. "PowerFlex 525") — keep as-is.
+            label = mdl
+
+    if mfr and label and not label.lower().startswith(mfr.lower()):
+        label = f"{mfr} {label}"
+    elif mfr and not label:
+        label = mfr
+    elif not label and src_url:
+        # Last resort: derive a stub from the URL/path.
+        stub = src_url.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        stub = re.sub(r"[_\-]+", " ", stub).strip()
+        label = stub.title() if stub else "knowledge base"
+    elif not label:
+        label = "knowledge base"
+
+    if section:
+        label = f"{label} — {section}"
+    return label
+
+
 def _maybe_append_citation_footer(reply: str, kb_status: dict | None = None) -> str:
     """Append a Sources footer if KB chunks were used but the reply doesn't cite them."""
     citations = (kb_status or {}).get("citations") or []
@@ -186,16 +283,17 @@ def _maybe_append_citation_footer(reply: str, kb_status: dict | None = None) -> 
         return reply
     if "[Source:" in reply or "--- Sources ---" in reply:
         return reply
+    # Deduplicate identical labels so we don't show the same source twice.
+    seen: set[str] = set()
     lines = ["", "", "--- Sources ---"]
-    for i, c in enumerate(citations, 1):
-        mfr = c.get("manufacturer", "") or ""
-        mdl = c.get("model_number", "") or ""
-        section = c.get("section", "") or ""
-        label_parts = [p for p in [mfr, mdl] if p]
-        label = " ".join(label_parts) if label_parts else "knowledge base"
-        if section:
-            label += f" — {section}"
-        lines.append(f"[{i}] {label}")
+    idx = 1
+    for c in citations:
+        label = _format_citation_label(c)
+        if label in seen:
+            continue
+        seen.add(label)
+        lines.append(f"[{idx}] {label}")
+        idx += 1
     return reply + "\n".join(lines)
 
 

--- a/mira-bots/tests/test_citation_format.py
+++ b/mira-bots/tests/test_citation_format.py
@@ -1,0 +1,110 @@
+"""Tests for shared.response_formatter citation cleanup.
+
+Mike got '[1] 193 um011 en p' as a citation in production — meaning raw filename
+stems were being dumped instead of human-readable labels. These tests pin the
+expected clean output."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from shared.response_formatter import _format_citation_label, _maybe_append_citation_footer
+
+
+class TestCitationLabel:
+    def test_garbled_rockwell_filename_stem(self):
+        label = _format_citation_label(
+            {"manufacturer": "Allen-Bradley", "model_number": "193 um011 en p"}
+        )
+        assert "193" in label
+        assert "User Manual" in label
+        assert "um011" not in label
+        assert "en p" not in label
+
+    def test_clean_model_passes_through(self):
+        label = _format_citation_label(
+            {
+                "manufacturer": "Allen-Bradley",
+                "model_number": "PowerFlex 525",
+                "section": "Fault F006",
+            }
+        )
+        assert label == "Allen-Bradley PowerFlex 525 — Fault F006"
+
+    def test_filename_with_dashes(self):
+        label = _format_citation_label(
+            {"manufacturer": "Rockwell Automation", "model_number": "1756-in001-en-p"}
+        )
+        assert "ControlLogix 1756" in label
+        assert "Installation" in label
+
+    def test_pflex_filename_recognized(self):
+        label = _format_citation_label({"manufacturer": "", "model_number": "pflex_um001_en_p"})
+        assert "PowerFlex" in label
+        assert "User Manual" in label
+
+    def test_empty_falls_back_to_kb(self):
+        assert _format_citation_label({}) == "knowledge base"
+
+    def test_source_url_fallback(self):
+        label = _format_citation_label(
+            {"source_url": "https://example.com/docs/abb_acs550_manual.pdf"}
+        )
+        assert "Acs550" in label or "ACS550" in label.upper()
+
+    def test_section_appended(self):
+        label = _format_citation_label(
+            {
+                "manufacturer": "Siemens",
+                "model_number": "SINAMICS G120",
+                "section": "Fault F0005",
+            }
+        )
+        assert label.endswith("Fault F0005")
+
+    def test_no_double_manufacturer(self):
+        # If model already includes the manufacturer name, don't repeat it.
+        label = _format_citation_label(
+            {"manufacturer": "Allen-Bradley", "model_number": "Allen-Bradley PowerFlex 525"}
+        )
+        assert label.count("Allen-Bradley") == 1
+
+
+class TestCitationFooter:
+    def test_footer_dedupes_identical_labels(self):
+        kb_status = {
+            "citations": [
+                {"manufacturer": "Allen-Bradley", "model_number": "193 um011 en p"},
+                {"manufacturer": "Allen-Bradley", "model_number": "193 um011 en p"},
+                {
+                    "manufacturer": "Rockwell Automation",
+                    "model_number": "Bulletin 193 Overload Relay",
+                },
+            ]
+        }
+        out = _maybe_append_citation_footer("Reply text.", kb_status)
+        # Two distinct citation lines, not three
+        assert out.count("[1]") == 1
+        assert out.count("[2]") == 1
+        assert "[3]" not in out
+
+    def test_no_citations_no_footer(self):
+        out = _maybe_append_citation_footer("Reply text.", {"citations": []})
+        assert out == "Reply text."
+
+    def test_existing_footer_not_duplicated(self):
+        existing = "Reply text.\n\n--- Sources ---\n[1] something"
+        out = _maybe_append_citation_footer(
+            existing, {"citations": [{"manufacturer": "X", "model_number": "Y"}]}
+        )
+        assert out == existing  # unchanged
+
+    def test_inline_source_tags_block_footer(self):
+        existing = "The cause is X [Source: Allen-Bradley PowerFlex 525]"
+        out = _maybe_append_citation_footer(
+            existing, {"citations": [{"manufacturer": "AB", "model_number": "PF525"}]}
+        )
+        assert out == existing  # unchanged


### PR DESCRIPTION
## Why

Mike's live test produced citations like `[1] 193 um011 en p` — raw PDF filename stems leaking through because the chunk's `model_number` contained the file stem of the ingested Rockwell manual. The footer formatter just printed `manufacturer + model_number` without cleanup.

## What

Enhance `_maybe_append_citation_footer` (and a new `_format_citation_label` helper) to recognize Rockwell-style filename stems and expand to readable labels.

| Before | After |
|---|---|
| `[1] 193 um011 en p` | `[1] Allen-Bradley Bulletin 193 E1 Plus Overload Relay — User Manual 011` |
| `[1] pflex_um001_en_p` | `[1] PowerFlex Drive — User Manual 001` |
| `[1] 1756-in001-en-p` | `[1] Rockwell Automation ControlLogix 1756 — Installation Instructions 001` |

Doc-type codes recognized: `um/in/sg/qs/td/rm/pp/ds/wd/fl/at/rn/ap`. Bulletin numbers: `193 / 1756 / 1769 / 1734 / 150 / pflex / kinetix / stratix`. Clean labels like `PowerFlex 525` pass through unchanged. Falls back to source_url stem or `knowledge base`. Footer also de-duplicates identical labels.

## Tests

12 new in `tests/test_citation_format.py` (TestCitationLabel + TestCitationFooter). Total pass: 118/118 across engine + work_order + dispatcher_gate + citation_format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)