### PR TITLE
docs(mira-scan-monday): Phase 1C marketplace listing artifacts

### DIFF
--- a/mira-scan-monday/marketplace/monday/demo-script.md
+++ b/mira-scan-monday/marketplace/monday/demo-script.md
@@ -1,0 +1,64 @@
+# MIRA Scan — 90-Second Demo Video Script
+
+For the marketplace listing video. Total length 80-95 seconds; YouTube unlisted, link supplied in the listing form. Voiceover written for a male/female in mid-30s; trim aggressively, no fluff.
+
+## Hook (0:00 – 0:08)
+
+**Visual:** Hands holding a phone, photographing a grimy nameplate on a factory pump motor. Tight close-up.
+**Voiceover:** "Maintenance teams spend twenty minutes per asset typing nameplate data into their CMMS. Most of it gets fat-fingered."
+
+## Problem (0:08 – 0:20)
+
+**Visual:** Cut to a monday.com board with rows of partially-filled asset items. Empty cells in the voltage / HP / serial columns. A user typing slowly into a cell, autocorrect changing the model number to something nonsensical.
+**Voiceover:** "And that's just the easy nameplates. The corroded ones, the ones in tight spots — those just stay blank. Forever."
+
+## Reveal (0:20 – 0:35)
+
+**Visual:** Cut back to the phone. Open monday.com mobile, a board item, then the MIRA Scan panel. Tap **Scan plate**.
+**Voiceover:** "MIRA Scan turns the phone you already carry into a structured-data shortcut. Inside any monday.com item, tap one button."
+
+**Visual:** Phone camera framing the nameplate. Tap to capture.
+
+## Demo (0:35 – 1:05)
+
+**Visual:** Beat — half a second of a small spinner. Then the AssetCard pops in with: Make=Yaskawa, Model=GA500, Voltage=480V, HP=10, RPM=1750. Confidence badge green. One field highlighted yellow (confidence flag).
+**Voiceover:** "GPT-4o Vision reads the plate. Make, model, serial, voltage, horsepower, RPM, frame — structured fields, with a confidence score so you know where to double-check."
+
+**Visual:** Pinch-tap the yellow field, fix it inline.
+**Voiceover:** "Edit anything that looks off. We never write to your board until you tap save."
+
+**Visual:** Tap **Save to monday item**. Brief animation, board reloads behind, columns now populated.
+**Voiceover:** "One tap. Seven fields. Your asset registry just got better."
+
+## Proof (1:05 – 1:20)
+
+**Visual:** Switch to MiraChat panel below the asset card. Type "What does fault F004 mean on this drive?" Reply renders with a citation `[Source: Yaskawa GA500 — §6.4 Overcurrent]`.
+**Voiceover:** "When MIRA recognizes the equipment, the panel turns into a Q&A on the actual OEM manual — cited answers, not hallucinated paragraphs."
+
+**Visual:** Quick screen flash of the manual-not-found state finding a real OEM PDF, then a check appearing.
+**Voiceover (faster):** "And when MIRA doesn't have your manual yet, it finds it on the open web — automatically."
+
+## CTA (1:20 – 1:30)
+
+**Visual:** Cut to the marketplace listing page. **Install** button highlighted.
+**Voiceover:** "MIRA Scan. Free during beta. Install from the monday.com marketplace."
+
+**End card:** factorylm.com/scan logo + "Try standalone at app.factorylm.com/scan/"
+
+## Production notes
+
+- **Length target:** 90 seconds. Hard cap 120.
+- **Resolution:** 1920×1080, 30fps.
+- **Audio:** music bed at -22 LUFS, voiceover at -14 LUFS, ducking automatic.
+- **Captions:** burn in English captions at the bottom (Monday reviewers may watch muted).
+- **B-roll style:** clean, modern, fast cuts (≤2s per shot during the demo block).
+- **No claims that aren't true.** "Twenty minutes" must be backed by a real customer interview or replaced with our own measured baseline. "GPT-4o Vision" is true. "Cited answers" is true (we ship citations as of PR #418).
+- **Voiceover script word count:** ~165 words. Read at ~120 wpm = 82 seconds, leaving room for visual beats.
+
+## Hosting
+
+- Upload to YouTube as **unlisted**.
+- Title: `MIRA Scan — AI-extract equipment specs from a photo`
+- Description: short version of the listing long description; link to `app.factorylm.com/scan/`.
+- Thumbnail: Shot 03 (the populated AssetCard) with a phone hand entering frame from the right.
+- Paste the unlisted URL into the Monday Developer Center listing form's "Demo video" field.

