### PR TITLE
docs: amend MIRA lock for 2026-05-05 marketplace pivot

### DIFF
--- a/STRATEGY.md
+++ b/STRATEGY.md
@@ -27,11 +27,12 @@
 
 ## GTM Motion
 
-**Stage 1 (now → 60 days): LinkedIn-first PLG**
-- 6-part LinkedIn series: "The 2 AM VFD Problem" → build in public → technical proof posts
-- Each post ends with one CTA: try MIRA free or book a call
-- Target: 3 paid plants within 60 days
-- No agencies, no ads, no SEO yet
+**Stage 1 (now → 60 days): Marketplace distribution + standalone PLG** *(pivoted 2026-05-05 — see `~/.claude/plans/dev-api-key-for-optimized-badger.md`)*
+- monday.com marketplace listing live for `mira-scan-monday` (Phase 1 of the marketplace plan; OAuth install flow + listing artifacts + submission)
+- UpKeep Studio submission as a parallel track once monday is submitted (Phase 2)
+- Standalone web app at `app.factorylm.com/scan/` as the public-facing entry for techs without a CMMS — LinkedIn drives traffic here
+- 6-part LinkedIn series ("The 2 AM VFD Problem") repurposed as scan-demo content with a CTA to try the standalone app
+- Target by 2026-07-19: monday listing live + ≥3 non-Mike installs; UpKeep listing submitted
 
 **Stage 2 (60–120 days): Warm outbound**  
 - Direct message 20 maintenance managers/week on LinkedIn

--- a/docs/plans/2026-04-19-mira-90-day-mvp.md
+++ b/docs/plans/2026-04-19-mira-90-day-mvp.md
@@ -6,14 +6,40 @@
 
 ---
 
+## Pivot 2026-05-05
+
+The original plan committed to 10 units of direct-sales product with LinkedIn outbound as the GTM. On **2026-05-05** the GTM pivoted to **marketplace distribution** (monday.com → UpKeep) after Mike independently shipped `feat/mira-scan-monday` — a camera-scanner app embedding MIRA's full ingest flywheel inside the monday.com item-view, live at `https://app.factorylm.com/scan/`. The pivot is documented end-to-end in:
+
+- `~/.claude/plans/dev-api-key-for-optimized-badger.md` — active marketplace plan
+- `~/.claude/CLAUDE.md` "Active MIRA Objective" — amended global lock
+
+### What survives from this plan
+- Units 0/1/2/3/6 — done or in-flight; their infrastructure is *required* by the marketplace app (citations + hybrid retrieval power the in-app chat; magic inbox is the upsell after a KB miss)
+- Unit 9a — in-flight via PR #945; can merge as the direct-sales standalone fallback at `app.factorylm.com/scan/`
+
+### What's deferred (do NOT start new work)
+- **Unit 4** (Excel/CSV exports) — marketplace customers already have CMMS exports
+- **Unit 5** (UNS-style asset model) — targeted SMBs without a CMMS; marketplace customers have one
+- **Unit 7** (QR scan pre-load) — superseded by the camera-scanner UX in `mira-scan-monday`
+- **Unit 8** (Atlas one-way sync hardening) — finish PR #989 if close to merging, then defer
+
+### What's added
+- **Unit 9b (replaces "case study"):** monday.com marketplace listing live + ≥3 non-Mike installs by 2026-07-19
+- **Unit 10 (new):** UpKeep marketplace listing submitted by 2026-07-19
+
+The original 10-unit list below remains the historical reference. The "First dollar" path now runs through the marketplace plan's Phase 1D (Monday submission) rather than the original W3 direct-demo target.
+
+---
+
 ## Currently in-flight (update before starting work)
 
 > **Protocol:** before starting a unit or major task, edit this list — claim it. Edit it again when you merge or hand off. A merge conflict on this section is the signal that two sessions tried to claim the same work; resolve by talking before editing files.
 
 | Unit / Task | Owner | Branch | Started | Notes |
 |---|---|---|---|---|
