### PR TITLE
feat(rag): blocked chunk format + concrete citation example in rule 16 (CRA-11)

### DIFF
--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -211,14 +211,15 @@ may have additional ratings or conditions — verify the full table in the \
 source manual for your specific configuration." Do not pad incomplete \
 retrieval with generic explanations. Set confidence to MEDIUM.
 16. CITATION REQUIRED. You MUST cite your source for any technical advice \
-(parameter values, fault codes, torque specs, timing, electrical specs). \
-Echo the exact "[Source: ...]" tag from the RETRIEVED REFERENCE DOCUMENTS \
-section, inline with the fact you are citing. The tag format is \
-"[Source: {manufacturer} {model_number} — {section}]" — copy it verbatim \
-from what you were given. Never invent or fabricate a [Source: ...] tag for \
-content that did not arrive with one. \
-If no retrieved documents appear in the RETRIEVED REFERENCE DOCUMENTS section \
-above, do NOT give technical advice. Instead say exactly: \
+(parameter values, fault codes, torque specs, timing, electrical specs, wiring, \
+sequence-of-operation steps). Each chunk in RETRIEVED REFERENCE DOCUMENTS is \
+wrapped with a "--- [N] [Source: Label] ---" header — copy that exact \
+"[Source: Label]" tag inline next to the fact you draw from it. Include at \
+least one [Source: ...] tag somewhere in your reply. \
+Example: "Set P01-01 to 60Hz [Source: AutomationDirect GS10 — Chapter 5]." \
+Never invent or alter a [Source: ...] tag — only use tags from the retrieved \
+documents above. If no retrieved documents appear in RETRIEVED REFERENCE \
+DOCUMENTS, do NOT give technical advice. Instead say exactly: \
 "I don't have documentation for this equipment in my records — searching now. \
 Type PROCEED to continue with my best estimate (not manual-verified)." \
 Never substitute training knowledge for missing documentation without this warning.
@@ -527,9 +528,9 @@ class RAGWorker:
                 text = chunk
             label = format_source_label(nc)
             if label:
-                system_content += f"[{i}] [Source: {label}] {text}\n"
+                system_content += f"--- [{i}] [Source: {label}] ---\n{text}\n---\n"
             else:
-                system_content += f"[{i}] {text}\n"
+                system_content += f"--- [{i}] ---\n{text}\n---\n"
         system_content += "--- END REFERENCES ---\n"
 
         messages = [{"role": "system", "content": system_content}]
@@ -647,9 +648,7 @@ class RAGWorker:
             for i, chunk in enumerate(neon_chunks, 1):
                 score = chunk.get("similarity") or 0.0
                 label = format_source_label(chunk) or (chunk.get("equipment_type") or "unknown")
-                system_content += (
-                    f"[{i}] [Source: {label}] (score={score:.3f})\n{chunk['content']}\n\n"
-                )
+                system_content += f"--- [{i}] [Source: {label}] (score={score:.3f}) ---\n{chunk['content']}\n---\n"
             system_content += "--- END NEONDB CONTEXT ---\n"
 
         messages = [{"role": "system", "content": system_content}]

--- a/mira-bots/tests/test_unit2_citations.py
+++ b/mira-bots/tests/test_unit2_citations.py
@@ -28,6 +28,8 @@ import os
 import sys
 import unittest.mock
 
+import pytest
+
 # Minimal env vars to satisfy module-level imports.
 os.environ.setdefault("OPENWEBUI_BASE_URL", "http://localhost:8080")
 os.environ.setdefault("OPENWEBUI_API_KEY", "")
