### PR TITLE
feat(mira-scan-monday): cleanups — quota gate + OAuth state CSRF + dev deps

### DIFF
--- a/mira-scan-monday/backend/main.py
+++ b/mira-scan-monday/backend/main.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import html
 import logging
 import os
+import secrets
 from contextlib import asynccontextmanager
 
-from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
+from fastapi import BackgroundTasks, Cookie, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, RedirectResponse
 
@@ -87,20 +88,63 @@ async def oauth_install(state: str = "") -> RedirectResponse:
     typically jump straight to /oauth/monday/callback with a code from
     Monday's authorize endpoint, but exposing /install lets us issue
     the same URL for manual or automated reinstalls.
+
+    Sets a short-lived `mira_oauth_state` cookie so /callback can verify
+    the round-tripped state matches (CSRF defense in depth). The cookie
+    is HTTPOnly + SameSite=Lax so it survives Monday's redirect back.
     """
     if not oauth.configured():
         raise HTTPException(
             status_code=503,
             detail="OAuth is not configured (MONDAY_OAUTH_CLIENT_ID/SECRET missing)",
         )
-    return RedirectResponse(oauth.install_url(state=state or None), status_code=302)
+    state_value = state or secrets.token_urlsafe(24)
+    redirect = RedirectResponse(oauth.install_url(state=state_value), status_code=302)
+    redirect.set_cookie(
+        key="mira_oauth_state",
+        value=state_value,
+        max_age=600,  # 10 min — generous window for slow consent flows
+        httponly=True,
+        # Plain HTTP only in local dev (set MIRA_DEV_MODE=1).
+        secure=os.getenv("MIRA_DEV_MODE") != "1",
+        samesite="lax",
+        path="/oauth/monday/",
+    )
+    return redirect
 
 
 @app.get("/oauth/monday/callback", response_class=HTMLResponse)
-async def oauth_callback(code: str = "", state: str = "") -> HTMLResponse:
-    """Trade Monday's auth code for an access token, persist by account_id."""
+async def oauth_callback(
+    code: str = "",
+    state: str = "",
+    mira_oauth_state: str | None = Cookie(default=None),
+) -> HTMLResponse:
+    """Trade Monday's auth code for an access token, persist by account_id.
+
+    CSRF defense: when state was set via /install, verify the round-
+    tripped value matches the cookie. Marketplace-direct callbacks
+    (Monday → /callback without going through /install) won't have a
+    cookie; that path is allowed since Monday originates the redirect
+    and the auth code itself is single-use + bound to our client_id.
+    """
     if not code:
         raise HTTPException(status_code=400, detail="missing 'code' query parameter")
+
+    # CSRF check — only enforced when /install set a cookie (i.e. when
+    # the user came through our reinstall flow). Marketplace installs
+    # land here directly with no cookie; that's a legitimate path.
+    if mira_oauth_state:
+        if not state:
+            raise HTTPException(
+                status_code=400,
+                detail="state cookie set but query 'state' missing — flow corrupted",
+            )
+        if not secrets.compare_digest(state, mira_oauth_state):
+            raise HTTPException(
+                status_code=400,
+                detail="state mismatch — possible CSRF attempt",
+            )
+
     try:
         token_data = await oauth.exchange_code_for_token(code)
     except oauth.OAuthError as exc:
@@ -167,14 +211,37 @@ async def oauth_callback(code: str = "", state: str = "") -> HTMLResponse:
 async def scan_extract(req: ScanRequest, request: Request) -> AssetPlate:
     if not req.image_base64:
         raise HTTPException(status_code=400, detail="image_base64 is required")
+
+    account_id = session.account_id_from_headers(request.headers)
+
+    # Free-tier quota gate — only enforced when authenticated via Monday.
+    # Standalone path (no header → no account_id) is exempt. Fail-open
+    # on DB error: usage.month_scan_count returns 0 silently when NeonDB
+    # is unavailable, so a transient outage never locks paying users out.
+    if account_id:
+        used = await usage.month_scan_count(account_id)
+        if used >= usage.FREE_TIER_MONTHLY_CAP:
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "error": "quota_exceeded",
+                    "message": (
+                        f"Free-tier limit of {usage.FREE_TIER_MONTHLY_CAP} scans/month "
+                        "reached. Email support@factorylm.com to upgrade."
+                    ),
+                    "used": used,
+                    "cap": usage.FREE_TIER_MONTHLY_CAP,
+                },
+            )
+
     try:
         plate = await vision.extract_asset_plate(req.image_base64, req.mime_type)
     except Exception as exc:
         logger.exception("vision extract failed")
         raise HTTPException(status_code=502, detail=f"vision extract failed: {exc}") from exc
