### PR TITLE
feat(telegram): live progress updates during multi-photo processing

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -7,6 +7,7 @@ import os
 import re
 import sqlite3
 import time
+from collections.abc import Awaitable, Callable
 from datetime import datetime, timedelta, timezone
 
 import httpx
@@ -625,6 +626,7 @@ class Supervisor:
         platform: str = "telegram",
         tenant_id: str | None = None,
         mira_user_id: str | None = None,
+        on_progress: Callable[[int, int], Awaitable[None]] | None = None,
     ) -> str:
         """Burst entry point. Returns combined reply for N photos (N >= 1).
 
@@ -636,6 +638,12 @@ class Supervisor:
         (every cascade provider down), the method falls back to a deterministic
         numbered list. Only the LAST photo is persisted via _save_session_photo
         so follow-up turns ("tell me more about photo 4") have a single anchor.
+
+        ``on_progress(idx_done, n_total)`` — optional async callback fired after
+        each photo's vision call completes (idx_done is 1-based, fires N times
+        across the burst). Callers (the photo-batch worker) use this to edit
+        the chat ack message ("Processing photo 2/4..."). Callback exceptions
+        are caught and logged so a flaky chat-edit can't take down the engine.
         """
         self._current_tenant_id = tenant_id or getattr(self, "tenant_id", "") or ""
         self._current_mira_user_id = mira_user_id or ""
@@ -666,6 +674,15 @@ class Supervisor:
                         "drawing_type_confidence": 0.0,
                     }
                 analyses.append(vresult)
+                if on_progress is not None:
+                    try:
+                        await on_progress(idx, n)
+                    except Exception as cb_exc:
+                        logger.warning(
+                            "MULTI_PHOTO_PROGRESS_CALLBACK_FAILURE "
+                            "chat_id=%s idx=%d/%d error=%s",
+                            chat_id, idx, n, cb_exc,
+                        )
 
             bullets = []
             for idx, a in enumerate(analyses, start=1):

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -638,12 +638,35 @@ async def _photo_batch_worker(application: Application) -> None:
             "PHOTO_QUEUE_WORKER processing batch_id=%d chat=%s n=%d",
             rec.id, rec.chat_id, n,
         )