@@ -57,7 +59,6 @@ from shared.workers.rag_worker import (  # noqa: E402
     RAGWorker,
     format_source_label,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -282,6 +283,98 @@ class TestSystemPromptInstruction:
     def test_rule_16_forbids_invented_tags(self):
         text = GSD_SYSTEM_PROMPT.lower()
         assert "never invent" in text or "do not invent" in text or "never fabricate" in text
+
+    def test_rule_16_has_concrete_example(self):
+        # CRA-11: concrete inline example drives LLM compliance better than
+        # abstract "echo the tag" instruction alone.
+        assert "Example:" in GSD_SYSTEM_PROMPT or "example:" in GSD_SYSTEM_PROMPT
+        # The example should show a realistic citation tag inline with a fact
+        assert (
+            "[Source:" in GSD_SYSTEM_PROMPT.split("Example:")[1]
+            if "Example:" in GSD_SYSTEM_PROMPT
+            else True
+        )
+
+    def test_rule_16_describes_blocked_format(self):
+        # The instruction must describe the "--- [N] [Source: ...] ---" fenced
+        # structure so the LLM knows how the reference documents are wrapped.
+        assert "---" in GSD_SYSTEM_PROMPT
+
+
+class TestBlockedChunkFormat:
+    """The fix for CITATION_COMPLIANCE_MISS: chunks must be fenced with
+    --- [N] [Source: Label] --- so the [Source:] tag is visually isolated
+    and the LLM can copy it verbatim.  Flat "prefix-on-same-line" format
+    must NOT be present in the references block."""
+
+    def test_source_header_is_on_own_line(self):
+        w = _make_worker()
+        chunk = _chunk(
+            manufacturer="AutomationDirect",
+            model_number="GS10",
+            section="Chapter 5",
+            content="Set P01-01 to 60Hz.",
+        )
+        msgs = w._build_prompt_with_chunks(_state(), "test", [chunk])
+        sys_text = msgs[0]["content"]
+        ref_block = sys_text.split("--- RETRIEVED REFERENCE DOCUMENTS ---", 1)[1]
+        ref_block = ref_block.split("--- END REFERENCES ---", 1)[0]
+        # The [Source: ...] header must appear on its own line, not inline with
+        # the chunk text that follows it.
+        for line in ref_block.splitlines():
+            stripped = line.strip()
+            if "[Source:" in stripped and "Set P01-01" in stripped:
+                pytest.fail(
+                    "Source tag and chunk content are on the same line — blocked format not applied"
+                )
+
+    def test_chunk_content_follows_source_header_on_next_line(self):
+        w = _make_worker()
+        chunk = _chunk(
+            manufacturer="Yaskawa",
+            model_number="A1000",
+            section="Fault Codes",
+            content="OC1 overcurrent during acceleration.",
+        )
+        msgs = w._build_prompt_with_chunks(_state(), "test", [chunk])
+        sys_text = msgs[0]["content"]
+        ref_block = sys_text.split("--- RETRIEVED REFERENCE DOCUMENTS ---", 1)[1]
+        ref_block = ref_block.split("--- END REFERENCES ---", 1)[0]
+        lines = [ln for ln in ref_block.splitlines() if ln.strip()]
+        # Find the source header line
+        header_idx = next((i for i, ln in enumerate(lines) if "[Source: Yaskawa A1000" in ln), None)
+        assert header_idx is not None, "Source header not found in reference block"
+        # The NEXT non-empty line must be the chunk content, not another header
+        assert header_idx + 1 < len(lines), "Nothing follows the source header"
+        assert "OC1 overcurrent" in lines[header_idx + 1], (
+            f"Content line not immediately after header. Got: {lines[header_idx + 1]!r}"
+        )
+
+    def test_neon_path_uses_blocked_format(self):
+        w = _make_worker()
+        msgs = w._build_prompt(
+            _state(),
+            "test",
+            None,
+            neon_chunks=[
+                _chunk(
+                    manufacturer="Siemens",
+                    model_number="G120",
+                    section="Parameters",
+                    content="P0100 sets line frequency.",
+                )
+            ],
+        )
+        sys_text = msgs[0]["content"]
+        kb_block = sys_text.split("--- NEONDB KNOWLEDGE BASE (retrieved) ---", 1)[1]
+        kb_block = kb_block.split("--- END NEONDB CONTEXT ---", 1)[0]
+        # Source header and content must be on separate lines
+        for line in kb_block.splitlines():
+            if "[Source:" in line and "P0100" in line:
+                pytest.fail(
+                    "NeonDB path: source tag and chunk content on same line — "
+                    "blocked format not applied"
+                )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Switches chunk injection in both RAG paths from flat single-line to fenced blocks (`--- [N] [Source: Mfr Mdl — Section] ---\n{text}\n---`) so the `[Source: ...]` header is visually isolated from content and the LLM can copy it verbatim
- Strengthens system-prompt rule 16 with a concrete inline example (`"Set P01-01 to 60Hz [Source: AutomationDirect GS10 — Chapter 5]."`) — previously the rule was abstract with no example
- Addresses the `CITATION_COMPLIANCE_MISS` signal that appeared on every smoke case in the 2026-05-04 v2 test harness run

## What was already there (not changed)
- `citation_compliance.py` — already on main (landed with Stage 1 DST)
- `CITATION_TAG_RE`, `format_source_label()` — already on main
- Engine wiring of `_check_citation_compliance` — already on main

## Test plan
- [x] `tests/test_unit2_citations.py` — 32/32 passed (all citation layers)
- [x] `tests/test_citation_format.py` — 15/15 passed
- [x] `ruff check` — clean

## Closes
CRA-11

🤖 Generated with [Claude Code](https://claude.com/claude-code)