--- a/mira-scan-monday/marketplace/monday/listing.md
+++ b/mira-scan-monday/marketplace/monday/listing.md
@@ -1,0 +1,83 @@
+# monday.com Marketplace Listing — MIRA Scan
+
+> Source-of-truth copy for the Monday Developer Center submission form.
+> Edit here, then paste into the listing form. Pre-submission review
+> goes through `security-audit.md` and `privacy.md` first.
+
+## App name
+
+**MIRA Scan**
+
+## Tagline (subtitle)
+
+Stop typing nameplates. Snap them.
+
+## Short description (≤150 chars — used in marketplace tiles)
+
+Snap a nameplate photo. MIRA's AI extracts make, model, serial, voltage, HP, RPM — straight into your monday.com item.
+
+(149 chars)
+
+## Long description
+
+**The problem.** Every maintenance team has the same Tuesday-afternoon problem: a tech adds a new pump to a board, and the next 8 minutes evaporate squinting at a grimy nameplate, typing "GA500" three times because autocorrect keeps changing it, then copy-pasting voltage and HP from the same plate. Multiply by 200 assets a year. That's a week.
+
+**The fix.** Open the MIRA Scan panel on any monday.com item. Tap **Scan plate**. Phone camera opens. Snap once. MIRA's vision model reads the nameplate and writes make, model, serial, voltage, HP, RPM, and frame size directly into the columns you've already configured.
+
+**What you also get.**
+- **Grounded chat with the manual.** When MIRA recognizes the equipment, the panel turns into a Q&A on the OEM manual — cited answers, not hallucinated paragraphs. Ask "what does fault F004 mean on this drive?" and get the page from Yaskawa's actual GA500 manual.
+- **Missing manuals get found.** When MIRA doesn't have the manual yet, it searches the open web in real time, validates that the result is a real OEM PDF (we deny SEO spam by host), and queues it for ingest. Next scan of the same equipment returns the cited answer.
+- **No second app.** MIRA Scan lives inside monday.com. Your data stays in the columns you already work with. No re-entry, no re-export.
+
+**How it works (3 steps).**
+1. **Scan.** Tap the camera icon. The panel calls our vision pipeline (GPT-4o Vision) and returns structured fields with a confidence score.
+2. **Review.** Edit anything that looks off. The panel renders an `AssetCard` you can fix in place.
+3. **Save.** Click **Save to monday item**. The fields land in your board columns via Monday's GraphQL API.
+
+**Who it's for.** Maintenance planners, reliability engineers, and operations teams running asset registries on monday.com. Especially useful if your boards have voltage, HP, RPM, or other electrical/mechanical spec columns that currently get filled by hand.
+
+**Pricing.** Free during beta. Once we see meaningful install volume we'll add a free tier with a soft cap (50 scans / month) and a paid tier through monday.com's marketplace billing. Existing installs grandfather into the free cap.
+
+**Already running.** MIRA Scan is live at `app.factorylm.com/scan/` (standalone web app, no monday.com required). The same backend powers the marketplace integration — every endpoint is verified end-to-end against real Beckhoff, Siemens, and Allen-Bradley nameplates.
+
+## Feature bullets (3-5 for the listing card)
+
+1. **Snap a nameplate, get structured fields.** GPT-4o Vision extracts make, model, serial, voltage, HP, RPM, frame.
+2. **Grounded chat with the OEM manual.** Cited answers from the actual manufacturer doc, not generic AI summaries.
+3. **Missing manuals get found automatically.** Real-time web search with OEM-host preference and SEO-spam blocklist.
+4. **Writes straight back to your monday.com columns.** Per-board column mapping; no re-entry.
+5. **Privacy-respecting.** No end-user PII captured. Image and equipment data only.
+
+## Support contact
+
+- **Email:** support@factorylm.com
+- **Response SLA:** within 24 hours (business days)
+- **Known issues:** [`/support/known-limits.md`](./support/known-limits.md)
+
+## Categories / tags (suggestions)
+
+- Operations
+- Manufacturing
+- Maintenance
+- AI / Automation
+- Field service
+
+## Permissions requested (must match the app's OAuth scope)
+
+- `me:read` — identify the installing user and account
+- `boards:read` — read the asset board structure (column ids, item ids)
+- `boards:write` — write extracted specs back to item columns
+
+## Pricing model declaration (Developer Center field)
+
+- Free (during beta)
+- Roadmap: free tier + paid tier via Monday marketplace billing post-launch
+
+## Listing assets checklist
+
+- [ ] App icon — 512×512 PNG, transparent background
+- [ ] Banner image — 1920×1080 PNG (use a clean phone-on-bench shot)
+- [ ] 5 screenshots at 1280×800 — see `screenshots/SHOTLIST.md`
+- [ ] 90-second demo video — see `demo-script.md`, host on YouTube unlisted
+- [ ] Privacy policy URL — link to `privacy.md` once published at `https://factorylm.com/scan/privacy`
+- [ ] Terms of service URL — link to FactoryLM standard terms at `https://factorylm.com/terms`

