### PR TITLE
feat(mira-scan-monday): /monday/webhook + 429 CTA + marketplace setup driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,9 @@ wiki/.smart-env/
 **/* 2.txt
 
 .claire/
+
+# Playwright marketplace-setup runs (screenshots-on-failure, never commit)
+tools/monday-marketplace-setup/runs/
+tools/monday-marketplace-setup/node_modules/
+tools/monday-marketplace-setup/playwright-report/
+tools/monday-marketplace-setup/.chrome-profile/

--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -9,7 +9,7 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:
-      - "3010:8080"
+      - "127.0.0.1:3010:8080"
     environment:
       - WEBUI_AUTH=true
       - ENABLE_SIGNUP=true
@@ -151,7 +151,7 @@ services:
     build: ./mira-web
     container_name: mira-web
     ports:
-      - "3200:3000"
+      - "127.0.0.1:3200:3000"
     environment:
       - PORT=3000
       - PLG_JWT_SECRET=${PLG_JWT_SECRET}

--- a/docs/audits/2026-05-09.md
+++ b/docs/audits/2026-05-09.md
@@ -1,0 +1,48 @@
+# Site Audit — 2026-05-09
+
+## app.factorylm.com
+
+**Tool:** Playwright DOM crawl (4 public routes) + Lighthouse 13.3.0 + curl headers + edge probes  
+**Routes crawled:** /login/ · /signup · /pricing · /blog/fault-codes
+
+**Lighthouse scores:**
+| Route | Perf | A11y | Best Practices | SEO |
+|-------|------|------|----------------|-----|
+| /login/ | 69 | 94 | 100 | 100 |
+| /pricing | 92 | 96 | 96 | 66 |
+
+### Findings
+
+| # | Sev | Route | Title | GitHub | Linear |
+|---|-----|-------|-------|--------|--------|
+| 1 | 🟠 P1 | /pricing | Blocked from crawlers — robots.txt Disallow: / covers /pricing | [#1104](https://github.com/Mikecranesync/MIRA/issues/1104) | CRA-110 |
+| 2 | 🟠 P1 | /login | LCP 4.6s, TBT 540ms (perf 69) | [#1105](https://github.com/Mikecranesync/MIRA/issues/1105) | CRA-111 |
+| 3 | 🟠 P1 | all | nginx not serving HTTP/2 (est. 1,440ms on login) | [#1106](https://github.com/Mikecranesync/MIRA/issues/1106) | CRA-117 |
+| 4 | 🟠 P1 | all | Unknown paths return 308 instead of 404 | [#956](https://github.com/Mikecranesync/MIRA/issues/956) *(comment)* | CRA-114 |
+| 5 | 🟡 P2 | / | 3-hop redirect chain: / → /feed/ → /login?cb → /login/ | [#1113](https://github.com/Mikecranesync/MIRA/issues/1113) | CRA-116 |
+| 6 | 🟡 P2 | /pricing | Render-blocking adds 1,470ms | [#1115](https://github.com/Mikecranesync/MIRA/issues/1115) | CRA-119 |
+| 7 | 🟡 P2 | /pricing | Console errors on load | [#1116](https://github.com/Mikecranesync/MIRA/issues/1116) | CRA-121 |
+| 8 | 🟡 P2 | /pricing | Color contrast failures | [#1117](https://github.com/Mikecranesync/MIRA/issues/1117) | CRA-122 |
+| 9 | 🟡 P2 | /pricing | 12 tap targets <44px (desktop), 7 (mobile) | [#1107](https://github.com/Mikecranesync/MIRA/issues/1107) | CRA-112 |
+| 10 | 🟡 P2 | /login | Unnamed button (a11y) | [#1108](https://github.com/Mikecranesync/MIRA/issues/1108) | CRA-113 |
+| 11 | 🟡 P2 | /login | og:image missing | [#1109](https://github.com/Mikecranesync/MIRA/issues/1109) | CRA-115 |
+| 12 | 🟡 P2 | /login | 92 KiB unused JavaScript | [#1110](https://github.com/Mikecranesync/MIRA/issues/1110) | CRA-118 |
+| 13 | 🟡 P2 | /signup | Canonical points to / instead of /signup | [#1111](https://github.com/Mikecranesync/MIRA/issues/1111) | CRA-120 |
+| 14 | 🟡 P2 | /signup | Generic title "FactoryLM Hub" | [#1112](https://github.com/Mikecranesync/MIRA/issues/1112) | CRA-123 |
+| 15 | 🟡 P2 | /signup | 3 unlabelled form inputs + 1 unnamed button | [#1114](https://github.com/Mikecranesync/MIRA/issues/1114) | CRA-124 |
+| 16 | 🟡 P2 | all | CSP uses unsafe-inline + unsafe-eval | [#1118](https://github.com/Mikecranesync/MIRA/issues/1118) | CRA-125 |
+| 17 | 🟢 P3 | 404 | 404 page has no home link | [#1119](https://github.com/Mikecranesync/MIRA/issues/1119) | CRA-126 |
+
+### What's clean
+- HSTS ✓ · X-Content-Type-Options ✓ · X-Frame-Options ✓ · Referrer-Policy ✓ · Permissions-Policy ✓ · CSP present ✓
+- All pages: 0 images missing alt text · 0 network failures · 0 mixed content
+- /login: canonical correct · focus lands on email input (good UX)
+- /pricing: a11y score 96
+
+---
+
+## factorylm.com (reference — audited 2026-05-08)
+
+See `wiki/reviews/2026-05-08-factorylm.com.md` and GitHub issues #1092–#1102, CRA-96–CRA-109.
+
+**Top P0:** LCP 18.3s on homepage — root cause is unoptimized images (3,238 KiB savings). Fix #1093 first.

--- a/docs/wip/audit-fixes-2026-05-09/tasks.md
+++ b/docs/wip/audit-fixes-2026-05-09/tasks.md
@@ -1,0 +1,84 @@
+# Audit Fixes — 2026-05-09
+
+**Branch:** `feat/mira-scan-monday-webhook-and-builder`  
+**Audit reports:** `docs/audits/2026-05-09.md` · `wiki/reviews/2026-05-08-factorylm.com.md`  
+**Scope:** factorylm.com (mira-web v0.5.3) + app.factorylm.com (mira-hub v1.5.1)  
+**Status:** Batch 1 done — QA pending
+
+---
+
+## Batch 1 — Code fixes (committed 3ded94f)
+
+| # | Finding | File(s) | Status |
+|---|---------|---------|--------|
+| CRA-104 | h2→h4 heading skip on homepage | `mira-web/src/lib/components.ts` | ✅ done |
+| CRA-105 | /cmms missing JSON-LD | `mira-web/src/views/cmms.ts` | ✅ done |
+| CRA-109 | factorylm.com 404 no home link | `mira-web/src/server.ts` | ✅ done |
+| CRA-113 | /login icon-only buttons unlabelled | `mira-hub/src/app/login/page.tsx` | ✅ done |
+| CRA-115 | /login og:image missing | `mira-hub/src/app/login/layout.tsx` (new) | ✅ done |
+| CRA-117 | HTTP/2 missing on app.factorylm.com | `nginx-oracle.conf` | ✅ done (needs VPS deploy) |
+| CRA-120 | /signup canonical points to / | `mira-hub/src/app/signup/layout.tsx` (new) | ✅ done |
+| CRA-123 | Generic title "FactoryLM Hub" | `mira-hub/src/app/layout.tsx` | ✅ done |
+| CRA-124 | /signup unlabelled inputs + toggle | `mira-hub/src/app/signup/page.tsx` | ✅ done |
+| CRA-126 | mira-hub 404 no home link | `mira-hub/src/app/not-found.tsx` (new) | ✅ done |
+
+---
+
+## Batch 2 — QA proof of work
+
+- [ ] **Write Playwright spec** — `mira-hub/tests/e2e/audit-fixes-2026-05-09.spec.ts`
+  - [ ] /hub/login: verify magic-link button has `aria-label="Send magic link"`
+  - [ ] /hub/login: verify password toggle has `aria-label` present
+  - [ ] /hub/login: verify `<title>` contains "Sign In"
+  - [ ] /hub/signup: verify Name/Email/Password inputs each have `id` + matching `for` on label
+  - [ ] /hub/signup: verify password toggle has `aria-label` present
+  - [ ] /hub/signup: verify `<title>` contains "Create Account"
+  - [ ] /hub/404-test: visit a nonexistent path, verify 404 status + home link present
+  - [ ] factorylm.com/: verify heading order (no h4 before h3 under any h2)
+  - [ ] factorylm.com/cmms: verify JSON-LD `SoftwareApplication` present in DOM
+  - [ ] factorylm.com/notapage: verify 404 response + "Back to home" link
+- [ ] **Run spec** against live VPS (`https://app.factorylm.com`, `https://factorylm.com`)
+- [ ] **Screenshot proof** — save to `tools/web-review-runs/2026-05-09-audit-fixes/`
+
+---
+
+## Batch 3 — Remaining findings (deferred)
+
+| # | Finding | Effort | Notes |
+|---|---------|--------|-------|
+| CRA-96/97 | LCP 18.3s — no WebP, no lazy-load (3,238 KiB) | Large | Image pipeline + CDN decision |
+| CRA-98 | HTTP/2 on factorylm.com | Deploy only | nginx-factorylm-marketing.conf already has `http2`; just needs `scp` + reload |
+| CRA-99 | SVG console error `<rect> rx` | Unknown | Not reproduced locally; needs CDP console capture |
+| CRA-108 | CSP missing on factorylm.com | Deploy only | conf already has CSP; needs `scp` + reload |
+| CRA-110 | robots.txt blocks /pricing on app.* | Skip | Intentional — `X-Robots-Tag: noindex` set domain-wide for app subdomain |
+| CRA-111 | /login LCP 4.6s / TBT 540ms | Medium | JS bundle split; remove render-blocking resources |
+| CRA-114 | Unknown paths return 308 not 404 | Medium | Middleware intercepts before not-found; needs route-aware middleware |
+| CRA-116 | 3-hop redirect chain on / | Medium | nginx + middleware coordination |
+
+**CRA-98 + CRA-108 VPS deploy commands** (confirm before running):
+```bash
+scp deployment/nginx-factorylm-marketing.conf factorylm-prod:/etc/nginx/sites-available/factorylm-marketing
+ssh factorylm-prod "sudo nginx -t && sudo systemctl reload nginx"
+```
+
+---
+
+## Resume prompt
+
+> **Branch:** `feat/mira-scan-monday-webhook-and-builder`
+>
+> We ran a Playwright + Lighthouse audit of factorylm.com and app.factorylm.com (2026-05-09).
+> Reports are at `docs/audits/2026-05-09.md` and `wiki/reviews/2026-05-08-factorylm.com.md`.
+> 31 findings total (GitHub #1092–#1119, Linear CRA-96–CRA-126).
+>
+> **Batch 1 code fixes are committed** (3ded94f — mira-hub v1.5.1 + mira-web v0.5.3):
+> CRA-104/105/109/113/115/117/120/123/124/126 — see `docs/wip/audit-fixes-2026-05-09/tasks.md` for the full list.
+>
+> **Next step: Batch 2 — QA proof of work.**
+> Write and run the Playwright spec at `mira-hub/tests/e2e/audit-fixes-2026-05-09.spec.ts`
+> against the live VPS (app.factorylm.com + factorylm.com). Save screenshots to
+> `tools/web-review-runs/2026-05-09-audit-fixes/`. Spec checklist is in the tasks.md.
+>
+> After QA passes: open a PR from this branch. Then decide whether to do the VPS deploy
+> for CRA-98/CRA-108 (nginx-factorylm-marketing.conf already has http2 + CSP — just needs scp + reload).
+> Batch 3 (image optimization, LCP, redirect chain) is deferred — see tasks.md.

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/app/login/layout.tsx
+++ b/mira-hub/src/app/login/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Sign In",
+  description: "Sign in to FactoryLM — AI-powered industrial maintenance platform.",
+  openGraph: {
+    images: ["https://factorylm.com/og-image.png"],
+  },
+};
+
+export default function LoginLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/mira-hub/src/app/login/login-form.tsx
+++ b/mira-hub/src/app/login/login-form.tsx
@@ -159,6 +159,7 @@ function LoginFormInner() {
                 />
                 <button
                   type="submit"
+                  aria-label="Send magic link"
                   disabled={magicLoading || !magicEmail}
                   className="px-4 h-11 rounded-md font-medium text-white text-sm disabled:opacity-50 flex items-center gap-1.5"
                   style={{ background: "linear-gradient(135deg,#2563EB,#0891B2)" }}
@@ -214,6 +215,7 @@ function LoginFormInner() {
                   />
                   <button
                     type="button"
+                    aria-label={showPw ? "Hide password" : "Show password"}
                     onClick={() => setShowPw((v) => !v)}
                     className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200 transition-colors"
                   >

--- a/mira-hub/src/app/not-found.tsx
+++ b/mira-hub/src/app/not-found.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+import { Factory } from "lucide-react";
+
+export default function NotFound() {
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center px-4"
+      style={{ background: "linear-gradient(135deg, #0F172A 0%, #1E293B 50%, #0F172A 100%)" }}
+    >
+      <div className="text-center">
+        <div
+          className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto mb-6"
+          style={{
+            background: "linear-gradient(135deg, #2563EB, #0891B2)",
+            boxShadow: "0 0 32px rgba(37,99,235,0.4)",
+          }}
+        >
+          <Factory className="w-8 h-8 text-white" />
+        </div>
+        <h1 className="text-6xl font-bold text-white mb-3">404</h1>
+        <p className="text-slate-400 text-lg mb-8">This page doesn&apos;t exist.</p>
+        <Link
+          href="/feed"
+          className="inline-flex items-center px-6 py-3 rounded-lg font-medium text-white transition-opacity hover:opacity-90"
+          style={{ background: "linear-gradient(135deg, #2563EB, #0891B2)" }}
+        >
+          Back to dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/mira-hub/src/app/signup/layout.tsx
+++ b/mira-hub/src/app/signup/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Create Account",
+  description: "Create your FactoryLM account and get AI-powered industrial maintenance answers from cited OEM sources.",
+  alternates: {
+    canonical: "https://app.factorylm.com/hub/signup",
+  },
+};
+
+export default function SignupLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/mira-hub/src/app/signup/page.tsx
+++ b/mira-hub/src/app/signup/page.tsx
@@ -124,8 +124,9 @@ export default function SignupPage() {
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
-              <label className="block text-xs font-medium text-slate-400 mb-1.5">Name (optional)</label>
+              <label htmlFor="signup-name" className="block text-xs font-medium text-slate-400 mb-1.5">Name (optional)</label>
               <Input
+                id="signup-name"
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -136,8 +137,9 @@ export default function SignupPage() {
             </div>
 
             <div>
-              <label className="block text-xs font-medium text-slate-400 mb-1.5">Email</label>
+              <label htmlFor="signup-email" className="block text-xs font-medium text-slate-400 mb-1.5">Email</label>
               <Input
+                id="signup-email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -149,9 +151,10 @@ export default function SignupPage() {
             </div>
 
             <div>
-              <label className="block text-xs font-medium text-slate-400 mb-1.5">Password</label>
+              <label htmlFor="signup-password" className="block text-xs font-medium text-slate-400 mb-1.5">Password</label>
               <div className="relative">
                 <Input
+                  id="signup-password"
                   type={showPw ? "text" : "password"}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
@@ -163,6 +166,7 @@ export default function SignupPage() {
                 />
                 <button
                   type="button"
+                  aria-label={showPw ? "Hide password" : "Show password"}
                   onClick={() => setShowPw((v) => !v)}
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-200 transition-colors"
                 >

--- a/mira-hub/tests/e2e/audit-fixes-2026-05-09.spec.ts
+++ b/mira-hub/tests/e2e/audit-fixes-2026-05-09.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * QA proof — audit fixes 2026-05-09
+ * Verifies CRA-104/105/109/113/115/120/123/124/126 on live VPS.
+ * Screenshots → tools/web-review-runs/2026-05-09-audit-fixes/
+ */
+
+import { test, expect } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+const HUB  = process.env.HUB_URL  ?? "https://app.factorylm.com/hub";
+const SITE = process.env.SITE_URL ?? "https://factorylm.com";
+const OUT  = path.resolve(__dirname, "../../../../tools/web-review-runs/2026-05-09-audit-fixes");
+
+fs.mkdirSync(OUT, { recursive: true });
+
+async function shot(page: import("@playwright/test").Page, name: string) {
+  await page.screenshot({ path: path.join(OUT, `${name}.png`), fullPage: true }).catch(() => {});
+}
+
+// ─────────────────────────────────────────────────────────────
+// mira-hub /login
+// ─────────────────────────────────────────────────────────────
+
+test("CRA-113/115/123 — /login: aria-labels + og:image + title", async ({ page }) => {
+  await page.goto(`${HUB}/login`, { waitUntil: "networkidle" });
+  await shot(page, "login-desktop");
+
+  // CRA-123: title contains "Sign In"
+  const title = await page.title();
+  expect(title, "page title should contain 'Sign In'").toMatch(/sign in/i);
+
+  // CRA-113: magic-link button aria-label
+  const magicBtn = page.locator('button[aria-label="Send magic link"]');
+  await expect(magicBtn, "magic-link button must have aria-label='Send magic link'").toHaveCount(1);
+
+  // CRA-113: password toggle aria-label
+  const pwToggle = page.locator('button[aria-label*="password" i], button[aria-label*="show" i], button[aria-label*="hide" i]').first();
+  await expect(pwToggle, "password-toggle button must have an aria-label").toBeVisible();
+  const toggleLabel = await pwToggle.getAttribute("aria-label");
+  expect(toggleLabel, "password-toggle aria-label must not be empty").toBeTruthy();
+
+  // CRA-115: og:image meta tag present
+  const ogImage = page.locator('meta[property="og:image"]');
+  await expect(ogImage, "og:image meta must be present on /login").toHaveCount(1);
+  const ogContent = await ogImage.getAttribute("content");
+  expect(ogContent, "og:image content must not be empty").toBeTruthy();
+});
+
+// ─────────────────────────────────────────────────────────────
+// mira-hub /signup
+// ─────────────────────────────────────────────────────────────
+
+test("CRA-120/123/124 — /signup: labels + canonical + title", async ({ page }) => {
+  await page.goto(`${HUB}/signup`, { waitUntil: "networkidle" });
+  await shot(page, "signup-desktop");
+
+  // CRA-123: title contains "Create Account"
+  const title = await page.title();
+  expect(title, "page title should contain 'Create Account'").toMatch(/create account/i);
+
+  // CRA-120: canonical points to /signup (not /)
+  const canonical = page.locator('link[rel="canonical"]');
+  await expect(canonical, "canonical link must be present on /signup").toHaveCount(1);
+  const href = await canonical.getAttribute("href");
+  expect(href, "canonical href must include /signup, not bare /").toMatch(/\/signup/);
+
+  // CRA-124: Name input has id + matching label
+  const nameInput = page.locator('input[id][name*="name" i], input[id][placeholder*="name" i]').first();
+  await expect(nameInput, "Name input must be in the DOM with an id").toBeAttached();
+  const nameId = await nameInput.getAttribute("id");
+  expect(nameId, "Name input id must not be empty").toBeTruthy();
+  const nameLabel = page.locator(`label[for="${nameId}"]`);
+  await expect(nameLabel, `label[for="${nameId}"] must exist`).toHaveCount(1);
+
+  // CRA-124: Email input has id + matching label
+  const emailInput = page.locator('input[type="email"][id]').first();
+  await expect(emailInput, "Email input must have an id").toBeAttached();
+  const emailId = await emailInput.getAttribute("id");
+  expect(emailId, "Email input id must not be empty").toBeTruthy();
+  const emailLabel = page.locator(`label[for="${emailId}"]`);
+  await expect(emailLabel, `label[for="${emailId}"] must exist`).toHaveCount(1);
+
+  // CRA-124: Password input has id + matching label
+  const pwInput = page.locator('input[type="password"][id]').first();
+  await expect(pwInput, "Password input must have an id").toBeAttached();
+  const pwId = await pwInput.getAttribute("id");
+  expect(pwId, "Password input id must not be empty").toBeTruthy();
+  const pwLabel = page.locator(`label[for="${pwId}"]`);
+  await expect(pwLabel, `label[for="${pwId}"] must exist`).toHaveCount(1);
+
+  // CRA-124: password toggle has aria-label
+  const pwToggle = page.locator('button[aria-label*="password" i], button[aria-label*="show" i], button[aria-label*="hide" i]').first();
+  await expect(pwToggle, "password-toggle button must have an aria-label").toBeVisible();
+  const toggleLabel = await pwToggle.getAttribute("aria-label");
+  expect(toggleLabel, "password-toggle aria-label must not be empty").toBeTruthy();
+});
+
+// ─────────────────────────────────────────────────────────────
+// mira-hub 404
+// ─────────────────────────────────────────────────────────────
+
+test("CRA-126 — hub 404: home link present", async ({ page }) => {
+  const res = await page.goto(`${HUB}/__nonexistent_path_qa__`, { waitUntil: "networkidle" });
+  await shot(page, "hub-404");
+
+  // Home link must appear
+  const homeLink = page.locator('a[href="/hub"], a[href*="factorylm.com"], a').filter({ hasText: /home|back/i }).first();
+  await expect(homeLink, "404 page must contain a link back home").toBeVisible();
+});
+
+// ─────────────────────────────────────────────────────────────
+// factorylm.com homepage
+// ─────────────────────────────────────────────────────────────
+
+test("CRA-104 — factorylm.com/: no heading-level skip (h2→h4 without h3)", async ({ page }) => {
+  await page.goto(SITE, { waitUntil: "networkidle" });
+  await shot(page, "marketing-home");
+
+  // Collect heading levels in DOM order
+  const levels = await page.evaluate(() => {
+    return Array.from(document.querySelectorAll("h1,h2,h3,h4,h5,h6")).map(
+      h => parseInt(h.tagName[1], 10),
+    );
+  });
+
+  // No h4 should appear immediately after an h2 without an h3 in between
+  let lastH2Idx = -1;
+  let seenH3AfterH2 = false;
+  const violations: string[] = [];
+
+  for (let i = 0; i < levels.length; i++) {
+    if (levels[i] === 2) { lastH2Idx = i; seenH3AfterH2 = false; }
+    if (levels[i] === 3 && lastH2Idx !== -1) { seenH3AfterH2 = true; }
+    if (levels[i] === 4 && lastH2Idx !== -1 && !seenH3AfterH2) {
+      violations.push(`h4 at index ${i} follows h2 at index ${lastH2Idx} with no h3 in between`);
+    }
+  }
+
+  expect(violations, `Heading-skip violations: ${violations.join("; ")}`).toHaveLength(0);
+});
+
+// ─────────────────────────────────────────────────────────────
+// factorylm.com/cmms
+// ─────────────────────────────────────────────────────────────
+
+test("CRA-105 — factorylm.com/cmms: JSON-LD SoftwareApplication present", async ({ page }) => {
+  await page.goto(`${SITE}/cmms`, { waitUntil: "networkidle" });
+  await shot(page, "marketing-cmms");
+
+  const jsonLd = await page.evaluate(() => {
+    const scripts = Array.from(
+      document.querySelectorAll('script[type="application/ld+json"]'),
+    );
+    return scripts.map(s => {
+      try { return JSON.parse(s.textContent ?? "{}"); } catch { return {}; }
+    });
+  });
+
+  const hasSoftwareApp = jsonLd.some(
+    (obj: Record<string, unknown>) =>
+      obj["@type"] === "SoftwareApplication" ||
+      (Array.isArray(obj["@graph"]) &&
+        (obj["@graph"] as Record<string, unknown>[]).some(n => n["@type"] === "SoftwareApplication")),
+  );
+
+  expect(hasSoftwareApp, "JSON-LD SoftwareApplication must be present on /cmms").toBe(true);
+});
+
+// ─────────────────────────────────────────────────────────────
+// factorylm.com 404
+// ─────────────────────────────────────────────────────────────
+
+test("CRA-109 — factorylm.com 404: home link present", async ({ page }) => {
+  const res = await page.goto(`${SITE}/notapage-qa-probe`, { waitUntil: "networkidle" });
+  await shot(page, "marketing-404");
+
+  // Status should indicate not found (200 is acceptable if app renders a 404 page)
+  const bodyText = await page.locator("body").innerText();
+  const looks404 = /404|not found|page doesn.t exist/i.test(bodyText);
+  expect(looks404, "404 page body must signal 'not found'").toBe(true);
+
+  const homeLink = page.locator('a').filter({ hasText: /home|back/i }).first();
+  await expect(homeLink, "404 page must contain a 'Back to home' link").toBeVisible();
+});

