### PR TITLE
fix(agentic-os): hyphen-tolerant telegram_notify import

### DIFF
--- a/mira-crawler/agents/funnel_tracker.py
+++ b/mira-crawler/agents/funnel_tracker.py
@@ -50,13 +50,32 @@ logging.basicConfig(
 )
 logger = logging.getLogger("funnel_tracker")
 
-try:
-    from mira_crawler.reporting.telegram_notify import notify
-except ImportError:
 
-    def notify(agent_key: str, message: str, **_) -> bool:  # type: ignore[misc]
+def _load_notify():
+    try:
+        from mira_crawler.reporting.telegram_notify import notify as _n  # type: ignore
+
+        return _n
+    except ImportError:
+        pass
+    import importlib.util
+
+    tn_path = Path(__file__).resolve().parent.parent / "reporting" / "telegram_notify.py"
+    if tn_path.exists():
+        spec = importlib.util.spec_from_file_location("telegram_notify", tn_path)
+        if spec and spec.loader:
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod.notify
+
+    def _stub(agent_key: str, message: str, **_) -> bool:
         print(f"[{agent_key}] {message}")
         return True
+
+    return _stub
+
+
+notify = _load_notify()
 
 
 HUBSPOT_BASE = "https://api.hubapi.com"

--- a/mira-crawler/agents/heartbeat_monitor.py
+++ b/mira-crawler/agents/heartbeat_monitor.py
@@ -60,13 +60,36 @@ logging.basicConfig(
 )
 logger = logging.getLogger("heartbeat_monitor")
 
-try:
-    from mira_crawler.reporting.telegram_notify import notify
-except ImportError:
 
-    def notify(agent_key: str, message: str, **_: Any) -> bool:  # type: ignore[misc]
+def _load_notify():
+    """Import telegram_notify resiliently — the parent dir is `mira-crawler`
+    (hyphen, not a valid Python package name), so the dotted import only works
+    if a setup.py/pyproject installed it. We fall back to importing the file
+    by absolute path."""
+    try:
+        from mira_crawler.reporting.telegram_notify import notify as _n  # type: ignore
+
+        return _n
+    except ImportError:
+        pass
+    import importlib.util
+
+    tn_path = Path(__file__).resolve().parent.parent / "reporting" / "telegram_notify.py"
+    if tn_path.exists():
+        spec = importlib.util.spec_from_file_location("telegram_notify", tn_path)
+        if spec and spec.loader:
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod.notify
+
+    def _stub(agent_key: str, message: str, **_: Any) -> bool:
         print(f"[{agent_key}] {message}")
         return True
+
+    return _stub
+
+
+notify = _load_notify()
 
 
 # ── Status taxonomy ───────────────────────────────────────────────────────────

--- a/mira-crawler/agents/learning_capture.py
+++ b/mira-crawler/agents/learning_capture.py
@@ -52,13 +52,32 @@ logging.basicConfig(
 )
 logger = logging.getLogger("learning_capture")
 
-try:
-    from mira_crawler.reporting.telegram_notify import notify
-except ImportError:
 
-    def notify(agent_key: str, message: str, **_) -> bool:  # type: ignore[misc]
+def _load_notify():
+    try:
+        from mira_crawler.reporting.telegram_notify import notify as _n  # type: ignore
+
+        return _n
+    except ImportError:
+        pass
+    import importlib.util
+
+    tn_path = Path(__file__).resolve().parent.parent / "reporting" / "telegram_notify.py"
+    if tn_path.exists():
+        spec = importlib.util.spec_from_file_location("telegram_notify", tn_path)
+        if spec and spec.loader:
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod.notify
+
+    def _stub(agent_key: str, message: str, **_) -> bool:
         print(f"[{agent_key}] {message}")
         return True
+
+    return _stub
+
+
+notify = _load_notify()
 
 
 REGRESSION_THRESHOLD = 0.10  # 10pt absolute drop counts as a regression

--- a/mira-crawler/agents/self_healer.py
+++ b/mira-crawler/agents/self_healer.py
@@ -49,18 +49,37 @@ logging.basicConfig(
 )
 logger = logging.getLogger("self_healer")
 
-try:
-    from mira_crawler.reporting.telegram_notify import notify
-except ImportError:
 
-    def notify(agent_key: str, message: str, **_: Any) -> bool:  # type: ignore[misc]
+def _load_notify():
+    try:
+        from mira_crawler.reporting.telegram_notify import notify as _n  # type: ignore
+
+        return _n
+    except ImportError:
+        pass
+    import importlib.util
+
+    tn_path = Path(__file__).resolve().parent.parent / "reporting" / "telegram_notify.py"
+    if tn_path.exists():
+        spec = importlib.util.spec_from_file_location("telegram_notify", tn_path)
+        if spec and spec.loader:
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            return mod.notify
+
+    def _stub(agent_key: str, message: str, **_: Any) -> bool:
         print(f"[{agent_key}] {message}")
         return True
+
+    return _stub
+
+
+notify = _load_notify()
 
 
 # Re-use the heartbeat probes for the post-action re-check.
 try:
-    from mira_crawler.agents import heartbeat_monitor as hb
+    from mira_crawler.agents import heartbeat_monitor as hb  # type: ignore
 except ImportError:
     sys.path.insert(0, str(Path(__file__).resolve().parent))
     import heartbeat_monitor as hb  # type: ignore[no-redef]


### PR DESCRIPTION
Patches all four self-maintenance agents so the Telegram notify import works on the VPS. The repo dir is `mira-crawler` (hyphen) which can't be imported under the dotted name; falls back to importlib loading the file by absolute path. Caught during the first VPS deploy after #1015 — without this, alerts go to print() instead of Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)