### PR TITLE
feat(agentic-os): add self-maintenance layer (heartbeat, healer, learning, funnel)

### DIFF
--- a/docs/agentic-os/README.md
+++ b/docs/agentic-os/README.md
@@ -1,0 +1,379 @@
+# MIRA Agentic OS — Architecture & Runbook
+
+**Owner:** Mike Harper · **Last updated:** 2026-05-06
+
+The Agentic OS is the layer underneath every MIRA feature: it watches the
+system, fixes what it can, captures what it learns, and reports the numbers
+that matter. Most of it already existed (brand context, memory, skills,
+orchestrator, scheduled tasks, quality gate, Telegram bot). This document
+describes the new **self-maintenance** layer that closes the loop.
+
+---
+
+## Layer diagram
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  L5  Self-Maintenance        heartbeat → self-healer →             │
+│                              learning_capture → funnel_tracker     │
+├────────────────────────────────────────────────────────────────────┤
+│  L4  Orchestration           cron (install_crons.sh) · Celery      │
+│                              13-agent roster · scheduled tasks     │
+├────────────────────────────────────────────────────────────────────┤
+│  L3  Skills (50+)            promo-director · brand-voice ·        │
+│                              kb-benchmark · diagnostic-workflow … │
+├────────────────────────────────────────────────────────────────────┤
+│  L2  Memory                  ~/.claude/projects/.../memory/        │
+│                              MEMORY.md index + atomic notes        │
+├────────────────────────────────────────────────────────────────────┤
+│  L1  Brand & guardrails      CLAUDE.md · STRATEGY.md · NORTH_STAR  │
+│                              security-boundaries · python-stds     │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+L1–L4 already shipped. L5 is what this PR adds.
+
+---
+
+## L5: the self-maintenance loop
+
+```
+                ┌──────────────────────┐
+   every 15min  │  heartbeat_monitor   │  → 16 probes, score 0-100
+                └──────────┬───────────┘
+                           │  exit 2 (DOWN)
+                           ▼
+                ┌──────────────────────┐
+                │     self_healer      │  → run scoped playbook
+                └──────────┬───────────┘     re-probe → escalate if still red
+                           │
+                           ▼ NeonDB system_health_log (trend data)
+                ┌──────────────────────┐
+   weekly       │   learning_capture   │  → diff benchmarks → docs/learnings/
+                └──────────┬───────────┘     filed regressions on GitHub
+                           │
+                           ▼
+                ┌──────────────────────┐
+   daily +      │    funnel_tracker    │  → HubSpot · scan queue · bot · health
+   weekly Pulse └──────────────────────┘     → docs/reports/pulse/
+```
+
+Every component:
+
+- runs **on the VPS**, scheduled by `scripts/install_crons.sh`
+- fails open — a missing API token logs an error but never breaks the loop
+- writes evidence to NeonDB or `docs/`, never silent state
+- alerts via `mira_crawler.reporting.telegram_notify.notify(...)` — the same
+  bus as every other digital employee, so Mike has one inbox to watch
+
+---
+
+## Agent roster
+
+The full roster lives in `mira-crawler/reporting/telegram_notify.py::AGENTS`.
+Below: every agent that runs on a schedule today, plus what was added in L5.
+
+### Existing (L4 orchestration)
+
+| Agent | When | Where | What |
+|---|---|---|---|
+| `kb_growth` | every 6h | `mira-crawler/cron/kb_growth_cron.py` | ingest one PDF from `manual_queue.json` |
+| `corpus_refresh` | Sun 03:00 UTC | `mira-bots/benchmarks/corpus/scraper.py` | pull fresh Reddit Q&A |
+| `youtube_harvest` | Mon 04:00 UTC | `mira-bots/benchmarks/corpus/youtube_harvester.py` | transcripts → corpus |
+| `social_publisher` | Tue/Thu 11:30 UTC | `mira-crawler/social/publisher.py` | LinkedIn queue → live |
+| `morning_brief` | daily 09:00 UTC | container exec → `agents/morning_brief_runner.py` | overnight WO summary |
+| `pm_escalation` | daily 12:00 UTC | container exec → `agents/pm_escalation_runner.py` | overdue PM flags |
+| `safety_alert` | daily 10:00 UTC | container exec → `agents/safety_alert_runner.py` | safety keyword sweep |
+| `benchmark` | Sat 02:00 UTC | `pytest tests/eval/` | golden-case eval |
+| `billing_health` | Mon 12:00 UTC | `mira-crawler/tasks/billing_health.py` | Stripe failed payments / MRR |
+| `inbox_manager` | Cowork-driven | `mira-crawler/agents/inbox_triage.py` | Gmail morning summary |
+
+### New (L5 self-maintenance)
+
+| Agent | When | Where | What |
+|---|---|---|---|
+| `heartbeat` | every 15 min + 08:00 UTC daily | `mira-crawler/agents/heartbeat_monitor.py` | 16 probes → NeonDB → optional Telegram |
+| `self_healer` | on heartbeat exit-2 | `mira-crawler/agents/self_healer.py` | scoped remediation playbooks |
+| `learning_capture` | Sat 03:00 UTC (after benchmark) | `mira-crawler/agents/learning_capture.py` | benchmark diff → `docs/learnings/` + GitHub issues |
+| `funnel_tracker` | daily 13:00 UTC + Mon 13:30 UTC weekly | `mira-crawler/agents/funnel_tracker.py` | HubSpot · scans · bot · uptime → Pulse |
+
+---
+
+## heartbeat_monitor
+
+### What it checks
+
+```
+service                       category    notes
+─────────────────────────────  ──────────  ──────────────────────────────────
+mira-hub                       service     docker ps + status string
+mira-pipeline                  service     "
+mira-bot-telegram              service     "
+mira-scan-backend              service     "
+atlas-api                      service     "
+mira-docling                   service     "
+mira-web                       service     "
+mira-mcp                       service     "
+app.factorylm.com/api/health   endpoint    GET 200 · <2s = healthy
+.../api/scanbe/healthz         endpoint    "
+factorylm.com                  endpoint    "
+telegram_polling               service     `getUpdates` in last 5 min of logs
+neondb                         data        SELECT 1 · <3s = healthy
+kb_cron                        data        manual_queue.json mtime <24h
+disk                           resource    df / · warn 80%, down 90%
+memory                         resource    free -m · warn 85%, down 95%
+```
+
+### Status taxonomy
+
+| Status | Meaning | Action |
+|---|---|---|
+| `healthy` | all signals green | silent (rolled into daily summary) |
+| `degraded` | working but slow / unhealthy | alert only after 30 min consecutive |
+| `down` | not working | immediate alert + trigger `self_healer` |
+| `unknown` | probe couldn't run (e.g. no docker) | logged, no alert |
+
+### Health score
+
+`score = 100 × Σ weight(status) / count(scored)`
+where weights are: healthy 1.0, degraded 0.5, down 0.0. `unknown` is excluded.
+
+### NeonDB persistence
+
+Every probe writes a row into `system_health_log` (auto-created on first run):
+
+```sql
+CREATE TABLE system_health_log (
+    id           BIGSERIAL PRIMARY KEY,
+    ts           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    service      TEXT NOT NULL,
+    status       TEXT NOT NULL,        -- healthy | degraded | down | unknown | healed | heal_failed
+    latency_ms   INTEGER NOT NULL,
+    details      TEXT,
+    category     TEXT,                 -- service | endpoint | resource | data | heal
+    score        INTEGER,              -- overall run score, NULL for heal rows
+    action_taken TEXT,                 -- what self_healer did, NULL otherwise
+    extra        JSONB                 -- remediation_hint, pct, etc.
+);
+```
+
+Two indices: `ts DESC` and `(service, ts DESC)` — every dashboard query hits one.
+
+### Run modes
+
+```bash
+# normal probe (cron)
+python3 mira-crawler/agents/heartbeat_monitor.py
+
+# pipe to self_healer
+python3 mira-crawler/agents/heartbeat_monitor.py --json | \
+  python3 mira-crawler/agents/self_healer.py --stdin
+
+# daily 08:00 UTC summary (always sends)
+python3 mira-crawler/agents/heartbeat_monitor.py --daily-summary
+
+# debugging
+python3 mira-crawler/agents/heartbeat_monitor.py --dry-run --json
+```
+
+---
+
+## self_healer
+
+### Playbook map
+
+| `remediation_hint` (set by heartbeat) | Playbook | Side-effects |
+|---|---|---|
+| `container_missing`, `container_exited`, `container_unhealthy`, `container_restarting` | `restart_container` | `docker restart <name>` |
+| `api_5xx` | `restart_container` (resolves endpoint label → container via `ENDPOINT_TO_CONTAINER`) | "" |
+| `bot_not_polling` | `restart_container` mira-bot-telegram | "" |
+| `endpoint_unreachable` | `noop_escalate` | nothing — likely DNS/TLS/nginx, never touch |
+| `neondb_connection` | `neondb_retry` | 3 SELECT 1 retries, then escalate |
+| `disk_full` | `disk_cleanup` | `docker system prune -f` + truncate >100M `*.log` files in `LOG_DIR` |
+| `kb_cron_stale` | `trigger_kb_cron` | run `kb_growth_cron.py` once |
+| _anything else_ | `noop_escalate` | escalation only |
+
+### Hard safety rules
+
+The healer **never**:
+
+1. removes images or containers (`docker rm`, `docker rmi`)
+2. touches nginx, the host's systemd, or NeonDB schema
+3. runs `rm -rf` on anything — disk_cleanup truncates logs in place
+4. runs as root unless `MIRA_HEALER_ALLOW_ROOT=1` is set
+
+After every action, the healer **re-probes** the same service. If still down,
+it sets `escalated=true` in the log and the Telegram summary shows
+"⚠️ escalating — manual fix needed". The cron will not re-trigger the same
+playbook on the next heartbeat tick because the next probe also returns
+`down`, which means the next self_healer run will be the next escalation, not
+a loop. (We intentionally do **not** rate-limit retries — if a container is
+in a crash loop the heartbeat will keep firing and we want to know.)
+
+### Run modes
+
+```bash
+# probe → heal → re-probe (fresh)
+python3 mira-crawler/agents/self_healer.py
+
+# consume heartbeat from stdin (cron-driven path)
+python3 mira-crawler/agents/self_healer.py --stdin < heartbeat.json
+
+# one-shot: pretend a single service is down
+python3 mira-crawler/agents/self_healer.py --service mira-pipeline
+
+# preview (no actions, no Telegram)
+python3 mira-crawler/agents/self_healer.py --dry-run
+```
+
+---
+
+## learning_capture
+
+Runs after every benchmark. Diffs the latest `benchmark_v*.json` against the
+previous run and produces:
+
+1. **Learning note** in `docs/learnings/YYYY-MM-DD_<version>.md`:
+   - overall delta + grade
+   - dimension table
+   - per-case regressions with `{previous, current, likely_cause, suggested_fix}`
+   - improvements
+   - "rubric drift candidates" — cases that have regressed 3+ runs in a row
+2. **GitHub issues** — one per *new* regression, deduped by `case_id` so
+   re-runs don't spam the tracker. Issues are labelled `benchmark-regression`.
+3. **Telegram summary** under the `benchmark` (📊 QA Engineer) persona.
+
+### Heuristics for `likely_cause`
+
+```
+runtime error                    → "fix the runtime error first"
+"not found" / "no relevant"      → retrieval miss
+"incorrect" / "wrong"            → bad reasoning despite retrieval
+"incomplete" / "missing"         → answer too sparse
+otherwise                        → "unknown — review reasoning"
+```
+
+These are intentionally simple — the goal is to give Mike a starting hypothesis,
+not a verdict.
+
+---
+
+## funnel_tracker
+
+Daily snapshot + weekly Pulse. Everything is best-effort: a missing data
+source becomes a line in the "Collection errors" section, not a crash.
+
+### Inputs
+
+| Source | Auth | What we read |
+|---|---|---|
+| HubSpot REST | `HUBSPOT_API_KEY` (or `..._ACCESS_TOKEN`) | companies by stage · new leads 7d · open deals + value |
+| NeonDB `scan_queue` | `NEON_DATABASE_URL` | scans 7d · KB hit rate · |
+| `manual_queue.json` | filesystem | manuals queued |
+| NeonDB `bot_messages` | `NEON_DATABASE_URL` | messages 7d · unique users (preferred source) |
+| `docker logs mira-bot-telegram` | docker | fallback message count if `bot_messages` missing |
+| NeonDB `system_health_log` | `NEON_DATABASE_URL` | 7-day uptime score |
+
+### Output
+
+`docs/reports/pulse/YYYY-Www.md` — daily snapshot overwrites the same week
+file. The Monday `--weekly` run is the canonical close + Telegram push.
+
+---
+
+## Cron schedule (full L5 picture)
+
+```
+*/15 * * * *   heartbeat_monitor.py --quiet --json > /tmp/mira_heartbeat.json
+                 → on exit 2: self_healer.py --stdin < /tmp/mira_heartbeat.json
+0 8 * * *      heartbeat_monitor.py --daily-summary
+0 3 * * 6      learning_capture.py                  (Sat 03:00 UTC, after weekly bench)
+0 13 * * *     funnel_tracker.py                    (daily snapshot)
+30 13 * * 1    funnel_tracker.py --weekly           (Mon 13:30 UTC Pulse)
+```
+
+Source of truth: `scripts/install_crons.sh`. To install/refresh on the VPS:
+
+```bash
+ssh factorylm-prod "cd /opt/mira && bash scripts/install_crons.sh"
+```
+
+---
+
+## Runbooks
+
+### "Heartbeat is alerting on `mira-pipeline` every 15 min"
+
+1. SSH to VPS, check container: `docker ps -a | grep mira-pipeline`
+2. Look at logs: `docker logs --tail 200 mira-pipeline`
+3. Check the heal log: `tail -50 /var/log/mira-agents/self_healer.log` —
+   how many restart attempts have already failed?
+4. Inspect NeonDB:
+   ```sql
+   SELECT ts, status, details, action_taken
+   FROM system_health_log
+   WHERE service = 'mira-pipeline'
+   ORDER BY ts DESC LIMIT 30;
+   ```
+5. If the container is in a crash loop, restarts won't help — fix the
+   underlying error, then restart manually. The heartbeat will go green on
+   the next 15-min tick.
+
+### "I want to add a new health check"
+
+1. Add the probe function in `heartbeat_monitor.py`. It must return a
+   `HealthCheck(service, status, latency_ms, details, category, extra={...})`.
+2. If the failure has a fixable signature, set
+   `extra={"remediation_hint": "<key>"}`.
+3. Wire into `run_all_checks()`.
+4. If you added a new hint, add a playbook in `self_healer.py` `PLAYBOOKS`
+   dict. Otherwise it falls through to `noop_escalate`.
+5. Run `python3 mira-crawler/agents/heartbeat_monitor.py --dry-run --json` to
+   verify the new probe shows up.
+
+### "I want to add a new remediation playbook"
+
+1. Write a function `def my_playbook(service: str, hint: str) -> HealAction`.
+   It must be idempotent and bounded — no unbounded retries, no destructive
+   ops.
+2. Register it in `PLAYBOOKS` keyed by the hint.
+3. Test:
+   ```
+   python3 mira-crawler/agents/self_healer.py --dry-run --service <name>
+   ```
+
+### "Pulse report is missing pipeline numbers"
+
+`HUBSPOT_API_KEY` not set in Doppler `factorylm/prd`. Pull from settings →
+private app token → put in Doppler. Re-run:
+
+```
+doppler run -- python3 mira-crawler/agents/funnel_tracker.py --dry-run
+```
+
+### "Benchmark fired, but no learning note"
+
+Either:
+- `benchmark_v*.json` not in repo root after the run (check the test command
+  emits it)
+- `--results-dir` mismatch — funnel writes to `docs/reports/`, learning reads
+  from `.` by default. Pass `--results-dir <dir>` if needed.
+
+---
+
+## Adding a new agent to the L4 roster
+
+If you're not extending self-maintenance and just want a new digital employee:
+
+1. Pick a slug + emoji and add it to `AGENTS` in
+   `mira-crawler/reporting/telegram_notify.py`.
+2. Drop a script in `mira-crawler/agents/<your_agent>.py`. Use the existing
+   ones as a template — argparse with `--dry-run`, structured logging, log
+   to `/var/log/mira-agents/<slug>.log`.
+3. Add the cron line to `scripts/install_crons.sh`. Schedule rule of thumb:
+   - resource probes: every 5–15 min
+   - data refreshes: hourly to 6h
+   - reports: daily or weekly
+4. Document the agent in this file's "Agent roster" table.
+
+That's the full surface area. The self-maintenance layer keeps it honest.