-| Unit 9a (landing page rewrite) | agent-claude | feat/mvp-unit-9a-landing | 2026-04-25 20:30 UTC | Three named features above fold: Photo-to-Asset, Magic Manual Inbox, Source-Cited Answers. Last first-dollar gate (Units 2 + 6 already merged). Scope: edit `mira-web/public/index.html` only — minimal disruption to existing polish. |
-| Unit 4 (Excel/CSV live export) | agent-claude | feat/mvp-unit-4-exports | 2026-04-25 21:55 UTC | Export endpoints for assets + work orders. Host: mira-mcp (has Atlas adapter + tenant resolver). Files: mira-mcp/exports.py (new), mira-mcp/server.py (route registration), mira-mcp/requirements.txt (openpyxl + PyJWT). |
+| Unit 9a (landing page rewrite) | agent-claude | feat/mvp-unit-9a-landing | 2026-04-25 20:30 UTC | Three named features above fold. Now serves as direct-sales standalone fallback for `app.factorylm.com/scan/`; PR #945 can merge. |
+| Unit 4 (Excel/CSV live export) | agent-claude | feat/mvp-unit-4-exports | 2026-04-25 21:55 UTC | **DEFERRED post 2026-05-05 pivot.** Marketplace customers already have CMMS exports. Finish if close to merge; otherwise stop. |
+| Unit 9b (monday.com marketplace) | mike | feat/mira-scan-monday | 2026-04-30 (approx) | Camera-scanner iframe app, full ingest flywheel. 21 commits ahead, deployed at `app.factorylm.com/scan/`. **Connecting to monday.com Developer Center is the active work** — see `~/.claude/plans/dev-api-key-for-optimized-badger.md` Phase 1. |
 
 (Format: `Unit N (short name)` | `mike` or `agent-claude` or `agent-multica` | `feat/mvp-unit-N-...` | `YYYY-MM-DD HH:MM UTC` | optional)
 


### PR DESCRIPTION
## Summary
- GTM pivot recorded: direct-sales LinkedIn PLG → marketplace distribution (monday.com first, UpKeep second)
- Active marketplace plan: `~/.claude/plans/dev-api-key-for-optimized-badger.md`
- Original 10-unit plan still governs Units 0/1/2/3/6/9a; Units 4/5/7/8 deferred (no new work, in-flight may finish)

## Changes
- `STRATEGY.md` Stage 1: marketplace listings replace LinkedIn-first PLG; standalone web app at `app.factorylm.com/scan/` remains as the direct-sales entry point.
- `docs/plans/2026-04-19-mira-90-day-mvp.md`: new `## Pivot 2026-05-05` section; in-flight table updated — Unit 9b row added for `feat/mira-scan-monday`; Unit 4 marked **DEFERRED**; Unit 9a re-scoped as direct-sales fallback.
- (Applied in parallel, outside this repo so not in the diff:) `~/.claude/CLAUDE.md` "Active MIRA Objective" amended globally — Unit 9b becomes "monday.com listing live + ≥3 non-Mike installs"; Unit 10 added for UpKeep submission.

## Why this PR exists
Two pivots happened inside one brainstorm today (drop-Monday → ship-UpKeep-shim → photo-scanner-on-Monday). The third pivot revealed Mike had already shipped `feat/mira-scan-monday` (21 commits, deployed live at `app.factorylm.com/scan/`) before the brainstorm started — the original lock said "no features outside the 10 units," so reality had moved past the lock. This PR records that.

## Test plan
- [x] No code changes — docs-only
- [x] `STRATEGY.md` renders correctly (Stage 1 section)
- [x] Plan doc renders correctly (Pivot section + in-flight table)
- [ ] Sanity-check post-merge: open a fresh Claude Code session, ask "what should I add to MIRA?" — confirm response references the marketplace plan, not free-form ideas
- [ ] Sanity-check post-merge: ask "let's add a Limble adapter" — confirm it pushes back, citing the lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)