### PR TITLE
fix(hub): graceful 200 degraded fallbacks on /api/cmms/stats + /api/uploads (CRA-37, CRA-38)

### DIFF
--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -27,6 +27,13 @@ services:
       - DROPBOX_APP_SECRET=${DROPBOX_APP_SECRET}
       - ATLASSIAN_CLIENT_ID=${ATLASSIAN_CLIENT_ID}
       - ATLASSIAN_CLIENT_SECRET=${ATLASSIAN_CLIENT_SECRET}
+      # Atlas CMMS live stats — required for /api/cmms/stats to return real
+      # data instead of {degraded: true}. Mirrors docker-compose.saas.yml
+      # (the VPS deploy target) so local dev with hub.yml shows live stats
+      # too. Set values via Doppler factorylm/prd.
+      - HUB_CMMS_API_URL=${HUB_CMMS_API_URL:-https://cmms.factorylm.com}
+      - ATLAS_API_USER=${ATLAS_API_USER:-}
+      - ATLAS_API_PASSWORD=${ATLAS_API_PASSWORD:-}
     healthcheck:
       test: ["CMD", "sh", "-c", "wget -qO- http://127.0.0.1:3000/api/health || wget -qO- http://127.0.0.1:3000/hub/api/health"]
       interval: 30s

--- a/mira-hub/src/app/(hub)/cmms/page.tsx
+++ b/mira-hub/src/app/(hub)/cmms/page.tsx
@@ -43,8 +43,13 @@ export default function CMMSPage() {
     try {
       const res = await fetch("/api/cmms/stats");
       if (res.ok) {
-        const data: CMMSStats = await res.json();
-        setLiveStats(data);
+        // CRA-37: server now returns 200 with `degraded: true` when Atlas
+        // is unconfigured/unreachable (instead of 503/502). Treat that as
+        // "no live data" so STATIC_SUMMARY keeps rendering.
+        const data: CMMSStats & { degraded?: boolean } = await res.json();
+        if (!data.degraded) {
+          setLiveStats(data);
+        }
       }
     } catch {
       // silently fall back to static data

--- a/mira-hub/src/app/api/cmms/stats/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/cmms/stats/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+// Tests for the CMMS stats degraded path (CRA-37).
+//
+// The route used to return 503 when Atlas creds were missing and 502 when
+// Atlas POSTs failed; both lit up the /cmms page with red errors in the
+// browser network tab and Lighthouse audits. It now returns 200 with a
+// `degraded: true` marker so the client falls back to STATIC_SUMMARY
+// without surfacing a 5xx response.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/session", () => ({
+  sessionOr401: vi.fn(),
+}));
+
+import { sessionOr401 } from "@/lib/session";
+import { GET } from "../route";
+
+const goodCtx = { userId: "u_1", tenantId: "t_1", role: "member" as const };
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (sessionOr401 as ReturnType<typeof vi.fn>).mockResolvedValue(goodCtx);
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  delete process.env.ATLAS_API_USER;
+  delete process.env.ATLAS_API_PASSWORD;
+});
+
+describe("GET /api/cmms/stats — CRA-37 degraded path", () => {
+  it("returns 200 + degraded:credentials_not_configured when Atlas creds are missing", async () => {
+    // Both env vars absent → getToken short-circuits to null
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      degraded: true,
+      reason: "credentials_not_configured",
+    });
+  });
+
+  it("returns 200 + degraded:atlas_unreachable when Atlas search throws", async () => {
+    process.env.ATLAS_API_USER = "user@example.com";
+    process.env.ATLAS_API_PASSWORD = "pw";
+
+    // First fetch (signin) succeeds; subsequent searches throw.
+    let call = 0;
+    globalThis.fetch = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return new Response(JSON.stringify({ token: "fake" }), { status: 200 });
+      }
+      return new Response("upstream down", { status: 503 });
+    }) as typeof fetch;
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      degraded: true,
+      reason: "atlas_unreachable",
+    });
+  });
+
+  it("returns 200 + real stats on the happy path (regression guard)", async () => {
+    process.env.ATLAS_API_USER = "user@example.com";
+    process.env.ATLAS_API_PASSWORD = "pw";
+
+    let call = 0;
+    globalThis.fetch = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return new Response(JSON.stringify({ token: "fake" }), { status: 200 });
+      }
+      // Each search responds with a totalElements payload
+      return new Response(JSON.stringify({ totalElements: call }), { status: 200 });
+    }) as typeof fetch;
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).not.toHaveProperty("degraded");
+    expect(body.workOrders).toBeDefined();
+    expect(body.assets).toBeDefined();
+    expect(body.pms).toBeDefined();
+    expect(typeof body.fetchedAt).toBe("string");
+  });
+
+  it("returns the 401 short-circuit when sessionOr401 fails", async () => {
+    const unauthorized = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    (sessionOr401 as ReturnType<typeof vi.fn>).mockResolvedValue(unauthorized);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+});