+
     # Per-account billing signal — only count successful scans. Fire and
     # forget; counter writes are best-effort and never block the response.
-    account_id = session.account_id_from_headers(request.headers)
     if account_id:
         await usage.bump_scan_count(account_id)
     return plate

--- a/mira-scan-monday/backend/requirements-dev.txt
+++ b/mira-scan-monday/backend/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Dev / test dependencies — NOT installed into the production runtime
+# image. Install separately in CI: pip install -r requirements-dev.txt
+# Run from mira-scan-monday/: python -m pytest backend/tests/ -v
+
+pytest>=8.3.0,<9.0.0
+pytest-asyncio>=0.24.0,<1.0.0

--- a/mira-scan-monday/backend/tests/test_usage.py
+++ b/mira-scan-monday/backend/tests/test_usage.py
@@ -1,0 +1,63 @@
+"""Tests for usage helpers — fail-open behavior when DB is unavailable."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+
+def _reload_usage():
+    from backend import db as _db
+    from backend import usage as _usage
+
+    importlib.reload(_db)
+    return importlib.reload(_usage)
+
+
+def test_free_tier_cap_constant_set():
+    usage = _reload_usage()
+    assert usage.FREE_TIER_MONTHLY_CAP > 0
+    assert isinstance(usage.FREE_TIER_MONTHLY_CAP, int)
+
+
+def test_free_tier_cap_overridable_via_env(monkeypatch):
+    monkeypatch.setenv("MIRA_FREE_TIER_MONTHLY_CAP", "12345")
+    usage = _reload_usage()
+    assert usage.FREE_TIER_MONTHLY_CAP == 12345
+
+
+def test_month_scan_count_returns_zero_for_empty_account_id(monkeypatch):
+    monkeypatch.setenv("NEON_DATABASE_URL", "")  # also unavailable
+    usage = _reload_usage()
+    result = asyncio.run(usage.month_scan_count(""))
+    assert result == 0
+
+
+def test_month_scan_count_returns_zero_when_db_unavailable(monkeypatch):
+    monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+    usage = _reload_usage()
+    # DBUnavailable is raised internally and swallowed → 0 (fail-open).
+    # A real account_id with no DB should never lock out a user.
+    result = asyncio.run(usage.month_scan_count("99999"))
+    assert result == 0
+
+
+def test_bump_scan_count_no_op_when_db_unavailable(monkeypatch):
+    monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+    usage = _reload_usage()
+    # Should not raise even though DB is unreachable.
+    asyncio.run(usage.bump_scan_count("99999"))
+
+
+def test_today_scan_count_returns_zero_when_db_unavailable(monkeypatch):
+    monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+    usage = _reload_usage()
+    result = asyncio.run(usage.today_scan_count("99999"))
+    assert result == 0
+
+
+def test_days_summary_returns_empty_when_db_unavailable(monkeypatch):
+    monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+    usage = _reload_usage()
+    result = asyncio.run(usage.days_summary("99999", days=7))
+    assert result == []

--- a/mira-scan-monday/backend/usage.py
+++ b/mira-scan-monday/backend/usage.py
@@ -1,21 +1,32 @@
-"""Per-installation daily scan counters.
+"""Per-installation daily scan counters + free-tier quota gate.
 
-Counts successful /scan/extract calls per Monday account_id per day.
-Used as the billing-tier signal — once we see a meaningful install
-volume, this gets wired into a free-tier cap (e.g. 50 scans/mo) with
-a softer paywall in the iframe.
+Counts successful /scan/extract calls per Monday account_id per day,
+sums the trailing 30 days for the free-tier monthly cap, and exposes
+helpers for `/scan/extract` to gate on quota before burning an OpenAI
+Vision call on a request that's just going to 429.
 
 The counter is best-effort. If NeonDB is unavailable, bumps no-op
 silently — a scan flow must never fail because telemetry is offline.
+The quota gate is fail-open for the same reason: if `month_scan_count`
+can't reach the DB, callers should let the scan through rather than
+locking out a paying user because of an unrelated infra glitch.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 
 from . import db
 
 logger = logging.getLogger("mira-scan.usage")
+
+
+# Free-tier monthly cap. Scans beyond this for an authenticated install
+# return HTTP 429 from `/scan/extract` so the iframe can prompt "upgrade
+# to keep scanning." Set to a generous default — adjust via env once we
+# have real install-volume data.
+FREE_TIER_MONTHLY_CAP = int(os.getenv("MIRA_FREE_TIER_MONTHLY_CAP", "50"))
 
 
 async def bump_scan_count(account_id: str) -> None:
@@ -56,6 +67,33 @@ async def today_scan_count(account_id: str) -> int:
         logger.exception("usage.today_scan_count failed for account_id=%s", account_id)
         return 0
     return int(row[0]) if row else 0
+
+
+async def month_scan_count(account_id: str) -> int:
+    """Sum scan_count over the trailing 30 days for an account.
+
+    Used as the free-tier quota gate input. Returns 0 when account_id is
+    empty (standalone path), DB is unavailable, or the account has no
+    activity in the window. Never raises — the caller should fail-open
+    on a 0 from a real (non-empty) account_id rather than locking out
+    paying customers because telemetry is down.
+    """
+    if not account_id:
+        return 0
+    sql = """
+        SELECT COALESCE(SUM(scan_count), 0)::integer
+          FROM account_usage_daily
+         WHERE account_id = %s
+           AND usage_date >= CURRENT_DATE - INTERVAL '30 days'
+    """
+    try:
+        row = await db.fetch_one(sql, (account_id,))
+    except db.DBUnavailable:
+        return 0
+    except Exception:
+        logger.exception("usage.month_scan_count failed for account_id=%s", account_id)
+        return 0
+    return int(row[0]) if row and row[0] is not None else 0
 
 
 async def days_summary(account_id: str, days: int = 30) -> list[dict]:


### PR DESCRIPTION
## Summary
Closes the three "Open" items from the Phase 1C security audit (audit doc lives in #1005). Stacks on top of #1004 (Phase 1A OAuth + Phase 1B multi-tenant safety).

**Targeting** `feat/mira-scan-monday-oauth-install` so the diff is just the cleanups, not the entire OAuth code. Once #1004 merges to main, GitHub auto-rebases this PR's base.

## What's in

### 1. Per-account scan-count cap (audit item 1)
- `usage.py` — `FREE_TIER_MONTHLY_CAP` env-overridable constant (default 50); `month_scan_count()` sums `account_usage_daily` over the trailing 30 days. **Fail-open** on DB error so transient outages don't lock out paying users.
- `main.py` — `/scan/extract` checks `usage.month_scan_count` **before** the OpenAI Vision call; over-cap returns `429` with structured error `{error, message, used, cap}` so the frontend can render an upgrade CTA. Standalone path (no Monday session token) is exempt — quota only enforced when `account_id` is present.

### 2. OAuth state CSRF defense in depth (audit item 2)
- `main.py` — `/oauth/monday/install` sets a short-lived (10 min) `HTTPOnly` `SameSite=Lax` cookie `mira_oauth_state` carrying the state value. `Secure` flag on in production (off in `MIRA_DEV_MODE=1`).
- `main.py` — `/oauth/monday/callback` verifies cookie matches the round-tripped state via `secrets.compare_digest`. Marketplace-direct callbacks (Monday → `/callback` without going through `/install`) won't have a cookie; that path is allowed since Monday originates the redirect and the auth code is single-use + bound to our client_id.

### 3. Dev dependencies extracted (audit item 4)
- `requirements-dev.txt` (NEW) — `pytest>=8.3`, `pytest-asyncio>=0.24`. Keeps the runtime image lean; CI installs separately for testing.

## Tests
**19/19 passing locally** (12 prior + 7 new):
```
$ python -m pytest backend/tests/ -v
======================== 19 passed in 0.56s ========================
```
- `backend/tests/test_usage.py` (NEW, 7 tests):
  - `FREE_TIER_MONTHLY_CAP` constant + env override
  - `month_scan_count` returns 0 for empty `account_id`
  - `month_scan_count` fail-open on DB unavailable
  - `bump_scan_count` no-op on DB unavailable
  - `today_scan_count` returns 0 on DB unavailable
  - `days_summary` returns `[]` on DB unavailable

## What's NOT in this PR
- **Frontend handling of 429** — currently the iframe surfaces the raw error message. The structured response shape is ready for the frontend to render an "upgrade" CTA; that change is a separate PR (Phase 1D-adjacent, post-submission).
- **Updating `security-audit.md`** — that file lives on #1005 (docs branch); not on this branch's parent. After both #1004 and #1005 merge, a follow-up should mark the audit items as closed.

## Test plan
- [x] All 19 unit tests pass locally
- [x] Standalone path: scan with no Monday header — no quota check, no 429
- [ ] Iframe path with real install: scan 51 times → 51st returns 429 with `{used: 50, cap: 50}` (requires Monday OAuth app registration first)
- [ ] CSRF: hit `/oauth/monday/install`, copy the cookie, then hit `/callback` with a mismatched `state` — expect 400 (manual test, requires running backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)