### PR TITLE
fix(wo): remove uninvited WO previews + clear all SQLite state on /new

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -1291,31 +1291,15 @@ class Supervisor:
                 ctx_sc.pop("revision_critique", None)
                 state["context"] = ctx_sc
 
-        # RESOLVED hook: build UNS-structured WO draft and show preview.
-        # Amend parsed["reply"] now so both history and formatted output include it.
-        _wo_draft = None
+        # RESOLVED hook: previously this auto-appended a WO preview and set
+        # cmms_pending=True any time the FSM landed on RESOLVED. That made
+        # MIRA "uninvited" propose a work order after every diagnosis.
+        # The WO flow is now ONLY entered when the LLM router classifies
+        # intent as "log_work_order" → _handle_wo_request — i.e. the user
+        # explicitly says "create a work order", "log this", etc.
+        # We still run recurring-fault annotation on RESOLVED so persistent
+        # issues are flagged, but we do not push the WO preview.
         if state["state"] == "RESOLVED":
-            try:
-                _wo = build_uns_wo_from_state(state)
-                _wo_draft = _wo.to_dict()
-                _preview = format_wo_preview(_wo)
-                parsed["reply"] = parsed.get("reply", "").rstrip() + "\n\n" + _preview
-            except Exception as _woe:
-                logger.error(
-                    "WO_BUILD_ERROR chat_id=%s error=%s",
-                    chat_id,
-                    _woe,
-                    exc_info=True,
-                )
-                # Diagnosis text is already in parsed["reply"]; append manual WO note
-                diagnosis_summary = parsed.get("reply", "")[:300]
-                parsed["reply"] = (
-                    parsed.get("reply", "").rstrip()
-                    + "\n\n"
-                    + work_order_failure(diagnosis_summary)
-                )
-
-            # Recurring fault detection — annotate reply if same fault recurred
             try:
                 _annotated, _pushed = await check_recurring_and_annotate(
                     self.db_path, state, parsed["reply"]
@@ -1338,12 +1322,9 @@ class Supervisor:
         sc["last_options"] = parsed.get("options", [])
         ctx["session_context"] = sc
 
-        # Persist work-order draft so _handle_cmms_pending can use it next turn.
-        if _wo_draft is not None:
-            ctx["cmms_pending"] = True
-            ctx["cmms_wo_draft"] = _wo_draft
-            logger.info("CMMS_WO_PENDING chat_id=%s title=%r", chat_id, _wo_draft.get("title"))
-
+        # No auto-persist of WO draft here — the WO flow is now opt-in via
+        # _handle_wo_request, which sets cmms_pending itself when the user
+        # explicitly asks to log a work order.
         state["context"] = ctx
 
         self._save_state(chat_id, state)
@@ -1649,13 +1630,32 @@ class Supervisor:
         return self._make_result(reply, "none", trace_id, "RESOLVED")
 
     def reset(self, chat_id: str) -> None:
-        """Reset conversation to IDLE state."""
+        """Reset conversation to IDLE state.
+
+        Deletes any conversation_state row matching this chat_id under any of
+        the known key formats:
+          - exact match (legacy/internal callers passing the raw key)
+          - "telegram:<id>"           (current ChatDispatcher key, no thread)
+          - "telegram:<id>:..."       (current ChatDispatcher key with thread)
+        Same shape for slack/teams/etc. We delete via LIKE prefix so a /new
+        from any caller wipes all rows that could re-surface stale state.
+        """
         self._clear_session_photo(chat_id)
         db = sqlite3.connect(self.db_path)
         db.execute("PRAGMA journal_mode=WAL")
+        # Exact key
         db.execute("DELETE FROM conversation_state WHERE chat_id = ?", (chat_id,))
+        # Composite keys for known platforms ending in this raw chat id
+        for platform in ("telegram", "slack", "teams", "gchat", "webui"):
+            prefix = f"{platform}:{chat_id}"
+            db.execute(
+                "DELETE FROM conversation_state WHERE chat_id = ? OR chat_id LIKE ?",
+                (prefix, f"{prefix}:%"),
+            )
         db.commit()
+        deleted = db.total_changes
         db.close()
+        logger.info("ENGINE_RESET chat_id=%s rows_deleted=%d", chat_id, deleted)
 
     def log_feedback(self, chat_id: str, feedback: str, reason: str = "") -> None:
         state = self._load_state(chat_id)

--- a/mira-bots/shared/models/work_order.py
+++ b/mira-bots/shared/models/work_order.py
@@ -246,18 +246,14 @@ def build_uns_wo_from_state(state: dict) -> UNSWorkOrder:
                     fault_desc = content[:500]
                     break
 
-    # Resolution: prefer session_context summary, otherwise last substantive assistant
-    # turn — explicitly skip WO preview / failure notice messages.
+    # Resolution: only use an explicit diagnosis_summary that the engine wrote
+    # for THIS work-order context. We deliberately do NOT scrape the most
+    # recent assistant turn — that turn is usually a clarifying question or
+    # an unrelated reply, and grabbing it produced wrong WOs in production
+    # (Mike 2026-05-04 saw a prior MIRA answer pulled in as the resolution).
+    # When no explicit resolution exists, leave the field blank for the user
+    # to fill in via the WO edit flow.
     resolution = sc.get("diagnosis_summary", "")
-    if not resolution:
-        history = ctx.get("history", [])
-        asst_turns = [
-            t.get("content", "")[:300]
-            for t in reversed(history[-8:])
-            if t.get("role") == "assistant"
-            and not any((t.get("content") or "").strip().startswith(p) for p in _WO_META_PREFIXES)
-        ]
-        resolution = asst_turns[0] if asst_turns else ""
 
     priority = "HIGH" if fault in _HIGH_PRIORITY_FAULTS else "MEDIUM"
     title = f"[MIRA] {asset_raw[:60]} — {fault} action" if asset_raw else "[MIRA] corrective action"

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -5,6 +5,7 @@ import base64
 import io as _io
 import logging
 import os
+import re
 
 import httpx
 from admin_commands import (
@@ -551,6 +552,21 @@ async def new_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await update.message.reply_text("🔄 Fresh start. What can I help with?")
 
 
+# Tolerant /new matcher: catches "/new", "/ new", "/New", "/  new", "/NEW", etc.
+# Telegram normally only fires CommandHandler on exact "/new"; users on shaky
+# autocorrect or copy-paste end up with stray spaces or capitalised variants
+# that fall through to the message handler and confuse the engine.
+_NEW_VARIANT_RE = re.compile(r"^\s*/\s*new(?:@\w+)?\s*$", re.IGNORECASE)
+
+
+async def new_command_variant(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle text-message variants of /new that don't match PTB's CommandHandler."""
+    text = update.message.text or ""
+    if not _NEW_VARIANT_RE.match(text):
+        return
+    await new_command(update, context)
+
+
 async def status_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Query Open WebUI for an equipment status summary."""
     headers = {"Content-Type": "application/json"}
@@ -812,6 +828,15 @@ def main():
     app.add_handler(CommandHandler("voice", voice_command))
     app.add_handler(CommandHandler("bad", bad_command))
     app.add_handler(CommandHandler("help", help_command))
+    # /new variant matcher: catches "/ new", "/New", " /new ", etc. that PTB's
+    # CommandHandler doesn't match. Must be registered BEFORE the catch-all
+    # text handler so a stray-space /new doesn't get diagnosed as a question.
+    app.add_handler(
+        MessageHandler(
+            filters.Regex(r"^\s*/\s*new(?:@\w+)?\s*$") & ~filters.COMMAND,
+            new_command_variant,
+        )
+    )
     app.add_handler(MessageHandler(filters.Document.PDF, document_handler))
     app.add_handler(MessageHandler(filters.PHOTO, photo_handler))
     app.add_handler(MessageHandler(filters.VOICE, voice_message_handler))

--- a/mira-bots/tests/test_engine.py
+++ b/mira-bots/tests/test_engine.py
@@ -815,3 +815,41 @@ class TestFreshQuestionDuringWO:
 
         assert not f("")
         assert not f("   ")
+
+
+class TestResetWipesAllChatKeys:
+    """Mike 2026-05-04 — /new wasn't clearing the right SQLite row because
+    the dispatcher saves under composite key 'telegram:<id>' but the bot
+    handler called engine.reset(<raw_id>). reset() must wipe all variants."""
+
+    def test_reset_deletes_composite_telegram_key(self, supervisor):
+        # Seed a row under the composite key the dispatcher uses
+        composite = "telegram:8445149012"
+        state = supervisor._load_state(composite)
+        state["asset_identified"] = "Pump A3"
+        state["context"]["session_context"]["symptom_summary"] = "high differential filter pressure"
+        supervisor._save_state(composite, state)
+        # Reset using the RAW chat id (what bot.py passes)
+        supervisor.reset("8445149012")
+        # The composite row must be gone now
+        reloaded = supervisor._load_state(composite)
+        assert reloaded.get("asset_identified") in (None, "")
+        assert reloaded["context"].get("session_context", {}).get("symptom_summary", "") == ""
+
+    def test_reset_deletes_composite_with_thread_key(self, supervisor):
+        composite = "telegram:12345:67890"
+        state = supervisor._load_state(composite)
+        state["asset_identified"] = "Conveyor 7"
+        supervisor._save_state(composite, state)
+        supervisor.reset("12345")
+        reloaded = supervisor._load_state(composite)
+        assert reloaded.get("asset_identified") in (None, "")
+
+    def test_reset_deletes_exact_key_too(self, supervisor):
+        # Some legacy callers pass the raw key directly
+        state = supervisor._load_state("legacy_chat_id")
+        state["asset_identified"] = "Old equipment"
+        supervisor._save_state("legacy_chat_id", state)
+        supervisor.reset("legacy_chat_id")
+        reloaded = supervisor._load_state("legacy_chat_id")
+        assert reloaded.get("asset_identified") in (None, "")

--- a/mira-bots/tests/test_work_order.py
+++ b/mira-bots/tests/test_work_order.py
@@ -6,7 +6,12 @@ import sys
 
 sys.path.insert(0, "mira-bots")
 
-from shared.models.work_order import UNSWorkOrder, apply_wo_edit, format_wo_preview
+from shared.models.work_order import (
+    UNSWorkOrder,
+    apply_wo_edit,
+    build_uns_wo_from_state,
+    format_wo_preview,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -92,7 +97,9 @@ class TestApplyWoEdit:
 
 class TestUNSWorkOrderValidation:
     def test_valid_when_all_required_fields_present(self):
-        wo = UNSWorkOrder(asset="Pump A3", title="[MIRA] Pump A3 action", fault_description="overheating")
+        wo = UNSWorkOrder(
+            asset="Pump A3", title="[MIRA] Pump A3 action", fault_description="overheating"
+        )
         assert wo.is_valid is True
 
     def test_invalid_when_asset_missing(self):
@@ -106,7 +113,9 @@ class TestUNSWorkOrderValidation:
         assert "fault_description" in wo.missing_fields
 
     def test_missing_fields_empty_when_valid(self):
-        wo = UNSWorkOrder(asset="Pump A3", title="[MIRA] Pump A3 action", fault_description="overheating")
+        wo = UNSWorkOrder(
+            asset="Pump A3", title="[MIRA] Pump A3 action", fault_description="overheating"
+        )
         assert wo.missing_fields == []
 
 
@@ -122,7 +131,9 @@ class TestFormatWoPreview:
         assert "Koolfog Pump" in preview
 
     def test_contains_fault_description(self):
-        wo = UNSWorkOrder(asset="A", title="T", fault_description="high differential filter pressure")
+        wo = UNSWorkOrder(
+            asset="A", title="T", fault_description="high differential filter pressure"
+        )
         preview = format_wo_preview(wo)
         assert "high differential filter pressure" in preview
 
@@ -130,3 +141,69 @@ class TestFormatWoPreview:
         wo = UNSWorkOrder(asset="A", title="T", fault_description="F")
         preview = format_wo_preview(wo)
         assert "yes/no" in preview.lower() or "yes" in preview.lower()
+
+
+# ---------------------------------------------------------------------------
+# build_uns_wo_from_state — resolution must NOT pull stale assistant turns
+# ---------------------------------------------------------------------------
+
+
+class TestBuildResolutionField:
+    """Mike 2026-05-04 — WO previews showed prior MIRA answers as resolution.
+    The builder must only use an explicit diagnosis_summary, never scrape the
+    last assistant turn from history."""
+
+    def test_resolution_empty_when_no_summary(self):
+        state = {
+            "chat_id": "x",
+            "state": "RESOLVED",
+            "asset_identified": "Pump A3",
+            "fault_category": "mechanical",
+            "context": {
+                "session_context": {},
+                "history": [
+                    {"role": "user", "content": "Pump is leaking"},
+                    {"role": "assistant", "content": "Inspect the seal"},
+                    {"role": "user", "content": "OK"},
+                    {"role": "assistant", "content": "And check the gasket too"},
+                ],
+            },
+        }
+        wo = build_uns_wo_from_state(state)
+        assert wo.resolution == ""
+
+    def test_resolution_uses_explicit_summary(self):
+        state = {
+            "chat_id": "x",
+            "state": "RESOLVED",
+            "asset_identified": "Pump A3",
+            "fault_category": "mechanical",
+            "context": {
+                "session_context": {"diagnosis_summary": "Replace mechanical seal"},
+                "history": [{"role": "assistant", "content": "Some other answer"}],
+            },
+        }
+        wo = build_uns_wo_from_state(state)
+        assert wo.resolution == "Replace mechanical seal"
+
+    def test_no_stale_resolution_from_unrelated_history(self):
+        # The bug Mike hit: "previous MIRA answer" leaked into a fresh WO.
+        state = {
+            "chat_id": "x",
+            "state": "RESOLVED",
+            "asset_identified": "VFD",
+            "fault_category": "power",
+            "context": {
+                "session_context": {},
+                "history": [
+                    {
+                        "role": "assistant",
+                        "content": "To check insulation: 1. Disconnect 2. Megger at 500V...",
+                    }
+                ],
+            },
+        }
+        wo = build_uns_wo_from_state(state)
+        # Old behaviour leaked the megger answer. New behaviour leaves blank.
+        assert "megger" not in wo.resolution.lower()
+        assert wo.resolution == ""


### PR DESCRIPTION
## Five fixes Mike reported (all WO-related)

| # | Issue | Fix |
|---|---|---|
| 1+5 | WO preview + cmms_pending auto-triggered after every diagnosis | Removed the RESOLVED-state hook that appended WO preview. WO flow now ONLY entered via explicit \`log_work_order\` router intent → \`_handle_wo_request\`. |
| 2 | \`/new\` cleared wrong SQLite row → stale fault descriptions across sessions | \`engine.reset()\` now wipes raw key + \`telegram:<id>\` + \`telegram:<id>:%\` (and same for slack/teams/gchat/webui). Logs row count. |
| 3 | Resolution field pulled prior MIRA answer | \`build_uns_wo_from_state()\` no longer scrapes the last assistant turn. Only uses \`session_context['diagnosis_summary']\` when set. |
| 4 | \`/ new\`, \`/New\`, etc. fell through to message handler | Added Regex MessageHandler matching \`^\\s*/\\s*new(?:@\\w+)?\\s*$\` before the catch-all. |

## Tests

- `TestBuildResolutionField` — 3 cases pinning resolution=empty when no summary, summary used when set, no stale leak.
- `TestResetWipesAllChatKeys` — 3 cases for composite key formats.
- 127/127 total pass across engine + work_order + dispatcher_gate + citation_format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)