+
+        async def _edit_ack(text: str) -> None:
+            if rec.ack_message_id is None:
+                return
+            try:
+                await application.bot.edit_message_text(
+                    chat_id=int(rec.chat_id),
+                    message_id=rec.ack_message_id,
+                    text=text,
+                )
+            except Exception as edit_exc:
+                logger.debug(
+                    "PHOTO_QUEUE_WORKER ack edit failed batch_id=%d: %s",
+                    rec.id, edit_exc,
+                )
+
+        async def _on_progress(idx_done: int, n_total: int) -> None:
+            if idx_done < n_total:
+                await _edit_ack(f"📸 Processing photo {idx_done + 1}/{n_total}…")
+            else:
+                await _edit_ack(f"📸 Synthesizing answer for {n_total} photos…")
+
         try:
             reply = await engine.process_multi_photo(
                 chat_id=rec.chat_id,
                 message=rec.caption,
                 photos_b64=rec.photos_b64,
                 platform=rec.platform,
+                on_progress=_on_progress,
             )
             if not reply:
                 reply = (

--- a/tests/test_multi_photo.py
+++ b/tests/test_multi_photo.py
@@ -253,3 +253,98 @@ async def test_vision_worker_failure_continues_with_placeholder():
 
     assert result  # returns something
     assert eng.vision.process.call_count == 2  # still attempted both
+
+
+# ---------------------------------------------------------------------------
+# Progress callback (on_progress) — fires once per photo, in order, never aborts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_progress_fires_once_per_photo_in_order():
+    """Callback fires (1, n), (2, n), ..., (n, n) — exactly N times, in order."""
+    eng = _make_engine()
+    eng.vision.process = AsyncMock(side_effect=[NAMEPLATE, BEARING_DAMAGE, FAULT_DISPLAY])
+    eng.router.complete = AsyncMock(return_value=("synth reply", {}))
+
+    events: list[tuple[int, int]] = []
+
+    async def on_progress(idx_done: int, n_total: int) -> None:
+        events.append((idx_done, n_total))
+
+    await eng.process_multi_photo(
+        chat_id="test-progress",
+        message="",
+        photos_b64=[_b64("img1"), _b64("img2"), _b64("img3")],
+        on_progress=on_progress,
+    )
+
+    assert events == [(1, 3), (2, 3), (3, 3)]
+
+
+@pytest.mark.asyncio
+async def test_on_progress_fires_even_when_vision_failed_for_a_photo():
+    """Vision failure on photo 2 still fires (2, n) — caller sees real progress, not stuck."""
+    eng = _make_engine()
+    eng.vision.process = AsyncMock(
+        side_effect=[NAMEPLATE, Exception("Ollama timeout"), BEARING_DAMAGE]
+    )
+    eng.router.complete = AsyncMock(return_value=("synth", {}))
+
+    events: list[tuple[int, int]] = []
+
+    async def on_progress(idx_done: int, n_total: int) -> None:
+        events.append((idx_done, n_total))
+
+    await eng.process_multi_photo(
+        chat_id="test-progress-fail",
+        message="",
+        photos_b64=[_b64("img1"), _b64("img2"), _b64("img3")],
+        on_progress=on_progress,
+    )
+
+    # All three photos still report progress, even though photo 2 had a vision
+    # exception (it degraded to the UNCLEAR placeholder).
+    assert events == [(1, 3), (2, 3), (3, 3)]
+
+
+@pytest.mark.asyncio
+async def test_on_progress_callback_exception_does_not_abort_engine():
+    """Flaky callback (e.g., Telegram edit_message rate-limited) must not break processing."""
+    eng = _make_engine()
+    eng.vision.process = AsyncMock(side_effect=[NAMEPLATE, BEARING_DAMAGE])
+    eng.router.complete = AsyncMock(return_value=("synth reply text", {}))
+
+    call_count = 0
+
+    async def flaky_on_progress(idx_done: int, n_total: int) -> None:
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("Telegram 429 rate-limited")
+
+    result = await eng.process_multi_photo(
+        chat_id="test-flaky-cb",
+        message="",
+        photos_b64=[_b64("img1"), _b64("img2")],
+        on_progress=flaky_on_progress,
+    )
+
+    # Engine completes normally despite every callback raising
+    assert result == "synth reply text"
+    assert call_count == 2  # called once per photo
+    assert eng.vision.process.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_on_progress_optional_default_none():
+    """Backwards-compatible — omitting on_progress works exactly as before."""
+    eng = _make_engine()
+    eng.vision.process = AsyncMock(side_effect=[NAMEPLATE])
+    eng.router.complete = AsyncMock(return_value=("single-photo reply", {}))
+
+    result = await eng.process_multi_photo(
+        chat_id="test-no-cb",
+        message="",
+        photos_b64=[_b64("img1")],
+    )
+    assert result == "single-photo reply"


### PR DESCRIPTION
## Summary

Multi-photo bursts can take 60s+ when each photo runs through the GPU-bound vision pipeline sequentially. Until now the user saw a single `"📸 Queued 4 photos…"` ack and then radio silence until the final synthesized reply landed — long enough for them to wonder if the bot crashed.

This PR edits the ack message after each photo so the user sees real progress.

## Stacked on PR #987

Builds on `feat/telegram-photo-batch-queue` (the queue + worker). **Base: `feat/telegram-photo-batch-queue`, not `main`.** Merge order: #987 first, then this.

## What the user sees now

```
📸 Queued 4 photos — I'll have results for you shortly.   ← initial ack
📸 Processing photo 2/4…                                   ← after #1 done
📸 Processing photo 3/4…                                   ← after #2 done
📸 Processing photo 4/4…                                   ← after #3 done
📸 Synthesizing answer for 4 photos…                       ← after #4 done
<final reply>                                              ← new message
```

The same `ack_message_id` is edited each time; final reply lands as a new message.

## Engine-side change (`Supervisor.process_multi_photo`)

New optional async callback parameter:
```python
on_progress: Callable[[int, int], Awaitable[None]] | None = None
```
Fires after each photo's vision call completes (1-indexed, fires N times across the burst).

**Guarantees:**
- Optional; default `None` preserves existing behaviour exactly.
- Callback exceptions are caught + logged, never propagated. A flaky Telegram edit (rate-limited, `"message is not modified"`, etc.) can't abort processing.
- Fires even when an individual photo's vision call hits the UNCLEAR-placeholder fallback path — caller sees real progress, not a hang.

## Worker-side change (`_photo_batch_worker`)

```python
async def _on_progress(idx_done: int, n_total: int) -> None:
    if idx_done < n_total:
        await _edit_ack(f"📸 Processing photo {idx_done + 1}/{n_total}…")
    else:
        await _edit_ack(f"📸 Synthesizing answer for {n_total} photos…")
```
- `ack_message_id is None` (initial ack send failed) → edits silently skipped.
- `bot.edit_message_text` failures are debug-logged only; progress is best-effort.

## Tests

**4 new in `tests/test_multi_photo.py`** (34 total photo-related tests still green):

- `test_on_progress_fires_once_per_photo_in_order` — exactly N invocations, ordered.
- `test_on_progress_fires_even_when_vision_failed_for_a_photo` — UNCLEAR fallback still reports progress.
- `test_on_progress_callback_exception_does_not_abort_engine` — flaky callback raises, engine still returns full reply.
- `test_on_progress_optional_default_none` — backwards compatibility.

```
tests/test_photo_batch_queue.py     ............... [15 passed]
tests/test_telegram_photo_buffer.py ........        [ 8 passed]
tests/test_multi_photo.py           ...........     [11 passed]
```

## Test plan

- [x] Unit tests pass (34/34).
- [x] `python -m ruff check` clean.
- [ ] Mike sends a 4-photo burst on production bot — sees ack edits after each photo + "Synthesizing answer…" before final reply.
- [ ] Mike sends 1 photo (FSM-aware single-photo path) — unchanged behaviour.

## Linear

Mirror ticket to be filed and linked in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)