--- a/mira-scan-monday/.env.example
+++ b/mira-scan-monday/.env.example
@@ -27,6 +27,13 @@ MONDAY_OAUTH_SCOPES=me:read boards:read boards:write
 # Monday ever splits the JWT signing key from the OAuth secret.
 MONDAY_SIGNING_SECRET=
 
+# monday.com app-lifecycle webhook (install / uninstall / subscription).
+# Set in Developer Center → Build → Webhooks; signing secret is shown
+# after saving the webhook URL. Defaults to MONDAY_OAUTH_CLIENT_SECRET
+# if unset (monday signs lifecycle deliveries with the same key).
+MONDAY_WEBHOOK_SIGNING_SECRET=
+MONDAY_WEBHOOK_PATH=/monday/webhook
+
 # Optional column-id overrides (defaults match field names)
 MONDAY_COL_MAKE=make
 MONDAY_COL_MODEL=model

--- a/mira-scan-monday/.env.example
+++ b/mira-scan-monday/.env.example
@@ -8,10 +8,24 @@ MIRA_KB_BASE_URL=
 MIRA_KB_API_KEY=
 MIRA_KB_TIMEOUT=30
 
-# monday.com
+# monday.com — server-side write fallback (used by the standalone
+# /scan/ path that doesn't run inside a Monday iframe). For the
+# marketplace app, per-account OAuth tokens replace this on a per-call
+# basis — see MONDAY_OAUTH_* below.
 MONDAY_API_TOKEN=
 MONDAY_API_URL=https://api.monday.com/v2
 MONDAY_API_VERSION=2024-01
+
+# monday.com OAuth 2.0 — required for the marketplace install flow.
+# Get these from your app in monday.com's Developer Center.
+# Redirect URI must match exactly what's configured there.
+MONDAY_OAUTH_CLIENT_ID=
+MONDAY_OAUTH_CLIENT_SECRET=
+MONDAY_OAUTH_REDIRECT_URI=http://localhost:8000/oauth/monday/callback
+MONDAY_OAUTH_SCOPES=me:read boards:read boards:write
+# Defaults to MONDAY_OAUTH_CLIENT_SECRET if unset; override only if
+# Monday ever splits the JWT signing key from the OAuth secret.
+MONDAY_SIGNING_SECRET=
 
 # Optional column-id overrides (defaults match field names)
 MONDAY_COL_MAKE=make

--- a/mira-scan-monday/CHANGELOG.md
+++ b/mira-scan-monday/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog — mira-scan-monday
+
+## v0.2.0 — 2026-05-05
+
+- **Webhook endpoint**: `POST /monday/webhook` handles app-lifecycle events (install / uninstall / app_subscription_*) with HMAC JWT verification. Falls back to `MONDAY_OAUTH_CLIENT_SECRET` when `MONDAY_WEBHOOK_SIGNING_SECRET` is unset.
+- **Subscription status column** added to `monday_installations` (idempotent migration on startup).
+- **429 quota upgrade CTA**: when `/scan/extract` returns `quota_exceeded`, the iframe now shows a distinct "Get more scans" CTA instead of a raw error string.
+- **Hybrid marketplace setup driver** at `tools/monday-marketplace-setup/` walks the Developer Center Build-tab sections and pipes generated OAuth + webhook secrets straight into Doppler `factorylm/prd`.
+- Compose adds explicit `environment:` block for the three new monday secrets so `doppler run -- docker compose up` reaches the container.
+
+## v0.1.0 — 2026-05-04 and earlier
+
+- OAuth install flow + per-account token storage (`monday_installations`).
+- Per-account session-token JWT verification on `/scan/extract`, `/kb/lookup`, `/chat/message`, `/monday/update-item`.
+- Per-account daily scan counter + free-tier quota gate (50 scans/month default).
+- 401 → mark_revoked → reinstall_required UI flow.
+- OAuth state CSRF protection.
+- Live `kb_chunks` lookup, Serper-backed manual search with OEM-domain boost + SEO blocklist + HEAD validation.
+- Scan queue (`mira_scan_queue`) with crawler-bridge handoff into existing `mira-crawler` ingest pipeline.

--- a/mira-scan-monday/backend/db.py
+++ b/mira-scan-monday/backend/db.py
@@ -149,6 +149,24 @@ async def ensure_monday_installations_table() -> None:
                 )
                 """
             )
+            # Idempotent migration for the subscription billing webhook —
+            # added 2026-05-05 alongside the /monday/webhook route.
+            await cur.execute(
+                """
+                ALTER TABLE monday_installations
+                  ADD COLUMN IF NOT EXISTS subscription_status text DEFAULT 'free'
+                """
+            )
+            # access_token NOT NULL was the original schema; the lifecycle
+            # webhook needs to upsert install rows BEFORE the OAuth
+            # callback delivers the token, so relax the constraint. Safe
+            # to re-run on rows that already have a token.
+            await cur.execute(
+                """
+                ALTER TABLE monday_installations
+                  ALTER COLUMN access_token DROP NOT NULL
+                """
+            )
         _ENSURED_OAUTH = True
         logger.info("monday_installations table is ready")
     except Exception:

--- a/mira-scan-monday/backend/db.py
+++ b/mira-scan-monday/backend/db.py
@@ -69,6 +69,7 @@ async def execute(sql: str, params: tuple[Any, ...] = ()) -> None:
 
 _ENSURED = False
 _ENSURED_OAUTH = False
+_ENSURED_USAGE = False
 
 
 async def ensure_scan_queue_table() -> None:
@@ -152,3 +153,40 @@ async def ensure_monday_installations_table() -> None:
         logger.info("monday_installations table is ready")
     except Exception:
         logger.exception("ensure_monday_installations_table failed; OAuth writes will fail")
+
+
+async def ensure_account_usage_table() -> None:
+    """Idempotent: create the per-account daily-usage counter table.
+
+    One row per (account_id, usage_date). Used as the billing-tier signal
+    — `usage.bump_scan_count(account_id)` upserts on this PK and treats
+    failure as a no-op (telemetry must never break a scan flow).
+    """
+    global _ENSURED_USAGE
+    if _ENSURED_USAGE:
+        return
+    if not NEON_DATABASE_URL:
+        return
+    try:
+        async with await _connect() as conn, conn.cursor() as cur:
+            await cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS account_usage_daily (
+                    account_id   text NOT NULL,
+                    usage_date   date NOT NULL DEFAULT CURRENT_DATE,
+                    scan_count   integer NOT NULL DEFAULT 0,
+                    last_seen_at timestamptz NOT NULL DEFAULT NOW(),
+                    PRIMARY KEY (account_id, usage_date)
+                )
+                """
+            )
+            await cur.execute(
+                """
+                CREATE INDEX IF NOT EXISTS account_usage_daily_date_idx
+                  ON account_usage_daily (usage_date DESC)
+                """
+            )
+        _ENSURED_USAGE = True
+        logger.info("account_usage_daily table is ready")
+    except Exception:
+        logger.exception("ensure_account_usage_table failed; counter writes will no-op")

--- a/mira-scan-monday/backend/db.py
+++ b/mira-scan-monday/backend/db.py
@@ -68,6 +68,7 @@ async def execute(sql: str, params: tuple[Any, ...] = ()) -> None:
 
 
 _ENSURED = False
+_ENSURED_OAUTH = False
 
 
 async def ensure_scan_queue_table() -> None:
@@ -117,3 +118,37 @@ async def ensure_scan_queue_table() -> None:
         logger.info("mira_scan_queue table is ready")
     except Exception:
         logger.exception("ensure_scan_queue_table failed; queue writes will no-op")
+
+
+async def ensure_monday_installations_table() -> None:
+    """Idempotent: create the per-account OAuth-token storage table.
+
+    One row per Monday account that installs the marketplace app. The
+    `access_token` is the long-lived OAuth token issued by Monday;
+    `revoked_at` is set when a 401 from Monday's GraphQL says the user
+    uninstalled or rotated their grant.
+    """
+    global _ENSURED_OAUTH
+    if _ENSURED_OAUTH:
+        return
+    if not NEON_DATABASE_URL:
+        return
+    try:
+        async with await _connect() as conn, conn.cursor() as cur:
+            await cur.execute(
+                """
+                CREATE TABLE IF NOT EXISTS monday_installations (
+                    account_id    text PRIMARY KEY,
+                    access_token  text NOT NULL,
+                    scope         text,
+                    user_id       text,
+                    installed_at  timestamptz NOT NULL DEFAULT NOW(),
+                    last_seen_at  timestamptz NOT NULL DEFAULT NOW(),
+                    revoked_at    timestamptz
+                )
+                """
+            )
+        _ENSURED_OAUTH = True
+        logger.info("monday_installations table is ready")
+    except Exception:
+        logger.exception("ensure_monday_installations_table failed; OAuth writes will fail")

--- a/mira-scan-monday/backend/main.py
+++ b/mira-scan-monday/backend/main.py
@@ -5,6 +5,7 @@ import logging
 import os
 import secrets
 from contextlib import asynccontextmanager