--- a/mira-crawler/agents/funnel_tracker.py
+++ b/mira-crawler/agents/funnel_tracker.py
@@ -1,0 +1,506 @@
+"""Funnel Tracker — daily probe + weekly "FactoryLM Pulse" report.
+
+What it pulls
+-------------
+* **HubSpot** (REST, `HUBSPOT_API_KEY` / `HUBSPOT_ACCESS_TOKEN`):
+    - companies grouped by lifecycle stage
+    - new leads in the last 7 days
+    - open deals + total value
+* **NeonDB** scan funnel (`scan_queue` table or `manual_queue.json` fallback):
+    - scans this week, KB hit rate, manuals queued
+* **Telegram bot** (NeonDB `bot_messages` if present, else docker log scan):
+    - messages, unique users, last 7 days
+* **Heartbeat** (`system_health_log`):
+    - uptime % over the last 7 days
+
+Outputs
+-------
+* `docs/reports/pulse/YYYY-Www.md` — checked into the repo
+* Telegram push (`weekly` mode only) under the `system` agent
+
+Usage
+-----
+    python3 mira-crawler/agents/funnel_tracker.py            # daily snapshot
+    python3 mira-crawler/agents/funnel_tracker.py --weekly   # full pulse report
+    python3 mira-crawler/agents/funnel_tracker.py --dry-run  # print, don't notify or save
+
+Failure mode: every fetcher returns a partial result on error so a missing
+HubSpot token doesn't break the whole pulse.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] funnel: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+logger = logging.getLogger("funnel_tracker")
+
+try:
+    from mira_crawler.reporting.telegram_notify import notify
+except ImportError:
+
+    def notify(agent_key: str, message: str, **_) -> bool:  # type: ignore[misc]
+        print(f"[{agent_key}] {message}")
+        return True
+
+
+HUBSPOT_BASE = "https://api.hubapi.com"
+LIFECYCLE_ORDER = [
+    "lead",
+    "marketingqualifiedlead",
+    "salesqualifiedlead",
+    "opportunity",
+    "customer",
+    "evangelist",
+    "other",
+]
+
+
+# ── Data shapes ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class FunnelSnapshot:
+    pipeline: dict[str, Any] = field(default_factory=dict)
+    product: dict[str, Any] = field(default_factory=dict)
+    bot: dict[str, Any] = field(default_factory=dict)
+    health: dict[str, Any] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+    ts: str = ""
+
+
+# ── HubSpot fetchers ─────────────────────────────────────────────────────────
+
+
+def _hubspot_token() -> str:
+    return os.environ.get("HUBSPOT_ACCESS_TOKEN") or os.environ.get("HUBSPOT_API_KEY", "")
+
+
+def fetch_hubspot() -> tuple[dict[str, Any], list[str]]:
+    """Return pipeline-shaped dict + list of errors."""
+    errors: list[str] = []
+    out: dict[str, Any] = {
+        "total_companies": 0,
+        "by_stage": {},
+        "new_leads_7d": 0,
+        "open_deals": 0,
+        "open_deal_value": 0.0,
+    }
+    token = _hubspot_token()
+    if not token:
+        errors.append("HUBSPOT token not set — pipeline metrics skipped")
+        return out, errors
+
+    try:
+        import httpx
+    except ImportError:
+        errors.append("httpx not installed")
+        return out, errors
+
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=7)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    try:
+        with httpx.Client(timeout=30, headers=headers) as client:
+            # Companies count + lifecycle stage breakdown via search
+            for stage in LIFECYCLE_ORDER:
+                resp = client.post(
+                    f"{HUBSPOT_BASE}/crm/v3/objects/companies/search",
+                    json={
+                        "filterGroups": [
+                            {
+                                "filters": [
+                                    {
+                                        "propertyName": "lifecyclestage",
+                                        "operator": "EQ",
+                                        "value": stage,
+                                    }
+                                ]
+                            }
+                        ],
+                        "limit": 1,  # we just want the total
+                        "properties": ["name"],
+                    },
+                )
+                if resp.status_code == 200:
+                    total = resp.json().get("total", 0)
+                    out["by_stage"][stage] = total
+                    out["total_companies"] += total
+
+            # New leads in last 7d (createdate >= cutoff)
+            resp = client.post(
+                f"{HUBSPOT_BASE}/crm/v3/objects/companies/search",
+                json={
+                    "filterGroups": [
+                        {
+                            "filters": [
+                                {"propertyName": "createdate", "operator": "GTE", "value": cutoff}
+                            ]
+                        }
+                    ],
+                    "limit": 1,
+                    "properties": ["name"],
+                },
+            )
+            if resp.status_code == 200:
+                out["new_leads_7d"] = resp.json().get("total", 0)
+
+            # Open deals + amount sum (paginate up to 200 — enough for early-stage)
+            resp = client.post(
+                f"{HUBSPOT_BASE}/crm/v3/objects/deals/search",
+                json={
+                    "filterGroups": [
+                        {
+                            "filters": [
+                                {
+                                    "propertyName": "dealstage",
+                                    "operator": "NEQ",
+                                    "value": "closedwon",
+                                },
+                                {
+                                    "propertyName": "dealstage",
+                                    "operator": "NEQ",
+                                    "value": "closedlost",
+                                },
+                            ]
+                        }
+                    ],
+                    "limit": 100,
+                    "properties": ["amount", "dealname", "dealstage"],
+                },
+            )
+            if resp.status_code == 200:
+                results = resp.json().get("results", [])
+                out["open_deals"] = len(results)
+                out["open_deal_value"] = sum(
+                    float(r.get("properties", {}).get("amount") or 0) for r in results
+                )
+            else:
+                errors.append(f"deals search HTTP {resp.status_code}")
+
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"HubSpot fetch failed: {exc}")
+    return out, errors
+
+
+# ── Scan funnel ──────────────────────────────────────────────────────────────
+
+
+def fetch_scan_funnel() -> tuple[dict[str, Any], list[str]]:
+    errors: list[str] = []
+    out: dict[str, Any] = {
+        "scans_7d": 0,
+        "kb_hits": 0,
+        "kb_misses": 0,
+        "kb_hit_rate": 0.0,
+        "manuals_queued": 0,
+    }
+    url = os.environ.get("NEON_DATABASE_URL", "")
+    if url:
+        try:
+            from sqlalchemy import create_engine, text
+            from sqlalchemy.pool import NullPool
+
+            engine = create_engine(url, poolclass=NullPool, connect_args={"sslmode": "require"})
+            with engine.connect() as conn:
+                # Best-effort: tolerate missing tables.
+                try:
+                    row = conn.execute(
+                        text(
+                            "SELECT COUNT(*) FROM scan_queue "
+                            "WHERE created_at >= NOW() - INTERVAL '7 days'"
+                        )
+                    ).first()
+                    out["scans_7d"] = int(row[0]) if row else 0
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(f"scan_queue 7d: {exc}".replace("\n", " ")[:120])
+
+                try:
+                    row = conn.execute(
+                        text(
+                            "SELECT "
+                            "  COUNT(*) FILTER (WHERE matched_kb = TRUE) as hits,"
+                            "  COUNT(*) FILTER (WHERE matched_kb = FALSE) as misses "
+                            "FROM scan_queue "
+                            "WHERE created_at >= NOW() - INTERVAL '7 days'"
+                        )
+                    ).first()
+                    if row:
+                        out["kb_hits"] = int(row[0] or 0)
+                        out["kb_misses"] = int(row[1] or 0)
+                        total = out["kb_hits"] + out["kb_misses"]
+                        out["kb_hit_rate"] = (
+                            round(100 * out["kb_hits"] / total, 1) if total else 0.0
+                        )
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(f"scan_queue hit-rate: {exc}".replace("\n", " ")[:120])
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"NeonDB scan funnel: {exc}")
+    else:
+        errors.append("NEON_DATABASE_URL not set — scan funnel skipped")
+
+    # manuals_queued: read manual_queue.json
+    for p in (
+        Path("/opt/mira/mira-crawler/cron/manual_queue.json"),
+        Path("mira-crawler/cron/manual_queue.json"),
+        Path("/opt/mira/manual_queue.json"),
+    ):
+        if p.exists():
+            try:
+                queue = json.loads(p.read_text())
+                if isinstance(queue, list):
+                    out["manuals_queued"] = sum(
+                        1 for item in queue if (item.get("status") or "queued") == "queued"
+                    )
+                break
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"manual_queue.json parse: {exc}")
+    return out, errors
+
+
+# ── Telegram bot stats ───────────────────────────────────────────────────────
+
+
+def fetch_bot_stats() -> tuple[dict[str, Any], list[str]]:
+    errors: list[str] = []
+    out: dict[str, Any] = {"messages_7d": 0, "unique_users_7d": 0, "source": "unknown"}
+
+    # Try NeonDB first.
+    url = os.environ.get("NEON_DATABASE_URL", "")
+    if url:
+        try:
+            from sqlalchemy import create_engine, text
+            from sqlalchemy.pool import NullPool
+
+            engine = create_engine(url, poolclass=NullPool, connect_args={"sslmode": "require"})
+            with engine.connect() as conn:
+                try:
+                    row = conn.execute(
+                        text(
+                            "SELECT COUNT(*), COUNT(DISTINCT user_id) "
+                            "FROM bot_messages "
+                            "WHERE created_at >= NOW() - INTERVAL '7 days'"
+                        )
+                    ).first()
+                    if row:
+                        out["messages_7d"] = int(row[0] or 0)
+                        out["unique_users_7d"] = int(row[1] or 0)
+                        out["source"] = "neondb.bot_messages"
+                        return out, errors
+                except Exception:  # noqa: BLE001
+                    pass  # table may not exist — fall through
+        except Exception as exc:  # noqa: BLE001
+            errors.append(f"bot stats NeonDB: {exc}")
+
+    # Fallback: docker logs grep (rough — uses message=… or User= patterns)
+    try:
+        proc = subprocess.run(
+            ["docker", "logs", "--since", "168h", "mira-bot-telegram"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        if proc.returncode == 0:
+            log = (proc.stdout + proc.stderr).lower()
+            out["messages_7d"] = log.count("update_id")  # heuristic
+            out["source"] = "docker logs (heuristic)"
+        else:
+            errors.append(f"docker logs rc={proc.returncode}")
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"bot stats logs: {exc}")
+    return out, errors
+
+
+# ── Health uptime ────────────────────────────────────────────────────────────
+
+
+def fetch_uptime() -> tuple[dict[str, Any], list[str]]:
+    errors: list[str] = []
+    out: dict[str, Any] = {"uptime_pct_7d": 0.0, "samples": 0}
+    url = os.environ.get("NEON_DATABASE_URL", "")
+    if not url:
+        errors.append("NEON_DATABASE_URL not set — uptime skipped")
+        return out, errors
+    try:
+        from sqlalchemy import create_engine, text
+        from sqlalchemy.pool import NullPool
+
+        engine = create_engine(url, poolclass=NullPool, connect_args={"sslmode": "require"})
+        with engine.connect() as conn:
+            try:
+                row = conn.execute(
+                    text(
+                        "SELECT "
+                        "  COUNT(*) FILTER (WHERE score IS NOT NULL),"
+                        "  AVG(score) FILTER (WHERE score IS NOT NULL) "
+                        "FROM system_health_log "
+                        "WHERE ts >= NOW() - INTERVAL '7 days' "
+                        "  AND category != 'heal'"
+                    )
+                ).first()
+                if row:
+                    out["samples"] = int(row[0] or 0)
+                    out["uptime_pct_7d"] = round(float(row[1] or 0), 1)
+            except Exception as exc:  # noqa: BLE001
+                errors.append(f"system_health_log: {exc}".replace("\n", " ")[:120])
+    except Exception as exc:  # noqa: BLE001
+        errors.append(f"uptime fetch: {exc}")
+    return out, errors
+
+
+# ── Aggregate ────────────────────────────────────────────────────────────────
+
+
+def collect() -> FunnelSnapshot:
+    snap = FunnelSnapshot(ts=datetime.now(timezone.utc).isoformat(timespec="seconds"))
+    snap.pipeline, errs = fetch_hubspot()
+    snap.errors.extend(errs)
+    snap.product, errs = fetch_scan_funnel()
+    snap.errors.extend(errs)
+    snap.bot, errs = fetch_bot_stats()
+    snap.errors.extend(errs)
+    snap.health, errs = fetch_uptime()
+    snap.errors.extend(errs)
+    return snap
+
+
+# ── Reporting ────────────────────────────────────────────────────────────────
+
+
+def render_pulse(snap: FunnelSnapshot, week_label: str) -> str:
+    p, prod, bot, health = snap.pipeline, snap.product, snap.bot, snap.health
+
+    stage_line = (
+        " → ".join(
+            f"{p.get('by_stage', {}).get(s, 0)} {s}"
+            for s in LIFECYCLE_ORDER
+            if p.get("by_stage", {}).get(s)
+        )
+        or "_no pipeline data_"
+    )
+
+    hit_rate = prod.get("kb_hit_rate", 0.0)
+    uptime = health.get("uptime_pct_7d", 0.0)
+
+    md = [
+        f"# FactoryLM Pulse — {week_label}",
+        f"\n_Generated {snap.ts}_",
+        "",
+        "## Pipeline (HubSpot)",
+        f"- **Total companies:** {p.get('total_companies', 0)}",
+        f"- **By stage:** {stage_line}",
+        f"- **New leads (7d):** {p.get('new_leads_7d', 0)}",
+        f"- **Open deals:** {p.get('open_deals', 0)} — ${p.get('open_deal_value', 0):,.0f}",
+        "",
+        "## Product (Scan funnel)",
+        f"- **Scans (7d):** {prod.get('scans_7d', 0)}",
+        f"- **KB hit rate:** {hit_rate}%  ({prod.get('kb_hits', 0)} hits / {prod.get('kb_misses', 0)} misses)",
+        f"- **Manuals queued:** {prod.get('manuals_queued', 0)}",
+        "",
+        "## Bot (Telegram)",
+        f"- **Messages (7d):** {bot.get('messages_7d', 0)}",
+        f"- **Unique users (7d):** {bot.get('unique_users_7d', 0)}",
+        f"- **Source:** {bot.get('source', 'unknown')}",
+        "",
+        "## Health",
+        f"- **7-day uptime score:** {uptime}/100",
+        f"- **Samples:** {health.get('samples', 0)}",
+        "",
+    ]
+    if snap.errors:
+        md.append("## Collection errors\n")
+        for e in snap.errors:
+            md.append(f"- _{e}_")
+        md.append("")
+    md.append("---\n_Generated by `mira-crawler/agents/funnel_tracker.py`_")
+    return "\n".join(md)
+
+
+def render_telegram(snap: FunnelSnapshot, week_label: str) -> str:
+    p, prod, bot, health = snap.pipeline, snap.product, snap.bot, snap.health
+    return (
+        f"*FactoryLM Pulse — {week_label}*\n\n"
+        f"*Pipeline:* {p.get('total_companies', 0)} companies · "
+        f"{p.get('new_leads_7d', 0)} new (7d) · "
+        f"{p.get('open_deals', 0)} open deals (${p.get('open_deal_value', 0):,.0f})\n"
+        f"*Product:* {prod.get('scans_7d', 0)} scans · "
+        f"{prod.get('kb_hit_rate', 0)}% KB hit · "
+        f"{prod.get('manuals_queued', 0)} queued\n"
+        f"*Bot:* {bot.get('messages_7d', 0)} msgs · "
+        f"{bot.get('unique_users_7d', 0)} users\n"
+        f"*Health:* {health.get('uptime_pct_7d', 0)}/100 (7d)"
+    )
+
+
+def save_pulse(content: str, out_dir: Path) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    today = datetime.now(timezone.utc)
+    iso_year, iso_week, _ = today.isocalendar()
+    fname = out_dir / f"{iso_year}-W{iso_week:02d}.md"
+    fname.write_text(content, encoding="utf-8")
+    return fname
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Daily/weekly funnel tracker")
+    parser.add_argument(
+        "--weekly", action="store_true", help="Generate the full pulse report (and Telegram push)"
+    )
+    parser.add_argument("--out-dir", default="docs/reports/pulse")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--json", action="store_true", help="Print snapshot JSON instead of human report"
+    )
+    args = parser.parse_args(argv)
+
+    snap = collect()
+
+    today = datetime.now(timezone.utc)
+    iso_year, iso_week, _ = today.isocalendar()
+    week_label = f"{iso_year}-W{iso_week:02d}"
+
+    if args.json:
+        from dataclasses import asdict
+
+        print(json.dumps(asdict(snap), indent=2))
+        return 0
+
+    pulse_md = render_pulse(snap, week_label)
+
+    if args.dry_run:
+        print(pulse_md)
+        print("\n---\nTelegram preview:\n")
+        print(render_telegram(snap, week_label))
+        return 0
+
+    # Save pulse on every run — daily snapshot overwrites the same week file,
+    # weekly run is the canonical close.
+    out_dir = Path(args.out_dir).resolve()
+    saved = save_pulse(pulse_md, out_dir)
+    logger.info("saved %s", saved)
+
+    if args.weekly:
+        notify("system", render_telegram(snap, week_label))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mira-crawler/agents/heartbeat_monitor.py
+++ b/mira-crawler/agents/heartbeat_monitor.py
@@ -1,0 +1,671 @@
+"""Heartbeat Monitor — runs every 15 min, checks health of every critical surface.
+
+Architecture
+------------
+This script is designed to run **on the VPS itself** under cron (see
+`scripts/install_crons.sh`). All checks are local to the VPS:
+
+  * `docker ps`                  → container liveness
+  * `curl http://localhost:…`    → API endpoint health
+  * `docker logs … --since 5m`   → bot poll evidence
+  * `psycopg2`/SQLAlchemy        → NeonDB SELECT 1
+  * stat(manual_queue.json)      → KB cron freshness
+  * `df -h /`, `free -m`         → host resource pressure
+
+Every probe returns a structured `HealthCheck` (service / status / latency /
+details). Results are persisted to NeonDB `system_health_log` for trend
+analysis, and surfaced via Telegram **only when something is wrong** so Mike
+isn't spammed when everything is green.
+
+Behaviour
+---------
+- DOWN  → immediate Telegram alert, also triggers self_healer (separate agent)
+- DEGRADED > 30 min  → escalating Telegram warning (state held in NeonDB)
+- HEALTHY  → silent, except for the 08:00 UTC daily roll-up
+
+Usage
+-----
+    python3 mira-crawler/agents/heartbeat_monitor.py
+    python3 mira-crawler/agents/heartbeat_monitor.py --json    # machine-readable
+    python3 mira-crawler/agents/heartbeat_monitor.py --dry-run # no DB write, no Telegram
+    python3 mira-crawler/agents/heartbeat_monitor.py --daily-summary  # 08:00 UTC roll-up
+
+Schedule (see scripts/install_crons.sh)
+    */15 * * * *    heartbeat_monitor.py
+    0 8 * * *       heartbeat_monitor.py --daily-summary
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Allow `python3 mira-crawler/agents/heartbeat_monitor.py` from repo root
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] heartbeat: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+logger = logging.getLogger("heartbeat_monitor")
+
+try:
+    from mira_crawler.reporting.telegram_notify import notify
+except ImportError:
+
+    def notify(agent_key: str, message: str, **_: Any) -> bool:  # type: ignore[misc]
+        print(f"[{agent_key}] {message}")
+        return True
+
+
+# ── Status taxonomy ───────────────────────────────────────────────────────────
+
+STATUS_HEALTHY = "healthy"
+STATUS_DEGRADED = "degraded"
+STATUS_DOWN = "down"
+STATUS_UNKNOWN = "unknown"
+
+# How slow before a working service is "degraded" (per-check, can override)
+DEFAULT_DEGRADED_LATENCY_MS = 2_000
+# After this long in DEGRADED, escalate to Mike (single alert, then quiet)
+DEGRADED_ALERT_AFTER_MIN = 30
+
+
+# ── Critical surface inventory ────────────────────────────────────────────────
+# Add/remove entries here — the inventory is the contract. Every other agent
+# consumes this list (self-healer remediations key off `service`).
+
+CRITICAL_CONTAINERS = [
+    "mira-hub",
+    "mira-pipeline",
+    "mira-bot-telegram",
+    "mira-scan-backend",
+    "atlas-api",
+    "mira-docling",
+    "mira-web",
+    "mira-mcp",
+]
+
+HTTP_ENDPOINTS = [
+    # (label, url, expect_status, timeout_s)
+    ("app.factorylm.com/api/health", "https://app.factorylm.com/api/health", 200, 10),
+    (
+        "app.factorylm.com/api/scanbe/healthz",
+        "https://app.factorylm.com/api/scanbe/healthz",
+        200,
+        10,
+    ),
+    ("factorylm.com", "https://factorylm.com", 200, 10),
+]
+
+# Container we expect to be polling Telegram. We grep its recent log for the
+# pattern emitted by python-telegram-bot's getUpdates loop.
+TELEGRAM_BOT_CONTAINER = "mira-bot-telegram"
+TELEGRAM_POLL_PATTERN = "getUpdates"
+TELEGRAM_LOG_WINDOW_MIN = 5
+
+# KB Growth cron freshness — `manual_queue.json` mtime should be < 24h on a
+# healthy node (cron runs every 6h).
+KB_QUEUE_PATHS = [
+    "/opt/mira/mira-crawler/cron/manual_queue.json",  # actual cron path
+    "/opt/mira/manual_queue.json",
+    "/opt/mira/mira-crawler/manual_queue.json",
+]
+KB_STALE_AFTER_HOURS = 24
+
+# Resource thresholds
+DISK_WARN_PCT = 80
+DISK_DOWN_PCT = 90
+MEM_WARN_PCT = 85
+MEM_DOWN_PCT = 95
+
+
+# ── Probe result type ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class HealthCheck:
+    service: str
+    status: str
+    latency_ms: int
+    details: str = ""
+    category: str = "service"  # service | endpoint | resource | data
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+# ── Probes ────────────────────────────────────────────────────────────────────
+
+
+def _run_cmd(cmd: list[str], timeout: int = 15) -> tuple[int, str, str]:
+    """Run a shell command, return (returncode, stdout, stderr). Never raises."""
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timeout after {timeout}s"
+    except FileNotFoundError as exc:
+        return 127, "", f"binary not found: {exc}"
+    except Exception as exc:  # noqa: BLE001
+        return 1, "", str(exc)
+
+
+def check_container(name: str) -> HealthCheck:
+    """Container is healthy if `docker ps` lists it AND state is `running`."""
+    start = time.perf_counter()
+    rc, out, err = _run_cmd(
+        ["docker", "ps", "--filter", f"name=^{name}$", "--format", "{{.Names}} {{.Status}}"],
+        timeout=10,
+    )
+    latency = int((time.perf_counter() - start) * 1000)
+
+    if rc == 127:
+        return HealthCheck(name, STATUS_UNKNOWN, latency, "docker not on PATH", "service")
+    if rc != 0:
+        return HealthCheck(
+            name, STATUS_DOWN, latency, f"docker ps failed: {err.strip()[:120]}", "service"
+        )
+
+    line = out.strip()
+    if not line:
+        return HealthCheck(
+            name,
+            STATUS_DOWN,
+            latency,
+            "container not running",
+            "service",
+            extra={"remediation_hint": "container_missing"},
+        )
+
+    # `Up 3 hours (healthy)` is the normal status. Anything starting with `Restarting` or
+    # `Exited` is degraded/down.
+    status_line = line.partition(" ")[2]
+    if status_line.startswith("Up"):
+        if "(unhealthy)" in status_line:
+            return HealthCheck(
+                name,
+                STATUS_DEGRADED,
+                latency,
+                status_line,
+                "service",
+                extra={"remediation_hint": "container_unhealthy"},
+            )
+        return HealthCheck(name, STATUS_HEALTHY, latency, status_line, "service")
+    if status_line.startswith("Restarting"):
+        return HealthCheck(
+            name,
+            STATUS_DEGRADED,
+            latency,
+            status_line,
+            "service",
+            extra={"remediation_hint": "container_restarting"},
+        )
+    return HealthCheck(
+        name,
+        STATUS_DOWN,
+        latency,
+        status_line,
+        "service",
+        extra={"remediation_hint": "container_exited"},
+    )
+
+
+def check_http(label: str, url: str, expect: int, timeout: int) -> HealthCheck:
+    start = time.perf_counter()
+    try:
+        import httpx
+
+        resp = httpx.get(url, timeout=timeout, follow_redirects=True)
+        latency = int((time.perf_counter() - start) * 1000)
+        if resp.status_code == expect:
+            status = STATUS_DEGRADED if latency > DEFAULT_DEGRADED_LATENCY_MS else STATUS_HEALTHY
+            return HealthCheck(label, status, latency, f"HTTP {resp.status_code}", "endpoint")
+        if 500 <= resp.status_code < 600:
+            return HealthCheck(
+                label,
+                STATUS_DOWN,
+                latency,
+                f"HTTP {resp.status_code}",
+                "endpoint",
+                extra={"remediation_hint": "api_5xx", "url": url},
+            )
+        return HealthCheck(
+            label,
+            STATUS_DEGRADED,
+            latency,
+            f"HTTP {resp.status_code} (expected {expect})",
+            "endpoint",
+        )
+    except Exception as exc:  # noqa: BLE001
+        latency = int((time.perf_counter() - start) * 1000)
+        return HealthCheck(
+            label,
+            STATUS_DOWN,
+            latency,
+            f"{type(exc).__name__}: {str(exc)[:120]}",
+            "endpoint",
+            extra={"remediation_hint": "endpoint_unreachable", "url": url},
+        )
+
+
+def check_telegram_polling() -> HealthCheck:
+    """Look for `getUpdates` in the bot container's last 5 minutes of logs."""
+    start = time.perf_counter()
+    rc, out, err = _run_cmd(
+        ["docker", "logs", "--since", f"{TELEGRAM_LOG_WINDOW_MIN}m", TELEGRAM_BOT_CONTAINER],
+        timeout=15,
+    )
+    latency = int((time.perf_counter() - start) * 1000)
+
+    if rc == 127:
+        return HealthCheck(
+            "telegram_polling", STATUS_UNKNOWN, latency, "docker not on PATH", "service"
+        )
+    if rc != 0:
+        return HealthCheck(
+            "telegram_polling",
+            STATUS_DOWN,
+            latency,
+            f"docker logs failed: {err.strip()[:120]}",
+            "service",
+        )
+
+    if TELEGRAM_POLL_PATTERN.lower() in (out + err).lower():
+        return HealthCheck(
+            "telegram_polling",
+            STATUS_HEALTHY,
+            latency,
+            f"poll evidence in last {TELEGRAM_LOG_WINDOW_MIN}m",
+            "service",
+        )
+
+    # No evidence of polling — bot may be alive but stuck.
+    return HealthCheck(
+        "telegram_polling",
+        STATUS_DOWN,
+        latency,
+        f"no '{TELEGRAM_POLL_PATTERN}' in last {TELEGRAM_LOG_WINDOW_MIN}m",
+        "service",
+        extra={"remediation_hint": "bot_not_polling"},
+    )
+
+
+def check_neondb() -> HealthCheck:
+    """Open an engine, run SELECT 1, return latency."""
+    start = time.perf_counter()
+    url = os.environ.get("NEON_DATABASE_URL", "")
+    if not url:
+        return HealthCheck("neondb", STATUS_UNKNOWN, 0, "NEON_DATABASE_URL not set", "data")
+
+    try:
+        from sqlalchemy import create_engine, text
+        from sqlalchemy.pool import NullPool
+
+        engine = create_engine(
+            url,
+            poolclass=NullPool,
+            connect_args={"sslmode": "require"},
+            pool_pre_ping=True,
+        )
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        latency = int((time.perf_counter() - start) * 1000)
+        status = STATUS_DEGRADED if latency > 3_000 else STATUS_HEALTHY
+        return HealthCheck("neondb", status, latency, "SELECT 1 ok", "data")
+    except Exception as exc:  # noqa: BLE001
+        latency = int((time.perf_counter() - start) * 1000)
+        return HealthCheck(
+            "neondb",
+            STATUS_DOWN,
+            latency,
+            f"{type(exc).__name__}: {str(exc)[:120]}",
+            "data",
+            extra={"remediation_hint": "neondb_connection"},
+        )
+
+
+def check_kb_cron_freshness() -> HealthCheck:
+    """KB growth cron writes manual_queue.json every 6h. >24h = stale."""
+    start = time.perf_counter()
+    for path in KB_QUEUE_PATHS:
+        p = Path(path)
+        if p.exists():
+            age_h = (time.time() - p.stat().st_mtime) / 3600
+            latency = int((time.perf_counter() - start) * 1000)
+            if age_h > KB_STALE_AFTER_HOURS:
+                return HealthCheck(
+                    "kb_cron",
+                    STATUS_DOWN,
+                    latency,
+                    f"manual_queue.json {age_h:.1f}h old",
+                    "data",
+                    extra={"remediation_hint": "kb_cron_stale", "path": path},
+                )
+            return HealthCheck(
+                "kb_cron", STATUS_HEALTHY, latency, f"manual_queue.json {age_h:.1f}h old", "data"
+            )
+
+    latency = int((time.perf_counter() - start) * 1000)
+    return HealthCheck(
+        "kb_cron",
+        STATUS_UNKNOWN,
+        latency,
+        f"no manual_queue.json found at {KB_QUEUE_PATHS}",
+        "data",
+    )
+
+
+def check_disk() -> HealthCheck:
+    start = time.perf_counter()
+    try:
+        usage = shutil.disk_usage("/")
+        pct = int(100 * usage.used / usage.total)
+        latency = int((time.perf_counter() - start) * 1000)
+        details = f"{pct}% used ({usage.used // 2**30}G / {usage.total // 2**30}G)"
+        if pct >= DISK_DOWN_PCT:
+            return HealthCheck(
+                "disk",
+                STATUS_DOWN,
+                latency,
+                details,
+                "resource",
+                extra={"remediation_hint": "disk_full", "pct": pct},
+            )
+        if pct >= DISK_WARN_PCT:
+            return HealthCheck(
+                "disk", STATUS_DEGRADED, latency, details, "resource", extra={"pct": pct}
+            )
+        return HealthCheck("disk", STATUS_HEALTHY, latency, details, "resource", extra={"pct": pct})
+    except Exception as exc:  # noqa: BLE001
+        latency = int((time.perf_counter() - start) * 1000)
+        return HealthCheck("disk", STATUS_UNKNOWN, latency, str(exc), "resource")
+
+
+def check_memory() -> HealthCheck:
+    """Parse `free -m`. Linux-only — silently UNKNOWN on macOS."""
+    start = time.perf_counter()
+    rc, out, _ = _run_cmd(["free", "-m"], timeout=5)
+    latency = int((time.perf_counter() - start) * 1000)
+
+    if rc != 0 or not out:
+        return HealthCheck("memory", STATUS_UNKNOWN, latency, "free not available", "resource")
+
+    try:
+        lines = out.strip().splitlines()
+        # `Mem: total used free shared buff/cache available`
+        mem_line = next(line for line in lines if line.lower().startswith("mem"))
+        parts = mem_line.split()
+        total = int(parts[1])
+        used = int(parts[2])
+        pct = int(100 * used / total) if total else 0
+        details = f"{pct}% used ({used}M / {total}M)"
+    except Exception as exc:  # noqa: BLE001
+        return HealthCheck("memory", STATUS_UNKNOWN, latency, f"parse error: {exc}", "resource")
+
+    if pct >= MEM_DOWN_PCT:
+        return HealthCheck("memory", STATUS_DOWN, latency, details, "resource", extra={"pct": pct})
+    if pct >= MEM_WARN_PCT:
+        return HealthCheck(
+            "memory", STATUS_DEGRADED, latency, details, "resource", extra={"pct": pct}
+        )
+    return HealthCheck("memory", STATUS_HEALTHY, latency, details, "resource", extra={"pct": pct})
+
+
+# ── Aggregator ───────────────────────────────────────────────────────────────
+
+
+def run_all_checks() -> list[HealthCheck]:
+    """Run every probe sequentially. Probes are cheap and cron-driven, so the
+    extra complexity of asyncio isn't worth it here."""
+    checks: list[HealthCheck] = []
+
+    for c in CRITICAL_CONTAINERS:
+        checks.append(check_container(c))
+
+    for label, url, expect, timeout in HTTP_ENDPOINTS:
+        checks.append(check_http(label, url, expect, timeout))
+
+    checks.append(check_telegram_polling())
+    checks.append(check_neondb())
+    checks.append(check_kb_cron_freshness())
+    checks.append(check_disk())
+    checks.append(check_memory())
+
+    return checks
+
+
+def health_score(checks: list[HealthCheck]) -> int:
+    """0-100 score. UNKNOWN doesn't penalise (we couldn't tell)."""
+    weights = {STATUS_HEALTHY: 1.0, STATUS_DEGRADED: 0.5, STATUS_DOWN: 0.0}
+    scored = [c for c in checks if c.status in weights]
+    if not scored:
+        return 0
+    return int(round(100 * sum(weights[c.status] for c in scored) / len(scored)))
+
+
+# ── Persistence ──────────────────────────────────────────────────────────────
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS system_health_log (
+    id           BIGSERIAL PRIMARY KEY,
+    ts           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    service      TEXT NOT NULL,
+    status       TEXT NOT NULL,
+    latency_ms   INTEGER NOT NULL DEFAULT 0,
+    details      TEXT,
+    category     TEXT,
+    score        INTEGER,
+    action_taken TEXT,
+    extra        JSONB
+);
+CREATE INDEX IF NOT EXISTS ix_health_log_ts ON system_health_log (ts DESC);
+CREATE INDEX IF NOT EXISTS ix_health_log_service_ts ON system_health_log (service, ts DESC);
+"""
+
+
+def persist(checks: list[HealthCheck], score: int, dry_run: bool = False) -> bool:
+    """Insert one row per check. Returns True on success, False on any error."""
+    if dry_run:
+        logger.info("dry-run: skipping persist (%d checks, score=%d)", len(checks), score)
+        return True
+
+    url = os.environ.get("NEON_DATABASE_URL", "")
+    if not url:
+        logger.warning("NEON_DATABASE_URL not set — skipping persist")
+        return False
+
+    try:
+        from sqlalchemy import create_engine, text
+        from sqlalchemy.pool import NullPool
+
+        engine = create_engine(url, poolclass=NullPool, connect_args={"sslmode": "require"})
+        with engine.begin() as conn:
+            for stmt in CREATE_TABLE_SQL.strip().split(";"):
+                stmt = stmt.strip()
+                if stmt:
+                    conn.execute(text(stmt))
+            for c in checks:
+                conn.execute(
+                    text(
+                        "INSERT INTO system_health_log "
+                        "(service, status, latency_ms, details, category, score, extra) "
+                        "VALUES (:service, :status, :latency_ms, :details, :category, :score, :extra)"
+                    ),
+                    {
+                        "service": c.service,
+                        "status": c.status,
+                        "latency_ms": c.latency_ms,
+                        "details": c.details[:500],
+                        "category": c.category,
+                        "score": score,
+                        "extra": json.dumps(c.extra) if c.extra else None,
+                    },
+                )
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("persist failed: %s", exc)
+        return False
+
+
+def degraded_for_minutes(service: str) -> int | None:
+    """How many minutes has `service` been DEGRADED in a row? None on DB error."""
+    url = os.environ.get("NEON_DATABASE_URL", "")
+    if not url:
+        return None
+    try:
+        from sqlalchemy import create_engine, text
+        from sqlalchemy.pool import NullPool
+
+        engine = create_engine(url, poolclass=NullPool, connect_args={"sslmode": "require"})
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT MIN(ts) FROM ("
+                    "  SELECT ts FROM system_health_log "
+                    "  WHERE service = :svc "
+                    "  ORDER BY ts DESC LIMIT 200"
+                    ") recent "
+                    "WHERE NOT EXISTS ("
+                    "  SELECT 1 FROM system_health_log h2 "
+                    "  WHERE h2.service = :svc AND h2.ts > recent.ts AND h2.status != 'degraded'"
+                    ")"
+                ),
+                {"svc": service},
+            ).first()
+        if not row or not row[0]:
+            return None
+        delta = datetime.now(timezone.utc) - row[0]
+        return int(delta.total_seconds() // 60)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ── Reporting ────────────────────────────────────────────────────────────────
+
+_STATUS_EMOJI = {
+    STATUS_HEALTHY: "🟢",
+    STATUS_DEGRADED: "🟡",
+    STATUS_DOWN: "🔴",
+    STATUS_UNKNOWN: "⚪",
+}
+
+
+def format_alert(checks: list[HealthCheck], score: int) -> str:
+    down = [c for c in checks if c.status == STATUS_DOWN]
+    degraded = [c for c in checks if c.status == STATUS_DEGRADED]
+    lines = [f"*Health: {score}/100*"]
+    if down:
+        lines.append(f"\n🔴 *{len(down)} DOWN*")
+        for c in down[:8]:
+            lines.append(f"  • `{c.service}` — {c.details[:80]}")
+    if degraded:
+        lines.append(f"\n🟡 *{len(degraded)} degraded*")
+        for c in degraded[:5]:
+            lines.append(f"  • `{c.service}` — {c.details[:80]} ({c.latency_ms}ms)")
+    return "\n".join(lines)
+
+
+def format_daily_summary(checks: list[HealthCheck], score: int) -> str:
+    by_status: dict[str, list[HealthCheck]] = {}
+    for c in checks:
+        by_status.setdefault(c.status, []).append(c)
+
+    lines = [
+        f"*Daily Health Summary — {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}*",
+        f"Overall: {score}/100",
+        "",
+    ]
+    for status in (STATUS_HEALTHY, STATUS_DEGRADED, STATUS_DOWN, STATUS_UNKNOWN):
+        items = by_status.get(status, [])
+        if not items:
+            continue
+        lines.append(f"{_STATUS_EMOJI[status]} *{status.title()}* ({len(items)})")
+        for c in items[:12]:
+            lines.append(f"  • `{c.service}` — {c.details[:60]}")
+        lines.append("")
+    return "\n".join(lines).strip()
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="MIRA heartbeat monitor")
+    parser.add_argument("--json", action="store_true", help="Print JSON report to stdout")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run checks but don't persist or send Telegram alerts",
+    )
+    parser.add_argument(
+        "--daily-summary",
+        action="store_true",
+        help="Send the daily summary regardless of state (use at 08:00 UTC)",
+    )
+    parser.add_argument("--quiet", action="store_true", help="Reduce log verbosity")
+    args = parser.parse_args(argv)
+
+    if args.quiet:
+        logger.setLevel(logging.WARNING)
+
+    checks = run_all_checks()
+    score = health_score(checks)
+    persist(checks, score, dry_run=args.dry_run)
+
+    down = [c for c in checks if c.status == STATUS_DOWN]
+    degraded = [c for c in checks if c.status == STATUS_DEGRADED]
+
+    # Always emit JSON to stdout if asked — useful for piping into self_healer
+    report = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "score": score,
+        "down": [asdict(c) for c in down],
+        "degraded": [asdict(c) for c in degraded],
+        "all": [asdict(c) for c in checks],
+    }
+    if args.json:
+        print(json.dumps(report, indent=2))
+
+    # Notify rules:
+    # - DOWN  → immediate alert (every run while down — heartbeat is the bell)
+    # - DEGRADED > 30min consecutively → one alert
+    # - daily summary if requested
+    if args.dry_run:
+        logger.info(
+            "dry-run: would alert: down=%d degraded=%d score=%d", len(down), len(degraded), score
+        )
+        return 0
+
+    if args.daily_summary:
+        notify("system", format_daily_summary(checks, score))
+        return 0 if not down else 2
+
+    if down:
+        notify("system", format_alert(checks, score))
+        logger.warning("DOWN: %s", [c.service for c in down])
+        return 2  # exit code 2 — caller (self_healer wrapper) can branch on this
+
+    if degraded:
+        # Suppress the alert unless we've been degraded > threshold.
+        worst = max((degraded_for_minutes(c.service) or 0) for c in degraded)
+        if worst >= DEGRADED_ALERT_AFTER_MIN:
+            notify("system", format_alert(checks, score))
+            logger.warning("DEGRADED >%dm: %s", worst, [c.service for c in degraded])
+            return 1
+
+    logger.info("all green — score=%d", score)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mira-crawler/agents/learning_capture.py
+++ b/mira-crawler/agents/learning_capture.py
@@ -1,0 +1,447 @@
+"""Learning Capture — diff benchmark runs, write learnings, file regressions.
+
+Runs after every benchmark suite (or weekly cron). Compares the latest
+`benchmark_v*.json` (in repo root) against the previous one and produces:
+
+  1. A dated learning note in `docs/learnings/YYYY-MM-DD_<version>.md`
+     summarising overall delta, regressions, and improvements.
+  2. A GitHub issue per *new* regression — one issue per case_id, deduped by
+     title so re-runs don't spam the tracker.
+  3. A Telegram summary (`benchmark` agent persona) so Mike sees it immediately.
+  4. A "rubric drift" report flagging cases that have regressed three runs in a
+     row — strong signal the rubric is wrong, not the model.
+
+Inputs
+------
+* `benchmark_v*.json` files in repo root (or `--results-dir` override).
+* Schema: each file has `version`, `overall_score`, `grade`, `case_results: [
+  {case_id, dimension, score, error, reasoning, ...}, ... ]`.
+
+Outputs
+-------
+* `docs/learnings/YYYY-MM-DD_<version>.md`
+* `gh issue create` for each NEW regression
+* Telegram summary
+
+Usage
+-----
+    python3 mira-crawler/agents/learning_capture.py
+    python3 mira-crawler/agents/learning_capture.py --dry-run
+    python3 mira-crawler/agents/learning_capture.py --results-dir /tmp/runs
+    python3 mira-crawler/agents/learning_capture.py --no-issues
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] learning: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+logger = logging.getLogger("learning_capture")
+
+try:
+    from mira_crawler.reporting.telegram_notify import notify
+except ImportError:
+
+    def notify(agent_key: str, message: str, **_) -> bool:  # type: ignore[misc]
+        print(f"[{agent_key}] {message}")
+        return True
+
+
+REGRESSION_THRESHOLD = 0.10  # 10pt absolute drop counts as a regression
+IMPROVEMENT_THRESHOLD = 0.10
+RUBRIC_DRIFT_RUNS = 3  # consecutive regressions → suggest rubric review
+
+
+@dataclass
+class CaseDelta:
+    case_id: str
+    dimension: str
+    previous_score: float
+    current_score: float
+    delta: float
+    likely_cause: str
+    suggested_fix: str
+    error: str | None = None
+    reasoning: str | None = None
+
+
+# ── File discovery ───────────────────────────────────────────────────────────
+
+
+def find_benchmark_files(results_dir: Path) -> list[Path]:
+    """Return all `benchmark_v*.json` sorted by version (newest last)."""
+    files = sorted(results_dir.glob("benchmark_v*.json"))
+    return files
+
+
+def load_benchmark(path: Path) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+# ── Diff logic ───────────────────────────────────────────────────────────────
+
+
+def index_cases(data: dict) -> dict[str, dict]:
+    return {c["case_id"]: c for c in data.get("case_results", [])}
+
+
+def classify_regression(prev: dict, curr: dict) -> CaseDelta | None:
+    delta = (curr.get("score") or 0) - (prev.get("score") or 0)
+    if delta > -REGRESSION_THRESHOLD:
+        return None
+
+    cause = "unknown"
+    fix = "Review reasoning + retrieval for this case"
+
+    err = curr.get("error")
+    reasoning = curr.get("reasoning") or ""
+    if err:
+        cause = f"runtime error: {err[:120]}"
+        fix = "Fix the runtime error first, then re-run benchmark"
+    elif "not found" in reasoning.lower() or "no relevant" in reasoning.lower():
+        cause = "retrieval miss — KB chunk likely missing"
+        fix = "Check KB ingest for the topic; consider re-chunking source manuals"
+    elif "incorrect" in reasoning.lower() or "wrong" in reasoning.lower():
+        cause = "incorrect reasoning despite retrieval"
+        fix = "Inspect prompt + tools — the retrieved context didn't drive the right answer"
+    elif "incomplete" in reasoning.lower() or "missing" in reasoning.lower():
+        cause = "answer too sparse"
+        fix = "Tune the response template / Supervisor verbosity for this dimension"
+
+    return CaseDelta(
+        case_id=curr.get("case_id", "?"),
+        dimension=curr.get("dimension", "?"),
+        previous_score=prev.get("score") or 0.0,
+        current_score=curr.get("score") or 0.0,
+        delta=delta,
+        likely_cause=cause,
+        suggested_fix=fix,
+        error=err,
+        reasoning=reasoning[:400] if reasoning else None,
+    )
+
+
+def classify_improvement(prev: dict, curr: dict) -> CaseDelta | None:
+    delta = (curr.get("score") or 0) - (prev.get("score") or 0)
+    if delta < IMPROVEMENT_THRESHOLD:
+        return None
+    return CaseDelta(
+        case_id=curr.get("case_id", "?"),
+        dimension=curr.get("dimension", "?"),
+        previous_score=prev.get("score") or 0.0,
+        current_score=curr.get("score") or 0.0,
+        delta=delta,
+        likely_cause="improvement",
+        suggested_fix="",
+    )
+
+
+def detect_rubric_drift(history: list[dict], case_id: str) -> bool:
+    """If the same case has regressed `RUBRIC_DRIFT_RUNS` runs in a row, the
+    rubric is more suspect than the model. Heuristic, not a verdict."""
+    if len(history) < RUBRIC_DRIFT_RUNS + 1:
+        return False
+    scores = []
+    for run in history[-(RUBRIC_DRIFT_RUNS + 1) :]:
+        case = next((c for c in run.get("case_results", []) if c.get("case_id") == case_id), None)
+        if case is None:
+            return False
+        scores.append(case.get("score") or 0)
+    # Strictly decreasing or all below 0.5
+    return all(s < 0.5 for s in scores[-RUBRIC_DRIFT_RUNS:])
+
+
+# ── Output: learning note ────────────────────────────────────────────────────
+
+
+def write_learning_note(
+    out_dir: Path,
+    curr: dict,
+    prev: dict | None,
+    regressions: list[CaseDelta],
+    improvements: list[CaseDelta],
+    drift: list[str],
+) -> Path:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    version = curr.get("version", "unknown")
+    fname = out_dir / f"{today}_v{version}.md"
+
+    lines: list[str] = []
+    lines.append(f"# Learning Capture — Benchmark v{version}")
+    lines.append(f"\n_Generated {datetime.now(timezone.utc).isoformat(timespec='seconds')}_\n")
+
+    overall = curr.get("overall_score", 0)
+    if prev is not None:
+        prev_overall = prev.get("overall_score", 0)
+        diff = overall - prev_overall
+        arrow = "↑" if diff > 0 else ("↓" if diff < 0 else "→")
+        lines.append(
+            f"## Headline\n\n**{overall:.1f}%** ({arrow}{abs(diff):.1f} from v{prev.get('version', '?')}) — grade {curr.get('grade', '?')}"
+        )
+    else:
+        lines.append(
+            f"## Headline\n\n**{overall:.1f}%** — grade {curr.get('grade', '?')} (no previous run to compare)"
+        )
+
+    lines.append("\n## Dimension scores")
+    lines.append("\n| Dimension | Score | Cases |")
+    lines.append("|-----------|-------|-------|")
+    for dim, score in curr.get("dimension_scores", {}).items():
+        n = curr.get("dimension_case_counts", {}).get(dim, "?")
+        lines.append(f"| {dim} | {score:.1f}% | {n} |")
+
+    if regressions:
+        lines.append(f"\n## Regressions ({len(regressions)})\n")
+        for r in regressions:
+            lines.append(f"### `{r.case_id}` ({r.dimension})")
+            lines.append(
+                f"- previous: **{r.previous_score:.2f}** → current: **{r.current_score:.2f}** (Δ {r.delta:+.2f})"
+            )
+            lines.append(f"- likely cause: {r.likely_cause}")
+            lines.append(f"- suggested fix: {r.suggested_fix}")
+            if r.error:
+                lines.append(f"- runtime error: `{r.error[:120]}`")
+            if r.reasoning:
+                lines.append(f"- reasoning: _{r.reasoning[:200]}_")
+            lines.append("")
+
+    if improvements:
+        lines.append(f"\n## Improvements ({len(improvements)})\n")
+        for imp in improvements:
+            lines.append(
+                f"- `{imp.case_id}` ({imp.dimension}): {imp.previous_score:.2f} → {imp.current_score:.2f} (Δ {imp.delta:+.2f})"
+            )
+
+    if drift:
+        lines.append(f"\n## Rubric Drift Candidates ({len(drift)})\n")
+        lines.append(
+            "These cases have regressed for 3+ runs. The rubric may be wrong, not the model.\n"
+        )
+        for case_id in drift:
+            lines.append(
+                f"- `{case_id}` — review the expected answer vs. what the model is producing"
+            )
+
+    lines.append("\n---\n_Generated by `mira-crawler/agents/learning_capture.py`_\n")
+
+    fname.write_text("\n".join(lines), encoding="utf-8")
+    return fname
+
+
+# ── GitHub issue creation ────────────────────────────────────────────────────
+
+
+def gh_available() -> bool:
+    return shutil.which("gh") is not None
+
+
+def existing_issue_titles() -> set[str]:
+    """List open issues with the `benchmark-regression` label so we don't dupe."""
+    if not gh_available():
+        return set()
+    try:
+        out = subprocess.check_output(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--label",
+                "benchmark-regression",
+                "--state",
+                "open",
+                "--json",
+                "title",
+                "--limit",
+                "200",
+            ],
+            text=True,
+            timeout=30,
+        )
+        return {item["title"] for item in json.loads(out)}
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("gh issue list failed: %s", exc)
+        return set()
+
+
+def file_issue(reg: CaseDelta, version: str, dry_run: bool) -> bool:
+    title = f"benchmark regression: {reg.case_id} ({reg.dimension}) v{version}"
+    body = "\n".join(
+        [
+            f"**Case:** `{reg.case_id}` ({reg.dimension})",
+            f"**Previous score:** {reg.previous_score:.2f}",
+            f"**Current score:** {reg.current_score:.2f}  (Δ {reg.delta:+.2f})",
+            f"**Likely cause:** {reg.likely_cause}",
+            f"**Suggested fix:** {reg.suggested_fix}",
+            "",
+            f"_Auto-filed by `learning_capture.py` from benchmark v{version}._",
+        ]
+    )
+    if reg.error:
+        body += f"\n\n**Runtime error:**\n```\n{reg.error[:500]}\n```"
+    if reg.reasoning:
+        body += f"\n\n**Reasoning:**\n> {reg.reasoning[:500]}"
+
+    if dry_run or not gh_available():
+        logger.info("[dry-run/no-gh] would file: %s", title)
+        return False
+    try:
+        subprocess.run(
+            [
+                "gh",
+                "issue",
+                "create",
+                "--title",
+                title,
+                "--body",
+                body,
+                "--label",
+                "benchmark-regression",
+            ],
+            check=True,
+            timeout=30,
+            capture_output=True,
+            text=True,
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("gh issue create failed for %s: %s", reg.case_id, exc)
+        return False
+
+
+# ── Telegram summary ─────────────────────────────────────────────────────────
+
+
+def telegram_summary(
+    curr: dict,
+    prev: dict | None,
+    regressions: list[CaseDelta],
+    improvements: list[CaseDelta],
+    note_path: Path,
+) -> str:
+    overall = curr.get("overall_score", 0)
+    version = curr.get("version", "?")
+    if prev is not None:
+        diff = overall - prev.get("overall_score", 0)
+        arrow = "↑" if diff > 0 else "↓"
+        head = f"*Benchmark v{version}: {overall:.1f}%* ({arrow}{abs(diff):.1f} from v{prev.get('version', '?')})"
+    else:
+        head = f"*Benchmark v{version}: {overall:.1f}%*"
+
+    lines = [
+        head,
+        f"Grade: {curr.get('grade', '?')} — {len(regressions)} regression(s), {len(improvements)} improvement(s)",
+    ]
+    if regressions:
+        lines.append("\n🔻 Regressions:")
+        for r in regressions[:5]:
+            lines.append(
+                f"  • `{r.case_id}` {r.previous_score:.2f}→{r.current_score:.2f} ({r.likely_cause[:40]})"
+            )
+    if improvements:
+        lines.append("\n🔼 Top improvements:")
+        for imp in sorted(improvements, key=lambda x: -x.delta)[:3]:
+            lines.append(f"  • `{imp.case_id}` {imp.previous_score:.2f}→{imp.current_score:.2f}")
+    lines.append(
+        f"\n📝 Full note: `{note_path.relative_to(Path.cwd()) if note_path.is_absolute() else note_path}`"
+    )
+    return "\n".join(lines)
+
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Capture learnings from benchmark runs")
+    parser.add_argument(
+        "--results-dir",
+        default=".",
+        help="Where to look for benchmark_v*.json (default: repo root)",
+    )
+    parser.add_argument(
+        "--learnings-dir",
+        default="docs/learnings",
+        help="Where to write learning notes (default: docs/learnings)",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--no-issues", action="store_true", help="Skip GitHub issue creation")
+    parser.add_argument("--no-telegram", action="store_true")
+    args = parser.parse_args(argv)
+
+    results_dir = Path(args.results_dir).resolve()
+    learnings_dir = Path(args.learnings_dir).resolve()
+
+    files = find_benchmark_files(results_dir)
+    if not files:
+        logger.error("no benchmark_v*.json found in %s", results_dir)
+        return 1
+
+    curr = load_benchmark(files[-1])
+    prev = load_benchmark(files[-2]) if len(files) > 1 else None
+    history = [load_benchmark(f) for f in files[-10:]]  # last 10 runs for drift
+
+    if prev is None:
+        logger.info("first benchmark run — no diff possible, writing snapshot only")
+        regressions: list[CaseDelta] = []
+        improvements: list[CaseDelta] = []
+    else:
+        prev_idx = index_cases(prev)
+        curr_idx = index_cases(curr)
+        regressions = []
+        improvements = []
+        for case_id, curr_case in curr_idx.items():
+            prev_case = prev_idx.get(case_id)
+            if prev_case is None:
+                continue
+            r = classify_regression(prev_case, curr_case)
+            if r:
+                regressions.append(r)
+                continue
+            i = classify_improvement(prev_case, curr_case)
+            if i:
+                improvements.append(i)
+
+    drift = [r.case_id for r in regressions if detect_rubric_drift(history, r.case_id)]
+
+    note_path = write_learning_note(learnings_dir, curr, prev, regressions, improvements, drift)
+    logger.info("wrote %s", note_path)
+
+    if regressions and not args.no_issues:
+        existing = existing_issue_titles()
+        version = curr.get("version", "?")
+        filed = 0
+        for r in regressions:
+            # dedupe by case_id to avoid filing per-version when the same case keeps regressing
+            if any(r.case_id in t for t in existing):
+                continue
+            if file_issue(r, version, args.dry_run):
+                filed += 1
+        logger.info("filed %d new GitHub issue(s)", filed)
+
+    if not args.no_telegram:
+        msg = telegram_summary(curr, prev, regressions, improvements, note_path)
+        if args.dry_run:
+            print(msg)
+        else:
+            notify("benchmark", msg)
+
+    return 0 if not regressions else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mira-crawler/agents/self_healer.py
+++ b/mira-crawler/agents/self_healer.py
@@ -1,0 +1,361 @@
+"""Self-Healer — runs scoped remediations against DOWN services.
+
+Triggered by heartbeat_monitor (`exit code 2`) or by a fresh probe of its own.
+Consumes the heartbeat JSON, looks up the `remediation_hint` recorded by each
+probe, and dispatches to a small set of safe playbooks. Every action is logged
+back to NeonDB `system_health_log.action_taken` and surfaced via Telegram.
+
+Safety
+------
+The healer's blast radius is *deliberately tiny*:
+
+  * Container restart only — never `docker rm`, never image rebuild.
+  * Disk cleanup is `docker system prune -f` and rotated log trim — never
+    arbitrary `rm`.
+  * **Never** touches nginx, NeonDB schema, or any persistent volume.
+  * Will not run as root unless `MIRA_HEALER_ALLOW_ROOT=1`.
+
+Each playbook is idempotent and re-checks the affected probe afterwards. If
+the probe still fails, we escalate (one Telegram alert with full context) and
+mark `escalated=true` in the log so we don't loop.
+
+Usage
+-----
+    python3 mira-crawler/agents/self_healer.py            # probe → heal → re-probe
+    python3 mira-crawler/agents/self_healer.py --dry-run  # log what we'd do
+    python3 mira-crawler/agents/self_healer.py --service mira-pipeline  # one-shot
+    cat heartbeat.json | python3 mira-crawler/agents/self_healer.py --stdin
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] healer: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+logger = logging.getLogger("self_healer")
+
+try:
+    from mira_crawler.reporting.telegram_notify import notify
+except ImportError:
+
+    def notify(agent_key: str, message: str, **_: Any) -> bool:  # type: ignore[misc]
+        print(f"[{agent_key}] {message}")
+        return True
+
+
+# Re-use the heartbeat probes for the post-action re-check.
+try:
+    from mira_crawler.agents import heartbeat_monitor as hb
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import heartbeat_monitor as hb  # type: ignore[no-redef]
+
+
+# ── Action result ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class HealAction:
+    service: str
+    hint: str
+    action: str
+    succeeded: bool
+    details: str
+    escalated: bool = False
+
+
+def _run(cmd: list[str], timeout: int = 60) -> tuple[int, str, str]:
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return proc.returncode, proc.stdout, proc.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timeout after {timeout}s"
+    except FileNotFoundError as exc:
+        return 127, "", f"binary not found: {exc}"
+    except Exception as exc:  # noqa: BLE001
+        return 1, "", str(exc)
+
+
+# ── Playbooks ────────────────────────────────────────────────────────────────
+# Each playbook returns a HealAction. They MUST be idempotent and bounded.
+
+
+def restart_container(service: str, hint: str) -> HealAction:
+    rc, out, err = _run(["docker", "restart", service], timeout=60)
+    if rc == 0:
+        return HealAction(
+            service, hint, f"docker restart {service}", True, out.strip()[:200] or "ok"
+        )
+    return HealAction(
+        service, hint, f"docker restart {service}", False, err.strip()[:200] or out.strip()[:200]
+    )
+
+
+def disk_cleanup(service: str, hint: str) -> HealAction:
+    """Prune dangling docker objects + truncate big rotated logs."""
+    rc1, out1, err1 = _run(["docker", "system", "prune", "-f"], timeout=120)
+    # Trim log files >100M under /var/log/mira-agents (rotated, append-only).
+    log_dir = Path(os.environ.get("LOG_DIR", "/var/log/mira-agents"))
+    trimmed = []
+    if log_dir.exists():
+        for log in log_dir.glob("*.log"):
+            try:
+                if log.stat().st_size > 100 * 2**20:
+                    log.write_text("")  # truncate, don't delete
+                    trimmed.append(log.name)
+            except Exception:  # noqa: BLE001
+                pass
+    details = (
+        f"docker prune rc={rc1} | trimmed={trimmed} | {out1.strip()[:120] or err1.strip()[:120]}"
+    )
+    return HealAction(service, hint, "docker system prune -f + log trim", rc1 == 0, details)
+
+
+def trigger_kb_cron(service: str, hint: str) -> HealAction:
+    """Manually run the KB growth cron once — same command as the cron line."""
+    mira_dir = Path(os.environ.get("MIRA_DIR", "/opt/mira"))
+    script = mira_dir / "mira-crawler" / "cron" / "kb_growth_cron.py"
+    if not script.exists():
+        return HealAction(service, hint, "trigger_kb_cron", False, f"script not found: {script}")
+    rc, out, err = _run(["python3", str(script)], timeout=300)
+    return HealAction(service, hint, f"python3 {script.name}", rc == 0, (err or out).strip()[:200])
+
+
+def neondb_retry(service: str, hint: str) -> HealAction:
+    """No restart possible — just re-probe a few times before escalating."""
+    import time
+
+    for attempt in range(3):
+        chk = hb.check_neondb()
+        if chk.status == hb.STATUS_HEALTHY:
+            return HealAction(
+                service, hint, "retry SELECT 1", True, f"recovered on attempt {attempt + 1}"
+            )
+        time.sleep(5)
+    return HealAction(
+        service, hint, "retry SELECT 1", False, "still failing after 3 retries — likely Neon-side"
+    )
+
+
+def noop_escalate(service: str, hint: str) -> HealAction:
+    return HealAction(
+        service,
+        hint,
+        "no playbook — escalate",
+        False,
+        "no automatic remediation defined",
+        escalated=True,
+    )
+
+
+# ── Hint → playbook routing ──────────────────────────────────────────────────
+
+PLAYBOOKS: dict[str, Callable[[str, str], HealAction]] = {
+    "container_missing": restart_container,
+    "container_exited": restart_container,
+    "container_unhealthy": restart_container,
+    "container_restarting": restart_container,  # may be flapping; restart resets
+    "api_5xx": restart_container,  # service field is the container name
+    "endpoint_unreachable": noop_escalate,  # could be DNS / TLS / nginx — don't touch
+    "bot_not_polling": restart_container,
+    "neondb_connection": neondb_retry,
+    "disk_full": disk_cleanup,
+    "kb_cron_stale": trigger_kb_cron,
+}
+
+
+# Map an HTTP-endpoint label to the container that backs it. If a /api/health
+# 5xx fires, this tells us which container to restart.
+ENDPOINT_TO_CONTAINER = {
+    "app.factorylm.com/api/health": "mira-web",
+    "app.factorylm.com/api/scanbe/healthz": "mira-scan-backend",
+    "factorylm.com": "mira-web",
+}
+
+
+# ── Orchestration ────────────────────────────────────────────────────────────
+
+
+def heal_one(check: dict[str, Any], dry_run: bool = False) -> HealAction:
+    service: str = check.get("service") or "?"
+    hint: str = (check.get("extra") or {}).get("remediation_hint") or ""
+    playbook = PLAYBOOKS.get(hint, noop_escalate)
+
+    # For api_5xx the "service" is the endpoint label, not a container name.
+    target = ENDPOINT_TO_CONTAINER.get(service, service) if hint == "api_5xx" else service
+
+    if dry_run:
+        return HealAction(
+            service, hint, f"DRY-RUN: would call {playbook.__name__}({target})", True, "dry-run"
+        )
+
+    logger.info("healing %s via %s (target=%s)", service, playbook.__name__, target)
+    action = playbook(target, hint)
+    action.service = service  # preserve original service label for logging
+    return action
+
+
+def reverify(checks: list[dict[str, Any]]) -> dict[str, str]:
+    """Re-run only the probes for services we tried to heal. Returns service→status."""
+    by_service: dict[str, str] = {}
+    for c in checks:
+        svc = c.get("service") or "?"
+        cat = c.get("category")
+        try:
+            if cat == "service" and svc in hb.CRITICAL_CONTAINERS:
+                by_service[svc] = hb.check_container(svc).status
+            elif svc == "telegram_polling":
+                by_service[svc] = hb.check_telegram_polling().status
+            elif svc == "neondb":
+                by_service[svc] = hb.check_neondb().status
+            elif svc == "kb_cron":
+                by_service[svc] = hb.check_kb_cron_freshness().status
+            elif svc == "disk":
+                by_service[svc] = hb.check_disk().status
+            else:
+                by_service[svc] = "unverified"
+        except Exception as exc:  # noqa: BLE001
+            by_service[svc] = f"verify_error: {exc}"
+    return by_service
+
+
+def log_actions(actions: list[HealAction], dry_run: bool = False) -> None:
+    if dry_run or not actions:
+        return
+    url = os.environ.get("NEON_DATABASE_URL", "")
+    if not url:
+        return
+    try:
+        from sqlalchemy import create_engine, text
+        from sqlalchemy.pool import NullPool
+
+        engine = create_engine(url, poolclass=NullPool, connect_args={"sslmode": "require"})
+        with engine.begin() as conn:
+            for a in actions:
+                conn.execute(
+                    text(
+                        "INSERT INTO system_health_log "
+                        "(service, status, latency_ms, details, category, action_taken, extra) "
+                        "VALUES (:service, :status, 0, :details, 'heal', :action, :extra)"
+                    ),
+                    {
+                        "service": a.service,
+                        "status": "healed" if a.succeeded else "heal_failed",
+                        "details": a.details[:500],
+                        "action": a.action[:200],
+                        "extra": json.dumps({"hint": a.hint, "escalated": a.escalated}),
+                    },
+                )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("log_actions failed: %s", exc)
+
+
+def format_telegram_summary(actions: list[HealAction], post_status: dict[str, str]) -> str:
+    if not actions:
+        return ""
+    lines = [f"*Self-Healer — {datetime.now(timezone.utc).strftime('%H:%M UTC')}*"]
+    for a in actions:
+        emoji = "✅" if a.succeeded and post_status.get(a.service) == hb.STATUS_HEALTHY else "❌"
+        lines.append(f"{emoji} `{a.service}` ({a.hint or 'unknown'})")
+        lines.append(f"   action: {a.action}")
+        if a.details:
+            lines.append(f"   details: {a.details[:140]}")
+        post = post_status.get(a.service, "unverified")
+        lines.append(f"   recheck: {post}")
+        if a.escalated or post != hb.STATUS_HEALTHY:
+            lines.append("   ⚠️ *escalating — manual fix needed*")
+    return "\n".join(lines)
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+
+def load_input(args: argparse.Namespace) -> dict[str, Any]:
+    """Get the heartbeat report we'll act on. Three sources, in priority order:
+    1. --stdin   (heartbeat piped in)
+    2. --service (one-shot, pretend that one service is down)
+    3. fresh probe (run heartbeat ourselves)"""
+    if args.stdin:
+        return json.loads(sys.stdin.read())
+    if args.service:
+        return {
+            "down": [
+                {
+                    "service": args.service,
+                    "category": "service",
+                    "extra": {"remediation_hint": "container_exited"},
+                }
+            ]
+        }
+    # Run a fresh probe.
+    checks = hb.run_all_checks()
+    score = hb.health_score(checks)
+    # Persist this probe so we have a fresh baseline before we touch anything.
+    hb.persist(checks, score, dry_run=False)
+    from dataclasses import asdict
+
+    down = [asdict(c) for c in checks if c.status == hb.STATUS_DOWN]
+    return {"down": down, "score": score}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Self-Healer — fix DOWN services")
+    parser.add_argument("--dry-run", action="store_true", help="Print actions, don't execute")
+    parser.add_argument(
+        "--stdin", action="store_true", help="Read heartbeat JSON from stdin instead of probing"
+    )
+    parser.add_argument("--service", default=None, help="One-shot: heal a specific service")
+    parser.add_argument("--quiet", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.quiet:
+        logger.setLevel(logging.WARNING)
+
+    if os.geteuid() == 0 and not os.environ.get("MIRA_HEALER_ALLOW_ROOT"):
+        logger.error("refusing to run as root — set MIRA_HEALER_ALLOW_ROOT=1 to override")
+        return 3
+
+    report = load_input(args)
+    down = report.get("down", [])
+    if not down:
+        logger.info("nothing down — exiting")
+        return 0
+
+    actions = [heal_one(c, dry_run=args.dry_run) for c in down]
+    log_actions(actions, dry_run=args.dry_run)
+
+    post_status = {} if args.dry_run else reverify(down)
+    summary = format_telegram_summary(actions, post_status)
+
+    if args.dry_run:
+        print(summary)
+        return 0
+
+    notify("system", summary)
+
+    failed = [
+        a
+        for a in actions
+        if not a.succeeded
+        or (post_status.get(a.service) and post_status[a.service] != hb.STATUS_HEALTHY)
+    ]
+    return 0 if not failed else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install_crons.sh
+++ b/scripts/install_crons.sh
@@ -87,6 +87,25 @@ PATH=/usr/local/bin:/usr/bin:/bin
 # Checks failed payments, expiring cards, MRR — Closes #849
 0 12 * * 1    cd \$MIRA_DIR && doppler run -- $PYTHON mira-crawler/tasks/billing_health.py >> \$LOG_DIR/billing_health.log 2>&1
 
+# ─── SELF-MAINTENANCE (Agentic OS) ───────────────────────────────────────────
+# See docs/agentic-os/README.md for architecture + runbook.
+
+# Heartbeat: every 15 min — checks containers, endpoints, NeonDB, KB cron, host
+# DOWN → exits 2; the wrapping shell triggers self_healer for the same probe.
+*/15 * * * *  cd \$MIRA_DIR && doppler run -- $PYTHON mira-crawler/agents/heartbeat_monitor.py --quiet --json > /tmp/mira_heartbeat.json 2>> \$LOG_DIR/heartbeat.log; if [ \$? -eq 2 ]; then doppler run -- $PYTHON mira-crawler/agents/self_healer.py --stdin < /tmp/mira_heartbeat.json >> \$LOG_DIR/self_healer.log 2>&1; fi
+
+# Daily health summary: 08:00 UTC
+0 8 * * *     cd \$MIRA_DIR && doppler run -- $PYTHON mira-crawler/agents/heartbeat_monitor.py --daily-summary >> \$LOG_DIR/heartbeat.log 2>&1
+
+# Learning capture: Saturday 03:00 UTC — runs after the weekly benchmark (02:00 UTC)
+0 3 * * 6     cd \$MIRA_DIR && doppler run -- $PYTHON mira-crawler/agents/learning_capture.py >> \$LOG_DIR/learning_capture.log 2>&1
+
+# Funnel tracker: daily 13:00 UTC (snapshot)
+0 13 * * *    cd \$MIRA_DIR && doppler run -- $PYTHON mira-crawler/agents/funnel_tracker.py >> \$LOG_DIR/funnel_tracker.log 2>&1
+
+# Funnel tracker: Monday 13:30 UTC (weekly Pulse + Telegram push)
+30 13 * * 1   cd \$MIRA_DIR && doppler run -- $PYTHON mira-crawler/agents/funnel_tracker.py --weekly >> \$LOG_DIR/funnel_tracker.log 2>&1
+
 CRONTAB
 
 # Validate the temp file has content


### PR DESCRIPTION
## Summary

Closes the agentic-OS loop with the four agents that make the existing orchestrator/skills/memory stack honest about its own state.

- **heartbeat_monitor.py** — 16 probes (8 containers · 3 endpoints · telegram_polling · neondb · kb_cron · disk · memory) → score 0-100 → NeonDB \`system_health_log\` (auto-created on first run) → Telegram only on DOWN / DEGRADED >30 min, plus 08:00 UTC daily summary.
- **self_healer.py** — consumes heartbeat JSON via \`--stdin\`, dispatches scoped playbooks (\`restart_container\`, \`disk_cleanup\`, \`neondb_retry\`, \`trigger_kb_cron\`, \`noop_escalate\`). Re-probes after every action, escalates on failure. Hard safety: refuses root, never touches nginx / schema / persistent volumes; \`docker system prune -f\` + log truncation only — no \`rm\`.
- **learning_capture.py** — diffs latest two \`benchmark_v*.json\`, writes \`docs/learnings/YYYY-MM-DD_v<ver>.md\` with per-case cause hypotheses, files dedup'd GitHub issues labelled \`benchmark-regression\`, flags rubric-drift candidates (3+ consecutive regressions).
- **funnel_tracker.py** — HubSpot pipeline + scan funnel + bot stats + uptime → \`docs/reports/pulse/YYYY-Www.md\`. Daily snapshot + Monday weekly Pulse Telegram. Every fetcher fails open.

Six new cron lines wired into \`scripts/install_crons.sh\`:

\`\`\`
*/15 * * * *    heartbeat (chains self_healer on exit 2)
0 8 * * *       heartbeat --daily-summary
0 3 * * 6       learning_capture (post-benchmark)
0 13 * * *      funnel_tracker (daily)
30 13 * * 1     funnel_tracker --weekly (Pulse)
\`\`\`

Architecture, runbooks, and "how to add a new check / playbook / agent" guides in \`docs/agentic-os/README.md\`.

## Test plan

- [x] Ruff clean across all four agents
- [x] Each agent has a \`--dry-run\` mode and was smoke-tested locally on Charlie
- [x] Heartbeat → self_healer pipe verified end-to-end (\`heartbeat --json | self_healer --stdin\`)
- [x] Bash syntax + shellcheck clean on \`install_crons.sh\`
- [ ] Deploy to VPS, run heartbeat manually, confirm:
  - [ ] NeonDB \`system_health_log\` table auto-created
  - [ ] Telegram alert/summary delivered
  - [ ] First health score reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)