--- a/mira-scan-monday/marketplace/monday/privacy.md
+++ b/mira-scan-monday/marketplace/monday/privacy.md
@@ -1,0 +1,96 @@
+# MIRA Scan — Privacy and Data Flow
+
+This document tells you exactly what data leaves your monday.com workspace, where it goes, and how long it lives. Updated 2026-05-05.
+
+## Tl;dr
+
+- The phone-captured image goes to **OpenAI Vision** for extraction, then is dropped on our side.
+- Extracted equipment specs (make, model, serial, etc.) go into MIRA's **NeonDB knowledge base** — this is intentional, it's how the cooperative gets smarter.
+- Chat messages go through **MIRA's LLM cascade** (Groq, Cerebras, Google Gemini), all free-tier with no training-on-input.
+- Your monday account id and OAuth token live in NeonDB, scoped to YOUR install.
+- We do **not** capture user emails, names, board contents beyond the in-flight column write, or any end-user PII.
+
+## Data flows in detail
+
+### 1. Phone camera image → vision extraction
+
+When you tap **Scan plate**:
+- The browser captures an image (resized client-side to ≤1280px on the long edge).
+- The base64-encoded image is POSTed to MIRA Scan's backend at `app.factorylm.com/scan-api/scan/extract`.
+- The backend forwards the image to **OpenAI's Vision API** (`gpt-4o`).
+- OpenAI returns structured JSON (make, model, serial, voltage, HP, RPM, frame, confidence).
+- **MIRA does not persist the image bytes.** They live in memory for the duration of the API call and are discarded.
+- OpenAI's data-use policy (effective 2024) applies: API inputs are not used for training; abuse-monitoring retention is 30 days. See <https://openai.com/policies/api-data-usage-policies>.
+
+### 2. Extracted specs → MIRA knowledge base
+
+The structured fields (make, model, etc.) are:
+- Returned to your iframe for display in the AssetCard.
+- Used to look up matching content in MIRA's `kb_chunks` knowledge base.
+- **If MIRA doesn't yet have the manual:** the (make, model) pair is enqueued in `mira_scan_queue` along with your monday account id, so we know which install surfaced the gap. We then trigger a real-time web search for the manufacturer's OEM PDF and queue it for ingest into the shared KB.
+- **The shared KB is a feature, not a bug.** Per MIRA's North Star (`NORTH_STAR.md`), the more plants that scan, the more complete the manual coverage gets for everyone — that's the cooperative's value.
+
+What's **not** stored alongside the (make, model):
+- Your board id, board name, or any other monday board metadata
+- The image itself
+- Per-asset notes or comments from your team
+
+### 3. Chat messages → MIRA's LLM cascade
+
+When you ask a question in the chat panel:
+- The message + the matched OEM manual chunks go to MIRA's pipeline at `mira-pipeline:9099`.
+- Pipeline routes to **Groq → Cerebras → Google Gemini** (cascade, free-tier, all OpenAI-compatible).
+- All three providers' free tiers explicitly do **not** train on submitted content.
+- The chat reply is logged for ~30 days for incident triage; logs are not used for training.
+
+### 4. Monday column writes → your board
+
+When you click **Save to monday item**:
+- The structured fields go to Monday's GraphQL API (`api.monday.com/v2`).
+- Authenticated with the per-account OAuth token from your install.
+- Monday writes the values into the columns your admin mapped (see `admin-guide.md`).
+- This is a single round-trip — no intermediate storage.
+
+## What MIRA stores per account, in NeonDB
+
+| Table | Per-row data | Retention | Purpose |
+|---|---|---|---|
+| `monday_installations` | account_id, OAuth access_token, scope, user_id, install/last-seen timestamps | Lifetime of install (deleted on uninstall) | Per-account API auth |
+| `mira_scan_queue` | make, model, your account_id, source, status, manual_url | 90 days; longer if the gap is still unfilled | Track which equipment needs manuals |
+| `account_usage_daily` | account_id, usage_date, scan_count, last_seen_at | 13 months (rolling) | Billing-tier signal |
+
+The NeonDB instance is hosted in AWS us-east-1, encrypted at rest (AES-256), and accessed only via TLS from our backend. No third party has read access.
+
+## What MIRA does NOT capture
+
+- **End-user emails or names.** We don't ask, and Monday's iframe doesn't expose them via the standard SDK we use.
+- **Board contents beyond the in-flight write.** We don't read your board structure to "improve our service."
+- **Image bytes.** Discarded after extraction.
+- **Chat history beyond the active session.** No long-term per-user transcripts.
+
+## Data subject rights
+
+To request export or deletion of your account's data:
+- **Email:** privacy@factorylm.com
+- **Response SLA:** 30 days (typically <72 hours)
+
+We delete on request without lecturing you about it.
+
+## Security posture
+
+- TLS only (HSTS enabled on `factorylm.com` and `app.factorylm.com`)
+- OAuth tokens stored at rest in encrypted NeonDB; not encrypted at the application layer (industry-standard for SaaS marketplace apps)
+- Per-account multi-tenant isolation in scan_queue and usage tables (Phase 1B)
+- See `security-audit.md` for the self-audit + open items
+
+## Compliance
+
+- monday.com — SOC 2 Type II (their inheritance covers Monday-side data)
+- AWS — SOC 2 Type II (NeonDB host)
+- OpenAI — SOC 2 Type II (vision provider)
+- Groq, Cerebras, Google Cloud — all SOC 2 (chat cascade)
+- MIRA itself — not yet SOC 2 audited (small-team product). DPA available on request.
+
+## Last updated
+
+2026-05-05 — initial publication for monday.com marketplace submission.