--- a/mira-hub/src/app/api/cmms/stats/route.ts
+++ b/mira-hub/src/app/api/cmms/stats/route.ts
@@ -65,7 +65,13 @@ export async function GET() {
 
   const token = await getToken();
   if (!token) {
-    return NextResponse.json({ error: "CMMS credentials not configured" }, { status: 503 });
+    // CRA-37: graceful 200 + degraded marker rather than 5xx so the /cmms
+    // page sees a clean network response and falls back to STATIC_SUMMARY
+    // via its `liveStats === null` path. Was 503.
+    return NextResponse.json(
+      { degraded: true, reason: "credentials_not_configured" },
+      { status: 200 },
+    );
   }
 
   try {
@@ -97,6 +103,10 @@ export async function GET() {
     cachedToken = null;
     tokenExpiresAt = 0;
     console.error("[api/cmms/stats]", err);
-    return NextResponse.json({ error: "CMMS fetch failed" }, { status: 502 });
+    // CRA-37: same graceful fallback. Was 502.
+    return NextResponse.json(
+      { degraded: true, reason: "atlas_unreachable" },
+      { status: 200 },
+    );
   }
 }

--- a/mira-hub/src/app/api/uploads/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/uploads/__tests__/route.test.ts
@@ -1,0 +1,62 @@
+// Tests for the /api/uploads GET degraded path (CRA-38).
+//
+// listUploads used to throw NeonDB connection errors / schema-drift errors
+// straight out as a 500. The /knowledge page polls this endpoint every 2s
+// while uploads are in flight, so a transient failure was lighting up the
+// browser network tab + Lighthouse audit. GET now wraps in try/catch and
+// returns an empty array (200) — the next poll picks up real data once
+// the underlying issue clears.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/session", () => ({
+  sessionOr401: vi.fn(),
+}));
+
+vi.mock("@/lib/uploads", () => ({
+  listUploads: vi.fn(),
+}));
+
+import { sessionOr401 } from "@/lib/session";
+import { listUploads } from "@/lib/uploads";
+import { GET } from "../route";
+
+const goodCtx = { userId: "u_1", tenantId: "t_1", role: "member" as const };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (sessionOr401 as ReturnType<typeof vi.fn>).mockResolvedValue(goodCtx);
+});
+
+describe("GET /api/uploads — CRA-38 degraded path", () => {
+  it("returns 200 + [] when listUploads throws (NeonDB blip / schema drift)", async () => {
+    (listUploads as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Neon connection terminated unexpectedly"),
+    );
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+  });
+
+  it("returns 200 + the row list on the happy path (regression guard)", async () => {
+    const fakeRows = [
+      { id: "u1", filename: "a.pdf", status: "complete" },
+      { id: "u2", filename: "b.pdf", status: "uploading" },
+    ];
+    (listUploads as ReturnType<typeof vi.fn>).mockResolvedValue(fakeRows);
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual(fakeRows);
+  });
+
+  it("returns the 401 short-circuit when sessionOr401 fails", async () => {
+    const unauthorized = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    (sessionOr401 as ReturnType<typeof vi.fn>).mockResolvedValue(unauthorized);
+    const res = await GET();
+    expect(res.status).toBe(401);
+    expect(listUploads).not.toHaveBeenCalled();
+  });
+});

