### PR TITLE
fix(telegram): handle multi-photo bursts without crashing

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -651,7 +651,10 @@ class Supervisor:
                 except Exception as exc:
                     logger.warning(
                         "MULTI_PHOTO_VISION_FAILURE chat_id=%s idx=%d/%d error=%s",
-                        chat_id, idx, n, exc,
+                        chat_id,
+                        idx,
+                        n,
+                        exc,
                     )
                     vresult = {
                         "classification": "UNCLEAR",
@@ -701,7 +704,9 @@ class Supervisor:
             except Exception as exc:
                 logger.warning(
                     "MULTI_PHOTO_ROUTER_FAILURE chat_id=%s n=%d error=%s",
-                    chat_id, n, exc,
+                    chat_id,
+                    n,
+                    exc,
                 )
                 reply_text = ""
 
@@ -719,7 +724,10 @@ class Supervisor:
         except Exception as exc:
             logger.error(
                 "MULTI_PHOTO_PROCESS_ERROR chat_id=%s n=%d error=%s",
-                chat_id, n, exc, exc_info=True,
+                chat_id,
+                n,
+                exc,
+                exc_info=True,
             )
             return GENERIC_ENGINE_ERROR
 

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -21,7 +21,6 @@ from .fallback_responses import (
     PHOTO_FAILURE,
     RAG_FAILURE,
     TIMEOUT_WARNING,
-    work_order_failure,
 )
 from .fsm import (
     _FAULT_INFO_RE,  # noqa: F401 — re-exported for test_engine.py backward compat
@@ -616,6 +615,124 @@ class Supervisor:
             platform=platform,
         )
         return result["reply"]
+
+    async def process_multi_photo(
+        self,
+        chat_id: str,
+        message: str,
+        photos_b64: list[str],
+        *,
+        platform: str = "telegram",
+        tenant_id: str | None = None,
+        mira_user_id: str | None = None,
+    ) -> str:
+        """Burst entry point. Returns combined reply for N photos (N >= 1).
+
+        Each photo runs through VisionWorker.process() sequentially because the
+        vision model is GPU-bound on a single Ollama node. Per-photo vision
+        failures degrade to a placeholder for that slot — the method never
+        raises to the caller. Combined results are sent through
+        InferenceRouter.complete() for synthesis; if the router returns empty
+        (every cascade provider down), the method falls back to a deterministic
+        numbered list. Only the LAST photo is persisted via _save_session_photo
+        so follow-up turns ("tell me more about photo 4") have a single anchor.
+        """
+        self._current_tenant_id = tenant_id or getattr(self, "tenant_id", "") or ""
+        self._current_mira_user_id = mira_user_id or ""
+
+        n = len(photos_b64)
+        t0 = time.monotonic()
+
+        try:
+            analyses: list[dict] = []
+            for idx, photo_b64 in enumerate(photos_b64, start=1):
+                try:
+                    vresult = await self.vision.process(photo_b64, message)
+                except Exception as exc:
+                    logger.warning(
+                        "MULTI_PHOTO_VISION_FAILURE chat_id=%s idx=%d/%d error=%s",
+                        chat_id, idx, n, exc,
+                    )
+                    vresult = {
+                        "classification": "UNCLEAR",
+                        "classification_confidence": 0.0,
+                        "vision_result": "unclear",
+                        "ocr_items": [],
+                        "tesseract_text": "",
+                        "drawing_type": None,
+                        "drawing_type_confidence": 0.0,
+                    }
+                analyses.append(vresult)
+
+            bullets = []
+            for idx, a in enumerate(analyses, start=1):
+                cls = str(a.get("classification", "")).strip()
+                vr = str(a.get("vision_result", "")).strip()
+                ocr = a.get("ocr_items") or []
+                ocr_str = ", ".join(str(o) for o in ocr[:6]) if ocr else ""
+                line = f"{idx}. [{cls}] {vr}" if cls else f"{idx}. {vr}"
+                if ocr_str:
+                    line += f" (OCR: {ocr_str})"
+                bullets.append(line)
+
+            system_prompt = (
+                "You are MIRA, an industrial maintenance assistant. The user just "
+                f"sent {n} photos in one burst. Below is each photo's vision/OCR "
+                "analysis. Briefly list each photo's content (numbered, one short "
+                "line each), then synthesize across them: if a nameplate and a "
+                "damage/fault photo are both present, connect the two; if photos "
+                "appear unrelated, ask which asset to troubleshoot first. Reference "
+                "photos by number. Keep under 300 words."
+            )
+            user_prompt = (
+                (f"User caption: {message}\n\n" if message else "")
+                + f"Photo analyses ({n}):\n"
+                + "\n".join(bullets)
+            )
+            try:
+                reply_text, _usage = await self.router.complete(
+                    [
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                    max_tokens=600,
+                    session_id=f"{chat_id}_multi_photo",
+                )
+            except Exception as exc:
+                logger.warning(
+                    "MULTI_PHOTO_ROUTER_FAILURE chat_id=%s n=%d error=%s",
+                    chat_id, n, exc,
+                )
+                reply_text = ""
+
+            if reply_text and reply_text.strip():
+                reply = reply_text.strip()
+            else:
+                reply = f"📸 Processed {n} photos:\n\n" + "\n".join(
+                    f"{i}. {(str(a.get('vision_result', '')).strip() or 'unclear')}"
+                    for i, a in enumerate(analyses, start=1)
+                )
+
+            if photos_b64:
+                self._save_session_photo(chat_id, photos_b64[-1])
+
+        except Exception as exc:
+            logger.error(
+                "MULTI_PHOTO_PROCESS_ERROR chat_id=%s n=%d error=%s",
+                chat_id, n, exc, exc_info=True,
+            )
+            return GENERIC_ENGINE_ERROR
+
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        self._log_interaction(
+            chat_id,
+            f"[multi-photo x{n}] {message}".strip(),
+            reply,
+            has_photo=True,
+            response_time_ms=elapsed_ms,
+            platform=platform,
+        )
+        return reply
 
     async def process_full(
         self,

--- a/mira-bots/shared/photo_handler.py
+++ b/mira-bots/shared/photo_handler.py
@@ -117,3 +117,23 @@ def build_print_reply(vision_data: dict) -> str:
         f"Labels I can see: {preview}\n"
         f"{next_step}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Photo-burst buffer caption merging
+# ---------------------------------------------------------------------------
+
+DEFAULT_PHOTO_CAPTION = "Analyze this equipment photo"
+
+
+def preserve_first_meaningful_caption(existing: str, incoming: str) -> str:
+    """Return the caption to keep when a photo joins an existing burst buffer.
+
+    Telegram media-groups put the user's caption only on the FIRST photo of
+    a burst; photos 2-N arrive with no caption and the bot fills in
+    ``DEFAULT_PHOTO_CAPTION``. Don't let those placeholders overwrite a real
+    caption from photo 1.
+    """
+    if existing == DEFAULT_PHOTO_CAPTION and incoming != DEFAULT_PHOTO_CAPTION:
+        return incoming
+    return existing

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -20,6 +20,10 @@ from shared import tts
 from shared.chat.dispatcher import ChatDispatcher
 from shared.engine import Supervisor
 from shared.identity.service import get_identity_service
+from shared.photo_handler import (
+    DEFAULT_PHOTO_CAPTION,
+    preserve_first_meaningful_caption,
+)
 from shared.tenant.authorizer import Authorizer
 from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
@@ -499,7 +503,7 @@ async def _flush_photos(
 async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
     """Buffer photos and process as a batch after PHOTO_BUFFER_WINDOW seconds."""
     chat_id_int = update.effective_chat.id
-    caption = update.message.caption or "Analyze this equipment photo"
+    caption = update.message.caption or DEFAULT_PHOTO_CAPTION
     logger.info("Photo from %s: %s", update.effective_user.first_name, caption)
 
     # Download and resize immediately; store raw bytes for KB ingest
@@ -523,7 +527,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if existing_task:
             existing_task.cancel()
         buf["batches"].append((raw_bytes, vision_bytes))
-        buf["caption"] = caption  # last caption wins
+        buf["caption"] = preserve_first_meaningful_caption(buf["caption"], caption)
         buf["update"] = update
     else:
         PHOTO_BUFFER[chat_id_int] = {

--- a/tests/test_multi_photo.py
+++ b/tests/test_multi_photo.py
@@ -1,11 +1,4 @@
-"""Tests for multi-photo burst processing (process_multi_photo + _combine_photo_analyses).
-
-SKIPPED MODULE: `Supervisor.process_multi_photo` does not exist in
-mira-bots/shared/engine.py. These tests describe an intended future API
-(burst-processing of multiple photos in a single message) that is out of
-scope for the locked 90-day plan (docs/plans/2026-04-19-mira-90-day-mvp.md).
-Un-skip the file once `process_multi_photo` ships.
-"""
+"""Tests for multi-photo burst processing (process_multi_photo + _combine_photo_analyses)."""
 
 from __future__ import annotations
 
@@ -13,11 +6,6 @@ import base64
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-pytestmark = pytest.mark.skip(
-    reason="process_multi_photo is unimplemented; out of scope for 2026-04-19 90-day plan. "
-    "Un-skip when the multi-photo burst API ships."
-)
 
 # ---------------------------------------------------------------------------
 # Fixtures — canned vision worker outputs

--- a/tests/test_telegram_photo_buffer.py
+++ b/tests/test_telegram_photo_buffer.py
@@ -1,0 +1,64 @@
+"""Tests for the Telegram photo-burst buffer caption logic.
+
+Telegram media-groups put the user's caption only on the FIRST photo. Photos
+2-N arrive with no caption, and the bot fills in a default placeholder. We
+must NOT let those placeholders overwrite the real first caption when later
+photos in the same burst land in the buffer.
+"""
+
+from __future__ import annotations
+
+import pytest
+from shared.photo_handler import (
+    DEFAULT_PHOTO_CAPTION,
+    preserve_first_meaningful_caption,
+)
+
+
+def test_real_caption_survives_default_placeholders_through_burst():
+    """4-photo burst: photo 1 had a real caption, photos 2-4 default."""
+    cap = "VFD pump-3 alarm code 47"
+    cap = preserve_first_meaningful_caption(cap, DEFAULT_PHOTO_CAPTION)
+    cap = preserve_first_meaningful_caption(cap, DEFAULT_PHOTO_CAPTION)
+    cap = preserve_first_meaningful_caption(cap, DEFAULT_PHOTO_CAPTION)
+    assert cap == "VFD pump-3 alarm code 47"
+
+
+def test_default_persists_when_no_real_caption_ever_arrives():
+    """Burst with no captions on any photo — placeholder stays."""
+    cap = DEFAULT_PHOTO_CAPTION
+    cap = preserve_first_meaningful_caption(cap, DEFAULT_PHOTO_CAPTION)
+    cap = preserve_first_meaningful_caption(cap, DEFAULT_PHOTO_CAPTION)
+    assert cap == DEFAULT_PHOTO_CAPTION
+
+
+def test_default_replaced_by_first_real_caption_to_arrive():
+    """Edge case: photo 1 had no caption (default), photo 2 had a real one."""
+    cap = DEFAULT_PHOTO_CAPTION
+    cap = preserve_first_meaningful_caption(cap, "Carrier 19DV nameplate")
+    cap = preserve_first_meaningful_caption(cap, DEFAULT_PHOTO_CAPTION)
+    assert cap == "Carrier 19DV nameplate"
+
+
+def test_real_caption_never_overwritten_by_another_real_caption():
+    """If two photos in a burst somehow both have captions, the first wins.
+
+    Telegram doesn't actually deliver this case, but the rule is "first
+    meaningful caption wins" — keep the contract simple and predictable.
+    """
+    cap = "first real caption"
+    cap = preserve_first_meaningful_caption(cap, "second real caption")
+    assert cap == "first real caption"
+
+
+@pytest.mark.parametrize(
+    "incoming",
+    ["", "  ", "VFD", "Carrier AquaEdge 19DV nameplate, fault code E04"],
+)
+def test_real_caption_preserved_against_any_incoming(incoming: str):
+    """A real caption survives any subsequent caption (default or otherwise)."""
+    cap = "first real caption"
+    cap = preserve_first_meaningful_caption(cap, DEFAULT_PHOTO_CAPTION)
+    assert cap == "first real caption"
+    cap = preserve_first_meaningful_caption(cap, incoming)
+    assert cap == "first real caption"


### PR DESCRIPTION
## What Mike saw

Sent 4 photos to the production Telegram bot. Got back:

> MIRA error processing 4 photos: 'Supervisor' object has no attribute 'process_multi_photo'

Every burst of ≥2 photos hits the same crash — the photo-buffer flushes and calls `engine.process_multi_photo(...)`, but that method has never existed. The contract for it lived as a skipped test in `tests/test_multi_photo.py` ("out of scope for the locked 90-day plan, un-skip when ships").

## What this PR does

**1. Implements `Supervisor.process_multi_photo()`** in `mira-bots/shared/engine.py` per the existing test contract:
- Sequentially runs `VisionWorker.process()` on each photo (vision is GPU-bound on the single Ollama node — sequential matches the test fixture, not slower in practice for 2-5 photo bursts).
- Builds a synthesis prompt from the per-photo vision/OCR results and routes through `InferenceRouter.complete()` for one combined reply.
- Falls back to a deterministic numbered list (\`📸 Processed N photos: ...\`) when the cascade returns empty.
- Per-photo vision failures degrade to a placeholder for that slot — never raises to the adapter.
- Only the **last** photo is persisted via `_save_session_photo` so follow-up turns ("tell me more about photo 4") have a single anchor.
- Un-skips `tests/test_multi_photo.py` — all 7 tests pass.

**2. Fixes a related caption bug** in `mira-bots/telegram/bot.py`. Telegram media-groups put the user's caption only on the **first** photo of a burst; photos 2–N arrive with no caption, and the bot fills in a default placeholder. The buffer previously did "last caption wins" (\`buf[\"caption\"] = caption\`), which silently erased a real first caption. New \`preserve_first_meaningful_caption\` helper in \`shared/photo_handler.py\` keeps the first non-default caption through the burst. Covered by 8 new tests in \`tests/test_telegram_photo_buffer.py\`.

**3. Ruff cleanup**: dropped an already-unused \`work_order_failure\` import that ruff flagged on touch.

## Test plan

\`\`\`
pytest tests/test_multi_photo.py tests/test_telegram_photo_buffer.py
# 15 passed, 0 failed
\`\`\`

Regression sweep on engine-touching tests (`test_cross_session.py`, `test_edge_cases.py`): 37 passed, 11 unrelated skips, 0 failed.

Live verification on Charlie after deploy:
\`\`\`
ssh charlienode@100.70.49.126 \"docker logs --tail 100 mira-bot-telegram | grep -E 'process_multi_photo|MIRA error'\"
\`\`\`
should return zero matches once the new image rolls out.

## Deploy

\`mira-bots\` lives on Charlie. Per the documented gotcha, build locally — never \`docker build\` over SSH (Mac keychain is locked under non-interactive SSH). Recommended: build on Bravo, \`docker save | ssh charlienode docker load\`, then \`docker compose restart mira-bot-telegram\`.

## Scope check (vs. 90-day plan)

This is a regression fix on a production-facing handler that Mike actively dogfoods (n=1 path) — hardening, not new scope vs. the 10-unit plan. The skipped test file already specified the contract, so we're un-skipping it, not designing new behavior.

## Versioning ⚠️

\`mira-bots/\` does NOT yet have a tag namespace (\`mira-hub\`, \`mira-web\`, \`mira-cmms\`, \`factorylm-landing\` do). I deliberately did **not** introduce one in this PR to keep the change focused on the bug. Mike: do we want to start a \`mira-bots/v0.x.0\` namespace + CHANGELOG on a follow-up PR, or leave \`mira-bots\` un-tagged for now?

## Out of scope (intentional follow-ups)

- FSM transitions for multi-photo bursts (single-photo path keeps dispatcher routing; multi-photo is the simpler "describe + synthesize" flow per test contract).
- Safety-keyword routing on burst vision results (a vision result like "exposed bus bar arc flash" should arguably escalate, but tests don't require it).
- Concurrent vision calls (sequential matches tests; bursts are rare on n=1 and Ollama is GPU-bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)