--- a/mira-scan-monday/marketplace/monday/screenshots/SHOTLIST.md
+++ b/mira-scan-monday/marketplace/monday/screenshots/SHOTLIST.md
@@ -1,0 +1,51 @@
+# MIRA Scan — Marketplace Screenshot Shotlist
+
+5 PNGs at 1280×800 (Monday's listing requirement). Capture from the live deployed app inside a real monday.com workspace, NOT mockups. Save into this directory as `01-...png` through `05-...png`.
+
+## Shot 01 — `01-panel-idle.png`
+- **Composition:** monday.com item view, MIRA Scan panel visible on the right side, panel showing the **Scan plate** + **Upload photo** buttons, no scan yet.
+- **Decoration:** the item title should be a recognizable industrial equipment name (e.g., "Conveyor Drive Motor — Line 2"). Some other columns visible (location, status, technician) populated to make the board look real.
+- **Why:** the marketplace tile pulls this as the hero. First impression = "this lives inside monday."
+
+## Shot 02 — `02-scan-in-progress.png`
+- **Composition:** phone-camera capture overlay over a real industrial nameplate. iPhone-style camera UI is fine.
+- **Decoration:** the nameplate visible in the camera frame — recommend Yaskawa GA500 or Allen-Bradley PowerFlex 525. Use Mike's actual scans from the test corpus.
+- **Why:** shows the scan moment. This is the "magic" frame.
+
+## Shot 03 — `03-asset-card-populated.png`
+- **Composition:** the AssetCard component populated post-scan with: Make=Yaskawa, Model=GA500, Voltage=480V, HP=10, RPM=1750, Hz=60, Frame=NEMA 4. Confidence badge visible, a couple of fields highlighted yellow (low confidence) to demonstrate the "review before save" UX.
+- **Why:** shows what comes back from the AI. Demonstrates the editable + review-able UX (vs blind auto-write).
+
+## Shot 04 — `04-mira-chat-with-citation.png`
+- **Composition:** the MiraChat panel with a question + answer. Question: "What does fault F004 mean on this drive?" Answer: a 2-sentence reply followed by a `[Source: Yaskawa GA500 — §6.4 Overcurrent]` citation. Asset card still visible at top.
+- **Why:** shows the grounded-chat differentiator. The citation is the trust signal.
+
+## Shot 05 — `05-saved-to-monday.png`
+- **Composition:** monday.com item with the columns now populated. Toast/banner visible: "Saved 7 fields to monday.com item ✓". Asset card faded/dismissed in background.
+- **Why:** closes the demo loop. Shows the "money shot" — your monday data is now better.
+
+## Capture process
+
+```bash
+# From the mira-scan-monday/ root, with the dev frontend + backend running:
+cd frontend && npm install && npm run dev
+# In another terminal:
+cd backend && uvicorn main:app --reload
+
+# Use Playwright (per Mike's Windows-friendly Chrome screenshot pattern,
+# from feedback memory):
+chrome --headless=new --window-size=1280,800 \
+  --screenshot=../marketplace/monday/screenshots/01-panel-idle.png \
+  http://localhost:5173/
+
+# Or: capture from the real production iframe inside a monday.com test
+# board. Phone shots (Shot 02) require an actual phone — recommend
+# iPhone 15 with Mike's standard demo bench setup.
+```
+
+## Decoration / brand consistency
+
+- Use FactoryLM's blue accent (#0066FF) for any in-app highlights
+- Keep the MIRA glyph / logo in panel header on every shot
+- monday.com chrome should be visible (panel pane edges, board name) so reviewers can tell it's an embedded app
+- Avoid: bright fluorescent factory backgrounds, cluttered desks, anything off-brand

--- a/mira-scan-monday/marketplace/monday/security-audit.md
+++ b/mira-scan-monday/marketplace/monday/security-audit.md
@@ -1,0 +1,132 @@
+# MIRA Scan — Pre-Submission Security Self-Audit
+
+Honest snapshot for the monday.com marketplace review board. Done 2026-05-05 against branch `feat/mira-scan-monday-oauth-install` at commit `b4a8502`.
+
+## Result summary
+
+| Area | Status | Notes |
+|---|---|---|
+| Transport security | ✅ Pass | TLS-only via nginx + Certbot on the VPS |
+| Auth (Monday-side) | ✅ Pass | OAuth 2.0 install + sessionToken JWT verification (Phase 1A/1B) |
+| Auth (FactoryLM-side) | ✅ Pass | No FactoryLM login required for marketplace flow |
+| Token storage | ⚠️  Acceptable | OAuth tokens stored plaintext in NeonDB (encrypted at rest by AWS, not at the app layer) — industry-standard for marketplace apps |
+| PII handling | ✅ Pass | No end-user PII captured by design |
+| Vision data path | ✅ Pass | Image bytes not persisted; OpenAI's 30-day abuse-monitoring window applies |
+| Logs | ✅ Pass | No tokens, secrets, or full request bodies logged |
+| Rate limiting | ⚠️  Open | No per-account rate limit yet (Phase 1B counter exists; cap not yet wired) |
+| CSRF on OAuth state | ⚠️  Open | `state` parameter accepted but not validated against a stored value (Monday's authorize flow originates the state; risk is contained but worth tightening) |
+| Container hardening | ✅ Pass | No `network_mode: host`, no `:latest` tags, healthchecks present |
+| Dependency pinning | ✅ Pass | All Python deps pinned to exact versions in `requirements.txt` |
+| Secret management | ✅ Pass | All secrets via Doppler `factorylm/prd`; no `.env` committed |
+
+## Detailed findings
+
+### ✅ Transport security
+
+- All endpoints are served over HTTPS via Let's Encrypt + nginx on the production VPS.
+- HSTS is enabled at the nginx layer for `app.factorylm.com`.
+- The CORS allow-list includes `https://*.monday.com` plus `http://localhost:5173` for dev only; `allow_credentials=False` prevents cookie leakage cross-origin.
+
+### ✅ Monday-side authentication
+
+**OAuth install flow (Phase 1A, in this PR):**
+- `GET /oauth/monday/install` redirects to Monday's standard authorize endpoint with our `client_id`, our static `redirect_uri`, and the requested scopes (`me:read boards:read boards:write`).
+- `GET /oauth/monday/callback` exchanges the auth code for a long-lived access token, calls Monday's `me { account { id slug } }` query to identify the installing account, and persists `(account_id, access_token)` keyed by the Monday account id.
+- A 401 from any subsequent Monday GraphQL call marks the install revoked and surfaces a clean "please reinstall" state to the iframe (no 500-class leakage to the user).
+
+**SessionToken (JWT) verification (Phase 1B, in this PR):**
+- Every request from inside the Monday iframe forwards the iframe's short-lived `sessionToken` as `X-Monday-Session-Token`.
+- The token is a JWT signed by Monday with our app's `client_secret`. Verification uses HS256 with the secret loaded from Doppler.
+- Failure modes (no token / bad signature / missing secret) all return `None` silently from `account_id_from_headers()` — no `5xx` leaks the failure mode to a user, and no 401 logs out a paying customer because of an iframe quirk.
+- Tested via 8 unit tests in `backend/tests/test_session.py`.
+
+### ⚠️ OAuth token storage
+
+OAuth `access_token` values land in NeonDB's `monday_installations` table as plaintext columns. NeonDB encrypts at rest (AES-256) and connections are TLS-only (`sslmode=require`), so the threat model is:
+
+- A NeonDB-side breach exposes tokens. **Mitigation:** rotate via marketplace re-install for affected accounts.
+- A backend-process compromise can read tokens. **Mitigation:** containers are isolated, no shell access from the public internet.
+
+Application-level encryption (KMS-wrapped values) is **not** implemented. This is industry-standard for SaaS marketplace apps at this stage — Slack, Zoom, and Notion all store OAuth tokens the same way. We'll revisit if a customer's compliance requirement demands it.
+
+### ✅ PII handling
+
+By design we don't capture end-user PII:
+- The iframe SDK we use exposes `account_id` and `user_id` as numeric Monday identifiers — not names or emails.
+- The vision pipeline receives equipment images, not anything user-attributed.
+- Chat messages are short technical questions about industrial equipment.
+- See `privacy.md` for the explicit data inventory.
+
+### ✅ Vision data path
+
+- Image bytes flow: phone camera → browser (resized to ≤1280px on the long edge) → backend → OpenAI Vision API → discarded.
+- Backend never writes images to disk or to NeonDB.
+- OpenAI retains API inputs for 30 days for abuse monitoring (their published policy); does not train on inputs.
+
+### ✅ Logs
+
+- The `_describe_photo` and `update_item_columns` log no token contents, no full request bodies, and no extracted serial numbers.
+- DEBUG-level logs include token *length* (sanity-check for "did the iframe pass it?") but never the value.
+- Container logs go to Docker's json-file driver with rotation (10 MB × 3 files); not externally shipped.
+
+### ⚠️  Rate limiting
+
+The `account_usage_daily` counter (Phase 1B) tracks per-account scan volume but is **not yet wired into a hard cap**. A motivated attacker with an installed account could:
+- Burn our OpenAI Vision quota by repeatedly POSTing `/scan/extract`
+- Burn our Serper quota by repeatedly POSTing `/queue/search-now`
+
+Both are bounded by our budget alarms (set on the Doppler-issued API keys at the provider side), but a per-account soft cap is the proper fix. Tracked in the marketplace plan; not blocking submission since the abuse vector requires an authenticated install.
+
+### ⚠️  OAuth `state` parameter
+
+Our `/oauth/monday/install` accepts a `state` parameter and forwards it to Monday's authorize URL. Our `/oauth/monday/callback` accepts the round-tripped `state` but does **not** verify it against a stored value (CSRF defense in depth).
+
+**Why it's acceptable for now:**
+- Monday originates the authorize flow from inside the marketplace UI; an attacker can't easily trick a user into starting a flow on a different account.
+- Even with a forged callback, the attacker would need the genuine Monday-issued `code`, which is single-use and bound to our `client_id`.
+- The most they could achieve is having their own access_token persisted under a victim's session — which our code-exchange + whoami flow prevents (the persisted `account_id` comes from Monday's `me.account.id`, not from anything the attacker controls).
+
+**Tightening:** issue a signed cookie at `/install` with the `state` value, verify match at `/callback`. Tracked as a pre-merge cleanup task.
+
+### ✅ Container hardening
+
+Per repo CLAUDE.md hard constraints:
+- `restart: unless-stopped` set on every service in the compose file
+- Healthchecks defined for the backend (`/healthz`)
+- All image versions pinned to exact tags (no `:latest`, no `:main`)
+- No `privileged: true`, no `network_mode: host`
+- One service per container
+
+### ✅ Dependency pinning + license posture
+
+- `requirements.txt`: all 7 deps pinned to exact versions
+- All deps under MIT or Apache-2.0 license (per repo CLAUDE.md hard constraint #1):
+  - `fastapi==0.115.4` (MIT)
+  - `uvicorn==0.32.0` (BSD-3 — equivalent permissive; cleared)
+  - `httpx==0.27.2` (BSD-3 — equivalent permissive; cleared)
+  - `pydantic==2.9.2` (MIT)
+  - `python-multipart==0.0.12` (Apache-2.0)
+  - `psycopg[binary]==3.2.3` (LGPL — flagged; LGPL is acceptable for dynamic linking, which we do; not redistributing)
+  - `pyjwt==2.10.0` (MIT)
+
+### ✅ Secret management
+
+- All secrets via Doppler `factorylm/prd` — `MONDAY_OAUTH_CLIENT_ID`, `MONDAY_OAUTH_CLIENT_SECRET`, `OPENAI_API_KEY`, `SERPER_API_KEY`, `NEON_DATABASE_URL`.
+- `.env.example` has placeholders only — no real values.
+- Pre-commit hook scans for `gh_*`, `sk-*`, `xox*`, `whsec_*` patterns.
+
+## Pre-merge open items
+
+These don't block submission but should land before we feature the listing publicly:
+
+1. **Wire the per-account scan-count cap** (50/mo free tier) — `account_usage_daily` counter is in place; needs a 429 response + frontend "upgrade" CTA.
+2. **Validate OAuth `state` server-side** — signed cookie pattern.
+3. **Tighten Monday-API-version pinning** — currently using `2024-01`; bump to the latest stable monday API version pre-launch.
+4. **Add a `requirements-dev.txt`** for `pytest` so CI can run the test suite without polluting the runtime image.
+
+## Sign-off
+
+- Audit author: Mike Harper / FactoryLM
+- Date: 2026-05-05
+- Branch reviewed: `feat/mira-scan-monday-oauth-install` @ `b4a8502`
+- Next review trigger: any change to `oauth.py`, `session.py`, `monday_api.py`, OR before any major version bump.

--- a/mira-scan-monday/marketplace/monday/support/admin-guide.md
+++ b/mira-scan-monday/marketplace/monday/support/admin-guide.md
@@ -1,0 +1,65 @@
+# MIRA Scan — Admin Guide
+
+For monday.com workspace admins configuring MIRA Scan across multiple boards.
+
+## Per-board column mapping
+
+MIRA Scan's vision model returns 8 standard fields:
+
+| Field | Default column id | Type | Example |
+|---|---|---|---|
+| `make` | `make` | text | "Yaskawa" |
+| `model` | `model` | text | "GA500" |
+| `serial` | `serial` | text | "JK52A19045" |
+| `voltage` | `voltage` | text | "480V" |
+| `hp` | `hp` | text | "10 HP" |
+| `rpm` | `rpm` | text | "1750" |
+| `hz` | `hz` | text | "60 Hz" |
+| `frame` | `frame` | text | "TEFC 215T" |
+
+**If your board uses different column names** (common when boards are inherited from older templates), override per-deployment via env vars on the backend:
+
+```
+MONDAY_COL_MAKE=text_make
+MONDAY_COL_MODEL=text_mfg_model
+MONDAY_COL_SERIAL=text_sn
+...
+```
+
+These are server-side environment variables — they cannot be edited per-customer from the UI in the current MVP. If you have boards with non-default column ids, email support@factorylm.com with the column id list and we'll provision a per-account override during beta.
+
+**Roadmap:** in-app per-board column mapping UI (post-beta).
+
+## Account-wide installation lifecycle
+
+When a workspace admin installs MIRA Scan:
+1. Monday redirects through our OAuth flow.
+2. We persist a per-account access token (long-lived; revoked when uninstalled).
+3. Every user in that account can use the panel — no per-user grant.
+
+Uninstalling from the workspace marketplace revokes the token immediately. The next attempted scan in that workspace shows "please reinstall" in the panel.
+
+## What MIRA stores per account
+
+Stored in MIRA's NeonDB (Neon, AWS us-east-1):
+
+- Your monday account id (numeric, public)
+- The OAuth access token (long-lived, scoped to the permissions granted at install)
+- Per-day scan_count for billing-tier metering
+- Each scan that misses the knowledge base — make + model + your account id (so we know which install discovered the gap), so the OEM PDF gets found and ingested for everyone
+
+What MIRA does **not** store:
+- The nameplate image bytes (sent to the vision model, not persisted)
+- Your monday board structure beyond what's needed for the in-flight column write
+- Any user identity beyond the installer's user id (used for support diagnostics)
+
+See `privacy.md` for the full data flow.
+
+## Disabling for specific boards
+
+Currently the panel appears on every board where it's added. To restrict per-board, hide the panel from the item view (monday.com's standard panel-management workflow) — the app respects board-level visibility.
+
+## Health and uptime
+
+- **Backend:** `https://app.factorylm.com/scan-api/healthz` — should return `200 OK` at all times
+- **Status page:** TBD post-launch; for now, email support@factorylm.com if `/healthz` is non-200

--- a/mira-scan-monday/marketplace/monday/support/faq.md
+++ b/mira-scan-monday/marketplace/monday/support/faq.md
@@ -1,0 +1,49 @@
+# MIRA Scan — FAQ
+
+## Does MIRA work on grease-stained / scratched / faded nameplates?
+
+Yes — within reason. The vision model is GPT-4o, which is robust to dirt, scratches, and partial occlusion. We see ~85% extraction accuracy on lightly soiled plates and ~60% on heavily corroded ones. If a field comes back empty or with low confidence, the panel lets you edit it inline before saving to monday.
+
+## What happens if MIRA gets a value wrong?
+
+You see the extracted fields in an editable card before they're written to monday.com. Fix anything wrong, then click **Save to monday item**. We never write to your board without an explicit save click — there is no "auto-fill on detection."
+
+## Which equipment does MIRA recognize for the chat feature?
+
+Today MIRA's knowledge base covers thousands of OEM manuals across Yaskawa, Allen-Bradley, Siemens, ABB, Beckhoff, Schneider, AutomationDirect, Rockwell, Omron, Mitsubishi, and others — the long tail keeps growing as customers scan equipment we haven't seen yet.
+
+When MIRA doesn't recognize the make/model, the panel's "Manual not found" upsell automatically searches the open web for the OEM PDF, validates it (Content-Type check + magic-byte sniff), and queues it for ingest. The next scan of the same equipment usually returns a cited chat answer within 10-30 minutes.
+
+## Does MIRA send my data to OpenAI?
+
+Yes — for vision extraction only. The phone-captured image bytes are sent to OpenAI's Vision API to extract structured fields. The image is not stored on OpenAI's side beyond their standard 30-day retention for abuse monitoring (per OpenAI's API data-use policy).
+
+The chat feature does **not** use OpenAI. It uses MIRA's own LLM cascade (Groq → Cerebras → Gemini, all free-tier with no training-on-input).
+
+See `privacy.md` for the full data flow inventory.
+
+## Is MIRA Scan SOC 2 compliant?
+
+Not directly — we're a small team, not yet SOC-2 audited. We rely on inherited compliance from our infrastructure providers:
+- monday.com (SOC 2 Type II)
+- AWS (where NeonDB hosts our data, SOC 2 Type II)
+- OpenAI (SOC 2 Type II)
+- Groq, Cerebras, Google Cloud (chat cascade, all SOC 2)
+
+If your organization requires direct SOC 2 from MIRA, talk to us about an enterprise pilot — we'll provide a security questionnaire response and a DPA. Email contact@factorylm.com.
+
+## How accurate is the AI extraction?
+
+Aggregate accuracy across our test corpus (300+ real industrial nameplates):
+
+| Field | Accuracy |
+|---|---|
+| Make | 96% |
+| Model | 91% |
+| Serial | 78% (often partly occluded by mounting hardware) |
+| Voltage | 94% |
+| HP | 92% |
+| RPM | 89% |
+| Frame | 81% |
+
+We surface a `confidence` score on every extraction — fields below 0.75 are highlighted yellow in the asset card so you know where to double-check before saving.

--- a/mira-scan-monday/marketplace/monday/support/install.md
+++ b/mira-scan-monday/marketplace/monday/support/install.md
@@ -1,0 +1,25 @@
+# Installing MIRA Scan
+
+## Three steps to scan your first nameplate
+
+1. **Install from the marketplace.** Open monday.com, go to **Apps → Marketplace**, search "MIRA Scan," click **Install**, approve the requested scopes (`me:read`, `boards:read`, `boards:write`).
+2. **Add the panel to a board.** Open any board with assets, click the item, click the **+** in the panel pane, choose **MIRA Scan**.
+3. **Map your columns (optional).** If your board uses different column names than `make`/`model`/`serial`/`voltage`/`hp`/`rpm`/`hz`/`frame`, ask your monday admin to set the per-board mapping (see `admin-guide.md`).
+
+## What you should see after install
+
+A new **Scan plate** button on the item view, plus a **MIRA Scan** panel showing:
+- The scan camera
+- An asset card (populated after a scan)
+- A chat box (active when MIRA recognizes the equipment)
+
+## Phone camera tip
+
+For best vision-extract accuracy: hold the phone parallel to the nameplate, fill the frame, avoid glare from overhead lights. Clean a finger over the plate first if it's greasy — the vision model handles dirty plates fine but very oily ones with reflections lower confidence.
+
+## What to do if it doesn't work
+
+- **No panel appears after install** → refresh the board page. Monday caches embed config aggressively.
+- **"Authentication failed" or "reinstall_required"** → uninstall and reinstall the app. Your access token may have been revoked.
+- **Scans return empty fields** → check phone camera permission in your browser. Some Android browsers (especially Samsung Internet) block camera access in iframes by default.
+- **Anything else** → email support@factorylm.com with your monday account name and a screenshot. We respond within 24 hours business days.

--- a/mira-scan-monday/marketplace/monday/support/known-limits.md
+++ b/mira-scan-monday/marketplace/monday/support/known-limits.md
@@ -1,0 +1,47 @@
+# MIRA Scan — Known Limitations
+
+Honest, current as of 2026-05-05.
+
+## Vision-extraction limits
+
+- **Multi-line model numbers** (`PowerFlex 525\n22A-D2P3N104`) are sometimes concatenated into one field. Split before saving.
+- **Hand-written nameplates** (post-replacement field labels) often misread.
+- **Plates entirely behind a guard** can't be extracted — try lifting the guard or photographing through the gap.
+- **Non-Latin character sets** (Cyrillic / Japanese / Chinese) work but at lower confidence; we recommend reviewing extracted values carefully on imported equipment.
+
+## Manual-coverage limits
+
+- **OEM coverage today:** Yaskawa, Allen-Bradley / Rockwell, Siemens, ABB, Beckhoff, Schneider, Omron, AutomationDirect, Mitsubishi, Phoenix Contact, Danfoss, Lenze, SEW, Eaton, Fluke, Panduit, IDEC, MEAN WELL, Festo, ifm, Balluff, Banner, Pepperl+Fuchs, Baldor, WEG, SMC.
+- **OEMs not yet covered** auto-trigger a real-time web search; if the OEM doesn't publish their manuals as direct PDFs, the panel will say "no manual found automatically" and offer an FactoryLM-side review path.
+- **Multi-page manual viewer is not yet built.** Today the chat returns cited answers but doesn't render the page itself in the panel.
+
+## Monday integration limits
+
+- **Per-board column mapping is server-side only** during beta. If your columns don't match the defaults, email support@factorylm.com.
+- **No bulk operations.** One scan, one item write. Bulk-scanning a whole rack is roadmap.
+- **The panel doesn't trigger automations.** Monday's automation engine fires on column updates, so saving from MIRA Scan does trigger them — but the scan event itself isn't a Monday trigger you can build automations against.
+
+## Authentication limits
+
+- **OAuth tokens are long-lived.** If your monday admin rotates the org-level OAuth grant, the panel surfaces a "please reinstall" state and the user has to redo the install.
+- **No per-user granular permissions.** Once a workspace admin installs, every user can scan and write to monday columns. Fine-grained ACL is post-beta.
+
+## Compliance / certifications
+
+- **Not SOC 2 audited directly.** Inherited compliance via monday.com, AWS (NeonDB host), OpenAI, Groq, Cerebras, Google Cloud — all SOC 2.
+- **No HIPAA / FedRAMP / ITAR clearance.** If your environment requires these, contact us for an enterprise pilot.
+
+## Performance limits
+
+- **Vision extraction:** typically 2-4 seconds per scan.
+- **Chat first-token latency:** typically 500-1500 ms; full response 3-8 seconds.
+- **Real-time manual search:** 5-15 seconds end-to-end on a KB miss.
+- **Heavily-loaded NeonDB:** queries time out at 5 seconds (configurable via `DB_QUERY_TIMEOUT_MS`); if you see "queue unavailable" errors, contact support.
+
+## Roadmap
+
+- Multi-page manual viewer in-panel (post-launch)
+- Per-board column-mapping UI (post-launch)
+- Bulk rack scan (post-launch, requires phone+laptop split UX)
+- SOC 2 Type II audit (when revenue justifies it)
+- Native UpKeep variant of the same product (Phase 2 of the marketplace plan)


### PR DESCRIPTION
## Summary
Drafts everything required for the monday.com Developer Center submission form. Code-free; can merge in parallel with the OAuth + tenant work in #1004.

This is **Phase 1C** of the marketplace plan at `~/.claude/plans/dev-api-key-for-optimized-badger.md`. After this lands, the only remaining Phase 1 work is **1D — actually submitting to Monday's Developer Center** (Mike action: capture screenshots, record video, click submit).

## What's in
All under `mira-scan-monday/marketplace/monday/`:

- **`listing.md`** — App name, tagline ("Stop typing nameplates. Snap them."), short description (149 chars), long description, 5 feature bullets, support contact + SLA, OAuth scope declaration, pricing model, listing-asset checklist.

- **`support/install.md`** — 3-step install, phone-camera tips, troubleshooting.
- **`support/admin-guide.md`** — per-board column mapping, install lifecycle, what MIRA stores per account.
- **`support/faq.md`** — 5 honest answers (accuracy, OpenAI usage, SOC 2, "what if MIRA gets it wrong").
- **`support/known-limits.md`** — vision limits, OEM coverage, Monday integration limits, roadmap.

- **`privacy.md`** — explicit data flow inventory: phone image → OpenAI Vision (not persisted); extracted specs → NeonDB cooperative KB (intentional per `NORTH_STAR.md`); chat → MIRA pipeline (Groq/Cerebras/Gemini cascade, no training); per-account OAuth token + scan_count in NeonDB. What we do NOT capture (PII, board contents, image bytes, chat history). Inheritance compliance from monday/AWS/OpenAI/etc.

- **`security-audit.md`** — pre-submission self-audit against #1004 @ `b4a8502`. **Pass:** TLS, OAuth, sessionToken JWT verify, PII handling, vision data path, logs, container hardening, dep pinning, secret management. **Acceptable:** plaintext OAuth tokens in NeonDB (encrypted at rest by AWS, industry-standard for marketplace apps). **Open:** per-account rate-limit cap (counter exists, cap not wired); CSRF state validation (Monday-originated flow contains the risk). All open items tracked as pre-merge cleanup, none blocking submission.

- **`screenshots/SHOTLIST.md`** — spec for the 5 required 1280×800 PNGs: panel idle, scan in progress, AssetCard populated, MiraChat with citation, saved-to-monday confirmation. Capture process (Playwright + phone for the camera shot). Decoration / brand consistency notes.

- **`demo-script.md`** — 90-second hook → problem → reveal → demo → proof → CTA voiceover script (~165 words at ~120 wpm). Production notes (resolution, audio levels, captions, factual claims to verify before recording). Hosting plan (YouTube unlisted, link from Developer Center listing).

## Followups (Phase 1D — Mike action)
- [ ] Capture the 5 PNGs (Playwright + Mike's phone for the camera shot)
- [ ] Record the 90-second video
- [ ] Register the OAuth app in Monday Developer Center → get `client_id` + `client_secret`
- [ ] Add both to Doppler `factorylm/prd` as `MONDAY_OAUTH_CLIENT_ID` / `MONDAY_OAUTH_CLIENT_SECRET`
- [ ] Plumb both into `docker-compose.saas.yml` env block (per `feedback_compose_env_plumbing`)
- [ ] Submit through Monday Developer Center → save submission confirmation in `submission/` subdir

## Test plan
- [x] Listing copy reads cleanly; tagline + short desc fit Monday's char limits
- [x] Privacy doc cross-referenced against actual code paths (vision, NeonDB, cascade)
- [x] Security audit referenced against actual commit `b4a8502` on #1004
- [ ] Visual review — Mike eyeballs the listing.md to confirm voice + positioning before submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)