--- a/mira-hub/src/app/api/uploads/route.ts
+++ b/mira-hub/src/app/api/uploads/route.ts
@@ -194,7 +194,18 @@ function idempotentResponse(existing: Upload, requestId: string): NextResponse {
 export async function GET() {
   const ctx = await sessionOr401();
   if (ctx instanceof NextResponse) return ctx;
-  const rows = await listUploads(ctx.tenantId);
-  return NextResponse.json(rows);
+  try {
+    const rows = await listUploads(ctx.tenantId);
+    return NextResponse.json(rows);
+  } catch (err) {
+    // CRA-38: a Neon connection blip or a schema-drift error here used to
+    // bubble out as a 500, lighting up the /knowledge page's network tab
+    // and Lighthouse audit. The list is non-essential UI (the page polls
+    // again every 2s while uploads are in-flight), so an empty-array 200
+    // is the right degradation: clean network, page keeps working, the
+    // next poll picks up real data when the underlying issue clears.
+    console.error("[api/uploads GET] listUploads failed:", err);
+    return NextResponse.json([], { status: 200 });
+  }
 }
 


### PR DESCRIPTION
## Summary

The 2026-05-03 web-review audit flagged two P0 noisy-network errors on hub pages:

| Page | Endpoint | Old behaviour |
|---|---|---|
| `/cmms` | `GET /api/cmms/stats` | 503 when ATLAS_API_USER/PASSWORD unset |
| `/cmms` | `GET /api/cmms/stats` | 502 when Atlas downstream POST throws |
| `/knowledge` | `GET /api/uploads` | 500 when `listUploads` throws |

Neither was a hard UI break — both client pages already swallow fetch failures via try/catch. But the 5xx responses lit up the browser network tab and Lighthouse audit, and looked broken at a glance. Fix is server-side: degrade to 200 + an explicit marker so the network tab is clean and the page keeps rendering.

## Closes

- Linear: [CRA-37](https://linear.app/cranesync/issue/CRA-37) — `[web-review/P0] /cmms — 503 on /api/cmms/stats/`
- Linear: [CRA-38](https://linear.app/cranesync/issue/CRA-38) — `[web-review/P0] /knowledge — 500 on /api/uploads/`
- GitHub: closes #960, #961

## What changed

### `mira-hub/src/app/api/cmms/stats/route.ts` (CRA-37)
- "Atlas creds not configured" path → `200 {degraded: true, reason: "credentials_not_configured"}` (was 503).
- Atlas downstream POST failure → `200 {degraded: true, reason: "atlas_unreachable"}` (was 502). Token-cache invalidation on this path is preserved.

### `mira-hub/src/app/(hub)/cmms/page.tsx`
One-line guard — client now reads `data.degraded` and skips `setLiveStats` when true, so the existing `STATIC_SUMMARY` fallback keeps rendering. No other UI change.

### `mira-hub/src/app/api/uploads/route.ts` (CRA-38)
GET handler wraps `listUploads` in try/catch. Neon connection blips and schema-drift errors now return `200 []` instead of 500. The knowledge page polls every 2s while uploads are in flight, so the next poll picks up real data once the underlying issue clears.

### Tests (NEW)

`mira-hub/src/app/api/cmms/stats/__tests__/route.test.ts` — **4 tests:**
- no-creds → `degraded: credentials_not_configured`
- atlas-503 → `degraded: atlas_unreachable`
- happy-path regression guard (no `degraded` field on success)
- 401 short-circuit when `sessionOr401` fails

`mira-hub/src/app/api/uploads/__tests__/route.test.ts` — **3 tests:**
- `listUploads` throws → `200 []`
- happy-path regression guard
- 401 short-circuit when `sessionOr401` fails

```
 ✓ src/app/api/cmms/stats/__tests__/route.test.ts (4 tests)
 ✓ src/app/api/uploads/__tests__/route.test.ts (3 tests)
 Test Files  2 passed
       Tests  7 passed
```

## Test plan / acceptance gate

- [x] Vitest 7/7 pass
- [x] No regressions in the happy path (real data still flows through)
- [ ] Mike re-runs Lighthouse on `app.factorylm.com/cmms` and `/knowledge` post-deploy → no 5xx in the network panel
- [ ] If you actually want Atlas wired in production, the underlying CMMS-credentials gap is independent (set ATLAS_API_USER/PASSWORD via Doppler); this PR only fixes the cosmetic noise

## Linear cross-link

Mirror to be added in a follow-up comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)