### PR TITLE
feat(telegram): SQLite-backed durable queue for multi-photo bursts

### DIFF
--- a/mira-bots/shared/photo_batch_queue.py
+++ b/mira-bots/shared/photo_batch_queue.py
@@ -1,0 +1,329 @@
+"""SQLite-backed durable photo-batch queue for multi-photo bursts.
+
+Replaces the in-memory ``PHOTO_BUFFER`` dict in ``mira-bots/telegram/bot.py``.
+Telegram users sending multiple photos in rapid succession (a "burst") get
+them collected into a single batch, queued for processing, drained by a
+single async worker (vision is GPU-bound on one Ollama node), and the
+result delivered back to the chat.
+
+Why SQLite-backed: bot container restarts no longer drop in-flight bursts.
+Why single worker: vision is the GPU bottleneck — multiple workers fight
+for the same Ollama node, so concurrency = 1.
+
+Schema (one table, ``photo_batches``):
+    id               INTEGER PRIMARY KEY
+    chat_id          TEXT
+    platform         TEXT          'telegram' | 'slack'
+    status           TEXT          'collecting' | 'queued' | 'processing'
+                                   | 'done' | 'failed'
+    caption          TEXT
+    photos_json      TEXT          JSON list of base64 vision-resized bytes
+    photo_count      INTEGER
+    ack_message_id   INTEGER       NULL until adapter sends ack
+    created_at       REAL
+    queued_at        REAL
+    started_at       REAL
+    completed_at     REAL
+    error_message    TEXT
+    reply_text       TEXT
+
+Bounds:
+    MAX_PHOTOS_PER_BURST = 10      photos past cap raise BurstFull
+    MAX_QUEUE_DEPTH      = 20      queued+processing past cap raise QueueFull
+    BURST_WINDOW_SECONDS = 4.0     wait window before flipping collecting -> queued
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sqlite3
+import time
+from dataclasses import dataclass
+
+from shared.photo_handler import DEFAULT_PHOTO_CAPTION, preserve_first_meaningful_caption
+
+logger = logging.getLogger("mira-gsd")
+
+
+MAX_PHOTOS_PER_BURST = 10
+MAX_QUEUE_DEPTH = 20
+BURST_WINDOW_SECONDS = 4.0
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS photo_batches (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    chat_id         TEXT NOT NULL,
+    platform        TEXT NOT NULL,
+    status          TEXT NOT NULL,
+    caption         TEXT NOT NULL,
+    photos_json     TEXT NOT NULL,
+    photo_count     INTEGER NOT NULL,
+    ack_message_id  INTEGER,
+    created_at      REAL NOT NULL,
+    queued_at       REAL,
+    started_at      REAL,
+    completed_at    REAL,
+    error_message   TEXT,
+    reply_text      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_photo_batches_status_created
+    ON photo_batches(status, created_at);
+CREATE INDEX IF NOT EXISTS idx_photo_batches_chat_status
+    ON photo_batches(chat_id, platform, status);
+"""
+
+
+class BurstFull(Exception):
+    """Raised when a single burst exceeds MAX_PHOTOS_PER_BURST."""
+
+
+class QueueFull(Exception):
+    """Raised when queued+processing rows exceed MAX_QUEUE_DEPTH."""
+
+
+@dataclass
+class PhotoBatchRecord:
+    id: int
+    chat_id: str
+    platform: str
+    caption: str
+    photos_b64: list[str]
+    ack_message_id: int | None
+    created_at: float
+
+
+class PhotoBatchQueue:
+    """Durable photo-batch queue.
+
+    SQLite is the source of truth; a small in-process ``asyncio.Queue`` is
+    used purely to wake the worker when something becomes ready. On worker
+    startup ``recover_orphans()`` should be called to flip any rows left in
+    ``processing`` (the previous worker was killed mid-job) back to
+    ``queued`` so they get retried.
+    """
+
+    def __init__(self, db_path: str) -> None:
+        self.db_path = db_path
+        self._conn = sqlite3.connect(db_path, isolation_level=None, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA foreign_keys=ON")
+        self._conn.executescript(_SCHEMA)
+        self._notify: asyncio.Queue[int] = asyncio.Queue()
+        self._lock = asyncio.Lock()
+
+    # --------------------------------------------------------------- producer
+
+    async def add_photo_to_burst(
+        self,
+        chat_id: str,
+        platform: str,
+        photo_b64: str,
+        caption: str,
+        ack_message_id: int | None = None,
+    ) -> tuple[int, int]:
+        """Add a photo to the current open burst for (chat_id, platform).
+
+        If no ``collecting`` row exists, one is created. Otherwise the photo
+        is appended to the existing one and the caption is merged via
+        ``preserve_first_meaningful_caption``.
+
+        Returns ``(batch_id, photo_count_after)``.
+
+        Raises ``BurstFull`` if the resulting photo count would exceed
+        ``MAX_PHOTOS_PER_BURST``.
+        """
+        async with self._lock:
+            row = self._conn.execute(
+                "SELECT id, photos_json, caption, photo_count, ack_message_id "
+                "FROM photo_batches "
+                "WHERE chat_id = ? AND platform = ? AND status = 'collecting' "
+                "ORDER BY id DESC LIMIT 1",
+                (chat_id, platform),
+            ).fetchone()
+
+            if row is None:
+                now = time.time()
+                photos = [photo_b64]
+                cur = self._conn.execute(
+                    "INSERT INTO photo_batches "
+                    "(chat_id, platform, status, caption, photos_json, "
+                    " photo_count, ack_message_id, created_at) "
+                    "VALUES (?, ?, 'collecting', ?, ?, ?, ?, ?)",
+                    (chat_id, platform, caption, json.dumps(photos), 1,
+                     ack_message_id, now),
+                )
+                return int(cur.lastrowid), 1
+
+            batch_id, photos_json, existing_caption, photo_count, existing_ack = row
+            new_count = photo_count + 1
+            if new_count > MAX_PHOTOS_PER_BURST:
+                raise BurstFull(
+                    f"burst {batch_id} already at {photo_count} photos "
+                    f"(cap {MAX_PHOTOS_PER_BURST})"
+                )
+
+            photos = json.loads(photos_json)
+            photos.append(photo_b64)
+            merged_caption = preserve_first_meaningful_caption(existing_caption, caption)
+            new_ack = existing_ack if existing_ack is not None else ack_message_id
+
+            self._conn.execute(
+                "UPDATE photo_batches SET photos_json = ?, photo_count = ?, "
+                "caption = ?, ack_message_id = ? WHERE id = ?",
+                (json.dumps(photos), new_count, merged_caption, new_ack, batch_id),
+            )
+            return int(batch_id), new_count
+
+    async def set_ack_message(self, batch_id: int, ack_message_id: int) -> None:
+        async with self._lock:
+            self._conn.execute(
+                "UPDATE photo_batches SET ack_message_id = ? "
+                "WHERE id = ? AND ack_message_id IS NULL",
+                (ack_message_id, batch_id),
+            )
+
+    async def close_burst(self, batch_id: int) -> bool:
+        """Flip a ``collecting`` batch to ``queued``.
+
+        Returns ``True`` if the flip happened (and the worker has been
+        notified), ``False`` if the batch was already past collecting (e.g.
+        a concurrent close).
+
+        Raises ``QueueFull`` if too many batches are already queued or
+        processing — caller should tell the user to retry.
+        """
+        async with self._lock:
+            depth = self._conn.execute(
+                "SELECT COUNT(*) FROM photo_batches "
+                "WHERE status IN ('queued', 'processing')"
+            ).fetchone()[0]
+            if depth >= MAX_QUEUE_DEPTH:
+                raise QueueFull(f"queue depth {depth} >= cap {MAX_QUEUE_DEPTH}")
+
+            now = time.time()
+            cur = self._conn.execute(
+                "UPDATE photo_batches SET status = 'queued', queued_at = ? "
+                "WHERE id = ? AND status = 'collecting'",
+                (now, batch_id),
+            )
+            if cur.rowcount == 0:
+                return False
+
+        await self._notify.put(batch_id)
+        return True
+
+    # --------------------------------------------------------------- consumer
+
+    async def dequeue(self) -> PhotoBatchRecord:
+        """Block until the next queued batch is available; flip to processing.
+
+        Returns the record. Caller must follow with ``mark_done`` or
+        ``mark_failed``.
+        """
+        while True:
+            await self._notify.get()
+            async with self._lock:
+                row = self._conn.execute(
+                    "SELECT id, chat_id, platform, caption, photos_json, "
+                    " ack_message_id, created_at "
+                    "FROM photo_batches WHERE status = 'queued' "
+                    "ORDER BY queued_at ASC, id ASC LIMIT 1"
+                ).fetchone()
+                if row is None:
+                    continue
+                batch_id, chat_id, platform, caption, photos_json, ack_id, created_at = row
+                now = time.time()
+                self._conn.execute(
+                    "UPDATE photo_batches SET status = 'processing', started_at = ? "
+                    "WHERE id = ? AND status = 'queued'",
+                    (now, batch_id),
+                )
+            return PhotoBatchRecord(
+                id=int(batch_id),
+                chat_id=str(chat_id),
+                platform=str(platform),
+                caption=str(caption),
+                photos_b64=list(json.loads(photos_json)),
+                ack_message_id=int(ack_id) if ack_id is not None else None,
+                created_at=float(created_at),
+            )
+
+    async def mark_done(self, batch_id: int, reply_text: str) -> None:
+        async with self._lock:
+            self._conn.execute(
+                "UPDATE photo_batches SET status = 'done', completed_at = ?, "
+                " reply_text = ? WHERE id = ?",
+                (time.time(), reply_text, batch_id),
+            )
+
+    async def mark_failed(self, batch_id: int, error: str) -> None:
+        async with self._lock:
+            self._conn.execute(
+                "UPDATE photo_batches SET status = 'failed', completed_at = ?, "
+                " error_message = ? WHERE id = ?",
+                (time.time(), error, batch_id),
+            )
+
+    # ---------------------------------------------------------------- recovery
+
+    async def recover_orphans(self) -> int:
+        """On worker startup, flip any ``processing`` rows back to ``queued``.
+
+        Assumes the previous worker died mid-job (container restart). The
+        worker will retry from scratch — vision is idempotent, so running
+        it twice on the same input is safe.
+
+        Also re-notifies the asyncio queue for every existing ``queued``
+        row so they get drained on startup.
+
+        Returns the number of orphan rows reset.
+        """
+        async with self._lock:
+            cur = self._conn.execute(
+                "UPDATE photo_batches SET status = 'queued', started_at = NULL "
+                "WHERE status = 'processing'"
+            )
+            n_orphans = cur.rowcount
+
+            queued = [
+                row[0]
+                for row in self._conn.execute(
+                    "SELECT id FROM photo_batches WHERE status = 'queued' "
+                    "ORDER BY queued_at ASC, id ASC"
+                ).fetchall()
+            ]
+
+        for batch_id in queued:
+            await self._notify.put(int(batch_id))
+
+        if n_orphans:
+            logger.warning("PHOTO_QUEUE_RECOVER orphans=%d requeued=%d",
+                           n_orphans, len(queued))
+        return n_orphans
+
+    # ------------------------------------------------------------- diagnostics
+
+    def stats(self) -> dict[str, int]:
+        """Return current queue depth by status (for /health and tests)."""
+        rows = self._conn.execute(
+            "SELECT status, COUNT(*) FROM photo_batches GROUP BY status"
+        ).fetchall()
+        return {row[0]: int(row[1]) for row in rows}
+
+    def close(self) -> None:
+        self._conn.close()
+
+
+__all__ = [
+    "BURST_WINDOW_SECONDS",
+    "BurstFull",
+    "MAX_PHOTOS_PER_BURST",
+    "MAX_QUEUE_DEPTH",
+    "PhotoBatchQueue",
+    "PhotoBatchRecord",
+    "QueueFull",
+    "DEFAULT_PHOTO_CAPTION",
+]

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -20,6 +20,13 @@ from shared import tts
 from shared.chat.dispatcher import ChatDispatcher
 from shared.engine import Supervisor
 from shared.identity.service import get_identity_service
+from shared.photo_batch_queue import (
+    BURST_WINDOW_SECONDS,
+    BurstFull,
+    PhotoBatchQueue,
+    PhotoBatchRecord,
+    QueueFull,
+)
 from shared.photo_handler import (
     DEFAULT_PHOTO_CAPTION,
     preserve_first_meaningful_caption,
@@ -104,9 +111,22 @@ FAULT_KEYWORDS = {
     "warning",
 }
 
-# Photo batching: accumulate rapid-fire multi-photo messages before processing
-PHOTO_BUFFER: dict[int, dict] = {}
-PHOTO_BUFFER_WINDOW = 4.0  # seconds to wait for additional photos in same burst
+# Photo batching: in-memory pre-collector decides single vs multi after a 4s
+# window. Single-photo bursts go through the FSM-aware ChatDispatcher (the
+# existing path, unchanged). Multi-photo bursts (2+) are enqueued to the
+# durable PhotoBatchQueue and drained by a single async worker — vision is
+# GPU-bound on one Ollama node, so worker concurrency is 1.
+#
+# Pre-collector state lives in memory and is dropped on bot restart (max
+# data loss = the 4s burst window). Anything that makes it into the durable
+# queue survives restarts.
+_BURST_COLLECTOR: dict[int, dict] = {}
+_PHOTO_QUEUE_DB_PATH = os.environ.get(
+    "PHOTO_QUEUE_DB_PATH",
+    os.path.join(os.path.dirname(os.environ.get("MIRA_DB_PATH", "/data/mira.db")),
+                 "photo_batches.db"),
+)
+photo_queue = PhotoBatchQueue(_PHOTO_QUEUE_DB_PATH)
 
 
 class typing_action:
@@ -420,93 +440,147 @@ async def voice_message_handler(update: Update, context: ContextTypes.DEFAULT_TY
         await update.message.reply_text(f"MIRA error: {exc}")
 
 
-async def _process_photo_batch(
-    batches: list[tuple[bytes, bytes]],
+async def _dispatch_single_photo(
+    raw_bytes: bytes,
+    vision_bytes: bytes,
     caption: str,
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
 ) -> None:
-    """Process buffered (raw_bytes, vision_bytes) pairs.
+    """Single-photo path — FSM-aware dispatch through ChatDispatcher.
 
-    Single photo: dispatches through ChatDispatcher (FSM-aware, unchanged path).
-    Multi-photo burst: sends acknowledgment immediately, runs each photo through
-    VisionWorker sequentially, then combines results into one intelligent reply.
+    Unchanged behaviour from the previous in-memory PHOTO_BUFFER. Single
+    photos still need work-order / FSM context, so they bypass the durable
+    queue and run synchronously while we still hold the original Update.
     """
     chat_id = str(update.effective_chat.id)
+    await update.message.reply_text("Analyzing equipment...")
+    update_dict = update.to_dict()
 
-    if len(batches) == 1:
-        # Single-photo path — unchanged; goes through ChatDispatcher for FSM routing
-        await update.message.reply_text("Analyzing equipment...")
-        _raw_bytes, vision_bytes = batches[0]
-        update_dict = update.to_dict()
-        async with typing_action(context, update.effective_chat.id):
+    async with typing_action(context, update.effective_chat.id):
+        try:
+            normalized = await adapter.normalize_incoming(update_dict)
+            normalized.text = caption
+            if normalized.attachments:
+                normalized.attachments[0].data = vision_bytes
+            process_task = asyncio.create_task(dispatcher.dispatch(normalized))
             try:
-                normalized = await adapter.normalize_incoming(update_dict)
-                normalized.text = caption
-                if normalized.attachments:
-                    normalized.attachments[0].data = vision_bytes
-                process_task = asyncio.create_task(dispatcher.dispatch(normalized))
-                try:
-                    response = await asyncio.wait_for(asyncio.shield(process_task), timeout=10.0)
-                except asyncio.TimeoutError:
-                    await update.message.reply_text(
-                        "Processing equipment photo — this may take up to 90 seconds"
-                        " for detailed images..."
-                    )
-                    response = await process_task
-                final_reply = response.text or "MIRA error: no response from vision pipeline."
-            except Exception as e:
-                logger.error("Photo processing error: %s", e)
-                final_reply = f"MIRA error: {e}"
-    else:
-        # Multi-photo burst — ack immediately, process sequentially, combine
-        n = len(batches)
-        await update.message.reply_text(
-            f"📸 Processing {n} photos — I'll have results for you shortly."
-        )
-        async with typing_action(context, update.effective_chat.id):
-            photos_b64 = [base64.b64encode(vision_bytes).decode() for _, vision_bytes in batches]
-            try:
-                final_reply = await engine.process_multi_photo(
-                    chat_id=chat_id,
-                    message=caption,
-                    photos_b64=photos_b64,
-                    platform="telegram",
+                response = await asyncio.wait_for(asyncio.shield(process_task), timeout=10.0)
+            except asyncio.TimeoutError:
+                await update.message.reply_text(
+                    "Processing equipment photo — this may take up to 90 seconds"
+                    " for detailed images..."
                 )
-            except Exception as e:
-                logger.error("Multi-photo processing error: %s", e)
-                final_reply = f"MIRA error processing {n} photos: {e}"
+                response = await process_task
+            final_reply = response.text or "MIRA error: no response from vision pipeline."
+        except Exception as e:
+            logger.error("Photo processing error: %s", e)
+            final_reply = f"MIRA error: {e}"
 
     if INGEST_SERVICE_URL:
         asset_tag = caption.split()[0] if caption else "UNKNOWN"
-        for raw_bytes, _ in batches:
-            asyncio.create_task(_ingest_photo_background(raw_bytes, asset_tag))
-        final_reply += "\n\nPhoto(s) queued for knowledge base."
+        asyncio.create_task(_ingest_photo_background(raw_bytes, asset_tag))
+        final_reply += "\n\nPhoto queued for knowledge base."
 
     await update.message.reply_text(final_reply)
     await _maybe_send_voice(update, context, chat_id, final_reply)
 
 
-async def _flush_photos(
+async def _enqueue_multi_photo_burst(
+    batches: list[tuple[bytes, bytes]],
+    caption: str,
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+) -> None:
+    """Multi-photo path — push every photo into the durable queue, ack now.
+
+    The actual processing happens later inside ``_photo_batch_worker``, so
+    a bot restart between burst-close and worker-pickup is recoverable. We
+    still need the Update here only to send the immediate ack message;
+    everything else (vision, synthesis, reply) happens worker-side using
+    only ``application.bot``.
+    """
+    chat_id = str(update.effective_chat.id)
+    n = len(batches)
+    ack = await update.message.reply_text(
+        f"📸 Queued {n} photos — I'll have results for you shortly."
+    )
+
+    batch_id: int | None = None
+    rejected = 0
+    for raw_bytes, vision_bytes in batches:
+        photo_b64 = base64.b64encode(vision_bytes).decode()
+        try:
+            batch_id, _ = await photo_queue.add_photo_to_burst(
+                chat_id=chat_id,
+                platform="telegram",
+                photo_b64=photo_b64,
+                caption=caption,
+                ack_message_id=ack.message_id,
+            )
+        except BurstFull:
+            rejected += 1
+            continue
+
+    if batch_id is None:
+        await update.message.reply_text(
+            "MIRA: every photo in this burst was rejected — please retry."
+        )
+        return
+
+    if rejected:
+        await update.message.reply_text(
+            f"⚠️ Burst capped at {n - rejected}/{n} photos "
+            f"({rejected} dropped — try fewer photos at once)."
+        )
+
+    try:
+        await photo_queue.close_burst(batch_id)
+    except QueueFull:
+        await update.message.reply_text(
+            "🚧 The photo queue is full right now. Please retry in a moment."
+        )
+        await photo_queue.mark_failed(batch_id, "queue full at close_burst")
+        return
+
+    if INGEST_SERVICE_URL:
+        asset_tag = caption.split()[0] if caption else "UNKNOWN"
+        for raw_bytes, _ in batches:
+            asyncio.create_task(_ingest_photo_background(raw_bytes, asset_tag))
+
+
+async def _flush_collector(
     chat_id_int: int,
     update: Update,
     context: ContextTypes.DEFAULT_TYPE,
 ) -> None:
-    """Wait for buffer window, then process all buffered photos as a batch."""
-    await asyncio.sleep(PHOTO_BUFFER_WINDOW)
-    buf = PHOTO_BUFFER.pop(chat_id_int, None)
+    """After the burst window closes, route to single or multi path."""
+    try:
+        await asyncio.sleep(BURST_WINDOW_SECONDS)
+    except asyncio.CancelledError:
+        return
+
+    buf = _BURST_COLLECTOR.pop(chat_id_int, None)
     if not buf:
         return
-    await _process_photo_batch(buf["batches"], buf["caption"], update, context)
+
+    batches = buf["batches"]
+    caption = buf["caption"]
+    last_update = buf["update"]
+
+    if len(batches) == 1:
+        raw_bytes, vision_bytes = batches[0]
+        await _dispatch_single_photo(raw_bytes, vision_bytes, caption, last_update, context)
+    else:
+        await _enqueue_multi_photo_burst(batches, caption, last_update, context)
 
 
 async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Buffer photos and process as a batch after PHOTO_BUFFER_WINDOW seconds."""
+    """Collect photos for ``BURST_WINDOW_SECONDS``, then route single/multi."""
     chat_id_int = update.effective_chat.id
     caption = update.message.caption or DEFAULT_PHOTO_CAPTION
     logger.info("Photo from %s: %s", update.effective_user.first_name, caption)
 
-    # Download and resize immediately; store raw bytes for KB ingest
     try:
         photo = update.message.photo[-1]
         await context.bot.send_chat_action(
@@ -520,8 +594,7 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(f"MIRA error: {e}")
         return
 
-    # Add to buffer; cancel and restart the flush timer
-    buf = PHOTO_BUFFER.get(chat_id_int)
+    buf = _BURST_COLLECTOR.get(chat_id_int)
     if buf:
         existing_task = buf.get("task")
         if existing_task:
@@ -530,15 +603,78 @@ async def photo_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         buf["caption"] = preserve_first_meaningful_caption(buf["caption"], caption)
         buf["update"] = update
     else:
-        PHOTO_BUFFER[chat_id_int] = {
+        _BURST_COLLECTOR[chat_id_int] = {
             "batches": [(raw_bytes, vision_bytes)],
             "caption": caption,
             "update": update,
             "task": None,
         }
 
-    flush_task = asyncio.create_task(_flush_photos(chat_id_int, update, context))
-    PHOTO_BUFFER[chat_id_int]["task"] = flush_task
+    flush_task = asyncio.create_task(_flush_collector(chat_id_int, update, context))
+    _BURST_COLLECTOR[chat_id_int]["task"] = flush_task
+
+
+async def _photo_batch_worker(application: Application) -> None:
+    """Drain the durable photo-batch queue forever.
+
+    Vision is GPU-bound on a single Ollama node, so concurrency = 1 by
+    design. On every iteration: dequeue (blocks), process via
+    ``engine.process_multi_photo``, deliver reply via ``application.bot``,
+    mark done/failed. Worker exceptions are logged but never propagated —
+    the loop must outlive any single bad batch.
+    """
+    logger.info("PHOTO_QUEUE_WORKER starting (db=%s)", _PHOTO_QUEUE_DB_PATH)
+    while True:
+        rec: PhotoBatchRecord
+        try:
+            rec = await photo_queue.dequeue()
+        except Exception as exc:
+            logger.error("PHOTO_QUEUE_WORKER dequeue error: %s", exc)
+            await asyncio.sleep(1.0)
+            continue
+
+        n = len(rec.photos_b64)
+        logger.info(
+            "PHOTO_QUEUE_WORKER processing batch_id=%d chat=%s n=%d",
+            rec.id, rec.chat_id, n,
+        )
+        try:
+            reply = await engine.process_multi_photo(
+                chat_id=rec.chat_id,
+                message=rec.caption,
+                photos_b64=rec.photos_b64,
+                platform=rec.platform,
+            )
+            if not reply:
+                reply = (
+                    f"MIRA error: vision pipeline returned no response for "
+                    f"{n} photos. Please retry."
+                )
+            try:
+                await application.bot.send_message(
+                    chat_id=int(rec.chat_id), text=reply
+                )
+            except Exception as send_exc:
+                logger.error(
+                    "PHOTO_QUEUE_WORKER reply send failed batch_id=%d: %s",
+                    rec.id, send_exc,
+                )
+            await photo_queue.mark_done(rec.id, reply)
+        except Exception as exc:
+            logger.exception(
+                "PHOTO_QUEUE_WORKER processing error batch_id=%d", rec.id
+            )
+            try:
+                await application.bot.send_message(
+                    chat_id=int(rec.chat_id),
+                    text=f"MIRA error processing {n} photos: {exc}",
+                )
+            except Exception as send_exc:
+                logger.error(
+                    "PHOTO_QUEUE_WORKER error-reply send failed batch_id=%d: %s",
+                    rec.id, send_exc,
+                )
+            await photo_queue.mark_failed(rec.id, str(exc))
 
 
 async def reset_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -702,7 +838,7 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def _startup(application: Application) -> None:
-    """Clear any competing webhook/poller and verify bot identity before polling."""
+    """Clear any competing webhook/poller, verify identity, start photo worker."""
     try:
         await application.bot.delete_webhook(drop_pending_updates=True)
         logger.info("Webhook cleared (drop_pending_updates=True)")
@@ -721,6 +857,14 @@ async def _startup(application: Application) -> None:
             exc,
         )
         raise SystemExit(1) from exc
+
+    n_recovered = await photo_queue.recover_orphans()
+    if n_recovered:
+        logger.warning(
+            "PHOTO_QUEUE recovered %d orphan batch(es) from previous shutdown",
+            n_recovered,
+        )
+    application.create_task(_photo_batch_worker(application), name="photo_batch_worker")
 
 
 async def _conflict_error_handler(update: object, context) -> None:

--- a/tests/test_photo_batch_queue.py
+++ b/tests/test_photo_batch_queue.py
@@ -1,0 +1,233 @@
+"""Tests for PhotoBatchQueue — the SQLite-backed photo-burst queue.
+
+Covers bounds (per-burst cap, queue-depth cap), FIFO ordering, caption
+preservation across photos in a burst, and recovery of orphaned
+``processing`` rows on worker restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "mira-bots"))
+
+from shared.photo_batch_queue import (  # noqa: E402
+    BURST_WINDOW_SECONDS,  # noqa: F401  (re-export sanity)
+    MAX_PHOTOS_PER_BURST,
+    MAX_QUEUE_DEPTH,
+    BurstFull,
+    PhotoBatchQueue,
+    PhotoBatchRecord,
+    QueueFull,
+)
+from shared.photo_handler import DEFAULT_PHOTO_CAPTION  # noqa: E402
+
+
+@pytest.fixture
+def queue(tmp_path):
+    db = tmp_path / "photo_batches.db"
+    q = PhotoBatchQueue(str(db))
+    yield q
+    q.close()
+
+
+# --- producer side ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_first_photo_creates_collecting_batch(queue):
+    batch_id, count = await queue.add_photo_to_burst(
+        chat_id="42", platform="telegram", photo_b64="aGVsbG8=", caption="VFD pump"
+    )
+    assert batch_id > 0
+    assert count == 1
+    stats = queue.stats()
+    assert stats == {"collecting": 1}
+
+
+@pytest.mark.asyncio
+async def test_second_photo_joins_existing_burst(queue):
+    bid1, _ = await queue.add_photo_to_burst("42", "telegram", "aaaa", "first cap")
+    bid2, count = await queue.add_photo_to_burst("42", "telegram", "bbbb", DEFAULT_PHOTO_CAPTION)
+    assert bid1 == bid2
+    assert count == 2
+
+
+@pytest.mark.asyncio
+async def test_first_real_caption_survives_default_followups(queue):
+    bid, _ = await queue.add_photo_to_burst("42", "telegram", "aa", "VFD pump-3 alarm 47")
+    await queue.add_photo_to_burst("42", "telegram", "bb", DEFAULT_PHOTO_CAPTION)
+    await queue.add_photo_to_burst("42", "telegram", "cc", DEFAULT_PHOTO_CAPTION)
+
+    await queue.close_burst(bid)
+    rec = await asyncio.wait_for(queue.dequeue(), timeout=1.0)
+    assert rec.caption == "VFD pump-3 alarm 47"
+
+
+@pytest.mark.asyncio
+async def test_burst_cap_enforced(queue):
+    bid, _ = await queue.add_photo_to_burst("42", "telegram", "p1", "cap")
+    for _ in range(MAX_PHOTOS_PER_BURST - 1):
+        await queue.add_photo_to_burst("42", "telegram", "p", DEFAULT_PHOTO_CAPTION)
+    with pytest.raises(BurstFull):
+        await queue.add_photo_to_burst("42", "telegram", "overflow", DEFAULT_PHOTO_CAPTION)
+
+
+@pytest.mark.asyncio
+async def test_different_chats_do_not_share_burst(queue):
+    bid_a, _ = await queue.add_photo_to_burst("A", "telegram", "a1", "alpha")
+    bid_b, _ = await queue.add_photo_to_burst("B", "telegram", "b1", "bravo")
+    assert bid_a != bid_b
+
+
+# --- queue-depth cap --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_queue_full_raises(queue):
+    open_ids = []
+    for chat in range(MAX_QUEUE_DEPTH):
+        bid, _ = await queue.add_photo_to_burst(
+            chat_id=f"chat-{chat}", platform="telegram", photo_b64="x", caption="c"
+        )
+        await queue.close_burst(bid)
+        open_ids.append(bid)
+
+    bid_full, _ = await queue.add_photo_to_burst(
+        chat_id="chat-overflow", platform="telegram", photo_b64="x", caption="c"
+    )
+    with pytest.raises(QueueFull):
+        await queue.close_burst(bid_full)
+
+
+# --- consumer side ----------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dequeue_returns_oldest_queued_first(queue):
+    bid_a, _ = await queue.add_photo_to_burst("A", "telegram", "a1", "first")
+    bid_b, _ = await queue.add_photo_to_burst("B", "telegram", "b1", "second")
+    await queue.close_burst(bid_a)
+    await asyncio.sleep(0.01)
+    await queue.close_burst(bid_b)
+
+    rec1 = await asyncio.wait_for(queue.dequeue(), timeout=1.0)
+    rec2 = await asyncio.wait_for(queue.dequeue(), timeout=1.0)
+    assert rec1.id == bid_a
+    assert rec2.id == bid_b
+
+
+@pytest.mark.asyncio
+async def test_dequeue_blocks_until_close(queue):
+    bid, _ = await queue.add_photo_to_burst("42", "telegram", "a", "c")
+
+    async def closer():
+        await asyncio.sleep(0.05)
+        await queue.close_burst(bid)
+
+    closer_task = asyncio.create_task(closer())
+    rec = await asyncio.wait_for(queue.dequeue(), timeout=1.0)
+    await closer_task
+    assert rec.id == bid
+    assert isinstance(rec, PhotoBatchRecord)
+
+
+@pytest.mark.asyncio
+async def test_close_burst_idempotent(queue):
+    bid, _ = await queue.add_photo_to_burst("42", "telegram", "a", "c")
+    assert await queue.close_burst(bid) is True
+    assert await queue.close_burst(bid) is False
+
+
+@pytest.mark.asyncio
+async def test_mark_done_records_reply(queue):
+    bid, _ = await queue.add_photo_to_burst("42", "telegram", "a", "c")
+    await queue.close_burst(bid)
+    rec = await asyncio.wait_for(queue.dequeue(), timeout=1.0)
+    await queue.mark_done(rec.id, "diagnosis: replace bearing on pump-3")
+
+    row = queue._conn.execute(
+        "SELECT status, reply_text FROM photo_batches WHERE id = ?", (rec.id,)
+    ).fetchone()
+    assert row[0] == "done"
+    assert row[1] == "diagnosis: replace bearing on pump-3"
+
+
+@pytest.mark.asyncio
+async def test_mark_failed_records_error(queue):
+    bid, _ = await queue.add_photo_to_burst("42", "telegram", "a", "c")
+    await queue.close_burst(bid)
+    rec = await asyncio.wait_for(queue.dequeue(), timeout=1.0)
+    await queue.mark_failed(rec.id, "vision pipeline timeout after 90s")
+
+    row = queue._conn.execute(
+        "SELECT status, error_message FROM photo_batches WHERE id = ?", (rec.id,)
+    ).fetchone()
+    assert row[0] == "failed"
+    assert "vision pipeline timeout" in row[1]
+
+
+# --- recovery ---------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_recover_orphans_resets_processing_to_queued(tmp_path):
+    db = tmp_path / "photo_batches.db"
+    q1 = PhotoBatchQueue(str(db))
+    bid, _ = await q1.add_photo_to_burst("42", "telegram", "a", "c")
+    await q1.close_burst(bid)
+    rec = await asyncio.wait_for(q1.dequeue(), timeout=1.0)
+    assert rec.id == bid
+    assert q1.stats() == {"processing": 1}
+    q1.close()
+
+    q2 = PhotoBatchQueue(str(db))
+    n = await q2.recover_orphans()
+    assert n == 1
+    assert q2.stats() == {"queued": 1}
+
+    rec_again = await asyncio.wait_for(q2.dequeue(), timeout=1.0)
+    assert rec_again.id == bid
+    q2.close()
+
+
+@pytest.mark.asyncio
+async def test_recover_orphans_renotifies_existing_queued(tmp_path):
+    db = tmp_path / "photo_batches.db"
+    q1 = PhotoBatchQueue(str(db))
+    bid, _ = await q1.add_photo_to_burst("42", "telegram", "a", "c")
+    await q1.close_burst(bid)
+    q1.close()
+
+    q2 = PhotoBatchQueue(str(db))
+    await q2.recover_orphans()
+    rec = await asyncio.wait_for(q2.dequeue(), timeout=1.0)
+    assert rec.id == bid
+    q2.close()
+
+
+# --- ack message id ---------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ack_message_id_round_trip(queue):
+    bid, _ = await queue.add_photo_to_burst(
+        "42", "telegram", "a", "c", ack_message_id=12345
+    )
+    await queue.close_burst(bid)
+    rec = await asyncio.wait_for(queue.dequeue(), timeout=1.0)
+    assert rec.ack_message_id == 12345
+
+
+@pytest.mark.asyncio
+async def test_ack_message_id_can_be_set_late(queue):
+    bid, _ = await queue.add_photo_to_burst("42", "telegram", "a", "c")
+    await queue.set_ack_message(bid, 99999)
+    await queue.close_burst(bid)
+    rec = await asyncio.wait_for(queue.dequeue(), timeout=1.0)
+    assert rec.ack_message_id == 99999


### PR DESCRIPTION
## Summary

Replaces the in-memory `PHOTO_BUFFER` dict in `mira-bots/telegram/bot.py` with a two-tier system: a small 4-second in-memory pre-collector that decides single vs multi, plus a durable SQLite-backed `PhotoBatchQueue` that drives a single async worker. Bot container restarts no longer drop in-flight multi-photo bursts.

Builds on PR #986 (the crash-fix that shipped `engine.process_multi_photo`).

## Problems with the old buffer

- 50-photo spam had no upper bound → could OOM the bot container.
- Vision is GPU-bound on a single Ollama node, but multi-user bursts had no fairness/serialization.
- `task.cancel()` + `create_task` on every photo had a small race window where two flush tasks could both pop the buffer.
- Bot restart silently dropped any photos still in `PHOTO_BUFFER`.

## Architecture

- **`_BURST_COLLECTOR`** (in-memory, per-chat) — same 4s sliding window as before. Holds photos awaiting the single-vs-multi decision. Lost on restart, but worst-case data loss = 4 seconds of incoming.
- After window closes:
  - **1 photo** → `_dispatch_single_photo` (existing FSM-aware `ChatDispatcher` path, unchanged behaviour while we still hold the original `Update`).
  - **2+ photos** → `_enqueue_multi_photo_burst` pushes every photo into the durable queue and sends an immediate ack.
- **Single async worker** (`_photo_batch_worker`, spawned in `_startup`) drains the queue FIFO, calls `engine.process_multi_photo`, delivers reply via `application.bot.send_message`. No `Update` object needed → works fine after restart.
- Worker concurrency hard-coded to **1** because vision is the bottleneck and parallel workers would just fight on Ollama.

## Bounds (with user-visible messages)

| Constant | Value | When hit |
|---|---|---|
| `MAX_PHOTOS_PER_BURST` | 10 | Burst capped: `"⚠️ Burst capped at N/M photos (rejected dropped)"` |
| `MAX_QUEUE_DEPTH` | 20 | `"🚧 The photo queue is full right now. Please retry in a moment."` |
| `BURST_WINDOW_SECONDS` | 4.0 | (sliding window before the collector flushes) |

## Recovery

On worker startup, `recover_orphans()`:
1. Flips any `processing` rows back to `queued` (assumes the previous worker died mid-job — vision is idempotent, so retry is safe).
2. Re-notifies the asyncio queue for every existing `queued` row so they get drained on resume.

## Schema

Single table, WAL mode (per `python-standards.md` SQLite policy):

```
photo_batches(id, chat_id, platform, status, caption, photos_json,
              photo_count, ack_message_id, created_at, queued_at,
              started_at, completed_at, error_message, reply_text)
```

DB path defaults to alongside `MIRA_DB_PATH`; override via `PHOTO_QUEUE_DB_PATH`.

`status` lifecycle: `collecting → queued → processing → done | failed`.

## Tests

`tests/test_photo_batch_queue.py` (15 tests):

- Producer: first-photo creates batch, second-photo joins, burst cap enforced, different chats don't share.
- Caption: first real caption survives default-placeholder followups (Telegram media-group caption-on-first-only quirk).
- Consumer: dequeue returns oldest first (FIFO), blocks until close, idempotent close, mark_done/mark_failed records reply/error.
- Recovery: orphan `processing` reset on worker restart, queued rows re-notified.
- Ack message ID round-trip + late-set.

All 30 photo-related tests still green:

```
tests/test_photo_batch_queue.py     ............... [15 passed]
tests/test_telegram_photo_buffer.py ........        [ 8 passed]
tests/test_multi_photo.py           .......         [ 7 passed]
```

## Test plan

- [x] Unit tests pass (30/30).
- [x] `python -m ruff check` clean.
- [x] `python -m ast.parse` confirms `bot.py` parses.
- [ ] Mike sends a 4-photo burst on production bot — gets queued ack + combined reply.
- [ ] Mike sends a single photo on production bot — still hits the FSM-aware dispatcher path (unchanged behaviour).
- [ ] Mike restarts the `mira-bot-telegram` container mid-burst — multi-photo burst resumes from the queue (orphan recovery in `_startup` logs).
- [ ] Mike sends 11 photos in one burst — gets `"⚠️ Burst capped at 10/11..."`.

## Linear

Mirror ticket to be filed and linked in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)