### PR TITLE
fix(mobile): 44x44 tap targets — Open MIRA footer + Open WebUI login (CRA-24)

### DIFF
--- a/mira-core/docker-compose.yml
+++ b/mira-core/docker-compose.yml
@@ -30,7 +30,12 @@ services:
       - PDF_EXTRACT_IMAGES=true
       # KB status indicator — red outline by default (unknown = caution).
       # Per-turn 🟢/🟡/🔴 banners in pipeline responses provide the live signal.
-      - "WEBUI_CUSTOM_CSS=#app > div:first-child { outline: 3px solid #cc3333; outline-offset: -3px; border-radius: 4px; transition: outline-color 0.5s ease; }"
+      # CRA-24: also enforce 44x44 minimum tap target on mobile widths so the
+      # OAuth/password buttons on /auth pass iOS HIG / WCAG 2.5.5. Open WebUI
+      # uses Svelte-generated class names that drift across releases, so we
+      # target generic interactive elements (button / a[href] / input
+      # submit/button) inside a mobile media query — desktop unchanged.
+      - "WEBUI_CUSTOM_CSS=#app > div:first-child { outline: 3px solid #cc3333; outline-offset: -3px; border-radius: 4px; transition: outline-color 0.5s ease; } @media (max-width: 768px) { button, a[href], input[type=submit], input[type=button] { min-height: 44px; } }"
       # STT — Groq Whisper free tier (voice-to-text)
       - AUDIO_STT_ENGINE=openai
       - AUDIO_STT_OPENAI_API_BASE_URL=https://api.groq.com/openai/v1

--- a/mira-web/src/routes/__tests__/m-chooser.test.ts
+++ b/mira-web/src/routes/__tests__/m-chooser.test.ts
@@ -56,6 +56,15 @@ describe("GET /m/:asset_tag/choose", () => {
     expect(html).toContain("Asset not found");
   });
 
