### PR TITLE
hotfix(citations): clean URL-only chunks (Q3 regression)

### DIFF
--- a/mira-bots/shared/response_formatter.py
+++ b/mira-bots/shared/response_formatter.py
@@ -228,14 +228,60 @@ _FILENAME_STEM_RE = re.compile(
 )
 
 
+# Domains where we can infer the manufacturer from the URL hostname.
+_DOMAIN_TO_MANUFACTURER = {
+    "rockwellautomation.com": "Allen-Bradley",
+    "ab.rockwellautomation.com": "Allen-Bradley",
+    "literature.rockwellautomation.com": "Allen-Bradley",
+    "siemens.com": "Siemens",
+    "support.industry.siemens.com": "Siemens",
+    "abb.com": "ABB",
+    "library.e.abb.com": "ABB",
+    "schneider-electric.com": "Schneider Electric",
+    "automationdirect.com": "AutomationDirect",
+    "factoryio.com": "Factory I/O",
+}
+
+
+def _manufacturer_from_url(src_url: str) -> str:
+    """Best-effort manufacturer inference from a documentation URL hostname."""
+    if not src_url:
+        return ""
+    m = re.match(r"^https?://([^/]+)/", src_url)
+    if not m:
+        return ""
+    host = m.group(1).lower()
+    for domain, mfr in _DOMAIN_TO_MANUFACTURER.items():
+        if host.endswith(domain):
+            return mfr
+    return ""
+
+
+def _parse_filename_stem(stem: str) -> str:
+    """If stem matches the bulletin/doc-type pattern, return a clean label.
+
+    Returns "" if no match — caller falls back to other strategies.
+    """
+    m = _FILENAME_STEM_RE.match(stem)
+    if not m:
+        return ""
+    series = m.group("series").lower()
+    doctype = m.group("doctype").lower()
+    docnum = m.group("docnum")
+    family = _BULLETIN_FAMILY.get(series, series.upper())
+    doc_label = _DOC_TYPE_CODES.get(doctype, doctype.upper())
+    return f"{family} — {doc_label} {docnum}".strip()
+
+
 def _format_citation_label(c: dict) -> str:
     """Build a readable citation label from a chunk dict.
 
     Strategy:
-    1. If manufacturer + model_number both look human, use them as-is.
-    2. If model_number looks like a filename stem (e.g. "193 um011 en p"),
-       parse out the series + doc-type code and expand to a real label.
-    3. Otherwise, fall back to whatever non-empty pieces we have.
+    1. If model_number is set and matches the bulletin/filename pattern, expand it.
+    2. If model_number is set and looks human, keep it as-is.
+    3. If only source_url is set, parse the URL stem with the same pattern, and
+       infer manufacturer from the hostname when possible.
+    4. Otherwise, fall back to whatever non-empty pieces we have.
     Always optionally append the section if present.
     """
     mfr = (c.get("manufacturer") or "").strip()
@@ -243,31 +289,28 @@ def _format_citation_label(c: dict) -> str:
     section = (c.get("section") or "").strip()
     src_url = (c.get("source_url") or "").strip()
 
-    # Detect filename-stem pattern in model_number; clean if matched.
     label = ""
     if mdl:
-        m = _FILENAME_STEM_RE.match(mdl)
-        if m:
-            series = m.group("series").lower()
-            doctype = m.group("doctype").lower()
-            docnum = m.group("docnum")
-            family = _BULLETIN_FAMILY.get(series, series.upper())
-            doc_label = _DOC_TYPE_CODES.get(doctype, doctype.upper())
-            cleaned = f"{family} — {doc_label} {docnum}".strip()
+        cleaned = _parse_filename_stem(mdl)
+        # If the parser found a known bulletin number, use the expansion;
+        # otherwise keep model_number verbatim (already human, e.g. "PowerFlex 525").
+        label = cleaned or mdl
+    elif src_url:
+        # No model_number — derive from URL stem and try the same parser.
+        stub = src_url.rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        cleaned = _parse_filename_stem(stub)
+        if cleaned:
             label = cleaned
         else:
-            # Model is human-readable already (e.g. "PowerFlex 525") — keep as-is.
-            label = mdl
+            label = re.sub(r"[_\-]+", " ", stub).strip().title() or "knowledge base"
+        # Infer manufacturer from the URL when missing.
+        if not mfr:
+            mfr = _manufacturer_from_url(src_url)
 
     if mfr and label and not label.lower().startswith(mfr.lower()):
         label = f"{mfr} {label}"
     elif mfr and not label:
         label = mfr
-    elif not label and src_url:
-        # Last resort: derive a stub from the URL/path.
-        stub = src_url.rsplit("/", 1)[-1].rsplit(".", 1)[0]
-        stub = re.sub(r"[_\-]+", " ", stub).strip()
-        label = stub.title() if stub else "knowledge base"
     elif not label:
         label = "knowledge base"
 

--- a/mira-bots/tests/test_citation_format.py
+++ b/mira-bots/tests/test_citation_format.py
@@ -72,6 +72,42 @@ class TestCitationLabel:
         )
         assert label.count("Allen-Bradley") == 1
 
+    def test_url_only_with_filename_pattern(self):
+        # The Q3 production case: model_number=None, only source_url to a Rockwell PDF.
+        label = _format_citation_label(
+            {
+                "manufacturer": None,
+                "model_number": None,
+                "source_url": "https://literature.rockwellautomation.com/idc/groups/literature/documents/um/520-um001_-en-e.pdf",
+                "section": "A490 [Load Loss Level]",
+            }
+        )
+        assert "Allen-Bradley" in label
+        assert "User Manual" in label
+        assert "520-um001" not in label
+        assert "Um001" not in label
+        assert "A490" in label
+
+    def test_url_only_unknown_vendor(self):
+        # Unknown domain still cleans the stem and appends section.
+        label = _format_citation_label(
+            {
+                "source_url": "https://example.com/docs/some_random_manual.pdf",
+                "section": "Section 5",
+            }
+        )
+        assert "Some Random Manual" in label
+        assert "Section 5" in label
+
+    def test_url_manufacturer_inference(self):
+        for url, expected in [
+            ("https://literature.rockwellautomation.com/foo.pdf", "Allen-Bradley"),
+            ("https://support.industry.siemens.com/cs/doc.pdf", "Siemens"),
+            ("https://library.e.abb.com/public/x.pdf", "ABB"),
+        ]:
+            label = _format_citation_label({"source_url": url})
+            assert expected in label, f"{url} → {label!r}"
+
 
 class TestCitationFooter:
     def test_footer_dedupes_identical_labels(self):


### PR DESCRIPTION
Live test of #981 surfaced one remaining case: chunks with `manufacturer=None, model_number=None, source_url=<PDF>`. Fallback just title-cased the filename. Now we run the same bulletin parser on the URL stem and infer the manufacturer from the hostname (rockwellautomation.com → Allen-Bradley, etc.). Q3 case: `520 Um001 En E` → `Allen-Bradley 520 — User Manual 001`. 121/121 tests pass.