+from typing import Any
 
 from fastapi import BackgroundTasks, Cookie, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -20,6 +21,7 @@ from . import (
     session,
     usage,
     vision,
+    webhooks,
 )
 from .models import (
     AssetPlate,
@@ -413,3 +415,26 @@ async def monday_update_item(
         logger.exception("monday update unexpected error")
         return MondayUpdateResponse(ok=False, error=f"{exc.__class__.__name__}: {exc}")
     return MondayUpdateResponse(ok=True, monday_item_id=new_id)
+
+
+# ── monday.com app-lifecycle webhook ───────────────────────────────────────
+# Configured in Developer Center → Build → Webhooks. Subscribed to:
+# install, uninstall, app_subscription_*. Verification mirrors the
+# session-token JWT pattern in `session.verify_session_token`.
+@app.post("/monday/webhook")
+async def monday_webhook(request: Request) -> dict[str, Any]:
+    raw = await request.body()
+    try:
+        body = await request.json() if raw else {}
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid json body")
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="body must be a json object")
+
+    auth = request.headers.get("authorization") or request.headers.get("Authorization")
+    try:
+        result = await webhooks.handle_event(authorization_header=auth, body=body)
+    except webhooks.WebhookInvalid as exc:
+        logger.warning("webhook signature invalid: %s", exc)
+        raise HTTPException(status_code=401, detail="invalid webhook signature")
+    return result

--- a/mira-scan-monday/backend/main.py
+++ b/mira-scan-monday/backend/main.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
+import html
 import logging
 import os
 from contextlib import asynccontextmanager
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import HTMLResponse, RedirectResponse
 
-from . import db, manual_search, mira_rag, monday_api, scan_queue, vision
+from . import (
+    db,
+    manual_search,
+    mira_rag,
+    monday_api,
+    oauth,
+    scan_queue,
+    session,
+    vision,
+)
 from .models import (
     AssetPlate,
     ChatMessageRequest,
@@ -29,6 +40,7 @@ logger = logging.getLogger("mira-scan")
 @asynccontextmanager
 async def lifespan(_app: FastAPI):
     await db.ensure_scan_queue_table()
+    await db.ensure_monday_installations_table()
     yield
 
 
@@ -55,6 +67,98 @@ app.add_middleware(
 @app.get("/healthz")
 async def healthz() -> dict[str, str]:
     return {"status": "ok"}
+
+
+# ── OAuth install flow ─────────────────────────────────────────────────────
+# When a customer installs the app from monday.com's marketplace, Monday
+# redirects them through these two endpoints. The install URL is what
+# Monday calls; the callback exchanges the code for a per-account access
+# token we persist in `monday_installations`.
+
+
+@app.get("/oauth/monday/install")
+async def oauth_install(state: str = "") -> RedirectResponse:
+    """Redirect to Monday's consent screen.
+
+    Mainly used for the reinstall flow when a token has been revoked
+    (frontend `redirectToInstall()` lands here). Marketplace installs
+    typically jump straight to /oauth/monday/callback with a code from
+    Monday's authorize endpoint, but exposing /install lets us issue
+    the same URL for manual or automated reinstalls.
+    """
+    if not oauth.configured():
+        raise HTTPException(
+            status_code=503,
+            detail="OAuth is not configured (MONDAY_OAUTH_CLIENT_ID/SECRET missing)",
+        )
+    return RedirectResponse(oauth.install_url(state=state or None), status_code=302)
+
+
+@app.get("/oauth/monday/callback", response_class=HTMLResponse)
+async def oauth_callback(code: str = "", state: str = "") -> HTMLResponse:
+    """Trade Monday's auth code for an access token, persist by account_id."""
+    if not code:
+        raise HTTPException(status_code=400, detail="missing 'code' query parameter")
+    try:
+        token_data = await oauth.exchange_code_for_token(code)
+    except oauth.OAuthError as exc:
+        raise HTTPException(status_code=400, detail=f"token exchange failed: {exc}") from exc
+
+    access_token = token_data.get("access_token")
+    scope = token_data.get("scope", "")
+    if not access_token:
+        raise HTTPException(
+            status_code=502,
+            detail=f"monday returned no access_token: {token_data!r}",
+        )
+
+    try:
+        me = await oauth.whoami(access_token)
+    except oauth.OAuthError as exc:
+        raise HTTPException(status_code=502, detail=f"whoami failed: {exc}") from exc
+
+    account = (me or {}).get("account") or {}
+    account_id = str(account.get("id") or "")
+    user_id = str(me.get("id") or "") or None
+    slug = str(account.get("slug") or "app")
+    if not account_id:
+        raise HTTPException(
+            status_code=500,
+            detail="could not resolve installing account id from Monday whoami response",
+        )
+
+    try:
+        await oauth.save_installation(
+            account_id=account_id,
+            access_token=access_token,
+            scope=scope,
+            user_id=user_id,
+        )
+    except db.DBUnavailable as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="cannot persist installation: NEON_DATABASE_URL not configured",
+        ) from exc
+
+    # Sanitize before interpolating into the HTML response. Monday's
+    # slug + account_id should already be safe (slug matches [a-z0-9_-]+
+    # and id is numeric) but we cheaply escape both for defense in depth.
+    safe_slug = html.escape(slug, quote=True)
+    safe_account = html.escape(account_id, quote=True)
+    redirect_back = f"https://{safe_slug}.monday.com/apps/installed_apps"
+    return HTMLResponse(
+        f"""<!doctype html>
+<html><head>
+<title>MIRA Scan installed</title>
+<meta http-equiv="refresh" content="2; url={redirect_back}">
+<style>body{{font-family:system-ui,sans-serif;padding:2rem;text-align:center}}</style>
+</head><body>
+<h2>MIRA Scan installed ✓</h2>
+<p>Account: <code>{safe_account}</code></p>
+<p>Redirecting back to monday.com…</p>
+<p><a href="{redirect_back}">Go now</a></p>
+</body></html>"""
+    )
 
 
 @app.post("/scan/extract", response_model=AssetPlate)
@@ -191,16 +295,21 @@ async def monday_update_item(
     if not req.columns:
         raise HTTPException(status_code=400, detail="columns must not be empty")
 
-    session_token = request.headers.get("x-monday-session-token")
-    if session_token:
-        logger.debug("received monday session token (len=%d)", len(session_token))
+    account_id = session.account_id_from_headers(request.headers)
+    if account_id:
+        await oauth.touch_last_seen(account_id)
 
     try:
         new_id = await monday_api.update_item_columns(
             board_id=req.board_id,
             item_id=req.item_id,
             columns=req.columns,
+            account_id=account_id,
         )
+    except monday_api.MondayTokenRevoked as exc:
+        # Specific code so the frontend can branch to redirectToInstall().
+        logger.warning("monday install revoked for account_id=%s: %s", account_id, exc)
+        return MondayUpdateResponse(ok=False, error=f"reinstall_required: {exc}")
     except monday_api.MondayError as exc:
         logger.warning("monday update failed: %s", exc)
         return MondayUpdateResponse(ok=False, error=str(exc))

--- a/mira-scan-monday/backend/main.py
+++ b/mira-scan-monday/backend/main.py
@@ -17,6 +17,7 @@ from . import (
     oauth,
     scan_queue,
     session,
+    usage,
     vision,
 )
 from .models import (
@@ -41,6 +42,7 @@ logger = logging.getLogger("mira-scan")
 async def lifespan(_app: FastAPI):
     await db.ensure_scan_queue_table()
     await db.ensure_monday_installations_table()
+    await db.ensure_account_usage_table()
     yield
 
 
@@ -162,7 +164,7 @@ async def oauth_callback(code: str = "", state: str = "") -> HTMLResponse:
 
 
 @app.post("/scan/extract", response_model=AssetPlate)
-async def scan_extract(req: ScanRequest) -> AssetPlate:
+async def scan_extract(req: ScanRequest, request: Request) -> AssetPlate:
     if not req.image_base64:
         raise HTTPException(status_code=400, detail="image_base64 is required")
     try:
@@ -170,12 +172,18 @@ async def scan_extract(req: ScanRequest) -> AssetPlate:
     except Exception as exc:
         logger.exception("vision extract failed")
         raise HTTPException(status_code=502, detail=f"vision extract failed: {exc}") from exc
+    # Per-account billing signal — only count successful scans. Fire and
+    # forget; counter writes are best-effort and never block the response.
+    account_id = session.account_id_from_headers(request.headers)
+    if account_id:
+        await usage.bump_scan_count(account_id)
     return plate
 
 
 @app.get("/kb/lookup", response_model=KBResult)
 async def kb_lookup(
     background: BackgroundTasks,
+    request: Request,
     make: str = "",
     model: str = "",
 ) -> KBResult:
@@ -184,16 +192,22 @@ async def kb_lookup(
     On miss we enqueue (make, model) into mira_scan_queue AND fire a
     background task that runs a real-time web search for the manual.
     The frontend polls `/queue/status?make=&model=` for progress.
+
+    The KB itself stays shared (cooperative-by-design per NORTH_STAR.md);
+    `account_id` only stamps the queue row so we know which install the
+    miss came from.
     """
     if not make and not model:
         raise HTTPException(status_code=400, detail="make or model is required")
 
+    account_id = session.account_id_from_headers(request.headers)
     result = await mira_rag.lookup_asset(make=make, model=model)
     if not result.matched:
         ack = await scan_queue.enqueue(
             make=make,
             model=model,
             source="mira-scan",
+            tenant_id=account_id,
             notes="auto-enqueued from /kb/lookup miss",
         )
         if ack:
@@ -204,7 +218,9 @@ async def kb_lookup(
 
 
 @app.post("/queue/search-now", response_model=ManualRequestQueueResponse)
-async def queue_search_now(req: ManualRequestQueueRequest) -> ManualRequestQueueResponse:
+async def queue_search_now(
+    req: ManualRequestQueueRequest, request: Request
+) -> ManualRequestQueueResponse:
     """Synchronous variant of the background search.
 
     Enqueues if needed, runs the search inline, and returns the final
@@ -214,11 +230,13 @@ async def queue_search_now(req: ManualRequestQueueRequest) -> ManualRequestQueue
     if not (req.make.strip() and req.model.strip()):
         raise HTTPException(status_code=400, detail="make and model are required")
 
+    account_id = session.account_id_from_headers(request.headers)
     await scan_queue.enqueue(
         make=req.make,
         model=req.model,
         serial=req.serial,
         source=req.source or "mira-scan",
+        tenant_id=account_id,
         notes=req.notes,
     )
     await manual_search.run_search_and_update(req.make, req.model)
@@ -238,9 +256,16 @@ async def queue_search_now(req: ManualRequestQueueRequest) -> ManualRequestQueue
 
 
 @app.post("/chat/message", response_model=ChatMessageResponse)
-async def chat_message(req: ChatMessageRequest) -> ChatMessageResponse:
+async def chat_message(
+    req: ChatMessageRequest, request: Request
+) -> ChatMessageResponse:
     if not req.message.strip():
         raise HTTPException(status_code=400, detail="message is required")
+    # Chat is downstream of scan — bump last_seen so we know the install
+    # is active, but don't bump scan_count (that would double-count).
+    account_id = session.account_id_from_headers(request.headers)
+    if account_id:
+        await oauth.touch_last_seen(account_id)
     reply, sources = await mira_rag.chat(
         message=req.message,
         asset_id=req.asset_id,
@@ -251,14 +276,18 @@ async def chat_message(req: ChatMessageRequest) -> ChatMessageResponse:
 
 
 @app.post("/queue/manual-request", response_model=ManualRequestQueueResponse)
-async def queue_manual_request(req: ManualRequestQueueRequest) -> ManualRequestQueueResponse:
+async def queue_manual_request(
+    req: ManualRequestQueueRequest, request: Request
+) -> ManualRequestQueueResponse:
     if not (req.make.strip() and req.model.strip()):
         raise HTTPException(status_code=400, detail="make and model are required")
+    account_id = session.account_id_from_headers(request.headers)
     ack = await scan_queue.enqueue(
         make=req.make,
         model=req.model,
         serial=req.serial,
         source=req.source or "mira-scan",
+        tenant_id=account_id,
         notes=req.notes,
     )
     if ack is None:

--- a/mira-scan-monday/backend/main.py
+++ b/mira-scan-monday/backend/main.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import html
 import logging
 import os
+import secrets
 from contextlib import asynccontextmanager
 
-from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
+from fastapi import BackgroundTasks, Cookie, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, RedirectResponse
 
@@ -87,20 +88,63 @@ async def oauth_install(state: str = "") -> RedirectResponse:
     typically jump straight to /oauth/monday/callback with a code from
     Monday's authorize endpoint, but exposing /install lets us issue
     the same URL for manual or automated reinstalls.
+
+    Sets a short-lived `mira_oauth_state` cookie so /callback can verify
+    the round-tripped state matches (CSRF defense in depth). The cookie
+    is HTTPOnly + SameSite=Lax so it survives Monday's redirect back.
     """
     if not oauth.configured():
         raise HTTPException(
             status_code=503,
             detail="OAuth is not configured (MONDAY_OAUTH_CLIENT_ID/SECRET missing)",
         )
-    return RedirectResponse(oauth.install_url(state=state or None), status_code=302)
+    state_value = state or secrets.token_urlsafe(24)
+    redirect = RedirectResponse(oauth.install_url(state=state_value), status_code=302)
+    redirect.set_cookie(
+        key="mira_oauth_state",
+        value=state_value,
+        max_age=600,  # 10 min — generous window for slow consent flows
+        httponly=True,
+        # Plain HTTP only in local dev (set MIRA_DEV_MODE=1).
+        secure=os.getenv("MIRA_DEV_MODE") != "1",
+        samesite="lax",
+        path="/oauth/monday/",
+    )
+    return redirect
 
 
 @app.get("/oauth/monday/callback", response_class=HTMLResponse)
-async def oauth_callback(code: str = "", state: str = "") -> HTMLResponse:
-    """Trade Monday's auth code for an access token, persist by account_id."""
+async def oauth_callback(
+    code: str = "",
+    state: str = "",
+    mira_oauth_state: str | None = Cookie(default=None),
+) -> HTMLResponse:
+    """Trade Monday's auth code for an access token, persist by account_id.
+
+    CSRF defense: when state was set via /install, verify the round-
+    tripped value matches the cookie. Marketplace-direct callbacks
+    (Monday → /callback without going through /install) won't have a
+    cookie; that path is allowed since Monday originates the redirect
+    and the auth code itself is single-use + bound to our client_id.
+    """
     if not code:
         raise HTTPException(status_code=400, detail="missing 'code' query parameter")
+
+    # CSRF check — only enforced when /install set a cookie (i.e. when
+    # the user came through our reinstall flow). Marketplace installs
+    # land here directly with no cookie; that's a legitimate path.
+    if mira_oauth_state:
+        if not state:
+            raise HTTPException(
+                status_code=400,
+                detail="state cookie set but query 'state' missing — flow corrupted",
+            )
+        if not secrets.compare_digest(state, mira_oauth_state):
+            raise HTTPException(
+                status_code=400,
+                detail="state mismatch — possible CSRF attempt",
+            )
+
     try:
         token_data = await oauth.exchange_code_for_token(code)
     except oauth.OAuthError as exc:
@@ -167,14 +211,37 @@ async def oauth_callback(code: str = "", state: str = "") -> HTMLResponse:
 async def scan_extract(req: ScanRequest, request: Request) -> AssetPlate:
     if not req.image_base64:
         raise HTTPException(status_code=400, detail="image_base64 is required")
+
+    account_id = session.account_id_from_headers(request.headers)
+
+    # Free-tier quota gate — only enforced when authenticated via Monday.
+    # Standalone path (no header → no account_id) is exempt. Fail-open
+    # on DB error: usage.month_scan_count returns 0 silently when NeonDB
+    # is unavailable, so a transient outage never locks paying users out.
+    if account_id:
+        used = await usage.month_scan_count(account_id)
+        if used >= usage.FREE_TIER_MONTHLY_CAP:
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "error": "quota_exceeded",
+                    "message": (
+                        f"Free-tier limit of {usage.FREE_TIER_MONTHLY_CAP} scans/month "
+                        "reached. Email support@factorylm.com to upgrade."
+                    ),
+                    "used": used,
+                    "cap": usage.FREE_TIER_MONTHLY_CAP,
+                },
+            )
+
     try:
         plate = await vision.extract_asset_plate(req.image_base64, req.mime_type)
     except Exception as exc:
         logger.exception("vision extract failed")
         raise HTTPException(status_code=502, detail=f"vision extract failed: {exc}") from exc
+
     # Per-account billing signal — only count successful scans. Fire and
     # forget; counter writes are best-effort and never block the response.
-    account_id = session.account_id_from_headers(request.headers)
     if account_id:
         await usage.bump_scan_count(account_id)
     return plate

--- a/mira-scan-monday/backend/monday_api.py
+++ b/mira-scan-monday/backend/monday_api.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import httpx
 
+from . import oauth
+
 logger = logging.getLogger("mira-scan.monday")
 
 MONDAY_API_TOKEN = os.getenv("MONDAY_API_TOKEN", "")
@@ -18,25 +20,57 @@ class MondayError(RuntimeError):
     pass
 
 
-def _headers() -> dict[str, str]:
-    if not MONDAY_API_TOKEN:
-        raise MondayError("MONDAY_API_TOKEN is not configured")
-    return {
-        "Authorization": MONDAY_API_TOKEN,
+class MondayTokenRevoked(MondayError):
+    """Raised when a 401 indicates the customer's install was revoked.
+
+    Callers should surface a "please reinstall" UI state — see
+    `frontend/src/lib/monday.js: redirectToInstall()`.
+    """
+
+
+async def _resolve_token(account_id: str | None) -> str:
+    """Per-account token via OAuth storage, with the env-var fallback.
+
+    The fallback is used by the standalone path (`app.factorylm.com/scan/`
+    running without a Monday iframe context) so dev and standalone testing
+    keep working before any account has installed via OAuth.
+    """
+    if account_id:
+        token = await oauth.get_token_for_account(account_id)
+        if token:
+            return token
+    if MONDAY_API_TOKEN:
+        return MONDAY_API_TOKEN
+    raise MondayError(
+        "no Monday token available — neither account-scoped OAuth "
+        f"(account_id={account_id!r}) nor MONDAY_API_TOKEN fallback"
+    )
+
+
+async def _gql(
+    query: str,
+    variables: dict[str, Any],
+    account_id: str | None = None,
+) -> dict[str, Any]:
+    token = await _resolve_token(account_id)
+    headers = {
+        "Authorization": token,
         "Content-Type": "application/json",
         "API-Version": MONDAY_API_VERSION,
     }
-
-
-async def _gql(query: str, variables: dict[str, Any]) -> dict[str, Any]:
     async with httpx.AsyncClient(timeout=30) as client:
         resp = await client.post(
             MONDAY_API_URL,
-            headers=_headers(),
+            headers=headers,
             json={"query": query, "variables": variables},
         )
-        resp.raise_for_status()
-        data = resp.json()
+    if resp.status_code == 401 and account_id:
+        await oauth.mark_revoked(account_id)
+        raise MondayTokenRevoked(
+            f"monday returned 401 for account_id={account_id} — install revoked"
+        )
+    resp.raise_for_status()
+    data = resp.json()
     if data.get("errors"):
         raise MondayError(json.dumps(data["errors"]))
     return data.get("data") or {}
@@ -59,18 +93,22 @@ async def update_item_columns(
     board_id: str,
     item_id: str,
     columns: dict[str, Any],
+    account_id: str | None = None,
 ) -> str:
     """Update one or more column values on a monday.com item.
 
     `columns` keys are monday column ids; values follow the shape monday
     expects per column type (text → str, status → {"label": "..."}, etc.).
+
+    `account_id` selects the per-account OAuth token. When omitted, the
+    legacy `MONDAY_API_TOKEN` env-var fallback is used (standalone path).
     """
     variables = {
         "boardId": str(board_id),
         "itemId": str(item_id),
         "columnValues": json.dumps(columns),
     }
-    data = await _gql(UPDATE_QUERY, variables)
+    data = await _gql(UPDATE_QUERY, variables, account_id=account_id)
     payload = data.get("change_multiple_column_values") or {}
     new_id = payload.get("id")
     if not new_id:

--- a/mira-scan-monday/backend/oauth.py
+++ b/mira-scan-monday/backend/oauth.py
@@ -1,0 +1,188 @@
+"""monday.com OAuth 2.0 install flow.
+
+Marketplace apps need a per-account access token to call Monday's GraphQL
+API on behalf of the installing account. This module:
+
+1. Builds the install URL the user clicks from the marketplace listing.
+2. Handles the redirect-back callback that exchanges the auth code for a
+   long-lived access token.
+3. Persists `(account_id -> access_token)` in the `monday_installations`
+   table (idempotent table creation lives in `db.ensure_monday_installations_table`).
+4. Looks up the right token for the account on every Monday GraphQL call
+   from `monday_api`.
+
+Monday's default OAuth flow issues long-lived tokens (no refresh token).
+If a token is revoked we mark the row and `monday_api._gql` surfaces a
+"please reinstall" error so the iframe can call `redirectToInstall()`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+from . import db
+
+logger = logging.getLogger("mira-scan.oauth")
+
+MONDAY_OAUTH_CLIENT_ID = os.getenv("MONDAY_OAUTH_CLIENT_ID", "")
+MONDAY_OAUTH_CLIENT_SECRET = os.getenv("MONDAY_OAUTH_CLIENT_SECRET", "")
+MONDAY_OAUTH_REDIRECT_URI = os.getenv(
+    "MONDAY_OAUTH_REDIRECT_URI",
+    "http://localhost:8000/oauth/monday/callback",
+)
+MONDAY_OAUTH_SCOPES = os.getenv(
+    "MONDAY_OAUTH_SCOPES",
+    "me:read boards:read boards:write",
+)
+
+MONDAY_OAUTH_AUTHORIZE_URL = "https://auth.monday.com/oauth2/authorize"
+MONDAY_OAUTH_TOKEN_URL = "https://auth.monday.com/oauth2/token"
+MONDAY_API_URL = os.getenv("MONDAY_API_URL", "https://api.monday.com/v2")
+
+
+class OAuthError(RuntimeError):
+    pass
+
+
+def configured() -> bool:
+    """True iff both client_id and client_secret are set in env."""
+    return bool(MONDAY_OAUTH_CLIENT_ID and MONDAY_OAUTH_CLIENT_SECRET)
+
+
+def install_url(state: str | None = None) -> str:
+    """Return the Monday OAuth authorize URL the user clicks to install.
+
+    `state` is an anti-CSRF nonce. Caller may pass one to bind the
+    callback to a session; if omitted we generate a fresh one. The
+    callback verifies it round-tripped intact.
+    """
+    if not configured():
+        raise OAuthError("MONDAY_OAUTH_CLIENT_ID/SECRET not configured")
+    params = {
+        "client_id": MONDAY_OAUTH_CLIENT_ID,
+        "redirect_uri": MONDAY_OAUTH_REDIRECT_URI,
+        "scope": MONDAY_OAUTH_SCOPES,
+        "state": state or secrets.token_urlsafe(24),
+    }
+    return f"{MONDAY_OAUTH_AUTHORIZE_URL}?{urlencode(params)}"
+
+
+async def exchange_code_for_token(code: str) -> dict[str, Any]:
+    """Trade a Monday authorization code for an access token."""
+    if not configured():
+        raise OAuthError("OAuth not configured")
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.post(
+            MONDAY_OAUTH_TOKEN_URL,
+            data={
+                "client_id": MONDAY_OAUTH_CLIENT_ID,
+                "client_secret": MONDAY_OAUTH_CLIENT_SECRET,
+                "code": code,
+                "redirect_uri": MONDAY_OAUTH_REDIRECT_URI,
+            },
+        )
+    if resp.status_code >= 400:
+        raise OAuthError(f"token exchange failed ({resp.status_code}): {resp.text[:200]}")
+    return resp.json()
+
+
+async def whoami(access_token: str) -> dict[str, Any]:
+    """Identify the installing account using the freshly issued token.
+
+    Returns the `me` payload as Monday's GraphQL returns it, including
+    nested `account { id, name, slug }`.
+    """
+    query = "query { me { id name email account { id name slug } } }"
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.post(
+            MONDAY_API_URL,
+            headers={
+                "Authorization": access_token,
+                "Content-Type": "application/json",
+            },
+            json={"query": query},
+        )
+    if resp.status_code >= 400:
+        raise OAuthError(f"whoami failed ({resp.status_code}): {resp.text[:200]}")
+    data = resp.json()
+    if data.get("errors"):
+        raise OAuthError(f"whoami errors: {data['errors']}")
+    return (data.get("data") or {}).get("me") or {}
+
+
+async def save_installation(
+    *,
+    account_id: str,
+    access_token: str,
+    scope: str,
+    user_id: str | None = None,
+) -> None:
+    """Upsert one (account_id, access_token) row. Reinstalls overwrite
+    the existing token and clear the `revoked_at` flag."""
+    sql = """
+        INSERT INTO monday_installations
+            (account_id, access_token, scope, user_id, installed_at, last_seen_at)
+        VALUES (%s, %s, %s, %s, NOW(), NOW())
+        ON CONFLICT (account_id) DO UPDATE
+            SET access_token = EXCLUDED.access_token,
+                scope        = EXCLUDED.scope,
+                user_id      = COALESCE(EXCLUDED.user_id, monday_installations.user_id),
+                last_seen_at = NOW(),
+                revoked_at   = NULL
+    """
+    await db.execute(sql, (account_id, access_token, scope, user_id))
+    logger.info("monday_installations: saved account_id=%s scope=%s", account_id, scope)
+
+
+async def get_token_for_account(account_id: str) -> str | None:
+    """Return the stored access_token for an installing account, or
+    None if not installed (or revoked, or DB unavailable)."""
+    if not account_id:
+        return None
+    sql = """
+        SELECT access_token, revoked_at
+          FROM monday_installations
+         WHERE account_id = %s
+         LIMIT 1
+    """
+    try:
+        row = await db.fetch_one(sql, (account_id,))
+    except db.DBUnavailable:
+        return None
+    except Exception:
+        logger.exception("get_token_for_account: lookup failed for %s", account_id)
+        return None
+    if not row:
+        return None
+    if row[1] is not None:
+        return None
+    return str(row[0])
+
+
+async def mark_revoked(account_id: str) -> None:
+    """Mark an installation revoked. Triggered by 401 from Monday."""
+    if not account_id:
+        return
+    sql = "UPDATE monday_installations SET revoked_at = NOW() WHERE account_id = %s"
+    try:
+        await db.execute(sql, (account_id,))
+        logger.warning("monday_installations: marked revoked account_id=%s", account_id)
+    except Exception:
+        logger.exception("mark_revoked failed for %s", account_id)
+
+
+async def touch_last_seen(account_id: str) -> None:
+    """Bump last_seen_at — best-effort signal of an active install."""
+    if not account_id:
+        return
+    sql = "UPDATE monday_installations SET last_seen_at = NOW() WHERE account_id = %s"
+    try:
+        await db.execute(sql, (account_id,))
+    except Exception:
+        pass

--- a/mira-scan-monday/backend/oauth.py
+++ b/mira-scan-monday/backend/oauth.py
@@ -186,3 +186,28 @@ async def touch_last_seen(account_id: str) -> None:
         await db.execute(sql, (account_id,))
     except Exception:
         pass
+
+
+async def update_subscription_status(account_id: str, status: str) -> None:
+    """Record the latest subscription_status reported by a billing webhook.
+
+    Best-effort — DB failures are swallowed so we never 500 on a webhook
+    delivery and trigger needless monday retries.
+    """
+    if not account_id or not status:
+        return
+    sql = """
+        UPDATE monday_installations
+           SET subscription_status = %s,
+               last_seen_at        = NOW()
+         WHERE account_id = %s
+    """
+    try:
+        await db.execute(sql, (status, account_id))
+        logger.info(
+            "monday_installations: subscription_status=%s account_id=%s",
+            status,
+            account_id,
+        )
+    except Exception:
+        logger.exception("update_subscription_status failed for %s", account_id)

--- a/mira-scan-monday/backend/pyproject.toml
+++ b/mira-scan-monday/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mira-scan-backend"
-version = "0.1.0"
+version = "0.2.0"
 requires-python = ">=3.12"
 
 [tool.ruff]

--- a/mira-scan-monday/backend/requirements-dev.txt
+++ b/mira-scan-monday/backend/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Dev / test dependencies — NOT installed into the production runtime
+# image. Install separately in CI: pip install -r requirements-dev.txt
+# Run from mira-scan-monday/: python -m pytest backend/tests/ -v
+
+pytest>=8.3.0,<9.0.0
+pytest-asyncio>=0.24.0,<1.0.0

--- a/mira-scan-monday/backend/requirements.txt
+++ b/mira-scan-monday/backend/requirements.txt
@@ -4,3 +4,4 @@ httpx==0.27.2
 pydantic==2.9.2
 python-multipart==0.0.12
 psycopg[binary]==3.2.3
+pyjwt==2.10.0

--- a/mira-scan-monday/backend/session.py
+++ b/mira-scan-monday/backend/session.py
@@ -1,0 +1,88 @@
+"""Verify Monday's iframe sessionToken to extract `account_id` server-side.
+
+Monday's iframe SDK passes a short-lived JWT (signed with the app's
+client_secret) on every request from inside the iframe. The frontend
+already forwards it as `X-Monday-Session-Token` (see
+`frontend/src/lib/api.js`). This module verifies the signature and
+extracts the installing account id so we can stamp scan_queue rows
+with the right tenant.
+
+Standalone path (no Monday iframe context): no header → returns None,
+endpoints carry on without per-account scoping (KB lookups stay shared,
+queue rows store NULL tenant_id).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import jwt
+
+logger = logging.getLogger("mira-scan.session")
+
+# Monday signs sessionTokens with the app's OAuth client_secret. Using
+# MONDAY_SIGNING_SECRET as an explicit override lets ops rotate the JWT
+# secret independently of the OAuth client_secret if Monday ever splits
+# them — for now they're the same value.
+MONDAY_SIGNING_SECRET = os.getenv(
+    "MONDAY_SIGNING_SECRET",
+    os.getenv("MONDAY_OAUTH_CLIENT_SECRET", ""),
+)
+
+
+class SessionInvalid(RuntimeError):
+    pass
+
+
+def _signing_secret() -> str:
+    if not MONDAY_SIGNING_SECRET:
+        raise SessionInvalid("server signing secret not configured")
+    return MONDAY_SIGNING_SECRET
+
+
+def verify_session_token(token: str) -> dict[str, Any]:
+    """Decode + verify a Monday session token. Returns claims on success.
+
+    Raises SessionInvalid on any decode/signature/expiry failure.
+    """
+    if not token:
+        raise SessionInvalid("empty token")
+    try:
+        return jwt.decode(
+            token,
+            _signing_secret(),
+            algorithms=["HS256"],
+            options={"verify_aud": False},
+        )
+    except jwt.PyJWTError as exc:
+        raise SessionInvalid(f"jwt decode failed: {exc}") from exc
+
+
+def account_id_from_headers(headers: Any) -> str | None:
+    """Extract a verified `account_id` from request headers, or None.
+
+    Accepts FastAPI's `request.headers` (case-insensitive Mapping). Returns
+    None silently when:
+      - no `x-monday-session-token` header is present (standalone path)
+      - the token fails verification (logged at warning)
+    Never raises — multi-tenant scoping is best-effort by design.
+    """
+    raw = None
+    if hasattr(headers, "get"):
+        raw = headers.get("x-monday-session-token")
+    if not raw:
+        return None
+    try:
+        claims = verify_session_token(raw)
+    except SessionInvalid as exc:
+        logger.warning("session token rejected: %s", exc)
+        return None
+    aid = claims.get("aid")
+    if aid is None:
+        dat = claims.get("dat") or {}
+        aid = dat.get("account_id")
+    if aid is None:
+        return None
+    return str(aid)

--- a/mira-scan-monday/backend/tests/test_oauth.py
+++ b/mira-scan-monday/backend/tests/test_oauth.py
@@ -1,0 +1,76 @@
+"""Tests for OAuth helpers that don't require a live DB.
+
+Run from the `mira-scan-monday/` directory:
+
+    python -m pytest backend/tests/test_oauth.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+
+def _reload_oauth():
+    """Re-import the oauth module so it picks up monkey-patched env vars
+    (env is read at module-import time)."""
+    from backend import oauth as _oauth
+
+    return importlib.reload(_oauth)
+
+
+def test_install_url_includes_required_params(monkeypatch):
+    monkeypatch.setenv("MONDAY_OAUTH_CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("MONDAY_OAUTH_CLIENT_SECRET", "test-secret")
+    monkeypatch.setenv("MONDAY_OAUTH_REDIRECT_URI", "https://example.test/cb")
+    monkeypatch.setenv(
+        "MONDAY_OAUTH_SCOPES", "me:read boards:read boards:write"
+    )
+    oauth = _reload_oauth()
+
+    url = oauth.install_url(state="abc123")
+    parsed = urlparse(url)
+    qs = parse_qs(parsed.query)
+
+    assert parsed.netloc == "auth.monday.com"
+    assert parsed.path == "/oauth2/authorize"
+    assert qs["client_id"] == ["test-client-id"]
+    assert qs["redirect_uri"] == ["https://example.test/cb"]
+    assert qs["state"] == ["abc123"]
+    assert "boards:write" in qs["scope"][0]
+
+
+def test_install_url_generates_random_state_when_none(monkeypatch):
+    monkeypatch.setenv("MONDAY_OAUTH_CLIENT_ID", "x")
+    monkeypatch.setenv("MONDAY_OAUTH_CLIENT_SECRET", "y")
+    oauth = _reload_oauth()
+
+    url1 = oauth.install_url()
+    url2 = oauth.install_url()
+    state1 = parse_qs(urlparse(url1).query)["state"][0]
+    state2 = parse_qs(urlparse(url2).query)["state"][0]
+
+    assert state1 != state2
+    assert len(state1) >= 16  # secrets.token_urlsafe(24) is comfortably > 16
+
+
+def test_install_url_raises_when_unconfigured(monkeypatch):
+    monkeypatch.delenv("MONDAY_OAUTH_CLIENT_ID", raising=False)
+    monkeypatch.delenv("MONDAY_OAUTH_CLIENT_SECRET", raising=False)
+    oauth = _reload_oauth()
+
+    with pytest.raises(oauth.OAuthError):
+        oauth.install_url()
+
+
+def test_configured_flag(monkeypatch):
+    monkeypatch.setenv("MONDAY_OAUTH_CLIENT_ID", "x")
+    monkeypatch.setenv("MONDAY_OAUTH_CLIENT_SECRET", "y")
+    oauth = _reload_oauth()
+    assert oauth.configured() is True
+
+    monkeypatch.delenv("MONDAY_OAUTH_CLIENT_SECRET", raising=False)
+    oauth = _reload_oauth()
+    assert oauth.configured() is False

--- a/mira-scan-monday/backend/tests/test_session.py
+++ b/mira-scan-monday/backend/tests/test_session.py
@@ -1,0 +1,88 @@
+"""Tests for Monday sessionToken JWT verification."""
+
+from __future__ import annotations
+
+import importlib
+import time
+
+import jwt as pyjwt
+import pytest
+
+
+def _reload_session():
+    from backend import session as _session
+
+    return importlib.reload(_session)
+
+
+def _sign(claims: dict, secret: str = "test-secret") -> str:
+    return pyjwt.encode(claims, secret, algorithm="HS256")
+
+
+def test_verify_roundtrip(monkeypatch):
+    monkeypatch.setenv("MONDAY_SIGNING_SECRET", "test-secret")
+    session = _reload_session()
+
+    token = _sign({"aid": 12345, "uid": 999, "iat": int(time.time())})
+    claims = session.verify_session_token(token)
+    assert claims["aid"] == 12345
+
+
+def test_verify_rejects_bad_signature(monkeypatch):
+    monkeypatch.setenv("MONDAY_SIGNING_SECRET", "test-secret")
+    session = _reload_session()
+
+    token = _sign({"aid": 1}, secret="WRONG-SECRET")
+    with pytest.raises(session.SessionInvalid):
+        session.verify_session_token(token)
+
+
+def test_verify_rejects_empty(monkeypatch):
+    monkeypatch.setenv("MONDAY_SIGNING_SECRET", "test-secret")
+    session = _reload_session()
+    with pytest.raises(session.SessionInvalid):
+        session.verify_session_token("")
+
+
+def test_verify_rejects_when_no_secret(monkeypatch):
+    monkeypatch.delenv("MONDAY_SIGNING_SECRET", raising=False)
+    monkeypatch.delenv("MONDAY_OAUTH_CLIENT_SECRET", raising=False)
+    session = _reload_session()
+    token = _sign({"aid": 1})
+    with pytest.raises(session.SessionInvalid):
+        session.verify_session_token(token)
+
+
+def test_account_id_from_headers_no_token(monkeypatch):
+    monkeypatch.setenv("MONDAY_SIGNING_SECRET", "test-secret")
+    session = _reload_session()
+    # Standalone path — no header — returns None silently.
+    assert session.account_id_from_headers({}) is None
+
+
+def test_account_id_from_headers_extracts_aid(monkeypatch):
+    monkeypatch.setenv("MONDAY_SIGNING_SECRET", "test-secret")
+    session = _reload_session()
+
+    token = _sign({"aid": 42, "uid": 7})
+    aid = session.account_id_from_headers({"x-monday-session-token": token})
+    assert aid == "42"
+
+
+def test_account_id_falls_back_to_dat(monkeypatch):
+    """Some Monday tokens nest the account_id under `dat`."""
+    monkeypatch.setenv("MONDAY_SIGNING_SECRET", "test-secret")
+    session = _reload_session()
+
+    token = _sign({"dat": {"account_id": 7777, "user_id": 1}})
+    aid = session.account_id_from_headers({"x-monday-session-token": token})
+    assert aid == "7777"
+
+
+def test_account_id_returns_none_on_bad_signature(monkeypatch):
+    """Bad sig → None silently, never raises."""
+    monkeypatch.setenv("MONDAY_SIGNING_SECRET", "test-secret")
+    session = _reload_session()
+
+    token = _sign({"aid": 1}, secret="WRONG")
+    assert session.account_id_from_headers({"x-monday-session-token": token}) is None

--- a/mira-scan-monday/backend/tests/test_usage.py
+++ b/mira-scan-monday/backend/tests/test_usage.py
@@ -1,0 +1,63 @@
+"""Tests for usage helpers — fail-open behavior when DB is unavailable."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+
+def _reload_usage():
+    from backend import db as _db
+    from backend import usage as _usage
+
+    importlib.reload(_db)
+    return importlib.reload(_usage)
+
+
+def test_free_tier_cap_constant_set():
+    usage = _reload_usage()
+    assert usage.FREE_TIER_MONTHLY_CAP > 0
+    assert isinstance(usage.FREE_TIER_MONTHLY_CAP, int)
+
+
+def test_free_tier_cap_overridable_via_env(monkeypatch):
+    monkeypatch.setenv("MIRA_FREE_TIER_MONTHLY_CAP", "12345")
+    usage = _reload_usage()
+    assert usage.FREE_TIER_MONTHLY_CAP == 12345
+
+
+def test_month_scan_count_returns_zero_for_empty_account_id(monkeypatch):
+    monkeypatch.setenv("NEON_DATABASE_URL", "")  # also unavailable
+    usage = _reload_usage()
+    result = asyncio.run(usage.month_scan_count(""))
+    assert result == 0
+
+
+def test_month_scan_count_returns_zero_when_db_unavailable(monkeypatch):
+    monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+    usage = _reload_usage()
+    # DBUnavailable is raised internally and swallowed → 0 (fail-open).
+    # A real account_id with no DB should never lock out a user.
+    result = asyncio.run(usage.month_scan_count("99999"))
+    assert result == 0
+
+
+def test_bump_scan_count_no_op_when_db_unavailable(monkeypatch):
+    monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+    usage = _reload_usage()
+    # Should not raise even though DB is unreachable.
+    asyncio.run(usage.bump_scan_count("99999"))
+
+
+def test_today_scan_count_returns_zero_when_db_unavailable(monkeypatch):
+    monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+    usage = _reload_usage()
+    result = asyncio.run(usage.today_scan_count("99999"))
+    assert result == 0
+
+
+def test_days_summary_returns_empty_when_db_unavailable(monkeypatch):
+    monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+    usage = _reload_usage()
+    result = asyncio.run(usage.days_summary("99999", days=7))
+    assert result == []

--- a/mira-scan-monday/backend/tests/test_webhooks.py
+++ b/mira-scan-monday/backend/tests/test_webhooks.py
@@ -1,0 +1,195 @@
+"""Tests for the monday.com app-lifecycle webhook handler.
+
+These tests verify signature handling and event dispatch in isolation —
+they monkey-patch oauth's persistence helpers so no DB is required.
+
+Run from the `mira-scan-monday/` directory:
+
+    python -m pytest backend/tests/test_webhooks.py -v
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+import jwt as pyjwt
+import pytest
+
+
+def _reload_webhooks(monkeypatch, secret: str = "test-secret"):
+    """Reload the webhooks module after env tweaks. Returns (webhooks, oauth)."""
+    monkeypatch.setenv("MONDAY_WEBHOOK_SIGNING_SECRET", secret)
+    from backend import oauth as _oauth
+    from backend import webhooks as _webhooks
+
+    importlib.reload(_oauth)
+    return importlib.reload(_webhooks), _oauth
+
+
+def _sign(claims: dict, secret: str = "test-secret") -> str:
+    return pyjwt.encode(claims, secret, algorithm="HS256")
+
+
+def _stub_oauth(monkeypatch, oauth, *, existing_token: str | None = None):
+    """Replace oauth's DB-touching helpers with in-memory recorders."""
+    state: dict = {
+        "saved": [],
+        "revoked": [],
+        "subscription": [],
+        "touched": [],
+        "existing_token": existing_token,
+    }
+
+    async def _save_installation(**kwargs):
+        state["saved"].append(kwargs)
+
+    async def _mark_revoked(account_id):
+        state["revoked"].append(account_id)
+
+    async def _update_subscription_status(account_id, status):
+        state["subscription"].append((account_id, status))
+
+    async def _touch_last_seen(account_id):
+        state["touched"].append(account_id)
+
+    async def _get_token_for_account(account_id):
+        return state["existing_token"]
+
+    monkeypatch.setattr(oauth, "save_installation", _save_installation)
+    monkeypatch.setattr(oauth, "mark_revoked", _mark_revoked)
+    monkeypatch.setattr(oauth, "update_subscription_status", _update_subscription_status)
+    monkeypatch.setattr(oauth, "touch_last_seen", _touch_last_seen)
+    monkeypatch.setattr(oauth, "get_token_for_account", _get_token_for_account)
+    return state
+
+
+def test_install_event_records_install(monkeypatch):
+    webhooks, oauth = _reload_webhooks(monkeypatch)
+    state = _stub_oauth(monkeypatch, oauth)
+
+    auth = "Bearer " + _sign({"aid": 4242, "type": "install"})
+    body = {"type": "install", "data": {"account_id": 4242, "user_id": 99, "scope": "boards:read"}}
+
+    result = asyncio.run(
+        webhooks.handle_event(authorization_header=auth, body=body),
+    )
+
+    assert result["status"] == "ok"
+    assert result["account_id"] == "4242"
+    assert len(state["saved"]) == 1
+    assert state["saved"][0]["account_id"] == "4242"
+    assert state["saved"][0]["scope"] == "boards:read"
+    # No prior token → save_installation, NOT touch_last_seen
+    assert state["touched"] == []
+
+
+def test_install_event_idempotent_when_token_already_stored(monkeypatch):
+    """A second install delivery (or one fired after OAuth callback already
+    saved a real token) should NOT overwrite the access_token. It should
+    just bump last_seen_at."""
+    webhooks, oauth = _reload_webhooks(monkeypatch)
+    state = _stub_oauth(monkeypatch, oauth, existing_token="real-oauth-token-xyz")
+
+    auth = "Bearer " + _sign({"aid": 4242})
+    body = {"type": "install", "data": {"account_id": 4242, "user_id": 99}}
+
+    result = asyncio.run(
+        webhooks.handle_event(authorization_header=auth, body=body),
+    )
+
+    assert result["status"] == "ok"
+    assert state["saved"] == []  # never overwrites a real token
+    assert state["touched"] == ["4242"]
+
+
+def test_uninstall_event_marks_revoked(monkeypatch):
+    webhooks, oauth = _reload_webhooks(monkeypatch)
+    state = _stub_oauth(monkeypatch, oauth)
+
+    auth = "Bearer " + _sign({"aid": 7000})
+    body = {"type": "uninstall", "data": {"account_id": 7000}}
+
+    result = asyncio.run(
+        webhooks.handle_event(authorization_header=auth, body=body),
+    )
+
+    assert result["status"] == "ok"
+    assert state["revoked"] == ["7000"]
+
+
+def test_subscription_changed_records_status(monkeypatch):
+    webhooks, oauth = _reload_webhooks(monkeypatch)
+    state = _stub_oauth(monkeypatch, oauth)
+
+    auth = "Bearer " + _sign({"aid": 1234})
+    body = {
+        "type": "app_subscription_changed",
+        "data": {"account_id": 1234, "subscription": {"status": "active"}},
+    }
+
+    result = asyncio.run(
+        webhooks.handle_event(authorization_header=auth, body=body),
+    )
+
+    assert result["status"] == "ok"
+    assert result["subscription_status"] == "active"
+    assert state["subscription"] == [("1234", "active")]
+
+
+def test_bad_signature_raises(monkeypatch):
+    webhooks, oauth = _reload_webhooks(monkeypatch)
+    _stub_oauth(monkeypatch, oauth)
+
+    auth = "Bearer " + _sign({"aid": 1}, secret="WRONG-SECRET")
+    body = {"type": "install", "data": {"account_id": 1}}
+
+    with pytest.raises(webhooks.WebhookInvalid):
+        asyncio.run(webhooks.handle_event(authorization_header=auth, body=body))
+
+
+def test_missing_authorization_raises(monkeypatch):
+    webhooks, _ = _reload_webhooks(monkeypatch)
+
+    with pytest.raises(webhooks.WebhookInvalid):
+        asyncio.run(
+            webhooks.handle_event(
+                authorization_header=None,
+                body={"type": "install", "data": {"account_id": 1}},
+            )
+        )
+
+
+def test_unknown_event_type_is_ignored_not_raised(monkeypatch):
+    webhooks, oauth = _reload_webhooks(monkeypatch)
+    state = _stub_oauth(monkeypatch, oauth)
+
+    auth = "Bearer " + _sign({"aid": 9})
+    body = {"type": "future_event_we_dont_handle", "data": {"account_id": 9}}
+
+    result = asyncio.run(
+        webhooks.handle_event(authorization_header=auth, body=body),
+    )
+
+    assert result["status"] == "ignored"
+    assert result["reason"] == "unknown_type"
+    assert state["saved"] == []
+    assert state["revoked"] == []
+    assert state["subscription"] == []
+
+
+def test_account_id_falls_back_from_dat_or_body(monkeypatch):
+    """account_id can come from claim.aid, claim.dat.account_id, or body.data.account_id."""
+    webhooks, oauth = _reload_webhooks(monkeypatch)
+    state = _stub_oauth(monkeypatch, oauth)
+
+    # No `aid` claim — only nested `dat.account_id`
+    auth = "Bearer " + _sign({"dat": {"account_id": 5151}})
+    body = {"type": "uninstall", "data": {}}
+
+    result = asyncio.run(
+        webhooks.handle_event(authorization_header=auth, body=body),
+    )
+
+    assert result["status"] == "ok"
+    assert state["revoked"] == ["5151"]

--- a/mira-scan-monday/backend/usage.py
+++ b/mira-scan-monday/backend/usage.py
@@ -1,0 +1,90 @@
+"""Per-installation daily scan counters.
+
+Counts successful /scan/extract calls per Monday account_id per day.
+Used as the billing-tier signal — once we see a meaningful install
+volume, this gets wired into a free-tier cap (e.g. 50 scans/mo) with
+a softer paywall in the iframe.
+
+The counter is best-effort. If NeonDB is unavailable, bumps no-op
+silently — a scan flow must never fail because telemetry is offline.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from . import db
+
+logger = logging.getLogger("mira-scan.usage")
+
+
+async def bump_scan_count(account_id: str) -> None:
+    """Increment today's scan_count for an account. Best-effort no-op
+    on any failure (DB down, tenant unset, etc.)."""
+    if not account_id:
+        return
+    sql = """
+        INSERT INTO account_usage_daily
+            (account_id, usage_date, scan_count, last_seen_at)
+        VALUES (%s, CURRENT_DATE, 1, NOW())
+        ON CONFLICT (account_id, usage_date) DO UPDATE
+            SET scan_count   = account_usage_daily.scan_count + 1,
+                last_seen_at = NOW()
+    """
+    try:
+        await db.execute(sql, (account_id,))
+    except db.DBUnavailable:
+        return
+    except Exception:
+        logger.exception("usage.bump_scan_count failed for account_id=%s", account_id)
+
+
+async def today_scan_count(account_id: str) -> int:
+    """Return today's scan_count for an account, or 0 on miss/failure."""
+    if not account_id:
+        return 0
+    sql = """
+        SELECT scan_count FROM account_usage_daily
+         WHERE account_id = %s AND usage_date = CURRENT_DATE
+         LIMIT 1
+    """
+    try:
+        row = await db.fetch_one(sql, (account_id,))
+    except db.DBUnavailable:
+        return 0
+    except Exception:
+        logger.exception("usage.today_scan_count failed for account_id=%s", account_id)
+        return 0
+    return int(row[0]) if row else 0
+
+
+async def days_summary(account_id: str, days: int = 30) -> list[dict]:
+    """Return up to N most-recent days of scan_count for an account.
+
+    Empty list on no data or DB unavailable. Used by an admin dashboard
+    (not yet built) to show install activity over time.
+    """
+    if not account_id:
+        return []
+    sql = """
+        SELECT usage_date, scan_count, last_seen_at
+          FROM account_usage_daily
+         WHERE account_id = %s
+         ORDER BY usage_date DESC
+         LIMIT %s
+    """
+    try:
+        rows = await db.fetch_all(sql, (account_id, max(1, min(int(days), 365))))
+    except db.DBUnavailable:
+        return []
+    except Exception:
+        logger.exception("usage.days_summary failed for account_id=%s", account_id)
+        return []
+    return [
+        {
+            "usage_date": r[0].isoformat() if r[0] else None,
+            "scan_count": int(r[1]),
+            "last_seen_at": r[2].isoformat() if r[2] else None,
+        }
+        for r in rows
+    ]

--- a/mira-scan-monday/backend/usage.py
+++ b/mira-scan-monday/backend/usage.py
@@ -1,21 +1,32 @@
-"""Per-installation daily scan counters.
+"""Per-installation daily scan counters + free-tier quota gate.
 
-Counts successful /scan/extract calls per Monday account_id per day.
-Used as the billing-tier signal — once we see a meaningful install
-volume, this gets wired into a free-tier cap (e.g. 50 scans/mo) with
-a softer paywall in the iframe.
+Counts successful /scan/extract calls per Monday account_id per day,
+sums the trailing 30 days for the free-tier monthly cap, and exposes
+helpers for `/scan/extract` to gate on quota before burning an OpenAI
+Vision call on a request that's just going to 429.
 
 The counter is best-effort. If NeonDB is unavailable, bumps no-op
 silently — a scan flow must never fail because telemetry is offline.
+The quota gate is fail-open for the same reason: if `month_scan_count`
+can't reach the DB, callers should let the scan through rather than
+locking out a paying user because of an unrelated infra glitch.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 
 from . import db
 
 logger = logging.getLogger("mira-scan.usage")
+
+
+# Free-tier monthly cap. Scans beyond this for an authenticated install
+# return HTTP 429 from `/scan/extract` so the iframe can prompt "upgrade
+# to keep scanning." Set to a generous default — adjust via env once we
+# have real install-volume data.
+FREE_TIER_MONTHLY_CAP = int(os.getenv("MIRA_FREE_TIER_MONTHLY_CAP", "50"))
 
 
 async def bump_scan_count(account_id: str) -> None:
@@ -56,6 +67,33 @@ async def today_scan_count(account_id: str) -> int:
         logger.exception("usage.today_scan_count failed for account_id=%s", account_id)
         return 0
     return int(row[0]) if row else 0
+
+
+async def month_scan_count(account_id: str) -> int:
+    """Sum scan_count over the trailing 30 days for an account.
+
+    Used as the free-tier quota gate input. Returns 0 when account_id is
+    empty (standalone path), DB is unavailable, or the account has no
+    activity in the window. Never raises — the caller should fail-open
+    on a 0 from a real (non-empty) account_id rather than locking out
+    paying customers because telemetry is down.
+    """
+    if not account_id:
+        return 0
+    sql = """
+        SELECT COALESCE(SUM(scan_count), 0)::integer
+          FROM account_usage_daily
+         WHERE account_id = %s
+           AND usage_date >= CURRENT_DATE - INTERVAL '30 days'
+    """
+    try:
+        row = await db.fetch_one(sql, (account_id,))
+    except db.DBUnavailable:
+        return 0
+    except Exception:
+        logger.exception("usage.month_scan_count failed for account_id=%s", account_id)
+        return 0
+    return int(row[0]) if row and row[0] is not None else 0
 
 
 async def days_summary(account_id: str, days: int = 30) -> list[dict]:

--- a/mira-scan-monday/backend/webhooks.py
+++ b/mira-scan-monday/backend/webhooks.py
@@ -1,0 +1,214 @@
+"""monday.com app-lifecycle webhook handler.
+
+When a customer installs, uninstalls, or changes their subscription on
+the marketplace listing, monday.com POSTs a JWT-signed event to the
+webhook URL registered in the Developer Center → Build → Webhooks tab.
+
+This module verifies the JWT, parses the event, and updates the
+`monday_installations` row for that account. Verification mirrors
+`session.py:verify_session_token` — same algorithm (HS256), same key
+material (the app's OAuth client_secret) by default, with an explicit
+`MONDAY_WEBHOOK_SIGNING_SECRET` override if monday ever splits them.
+
+Supported event types:
+  - install                       → upsert row (idempotent on retry)
+  - uninstall                     → mark `revoked_at`
+  - app_subscription_created      → set `subscription_status`
+  - app_subscription_changed      → set `subscription_status`
+  - app_subscription_renewed      → set `subscription_status`
+  - app_subscription_cancelled    → set `subscription_status`
+
+Unknown event types are logged and accepted (200) so monday doesn't
+flag the webhook as failing during their backwards-compat changes.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import jwt
+
+from . import oauth
+
+logger = logging.getLogger("mira-scan.webhooks")
+
+# Monday signs lifecycle webhook deliveries with the app's OAuth
+# client_secret. We allow a dedicated MONDAY_WEBHOOK_SIGNING_SECRET to
+# override only if/when monday splits them — same fallback discipline as
+# session.MONDAY_SIGNING_SECRET.
+MONDAY_WEBHOOK_SIGNING_SECRET = os.getenv(
+    "MONDAY_WEBHOOK_SIGNING_SECRET",
+    os.getenv("MONDAY_OAUTH_CLIENT_SECRET", ""),
+)
+
+INSTALL_EVENTS = {"install", "app_installed"}
+UNINSTALL_EVENTS = {"uninstall", "app_uninstalled"}
+SUBSCRIPTION_EVENTS = {
+    "app_subscription_created",
+    "app_subscription_changed",
+    "app_subscription_renewed",
+    "app_subscription_cancelled",
+    "app_subscription_renewal_status_changed",
+}
+
+
+class WebhookInvalid(RuntimeError):
+    pass
+
+
+def _signing_secret() -> str:
+    if not MONDAY_WEBHOOK_SIGNING_SECRET:
+        raise WebhookInvalid("webhook signing secret not configured")
+    return MONDAY_WEBHOOK_SIGNING_SECRET
+
+
+def verify_webhook_jwt(authorization_header: str | None) -> dict[str, Any]:
+    """Decode + verify the Authorization JWT monday sends with each delivery.
+
+    Returns the JWT claims on success. Raises `WebhookInvalid` on any
+    decode/signature failure or empty header.
+    """
+    if not authorization_header:
+        raise WebhookInvalid("missing Authorization header")
+    token = authorization_header.strip()
+    if token.lower().startswith("bearer "):
+        token = token[7:].strip()
+    if not token:
+        raise WebhookInvalid("empty token")
+    try:
+        return jwt.decode(
+            token,
+            _signing_secret(),
+            algorithms=["HS256"],
+            options={"verify_aud": False},
+        )
+    except jwt.PyJWTError as exc:
+        raise WebhookInvalid(f"jwt decode failed: {exc}") from exc
+
+
+def _extract_account_id(claims: dict[str, Any], body: dict[str, Any]) -> str | None:
+    """Pull account_id out of either the JWT claims or the JSON body.
+
+    monday's payload format has shifted across docs revisions — sometimes
+    `aid` lives at the top level of the JWT, sometimes nested under `dat`,
+    sometimes only in the body's `data.account_id`. Check all of them.
+    """
+    aid = claims.get("aid")
+    if aid is None:
+        dat = claims.get("dat") or {}
+        aid = dat.get("account_id")
+    if aid is None and isinstance(body, dict):
+        data = body.get("data") or {}
+        aid = data.get("account_id") or body.get("account_id")
+    return str(aid) if aid is not None else None
+
+
+def _extract_event_type(claims: dict[str, Any], body: dict[str, Any]) -> str | None:
+    """Pull the event type out of body first, then JWT claims as fallback."""
+    if isinstance(body, dict):
+        t = body.get("type") or (body.get("data") or {}).get("type")
+        if t:
+            return str(t)
+    t = claims.get("type")
+    if t:
+        return str(t)
+    return None
+
+
+async def handle_event(
+    *,
+    authorization_header: str | None,
+    body: dict[str, Any],
+) -> dict[str, Any]:
+    """Verify and dispatch a single webhook delivery.
+
+    Returns a small dict for logging (`{"status": "ok", "type": "...", "account_id": "..."}`).
+    Raises `WebhookInvalid` on signature failure (caller maps to 401).
+    """
+    claims = verify_webhook_jwt(authorization_header)
+    event_type = _extract_event_type(claims, body)
+    account_id = _extract_account_id(claims, body)
+
+    if not event_type:
+        logger.warning("webhook: missing event type, claims=%s", claims)
+        return {"status": "ignored", "reason": "missing_type"}
+
+    if not account_id:
+        logger.warning("webhook: missing account_id for type=%s", event_type)
+        return {"status": "ignored", "reason": "missing_account_id", "type": event_type}
+
+    if event_type in INSTALL_EVENTS:
+        data = body.get("data") if isinstance(body, dict) else None
+        user_id = None
+        scope = ""
+        access_token = ""
+        if isinstance(data, dict):
+            user_id = data.get("user_id")
+            scope = data.get("scope") or ""
+        # Lifecycle webhooks don't carry an access_token — that arrives
+        # via the OAuth callback. The install event just records that an
+        # install happened. If we already have a token row from the
+        # callback, this becomes a touch_last_seen no-op.
+        existing_token = await oauth.get_token_for_account(account_id)
+        if existing_token:
+            await oauth.touch_last_seen(account_id)
+        else:
+            # First-touch from webhook before/without OAuth callback —
+            # save a placeholder row so we have an install record. The
+            # OAuth callback will overwrite access_token on first user click.
+            await oauth.save_installation(
+                account_id=account_id,
+                access_token=access_token or "",
+                scope=str(scope),
+                user_id=str(user_id) if user_id is not None else None,
+            )
+        logger.info("webhook: install account_id=%s", account_id)
+        return {"status": "ok", "type": event_type, "account_id": account_id}
+
+    if event_type in UNINSTALL_EVENTS:
+        await oauth.mark_revoked(account_id)
+        logger.info("webhook: uninstall account_id=%s", account_id)
+        return {"status": "ok", "type": event_type, "account_id": account_id}
+
+    if event_type in SUBSCRIPTION_EVENTS:
+        status = _subscription_status_from_event(event_type, body)
+        await oauth.update_subscription_status(account_id, status)
+        logger.info(
+            "webhook: %s account_id=%s status=%s",
+            event_type,
+            account_id,
+            status,
+        )
+        return {
+            "status": "ok",
+            "type": event_type,
+            "account_id": account_id,
+            "subscription_status": status,
+        }
+
+    logger.info("webhook: ignoring unknown event type=%s account_id=%s", event_type, account_id)
+    return {"status": "ignored", "reason": "unknown_type", "type": event_type}
+
+
+def _subscription_status_from_event(event_type: str, body: dict[str, Any]) -> str:
+    """Map a subscription event to a `subscription_status` string.
+
+    monday's payload includes the new plan/status under `data.subscription`
+    when available; we default to a plausible status per event_type when
+    it doesn't.
+    """
+    data = body.get("data") if isinstance(body, dict) else None
+    if isinstance(data, dict):
+        sub = data.get("subscription") or {}
+        status = sub.get("status") or sub.get("plan_id")
+        if status:
+            return str(status)
+    if event_type == "app_subscription_cancelled":
+        return "cancelled"
+    if event_type == "app_subscription_renewed":
+        return "active"
+    if event_type == "app_subscription_renewal_status_changed":
+        return "past_due"
+    return "active"

--- a/mira-scan-monday/docker-compose.yml
+++ b/mira-scan-monday/docker-compose.yml
@@ -3,13 +3,22 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
-    image: mira-scan-backend:0.1.0
+    image: mira-scan-backend:0.2.0
     container_name: mira-scan-backend
     restart: unless-stopped
     ports:
       - "127.0.0.1:8090:8000"
     env_file:
       - .env
+    environment:
+      # Per CLAUDE.md feedback_compose_env_plumbing.md: Doppler-managed
+      # secrets only reach the container when explicitly listed here.
+      # `doppler run -- docker compose up` interpolates these from the
+      # shell env at compose-up time. env_file (above) covers local dev
+      # where Mike hand-edits .env; this block covers production deploys.
+      MONDAY_OAUTH_CLIENT_ID: ${MONDAY_OAUTH_CLIENT_ID:-}
+      MONDAY_OAUTH_CLIENT_SECRET: ${MONDAY_OAUTH_CLIENT_SECRET:-}
+      MONDAY_WEBHOOK_SIGNING_SECRET: ${MONDAY_WEBHOOK_SIGNING_SECRET:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:

--- a/mira-scan-monday/frontend/package.json
+++ b/mira-scan-monday/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mira-scan-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/mira-scan-monday/frontend/src/components/ScanPanel.jsx
+++ b/mira-scan-monday/frontend/src/components/ScanPanel.jsx
@@ -1,28 +1,47 @@
 import { useRef, useState } from "react";
 import { Button } from "@vibe/core";
 import { fileToBase64 } from "../lib/image.js";
-import { scanExtract } from "../lib/api.js";
+import { ApiError, scanExtract } from "../lib/api.js";
+
+const SIGNUP_URL =
+  import.meta.env.VITE_FACTORYLM_SIGNUP_URL || "https://app.factorylm.com/signup";
 
 export default function ScanPanel({ sessionToken, onResult }) {
   const fileInputRef = useRef(null);
   const cameraInputRef = useRef(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(null);
+  const [quota, setQuota] = useState(null);
 
   const handleFile = async (file) => {
     if (!file) return;
     setBusy(true);
     setError(null);
+    setQuota(null);
     try {
       const { base64, mimeType } = await fileToBase64(file);
       const plate = await scanExtract(base64, mimeType, sessionToken);
       onResult?.(plate);
     } catch (err) {
-      setError(err.message || String(err));
+      if (err instanceof ApiError && err.status === 429) {
+        // FastAPI's HTTPException(detail={...}) wraps the dict under
+        // `detail` in the JSON response.
+        const detail = (err.body && err.body.detail) || err.body || {};
+        setQuota({
+          used: detail.used,
+          cap: detail.cap,
+          message: detail.message || "Monthly scan limit reached.",
+        });
+      } else {
+        setError(err.message || String(err));
+      }
     } finally {
       setBusy(false);
     }
   };
+
+  const overCap = quota !== null;
+  const upgradeHref = `${SIGNUP_URL}?utm=monday-scan-cap`;
 
   return (
     <div className="card">
@@ -34,14 +53,14 @@ export default function ScanPanel({ sessionToken, onResult }) {
       <div className="btn-row" style={{ marginTop: 12 }}>
         <Button
           onClick={() => cameraInputRef.current?.click()}
-          disabled={busy}
+          disabled={busy || overCap}
         >
           Scan plate
         </Button>
         <Button
           kind="secondary"
           onClick={() => fileInputRef.current?.click()}
-          disabled={busy}
+          disabled={busy || overCap}
         >
           Upload photo
         </Button>
@@ -60,7 +79,35 @@ export default function ScanPanel({ sessionToken, onResult }) {
         accept="image/*"
         onChange={(e) => handleFile(e.target.files?.[0])}
       />
-      {error && (
+      {overCap && (
+        <div
+          style={{
+            marginTop: 12,
+            padding: 12,
+            borderRadius: 6,
+            background: "var(--primary-background-hover-color, #f4f6ff)",
+            border: "1px solid var(--ui-border-color, #d0d4e4)",
+          }}
+        >
+          <p style={{ margin: 0, fontWeight: 600 }}>
+            {quota.message}
+          </p>
+          {Number.isFinite(quota.used) && Number.isFinite(quota.cap) && (
+            <p className="muted" style={{ margin: "4px 0 8px" }}>
+              {quota.used} of {quota.cap} scans used this month.
+            </p>
+          )}
+          <Button
+            kind="primary"
+            onClick={() =>
+              window.open(upgradeHref, "_blank", "noopener,noreferrer")
+            }
+          >
+            Get more scans
+          </Button>
+        </div>
+      )}
+      {error && !overCap && (
         <p style={{ color: "var(--negative-color, #d83a52)", marginTop: 8 }}>
           {error}
         </p>

--- a/mira-scan-monday/frontend/src/lib/api.js
+++ b/mira-scan-monday/frontend/src/lib/api.js
@@ -1,5 +1,14 @@
 const BASE = import.meta.env.VITE_API_BASE_URL || "";
 
+export class ApiError extends Error {
+  constructor(status, body, message) {
+    super(message || `${status}`);
+    this.name = "ApiError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
 async function jsonFetch(path, opts = {}, sessionToken) {
   const headers = {
     "Content-Type": "application/json",
@@ -10,7 +19,13 @@ async function jsonFetch(path, opts = {}, sessionToken) {
   const resp = await fetch(`${BASE}${path}`, { ...opts, headers });
   if (!resp.ok) {
     const text = await resp.text();
-    throw new Error(`${resp.status}: ${text}`);
+    let body = null;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = { detail: text };
+    }
+    throw new ApiError(resp.status, body, `${resp.status}: ${text}`);
   }
   return resp.json();
 }

--- a/mira-scan-monday/frontend/src/lib/monday.js
+++ b/mira-scan-monday/frontend/src/lib/monday.js
@@ -16,4 +16,21 @@ export async function getMondayContext() {
   }
 }
 
+/**
+ * Send the user through the OAuth install flow. Call this when the
+ * backend returns `reinstall_required:` in an error message — the
+ * stored access_token has been revoked and we need fresh consent.
+ *
+ * Inside an iframe we redirect the top window so Monday's consent
+ * screen renders full-page instead of inside the embed.
+ */
+export function redirectToInstall(apiBaseUrl) {
+  const installUrl = `${apiBaseUrl || ""}/oauth/monday/install`;
+  if (window.top && window.top !== window) {
+    window.top.location.href = installUrl;
+  } else {
+    window.location.href = installUrl;
+  }
+}
+
 export default monday;

--- a/mira-web/src/lib/components.ts
+++ b/mira-web/src/lib/components.ts
@@ -96,7 +96,7 @@ export function stopCard(headline: string, body: string, ctas: StopCta[]): strin
     })
     .join("\n    ");
   return `<div class="fl-stop-card" role="alert">
-  <h4>${safeHeadline}</h4>
+  <h3>${safeHeadline}</h3>
   <p>${body}</p>
   <div class="fl-stop-cta">
     ${ctaHtml}

--- a/mira-web/src/server.ts
+++ b/mira-web/src/server.ts
@@ -1650,6 +1650,42 @@ app.get("/api/connect/status", requireActive, async (c) => {
 });
 
 // ---------------------------------------------------------------------------
+// 404 — custom page with home link (CRA-109)
+// ---------------------------------------------------------------------------
+
+app.notFound((c) => {
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Page not found — FactoryLM</title>
+  <link rel="stylesheet" href="/_tokens.css">
+  <link rel="stylesheet" href="/_dark-theme.css">
+  <style>
+    body { min-height: 100vh; display: flex; align-items: center; justify-content: center;
+           background: var(--fl-bg-50); margin: 0; font-family: system-ui, sans-serif; }
+    .wrap { text-align: center; padding: 2rem; }
+    .code { font-size: 5rem; font-weight: 700; color: var(--fl-navy-900); margin: 0; }
+    .msg  { color: var(--fl-muted-600); font-size: 1.125rem; margin: 0.5rem 0 2rem; }
+    .home { display: inline-block; padding: 0.75rem 1.5rem; border-radius: 0.5rem;
+            background: var(--fl-navy-900); color: #fff; text-decoration: none;
+            font-weight: 600; font-size: 0.9375rem; }
+    .home:hover { opacity: 0.85; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <p class="code">404</p>
+    <p class="msg">This page doesn't exist.</p>
+    <a class="home" href="/">Back to home</a>
+  </div>
+</body>
+</html>`;
+  return c.html(html, 404);
+});
+
+// ---------------------------------------------------------------------------
 // Startup
 // ---------------------------------------------------------------------------
 

--- a/mira-web/src/views/cmms.ts
+++ b/mira-web/src/views/cmms.ts
@@ -330,6 +330,25 @@ export function renderCmms(reqUrl?: string): string {
       description:
         "Send yourself a one-time sign-in link. No password, no demo call, no credit card. Upload your first manual and ask MIRA a question.",
       canonical: "https://factorylm.com/cmms",
+      jsonLd: {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "@id": "https://factorylm.com/cmms#app",
+        name: "FactoryLM CMMS",
+        applicationCategory: "BusinessApplication",
+        operatingSystem: "Web",
+        url: "https://factorylm.com/cmms",
+        description: "AI-powered CMMS for industrial maintenance. Work orders, PM scheduling, asset registry, and MIRA AI answers from cited OEM documentation.",
+        offers: {
+          "@type": "Offer",
+          name: "MIRA Troubleshooter",
+          price: "97",
+          priceCurrency: "USD",
+          priceSpecification: { "@type": "UnitPriceSpecification", unitText: "per plant per month" },
+          url: "https://factorylm.com/pricing",
+        },
+        publisher: { "@id": "https://factorylm.com/#org" },
+      },
     },
     reqUrl
   );

--- a/nginx-oracle.conf
+++ b/nginx-oracle.conf
@@ -164,7 +164,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    listen 443 ssl; # managed by Certbot
+    listen 443 ssl http2; # managed by Certbot
     ssl_certificate /etc/letsencrypt/live/app.factorylm.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/app.factorylm.com/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;

--- a/tools/monday-marketplace-setup/.gitignore
+++ b/tools/monday-marketplace-setup/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+runs/
+playwright-report/
+.chrome-profile/
+*.log

--- a/tools/monday-marketplace-setup/README.md
+++ b/tools/monday-marketplace-setup/README.md
@@ -1,0 +1,98 @@
+# MIRA Scan — monday.com marketplace setup (hybrid)
+
+Walks the four Build-tab sections in monday.com's Developer Center for
+the self-hosted MIRA Scan app, captures the generated OAuth + webhook
+secrets, and pipes them straight into Doppler `factorylm/prd`.
+
+## Why "hybrid"?
+
+monday.com's Developer Center exposes **no API** for self-hosted-app
+configuration — `@mondaycom/apps-cli` (`mapps`) only handles
+`code:push`/`env:set`/`tunnel:create` for monday-*hosted* apps. So the
+form-fill itself has to happen in a browser.
+
+Initial design tried to drive Chrome via Playwright. **Microsoft
+Defender on this Windows host blocks Playwright's CDP transports** —
+both the default Pipe transport (verified earlier, see memory
+`feedback_playwright_windows_chrome_screenshot.md`) and `connectOverCDP`
+against an externally-launched Chrome (verified 2026-05-05, memory
+`feedback_playwright_windows_cdp_websocket_blocked.md`). Pre-flight all
+green, Chrome's `/json/version` returns OK, but the websocket-upgrade to
+`ws://localhost:9222/devtools/browser/<id>` times out at 30s.
+
+So the script is hybrid: **everything programmable is automated**;
+**only the browser form-fill is manual** (1-3 minutes per section).
+
+## What's automated vs. manual
+
+| Step | Who |
+|---|---|
+| Pre-flight (bun + Doppler auth + healthz) | Script |
+| Compute the exact values for each section | Script |
+| Open Developer Center in your default browser | Script |
+| Click + fill + save each section | You (Mike) |
+| Capture generated OAuth client_id, client_secret, signing secret | You paste; script handles |
+| Pipe secrets to Doppler `factorylm/prd` via stdin (no disk, no stdout, no shell history) | Script |
+| Verify all three Doppler secrets are set | Script |
+
+## Prerequisites
+
+1. **bun 1.x** in PATH (`bun --version`)
+2. **doppler CLI** authenticated to `factorylm/prd`
+   (`doppler secrets --only-names --project factorylm --config prd`)
+3. `https://app.factorylm.com/scan/healthz` returning **200**
+
+## Run
+
+```powershell
+cd tools/monday-marketplace-setup
+bun install
+bun setup.ts
+```
+
+Modes:
+
+| Flag | Behavior |
+|---|---|
+| (default) | live mode; writes secrets to Doppler |
+| `--dry-run` | walks every step but skips Doppler writes |
+
+## What it does, step by step
+
+1. **Pre-flight**: refuses to run unless bun, Doppler, and the live
+   `/scan/healthz` are all green.
+2. **Opens Developer Center** in your default browser via `start chrome`
+   (no automation control).
+3. **Walks four sections** in order, each prompting you when ready:
+   - **Features** → Item view, iframe URL `https://app.factorylm.com/scan/`
+   - **OAuth** → redirect URI `https://app.factorylm.com/oauth/monday/callback`, scopes `me:read boards:read boards:write`, then prompts for the generated Client ID + Client Secret
+   - **Webhooks** → URL `https://app.factorylm.com/monday/webhook`, events install / uninstall / app_subscription_*, then prompts for the signing secret if monday shows one
+   - **App Onboarding** → recommend skip / leave blank
+4. **Pipes each secret** straight into `doppler secrets set <NAME>` via
+   stdin. Never echoes the value, never writes to a file, never enters
+   shell history.
+5. **Verifies** each Doppler secret by reading back its **length**
+   (never the value).
+
+## After running
+
+1. Confirm the three Doppler secrets are set:
+   ```
+   doppler secrets get MONDAY_OAUTH_CLIENT_ID MONDAY_OAUTH_CLIENT_SECRET MONDAY_WEBHOOK_SIGNING_SECRET --project factorylm --config prd --plain
+   ```
+2. Redeploy mira-scan-monday so the new env reaches the container:
+   ```
+   ssh root@165.245.138.91 "cd /opt/mira/mira-scan-monday && doppler run --project factorylm --config prd -- docker compose up -d --force-recreate"
+   ```
+3. Test the install round-trip from a non-Mike monday workspace and
+   confirm a row appears in `monday_installations` with the new
+   account_id (per the verification section of the active plan in
+   `~/.claude/plans/dev-api-key-for-optimized-badger.md`).
+
+## What this does NOT do
+
+- Submit the app to the marketplace (separate manual step in the
+  Developer Center after listing artifacts are ready)
+- Configure billing (Phase 1 ships with no in-app paywall — see active
+  plan)
+- Modify the running container (you redeploy yourself per step 2 above)

--- a/tools/monday-marketplace-setup/bun.lock
+++ b/tools/monday-marketplace-setup/bun.lock
@@ -6,12 +6,19 @@
       "name": "mira-monday-marketplace-setup",
       "devDependencies": {
         "@types/node": "20.12.7",
+        "playwright": "^1.59.1",
         "typescript": "5.4.5",
       },
     },
   },
   "packages": {
     "@types/node": ["@types/node@20.12.7", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "typescript": ["typescript@5.4.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="],
 

--- a/tools/monday-marketplace-setup/bun.lock
+++ b/tools/monday-marketplace-setup/bun.lock
@@ -1,0 +1,20 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "mira-monday-marketplace-setup",
+      "devDependencies": {
+        "@types/node": "20.12.7",
+        "typescript": "5.4.5",
+      },
+    },
+  },
+  "packages": {
+    "@types/node": ["@types/node@20.12.7", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg=="],
+
+    "typescript": ["typescript@5.4.5", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ=="],
+
+    "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+  }
+}

--- a/tools/monday-marketplace-setup/package.json
+++ b/tools/monday-marketplace-setup/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mira-monday-marketplace-setup",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Hybrid driver for monday.com Developer Center (Build tab) configuration of the MIRA Scan marketplace app. Walks the four sections, prints the exact values to enter, captures OAuth + webhook secrets via stdin, and pipes them into Doppler factorylm/prd. Browser automation NOT used — Defender on this Windows host blocks Playwright's CDP transports (see memory feedback_playwright_windows_cdp_websocket_blocked).",
+  "type": "module",
+  "scripts": {
+    "setup": "bun setup.ts",
+    "dry-run": "bun setup.ts --dry-run",
+    "typecheck": "bunx tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "typescript": "5.4.5"
+  }
+}

--- a/tools/monday-marketplace-setup/package.json
+++ b/tools/monday-marketplace-setup/package.json
@@ -1,17 +1,19 @@
 {
   "name": "mira-monday-marketplace-setup",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
-  "description": "Hybrid driver for monday.com Developer Center (Build tab) configuration of the MIRA Scan marketplace app. Walks the four sections, prints the exact values to enter, captures OAuth + webhook secrets via stdin, and pipes them into Doppler factorylm/prd. Browser automation NOT used — Defender on this Windows host blocks Playwright's CDP transports (see memory feedback_playwright_windows_cdp_websocket_blocked).",
+  "description": "Monday.com Developer Center configuration driver for MIRA Scan. Connects to Chrome via CDP and auto-fills all four Build-tab sections (Features, OAuth, Webhooks, App Onboarding), scrapes generated credentials, and writes them to Doppler factorylm/prd. Falls back to hybrid manual-assist mode if CDP is unavailable.",
   "type": "module",
   "scripts": {
     "setup": "bun setup.ts",
     "dry-run": "bun setup.ts --dry-run",
+    "hybrid": "bun setup.ts --hybrid",
     "typecheck": "bunx tsc --noEmit"
   },
   "dependencies": {},
   "devDependencies": {
     "@types/node": "20.12.7",
+    "playwright": "^1.59.1",
     "typescript": "5.4.5"
   }
 }

--- a/tools/monday-marketplace-setup/setup.ts
+++ b/tools/monday-marketplace-setup/setup.ts
@@ -1,0 +1,356 @@
+/**
+ * MIRA Scan — monday.com marketplace configuration driver (hybrid).
+ *
+ * The four Build-tab sections (Features, OAuth, Webhooks, App Onboarding)
+ * of the Developer Center for our self-hosted app are configured via a
+ * web UI; there is NO API or CLI for self-hosted-app config.
+ *
+ * Initial design tried to drive Chrome via Playwright (`connectOverCDP`)
+ * but Microsoft Defender on this Windows host blocks the websocket-CDP
+ * handshake (see `feedback_playwright_windows_cdp_websocket_blocked.md`
+ * in memory). So this script is a HYBRID:
+ *
+ *   - We do all the programmable parts: pre-flight, value generation,
+ *     secret capture into Doppler, end-to-end verification.
+ *   - You do the actual click + form-fill in monday's Developer Center
+ *     (1-3 minutes per section).
+ *   - Generated secrets go straight from your paste-in to Doppler via
+ *     stdin — never disk, never stdout, never shell history.
+ *
+ * USAGE
+ *   bun setup.ts              # default mode
+ *   bun setup.ts --dry-run    # walk through; skip Doppler writes
+ *
+ * REQUIREMENTS
+ *   - bun 1.x
+ *   - doppler CLI authenticated to factorylm/prd
+ *   - app.factorylm.com/scan/healthz returning 200
+ */
+
+import { spawn, spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as readline from "node:readline";
+
+// ── Configuration ────────────────────────────────────────────────────────
+
+const APP_FACTORYLM_HEALTH = "https://app.factorylm.com/scan/healthz";
+const DEVELOPER_HOME = "https://developer.monday.com";
+
+const VALUES = {
+  iframeUrl: "https://app.factorylm.com/scan/",
+  redirectUri: "https://app.factorylm.com/oauth/monday/callback",
+  scopes: "me:read boards:read boards:write",
+  webhookUrl: "https://app.factorylm.com/monday/webhook",
+  webhookEvents: [
+    "install",
+    "uninstall",
+    "app_subscription_created",
+    "app_subscription_changed",
+    "app_subscription_cancelled",
+  ],
+  onboardingMessage:
+    "Open any item, then click MIRA Scan in the right panel to capture an asset photo.",
+};
+
+// bun exposes import.meta.dir; fall back to deriving from import.meta.url for tsc-checks.
+const SCRIPT_DIR =
+  (import.meta as any).dir ??
+  path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
+const RUNS_DIR = path.join(SCRIPT_DIR, "runs");
+
+// ── Mode flags ───────────────────────────────────────────────────────────
+
+const argv = process.argv.slice(2);
+const DRY_RUN = argv.includes("--dry-run");
+
+// ── Tiny helpers ─────────────────────────────────────────────────────────
+
+const COLOR = {
+  reset: "\x1b[0m",
+  cyan: "\x1b[36m",
+  yellow: "\x1b[33m",
+  green: "\x1b[32m",
+  red: "\x1b[31m",
+  dim: "\x1b[2m",
+  bold: "\x1b[1m",
+};
+
+function log(msg: string, color: keyof typeof COLOR = "reset"): void {
+  process.stdout.write(`${COLOR[color]}${msg}${COLOR.reset}\n`);
+}
+
+function fail(msg: string): never {
+  log(msg, "red");
+  process.exit(1);
+}
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+
+function ask(question: string): Promise<string> {
+  return new Promise((resolve) => rl.question(question, resolve));
+}
+
+// ── Pre-flight ───────────────────────────────────────────────────────────
+
+function bunVersionOk(): boolean {
+  const r = spawnSync("bun", ["--version"], { encoding: "utf8", shell: true });
+  return r.status === 0 && /^\d+\./.test(r.stdout.trim());
+}
+
+function dopplerAuthOk(): boolean {
+  const r = spawnSync(
+    "doppler",
+    ["secrets", "--only-names", "--project", "factorylm", "--config", "prd"],
+    { encoding: "utf8", shell: true, stdio: ["ignore", "pipe", "pipe"] },
+  );
+  return r.status === 0;
+}
+
+async function appHealthOk(): Promise<boolean> {
+  try {
+    const resp = await fetch(APP_FACTORYLM_HEALTH, { method: "GET" });
+    return resp.ok;
+  } catch {
+    return false;
+  }
+}
+
+async function preflight(): Promise<void> {
+  log("Pre-flight checks…", "cyan");
+
+  if (!bunVersionOk()) fail("bun 1.x not found in PATH.");
+  log("  bun: ok", "dim");
+
+  if (!dopplerAuthOk())
+    fail("doppler CLI not authenticated to factorylm/prd. Run `doppler login` and `doppler setup`.");
+  log("  doppler factorylm/prd: ok", "dim");
+
+  if (!(await appHealthOk()))
+    fail(
+      `${APP_FACTORYLM_HEALTH} is NOT 200. The OAuth/webhook URLs we register would point at a dead service. Aborting.`,
+    );
+  log("  app.factorylm.com/scan/healthz: 200 (ok)", "dim");
+
+  fs.mkdirSync(RUNS_DIR, { recursive: true });
+}
+
+// ── Browser open (no automation control) ─────────────────────────────────
+
+function openBrowser(url: string): void {
+  // Windows: `start "" "<url>"` opens in the default browser.
+  // We don't try to control it — Defender on this host blocks Playwright
+  // CDP transports (see feedback_playwright_windows_cdp_websocket_blocked).
+  log(`\nOpening ${url} in your default browser…`, "cyan");
+  spawn("cmd.exe", ["/c", "start", "", url], { detached: true, stdio: "ignore" }).unref();
+}
+
+// ── Doppler write helper (never logs the value) ──────────────────────────
+
+function dopplerSet(name: string, value: string): boolean {
+  if (DRY_RUN) {
+    log(`  [dry-run] would set ${name} (length=${value.length})`, "dim");
+    return true;
+  }
+  if (!value) {
+    log(`  skip: ${name} is empty (nothing to write)`, "yellow");
+    return false;
+  }
+  const r = spawnSync(
+    "doppler",
+    ["secrets", "set", name, "--project", "factorylm", "--config", "prd"],
+    { input: value, shell: true, stdio: ["pipe", "pipe", "pipe"], encoding: "utf8" },
+  );
+  if (r.status !== 0) {
+    log(`  doppler set ${name}: FAILED — ${r.stderr.split("\n")[0]}`, "red");
+    return false;
+  }
+  // Verify by reading back length only — never echo the value.
+  const verify = spawnSync(
+    "doppler",
+    ["secrets", "get", name, "--project", "factorylm", "--config", "prd", "--plain"],
+    { shell: true, encoding: "utf8" },
+  );
+  const ok = verify.status === 0 && verify.stdout.trim().length > 0;
+  log(
+    ok
+      ? `  doppler ${name}: stored (length=${verify.stdout.trim().length})`
+      : `  doppler ${name}: write OK but verify FAILED`,
+    ok ? "green" : "red",
+  );
+  return ok;
+}
+
+// ── Section walkthroughs ─────────────────────────────────────────────────
+
+function printValueBlock(title: string, lines: string[]): void {
+  log(`\n${"─".repeat(60)}`, "dim");
+  log(title, "bold");
+  log(`${"─".repeat(60)}`, "dim");
+  for (const line of lines) log(`  ${line}`);
+  log(`${"─".repeat(60)}\n`, "dim");
+}
+
+async function section1Features(): Promise<void> {
+  log("\n[1/4] Features → Item view", "cyan");
+  printValueBlock("Enter these values in: Build → Features", [
+    "Click 'Add new feature' → choose 'Item view'",
+    "",
+    `iframe URL:     ${VALUES.iframeUrl}`,
+    "Mobile compat:  yes",
+    "",
+    "Click Save.",
+    "(Skip Board view, Dashboard widget, Workspace template — Item view",
+    " is the wedge for this app.)",
+  ]);
+  await ask(`${COLOR.yellow}When the Features → Item view section is saved, press Enter…${COLOR.reset} `);
+  log("  ✓ Features marked done.", "green");
+}
+
+async function section2OAuth(): Promise<void> {
+  log("\n[2/4] OAuth → redirect URI + scopes + capture credentials", "cyan");
+  printValueBlock("Enter these values in: Build → OAuth", [
+    `Redirect URI:   ${VALUES.redirectUri}`,
+    `Scopes:         ${VALUES.scopes}`,
+    "",
+    "Click Save.",
+    "monday will reveal Client ID and Client Secret on the same screen.",
+  ]);
+  await ask(`${COLOR.yellow}When OAuth is saved and the credentials are visible, press Enter…${COLOR.reset} `);
+
+  log(
+    "\nPaste the values below. They go straight into Doppler factorylm/prd via stdin —",
+    "dim",
+  );
+  log("never echoed back, never written to disk, never put in shell history.", "dim");
+
+  const clientId = (await ask(`  Client ID: `)).trim();
+  const clientSecret = (await ask(`  Client Secret: `)).trim();
+
+  if (!clientId || !clientSecret) {
+    log("  skipping Doppler write — empty values pasted", "yellow");
+    return;
+  }
+  dopplerSet("MONDAY_OAUTH_CLIENT_ID", clientId);
+  dopplerSet("MONDAY_OAUTH_CLIENT_SECRET", clientSecret);
+}
+
+async function section3Webhooks(): Promise<void> {
+  log("\n[3/4] Webhooks → URL + lifecycle events + capture signing secret", "cyan");
+  printValueBlock("Enter these values in: Build → Webhooks", [
+    `Webhook URL:    ${VALUES.webhookUrl}`,
+    `Subscribe to:   ${VALUES.webhookEvents.join(", ")}`,
+    "",
+    "Click Save.",
+    "monday will reveal a Signing Secret on the same screen.",
+    "",
+    "Note: monday may NOT show a separate signing secret — some app",
+    "shapes use the OAuth client_secret to sign lifecycle deliveries.",
+    "If there's no signing-secret field shown, just press Enter at the",
+    "prompt below; the backend falls back to MONDAY_OAUTH_CLIENT_SECRET.",
+  ]);
+  await ask(`${COLOR.yellow}When Webhooks is saved, press Enter…${COLOR.reset} `);
+
+  const secret = (await ask(`  Webhook Signing Secret (or empty if not shown): `)).trim();
+  if (!secret) {
+    log("  no separate signing secret — backend will fall back to MONDAY_OAUTH_CLIENT_SECRET", "dim");
+    return;
+  }
+  dopplerSet("MONDAY_WEBHOOK_SIGNING_SECRET", secret);
+}
+
+async function section4Onboarding(): Promise<void> {
+  log("\n[4/4] App Onboarding → minimal welcome (or skip)", "cyan");
+  printValueBlock("Enter this in: Build → App Onboarding", [
+    "Recommendation: leave blank if optional. The product is",
+    "self-explanatory (camera button → AI extraction).",
+    "",
+    "If a non-empty value is required, paste this welcome message:",
+    "",
+    `  ${VALUES.onboardingMessage}`,
+    "",
+    "Click Save.",
+  ]);
+  await ask(`${COLOR.yellow}When App Onboarding is saved (or skipped), press Enter…${COLOR.reset} `);
+  log("  ✓ All four sections walked.", "green");
+}
+
+// ── Final verification ────────────────────────────────────────────────────
+
+function verifyDoppler(): boolean {
+  log("\nDoppler verification:", "cyan");
+  let allOk = true;
+  for (const name of [
+    "MONDAY_OAUTH_CLIENT_ID",
+    "MONDAY_OAUTH_CLIENT_SECRET",
+    "MONDAY_WEBHOOK_SIGNING_SECRET",
+  ]) {
+    const r = spawnSync(
+      "doppler",
+      ["secrets", "get", name, "--project", "factorylm", "--config", "prd", "--plain"],
+      { shell: true, encoding: "utf8" },
+    );
+    const len = r.status === 0 ? r.stdout.trim().length : 0;
+    const ok = len > 0;
+    log(`  ${name}: ${ok ? `set (length=${len})` : "MISSING"}`, ok ? "green" : "red");
+    // Webhook signing secret is optional — backend falls back to client_secret.
+    if (!ok && name !== "MONDAY_WEBHOOK_SIGNING_SECRET") allOk = false;
+  }
+  return allOk;
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  log("MIRA Scan — monday.com marketplace setup (hybrid)", "cyan");
+  log(`  mode: ${DRY_RUN ? "dry-run" : "live"}`, "dim");
+
+  await preflight();
+
+  log("\nThis script will:", "cyan");
+  log("  1. Open developer.monday.com in your default browser", "dim");
+  log("  2. Print the exact values for each Build-tab section", "dim");
+  log("  3. Wait for you to save each section", "dim");
+  log("  4. Pipe generated OAuth + webhook secrets straight into Doppler", "dim");
+  log("  5. Verify the three Doppler secrets at the end", "dim");
+  log(
+    "\nWhy not full automation? Microsoft Defender on this Windows host blocks",
+    "dim",
+  );
+  log(
+    "Playwright's CDP transports — see memory feedback_playwright_windows_cdp_*.md",
+    "dim",
+  );
+  log("for the rationale. Hybrid is the reliable path on this machine.", "dim");
+
+  await ask(`\n${COLOR.yellow}Press Enter to open the Developer Center and begin…${COLOR.reset} `);
+
+  openBrowser(DEVELOPER_HOME);
+  log("(Sign in to monday.com if prompted, then navigate to your MIRA Scan app's Build tab.)", "dim");
+
+  await section1Features();
+  await section2OAuth();
+  await section3Webhooks();
+  await section4Onboarding();
+
+  const ok = verifyDoppler();
+
+  log("\nNext steps:", "cyan");
+  log("  1. Update mira-scan-monday/docker-compose.yml has been done (env block).", "dim");
+  log("  2. Merge the open PR for the webhook + 429 + setup script.", "dim");
+  log("  3. Redeploy mira-scan-monday on the VPS so new env reaches the container:", "dim");
+  log(
+    "     ssh root@165.245.138.91 'cd /opt/mira/mira-scan-monday && doppler run --project factorylm --config prd -- docker compose up -d --force-recreate'",
+    "dim",
+  );
+  log("  4. Test install round-trip from a non-Mike monday workspace.", "dim");
+
+  rl.close();
+  process.exit(ok ? 0 : 1);
+}
+
+main().catch((err) => {
+  log(`\nFatal: ${err?.message || err}`, "red");
+  rl.close();
+  process.exit(2);
+});

--- a/tools/monday-marketplace-setup/setup.ts
+++ b/tools/monday-marketplace-setup/setup.ts
@@ -1,41 +1,45 @@
 /**
- * MIRA Scan — monday.com marketplace configuration driver (hybrid).
+ * MIRA Scan — monday.com marketplace configuration driver.
  *
  * The four Build-tab sections (Features, OAuth, Webhooks, App Onboarding)
  * of the Developer Center for our self-hosted app are configured via a
  * web UI; there is NO API or CLI for self-hosted-app config.
  *
- * Initial design tried to drive Chrome via Playwright (`connectOverCDP`)
- * but Microsoft Defender on this Windows host blocks the websocket-CDP
- * handshake (see `feedback_playwright_windows_cdp_websocket_blocked.md`
- * in memory). So this script is a HYBRID:
+ * AUTOMATION MODE (macOS, default)
+ *   Connects to an existing Chrome via CDP on localhost:9222 and auto-fills
+ *   all four sections. Chrome must be launched with:
+ *     open -a "Google Chrome" --args --remote-debugging-port=9222
+ *   then navigate to developer.monday.com and sign in.
  *
- *   - We do all the programmable parts: pre-flight, value generation,
- *     secret capture into Doppler, end-to-end verification.
- *   - You do the actual click + form-fill in monday's Developer Center
- *     (1-3 minutes per section).
- *   - Generated secrets go straight from your paste-in to Doppler via
- *     stdin — never disk, never stdout, never shell history.
+ * HYBRID FALLBACK
+ *   If CDP connection fails (Chrome not listening, or on Windows where
+ *   Defender blocks the CDP websocket handshake), falls back to the
+ *   original manual-assist mode: prints exact values, waits for you to
+ *   fill each section, captures secrets via stdin → Doppler.
  *
  * USAGE
- *   bun setup.ts              # default mode
+ *   bun setup.ts              # default mode (automation → hybrid fallback)
  *   bun setup.ts --dry-run    # walk through; skip Doppler writes
+ *   bun setup.ts --hybrid     # force hybrid mode even on macOS
  *
  * REQUIREMENTS
  *   - bun 1.x
  *   - doppler CLI authenticated to factorylm/prd
  *   - app.factorylm.com/scan/healthz returning 200
+ *   For automation: Chrome open with --remote-debugging-port=9222
  */
 
 import { spawn, spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as readline from "node:readline";
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 
 // ── Configuration ────────────────────────────────────────────────────────
 
 const APP_FACTORYLM_HEALTH = "https://app.factorylm.com/scan/healthz";
 const DEVELOPER_HOME = "https://developer.monday.com";
+const CDP_ENDPOINT = "http://localhost:9222";
 
 const VALUES = {
   iframeUrl: "https://app.factorylm.com/scan/",
@@ -53,7 +57,6 @@ const VALUES = {
     "Open any item, then click MIRA Scan in the right panel to capture an asset photo.",
 };
 
-// bun exposes import.meta.dir; fall back to deriving from import.meta.url for tsc-checks.
 const SCRIPT_DIR =
   (import.meta as any).dir ??
   path.dirname(new URL(import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, "$1"));
@@ -63,6 +66,7 @@ const RUNS_DIR = path.join(SCRIPT_DIR, "runs");
 
 const argv = process.argv.slice(2);
 const DRY_RUN = argv.includes("--dry-run");
+const FORCE_HYBRID = argv.includes("--hybrid");
 
 // ── Tiny helpers ─────────────────────────────────────────────────────────
 
@@ -135,14 +139,19 @@ async function preflight(): Promise<void> {
   fs.mkdirSync(RUNS_DIR, { recursive: true });
 }
 
-// ── Browser open (no automation control) ─────────────────────────────────
+// ── Browser open (hybrid fallback only) ──────────────────────────────────
 
 function openBrowser(url: string): void {
-  // Windows: `start "" "<url>"` opens in the default browser.
-  // We don't try to control it — Defender on this host blocks Playwright
-  // CDP transports (see feedback_playwright_windows_cdp_websocket_blocked).
   log(`\nOpening ${url} in your default browser…`, "cyan");
-  spawn("cmd.exe", ["/c", "start", "", url], { detached: true, stdio: "ignore" }).unref();
+  const isWin = process.platform === "win32";
+  const isMac = process.platform === "darwin";
+  if (isWin) {
+    spawn("cmd.exe", ["/c", "start", "", url], { detached: true, stdio: "ignore" }).unref();
+  } else if (isMac) {
+    spawn("open", [url], { detached: true, stdio: "ignore" }).unref();
+  } else {
+    spawn("xdg-open", [url], { detached: true, stdio: "ignore" }).unref();
+  }
 }
 
 // ── Doppler write helper (never logs the value) ──────────────────────────
@@ -165,7 +174,6 @@ function dopplerSet(name: string, value: string): boolean {
     log(`  doppler set ${name}: FAILED — ${r.stderr.split("\n")[0]}`, "red");
     return false;
   }
-  // Verify by reading back length only — never echo the value.
   const verify = spawnSync(
     "doppler",
     ["secrets", "get", name, "--project", "factorylm", "--config", "prd", "--plain"],
@@ -181,7 +189,228 @@ function dopplerSet(name: string, value: string): boolean {
   return ok;
 }
 
-// ── Section walkthroughs ─────────────────────────────────────────────────
+// ── Playwright CDP automation ─────────────────────────────────────────────
+
+async function connectChrome(): Promise<{ browser: Browser; page: Page } | null> {
+  if (FORCE_HYBRID) return null;
+  try {
+    log("Connecting to Chrome via CDP (localhost:9222)…", "cyan");
+    const browser = await chromium.connectOverCDP(CDP_ENDPOINT);
+    const ctx: BrowserContext = browser.contexts()[0];
+    // Reuse existing Developer Center page or open a new one
+    let page = ctx.pages().find((p: Page) => p.url().includes("developer.monday.com")) ?? null;
+    if (!page) {
+      page = await ctx.newPage();
+      await page.goto(DEVELOPER_HOME + "/apps");
+      await page.waitForLoadState("networkidle");
+    }
+    await page.bringToFront();
+    log("  ✓ CDP connected", "green");
+    return { browser, page };
+  } catch (e) {
+    log(
+      `  CDP failed (${e instanceof Error ? e.message : String(e)}) — falling back to hybrid mode`,
+      "yellow",
+    );
+    return null;
+  }
+}
+
+/** Navigate to the MIRA Scan app's Build tab section. */
+async function ensureOnBuildTab(page: Page, section: string): Promise<void> {
+  const url = page.url();
+  if (!url.includes("/build/") && !url.includes("/apps/")) {
+    await page.goto(DEVELOPER_HOME + "/apps");
+    await page.waitForLoadState("networkidle");
+  }
+  // If on the apps listing, find and click the MIRA Scan app
+  if (!url.includes("/build/")) {
+    const appCard = page.getByText(/mira scan/i).first();
+    await appCard.waitFor({ timeout: 10_000 });
+    await appCard.click();
+    await page.waitForLoadState("networkidle");
+  }
+  // Click the section in the Build tab sidebar
+  const sectionLink = page
+    .getByRole("link", { name: new RegExp(section, "i") })
+    .or(page.getByText(new RegExp(`^${section}$`, "i")))
+    .first();
+  await sectionLink.waitFor({ timeout: 8_000 });
+  await sectionLink.click();
+  await page.waitForLoadState("networkidle");
+  await page.waitForTimeout(800);
+}
+
+/** Try to read a displayed value as input value, then textContent, then fallback. */
+async function scrapeValue(page: Page, labelPattern: RegExp, fallbackPrompt: string): Promise<string> {
+  // Try input/textarea near the label
+  try {
+    const container = page.getByText(labelPattern).locator("..").first();
+    const input = container.getByRole("textbox").first();
+    if (await input.isVisible({ timeout: 2_000 })) {
+      const val = await input.inputValue();
+      if (val.trim()) return val.trim();
+    }
+  } catch { /* ignore */ }
+  // Try adjacent code/span
+  try {
+    const codeEl = page.getByText(labelPattern).locator("..").locator("code, span[class*='value'], span[class*='secret']").first();
+    if (await codeEl.isVisible({ timeout: 1_500 })) {
+      const text = await codeEl.textContent();
+      if (text?.trim()) return text.trim();
+    }
+  } catch { /* ignore */ }
+  // Manual fallback
+  log(`  Auto-scrape failed for ${labelPattern.source} — paste manually:`, "yellow");
+  return (await ask(`  ${fallbackPrompt}: `)).trim();
+}
+
+// ── Automated sections ────────────────────────────────────────────────────
+
+async function autoSection1Features(page: Page): Promise<void> {
+  log("\n[1/4] Features → Item view (automated)", "cyan");
+  await ensureOnBuildTab(page, "features");
+
+  // Add new feature if button is visible
+  const addBtn = page.getByRole("button", { name: /add.*feature|new feature/i });
+  if (await addBtn.isVisible({ timeout: 3_000 })) {
+    await addBtn.click();
+    await page.waitForTimeout(600);
+  }
+
+  // Select Item view
+  const itemView = page.getByText(/item view/i).first();
+  await itemView.waitFor({ timeout: 6_000 });
+  await itemView.click();
+  await page.waitForTimeout(500);
+
+  // Fill iframe URL
+  const urlField = page
+    .getByLabel(/iframe url/i)
+    .or(page.getByPlaceholder(/https:\/\//i))
+    .first();
+  await urlField.waitFor({ timeout: 5_000 });
+  await urlField.clear();
+  await urlField.fill(VALUES.iframeUrl);
+
+  // Enable mobile compat if present
+  const mobileToggle = page.getByLabel(/mobile/i).first();
+  if (await mobileToggle.isVisible({ timeout: 1_500 })) {
+    if (!(await mobileToggle.isChecked())) await mobileToggle.check();
+  }
+
+  // Save
+  await page.getByRole("button", { name: /^save$/i }).first().click();
+  await page.waitForTimeout(1_500);
+  log("  ✓ Features → Item view saved", "green");
+}
+
+async function autoSection2OAuth(page: Page): Promise<[string, string]> {
+  log("\n[2/4] OAuth → redirect URI + scopes + capture credentials (automated)", "cyan");
+  await ensureOnBuildTab(page, "oauth");
+
+  // Redirect URI
+  const uriField = page
+    .getByLabel(/redirect uri/i)
+    .or(page.getByPlaceholder(/redirect/i))
+    .or(page.getByPlaceholder(/https/i))
+    .first();
+  await uriField.waitFor({ timeout: 5_000 });
+  await uriField.clear();
+  await uriField.fill(VALUES.redirectUri);
+
+  // Scopes — each scope may be a checkbox or a multi-select tag
+  for (const scope of VALUES.scopes.split(" ")) {
+    const label = new RegExp(scope.replace(":", ".*"), "i");
+    const chk = page.getByLabel(label).first();
+    if (await chk.isVisible({ timeout: 1_000 })) {
+      if (!(await chk.isChecked())) await chk.check();
+    } else {
+      // Try clicking a scope chip/tag
+      const chip = page.getByText(new RegExp(`^${scope}$`, "i")).first();
+      if (await chip.isVisible({ timeout: 800 })) await chip.click();
+    }
+  }
+
+  // Save
+  await page.getByRole("button", { name: /^save$/i }).first().click();
+  await page.waitForTimeout(2_000);
+
+  // Scrape revealed credentials
+  log("  Scraping OAuth credentials from page…", "dim");
+  const clientId = await scrapeValue(page, /client id/i, "Client ID (paste)");
+  const clientSecret = await scrapeValue(page, /client secret/i, "Client Secret (paste)");
+
+  log(`  Client ID: ${"*".repeat(Math.min(clientId.length, 8))}… (length=${clientId.length})`, "dim");
+  log(`  Client Secret: ${"*".repeat(Math.min(clientSecret.length, 8))}… (length=${clientSecret.length})`, "dim");
+  return [clientId, clientSecret];
+}
+
+async function autoSection3Webhooks(page: Page): Promise<string> {
+  log("\n[3/4] Webhooks → URL + lifecycle events + capture signing secret (automated)", "cyan");
+  await ensureOnBuildTab(page, "webhook");
+
+  // Webhook URL
+  const urlField = page
+    .getByLabel(/webhook url/i)
+    .or(page.getByPlaceholder(/https/i))
+    .first();
+  await urlField.waitFor({ timeout: 5_000 });
+  await urlField.clear();
+  await urlField.fill(VALUES.webhookUrl);
+
+  // Subscribe to each lifecycle event
+  for (const evt of VALUES.webhookEvents) {
+    const label = new RegExp(evt.replace(/_/g, "[_ ]"), "i");
+    const chk = page.getByLabel(label).first();
+    if (await chk.isVisible({ timeout: 1_000 })) {
+      if (!(await chk.isChecked())) await chk.check();
+    } else {
+      const chip = page.getByText(label).first();
+      if (await chip.isVisible({ timeout: 800 })) await chip.click();
+    }
+  }
+
+  // Save
+  await page.getByRole("button", { name: /^save$/i }).first().click();
+  await page.waitForTimeout(2_000);
+
+  // Try to scrape signing secret (optional — backend falls back to client_secret)
+  log("  Checking for webhook signing secret…", "dim");
+  let sigSecret = "";
+  try {
+    sigSecret = await scrapeValue(page, /signing secret/i, "Signing Secret (or empty to skip)");
+  } catch { /* ignore — secret field may not exist */ }
+
+  if (!sigSecret) {
+    log("  No signing secret shown — backend will use MONDAY_OAUTH_CLIENT_SECRET as fallback", "dim");
+  }
+  return sigSecret;
+}
+
+async function autoSection4Onboarding(page: Page): Promise<void> {
+  log("\n[4/4] App Onboarding → welcome message (automated)", "cyan");
+  await ensureOnBuildTab(page, "onboarding");
+
+  const msgField = page.getByRole("textbox").first();
+  if (await msgField.isVisible({ timeout: 3_000 })) {
+    const current = await msgField.inputValue().catch(() => "");
+    if (!current.trim()) {
+      await msgField.fill(VALUES.onboardingMessage);
+    } else {
+      log("  Onboarding message already set — leaving as-is", "dim");
+    }
+    // Save only if there's a save button (section may auto-save)
+    const saveBtn = page.getByRole("button", { name: /^save$/i }).first();
+    if (await saveBtn.isVisible({ timeout: 1_500 })) await saveBtn.click();
+    await page.waitForTimeout(1_000);
+  } else {
+    log("  No onboarding text field visible — skipping", "dim");
+  }
+  log("  ✓ App Onboarding done", "green");
+}
+
+// ── Hybrid section walkthroughs (manual fallback) ─────────────────────────
 
 function printValueBlock(title: string, lines: string[]): void {
   log(`\n${"─".repeat(60)}`, "dim");
@@ -302,41 +531,58 @@ function verifyDoppler(): boolean {
 // ── Main ─────────────────────────────────────────────────────────────────
 
 async function main(): Promise<void> {
-  log("MIRA Scan — monday.com marketplace setup (hybrid)", "cyan");
-  log(`  mode: ${DRY_RUN ? "dry-run" : "live"}`, "dim");
+  log("MIRA Scan — monday.com marketplace setup", "cyan");
+  log(`  mode: ${DRY_RUN ? "dry-run" : "live"} | automation: ${FORCE_HYBRID ? "hybrid (forced)" : "CDP → hybrid fallback"}`, "dim");
 
   await preflight();
 
-  log("\nThis script will:", "cyan");
-  log("  1. Open developer.monday.com in your default browser", "dim");
-  log("  2. Print the exact values for each Build-tab section", "dim");
-  log("  3. Wait for you to save each section", "dim");
-  log("  4. Pipe generated OAuth + webhook secrets straight into Doppler", "dim");
-  log("  5. Verify the three Doppler secrets at the end", "dim");
-  log(
-    "\nWhy not full automation? Microsoft Defender on this Windows host blocks",
-    "dim",
-  );
-  log(
-    "Playwright's CDP transports — see memory feedback_playwright_windows_cdp_*.md",
-    "dim",
-  );
-  log("for the rationale. Hybrid is the reliable path on this machine.", "dim");
+  // ── Automation path (Playwright CDP) ──────────────────────────────────
+  const cdp = await connectChrome();
 
-  await ask(`\n${COLOR.yellow}Press Enter to open the Developer Center and begin…${COLOR.reset} `);
+  if (cdp) {
+    log("\nPlaywright CDP connected — running fully automated setup…", "cyan");
+    log("(Chrome must already be signed in to monday.com Developer Center)", "dim");
 
-  openBrowser(DEVELOPER_HOME);
-  log("(Sign in to monday.com if prompted, then navigate to your MIRA Scan app's Build tab.)", "dim");
+    const { browser, page } = cdp;
+    try {
+      await autoSection1Features(page);
+      const [clientId, clientSecret] = await autoSection2OAuth(page);
+      const sigSecret = await autoSection3Webhooks(page);
+      await autoSection4Onboarding(page);
 
-  await section1Features();
-  await section2OAuth();
-  await section3Webhooks();
-  await section4Onboarding();
+      if (!DRY_RUN) {
+        if (clientId) dopplerSet("MONDAY_OAUTH_CLIENT_ID", clientId);
+        if (clientSecret) dopplerSet("MONDAY_OAUTH_CLIENT_SECRET", clientSecret);
+        if (sigSecret) dopplerSet("MONDAY_WEBHOOK_SIGNING_SECRET", sigSecret);
+      }
+    } finally {
+      // Disconnect without closing the Chrome window
+      await browser.close().catch(() => {});
+    }
+  } else {
+    // ── Hybrid fallback ────────────────────────────────────────────────
+    log("\nThis script will:", "cyan");
+    log("  1. Open developer.monday.com in your default browser", "dim");
+    log("  2. Print the exact values for each Build-tab section", "dim");
+    log("  3. Wait for you to save each section", "dim");
+    log("  4. Pipe generated OAuth + webhook secrets straight into Doppler", "dim");
+    log("  5. Verify the three Doppler secrets at the end", "dim");
+
+    await ask(`\n${COLOR.yellow}Press Enter to open the Developer Center and begin…${COLOR.reset} `);
+
+    openBrowser(DEVELOPER_HOME);
+    log("(Sign in to monday.com if prompted, then navigate to your MIRA Scan app's Build tab.)", "dim");
+
+    await section1Features();
+    await section2OAuth();
+    await section3Webhooks();
+    await section4Onboarding();
+  }
 
   const ok = verifyDoppler();
 
   log("\nNext steps:", "cyan");
-  log("  1. Update mira-scan-monday/docker-compose.yml has been done (env block).", "dim");
+  log("  1. mira-scan-monday/docker-compose.yml already has the env block (in this PR).", "dim");
   log("  2. Merge the open PR for the webhook + 429 + setup script.", "dim");
   log("  3. Redeploy mira-scan-monday on the VPS so new env reaches the container:", "dim");
   log(

--- a/tools/monday-marketplace-setup/tsconfig.json
+++ b/tools/monday-marketplace-setup/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["setup.ts"]
+}


### PR DESCRIPTION
## Summary

This PR covers two related batches of work on the `feat/mira-scan-monday-webhook-and-builder` branch:

### Batch A — monday.com marketplace (original scope)
- `POST /monday/webhook` — handles app-lifecycle events (install / uninstall / app_subscription_*) with HMAC JWT verification
- 429 quota CTA — when scan quota exceeded, returns branded upsell prompt routing to FactoryLM lead funnel
- Marketplace setup driver — step-by-step checklist for submitting the MIRA Scan app to monday.com marketplace
- Bumps versions to **mira-scan-backend 0.2.0** + **mira-scan-frontend 0.2.0**

### Batch B — Site audit fixes 2026-05-09 (CRA-104/105/109/113/115/117/120/123/124/126)
10 a11y + SEO fixes across `mira-hub` and `mira-web`:

| # | Fix | File(s) |
|---|-----|---------|
| CRA-104 | h2→h4 heading skip on homepage | `mira-web/src/lib/components.ts` |
| CRA-105 | /cmms missing JSON-LD SoftwareApplication | `mira-web/src/views/cmms.ts` |
| CRA-109 | factorylm.com 404 no home link | `mira-web/src/server.ts` |
| CRA-113 | /login icon-only buttons unlabelled | `mira-hub/src/app/login/page.tsx` |
| CRA-115 | /login og:image missing | `mira-hub/src/app/login/layout.tsx` (new) |
| CRA-117 | HTTP/2 missing on app.factorylm.com | `nginx-oracle.conf` |
| CRA-120 | /signup canonical points to / | `mira-hub/src/app/signup/layout.tsx` (new) |
| CRA-123 | Generic title "FactoryLM Hub" | `mira-hub/src/app/layout.tsx` |
| CRA-124 | /signup unlabelled inputs + toggle | `mira-hub/src/app/signup/page.tsx` |
| CRA-126 | mira-hub 404 no home link | `mira-hub/src/app/not-found.tsx` (new) |

Playwright QA spec: `mira-hub/tests/e2e/audit-fixes-2026-05-09.spec.ts` — runs against live VPS post-deploy.

## Deploy checklist
1. Merge this PR
2. `ssh root@165.245.138.91 "cd /opt/mira && doppler run --project factorylm --config prd -- docker compose up -d --build mira-hub mira-web"`
3. Re-run: `cd mira-hub && bunx playwright test tests/e2e/audit-fixes-2026-05-09.spec.ts`
4. Note: CRA-126 hub-404 test will still fail until CRA-114 (middleware 308 intercept) is fixed — deferred to Batch 3.

## What this is NOT
- Not the marketplace listing artifacts (listing.md, screenshots, demo.mp4). That's PR #1005.
- Not the UpKeep port (Phase 2). Gate: don't start until monday submission lands.
- Deferred (Batch 3): LCP/image optimization, 3-hop redirect chain, render-blocking JS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)