+  test("CRA-24: 'Open MIRA' link meets 44x44 tap target on mobile", async () => {
+    const res = await app.request("/m/NOEXIST-CHOOSER-TAG/choose");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("min-height: 44px");
+    expect(html).toContain("padding: 0.75rem 1rem");
+    expect(html).toContain('<a href="https://app.factorylm.com">Open MIRA</a>');
+  });
+
   test("sets mira_channel_pref cookie when ?set_pref=telegram is passed", async () => {
     const res = await app.request("/m/VFD-CHOOSER/choose?set_pref=telegram", {
       redirect: "manual",

--- a/mira-web/src/routes/__tests__/m-report.test.ts
+++ b/mira-web/src/routes/__tests__/m-report.test.ts
@@ -41,6 +41,22 @@ describe("GET /m/:asset_tag/report", () => {
     const res = await app.request("/m/BAD TAG/report");
     expect(res.status).toBe(400);
   });
+
+  test("200 not-found HTML for nonexistent tag", async () => {
+    const res = await app.request("/m/NOEXIST-REPORT-TAG/report");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("Asset not found");
+  });
+
+  test("CRA-24: 'Open MIRA' link meets 44x44 tap target on mobile", async () => {
+    const res = await app.request("/m/NOEXIST-REPORT-TAG/report");
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain("min-height: 44px");
+    expect(html).toContain("padding: 0.75rem 1rem");
+    expect(html).toContain('<a href="https://app.factorylm.com">Open MIRA</a>');
+  });
 });
 
 describe("POST /api/m/report", () => {

--- a/mira-web/src/routes/m-chooser.ts
+++ b/mira-web/src/routes/m-chooser.ts
@@ -35,7 +35,16 @@ const NOT_FOUND_HTML = `<!doctype html>
     body { font-family: system-ui, sans-serif; max-width: 480px; margin: 3rem auto; padding: 1rem; color: #111; }
     h1 { font-size: 1.25rem; font-weight: 600; }
     p { color: #444; line-height: 1.5; }
-    a { color: #f5a623; }
+    /* CRA-24: 44x44 mobile tap target (was ~82x18). */
+    a {
+      color: #f5a623;
+      display: inline-flex;
+      align-items: center;
+      min-height: 44px;
+      padding: 0.75rem 1rem;
+      text-decoration: none;
+    }
+    a:hover, a:focus { text-decoration: underline; }
   </style>
 </head><body>
   <h1>Asset not found in your plant</h1>

--- a/mira-web/src/routes/m-report.ts
+++ b/mira-web/src/routes/m-report.ts
@@ -28,7 +28,16 @@ const NOT_FOUND_HTML = `<!doctype html>
     body { font-family: system-ui, sans-serif; max-width: 480px; margin: 3rem auto; padding: 1rem; color: #111; }
     h1 { font-size: 1.25rem; font-weight: 600; }
     p { color: #444; line-height: 1.5; }
-    a { color: #f5a623; }
+    /* CRA-24: 44x44 mobile tap target (was ~82x18). */
+    a {
+      color: #f5a623;
+      display: inline-flex;
+      align-items: center;
+      min-height: 44px;
+      padding: 0.75rem 1rem;
+      text-decoration: none;
+    }
+    a:hover, a:focus { text-decoration: underline; }
   </style>
 </head><body>
   <h1>Asset not found in your plant</h1>


### PR DESCRIPTION
## Summary

The 2026-05-03 web-review audit (Lighthouse + Playwright on iPhone 375×812) flagged 4 elements failing iOS HIG / WCAG 2.5.5 minimum tap target. This PR ships fixes for all 4.

## Closes

- Linear: [CRA-24](https://linear.app/cranesync/issue/CRA-24) — `[P2] Tap targets under 44px on mobile`
- GitHub: closes #953

## Before / after

| Page | Element | Old size | Change |
|---|---|---|---|
| `/m/:tag/report` (NOT_FOUND) | "Open MIRA" footer link | 82×18 | min-height:44px + padding:0.75rem 1rem |
| `/m/:tag/choose` (NOT_FOUND) | "Open MIRA" footer link | 82×18 | same |
| Open WebUI `/auth` | "Continue with Google" | 278×39 | mobile-only min-height:44px |
| Open WebUI `/auth` | "Sign in with password" | 278×14 | same |
| Open WebUI `/auth` | Icon button | 42×39 | same |

## What changed

### `mira-web/src/routes/{m-report,m-chooser}.ts`

The NOT_FOUND_HTML page (rendered when an asset_tag exists in the URL but isn't bound to any tenant config) had a bare inline `<a>` styled only with `color: #f5a623`. Now styled:

```css
a {
  color: #f5a623;
  display: inline-flex;
  align-items: center;
  min-height: 44px;
  padding: 0.75rem 1rem;
  text-decoration: none;
}
a:hover, a:focus { text-decoration: underline; }
```

Both files have the same NOT_FOUND_HTML pattern; both updated for consistency.

### `mira-core/docker-compose.yml` — `WEBUI_CUSTOM_CSS`

Open WebUI's auth page uses Svelte-generated class names (`.svelte-1c3wzy` etc.) that drift across releases — targeting them by class is fragile. The robust approach: **mobile-only media query** that enforces 44px on every interactive element.

```css
@media (max-width: 768px) {
  button, a[href], input[type=submit], input[type=button] { min-height: 44px; }
}
```

- Hits the auth page's three offending buttons without depending on Svelte classes.
- Desktop layout unchanged.
- Won't break older WebUI elements that already meet the threshold.
- Existing red-outline KB-status indicator (lines 31-33) preserved on the same env-var line.

### Tests

`tests/__tests__/m-{report,chooser}.test.ts`:

- Existing m-chooser had a "200 not-found HTML" test for the NOT_FOUND_HTML path — extended with a CRA-24 assertion checking the response includes `min-height: 44px` + `padding: 0.75rem 1rem`.
- m-report had no NOT_FOUND test before — added one matching the m-chooser pattern + the same tap-target assertion.

Tests use real Hono `app.request()` and require `NEON_DATABASE_URL` — they'll run in CI; locally `bun build` confirmed TypeScript valid (84 modules bundled cleanly, no errors).

## Test plan / acceptance gate

- [x] `bun build src/routes/m-report.ts src/routes/m-chooser.ts` — clean
- [x] CSS-content assertions added to both NOT_FOUND tests (will run in CI with NeonDB)
- [ ] Mike re-runs the iPhone 375×812 audit on `app.factorylm.com/sample` and `cmms.factorylm.com/m/UNKNOWN/report` — confirm 0/4 violations.
- [ ] Mike redeploys mira-core (so `WEBUI_CUSTOM_CSS` env var picks up the new mobile rules).

## Linear cross-link

Mirror to be added in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)