### PR TITLE
docs(specs): per-module specs, context system, session stop hook

### DIFF
--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# .claude/hooks/stop.sh
+# Auto-appends a session entry to docs/context/PROGRESS.md when a Claude Code
+# session ends. Captures: branch, what changed, what's WIP.
+#
+# Wire-up: add to .claude/settings.json under hooks.Stop:
+#   { "type": "command", "command": "bash .claude/hooks/stop.sh" }
+#
+# Conventions
+#   - This script never fails the session — every step is best-effort.
+#   - Writes are append-only between the <!-- BEGIN AUTOLOG --> /
+#     <!-- END AUTOLOG --> markers.
+#   - Branches whose name starts with "release/" are skipped on shared
+#     environments to avoid noisy churn (override with FORCE_LOG=1).
+
+set -u
+PROGRESS_FILE="docs/context/PROGRESS.md"
+[ -f "$PROGRESS_FILE" ] || exit 0
+
+cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" || exit 0
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+TS="$(date -u +'%Y-%m-%d %H:%M UTC')"
+
+case "$BRANCH" in
+  release/*) [ "${FORCE_LOG:-0}" = "1" ] || exit 0 ;;
+esac
+
+BASE="$(git merge-base HEAD main 2>/dev/null || git merge-base HEAD origin/main 2>/dev/null || echo HEAD)"
+CHANGED_FILE="$(mktemp)"
+WIP_FILE="$(mktemp)"
+git diff --name-only "$BASE" HEAD 2>/dev/null | head -20 > "$CHANGED_FILE" || true
+git status --porcelain 2>/dev/null | head -20 > "$WIP_FILE" || true
+LAST_SUBJ="$(git log -1 --pretty='%h %s' 2>/dev/null || echo 'no commits yet')"
+
+PROGRESS_FILE="$PROGRESS_FILE" \
+TS="$TS" \
+BRANCH="$BRANCH" \
+LAST_SUBJ="$LAST_SUBJ" \
+CHANGED_FILE="$CHANGED_FILE" \
+WIP_FILE="$WIP_FILE" \
+python3 - <<'PY' || true
+import os, pathlib
+path     = pathlib.Path(os.environ["PROGRESS_FILE"])
+ts       = os.environ["TS"]
+branch   = os.environ["BRANCH"]
+last     = os.environ["LAST_SUBJ"]
+changed  = pathlib.Path(os.environ["CHANGED_FILE"]).read_text().strip()
+wip      = pathlib.Path(os.environ["WIP_FILE"]).read_text().strip()
+
+def block(label, body, empty):
+    if not body:
+        return f"**{label}:** {empty}"
+    bullets = "\n".join(f"- {line}" for line in body.splitlines() if line.strip())
+    return f"**{label}:**\n{bullets}"
+
+entry = "\n".join([
+    "",
+    f"### {ts} — `{branch}`",
+    f"**Last commit:** {last}",
+    block("Changed (vs. fork point)", changed, "(no committed diff vs. base)"),
+    block("Working tree", wip, "clean"),
+    "**Next:** _set by next session_",
+    "",
+])
+
+src = path.read_text()
+begin = "<!-- BEGIN AUTOLOG -->"
+end   = "<!-- END AUTOLOG -->"
+if begin not in src or end not in src:
+    raise SystemExit(0)
+head, rest      = src.split(begin, 1)
+body, tail      = rest.split(end, 1)
+new = f"{head}{begin}{body}{entry}{end}{tail}"
+path.write_text(new)
+PY
+
+rm -f "$CHANGED_FILE" "$WIP_FILE"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,6 +61,16 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/stop.sh"
+          }
+        ]
+      }
     ]
   },
   "enabledPlugins": {

--- a/docs/context/ARCHITECTURE.md
+++ b/docs/context/ARCHITECTURE.md
@@ -1,0 +1,83 @@
+# MIRA — Architecture Context
+**Last Updated:** 2026-05-05
+
+This file is the **session-loadable** view of the system. For canonical layered domain rules see `docs/ARCHITECTURE.md`. For container topology in mermaid see `docs/architecture/c4-containers.md`. For per-module contracts see `docs/specs/SPEC_INDEX.md`.
+
+## Layer map (dependencies flow downward only)
+```
+┌────────────────── PRESENTATION ──────────────────┐
+│  mira-web   ·   mira-hub   ·   atlas-frontend    │
+├────────────────── ADAPTERS ───────────────────────┤
+│  mira-bots/{telegram,slack,reddit,...}            │
+│  mira-pipeline                                    │
+├────────────────── ENGINE ─────────────────────────┤
+│  mira-bots/shared (Supervisor, RAGWorker,         │
+│                   guardrails, InferenceRouter)    │
+│  mira-mcp (FastMCP tools, equipment context)      │
+├────────────────── INFRASTRUCTURE ─────────────────┤
+│  mira-core/mira-ingest · mira-crawler             │
+│  mira-bridge · mira-cmms (atlas-*)                │
+│  NeonDB · SQLite (WAL) · Redis (broker) · Ollama  │
+└───────────────────────────────────────────────────┘
+```
+
+Cross-cutting concerns: secrets (Doppler `factorylm/prd`), inference (`InferenceRouter` cascade), observability (Langfuse, Flower, Prometheus, Grafana), PII sanitization (`InferenceRouter.sanitize_context()` — default-on inside `complete()`), tenant scoping (`MIRA_TENANT_ID`).
+
+## Active VPS chat path
+```
+User phone → Open WebUI → mira-pipeline:9099 → Supervisor (mira-bots/shared/engine.py) → cascade
+```
+- Cloud cascade: Groq → Cerebras → Gemini (no Anthropic since PR #610 / #649).
+- Local fallback: Open WebUI → qwen2.5vl:7b on Ollama.
+- Picks vision-capable provider when an image is present; skips text-only providers for image requests.
+
+## Container topology (one per service)
+| Container | Port(s) | Network(s) |
+|---|---|---|
+| mira-core (Open WebUI) | 3000→8080 | core-net, bot-net |
+| mira-pipeline | 9099 | core-net |
+| mira-ingest | 8002→8001 | core-net |
+| mira-mcp | 8000, 8001 | core-net |
+| mira-mcpo | 8000 | core-net |
+| mira-docling | 5001 | core-net |
+| mira-bridge (Node-RED) | 1880 | core-net |
+| mira-bot-telegram | — | bot-net, core-net |
+| mira-bot-slack | — | bot-net, core-net |
+| atlas-api | 8088→8080 | cmms-net, core-net |
+| atlas-db | 5433 | cmms-net |
+| atlas-frontend | 3100 | cmms-net |
+| atlas-minio | 9000, 9001 | cmms-net |
+| mira-web | 3200→3000 | core-net, cmms-net |
+| mira-hub | (internal) | core-net, cmms-net |
+
+SaaS overlay (`docker-compose.saas.yml`) adds `mira-relay` (cloud relay endpoint for Ignition factory→cloud tag streaming) and `mira-ingest-saas`.
+
+## Cluster nodes
+| Node | Role | Tailscale | LAN |
+|---|---|---|---|
+| Alpha | Orchestrator (Celery) | 100.107.140.12 | 192.168.4.28 |
+| Bravo | Compute (Ollama) | 100.86.236.11 | 192.168.1.11 |
+| Charlie | KB host (MIRA stack) | 100.70.49.126 | 192.168.1.12 |
+| Travel | Mobile (Tailscale-only) | — | — |
+
+Connectivity: Alpha ↔ Bravo/Charlie via Tailscale only (different subnets). Bravo ↔ Charlie via LAN (same subnet) with Tailscale fallback. Canonical source `deployment/network.yml`.
+
+## Data planes
+- **NeonDB (Postgres + pgvector):** tenants, knowledge_entries (~25,219 chunks as of 2026-03-28), fault_codes, manual_cache, manuals, kg_entities, kg_relationships, kg_triples_log, agent_health, api_usage. RLS by `app.current_tenant_id`.
+- **SQLite WAL `mira.db`:** owned by `mira-bridge`; read by every adapter, mira-mcp, mira-pipeline. Holds `conversation_state`, `equipment_status`, `faults`, `maintenance_notes`, `equipment_photos`, `feedback_log`.
+- **OpenViking store:** alternate retrieval backend used when `RETRIEVAL_BACKEND=openviking`.
+- **MinIO (Atlas):** asset images and work-order attachments.
+
+## Cross-service contracts
+- Bot adapter → engine: `Supervisor.process_full(chat_id: str, msg, photo_b64)` returns `{reply, confidence, trace_id, next_state}`.
+- Pipeline → engine: same call, `chat_id` = Open WebUI `user`.
+- Hub/Web → CMMS: never directly to Atlas; always via `mira-mcp` REST + bearer.
+- Anything writing `mira.db`: must use WAL retry pattern; mira-bridge holds the write lock.
+
+## Key reference docs
+- `docs/architecture/c4-containers.md` — container mermaid
+- `docs/architecture/c4-context.md` — system-context view
+- `docs/architecture/c4-dynamic-fault-flow.md` — runtime trace of a fault diagnosis
+- `docs/architecture/rag-pipeline.md` — full RAG snapshot
+- `docs/architecture/INGEST_PIPELINES.md` — ingest pipelines reference
+- `docs/architecture/SYSTEM_OVERVIEW.md` — top-level walkthrough

--- a/docs/context/FILE_STRUCTURE.md
+++ b/docs/context/FILE_STRUCTURE.md
@@ -1,0 +1,142 @@
+# MIRA — File Structure
+**Last Updated:** 2026-05-05
+
+Top-level repo map with one-line descriptions, plus where to look inside each module. For deep contracts, see `docs/specs/SPEC_INDEX.md`. For architecture rules, see `docs/context/ARCHITECTURE.md`.
+
+```
+MIRA/
+├── CLAUDE.md                       # Build state + hard constraints (target ~120 lines)
+├── NORTH_STAR.md                   # The flywheel; read before any feature work
+├── STRATEGY.md                     # ICP, pricing tiers, GTM motion
+├── docker-compose.yml              # Local stack
+├── docker-compose.saas.yml         # SaaS overlay (mira-relay, mira-ingest-saas)
+│
+├── mira-bots/                      # Adapters + shared diagnostic engine
+│   ├── shared/                     # Engine: Supervisor, workers, guardrails, InferenceRouter
+│   │   ├── engine.py               # Supervisor — entry point
+│   │   ├── workers/                # vision_worker, rag_worker, print_worker, plc_worker (stub)
+│   │   ├── guardrails.py           # intent classification, safety, abbreviations
+│   │   ├── inference/router.py     # Cascade Groq → Cerebras → Gemini, sanitizer
+│   │   ├── recall.py               # NeonDB recall paths
+│   │   └── agents/infra_guardian.py
+│   ├── prompts/                    # Active prompt registry (active.yaml hot-swap)
+│   ├── telegram/ slack/ teams/ whatsapp/ reddit/ webchat/ gchat/ email/
+│   ├── tests/                      # Engine + adapter unit tests
+│   ├── benchmark/                  # Latency + cost benchmarks
+│   └── v2_test_harness/            # Self-test harness + healer
+│
+├── mira-pipeline/                  # OpenAI-compat API on :9099 (active VPS chat path)
+│   ├── main.py                     # FastAPI app
+│   ├── eval_api.py                 # /eval/* endpoints
+│   ├── feedback_sync.py            # Feedback rollup
+│   ├── memory.py                   # Per-chat session NDJSON
+│   └── tools/                      # Pipeline-specific helpers
+│
+├── mira-mcp/                       # FastMCP server + REST proxy (CMMS bridge)
+│   ├── server.py                   # 4 equipment + 7 CMMS tools, /ingest/pdf, /api/cmms/*
+│   ├── cmms/                       # Adapter dispatch: atlas / maintainx / limble / fiix
+│   ├── atlas_client.py             # Atlas REST client
+│   ├── tenant_resolver.py          # Tenant resolution
+│   ├── exports.py                  # Bulk export endpoints
+│   └── tests/
+│
+├── mira-core/                      # Open WebUI + MCPO + ingest
+│   ├── docker-compose.yml          # mira-core stack
+│   ├── docker-compose.oracle.yml   # Oracle Cloud overrides
+│   ├── Dockerfile.mcpo             # MCPO image
+│   ├── Modelfile / Modelfile.staging
+│   ├── mcpo-config.json
+│   ├── entrypoint-mira.sh
+│   ├── mira-ingest/                # FastAPI ingest service
+│   │   ├── main.py                 # /ingest/photo, /ingest/search, /health/*
+│   │   ├── db/neon.py              # SQLAlchemy + NullPool, RLS
+│   │   └── ...
+│   └── scripts/                    # ingest_manuals.py, ingest_equipment_photos.py, etc.
+│
+├── mira-bridge/                    # Node-RED + canonical mira.db owner
+│   ├── flows/                      # Committed JSON (dashboard, scheduled, setup wizard)
+│   └── data/                       # mira.db (WAL) — bind-mounted to readers
+│
+├── mira-cmms/                      # Atlas CMMS overlay
+│   ├── docker-compose.yml          # 4 containers (db, api, frontend, minio)
+│   ├── docker-compose.local.yml
+│   └── smoke_test.sh
+│
+├── mira-crawler/                   # Celery ingestion fleet
+│   ├── celery_app.py celeryconfig.py bridge.py
+│   ├── agents/                     # 13 task agents incl. inbox_triage
+│   ├── tasks/                      # discover, ingest, freshness, rss, social, youtube, foundational, playwright
+│   ├── ingest/                     # Cross-task helpers
+│   ├── reporting/                  # agent_report, weekly_digest, telegram_notify
+│   ├── linkedin/                   # LinkedIn pipeline
+│   ├── social/                     # Reddit + LinkedIn signals
+│   └── sources.yaml manual_scrape_targets.csv
+│
+├── mira-web/                       # Public marketing + PLG funnel
+│   ├── server.js                   # Hono app
+│   ├── src/                        # views, lib (activation, mira-chat, scan)
+│   ├── emails/                     # Resend templates
+│   ├── tools/                      # Apps Script bridge
+│   └── docker-compose.yml
+│
+├── mira-hub/                       # Authenticated workspace (Next.js + Refine.dev)
+│   ├── src/app/(hub)/              # 17 sections (workorders, schedule, parts, ...)
+│   ├── src/app/api/                # Route handlers (proxy + aggregate)
+│   ├── auth.ts middleware.ts       # Magic-link / Google OAuth / admin bypass
+│   ├── db/migrations/              # Including 001_knowledge_graph.sql
+│   ├── playwright.*.config.ts      # smoke / signup / e2e suites
+│   └── tests/
+│
+├── mira-sidecar/                   # ⚠️ LEGACY (ADR-0008) — sunset pending OEM migration
+├── mira-relay/                     # Cloud relay endpoint for Ignition factory→cloud streaming (saas.yml)
+├── mira-connect/                   # ⚠️ DEFERRED to Config 4 (Modbus/PLC drivers)
+│
+├── ignition/                       # Ignition 8.1 ConveyorMIRA project
+│   ├── project/  tags/  gateway-scripts/  webdev/  config/  db/
+│   └── deploy_ignition.ps1         # 3-command Windows deployer
+├── plc/                            # PLC programs (Micro820)
+│
+├── nango-integrations/             # Nango credential vault + connectors (MaintainX first)
+│
+├── deployment/                     # nginx, network.yml, runbooks, customer agreement
+│
+├── docs/                           # PRDs, ADRs, C4, runbooks, specs (this index)
+│   ├── ARCHITECTURE.md             # Layered domain map (canonical rules)
+│   ├── PRD_v1.0.md                 # Top-level PRD
+│   ├── adr/                        # 12 ADRs (e.g. 0008-sidecar-deprecation)
+│   ├── architecture/               # C4, RAG pipeline, ingest pipelines, system overview
+│   ├── api-reference/              # External API references (Atlas, MaintainX, ...)
+│   ├── integrations/               # Per-integration API reference docs
+│   ├── runbooks/                   # cmms-onboarding, factorylm-vps, sidecar-oem-migration
+│   ├── specs/                      # PER-MODULE SPECS (this audit's focus)
+│   ├── context/                    # PROJECT_BRIEF, ARCHITECTURE, TECH_STACK, this file, RULES, PROGRESS
+│   ├── plans/                      # 90-day MVP plan, harness plan
+│   ├── design-history/             # Before/after screenshot pairs (mandatory for UI changes)
+│   └── promo-screenshots/          # Append-only archive (YYYY-MM-DD_feature_viewport.png)
+│
+├── tests/                          # 5-regime testing framework
+│   ├── eval/                       # 39 golden cases + analyze_sessions.py
+│   ├── property/                   # 11 hypothesis property tests
+│   ├── architecture/               # 6 boundary contracts
+│   └── regime7_ignition/           # Ignition-specific tests
+│
+├── tools/                          # photo pipeline, GDrive ingest, migrations, lead-hunter, video gen
+│
+├── wiki/                           # LLM-maintained ops wiki (Karpathy pattern)
+│   ├── hot.md                      # Read at session start, update at session end
+│   ├── SCHEMA.md                   # Wiki schema rules
+│   └── references/                 # coding-principles, kanban, dev-loop
+│
+├── .claude/                        # Agent rules, skills, hooks, settings
+│   ├── rules/                      # python-standards, security-boundaries
+│   ├── skills/
+│   └── settings.json
+│
+└── install/                        # Smoke tests + one-shot installers
+    └── smoke_test.sh
+```
+
+## Branch + commit conventions
+- Branch prefixes: `feat/`, `fix/`, `chore/`, `ops/`, `docs/`, `security/` — never push to `main` directly.
+- Commit format: `feat(scope): …`, `fix(scope): …`, etc. (Conventional Commits).
+- Safety tags: `# SAFETY`, `# PLC`, `# CRITICAL` — never modify without approval.

--- a/docs/context/PROGRESS.md
+++ b/docs/context/PROGRESS.md
@@ -70,4 +70,30 @@ Source of truth: `docs/plans/2026-04-19-mira-90-day-mvp.md`. Read its "Currently
 > ```
 
 <!-- BEGIN AUTOLOG -->
+
+### 2026-05-06 05:28 UTC — `docs/comprehensive-specs`
+**Last commit:** b9bfc8a docs(specs): add per-module specs, context system, session stop hook
+**Changed (vs. fork point):**
+- .claude/hooks/stop.sh
+- .claude/settings.json
+- docs/context/ARCHITECTURE.md
+- docs/context/FILE_STRUCTURE.md
+- docs/context/PROGRESS.md
+- docs/context/PROJECT_BRIEF.md
+- docs/context/RULES.md
+- docs/context/TECH_STACK.md
+- docs/specs/SPEC_INDEX.md
+- docs/specs/agentic-os-spec.md
+- docs/specs/auth-tenancy-spec.md
+- docs/specs/deployment-spec.md
+- docs/specs/dialogue-state-tracker-spec.md
+- docs/specs/hub-mobile-spec.md
+- docs/specs/ignition-exchange-spec.md
+- docs/specs/knowledge-graph-spec.md
+- docs/specs/mira-bots-spec.md
+- docs/specs/mira-bridge-spec.md
+- docs/specs/mira-cmms-spec.md
+- docs/specs/mira-core-spec.md
+**Working tree:** clean
+**Next:** _set by next session_
 <!-- END AUTOLOG -->

--- a/docs/context/PROGRESS.md
+++ b/docs/context/PROGRESS.md
@@ -1,0 +1,73 @@
+# MIRA — Progress Log
+**Last Updated:** 2026-05-05
+
+This is the file that **updates every session**. Top of the file is current state; below the divider is an append-only log written by the stop hook (`.claude/hooks/stop.sh`). Keep the top section short — if it grows past one screen, prune it into a section below the divider.
+
+---
+
+## Current state (top section — edit in place)
+
+### Phase
+**90-day MVP** (locked window: **2026-04-19 → 2026-07-19**).
+Source of truth: `docs/plans/2026-04-19-mira-90-day-mvp.md`. Read its "Currently in-flight" section + run the 3-command coordination check before claiming new work.
+
+### Where we are right now (2026-05-05)
+- **Main branch tip:** `3637023 docs(wiki): eval-fixer run 2026-05-05`.
+- **Recent shipped:** Open CMMS button on all asset-scan pages (CRA-20, 2026-05-04). Magic-link JWT fix (CRA-22, CRA-21, 2026-05-04). nginx routes `/sample` + `/activated` to mira-web (2026-04-26).
+- **In-flight branches:** `feat/mvp-unit-4-exports`, `feat/mvp-unit-9a-landing` (per memory `project_mira_state`).
+- **Eval pass rate:** 77 % (last recorded — stale per memory, re-run after retrieval/prompt changes).
+- **Anthropic removal:** complete (PR #610 + #649); `mira-bots/shared/inference/router.py` cascades Groq → Cerebras → Gemini. Do not reintroduce.
+- **mira-sidecar:** still legacy; OEM migration to Open WebUI KB is the cutover gate (issue #195).
+
+### What's done — broad strokes
+- Engine: Supervisor + workers + guardrails + InferenceRouter cascade (PII default-on).
+- Adapters: Telegram (polling singleton), Slack (Socket Mode), pipeline (`/v1/chat/completions`).
+- Knowledge: ~25,219 chunks (NeonDB pgvector); hybrid retrieval Unit 6 behind kill switch.
+- Atlas CMMS: 4 containers wired; mira-mcp brokers REST + 7 CMMS MCP tools across 4 providers.
+- Hub: mira-hub `v1.1.0` shipped 2026-04-24 (OAuth + full platform shell).
+- Web: PLG funnel live; magic-link JWT fixed; PostHog optional.
+- Knowledge graph schema: `kg_entities / kg_relationships / kg_triples_log` with RLS (#791) — runtime extraction not yet wired.
+
+### What's next (top of backlog)
+- **Auto-PM pipeline #1:** Extract PM schedules from manuals → structured JSON → auto-create PM work orders → push to downstream CMMS. Without this, the flywheel doesn't close.
+- **Triple extractor at runtime:** Wire conversation → KG triples to feed GraphRAG.
+- **Eval ratchet:** Pass rate 77 % → ≥ 90 %; refresh with current cascade.
+- **mira-sidecar sunset:** Migrate ChromaDB OEM corpus to Open WebUI KB; cut `mira-web` to `mira-pipeline` (PR #197).
+- **mira-pipeline test coverage:** 0 → ≥ 5 unit tests (currently grade F).
+- **Funnel digest weekly automation:** wire Cowork Sunday 02:00 to Discord `#weekly-review`.
+
+### Active decisions and constraints
+- LLM cascade is **non-negotiable** Groq → Cerebras → Gemini. No single-provider calls; no Anthropic.
+- Doppler `factorylm/prd` is the only legitimate secret store.
+- Anyone touching `mira.db` from outside `mira-bridge` must use WAL retry pattern (`Supervisor._ensure_table()`).
+- Magic-inbox PDF flow: relevance gate behind `RELEVANCE_GATE_ENABLED`; fail-open on Groq errors.
+- mira-hub uses a **custom internal Next.js fork** — read `node_modules/next/dist/docs/` before assuming.
+
+### Blockers
+- Eval pass rate stale; until refreshed we can't trust regression signal.
+- Triple extractor at runtime is a known gap — KG schema exists with no writer wired.
+- mira-pipeline has zero unit tests (graded F per `docs/QUALITY_SCORE.md`).
+
+### Pointers for the next agent
+- `docs/specs/SPEC_INDEX.md` — every module's contract.
+- `docs/context/RULES.md` — non-negotiable constraints.
+- `docs/context/ARCHITECTURE.md` — layer map + container topology.
+- `wiki/hot.md` — wiki entrypoint (read at session start).
+- `docs/plans/2026-04-19-mira-90-day-mvp.md` — 90-day plan, currently in-flight section.
+
+---
+
+## Session log (append-only — written by `.claude/hooks/stop.sh`)
+
+> Format per entry:
+>
+> ```
+> ### YYYY-MM-DD HH:MM session — <branch>
+> **Changed:** files / one-line summary
+> **In progress:** what is still WIP
+> **Blocked:** any blockers + cause
+> **Next:** the next action
+> ```
+
+<!-- BEGIN AUTOLOG -->
+<!-- END AUTOLOG -->

--- a/docs/context/PROJECT_BRIEF.md
+++ b/docs/context/PROJECT_BRIEF.md
@@ -1,0 +1,64 @@
+# MIRA — Project Brief
+**Last Updated:** 2026-05-05
+
+## What MIRA is
+MIRA is an **AI-powered industrial maintenance diagnostic platform**. A field tech opens MIRA from their phone, takes a photo of a misbehaving piece of equipment, and gets a Guided Socratic Dialogue that walks them toward a self-diagnosis grounded in OEM manuals, fault codes, and prior similar incidents — typically in seconds, not the hour they'd otherwise spend.
+
+## North Star (the one premise that owns every decision)
+**The entire premise of this business is a self-building maintenance knowledge base that gets smarter with every trouble call.** (Source: `NORTH_STAR.md`)
+
+The flywheel:
+1. Tech gets a trouble call → opens MIRA → takes a photo.
+2. MIRA identifies the equipment → queues OEM manual download.
+3. Manual parsed → PM schedules automatically extracted → calendar auto-populates.
+4. Every subsequent tech at any plant who encounters that equipment gets manual + fault codes + PM schedule + diagnostic patterns from every previous interaction.
+5. Every photo, conversation, and resolved fault makes the entire network smarter.
+
+Decision filter: *"Does this make the flywheel spin faster?"* If not, push it down the backlog or out of scope.
+
+## Auto-PM Pipeline (#1 priority)
+| Step | Status |
+|---|---|
+| Photo/tag → equipment ID | ✅ built (vision + OCR in GSDEngine) |
+| Manual not found → queue download | ✅ built (KB Builder agent) |
+| Parse PDF → RAG chunks | ✅ built (mira-ingest pipeline) |
+| Extract PM schedules → structured JSON | 🔲 not built |
+| Auto-create PM work orders | 🔲 not built |
+| Push PMs to downstream CMMS | 🔲 not built |
+| Knowledge Cooperative sharing | 🔲 not built |
+| Sub-component model | 🔲 not built |
+
+## Commercial strategy (from `STRATEGY.md`)
+- **ICP:** Industrial maintenance managers at SMB manufacturers (10–500 employees, 1–5 techs). Paper PM logs / spreadsheets. One unplanned downtime event ≥ $10K.
+- **Pricing:** Community (free, contributes data) → Troubleshooter ($97/mo, single plant) → Integrated ($297/mo, multi-site / CMMS sync) → Enterprise (custom).
+- **Distribution:**
+  - Stage 1 (now → 60 days): LinkedIn-first PLG. 6-part series, build-in-public, technical proof. Target 3 paid plants.
+  - Stage 2 (60–120 days): Warm outbound — DM 20 maintenance managers / week with the offer "I'll extract your top 3 PM schedules from your OEM manual for free."
+  - Stage 3 (120 days+): Partner channel — VFD distributors as referrals, OEM co-marketing, Community tier as viral top-of-funnel.
+- **Moat:** The Knowledge Cooperative. As more plants upload manuals, anonymized PM patterns compound into a corpus competitors cannot replicate.
+
+## Hard constraints (from `CLAUDE.md`)
+1. **Licenses:** Apache 2.0 or MIT only.
+2. **Cloud LLMs:** Groq + Cerebras + Gemini cascade (free tier, OpenAI-compat). NeonDB persistence. Doppler-managed secrets. **No Anthropic** (removed PR #610 + #649, never reintroduce).
+3. **No:** LangChain, TensorFlow, n8n, or any framework that abstracts the LLM call.
+4. **Secrets:** All via Doppler `factorylm/prd`. Never in committed `.env`.
+5. **Containers:** One per service, `restart: unless-stopped`, healthcheck, pinned image versions.
+6. **Commits:** Conventional format (`feat / fix / security / docs / refactor / test / chore / BREAKING`).
+
+## What success looks like (next 90 days)
+Source: `docs/plans/2026-04-19-mira-90-day-mvp.md` (locked 2026-04-19 → 2026-07-19).
+- 3 paid plants on Troubleshooter or Integrated.
+- Auto-PM pipeline end-to-end: photo → manual → structured PMs → calendar.
+- Eval pass rate ≥ 90 % on the 39 golden cases (today: 77 %, stale).
+- Knowledge graph triples wired from runtime conversations.
+- Hub mobile experience polished enough that field techs use it without training.
+
+## Source-of-truth pointers
+- North Star + flywheel: `NORTH_STAR.md`
+- GTM strategy: `STRATEGY.md`
+- Per-module specs: `docs/specs/SPEC_INDEX.md`
+- Architecture map: `docs/context/ARCHITECTURE.md` (this directory)
+- Tech stack: `docs/context/TECH_STACK.md`
+- Repo layout: `docs/context/FILE_STRUCTURE.md`
+- Project rules: `docs/context/RULES.md`
+- Where we are now: `docs/context/PROGRESS.md`

--- a/docs/context/RULES.md
+++ b/docs/context/RULES.md
@@ -1,0 +1,75 @@
+# MIRA — Rules & Constraints
+**Last Updated:** 2026-05-05
+
+Every rule that any agent or human contributor must follow, consolidated from `CLAUDE.md`, `.claude/rules/*`, and the cluster's 7 Laws. Anything in conflict with this file is wrong unless explicitly amended here in the same change.
+
+## Hard product constraints (CLAUDE.md §4)
+1. **Licenses:** Apache 2.0 or MIT only. GPL upstream allowed for opaque images (`mira-cmms` Atlas) where no code is imported.
+2. **Cloud LLMs:** Groq + Cerebras + Gemini cascade only. NeonDB persistence. Doppler-managed secrets. **No Anthropic** (removed PR #610 + #649; never reintroduce — runtime silently ignores any `ANTHROPIC_API_KEY`).
+3. **No frameworks that abstract the LLM call:** No LangChain, LlamaIndex, n8n, TensorFlow.
+4. **Secrets in Doppler only:** `factorylm/prd`. Never in committed `.env`. `.env.template` carries placeholders only.
+5. **Containers:** One per service. `restart: unless-stopped`. Healthcheck. Pinned image versions (`:latest` is forbidden).
+6. **Commits:** Conventional format — `feat(scope) / fix(scope) / security / docs / refactor / test / chore / BREAKING`.
+
+## Python standards (`.claude/rules/python-standards.md`)
+- Python 3.12; package manager `uv` (NOT pip / poetry / conda).
+- Lint + format: `ruff` (NOT flake8 / pylint / black). CI gate: `ruff check .` must pass.
+- HTTP: `httpx` async (NOT requests / urllib).
+- YAML: always `yaml.safe_load()`.
+- SQLAlchemy on Neon: `NullPool`, `sslmode=require`, `pool_pre_ping=True`.
+- SQLite: stdlib `sqlite3`, always `PRAGMA journal_mode=WAL`.
+- Async end-to-end; `asyncio.run()` only at entry points.
+- Modern type hints: `list[str]`, `dict[str,int]`, `str | None`. `from __future__ import annotations` for forward refs.
+- Logging: stdlib `logging`, never `print()`. Per-service logger names.
+- Error handling: catch specific exceptions; log with context; LLM calls return fallback never raise to user.
+- Imports: stdlib → third-party → local (`ruff I`); relative within packages; absolute from `shared` for bot adapters.
+- Secrets: never hardcode; every getenv has explicit empty-default + warn-then-disable.
+
+## Security boundaries (`.claude/rules/security-boundaries.md`)
+- All secrets via Doppler `factorylm/prd`. Never in committed `.env`.
+- Rotate before commit: `WEBUI_SECRET_KEY`, `MCPO_API_KEY` (both have a leak history).
+- Pre-commit checks: `git remote -v`, `git diff --cached`.
+- PII sanitizer: `InferenceRouter.sanitize_context()` — IPv4 → `[IP]`, MAC → `[MAC]`, Serial → `[SN]`. Default-on inside `complete()`. `mira-sidecar` Open WebUI fallback also sanitizes. `sanitize=False` only in offline evals.
+- Safety keywords: 21 phrase-level triggers in `mira-bots/shared/guardrails.py`. Match → immediate `SAFETY_ALERT`. Add as phrases (not single words) to avoid false positives.
+- Tier limits: `check_tier_limit(tenant_id)` returns `(allowed, reason)`. Fail-open on DB errors. Wire to HTTP 429 in ingest endpoints.
+- Docker: never `privileged: true`; never `network_mode: host`; never `:latest` / `:main` tags. Always `restart: unless-stopped`, healthcheck, pinned versions, named networks.
+- API auth: bearer tokens for mira-mcp REST, Open WebUI, mira-pipeline. Mira-ingest is core-net only (no auth). Mira-web JWT per tenant.
+- Input validation: Telegram 20 MB PDF limit; Slack MIME allowlist (images + PDF). Strip `@mention` tags via `guardrails.strip_mentions()` in every adapter.
+- Never accept arbitrary file paths, execute user strings as shell, or deserialize untrusted pickle.
+
+## Cluster 7 Laws (from `~/factorylm/CLUSTER.md`)
+1. **Evidence-only completion.** "Done" requires deterministic proof: file exists, port open, test exited 0. Write the proof to `/cluster/betterclaw/logs/`.
+2. **LLM vs. script separation.** LLM for reasoning + planning + language. Binary checks (file exists? port open? test pass?) are bash one-liners. Never use an LLM where a one-liner works.
+3. **300-line orchestrator limit.** This agent writes ≤ 300 lines of code directly. Larger tasks → write `Task.md` → delegate to coder sub-agent.
+4. **Task.md protocol.** Before any delegation: write `/cluster/betterclaw/task_queue/TASK-<DATE>-<NAME>.md` with why, full context, SSoT links, measurable pass/fail acceptance criteria. No Task.md = no delegation.
+5. **Lesson log every session.** Log human mistakes, AI mistakes, fine-tune candidates. Not optional.
+6. **Pattern rule creation.** Same mistake twice → write a new rule to `/cluster/betterclaw/rules/`. Rules must be specific (keyword triggers, examples, measurable conditions). "Be careful" is not a rule.
+7. **Self-patching.** Mistake despite an existing rule → inspect rule, patch with the new edge case, commit. Don't re-flag.
+
+## Workflow & process
+- **CLAUDE.md target:** ~120 lines. Compliance drops past ~150. If you repeat an instruction in chat > 2x, add it there. Delete rules followed naturally. Audit monthly.
+- **PRD reference:** Every PR mentions which `NORTH_STAR.md` flywheel step it supports.
+- **PLAN.md before code:** Create or update `PLAN.md` before writing code in `factorylm` repo (when applicable).
+- **Wiki cadence:** Read `wiki/hot.md` at session start; update at session end.
+- **Active 90-day plan:** `docs/plans/2026-04-19-mira-90-day-mvp.md` — locked window 2026-04-19 → 2026-07-19. Read its "Currently in-flight" section + run the 3-command coordination check before claiming any work.
+- **Promo screenshot rule:** Every Playwright proof-of-work screenshot must also be saved to `docs/promo-screenshots/` as `YYYY-MM-DD_feature-name_viewport.png`, capturing both desktop (1440 × 900) and mobile (412 × 915). Append-only archive — never delete.
+- **Design screenshot rule (memory `feedback_design_screenshot_routine`):** Any visible mira-web UI change ships a before/after screenshot pair via `bun run snapshot:before/after` and commits to `docs/design-history/`.
+- **Doppler secrets memory (`feedback_doppler_secrets_just_use`):** When keys are in Doppler `factorylm/prd` and Mike's authorized the purpose, pull and apply directly — don't re-ask.
+- **LLM cascade memory (`feedback_llm_cascade_default`):** Always Groq → Cerebras → Gemini cascade for any LLM call; never single-provider, never Anthropic.
+- **RESOLVED → new fault memory (`feedback_resolved_state_wo_rebuild`):** Clearing `cmms_pending` alone is insufficient when leaving `RESOLVED`; `_clear_diagnostic_carryover` must reset `state["state"]` too.
+
+## Code review (automated pipeline, installed 2026-04-20)
+- GH Action `.github/workflows/code-review.yml` runs on every PR to `main / develop / dev`: shellcheck → ast-grep (IPs / secrets / raw FastAPI body / missing socket error handling) → cascade review (Groq → Cerebras → Gemini) → PR comment.
+- ast-grep rules in `.ast-grep-rules/`; config in `sgconfig.yml`.
+- Self-fix: `bash scripts/pr_self_fix.sh <PR>` reads 🔴 IMPORTANT comments, asks the cascade for patches, applies + pushes (max 3 loops).
+- Pre-commit hook: shellcheck + rg credential scan + debug artifact scan on staged files. `git config core.hooksPath .githooks` (already set).
+- Tools required locally: `shellcheck`, `rg`, `sg` (ast-grep), `scc`, `difft`.
+
+## What we do not do
+- Push directly to `main`.
+- Skip Stripe-signature / HMAC verification on inbound webhooks.
+- Use a single LLM provider for any user-facing call.
+- Introduce LangChain / LlamaIndex / TensorFlow / n8n / Anthropic.
+- Run two Telegram pollers on the same token (singleton enforced by self-healer).
+- Mutate user data from an admin-bypass token (read-only).
+- Modify `# SAFETY`, `# PLC`, or `# CRITICAL`-tagged code without explicit approval.

--- a/docs/context/TECH_STACK.md
+++ b/docs/context/TECH_STACK.md
@@ -1,0 +1,89 @@
+# MIRA — Tech Stack
+**Last Updated:** 2026-05-05
+
+Source of truth for "what we use." Anything not on this list either doesn't exist in this repo or needs a deliberate decision (and probably an ADR) to introduce. Hard constraints from `CLAUDE.md` are restated where relevant.
+
+## Languages & runtimes
+| Layer | Choice | Notes |
+|---|---|---|
+| Engine, ingest, MCP, crawler | Python 3.12 | Use `Optional[X]` only for Python 3.9 in `~/factorylm`; in MIRA repo, use `str \| None` |
+| Hub | TypeScript (strict) on Next.js | Custom internal Next; read `node_modules/next/dist/docs/` before assuming |
+| Web (PLG) | TypeScript on Bun + Hono | MIT-licensed |
+| Atlas API | Java (Spring Boot) | Upstream image only — no code imports |
+| PLC layer | Structured Text + ladder | Micro820, deployed via Connected Components Workbench |
+| Ignition Project | Jython gateway scripts + Perspective + WebDev | Deployed to Ignition 8.1 |
+
+## Package & build tooling
+| Concern | Tool | Notes |
+|---|---|---|
+| Python deps | `uv` | Not pip / poetry / conda |
+| Python lint + format | `ruff` | Not flake8 / pylint / black |
+| Python type check | `pyright` (basic) | 57 warnings target → 0 |
+| Python tests | `pytest`, `hypothesis` | `asyncio_mode = "auto"` |
+| TS / JS deps | Bun (mira-web), npm/pnpm (mira-hub) | Bun.lock + package-lock.json committed |
+| Containers | Docker Compose | Pinned tags; `restart: unless-stopped`; healthcheck on every service |
+| Image scanning | Trivy | CI-enforced |
+| SAST | Semgrep + Bandit | CI-enforced |
+| Secrets scanning | Gitleaks | Pre-commit + CI |
+| Architecture contracts | Boundary tests | 6 contracts |
+
+## Storage
+| System | Use |
+|---|---|
+| NeonDB (Postgres + pgvector) | KB, tenancy, KG, usage; RLS by tenant |
+| SQLite WAL (`mira.db`) | Conversation state, equipment, faults, maintenance notes, photos, feedback |
+| MinIO | Atlas asset images + WO attachments |
+| Redis | Celery broker for `mira-crawler` |
+| ChromaDB | Legacy in `mira-sidecar` (deprecated, ADR-0008) |
+
+## LLMs & inference
+- **Cloud cascade (default):** Groq → Cerebras → Gemini (OpenAI-compat). Set via `INFERENCE_BACKEND=cloud`.
+- **Local fallback:** Open WebUI → Ollama → `qwen2.5vl:7b`. `INFERENCE_BACKEND=local`.
+- **Vision:** Gemini native; Groq via `GROQ_VISION_MODEL`; local via qwen2.5vl.
+- **Embeddings:** `nomic-embed-text-v1.5` (768-d) for text; `nomic-embed-vision-v1.5` for image.
+- **Forbidden:** Anthropic (removed PR #610, PR #649). Any LangChain / LlamaIndex / TensorFlow / n8n.
+
+## HTTP, async, and DB drivers
+- HTTP: `httpx` (async). Never `requests` / `urllib`.
+- Async: `asyncio` end-to-end. `asyncio.run()` only at entry points.
+- Postgres: SQLAlchemy + `NullPool` (Neon's PgBouncer pools); `sslmode=require`; `pool_pre_ping=True`.
+- SQLite: stdlib `sqlite3`, always `PRAGMA journal_mode=WAL`.
+- YAML: always `yaml.safe_load()`.
+
+## Frameworks
+| Surface | Framework |
+|---|---|
+| `mira-pipeline` | FastAPI |
+| `mira-mcp` | FastMCP + FastAPI |
+| `mira-ingest` | FastAPI |
+| `mira-bots/*` | python-telegram-bot 21.x, slack-bolt 1.x, botbuilder 4.17, twilio 9.x, custom for reddit/email/gchat/webchat |
+| `mira-bridge` | Node-RED 4.1.7-22 (image: `nodered/node-red:4.1.7-22`) |
+| `mira-web` | Hono on Bun |
+| `mira-hub` | Custom internal Next.js + Refine.dev + shadcn/ui + Tailwind |
+| `mira-cmms` (Atlas) | Spring Boot — upstream image |
+
+## Auth
+- Mira-web JWT — `jose` library, secret `PLG_JWT_SECRET`.
+- Mira-hub JWT — separate secret `HUB_JWT_SECRET`.
+- HMAC for inbound webhooks: Stripe (`STRIPE_WEBHOOK_SECRET`), Apps Script magic inbox (`INBOUND_HMAC_SECRET`), monday.com (`MONDAY_APP_SIGNING_SECRET`).
+- Magic-link via Resend; Google OAuth on hub; admin bypass via header `x-admin-token`.
+
+## Observability
+- Tracing: Langfuse (per-call traces from bot adapters and pipeline).
+- Metrics & dashboards: Prometheus + Grafana (`mira-ops` deferred / partial).
+- Worker monitoring: Flower (Celery).
+- Discord webhooks: `#alpha-status`, `#alpha-nightly`, `#alpha-morning`, `#weekly-review`.
+
+## CI / agent review pipeline
+- GH Action `.github/workflows/code-review.yml` triggers on every PR to `main / develop / dev`.
+  shellcheck → ast-grep (IPs / secrets / raw FastAPI body / missing socket error handling) → cascade review (Groq → Cerebras → Gemini) → PR comment.
+- Self-fix script `scripts/pr_self_fix.sh <PR>` reads 🔴 IMPORTANT comments, asks LLM cascade for patches, applies + pushes (max 3 loops).
+- Pre-commit hook `.githooks/pre-commit`: shellcheck + rg credential scan + debug artifact scan.
+- Tools required locally: `shellcheck`, `rg`, `sg` (ast-grep), `scc`, `difft`.
+
+## Logging
+- Python: stdlib `logging`, never `print()`. Service-specific loggers (`logging.getLogger("mira-gsd")`).
+- Never log secrets or full PII; sanitization runs at `InferenceRouter.complete()` boundary.
+
+## What we do NOT use
+- LangChain, LlamaIndex, TensorFlow, n8n, Anthropic SDK, OpenAI proper (we use OpenAI-*compat* via Groq/Cerebras/Gemini), Kubernetes.

--- a/docs/specs/SPEC_INDEX.md
+++ b/docs/specs/SPEC_INDEX.md
@@ -1,0 +1,46 @@
+# MIRA Spec Index
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+Every module in MIRA has a spec at `docs/specs/{module-name}-spec.md`. A spec is the source of truth for **what the module does, its API contract, its quality benchmarks, and its acceptance criteria**. If a future Claude Code session needs to validate that the code still meets spec, this is where to look first — before reading the implementation.
+
+Specs follow the same template (Purpose · Scope · Architecture · API Contract · Configuration · Quality Standards · Acceptance Criteria · Known Issues · Change Log). When a module changes materially, bump the spec's Change Log; when an acceptance criterion changes, bump the version.
+
+## Core Platform
+- [`mira-bots`](./mira-bots-spec.md) — Adapter containers + the shared diagnostic engine (Supervisor / GSDEngine, FSM, RAGWorker, guardrails, InferenceRouter cascade).
+- [`mira-pipeline`](./mira-pipeline-spec.md) — OpenAI-compat API on `:9099`; the active VPS chat path that wraps Supervisor for Open WebUI.
+- [`mira-hub`](./mira-hub-spec.md) — Authenticated Next.js workspace (17 sections); non-destructive overlay over the existing backend.
+- [`mira-web`](./mira-web-spec.md) — Public marketing site + PLG funnel (Hono/Bun, Stripe, Resend, Atlas provisioning).
+- [`mira-mcp`](./mira-mcp-spec.md) — FastMCP server + REST proxy for equipment + CMMS tools (Atlas / MaintainX / Limble / Fiix adapters).
+- [`mira-core`](./mira-core-spec.md) — Open WebUI + MCPO proxy + mira-ingest photo/PDF pipeline.
+
+## Data & Intelligence
+- [`mira-crawler`](./mira-crawler-spec.md) — Celery fleet that discovers, downloads, parses, chunks, and embeds knowledge into NeonDB.
+- [`knowledge-graph`](./knowledge-graph-spec.md) — `kg_entities`, `kg_relationships`, `kg_triples_log` schemas + RLS; foundation for GraphRAG.
+- [`rag-pipeline`](./rag-pipeline-spec.md) — End-to-end retrieval, hybrid (BM25 + pgvector + RRF), citation contract, eval discipline.
+- [`quality-gate`](./quality-gate-spec.md) — Output post-processor + confidence heuristic; deterministic, < 10 ms.
+- [`dialogue-state-tracker`](./dialogue-state-tracker-spec.md) — Stage-1 FSM that drives the Guided Socratic Dialogue.
+
+## Integrations
+- [`mira-cmms`](./mira-cmms-spec.md) — Atlas CMMS (4 containers); REST-only integration to keep license boundary clean.
+- [`mira-bridge`](./mira-bridge-spec.md) — Node-RED 4.x; canonical writer of the shared SQLite WAL `mira.db`.
+- [`mira-scan`](./mira-scan-spec.md) — Asset-tag scanner: standalone web flow + monday.com app; "Open CMMS" button on every page.
+- [`ignition-exchange`](./ignition-exchange-spec.md) — Ignition 8.1 ConveyorMIRA project, 36 tags, deploy script, optional `mira-relay` SaaS.
+
+## Infrastructure
+- [`agentic-os`](./agentic-os-spec.md) — Heartbeat, self-healer, learning capture, funnel tracker; the Cowork scheduled tasks.
+- [`auth-tenancy`](./auth-tenancy-spec.md) — Magic-link, Google OAuth, trial gate, admin bypass, JWT, HMAC inbound webhooks.
+- [`deployment`](./deployment-spec.md) — Compose layout, nginx routing, node map, Doppler injection, smoke test.
+
+## Interfaces
+- [`telegram-bot`](./telegram-bot-spec.md) — Primary field-tech surface; polling-only, voice WO, photo intake, slash commands.
+- [`hub-mobile`](./hub-mobile-spec.md) — Responsive Hub: bottom tabs < 768 px, side drawer ≥ 768 px; touch-target + safe-area rules.
+
+## Existing Reference Specs (kept for compatibility)
+- [`factorylm-platform-v2`](./factorylm-platform-v2.md) — Earlier overview; canonical platform context lives here in this index now.
+
+## Conventions
+- **Versioning:** A spec's `Version` bumps when an acceptance criterion changes. Change Log captures every notable update.
+- **Owner:** Mike Harper / FactoryLM unless explicitly delegated.
+- **Reviewing a PR:** Cross-check the PR diff against the affected spec's "Acceptance Criteria"; if the change implies a new criterion, the spec should change in the same PR.
+- **Auditing the system:** Read `docs/context/PROGRESS.md` first (current phase + decisions), then this index.

--- a/docs/specs/agentic-os-spec.md
+++ b/docs/specs/agentic-os-spec.md
@@ -1,0 +1,108 @@
+# Agentic OS Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+A small set of always-on agents that keep MIRA's services healthy and learning between active sessions. Composed of:
+- **Heartbeat** — periodically pings every container/service and writes liveness state to NeonDB / Discord.
+- **Self-healer** — `mira-bots/v2_test_harness/healer.py` and `shared/agents/infra_guardian.py`; restarts unhealthy containers, rotates competing pollers, surfaces escalations.
+- **Learning capture** — pulls recorded sessions (`SESSION_RECORDING_PATH`) and feedback rows into eval fixtures + lesson logs (`/cluster/betterclaw/logs/`).
+- **Funnel tracker** — pulls `tenants` + Stripe events + PostHog into a daily funnel digest.
+
+Together these form the "Cowork scheduled tasks" referenced in `~/factorylm/CLUSTER.md` (midnight, 6 AM, Sunday 02:00).
+
+## Scope
+**IN scope**
+- `mira-bots/shared/agents/infra_guardian.py`
+- `mira-bots/v2_test_harness/healer.py`
+- `mira-crawler/reporting/agent_report.py`, `weekly_digest.py`, `telegram_notify.py`
+- `tests/eval/analyze_sessions.py` (consumes recorded sessions for fixtures)
+- Discord webhooks: `#alpha-status`, `#alpha-nightly`, `#alpha-morning`, `#weekly-review`
+
+**OUT of scope**
+- Cluster bootstrap (`~/factorylm/bootstrap.sh`)
+- Per-service health endpoints (each service owns its own `/health`)
+
+## Architecture
+```
+┌─────────────── Cowork Scheduler (Alpha) ────────────────┐
+│                                                         │
+│  midnight    → run open Task.md, write proof,           │
+│                post #alpha-nightly                      │
+│  06:00       → scan logs/ for repeat mistakes,          │
+│                write rules, post #alpha-morning         │
+│  Sun 02:00   → consolidate week, prune,                 │
+│                push GitHub, post #weekly-review         │
+│  every 5 min → infra-guardian heartbeat → NeonDB        │
+│                                                         │
+└──────────────────────────────────────────────────────────┘
+```
+
+- **Layer:** Infrastructure
+- **Schedule owner:** Cowork on Alpha node (`192.168.1.10`)
+- **Persistence:**
+  - Liveness: NeonDB (`agent_health` table) + Discord
+  - Lesson logs: `/cluster/betterclaw/logs/LESSON-<DATE>.md`
+  - Eval fixtures: `tests/eval/`
+
+## API Contract
+
+### Heartbeat
+| Surface | Behavior |
+|---|---|
+| `infra_guardian.run()` | One pass: probe each container's healthcheck + Ollama, write `agent_health` row, alert on transition |
+| Discord post | `{node, service, status, since, last_error}` |
+
+### Self-healer
+- Detects competing Telegram pollers (per memory `project_mira_state` and CLAUDE.md gotcha) and shuts down older ones.
+- Restarts `mira-pipeline` if `/health` 5xx for > 60 s.
+- Never auto-pulls images; only restarts existing ones.
+- Hard stop: never `docker volume rm`, never `git push --force`.
+
+### Learning capture
+- Pulls per-chat NDJSON from `${SESSION_RECORDING_PATH}` and produces deterministic eval grades (LLM judge optional via `EVAL_DISABLE_JUDGE=0`).
+- Appends fixtures to `tests/eval/` only on rolled-up changes that survive 7-day decay window.
+
+### Funnel tracker
+- Reads `tenants` table + Stripe API + PostHog daily.
+- Outputs `register → active → churned` funnel + 7/30/60-day cohort retention.
+- Posts to `#weekly-review`.
+
+## Configuration
+| Var | Purpose |
+|---|---|
+| `DISCORD_ALERT_WEBHOOK` | `#alpha-status` |
+| `DISCORD_NIGHTLY_WEBHOOK` | `#alpha-nightly` |
+| `DISCORD_MORNING_WEBHOOK` | `#alpha-morning` |
+| `DISCORD_WEEKLY_WEBHOOK` | `#weekly-review` |
+| `SESSION_RECORDING_PATH` | Source of recorded sessions |
+| `EVAL_DISABLE_JUDGE` | Skip LLM grading when `1` |
+| `STRIPE_SECRET_KEY` | Funnel tracker pull |
+| `PLG_POSTHOG_KEY` (server-side equivalent) | Cohort retention |
+| `NEON_DATABASE_URL` | Heartbeat + tenants read |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| False-restart rate (self-healer) | unmeasured | < 1 / week |
+| Heartbeat freshness | unmeasured | every 5 min, p99 < 60 s lag |
+| Lesson log cadence | enforced (CLUSTER law #5) | one log per session |
+| Funnel digest delivery | not yet automated weekly | every Sunday 02:00 |
+
+## Acceptance Criteria
+1. **Cluster law #1 (evidence-only):** No "completed" claim is written without a deterministic check (file exists, port open, test exit code 0).
+2. **Cluster law #5 (lesson log):** Every session writes `/cluster/betterclaw/logs/LESSON-<DATE>.md` with mistakes (human + AI) + fine-tune candidates.
+3. **Self-healer safety:** Self-healer never deletes data, never force-pushes, never bypasses signing/hooks.
+4. **Heartbeat alerting:** A container kill produces a Discord alert in `#alpha-status` within 1 heartbeat cycle.
+5. **Stale-poller hygiene:** Two Telegram pollers running on the same token results in exactly one survivor inside 60 s.
+6. **Eval roll-up:** A session that grades < threshold produces a fixture suggestion in `tests/eval/` after 7-day decay window — not before.
+7. **300-line orchestrator limit:** No single agent exceeds 300 lines of orchestration code; anything larger is delegated via `Task.md` (cluster law #3).
+
+## Known Issues
+- Funnel tracker is partially automated; weekly Discord digest still manual.
+- Lesson-log writer expects `/cluster/betterclaw/logs/` to exist; fresh nodes need `bootstrap.sh` first.
+
+## Change Log
+- 2026-04 — `infra_guardian.py` added under `mira-bots/shared/agents/`.
+- 2026-04 — Cowork scheduled tasks (midnight / 06:00 / Sun 02:00) formalized in `CLUSTER.md`.

--- a/docs/specs/auth-tenancy-spec.md
+++ b/docs/specs/auth-tenancy-spec.md
@@ -1,0 +1,121 @@
+# Auth & Tenancy Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Single specification for **how a request becomes a tenant-scoped session** across MIRA's surfaces. Defines the magic-link flow, Google OAuth, trial gate, admin bypass, and the JWT/cookie shape consumed by `mira-web` (PLG) and `mira-hub` (authenticated workspace). All NeonDB queries depend on this spec setting `MIRA_TENANT_ID` correctly.
+
+## Scope
+**IN scope**
+- Magic-link sign-in (Resend email → click → cookie set)
+- Google OAuth sign-in (mira-hub)
+- Admin bypass (`PLG_ADMIN_TOKEN` for support staff in mira-web)
+- Trial / activation gate (tier `pending` vs `active`)
+- JWT shape and signing
+- Tenant resolution at the request boundary (`mira-mcp/tenant_resolver.py`, mira-hub middleware, mira-web auth)
+- HMAC for inbound webhooks (Stripe, Apps Script magic inbox, monday.com)
+
+**OUT of scope**
+- Atlas CMMS authentication (lives inside Atlas; surfaced through `mira-mcp` only)
+- API-key auth between internal services (covered in each service's spec)
+
+## Architecture
+
+```
+Marketing site (mira-web)
+   ├── /api/register         → tenant: pending
+   ├── Magic-link email (Resend)
+   ├── Stripe webhook → tier: active → finalizeActivation
+   └── /api/me cookie  → tier check
+
+Hub (mira-hub)
+   ├── auth.ts (jose) + middleware.ts → JWT cookie verify
+   ├── magic-link OR Google OAuth     → JWT cookie set
+   └── per-request: load tenant + role → set in handler context
+```
+
+Both services issue HS256 JWTs with **separate secrets**: `PLG_JWT_SECRET` (mira-web) and `HUB_JWT_SECRET` (mira-hub). Cross-service trust is via shared NeonDB `tenants` table; never share secrets across services.
+
+## API Contract
+
+### JWT shape (canonical)
+```json
+{
+  "sub": "<tenant_id>",
+  "email": "<user-email>",
+  "role": "owner" | "admin" | "tech" | "support_bypass",
+  "tier": "pending" | "active" | "churned",
+  "iat": <unix>,
+  "exp": <unix>
+}
+```
+- `role: support_bypass` is **only** issued when an `x-admin-token` request matches `PLG_ADMIN_TOKEN`. Bypass tokens never grant write access on customer data; they list and read only.
+- `tier` is duplicated from `tenants.tier` for cheap gating; the source of truth remains the DB.
+
+### Cookie
+- Name: `mira_session` (mira-web), `hub_session` (mira-hub)
+- Flags: `Secure; HttpOnly; SameSite=Lax; Path=/`
+- TTL: 7 days; refresh sliding 24 h
+
+### Magic-link
+- One-time signed link `https://<host>/auth/magic?t=<jwt-with-jti>`. `jti` is single-use; consumed in NeonDB `magic_links_used`.
+- Tokens expire in 30 min.
+
+### Google OAuth (mira-hub only)
+- Standard OAuth Authorization Code flow with PKCE. `state` parameter mandatory.
+- Email is matched against `tenants.email`; new emails create `pending` tenant unless invite exists.
+
+### Trial / activation gate
+- mira-web: `pending` tenants reach `/api/me` with limited fields and a Stripe Checkout CTA.
+- mira-hub: `pending` tenants are redirected to `/upgrade` for any `(hub)/*` route except `/upgrade`.
+
+### HMAC inbound webhooks
+| Webhook | Header | Secret env |
+|---|---|---|
+| Stripe | `Stripe-Signature` | `STRIPE_WEBHOOK_SECRET` |
+| Magic inbox (Apps Script) | `X-Inbox-Signature` | `INBOUND_HMAC_SECRET` |
+| monday.com (scan) | `X-Monday-Signature` | `MONDAY_APP_SIGNING_SECRET` |
+
+All three reject mismatched signatures with HTTP 401 and write **no DB rows** before verification.
+
+## Configuration
+| Var | Used by | Purpose |
+|---|---|---|
+| `PLG_JWT_SECRET` | mira-web | Sign/verify mira-web JWTs |
+| `HUB_JWT_SECRET` | mira-hub | Sign/verify hub JWTs |
+| `RESEND_API_KEY` | both | Magic-link email |
+| `GOOGLE_OAUTH_CLIENT_ID` / `_SECRET` | mira-hub | Google sign-in |
+| `PLG_ADMIN_TOKEN` | mira-web | Admin-bypass for `/api/admin/*` |
+| `ADMIN_BYPASS_TOKEN` | mira-hub | Admin support read access |
+| `STRIPE_WEBHOOK_SECRET` | mira-web | Stripe webhook signature |
+| `INBOUND_HMAC_SECRET` | mira-web | Magic-inbox webhook signature |
+| `MONDAY_APP_SIGNING_SECRET` | mira-web | monday.com scan webhook |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Magic-link expiry | 30 min | maintain |
+| Cross-tenant request rejection | required | covered by RLS regression in NeonDB-using services |
+| Webhook signature failure → 401 | required | regression-tested per webhook |
+| JWT token leakage in logs | 0 | log scrubbing test |
+| Admin bypass write blocked | required | covered by mira-web `/api/admin/*` tests |
+
+## Acceptance Criteria
+1. **Magic-link single-use:** A second click on the same magic-link URL returns HTTP 410.
+2. **Magic-link JWT fix (CRA-22 / CRA-21):** A magic-link click sets a usable session cookie and lands the user on the right surface (mira-web pending → activation, mira-hub active → workspace).
+3. **Stripe sig:** A POST to `/api/stripe/webhook` with a tampered signature returns HTTP 400 and writes nothing.
+4. **Tenant scoping:** Every NeonDB call after auth sets `app.current_tenant_id`; any RLS table query without it returns zero rows.
+5. **Admin bypass read-only:** A request with `x-admin-token: $PLG_ADMIN_TOKEN` to a write endpoint returns HTTP 403; to a list endpoint returns HTTP 200.
+6. **Tier gate:** A `pending` tenant calling `mira-hub` `/api/workorders` is redirected to `/upgrade`.
+7. **monday.com HMAC:** A scan event with a wrong HMAC returns 401 (CRA-related: `mira-scan-spec.md`).
+8. **No secrets in URL params:** Tokens, API keys, and webhook signatures never appear as query strings.
+9. **Doppler-only secrets:** No real values for any secret listed above appear in `git ls-files`.
+
+## Known Issues
+- Two JWT secrets (`PLG_JWT_SECRET`, `HUB_JWT_SECRET`) — intentional, but a unified identity service (e.g. WorkOS) is on the long-term roadmap.
+- Admin bypass is read-only by design; any write requires a real session.
+
+## Change Log
+- 2026-05-04 — Magic-link JWT fix landed (CRA-22, CRA-21).
+- 2026-04-26 — `/api/admin/activation-health` introduced for support staff (admin-bypass surface).

--- a/docs/specs/deployment-spec.md
+++ b/docs/specs/deployment-spec.md
@@ -1,0 +1,107 @@
+# Deployment Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Single-stop reference for **how MIRA is deployed**: which docker-compose profile lives where, what nginx routes for `factorylm.com` and `app.factorylm.com`, which node runs what, and how secrets reach a container. Intended to be followed by anyone bringing a fresh node online or debugging routing.
+
+## Scope
+**IN scope**
+- Compose files: `docker-compose.yml`, `docker-compose.saas.yml`, `mira-core/docker-compose.oracle.yml`, per-module compose files
+- Nginx config under `deployment/nginx-factorylm-marketing.conf`
+- VPS layout (factorylm.com + app.factorylm.com)
+- Per-node service map (Alpha / Bravo / Charlie / Travel)
+- Doppler injection (`doppler run -- docker compose up -d`)
+
+**OUT of scope**
+- Kubernetes (not used; explicit no per `docs/known-issues.md` style)
+- Per-service container internals (see each service spec)
+
+## Architecture
+
+### Node map
+| Node | Tailscale | LAN | Role | Services |
+|---|---|---|---|---|
+| Alpha | 100.107.140.12 | 192.168.4.28 (`192.168.4.x`) | Orchestrator | celery-worker, celery-beat, docker-desktop |
+| Bravo | 100.86.236.11 | 192.168.1.11 (`192.168.1.x`) | Compute | Ollama (`:11434`), mira-mcp |
+| Charlie | 100.70.49.126 | 192.168.1.12 (`192.168.1.x`) | KB host | mira-core, mira-ingest, mira-bots, atlas-cmms, open-webui |
+| Travel | Tailscale only | — | Mobile | Claude Code CLI, no local mounts |
+
+Connectivity rules:
+- Alpha ↔ Bravo/Charlie: Tailscale only (different subnets).
+- Bravo ↔ Charlie: LAN preferred, Tailscale fallback.
+- All nodes: SSH keys via Doppler `factorylm/prd` as `SSH_{NODE}_{PRIVATE_KEY,PUBLIC_KEY,CONFIG,AUTHORIZED_KEYS}`.
+- Canonical source: `deployment/network.yml`.
+
+### VPS routing (factorylm.com)
+Nginx (`deployment/nginx-factorylm-marketing.conf`):
+- `factorylm.com` → marketing site (mira-web)
+- `app.factorylm.com` → mira-web app surface, including `/sample`, `/activated` (added 2026-04-26)
+- Hub on its own subdomain (e.g., `hub.factorylm.com`) when wired; otherwise behind `app.` path prefix.
+
+### Compose layout
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` (repo root) | Local dev / on-node MIRA stack |
+| `docker-compose.saas.yml` | SaaS overlay — adds `mira-relay`, `mira-ingest-saas` |
+| `mira-core/docker-compose.yml` | mira-core internal compose |
+| `mira-core/docker-compose.oracle.yml` | Oracle Cloud overrides; needs `BRAVO_HOST` |
+| Module-level (`mira-bots`, `mira-bridge`, `mira-cmms`, `mira-mcp`, `mira-web`) | Per-module standalone runs |
+
+## API Contract (deploy commands)
+```bash
+# Standard local / on-node
+doppler run --project factorylm --config prd -- docker compose up -d
+doppler run --project factorylm --config prd -- docker compose down
+doppler run --project factorylm --config prd -- docker compose logs -f <service>
+bash install/smoke_test.sh
+
+# SaaS overlay (factorylm.com)
+doppler run --project factorylm --config prd -- docker compose -f docker-compose.yml -f docker-compose.saas.yml up -d
+```
+
+Conventions:
+- `restart: unless-stopped` + healthcheck on every service (CLAUDE.md hard constraint #5).
+- Pinned image versions (no `:latest` / `:main`).
+- Named networks; never `network_mode: host`; never `privileged: true`.
+
+## Configuration
+| Var / Setting | Purpose |
+|---|---|
+| Doppler project/config | `factorylm/prd` (production) — single source of truth for all secrets |
+| `MIRA_MCPO_VERSION` | Bump on `Dockerfile.mcpo` change |
+| `BRAVO_HOST` | Required for Oracle Cloud overrides |
+| `ATLAS_PUBLIC_*_URL` | Public URLs for Atlas surfaces |
+| `MIRA_INGEST_URL` | mira-web → mira-ingest-saas in saas overlay |
+| `INBOX_DOMAIN` | Magic-inbox URL builder (default `factorylm.com`) |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Smoke test green after deploy | required | enforced via `install/smoke_test.sh` |
+| Container restart MTTR | unmeasured | ≤ 60 s |
+| Image scanning | trivy in CI | maintain |
+| Schema migration safety | uses CREATE IF NOT EXISTS pattern | maintain |
+| Time to bring up new node | unmeasured | ≤ 30 minutes following `bootstrap.sh` |
+
+## Acceptance Criteria
+1. **Cold start:** Following the README on a clean Charlie node yields all 11 containers in `running (healthy)` state.
+2. **Healthchecks present:** Every service in every compose file has a `healthcheck:` block.
+3. **No `:latest`:** `grep -E "image:.*:latest" $(git ls-files '*compose*.yml')` returns nothing.
+4. **No `network_mode: host`:** Same grep returns nothing.
+5. **Doppler injection:** No secret string from `docker compose config` matches a real value (verified locally).
+6. **nginx routing:** `app.factorylm.com/sample`, `/activated`, `/cmms` all return 200 from `mira-web`.
+7. **SaaS overlay:** `docker-compose.saas.yml` adds `mira-relay` only when invoked; not present in default compose.
+8. **Smoke test passes:** `install/smoke_test.sh` exits 0 within 90 s of compose up.
+9. **Registered models:** Open WebUI shows "MIRA Diagnostic" pointing at `mira-pipeline:9099`.
+
+## Known Issues
+- macOS keychain over SSH breaks `docker build` and `doppler` on remote nodes; Bravo workaround: `doppler configure set token-storage file`. Generic workaround: `docker cp` + restart.
+- NeonDB SSL fails on Windows due to `channel_binding`; deploy from macOS hosts.
+- A single Telegram bot token cannot be served by two pollers; CHARLIE specifically has hosted stale pollers in the past.
+
+## Change Log
+- 2026-05-04 — nginx routes `/sample` + `/activated` to mira-web on `app.factorylm.com`.
+- 2026-04 — Oracle Cloud overrides via `BRAVO_HOST`.
+- 2026-04 — SaaS overlay adds `mira-relay` for factory→cloud Ignition tag streaming.

--- a/docs/specs/dialogue-state-tracker-spec.md
+++ b/docs/specs/dialogue-state-tracker-spec.md
@@ -1,0 +1,97 @@
+# Dialogue State Tracker (Stage 1 DST) Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Per-`chat_id` finite-state machine that drives MIRA's **Guided Socratic Dialogue** (GSD): forces the diagnostic conversation to proceed in a known sequence (`IDLE → Q1 → Q2 → Q3 → DIAGNOSIS → FIX_STEP → RESOLVED`) and enables side states (`ASSET_IDENTIFIED`, `ELECTRICAL_PRINT`, `SAFETY_ALERT`) without losing the conversation thread. The DST is what lets MIRA produce one-question-at-a-time replies instead of the LLM dumping a checklist.
+
+## Scope
+**IN scope**
+- `STATE_ORDER` and side-state list in `mira-bots/shared/engine.py`
+- `_advance_state()` validator — invalid LLM-suggested transitions hold at current state
+- `_clear_diagnostic_carryover()` — required when transitioning out of `RESOLVED`
+- SQLite `conversation_state` table (WAL) — state persistence per `chat_id`
+- `Supervisor.reset(chat_id)` — IDLE wipe
+
+**OUT of scope**
+- Intent classification (`guardrails.classify_intent` — upstream of DST)
+- LLM call / RAG retrieval (workers, downstream of DST)
+- Multi-tenant isolation (handled by `MIRA_TENANT_ID`)
+
+## Architecture
+```
+Supervisor.process(chat_id, msg)
+  ├── load state row from conversation_state
+  ├── classify_intent → maybe SAFETY_ALERT bypass
+  ├── _advance_state(current, proposed) → validated_next
+  │     ├── if RESOLVED → next non-IDLE → _clear_diagnostic_carryover()
+  │     └── if invalid → hold at current
+  ├── workers run with state in context
+  └── persist new state row
+```
+
+Side states branch:
+- `ASSET_IDENTIFIED` — equipment recognized via vision; future answers include asset context.
+- `ELECTRICAL_PRINT` — handled by `PrintWorker` for follow-up Qs.
+- `SAFETY_ALERT` — bypasses RAG and FSM order; returns canned safety response immediately.
+
+## API Contract
+
+### Library
+```python
+sup.reset(chat_id: str) -> None
+sup.process_full(chat_id, message, photo_b64) -> dict
+# returns {"reply", "confidence", "trace_id", "next_state"}
+```
+
+`next_state` is the validated state after this turn. Adapter logs/displays it for debugging only — should not branch UI on it.
+
+### Persistence
+SQLite table (created via `Supervisor._ensure_table()`):
+```sql
+CREATE TABLE IF NOT EXISTS conversation_state (
+    chat_id TEXT PRIMARY KEY,
+    state TEXT NOT NULL,
+    asset_id TEXT,
+    asset_identified INT DEFAULT 0,
+    cmms_pending INT DEFAULT 0,
+    last_message_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    history_json TEXT,
+    extras_json TEXT
+);
+```
+
+WAL mode required for concurrent reads from `mira-mcp` and writes from bot adapters / pipeline.
+
+## Configuration
+No service-level env vars beyond shared:
+| Var | Purpose |
+|---|---|
+| `MIRA_DB_PATH` | SQLite location |
+| `MIRA_HISTORY_LIMIT` | Trim history per turn (default 20) |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Property tests for FSM validity | included in 11 hypothesis tests | maintain |
+| Invalid-transition hold rate | required | regression test for every new state |
+| RESOLVED → new fault carryover | bug fixed; test covers it (memory `feedback_resolved_state_wo_rebuild`) | maintain |
+| Concurrent writers from bots + pipeline | WAL required | maintain |
+
+## Acceptance Criteria
+1. **State order:** A clean session walks `IDLE → Q1 → Q2 → Q3 → DIAGNOSIS → FIX_STEP → RESOLVED` over consecutive turns when each turn provides the requested info.
+2. **Invalid hold:** If the LLM proposes an out-of-order transition (e.g., `Q1 → DIAGNOSIS`), state stays at current and the LLM is re-prompted.
+3. **Safety bypass:** A safety keyword at any state immediately yields `SAFETY_ALERT`; on the next message the FSM resumes at IDLE unless safety persists.
+4. **RESOLVED rebuild:** After `RESOLVED`, a new fault report rebuilds the WO — `_clear_diagnostic_carryover` resets `state["state"]` AND clears `cmms_pending` (regression: clearing `cmms_pending` alone is insufficient).
+5. **Reset wipe:** `sup.reset(chat_id)` returns the row to `IDLE` and empties `history_json`/`extras_json`.
+6. **History cap:** With 50 turns, only the last `MIRA_HISTORY_LIMIT` survive in `history_json`.
+7. **Concurrent safety:** Telegram and pipeline both writing for the same `chat_id` do not corrupt the row (WAL retry test).
+
+## Known Issues
+- DST is **Stage 1**: state is a flat enum with side states. Stage 2 (slot-based DST tracking equipment, fault codes, parts, time-since-last-PM) is planned but not built.
+- LLM-suggested transitions occasionally try to skip ahead — invalid-hold rate matters as much as correct-advance rate.
+
+## Change Log
+- 2026-04 — `_clear_diagnostic_carryover` patched to reset `state["state"]` off RESOLVED (memory: feedback_resolved_state_wo_rebuild).
+- 2026-04 — Property tests added under `tests/property/`.

--- a/docs/specs/hub-mobile-spec.md
+++ b/docs/specs/hub-mobile-spec.md
@@ -1,0 +1,94 @@
+# Hub Mobile Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Field-tech-friendly responsive layout for `mira-hub`. Most plants run MIRA on a phone in the technician's pocket, with managers on tablet or laptop. This spec freezes the navigation contract: **bottom tabs on phones, side drawer on tablets/desktop**, with the same 17 sections rendered through the same Refine.dev resources. Anything that breaks this layout breaks the field experience.
+
+## Scope
+**IN scope**
+- `src/app/(hub)/layout.tsx` shell behavior on mobile vs. desktop
+- Bottom-tab nav on viewports < 768 px
+- Side drawer on viewports ≥ 768 px (collapsible on tablet)
+- Section-level mobile behaviors that differ from desktop (chat input pinned, lists virtualized, sticky filter bar)
+- Touch target ≥ 44 px, swipeable tabs, safe-area insets
+
+**OUT of scope**
+- Native iOS/Android apps (not built; PWA is the strategy)
+- Specific section internals (each section owns its mobile-vs-desktop rules)
+
+## Architecture
+- **Layer:** Presentation (within `mira-hub`)
+- **Stack:** Next.js + Refine.dev + Tailwind + shadcn/ui
+- **Render:** Server components first; bottom-tab and drawer components hydrate.
+- **Detection:** CSS-only breakpoints (no UA sniffing). The layout key is `min-width: 768px`.
+
+```
+< 768 px:
+  ┌─────────────────────────┐
+  │ [Top: status pill]      │
+  │ [Section: full-width]   │
+  │ ...                     │
+  ├─────────────────────────┤
+  │ [Bottom Tabs (max 5)]   │  ← Workorders | Schedule | Chat | Assets | More
+  └─────────────────────────┘
+
+≥ 768 px:
+  ┌──────────────┬──────────────────────────────┐
+  │ Drawer       │ Section                      │
+  │ (17 items)   │ (master/detail when wide)    │
+  └──────────────┴──────────────────────────────┘
+```
+
+## API Contract
+
+### Bottom-tab contract
+- Maximum 5 tabs visible at all times: **Workorders, Schedule, Chat, Assets, More**.
+- "More" opens a sheet with the remaining 12 sections.
+- Active tab persists across reloads via cookie (`hub_active_tab`).
+
+### Drawer contract
+- 17 items, grouped: Operations (Workorders, Schedule, Requests, Alerts, Pending Approval), Assets (Assets, Parts, Documents, Knowledge), People (Team, Channels, Conversations), Admin (Integrations, Reports, Usage, Event Log, Admin), plus Magic + Upgrade callouts.
+- Drawer collapses to icon-only on tablet portrait; expanded on desktop.
+
+### Touch targets
+- Minimum 44 × 44 px on every interactive element on mobile.
+- Filter chips, primary CTA, and FAB use `min-h-12 min-w-12`.
+
+### Safe-area
+- Bottom nav respects iOS safe area (`env(safe-area-inset-bottom)`); content uses `pb-[calc(64px+env(safe-area-inset-bottom))]`.
+
+### Performance budgets
+- Initial JS per route ≤ 350 KB.
+- Largest Contentful Paint p75 (4G mobile) ≤ 2.5 s.
+- No layout shift on tab switch (CLS < 0.1).
+
+## Configuration
+No env vars exclusive to this spec. Inherits from `mira-hub-spec.md`.
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Lighthouse mobile perf | unmeasured | ≥ 80 |
+| Lighthouse mobile a11y | unmeasured | ≥ 95 |
+| Tab switch CLS | unmeasured | < 0.1 |
+| Touch-target audit | unmeasured | 100 % ≥ 44 px |
+| Playwright mobile suite | partial | full coverage of bottom-tab + drawer |
+
+## Acceptance Criteria
+1. **Bottom tabs visible:** On viewport 412 × 915 (Pixel 5), the 5 bottom tabs render and are tappable.
+2. **Drawer visible:** On viewport ≥ 768 px, the side drawer is the primary nav; bottom tabs are hidden.
+3. **Tab persistence:** Switching tab + reload returns to the same tab.
+4. **More sheet:** "More" opens a bottom sheet listing the other 12 sections.
+5. **Safe area:** On iOS, bottom tab bar does not overlap content (`env(safe-area-inset-bottom)` honored).
+6. **Touch target audit:** No interactive element on a key flow (login → asset → chat) is < 44 px.
+7. **No console errors:** Switching across all 17 sections produces zero browser console errors.
+8. **Promo-screenshot rule:** New mobile UI changes ship a `412×915` screenshot to `docs/promo-screenshots/` per CLAUDE.md.
+
+## Known Issues
+- Drawer sometimes flashes wider on first paint when rehydrating; mitigation is a server-rendered shell.
+- Some Refine.dev list views default to 50 rows — virtualize on mobile to keep scroll smooth.
+
+## Change Log
+- 2026-04-24 — Hub `v1.1.0` shipped with the bottom-tab + drawer pattern as the default.

--- a/docs/specs/ignition-exchange-spec.md
+++ b/docs/specs/ignition-exchange-spec.md
@@ -1,0 +1,94 @@
+# Ignition Exchange Resources Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Distributable **Ignition 8.1** project assets that demonstrate MIRA on a real industrial control surface (Conveyor MIRA scenario). Ships an Ignition project (`ConveyorMIRA`), 36 PLC tags, gateway scripts, web-dev modules, and a deploy script. Designed to install on a PLC laptop talking to a Micro820 over Modbus TCP. Pairs with `mira-relay` (cloud relay endpoint for factory→cloud tag streaming) for SaaS connectivity.
+
+## Scope
+**IN scope**
+- Ignition project under `ignition/project/` (Perspective views: ConveyorStatus + others)
+- 36 tags under `ignition/tags/`
+- Gateway scripts under `ignition/gateway-scripts/`
+- WebDev modules under `ignition/webdev/`
+- Config in `ignition/config/` and `ignition/db/`
+- PowerShell deployer `ignition/deploy_ignition.ps1`
+
+**OUT of scope**
+- The PLC ladder logic itself (lives under `plc/`)
+- Cloud relay implementation (`mira-relay`, separate spec target)
+- Custom Ignition modules (we use stock Perspective + WebDev)
+
+## Architecture
+- **Layer:** Industrial integration (off the standard MIRA layer map; runs on the PLC laptop)
+- **Targets:**
+  - Ignition Gateway 8.1 Standard (trial OK) on `http://localhost:8088`
+  - Micro820 PLC at `192.168.1.100:502` (Modbus TCP)
+- **Scenarios:** Standalone (LAN) and SaaS (`mira-relay` for factory→cloud streaming)
+
+```
+Micro820 (Modbus TCP) ──▶ Ignition Gateway ──▶ Perspective (ConveyorStatus)
+                                  │
+                                  └── WebDev → POST events to mira-relay (SaaS) → MIRA cloud
+```
+
+## API Contract
+### Deploy script (`deploy_ignition.ps1`)
+Sequence the script must execute, idempotently:
+1. Confirm Ignition gateway running.
+2. Locate Ignition `data/projects/` automatically.
+3. Copy `ignition/project/` → `ConveyorMIRA` project folder.
+4. Trigger project rescan via REST.
+5. Import all 36 tags via REST.
+6. Print Perspective URL.
+
+### Device connection (one-time, manual)
+| Field | Value |
+|---|---|
+| Driver | Modbus TCP |
+| Name | `Micro820_Conveyor` (case-sensitive) |
+| Hostname | `192.168.1.100` (try first) or `169.254.32.93` |
+| Port | `502` |
+| Unit ID | `1` |
+
+### Cloud relay (when wired)
+WebDev `POST` body to `mira-relay`:
+```json
+{ "asset_id": "<tag-or-asset>", "tag": "<name>", "value": <number|str>, "ts": "<iso8601>" }
+```
+Authentication is a per-tenant signing key (held in Doppler).
+
+## Configuration
+| Setting | Where | Purpose |
+|---|---|---|
+| Gateway URL | `http://localhost:8088` | Ignition Gateway |
+| Project name | `ConveyorMIRA` | Created by deploy script |
+| Tag-import REST | Ignition Gateway API | Import 36 tags |
+| `MIRA_RELAY_URL` | env on PLC laptop | Cloud relay endpoint when SaaS-connected |
+| `MIRA_RELAY_SIGNING_KEY` | Doppler / DPAPI | HMAC for relay POSTs |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Deploy script idempotency | required | re-run safe |
+| Tag count after import | 36 | exact match |
+| Gateway → PLC connection | "Connected" before tag import | enforced via deploy script |
+| Mean install time | unmeasured | ≤ 5 minutes |
+
+## Acceptance Criteria
+1. **Cold install:** Following the README on a clean PLC laptop with Ignition 8.1 results in a `Connected` Modbus device, 36 imported tags, and a working Perspective URL.
+2. **Re-run safety:** Running `deploy_ignition.ps1` a second time does not duplicate tags or break the project.
+3. **ConveyorStatus view:** Loads at `/ConveyorMIRA` and shows VFD metrics + status pills wired to live tags.
+4. **Tag naming invariant:** The device connection is named `Micro820_Conveyor` exactly; renaming breaks tag references.
+5. **SaaS mode:** With `MIRA_RELAY_URL` and signing key set, tag changes appear in the MIRA cloud within 5 s.
+6. **Trial-license tolerance:** Setup works on Ignition Standard trial without Maker license features.
+
+## Known Issues
+- Hostname depends on the PLC's network mode (Ethernet vs. APIPA fallback). Two hostnames are documented; users may need to try both.
+- Tag import is REST-driven; firewalls that block local REST to `:8088` will block the deployer.
+- The deploy script is PowerShell-only (Windows host).
+
+## Change Log
+- 2026-04 — `mira-relay` added as SaaS endpoint; Ignition WebDev modules updated to POST scoped tag events.
+- 2026-04 — `deploy_ignition.ps1` 3-command flow established as the canonical install path.

--- a/docs/specs/knowledge-graph-spec.md
+++ b/docs/specs/knowledge-graph-spec.md
@@ -1,0 +1,118 @@
+# Knowledge Graph Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+A tenant-scoped graph of entities (equipment, components, fault codes, procedures, specifications) and the relationships between them, plus an append-only **triples log** that captures every (subject, predicate, object) extracted from a conversation. Powers GraphRAG-style retrieval (hop from "PowerFlex 40" → "DC bus capacitor" → procedure F-201) and structured equipment intelligence in the Hub.
+
+## Scope
+**IN scope**
+- NeonDB tables `kg_entities`, `kg_relationships`, `kg_triples_log` (created by `mira-hub/db/migrations/001_knowledge_graph.sql`)
+- Row-level security policies that enforce `tenant_id`
+- Migration 004 in `docs/migrations/` (planned alternate schema with embedding column)
+- Hub UI views under `/(hub)/knowledge` and `/(hub)/assets`
+
+**OUT of scope**
+- Triple **extraction** at runtime (planned; not yet wired into engine)
+- Cross-tenant analytics (Knowledge Cooperative — separate spec)
+- Free-text RAG retrieval (`rag-pipeline-spec.md`)
+
+## Architecture
+
+```
+Conversation → triple-extractor (LLM JSON mode) → kg_triples_log
+                                                       │
+                                              upsert kg_entities
+                                                       │
+                                              link kg_relationships
+                                                       │
+                                       Hub /(hub)/assets  &  GraphRAG retrieval
+```
+
+- **Storage:** NeonDB (Postgres + pgvector); RLS enforced via `app.current_tenant_id` session setting
+- **Indexes:** `(tenant_id, entity_type)`, `(tenant_id, entity_id)`, `(source_id)`, `(target_id)`, `(tenant_id, relationship_type)`, `(tenant_id)` on triples
+- **Constraint:** `CHECK (source_id != target_id)` — no self-loops in `kg_relationships`
+
+## API Contract
+
+### Schema (canonical — `mira-hub/db/migrations/001_knowledge_graph.sql`)
+
+```sql
+kg_entities (
+  id UUID PK,
+  tenant_id UUID NOT NULL,
+  entity_type TEXT NOT NULL,        -- 'equipment' | 'component' | 'fault_code' | 'procedure' | 'specification'
+  entity_id   TEXT NOT NULL,        -- stable external id (e.g. "PowerFlex 40")
+  name        TEXT NOT NULL,
+  properties  JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ,
+  UNIQUE (tenant_id, entity_type, entity_id)
+)
+
+kg_relationships (
+  id UUID PK,
+  tenant_id UUID NOT NULL,
+  source_id UUID FK kg_entities ON DELETE CASCADE,
+  target_id UUID FK kg_entities ON DELETE CASCADE,
+  relationship_type TEXT NOT NULL,  -- 'has_component' | 'fault_of' | 'remedied_by' | ...
+  properties JSONB DEFAULT '{}',
+  confidence FLOAT DEFAULT 1.0,
+  source_conversation_id UUID,
+  created_at TIMESTAMPTZ,
+  CHECK (source_id <> target_id)
+)
+
+kg_triples_log (
+  id UUID PK,
+  tenant_id UUID NOT NULL,
+  conversation_id UUID,
+  subject TEXT, predicate TEXT, object TEXT,
+  confidence FLOAT, source TEXT,
+  extracted_at TIMESTAMPTZ
+)
+```
+
+### Planned schema variant (migration 004)
+`docs/migrations/004_kg_entities.sql` adds an `embedding vector(768)` column on entities and replaces `entity_id`-based unique key with `(tenant_id, entity_type, name)` plus a `source_chunk_id` FK to `knowledge_entries.id`. Migrate once Phase 3C section-level metadata exists.
+
+### Read paths
+- Hub `/api/assets/{id}` joins `kg_entities` + `kg_relationships(has_component)` to render the asset's component tree.
+- Engine retrieval (planned): hop from a query-resolved equipment entity to its connected fault codes and procedures, append to the RAG context window with a `kg:` source label.
+
+## Configuration
+| Var | Purpose |
+|---|---|
+| `NEON_DATABASE_URL` | DB |
+| `MIRA_TENANT_ID` | Set on every connection via `SET app.current_tenant_id = …` |
+
+No service-level env vars beyond shared NeonDB config.
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Migration applied (RLS on) | yes (#791) | maintain |
+| Self-loop check | enforced via CHECK | maintain |
+| Triple extractor unit tests | none | ≥ 10 (precision/recall) |
+| Entity dedup precision | unmeasured | ≥ 95 % at ingest |
+| Hop latency (Hub asset view) | unmeasured | ≤ 200 ms |
+| Cross-tenant leakage | must be 0 | RLS regression test required |
+
+## Acceptance Criteria
+1. **RLS enforced:** A query without `app.current_tenant_id` set returns zero rows; with the wrong tenant returns zero rows.
+2. **Self-loop rejected:** Inserting a row with `source_id = target_id` fails with the CHECK constraint.
+3. **Cascade delete:** Deleting an entity removes all relationships referencing it.
+4. **Idempotent upsert:** Re-extracting the same triple does not create a duplicate `kg_entities` row.
+5. **Triple log append-only:** No update or delete path on `kg_triples_log`; ingest only appends.
+6. **Hub view:** `/(hub)/assets/{id}` renders the component tree using only `kg_*` tables (no orphans).
+7. **Schema migration safety:** Running migration 001 on a fresh DB and again is a no-op (`CREATE TABLE IF NOT EXISTS`).
+
+## Known Issues
+- Triple extractor at runtime is **not yet wired into the engine** — the schema exists and the Hub UI consumes it, but extraction is currently manual / via crawler tasks.
+- Two parallel schema flavors exist (Hub `001_knowledge_graph.sql` vs. `docs/migrations/004_kg_entities.sql`) — pick one before GraphRAG launch.
+- `kg_triples_log` has no retention policy; growth is unbounded.
+
+## Change Log
+- 2026-04 — Schema landed in mira-hub migrations (#791). RLS enabled.
+- 2026-04 — Migration 004 drafted for embedding-aware variant; not yet applied.

--- a/docs/specs/mira-bots-spec.md
+++ b/docs/specs/mira-bots-spec.md
@@ -1,0 +1,136 @@
+# mira-bots Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Channel-agnostic adapters (Telegram, Slack, Teams, WhatsApp, Reddit, webchat, gchat, email) plus the **shared diagnostic engine** (`shared/`) that every chat surface and the VPS pipeline call. The shared engine — `Supervisor` (a.k.a. GSDEngine) — is the single source of truth for MIRA's diagnostic conversation: intent classification, FSM state, RAG retrieval, multi-provider LLM cascade, guardrails, and feedback logging.
+
+## Scope
+**IN scope**
+- Adapter containers that translate platform-specific events to/from the engine (`telegram/`, `slack/`, `teams/`, `whatsapp/`, `reddit/`, `webchat/`, `gchat/`, `email/`)
+- Shared engine library: `shared/engine.py`, `shared/workers/*`, `shared/guardrails.py`, `shared/inference/router.py`, `shared/recall.py`
+- Prompt registry under `shared/../prompts/diagnose/active.yaml`
+- Bot-level test harness (`tests/`, `v2_test_harness/`, `benchmark/`)
+
+**OUT of scope**
+- VPS chat path (handled by `mira-pipeline` — but it imports `shared/`)
+- Knowledge ingestion (handled by `mira-ingest` and `mira-crawler`)
+- CMMS work-order creation (handled by `mira-mcp`)
+
+## Architecture
+- **Layer:** Adapter (`telegram`/`slack`/etc.) → Engine (`shared/`) per `docs/ARCHITECTURE.md`
+- **Containers:** `mira-bot-telegram`, `mira-bot-slack`, `mira-bot-teams` (`:8030`), `mira-bot-whatsapp` (`:8010`)
+- **Networks:** `bot-net` + `core-net` (so adapters can reach `mira-ingest`, `mira-mcp`, Open WebUI)
+- **Persistence:** Shared SQLite WAL at `mira-bridge/data/mira.db` (mounted read/write)
+- **Dependencies:**
+  - Upstream: Telegram/Slack/Teams/Twilio (inbound events)
+  - Downstream: Ollama (`:11434`), Open WebUI (`:8080`), `mira-ingest` (`:8001`), NeonDB (RAG recall), Groq/Cerebras/Gemini APIs
+
+```
+[Channel platform] → [Adapter] → Supervisor.process()
+                                   ├── classify_intent (guardrails)
+                                   ├── FSM advance
+                                   ├── RAGWorker (recall + InferenceRouter)
+                                   ├── VisionWorker (qwen2.5vl:7b)
+                                   └── feedback_log + api_usage → mira.db
+```
+
+## API Contract
+### Library (called by adapters and `mira-pipeline`)
+```python
+sup = Supervisor(
+    db_path: str,
+    openwebui_url: str,
+    api_key: str,
+    collection_id: str,
+    vision_model: str = "qwen2.5vl:7b",
+    tenant_id: str | None = None,
+)
+
+reply: str = sup.process(chat_id: str, message: str, photo_b64: str | None = None)
+
+full = sup.process_full(chat_id, message, photo_b64)
+# → {"reply": str, "confidence": "high"|"medium"|"low"|"none", "trace_id": str, "next_state": str}
+
+sup.reset(chat_id: str) -> None
+sup.log_feedback(chat_id: str, feedback: "up"|"down", reason: str = "") -> None
+```
+
+### Adapter behavior contract
+- Cast `chat_id` to `str` before calling (`Telegram` sends `int`)
+- `photo_b64` MUST be base-64 string, not raw bytes
+- Strip `@mention` tags via `guardrails.strip_mentions()` before forwarding
+- File-size enforcement: Telegram ≤ 20 MB PDF; Slack MIME allowlist (images + PDF)
+
+### FSM contract
+`STATE_ORDER = ["IDLE", "Q1", "Q2", "Q3", "DIAGNOSIS", "FIX_STEP", "RESOLVED"]`
+Plus side states: `ASSET_IDENTIFIED`, `ELECTRICAL_PRINT`, `SAFETY_ALERT`.
+`_advance_state()` rejects invalid transitions silently — adapter does not need to validate.
+
+## Configuration
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `TELEGRAM_BOT_TOKEN` | telegram | — | Bot API token (Doppler) |
+| `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` | slack | — | Socket Mode auth |
+| `INFERENCE_BACKEND` | yes | `cloud` | `cloud` (Groq→Cerebras→Gemini cascade) or `local` (Open WebUI fallback) |
+| `GROQ_API_KEY` / `CEREBRAS_API_KEY` / `GEMINI_API_KEY` | ≥1 in cloud | — | Cascade providers |
+| `GROQ_MODEL` | no | `llama-3.3-70b-versatile` | Groq text model |
+| `GROQ_VISION_MODEL` | no | `meta-llama/llama-4-scout-17b-16e-instruct` | Groq vision |
+| `GEMINI_MODEL` / `GEMINI_VISION_MODEL` | no | `gemini-2.5-flash` | Gemini text + vision |
+| `CEREBRAS_MODEL` | no | `llama3.1-8b` | Cerebras text |
+| `OPENWEBUI_BASE_URL` | yes | `http://mira-core:8080` | Open WebUI for KB retrieval + local fallback |
+| `OPENWEBUI_API_KEY` | yes | — | Bearer token for Open WebUI |
+| `KNOWLEDGE_COLLECTION_ID` | yes | — | Open WebUI collection UUID |
+| `MIRA_DB_PATH` | yes | `/data/mira.db` | SQLite WAL location |
+| `MIRA_TENANT_ID` | yes | — | Tenant scope for NeonDB recall |
+| `NEON_DATABASE_URL` | yes | — | NeonDB recall |
+| `MIRA_HISTORY_LIMIT` | no | `20` | Max conversation turns kept in context |
+| `MIRA_RETRIEVAL_HYBRID_ENABLED` | no | `true` | Unit-6 BM25 + pgvector hybrid retrieval kill switch |
+| `MIRA_RRF_K` | no | `60` | Reciprocal Rank Fusion constant |
+| `MIRA_PLC_ENABLED` | no | off | Enables (stub) PLCWorker for Config 4 |
+| `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` | no | — | Tracing |
+
+### Forbidden
+- `ANTHROPIC_API_KEY` — Anthropic was removed in PR #610 + #649. The runtime silently ignores any value.
+- LangChain, n8n, TensorFlow — banned per CLAUDE.md hard constraints.
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Test files | 12 | maintain ≥ 12, grow with engine |
+| pytest coverage (shared) | 27–32 % measured | 50 % |
+| Property tests (hypothesis) | 11 | maintain |
+| Boundary contracts | 6 architectural rules | maintain |
+| Type checking | pyright basic, 57 warnings | 0 warnings (treat as errors) |
+| First-token latency | ≤ 3 s p50 (cloud cascade) | ≤ 2 s |
+| Cascade fallback | < 200 ms switch on 5xx | maintain |
+| Provider error rate | < 1 % per provider | < 0.5 % |
+
+Domain grade per `docs/QUALITY_SCORE.md`: **C+**.
+
+## Acceptance Criteria
+A change is acceptance-tested only if all of the following still pass:
+
+1. **Cold start:** New `chat_id` enters `IDLE`; first user message advances to `Q1` (industrial intent) or `SAFETY_ALERT` (safety intent).
+2. **Cascade failover:** Forcing Groq 500 → Cerebras success returns a non-empty `reply`; both events appear in `api_usage`.
+3. **PII sanitization:** A message containing `192.168.1.42`, `aa:bb:cc:dd:ee:ff`, and `SN12345` is sanitized before any provider call (verified in `InferenceRouter.sanitize_context()` test).
+4. **Safety bypass:** `"there's smoke from the panel"` returns `SAFETY_ALERT` regardless of FSM position; engine does not call RAG.
+5. **No-Anthropic invariant:** `grep -r "anthropic" mira-bots/shared/inference/` returns zero non-comment hits.
+6. **History cap:** A 50-turn conversation keeps only the last `MIRA_HISTORY_LIMIT` turns in the LLM context window.
+7. **Feedback logging:** `log_feedback(chat_id, "down", "wrong_part")` writes a row to `feedback_log`.
+8. **Resolved-state reset:** Setting state = `RESOLVED` then sending a new fault rebuilds — `_clear_diagnostic_carryover` resets `state["state"]` (regression: feedback_resolved_state_wo_rebuild).
+9. **Prompt hot-swap:** Editing `prompts/diagnose/active.yaml` and re-issuing a request picks up the new prompt without a restart.
+10. **All 6 boundary contracts** (`tests/architecture/`) pass.
+
+## Known Issues
+- `mira-bots/shared` coverage below 50 % target.
+- `plc_worker.py` is a stub (Config 4 deferred).
+- Intent classifier biases toward `industrial` for unrecognized queries (intentional, but produces false positives on chit-chat < 20 chars; greeting word required for `greeting`).
+- Competing Telegram pollers: only one process per token. Stale pollers on Charlie have caused incidents.
+
+## Change Log
+- 2026-04-26 — PR #649 final Anthropic removal, cascade reordered to Groq → Cerebras → Gemini.
+- 2026-04-25 — PR #610 ripped out Anthropic dependency.
+- 2026-04-15 — #280: intent classifier defaults to `industrial`, greeting requires keyword + length.
+- 2026-04-17 — Hybrid BM25 + pgvector retrieval (Unit 6) added behind `MIRA_RETRIEVAL_HYBRID_ENABLED`.

--- a/docs/specs/mira-bridge-spec.md
+++ b/docs/specs/mira-bridge-spec.md
@@ -1,0 +1,77 @@
+# mira-bridge Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Node-RED 4.x container that owns the **shared SQLite WAL database** (`mira-bridge/data/mira.db`) and routes inbound webhooks / REST triggers to MIRA core services. Acts as the canonical writer for `mira.db`; every other container that touches the file (mira-mcp, mira-ingest, mira-pipeline, bot adapters) reads via the same Docker volume — never copy.
+
+## Scope
+**IN scope**
+- `nodered/node-red:4.1.7-22` container on `:1880`
+- Flow definitions in `flows/` (committed JSON)
+- SQLite WAL DB + bind-mount layout
+- Visual orchestration of dashboards, scheduled tasks, setup wizard
+
+**OUT of scope**
+- Diagnostic engine logic (`mira-bots/shared`)
+- KB ingestion (`mira-ingest`, `mira-crawler`)
+- CMMS integration (`mira-mcp`)
+
+## Architecture
+- **Layer:** Infrastructure
+- **Network:** `core-net`
+- **Persistence:** SQLite WAL at `data/mira.db` — bind-mounted into:
+  - `mira-bridge` itself at `/data` (read/write — owner)
+  - `mira-mcp` at `/mira-db` (read)
+  - `mira-pipeline` at `/data` (read/write for state + sessions)
+  - bot adapters at `/data` (read/write for state + history)
+
+```
+Inbound (webhook / REST / cron) → Node-RED flows → mira-bridge writes mira.db
+                                                          │
+                              other containers read same file via volume
+```
+
+## API Contract
+| Surface | Endpoint | Notes |
+|---|---|---|
+| HTTP-in nodes | `:1880/<flow-defined>` | Configurable per flow |
+| Editor UI | `:1880/` | Authenticated (Node-RED admin auth) |
+| Healthcheck | `curl -f http://localhost:1880/` | 200 when HTTP server up |
+
+### Flows committed
+- `mira-dashboard-conveyor.json` — operator dashboard for the Conveyor MIRA demo
+- `mira-scheduled-tasks.json` — scheduled jobs (e.g., heartbeat, log rotations)
+- `mira-setup-wizard.json` — first-run setup wizard
+
+Editing pattern: open Node-RED UI → modify → export JSON → commit the updated file.
+
+## Configuration
+| Var | Default | Purpose |
+|---|---|---|
+| `NODERED_PORT` | `1880` | Host port |
+| `MIRA_DB_PATH` | `./data` | Host directory bind-mounted to `/mira-db` (writers see `/data/mira.db`) |
+| Node-RED admin user/pass | set in Node-RED settings | UI auth |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Tests | none | Add a smoke flow that opens DB, runs a SELECT, asserts WAL mode |
+| Schema drift | not tracked | Migrations live with the consumer; bridge never adds tables |
+| Restart MTTR | unmeasured | ≤ 30 s |
+
+## Acceptance Criteria
+1. **WAL mode:** `PRAGMA journal_mode` on `mira.db` returns `wal`.
+2. **Single writer invariant:** No schema migration is run from any other container while `mira-bridge` is up. Migrations either run with bridge stopped or use `Supervisor._ensure_table()` patterns (CREATE IF NOT EXISTS + retry on `database is locked`).
+3. **Volume sharing:** Modifying a row from `mira-bridge` is visible to `mira-mcp` immediately on next read.
+4. **Healthcheck:** `:1880/` returns HTTP 200 within 30 s of container start.
+5. **Flow stability:** Restarting `mira-bridge` reloads all 3 flows from `flows/`.
+6. **Backup:** A daily SQLite backup of `mira.db` exists (operational, not in this repo).
+
+## Known Issues
+- `mira-bridge` holds the SQLite write lock; running schema migrations against `mira.db` from other containers while it is up risks `database is locked` errors.
+- Flow JSON edits made in the UI are not auto-committed — must export + commit by hand.
+
+## Change Log
+- 2026-04 — Setup wizard flow added.

--- a/docs/specs/mira-cmms-spec.md
+++ b/docs/specs/mira-cmms-spec.md
@@ -1,0 +1,87 @@
+# mira-cmms (Atlas CMMS) Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Free, self-hosted **Computerized Maintenance Management System** that gives technicians and managers work-order tracking, preventive-maintenance scheduling, equipment registry, parts inventory, and file/image storage. Sourced from upstream **Atlas CMMS** (`Teptac/Atlas_CMMS`, GPL-3.0). MIRA integrates **REST-only** — no Atlas/Frappe code is imported, so MIRA's MIT/Apache 2.0 licensing is preserved.
+
+## Scope
+**IN scope**
+- 4 Atlas containers: `atlas-db`, `atlas-api`, `atlas-frontend`, `atlas-minio`
+- Compose files: `docker-compose.yml`, `docker-compose.local.yml`
+- Smoke test (`smoke_test.sh`)
+- Network mapping (`atlas-api` exposed on `core-net` for `mira-mcp`)
+
+**OUT of scope**
+- Custom code inside Atlas (we run upstream images, no patches)
+- Direct UI access for end users — they hit the Hub or marketing site, which use Atlas only via the `mira-mcp` REST proxy
+
+## Architecture
+- **Layer:** Infrastructure
+- **Networks:** `cmms-net` (internal), `core-net` (`atlas-api` only)
+
+| Container | Image | Host Port | Purpose |
+|---|---|---|---|
+| `atlas-db` | `postgres:16-alpine` | 5433 | PostgreSQL DB |
+| `atlas-api` | `intelloop/atlas-cmms-backend:v1.5.0` | 8088 | Spring Boot REST API |
+| `atlas-frontend` | `intelloop/atlas-cmms-frontend:v1.5.0` | 3100 | React UI |
+| `atlas-minio` | `minio/minio:RELEASE.2025-04-22T22-12-26Z` | 9000, 9001 | File/image storage |
+
+Port remap rationale (collisions with MIRA defaults):
+| Service | Atlas default | MIRA remap | Reason |
+|---|---|---|---|
+| Frontend | 3000 | 3100 | 3000 = mira-core (Open WebUI) |
+| API | 8080 | 8088 | 8080 = mira-core internal |
+| Postgres | 5432 | 5433 | Standard avoidance |
+
+## API Contract
+Atlas CMMS REST API at `http://atlas-api:8080` (internal) / `http://localhost:8088` (host). JWT bearer obtained via `/api/auth/signin`.
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/auth/signin` | `{username,password}` → `{token}` |
+| GET | `/api/work-orders` | List |
+| POST | `/api/work-orders` | Create |
+| PATCH | `/api/work-orders/{id}` | Update |
+| GET | `/api/assets` | List |
+| POST | `/api/assets` | Register |
+| GET | `/api/preventive-maintenances` | List |
+| POST | `/api/preventive-maintenances` | Create |
+| GET | `/api/parts` | List |
+
+All MIRA usage goes through `mira-mcp` (REST + MCP tools); never call Atlas directly from `mira-web`/`mira-hub` to keep auth and tenancy translation in one place.
+
+## Configuration
+| Var | Purpose |
+|---|---|
+| `ATLAS_DB_PASSWORD` | Postgres password |
+| `ATLAS_JWT_SECRET` | JWT signing key |
+| `ATLAS_MINIO_PASSWORD` | MinIO root password |
+| `ATLAS_PUBLIC_API_URL` | Public URL hint (e.g. `http://bravo:8088`) |
+| `ATLAS_PUBLIC_FRONT_URL` | Public frontend URL |
+| `ATLAS_PUBLIC_MINIO_URL` | Public MinIO URL |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Tests | 0 in this repo | At least one smoke test ⇒ done; add MaintainX/Limble-style integration coverage in `mira-mcp` |
+| MTTR after Atlas restart | unmeasured | ≤ 60 s to reach `/api/auth/signin` 200 |
+| Backup cadence | not configured | nightly Postgres dump + MinIO sync |
+
+Domain grade: **F** (no MIRA-side tests; we rely on upstream image quality).
+
+## Acceptance Criteria
+1. **Smoke test:** `bash mira-cmms/smoke_test.sh` exits 0 and verifies all 4 containers are healthy.
+2. **Auth round-trip:** `POST /api/auth/signin` with the seeded admin returns a JWT; subsequent calls with the JWT succeed.
+3. **Work-order create:** `POST /api/work-orders` from `mira-mcp` succeeds and is visible in `/api/work-orders`.
+4. **License boundary:** No Atlas/Frappe Python or Java imports inside MIRA repo (`grep -ri "from atlas\|import atlas" mira-*`).
+5. **Image storage:** Uploading an image to a WO via the API persists into MinIO and is retrievable via the public URL.
+6. **First-time setup:** Following the runbook (`docs/runbooks/cmms-onboarding.md`) results in a working admin account and first asset.
+
+## Known Issues
+- Upstream image is GPL-3.0 — strict no-code-import policy.
+- Default ports collide with MIRA; only the documented remaps are supported.
+
+## Change Log
+- 2026-04 — Multi-provider abstraction (`CMMS_PROVIDER`) added in `mira-mcp`; Atlas remains default.

--- a/docs/specs/mira-core-spec.md
+++ b/docs/specs/mira-core-spec.md
@@ -1,0 +1,109 @@
+# mira-core Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Hosts the **Open WebUI** chat surface (which Open WebUI users see, and which `mira-pipeline` registers with as a model), the **MCPO proxy** that bridges Open WebUI tool-calls to MCP servers, and the **mira-ingest** photo/PDF pipeline. mira-core is the front door for everything that's not the marketing site or the authenticated hub.
+
+## Scope
+**IN scope**
+- `mira-core` container — Open WebUI v0.8.10 (chat UI + KB admin) on `:3000 → :8080`
+- `mira-mcpo` container — `mcpo + fastmcp` MCP-over-HTTP proxy on `:8000`
+- `mira-docling` container — PDF parsing on `:5001`
+- `mira-ingest` (lives in `mira-core/mira-ingest/`) — see below
+- Build assets: `Dockerfile.mcpo`, `Modelfile`/`Modelfile.staging`, `mcpo-config.json`, `entrypoint-mira.sh`
+
+**OUT of scope**
+- Diagnostic engine (`mira-bots/shared`) — Open WebUI sends chat to `mira-pipeline`
+- Vector store (`mira-mcp` for OpenViking, NeonDB for KB)
+
+## Architecture
+- **Layer:** Infrastructure
+- **Containers:**
+  - `mira-core` — Open WebUI (`3000 → 8080`); networks `core-net`, `bot-net`
+  - `mira-mcpo` — MCP proxy (`:8000`); network `core-net`; image tag set by `MIRA_MCPO_VERSION`
+  - `mira-docling` — Docling parser (`:5001`); network `core-net`
+  - `mira-ingest` — FastAPI on `8002 → 8001`; network `core-net`
+- **External deps:** Ollama on host (`:11434`), NeonDB, mira-mcp, mira-pipeline
+
+## API Contract
+
+### Open WebUI (mira-core)
+- Standard Open WebUI REST + WebSocket. Bearer token = `OPENWEBUI_API_KEY`.
+- Knowledge collection accepts file uploads via `/api/v1/files`, then attachment to a collection by UUID (`KNOWLEDGE_COLLECTION_ID`).
+- "MIRA Diagnostic" model is registered as an external OpenAI-compat backend pointing at `mira-pipeline:9099`.
+
+### mira-mcpo
+- Exposes MCP tools as HTTP for Open WebUI's tool calling. Bearer token = `MCPO_API_KEY`.
+
+### mira-ingest
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/health` | Liveness |
+| GET | `/health/db` | NeonDB connectivity + row counts |
+| POST | `/ingest/photo` | multipart {asset_tag, location, notes, file} |
+| POST | `/ingest/search` | Vector search over equipment_photos |
+
+#### Photo pipeline
+1. Multipart accepted; required `asset_tag`.
+2. `_sanitize_image()` — strip EXIF, resize to `MAX_INGEST_PX` (default 1024) via Pillow.
+3. `_describe_image()` — qwen2.5vl:7b via Ollama → ≤ 100-word maintenance description.
+4. Embed text via `nomic-embed-text-v1.5`; embed image via `nomic-embed-vision-v1.5`.
+5. Write SQLite `equipment_photos` row + push to Open WebUI knowledge collection.
+6. `check_tier_limit(tenant_id)` — HTTP 429 if daily limit exceeded; **fail-open on DB error** (returns `(True, "")`).
+
+#### NeonDB module (`db/neon.py`)
+SQLAlchemy with `NullPool` (Neon PgBouncer handles pooling), `sslmode=require`.
+| Function | Purpose |
+|---|---|
+| `recall_knowledge(emb, tenant_id, limit=5)` | pgvector `embedding <=> cast(:emb AS vector)` |
+| `insert_knowledge_entry(...)` | Write a chunk |
+| `knowledge_entry_exists(...)` | Dedup |
+| `check_tier_limit(tenant_id)` | `(allowed, reason)` |
+| `health_check()` | Tenant + knowledge_entries counts |
+
+## Configuration
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `OPENWEBUI_API_KEY` | yes | — | Bearer for Open WebUI + KB push |
+| `MCPO_API_KEY` | yes | — | Bearer for MCPO |
+| `MIRA_MCPO_VERSION` | no | `3.4` | Image tag for built MCPO container |
+| `BRAVO_HOST` | optional | — | Used by Oracle Cloud overrides |
+| `NEON_DATABASE_URL` | yes (ingest) | — | NeonDB |
+| `MIRA_TENANT_ID` | yes (ingest) | — | Tenant scope |
+| `OLLAMA_BASE_URL` | yes | `http://host.docker.internal:11434` | Ollama host |
+| `MIRA_DB_PATH` | yes (ingest) | `/app/mira.db` | SQLite path |
+| `DESCRIBE_MODEL` | no | `qwen2.5vl:7b` | Vision description model |
+| `MAX_INGEST_PX` | no | `1024` | Image dim cap |
+| `KNOWLEDGE_COLLECTION_ID` | yes (ingest) | — | Open WebUI collection |
+| `RELEVANCE_GATE_ENABLED` | no | off | Magic-inbox PDF relevance check via Groq |
+| `GROQ_API_KEY` | when relevance gate on | — | Groq for relevance classifier |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| ingest test files | 4 | ≥ 8 (cover dedup, tier-limit fail-open, embed dimension) |
+| Coverage (ingest) | 20 % measured | 50 % |
+| Photo ingest p95 | unmeasured | ≤ 4 s including Ollama |
+| EXIF leak | must strip | regression test required |
+
+Domain grade: **C** (ingest), pending for Open WebUI surface (operational).
+
+## Acceptance Criteria
+1. **Photo round-trip:** `POST /ingest/photo` with a JPEG returns 200 and a row appears in `equipment_photos` and the Open WebUI collection.
+2. **EXIF stripped:** Verify ingested file has no EXIF tags (`exiftool`).
+3. **Resize cap:** A 4000px input image is resized to ≤ 1024 px on the longest edge.
+4. **Tier-limit fail-open:** Killing NeonDB connectivity does not 5xx — request still ingests with a logged warning.
+5. **Tier-limit enforce:** With NeonDB up and tenant over `daily_photo_limit`, request returns HTTP 429 with `reason`.
+6. **Relevance gate:** With `RELEVANCE_GATE_ENABLED=true`, an irrelevant PDF posted via the magic-inbox path is rejected with reason; on Groq error, fail-open.
+7. **MCP tool calling:** Open WebUI can call any of the 4 equipment tools via the MCPO proxy.
+8. **Pipeline registration:** "MIRA Diagnostic" appears in Open WebUI model picker and routes to `mira-pipeline:9099`.
+
+## Known Issues
+- Embedding-provider switch requires deleting the relevant store + full re-ingest (dimension mismatch).
+- Magic-inbox PDF path: relevance-gate cost is ~$0.00005/file via Groq; fail-open on any Groq error.
+
+## Change Log
+- 2026-04 — Magic-inbox PDF flow added; relevance gate (Unit 3.5) introduced behind flag.
+- 2026-04 — Open WebUI upgraded to v0.8.10.

--- a/docs/specs/mira-crawler-spec.md
+++ b/docs/specs/mira-crawler-spec.md
@@ -1,0 +1,103 @@
+# mira-crawler Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Celery-based ingestion fleet that **discovers, downloads, parses, and chunks OEM manuals + supporting docs** into NeonDB so the diagnostic engine has knowledge to retrieve. It also ingests YouTube transcripts, RSS feeds, Reddit threads, and LinkedIn signals; reports weekly digests; and runs the inbox-triage agent. This is the engine that feeds the **flywheel** described in `NORTH_STAR.md` — without crawler ingest, MIRA's answers degrade.
+
+## Scope
+**IN scope**
+- 13 Celery agents under `mira-crawler/agents/` and `mira-crawler/tasks/` (discover, freshness, ingest, RSS, social, YouTube, foundational, playwright_crawler, inbox_triage, etc.)
+- Bridge process (`bridge.py`), Celery beat schedule (`celeryconfig.py`)
+- LinkedIn pipeline (`linkedin/`), social ingest (`social/`)
+- Reporting: `reporting/agent_report.py`, `reporting/weekly_digest.py`, `reporting/telegram_notify.py`
+- Sources manifest (`sources.yaml`), manual scrape targets (`manual_scrape_targets.csv`)
+
+**OUT of scope**
+- Photo ingestion (`mira-ingest`)
+- Retrieval at query time (`mira-bots/shared` RAGWorker)
+- Knowledge graph triple extraction at runtime (planned, see `kg-graph-spec.md`)
+
+## Architecture
+- **Layer:** Infrastructure
+- **Containers:** `mira-celery-worker`, `mira-celery-beat` (no exposed ports)
+- **Broker:** Redis
+- **Result store:** NeonDB
+- **External deps:** Ollama (embeddings), NeonDB, Playwright, optional Docling
+- **Schedule:** Cron-driven beat. E.g., `discover_manuals.py` runs Sundays 03:00.
+
+```
+Beat schedule ──▶ Tasks (discover, download, extract, chunk, embed, insert)
+                     │
+                     ├── pdfplumber / Docling → blocks
+                     ├── chunker.py → chunks (≥ MIN_CHUNK_CHARS)
+                     ├── Ollama (nomic-embed-text-v1.5) → 768-d vectors
+                     └── NeonDB.insert_knowledge_entry()
+```
+
+## API Contract
+
+### Internal (Celery tasks)
+| Task | File | Purpose |
+|---|---|---|
+| `tasks.discover.discover_manuals` | `tasks/discover.py` | Insert URLs into `manual_cache` |
+| `tasks.ingest.process_url` | `tasks/ingest.py` | Download → extract → chunk → embed → insert |
+| `tasks.full_ingest_pipeline.*` | — | Orchestrates the whole flywheel run |
+| `tasks.rss.poll_feeds` | `tasks/rss.py` | RSS for OEM news |
+| `tasks.youtube.process_video` | `tasks/youtube.py` | Transcript ingest |
+| `tasks.social.harvest_*` | `tasks/social.py` | Reddit/LinkedIn signals |
+| `tasks.foundational.refresh_corpus` | `tasks/foundational.py` | Refresh case corpus |
+| `tasks.freshness.recheck_sources` | `tasks/freshness.py` | Re-validate source URLs |
+| `tasks.playwright_crawler.fetch` | `tasks/playwright_crawler.py` | JS-rendered pages |
+| `agents.inbox_triage.run` | `agents/inbox_triage.py` | Triage incoming docs |
+
+### External (reporting)
+- Weekly digest posted to `#alpha-status` and the operator's Telegram via `reporting/telegram_notify.py`.
+
+## Configuration
+| Var | Default | Purpose |
+|---|---|---|
+| `NEON_DATABASE_URL` | required | Sink |
+| `OLLAMA_BASE_URL` | `http://host.docker.internal:11434` | Embedding model host |
+| `EMBED_MODEL` | `nomic-embed-text-v1.5` | 768-d text embedder |
+| `USE_DOCLING` | `false` | Use Docling adapter for OCR + semantic parsing |
+| `DOWNLOAD_TIMEOUT` | `60` (s) | HTTP fetch timeout |
+| `REQUEST_DELAY` | `0.5` (s) | Politeness delay |
+| `MAX_PDF_PAGES` | `300` | Skip enormous manuals |
+| `MIN_CHUNK_CHARS` | `80` | Drop micro-chunks |
+| `LEAD_HUNTER_TIMEOUT_SECS` | `1500` | Hard cap on hourly run |
+| `HARDENING_LOCK_DIR` | `/tmp` | Singleton lock dir |
+| `DISCORD_ALERT_WEBHOOK` | optional | Degraded-run alerts |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Test files | 22 | maintain + ratchet coverage |
+| Type checking | not included | pyright basic |
+| Coverage | unmeasured | 50 % |
+| Successful manual ingest rate | unmeasured | ≥ 85 % per run |
+| Time-to-first-chunk (1 PDF) | unmeasured | ≤ 30 s |
+
+Domain grade: **D+**.
+
+## Acceptance Criteria
+1. **Discovery → ingest:** A new make/model pair surfaced by `discover_manuals` results in chunks landing in `knowledge_entries` within 24 h, deduplicated against existing entries.
+2. **Embedding dimension:** All inserted vectors are 768-d; mismatch raises and aborts the task instead of silently inserting corrupt rows.
+3. **Politeness:** No source domain is hit more than once per `REQUEST_DELAY`.
+4. **Bot blocking:** A 403 returns `chunks=0`, logs the URL, and does not retry indefinitely.
+5. **Docling fallback:** With `USE_DOCLING=true`, scanned-image PDFs produce non-empty chunks.
+6. **Inbox triage:** A new file in the queue is classified as relevant/irrelevant; irrelevant files are not embedded.
+7. **Weekly digest:** Sunday 02:00 produces a Telegram digest covering the week's discovered, ingested, dropped, and failed sources.
+8. **Lock contention:** Two simultaneous `lead-hunter` runs result in exactly one acquiring the lock; the other exits cleanly within 5 s.
+
+## Known Issues
+- Coverage and type checking are unmeasured — domain grade D+.
+- pdfplumber flattens tables to prose (loses column structure); Docling required for table-heavy manuals.
+- Sites with strict bot blocking are silently underrepresented.
+- 13 agents — single-author cognitive load is high; favor reuse via `tasks/full_ingest_pipeline.py`.
+
+## Change Log
+- 2026-04 — Inbox triage agent added (`agents/inbox_triage.py`).
+- 2026-04 — Lead-hunter hardening (timeout, lock, Discord webhook).
+- 2026-03 — Docling optional adapter introduced.

--- a/docs/specs/mira-hub-spec.md
+++ b/docs/specs/mira-hub-spec.md
@@ -1,0 +1,91 @@
+# mira-hub Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Authenticated **Next.js hub** that becomes the technician/manager workspace once a tenant is `active`: 17 sections covering work orders, assets, schedule, parts, channels, integrations, knowledge, and admin. Acts as a **non-destructive overlay** on top of the existing MIRA backend — every endpoint proxies to `mira-pipeline:9099`, `mira-mcp:8001`, or NeonDB; no Python service is modified. (See `docs/specs/factorylm-platform-v2.md`.)
+
+## Scope
+**IN scope**
+- All authenticated routes under `/(hub)/*` — workorders, assets, schedule, parts, channels, integrations, knowledge, conversations, alerts, requests, reports, more, admin, magic, team, usage, upgrade
+- `src/app/(hub)/layout.tsx` shell (drawer + bottom tabs + responsive nav)
+- API route handlers under `src/app/api/*` that proxy/aggregate
+- Auth — `src/auth.ts` + magic-link, Google OAuth, admin bypass
+- Refine.dev resource configuration (`src/app/refine-providers.tsx`)
+- Playwright suites: smoke, signup, e2e
+
+**OUT of scope**
+- Marketing pages and PLG onboarding (lives in `mira-web`)
+- Diagnostic engine, retrieval, vision (lives in `mira-bots/shared` + `mira-pipeline`)
+- CMMS data plane (proxies to Atlas via `mira-mcp`)
+
+## Architecture
+- **Layer:** Presentation
+- **Container:** `mira-hub` (Next.js + Bun; standalone build)
+- **Stack:** Next.js (custom internal version — read `node_modules/next/dist/docs/` before assuming defaults), Refine.dev, shadcn/ui, Tailwind, Vitest, Playwright
+- **Network:** `core-net`, `cmms-net`
+- **Persistence:** No DB of its own; uses NeonDB via API routes and proxies to `mira-pipeline`/`mira-mcp`
+- **Versioning:** Independent namespaced git tags `mira-hub/vMAJOR.MINOR.PATCH`. First tagged release: `mira-hub/v1.1.0` (2026-04-24).
+
+```
+Browser ──HTTPS──▶ mira-hub (Next.js) ──HTTP──▶ mira-pipeline:9099 (chat)
+                                       └─HTTP──▶ mira-mcp:8001     (CMMS REST)
+                                       └─SQL───▶ NeonDB            (tenants, KG, usage)
+```
+
+## API Contract
+Hub-internal route handlers (subset). Authentication is JWT (cookie set by `auth.ts`).
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/me` | Tenant profile, quota, provisioning state |
+| POST | `/api/chat` | Proxy to `mira-pipeline:9099/v1/chat/completions` |
+| GET/POST | `/api/workorders` | Proxy to `mira-mcp:8001/api/cmms/work-orders` |
+| GET | `/api/assets` | Proxy to Atlas via mira-mcp |
+| GET | `/api/schedule` | PM calendar view |
+| POST | `/api/integrations/connect` | Initiate OAuth on a CMMS connector |
+| GET | `/api/admin/*` | Admin-bypass routes; gated on session role |
+
+UI routes follow Next.js App Router; each `(hub)/<section>/page.tsx` is server-rendered first, then hydrates Refine.dev list/show/edit views.
+
+## Configuration
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `NEXT_PUBLIC_HUB_BASE_URL` | yes | — | Public origin of the hub |
+| `MIRA_PIPELINE_URL` | yes | `http://mira-pipeline:9099` | Pipeline target |
+| `MIRA_PIPELINE_API_KEY` | yes | — | Bearer for pipeline |
+| `MCP_REST_API_KEY` | yes | — | Bearer for mira-mcp REST |
+| `NEON_DATABASE_URL` | yes | — | Tenancy + usage |
+| `HUB_JWT_SECRET` | yes | — | Sign/verify hub JWTs |
+| `GOOGLE_OAUTH_CLIENT_ID/SECRET` | optional | — | Google sign-in |
+| `RESEND_API_KEY` | yes | — | Magic-link email |
+| `ADMIN_BYPASS_TOKEN` | optional | — | Admin staff sign-in for support |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Smoke test pass | 100 % | maintain |
+| Signup test pass | 100 % | maintain |
+| Vitest unit suite | exists, partial | ≥ 60 unit tests |
+| TS strict | enforced | maintain |
+| Lighthouse (mobile) | unmeasured | ≥ 80 perf, ≥ 95 a11y |
+| Bundle size budget | unset | < 350 KB initial JS per route |
+
+## Acceptance Criteria
+1. **Auth:** Magic-link email lands in Resend, link sets cookie, redirect lands on `/(hub)`.
+2. **Section nav:** Each of the 17 sections renders without a console error.
+3. **Drawer + tabs:** On viewports < 768 px, bottom tabs are visible; ≥ 768 px, side drawer.
+4. **CMMS proxy:** Creating a work order from `/(hub)/workorders/new` results in a row in Atlas (verify via `mira-mcp /api/cmms/work-orders`).
+5. **Chat:** Sending a message from `/(hub)/conversations` calls `mira-pipeline /v1/chat/completions` with the right `user` id (visible in `x-mira-trace-id`).
+6. **Quota:** `/api/me` returns `{tier, quota_used, quota_limit, provisioning}` and the upgrade banner shows when `quota_used >= quota_limit`.
+7. **Smoke + signup Playwright suites:** Both green in CI.
+8. **No direct engine import:** No `@mira-bots/shared` import — all chat goes via `mira-pipeline`.
+
+## Known Issues
+- Custom internal Next.js fork — assistants must read `node_modules/next/dist/docs/` before relying on stock APIs (per `mira-hub/AGENTS.md`).
+- Several sections still scaffolded — see `mira-hub/CHANGELOG.md` for stub vs. live.
+
+## Change Log
+- 2026-04-24 — `mira-hub/v1.1.0`: OAuth persistence + full platform build.
+- 2026-04 — Established as authenticated workspace; non-destructive overlay model.

--- a/docs/specs/mira-mcp-spec.md
+++ b/docs/specs/mira-mcp-spec.md
@@ -1,0 +1,110 @@
+# mira-mcp Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+FastMCP server that exposes equipment-diagnostic tools and CMMS bridges over **MCP/SSE** (for Claude Desktop and other MCP clients) and a parallel **REST surface** (for `mira-web`, `mira-hub`, and ad-hoc PDF ingest). It is the single integration point for everything that needs structured equipment + work-order data; all callers go through it and never reach Atlas/MaintainX directly.
+
+## Scope
+**IN scope**
+- 4 equipment-diagnostic MCP tools (status, faults, history, notes)
+- 7 CMMS MCP tools dispatched via `cmms/factory.py` to `atlas`/`maintainx`/`limble`/`fiix` adapters
+- `/ingest/pdf` REST endpoint (writes to OpenViking store)
+- CMMS REST proxy at `/api/cmms/*`
+
+**OUT of scope**
+- KB ingestion of photos (`mira-ingest`)
+- Crawling/discovery of new manuals (`mira-crawler`)
+- Diagnostic conversation engine (`mira-bots/shared`)
+
+## Architecture
+- **Layer:** Engine
+- **Container:** `mira-mcp` on `:8000` (SSE, host `MCP_SSE_PORT`, default `8009`) and `:8001` (REST)
+- **Network:** `core-net`
+- **Volume:** mounts `mira-bridge/data:/mira-db` so it reads the same `mira.db` file `mira-bridge` writes
+- **Adapters:** `cmms/{atlas,maintainx,limble,fiix}.py`
+- **External integrations:** Atlas REST (`atlas-api:8080`), MaintainX API, OpenViking/NeonDB
+
+```
+Claude Desktop ──SSE :8000──▶ mira-mcp ──┬──▶ sqlite mira.db (faults, equipment, notes)
+                                         ├──▶ Atlas/MaintainX/Limble/Fiix REST
+                                         └──▶ OpenViking store (when RETRIEVAL_BACKEND=openviking)
+mira-web/hub ──REST :8001──▶ mira-mcp /api/cmms/*
+```
+
+## API Contract
+
+### MCP tools — equipment diagnostics
+| Tool | Signature | Backing data |
+|---|---|---|
+| `get_equipment_status` | `(equipment_id="")` | `equipment_status` table |
+| `list_active_faults` | `()` | `faults WHERE resolved=0` |
+| `get_fault_history` | `(equipment_id="", limit=50)` | `faults` + OpenViking chunks if backend set |
+| `get_maintenance_notes` | `(equipment_id="", category="", limit=50)` | `maintenance_notes` |
+
+### MCP tools — CMMS (selected via `CMMS_PROVIDER`)
+| Tool | Signature |
+|---|---|
+| `cmms_list_work_orders` | `(status="", limit=20)` |
+| `cmms_create_work_order` | `(title, description, priority, asset_id, category)` |
+| `cmms_complete_work_order` | `(work_order_id, feedback="")` |
+| `cmms_list_assets` | `(limit=50)` |
+| `cmms_get_asset` | `(asset_id)` |
+| `cmms_list_pm_schedules` | `(asset_id=0, limit=20)` |
+| `cmms_health` | `()` |
+
+### REST surface
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| GET | `/health` | none | Liveness |
+| POST | `/ingest/pdf` | Bearer | Multipart upload → OpenViking |
+| GET | `/api/cmms/work-orders?status=&limit=` | Bearer | List WOs |
+| POST | `/api/cmms/work-orders` | Bearer | Create WO |
+| GET | `/api/cmms/assets?limit=` | Bearer | List assets |
+| GET | `/api/cmms/pm-schedules?asset_id=&limit=` | Bearer | List PM schedules |
+| GET | `/api/cmms/health` | Bearer | Atlas connectivity |
+| POST | `/api/cmms/invite` | Bearer | **Atlas-only**; HTTP 501 for other providers |
+
+Bearer token: `Authorization: Bearer ${MCP_REST_API_KEY}`.
+
+## Configuration
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `MCP_REST_API_KEY` | yes | — | Bearer auth for REST |
+| `MCP_SSE_PORT` | no | `8009` | Host port for SSE |
+| `MIRA_DB_PATH` | yes | `/mira-db/mira.db` | SQLite path |
+| `RETRIEVAL_BACKEND` | no | `openwebui` | `openwebui` or `openviking` |
+| `MIRA_TENANT_ID` | needed when openviking | — | Tenant scope |
+| `CMMS_PROVIDER` | no | `atlas` | `atlas` \| `maintainx` \| `limble` \| `fiix` |
+| `ATLAS_API_URL` | atlas | `http://atlas-api:8080` | Atlas base URL |
+| `ATLAS_API_USER` / `ATLAS_API_PASSWORD` | atlas | — | Atlas auth |
+| `MAINTAINX_API_KEY` | maintainx | — | MaintainX API key |
+| `ATLAS_PUBLIC_API_URL` | optional | — | Public URL hint (used by hub deep-links) |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Tests | 1 file | ≥ 12 files (one per MCP tool + adapter contract) |
+| Adapter contract tests | none | one parametric suite across 4 providers |
+| MCP latency p50 | unmeasured | ≤ 250 ms tool call |
+| REST latency p50 | unmeasured | ≤ 150 ms |
+
+Domain grade: **D+**.
+
+## Acceptance Criteria
+1. **MCP discovery:** Claude Desktop with `mira-mcp` configured shows the 4 equipment + 7 CMMS tools.
+2. **Auth:** A REST request without a bearer returns HTTP 401; with the wrong token returns HTTP 403.
+3. **Adapter dispatch:** Setting `CMMS_PROVIDER=maintainx` and calling `cmms_list_work_orders` returns MaintainX data; `/api/cmms/invite` returns HTTP 501.
+4. **PDF ingest:** `POST /ingest/pdf` with a multipart file lands a file in `pdfs/` and indexes it via `viking_store.ingest_pdf()`; `equipment_type` is derived from the filename stem.
+5. **Read isolation:** mira-mcp does NOT write to `mira.db` while `mira-bridge` is up (verify via `lsof` or strace test).
+6. **Health surface:** `/health` returns 200 in < 50 ms; `/api/cmms/health` reflects upstream Atlas reachability.
+
+## Known Issues
+- Single test file → grade D+; needs adapter contract suite.
+- `/api/cmms/invite` is Atlas-specific by design; non-Atlas providers must return HTTP 501.
+- Volume mount must match `mira-bridge` path or both services see different `mira.db` files (silent corruption risk).
+
+## Change Log
+- 2026-04 — Multi-provider CMMS adapters introduced (`atlas`/`maintainx`/`limble`/`fiix`).
+- 2026-04 — OpenViking augmentation added behind `RETRIEVAL_BACKEND=openviking`.

--- a/docs/specs/mira-pipeline-spec.md
+++ b/docs/specs/mira-pipeline-spec.md
@@ -1,0 +1,105 @@
+# mira-pipeline Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+OpenAI-compatible HTTP API that wraps the shared `Supervisor` (GSDEngine) so that **Open WebUI on the VPS** can speak to MIRA as if it were any OpenAI model. This is the **active VPS chat path** (`User phone → Open WebUI → mira-pipeline:9099 → Supervisor → cascade providers`). It supersedes `mira-sidecar` (ADR-0008).
+
+## Scope
+**IN scope**
+- `/v1/chat/completions` and `/v1/models` OpenAI-compat surface
+- `/health`, `/eval/*`, `/feedback` REST endpoints
+- Per-chat session NDJSON recording for eval fixture replay
+- Bearer-token auth via `PIPELINE_API_KEY`
+
+**OUT of scope**
+- Diagnostic logic itself — that lives in `mira-bots/shared` and is COPY'd in at build time
+- Vector retrieval implementation (delegated to `RAGWorker`)
+- KB ingestion (delegated to `mira-ingest`)
+
+## Architecture
+- **Layer:** Adapter
+- **Container:** `mira-pipeline` on `:9099`
+- **Network:** `core-net`
+- **Build context:** repo root (so `shared/` and `prompts/` resolve from `mira-bots/`)
+- **Persistence:** Reads/writes the same `mira.db` as bot adapters; writes session NDJSON to `${SESSION_RECORDING_PATH:-/data/sessions}`
+- **Dependencies:** Open WebUI (`mira-core:8080`), Ollama, NeonDB, Groq/Cerebras/Gemini APIs
+
+```
+Open WebUI  ──POST /v1/chat/completions (Bearer PIPELINE_API_KEY)──▶  mira-pipeline:9099
+   │                                                                       │
+   │                                                       Supervisor.process_full(user, msg, photo_b64)
+   │                                                                       │
+   ◀────────────────── OpenAI-format response (choices[0].message.content) ─┘
+```
+
+## API Contract
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| GET | `/health` | none | Liveness — must return `{"status":"ok"}` in < 50 ms |
+| GET | `/v1/models` | Bearer | Returns `{"data":[{"id":"mira-diagnostic", ...}]}` |
+| POST | `/v1/chat/completions` | Bearer | OpenAI-compat single-turn or multi-turn diagnostic call |
+| POST | `/feedback` | Bearer | `{chat_id, feedback: "up"\|"down", reason}` → `Supervisor.log_feedback` |
+| POST | `/eval/run` | Bearer | Replay a recorded session against the engine for offline eval |
+
+**Request shape** (subset MIRA cares about):
+```json
+{
+  "model": "mira-diagnostic",
+  "user": "<chat_id>",
+  "messages": [
+    {"role": "user", "content": "<text>"},
+    {"role": "user", "content": [{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,..."}}]}
+  ]
+}
+```
+
+**Response shape:** standard OpenAI `chat.completion`. `choices[0].message.content` is the engine reply; `usage` reflects cascade cost when available; an `x-mira-trace-id` header is set for log correlation.
+
+**Chat-id mapping:** Open WebUI's `user` field → Supervisor `chat_id`. Falls back to `openwebui_anonymous` if absent.
+
+## Configuration
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `PIPELINE_API_KEY` | yes | — | Bearer auth for this service |
+| `MIRA_DB_PATH` | yes | `/data/mira.db` | Shared SQLite WAL |
+| `OPENWEBUI_BASE_URL` | yes | `http://mira-core:8080` | KB retrieval target |
+| `OPENWEBUI_API_KEY` | yes | — | Auth for Open WebUI |
+| `KNOWLEDGE_COLLECTION_ID` | yes | — | Open WebUI collection UUID |
+| `NEON_DATABASE_URL` | yes | — | NeonDB recall |
+| `MIRA_TENANT_ID` | yes | — | Tenant scope |
+| `INFERENCE_BACKEND` | yes | `cloud` | `cloud` cascade or `local` (Open WebUI fallback) |
+| `GROQ_API_KEY`, `CEREBRAS_API_KEY`, `GEMINI_API_KEY` | ≥1 in cloud | — | Cascade providers |
+| `VISION_MODEL` | no | `qwen2.5vl:7b` | Local vision model |
+| `SESSION_RECORDING_PATH` | no | `/data/sessions` | Per-chat NDJSON for eval replay |
+| `EVAL_DISABLE_JUDGE` | no | unset | If `1`, eval skips LLM grading |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Unit test files | 0 | ≥ 5 (eval-fixture replay + endpoint contract) |
+| Endpoint contract test | manual | automated against fixtures |
+| p50 latency `/v1/chat/completions` | unmeasured | ≤ 4 s end-to-end (cloud cascade) |
+| 5xx rate | unmeasured | < 0.5 % |
+| Cascade fallback budget | 1 cycle ≤ 6 s | maintain |
+
+Domain grade: **F → D** (priority lift; pipeline has zero unit tests).
+
+## Acceptance Criteria
+1. **Open WebUI registration:** Adding `https://<host>:9099/v1` with `PIPELINE_API_KEY` to Open WebUI's "OpenAI API" connections lists `mira-diagnostic` as a model.
+2. **Round-trip:** A POST to `/v1/chat/completions` with a single user message returns a non-empty `content` and an `x-mira-trace-id` header.
+3. **Image input:** A multipart message with `image_url` data URI flows to `Supervisor.process_full(... photo_b64=...)`.
+4. **Auth:** Missing or wrong bearer → HTTP 401; correct bearer → HTTP 200.
+5. **Failure budget:** With `GROQ_API_KEY` revoked, the call still succeeds via Cerebras or Gemini; eval session shows the fallback in `api_usage`.
+6. **Session recording:** Every `/v1/chat/completions` writes one line to `${SESSION_RECORDING_PATH}/<chat_id>.ndjson`.
+7. **Eval replay:** `tests/eval/analyze_sessions.py` can replay a recorded session and recompute graded metrics deterministically.
+
+## Known Issues
+- Zero unit tests (grade F per `docs/QUALITY_SCORE.md`).
+- Build context must be repo root; running `docker build .` from inside `mira-pipeline/` will fail (shared/ unavailable).
+- Single-process; do not horizontally scale until SQLite WAL contention is measured.
+
+## Change Log
+- 2026-04 — Adopted as the canonical VPS chat path; mira-sidecar deprecated (ADR-0008).
+- 2026-04-25 — Anthropic removal cascaded here automatically (no code in this service to change).

--- a/docs/specs/mira-scan-spec.md
+++ b/docs/specs/mira-scan-spec.md
@@ -1,0 +1,90 @@
+# MIRA Scan Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Field-tech entry point that turns a **physical asset tag (QR / barcode / nameplate photo)** into a fast diagnostic conversation. Two delivery surfaces share the same backend:
+
+1. **Standalone web scanner** — `app.factorylm.com/sample`, `/activated`, `/scan` flows in `mira-web` (already routed via nginx).
+2. **monday.com app** — embedded scanner that pushes a scan event to a monday.com board column and back to MIRA so a tech can scan from inside their workflow.
+
+Both surfaces resolve the scan to an asset, hand off to `mira-pipeline` chat, and write a record to NeonDB so the asset's history accrues per the flywheel.
+
+## Scope
+**IN scope**
+- Asset-scan landing pages in `mira-web` (`/scan`, `/sample`, `/activated`, `/cmms`, `src/views/scan-not-found.html`)
+- monday.com embedded scanner (manifest + view + auth)
+- Asset resolution against NeonDB (`assets` table) and Atlas via `mira-mcp`
+- "Open CMMS" button on every asset-scan page (CRA-20 — landed 2026-05-04)
+- QR onboarding skill (`qr-onboarding`) used at deployment time to print + assign tags
+
+**OUT of scope**
+- Building NFC / Bluetooth tag readers
+- Computer-vision nameplate OCR (planned; reuses `mira-ingest` photo pipeline)
+
+## Architecture
+```
+Tech scans QR
+   ├── Web: app.factorylm.com/scan?asset=<tag>
+   │     └── Hono route → resolve asset → embed Mira chat
+   └── monday.com app
+         └── frame inside monday item → POST to mira-web /api/scan/events
+               └── upsert asset_event in NeonDB → optional Atlas WO seed
+                     └── tech taps "Open chat" → mira-pipeline /v1/chat/completions
+```
+
+- **Layer:** Presentation (web), Integration (monday.com)
+- **Containers:** Hosted by `mira-web`; no dedicated container
+- **External services:** monday.com app framework, factorylm.com nginx (routes `/scan` → mira-web)
+
+## API Contract
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| GET | `/scan?asset=<tag>` | none | Resolve `asset` → asset page or `scan-not-found.html` |
+| GET | `/sample` | none | Demo asset experience |
+| GET | `/activated` | JWT | Post-Stripe activation landing |
+| POST | `/api/scan/events` | HMAC (monday.com) | Record a scan event |
+| GET | `/api/asset/{tag}` | optional JWT | Asset summary including last 5 events |
+
+### Asset resolution rules
+1. Lookup `assets.tag = ?` in NeonDB scoped to the resolving tenant.
+2. Fall back to `mira-mcp /api/cmms/assets` if not found locally.
+3. If still not found, render `scan-not-found.html` with a "Create asset" CTA that opens the Hub asset wizard.
+
+### "Open CMMS" button (CRA-20)
+Every asset-scan page must render a primary action that deep-links to:
+- Atlas asset page (`ATLAS_PUBLIC_FRONT_URL` + `/assets/{id}`) for active tenants, or
+- `/cmms` marketing landing for unauthenticated visitors.
+
+## Configuration
+| Var | Required | Purpose |
+|---|---|---|
+| `INBOX_DOMAIN` | yes | URL builder defaults |
+| `ATLAS_PUBLIC_FRONT_URL` | yes | "Open CMMS" deep-link target |
+| `MIRA_PIPELINE_URL` / `MIRA_PIPELINE_API_KEY` | yes | Embedded chat |
+| `MONDAY_APP_SIGNING_SECRET` | yes (monday) | Verify HMAC on `/api/scan/events` |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Scan-not-found UX | exists | A/B against "create asset" CTA |
+| Time to first message after scan | unmeasured | ≤ 1 s on 4G |
+| Mobile Lighthouse perf (scan page) | unmeasured | ≥ 80 |
+| Tests | none | smoke that scans → asset page → chat opens |
+
+## Acceptance Criteria
+1. **Open CMMS button (CRA-20):** Every asset-scan page renders the "Open CMMS" primary action; verified across `/scan`, `/sample`, `/activated`, `/cmms`.
+2. **Unknown asset:** A scan with an unknown `asset` query renders `scan-not-found.html` with the create-asset CTA.
+3. **monday.com event:** A monday-side scan posts to `/api/scan/events` with a valid HMAC; HTTP 200 and a row appears in `asset_events`.
+4. **HMAC required:** Posting to `/api/scan/events` without a valid HMAC returns HTTP 401.
+5. **Chat handoff:** The asset page opens an embedded chat that calls `mira-pipeline` with the tenant id and `asset` in the user message context.
+6. **Magic-link path:** A magic-link recipient who scans the same QR lands directly in chat (no second login).
+
+## Known Issues
+- monday.com app distribution flow not yet documented in this repo (lives with the monday.com developer account).
+- Nameplate-photo OCR fallback is planned but not built; today an unknown QR results in `scan-not-found`.
+
+## Change Log
+- 2026-05-04 — "Open CMMS" button added to all asset-scan pages (CRA-20).
+- 2026-04-26 — `/sample` and `/activated` routed via nginx to `mira-web` on `app.factorylm.com`.

--- a/docs/specs/mira-web-spec.md
+++ b/docs/specs/mira-web-spec.md
@@ -1,0 +1,106 @@
+# mira-web Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Public marketing site + **PLG onboarding funnel** for FactoryLM. Visitor → "Join the Beta" → email/name/company → tenant created `pending` → 7-day Loom nurture → Stripe Checkout $97/mo → tenant flipped to `active` → Atlas CMMS account provisioned → unlimited Mira AI chat. Hosts the public `/cmms` landing, `/sample`, `/activated`, the magic-inbox PDF intake, and the embedded Mira AI chat for evaluation prospects.
+
+No free tier. Pricing is hidden until Day 7 email.
+
+## Scope
+**IN scope**
+- Public marketing routes (`/`, `/cmms`, `/sample`, `/activated`, etc.)
+- PLG funnel API: `/api/register`, `/api/checkout`, `/api/stripe/webhook`, `/api/billing-portal`, `/api/me`, `/api/activation/retry`, `/api/admin/activation-health`, `/api/mira/chat`
+- Activation orchestration: `lib/activation.ts` (Atlas user provisioning, demo seeding, welcome email, retry budget)
+- Magic-inbox handoff (`Apps Script` → HMAC-signed webhook → `mira-ingest`)
+- PostHog client analytics (when `PLG_POSTHOG_KEY` set)
+
+**OUT of scope**
+- Authenticated workspace (lives in `mira-hub`)
+- Diagnostic engine (proxied to `mira-pipeline`/`mira-sidecar`)
+
+## Architecture
+- **Layer:** Presentation
+- **Container:** `mira-web` (`3200 → 3000`)
+- **Networks:** `core-net`, `cmms-net`
+- **Stack:** Bun runtime, Hono (TypeScript, MIT), `jose` JWT, Stripe SDK, `@neondatabase/serverless`, Resend HTTP, Atlas REST API
+- **Source of truth for tenant tier:** `tenants` table in NeonDB (`pending` | `active` | `churned`)
+
+```
+Visitor ──▶ mira-web (Hono on Bun)
+              ├─ POST /api/register      → NeonDB tenants(pending) + Resend nurture
+              ├─ POST /api/stripe/webhook → finalizeActivation(tenant)
+              │                             ├── Atlas user create
+              │                             ├── demo asset/WO seed
+              │                             └── welcome email (Resend)
+              ├─ GET  /api/me            → quota + provisioning state
+              └─ POST /api/mira/chat     → mira-sidecar /rag (cutover to mira-pipeline pending #197)
+```
+
+## API Contract
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| POST | `/api/register` | none | Create `pending` tenant; idempotent on email; origin allowlist `PLG_REGISTER_ALLOWED_ORIGINS` |
+| GET | `/api/checkout` | none (token in URL) | Redirect to Stripe Checkout for the listed `STRIPE_PRICE_ID` |
+| POST | `/api/stripe/webhook` | Stripe sig | Verify `STRIPE_WEBHOOK_SECRET`; on `checkout.session.completed` call `finalizeActivation` |
+| GET | `/api/billing-portal` | JWT | Return Stripe Customer Portal URL |
+| GET | `/api/me` | JWT (active) | Returns `{tier, quota, provisioning: {atlas, demo, email, attempts, ready}}` |
+| POST | `/api/activation/retry` | JWT (active) | Re-run `finalizeActivation`; 1 / minute cooldown |
+| GET | `/api/admin/activation-health` | `x-admin-token: $PLG_ADMIN_TOKEN` | Tenants stuck > 10 min in non-`ok` provisioning |
+| POST | `/api/mira/chat` | JWT (active) | Proxy to mira-sidecar `/rag` (or pipeline once #197 lands) |
+| POST | `/api/inbox/webhook` | HMAC `INBOUND_HMAC_SECRET` | Magic-inbox PDF handoff to `mira-ingest` |
+
+### Tenant tier contract
+| Tier | Effect |
+|---|---|
+| `pending` | In nurture sequence, no product access, no `/api/me` quota |
+| `active` | Full CMMS + unlimited Mira queries; portal access |
+| `churned` | No product access; emails suppressed |
+
+## Configuration
+| Var | Required | Purpose |
+|---|---|---|
+| `PLG_JWT_SECRET` | yes | Sign/verify mira-web JWTs |
+| `STRIPE_SECRET_KEY` | yes | Stripe API |
+| `STRIPE_WEBHOOK_SECRET` | yes | `whsec_...` for webhook verification |
+| `STRIPE_PRICE_ID` | yes | $97/mo price id |
+| `NEON_DATABASE_URL` | yes | Tenancy DB |
+| `RESEND_API_KEY` | yes | Transactional + drip email |
+| `LOOM_URL_1..5` | yes | Drip videos (env-swap, no redeploy) |
+| `PLG_ATLAS_ADMIN_USER` / `PLG_ATLAS_ADMIN_PASSWORD` | yes | Atlas admin to provision new users |
+| `PLG_ADMIN_TOKEN` | yes | Bearer for `/api/admin/activation-health` |
+| `PLG_REGISTER_ALLOWED_ORIGINS` | no | Comma-separated origin allowlist (defaults documented in module CLAUDE.md) |
+| `PLG_POSTHOG_KEY` / `PLG_POSTHOG_HOST` | no | PostHog public key + ingest host |
+| `INBOUND_HMAC_SECRET` | yes | Magic-inbox webhook signature key |
+| `MIRA_INGEST_URL` | yes | Magic-inbox forwarding target |
+| `INBOX_DOMAIN` | no | Default `factorylm.com` |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Test files | 5 | ≥ 20 (route + activation contract + Stripe webhook fakes) |
+| TS strict | enforced | maintain |
+| Stripe webhook signature failure handling | required | every signature failure → HTTP 400, no DB write |
+| Activation latency p95 | unmeasured | ≤ 30 s (Stripe success → Atlas user + welcome email) |
+| Funnel completion: register → active | tracked via PostHog | report weekly |
+
+## Acceptance Criteria
+1. **Origin allowlist:** A `POST /api/register` from an unlisted origin returns HTTP 403.
+2. **Idempotent register:** Posting the same email twice returns HTTP 200 once and HTTP 409 on the second; no duplicate tenant row.
+3. **Stripe round-trip:** Test-mode Stripe Checkout → webhook → `tenants.tier = 'active'` and Atlas API has a new user.
+4. **Provisioning retry:** Forcing Atlas API down on first attempt; `/api/activation/retry` succeeds the second time without duplicating users.
+5. **Magic-inbox HMAC:** A webhook with the wrong HMAC signature is rejected with HTTP 401.
+6. **Quota response:** `/api/me` returns `provisioning: { atlas: "ok", demo: "ok", email: "ok", attempts, ready: true }` for an active tenant.
+7. **Admin health:** `/api/admin/activation-health` lists tenants stuck > 10 min and respects `x-admin-token`.
+8. **No secret-in-URL:** Magic-link tokens use signed JWT in cookie, never query string visible in referrer logs.
+9. **Open CMMS button:** Every asset-scan page (CRA-20) routes to `/cmms`.
+
+## Known Issues
+- `mira-web/src/lib/mira-chat.ts` still calls `mira-sidecar /rag`; cutover to `mira-pipeline` tracked in PR #197.
+- PostHog ships a no-op stub if `PLG_POSTHOG_KEY` is unset (intentional).
+
+## Change Log
+- 2026-05-04 — Magic-link JWT fix merged (CRA-22, CRA-21).
+- 2026-05-04 — Open CMMS button added to asset-scan pages (CRA-20).
+- 2026-04-26 — `/sample` + `/activated` routed via nginx to mira-web on `app.factorylm.com`.

--- a/docs/specs/quality-gate-spec.md
+++ b/docs/specs/quality-gate-spec.md
@@ -1,0 +1,85 @@
+# Quality Gate Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+Response-validation middleware that runs **after** the diagnostic engine produces a reply and **before** the adapter ships it to the user. Catches hallucination artifacts, missing citations, intent leakage (industrial jargon in greetings, transcription artifacts in text-only chats), and unsafe responses where a SAFETY_ALERT path was missed. Exists because the engine is a probabilistic system and the failure mode of confidently wrong industrial advice is unacceptable.
+
+## Scope
+**IN scope**
+- `guardrails.check_output(response, intent, has_photo)` — output post-processor
+- `_infer_confidence(reply)` heuristic — `high | medium | low | none`
+- Hallucination strippers (industrial jargon in greetings, OCR/transcription artifacts in text-only inputs)
+- Citation presence check on industrial intent (warns when missing)
+
+**OUT of scope**
+- Input intent classification (`classify_intent` lives in guardrails but is upstream)
+- Safety keyword detection (separate path; bypasses everything)
+- LLM judge for offline eval (`tests/eval/analyze_sessions.py`)
+
+## Architecture
+```
+Supervisor.process()
+   → workers compute reply
+   → guardrails.check_output(reply, intent, has_photo)   ← Quality Gate
+   → confidence = _infer_confidence(reply)
+   → return reply, confidence to adapter
+```
+
+The gate is **synchronous** and **deterministic** — no LLM call. Decisions land in < 10 ms.
+
+## API Contract
+
+```python
+guardrails.check_output(
+    response: str,
+    intent: Literal["safety","industrial","greeting","help","off_topic"],
+    has_photo: bool,
+) -> str   # cleaned response
+```
+
+Behavior:
+- For `intent == "greeting"` — strip industrial jargon (e.g. "I'll check the VFD parameters") and return a clean greeting.
+- For `intent == "industrial"` and `has_photo == False` — strip transcription/OCR artifacts that imply visual context the user did not provide.
+- For `intent == "off_topic"` — return a polite redirect.
+- For `intent == "safety"` — pass-through; safety responses are owned by the safety branch and must not be mutated.
+
+```python
+guardrails._infer_confidence(reply: str) -> "high"|"medium"|"low"|"none"
+```
+- High signals: "replace", "fault code", "check wiring", "disconnect", "de-energize"
+- Low signals: "might be", "could be", "possibly", "not sure"
+
+## Configuration
+No env vars. The keyword lists are constants in `mira-bots/shared/guardrails.py`:
+- `SAFETY_KEYWORDS` (21 phrases)
+- `INTENT_KEYWORDS` (industrial)
+- `MAINTENANCE_ABBREVIATIONS` (query expansion)
+
+Changes to those lists require a code change + tests.
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| Property tests over guardrails | 11 | maintain ≥ 11; add for every new keyword |
+| False-positive rate (good answer mutated) | unmeasured | < 1 % on golden cases |
+| False-negative rate (bad answer passed) | unmeasured | < 5 % on adversarial set |
+| Latency overhead | < 10 ms | maintain |
+| Safety pass-through invariant | 100 % | regression-tested |
+
+## Acceptance Criteria
+1. **Greeting hygiene:** A reply containing industrial jargon to a `greeting` intent is stripped.
+2. **No-photo hygiene:** A reply implying visual analysis when `has_photo=False` is stripped.
+3. **Safety pass-through:** When `intent == "safety"`, output is byte-identical to input.
+4. **Confidence ladder:** `"replace the contactor and check wiring"` → `high`; `"it could be a bad capacitor, possibly"` → `low`; empty string → `none`.
+5. **Property tests:** All hypothesis property tests in `tests/property/` for guardrails pass.
+6. **No regression:** Per memory `feedback_resolved_state_wo_rebuild` — clearing `cmms_pending` alone is not enough; quality gate must not interfere with `_clear_diagnostic_carryover` resetting `state["state"]` off `RESOLVED`.
+
+## Known Issues
+- Heuristic confidence is keyword-based; long-term, replace with calibrated LLM-judge confidence (planned).
+- Citation presence is **warned, not enforced** — industrial replies without citations still pass.
+
+## Change Log
+- 2026-04 — `detect_session_followup` added to short-circuit intent for active sessions ("you said", "link", etc.).
+- 2026-04-15 — Intent classifier biased toward `industrial` for unknown queries; greetings require keyword + length < 20 (#280).

--- a/docs/specs/rag-pipeline-spec.md
+++ b/docs/specs/rag-pipeline-spec.md
@@ -1,0 +1,110 @@
+# RAG Pipeline Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+End-to-end retrieval-augmented generation across **knowledge ingest** (offline) and **query-time retrieval** (runtime). Produces grounded, cited diagnostic answers from MIRA's knowledge base of OEM manuals, equipment photos, and conversation history. Operates as **two completely separate pipelines** that share only NeonDB tables — no shared runtime, no shared framework, all hand-written Python (no LangChain / LlamaIndex per CLAUDE.md hard constraints).
+
+## Scope
+**IN scope**
+- Ingest pipeline (`mira-crawler` + `mira-core/scripts/ingest_*`)
+- Query pipeline inside `mira-bots/shared/workers/rag_worker.py` and `shared/recall.py`
+- Hybrid retrieval: pgvector (dense) + BM25 (lexical) fused via Reciprocal Rank Fusion (Unit 6)
+- Citation formatting in engine replies
+- NeonDB tables: `knowledge_entries`, `fault_codes`, `manual_cache`, `manuals`, `source_fingerprints`
+
+**OUT of scope**
+- Knowledge graph hop retrieval (`knowledge-graph-spec.md`)
+- Vision description (`mira-ingest /ingest/photo`)
+- ChromaDB legacy retrieval (`mira-sidecar`, deprecated)
+
+## Architecture
+
+### Ingest (offline)
+```
+manual_cache → ingest_manuals.py → pdfplumber|Docling → blocks
+                          → chunker.py → ≥ MIN_CHUNK_CHARS chunks
+                          → Ollama nomic-embed-text-v1.5 (768-d)
+                          → NeonDB.knowledge_entries (tenant_id scoped)
+Claude API (legacy)/Groq → extract_fault_codes.py → NeonDB.fault_codes
+```
+
+### Query (runtime, `RAGWorker`)
+```
+User query
+  ├── guardrails.expand_abbreviations()
+  ├── guardrails.rewrite_question()
+  ├── Hybrid retrieval (gated by MIRA_RETRIEVAL_HYBRID_ENABLED)
+  │     ├── pgvector cosine ANN top-K
+  │     ├── BM25 over chunk text top-K
+  │     └── ILIKE product filter
+  │     → Reciprocal Rank Fusion (k=MIRA_RRF_K, default 60) → top-N chunks
+  ├── Build prompt with chunks as context (cited)
+  ├── InferenceRouter.complete(messages, sanitize=True)
+  └── reply with [source N] citations
+```
+
+## API Contract
+
+### Internal — `RAGWorker`
+```python
+RAGWorker(db_path, openwebui_url, api_key, collection_id, tenant_id)
+  .retrieve(query: str, k: int = 5) -> list[Chunk]
+  .answer(query: str, history, photo_b64=None) -> EngineReply
+```
+
+`Chunk` shape: `{id, text, score, source_url, equipment_id, page_num, section}`.
+
+### NeonDB schema (canonical)
+- `knowledge_entries (id UUID, tenant_id, equipment_id, content TEXT, embedding vector(768), source_url, page_num, section, created_at)`
+- `fault_codes (id, tenant_id, equipment_id, code TEXT, description, remedy, source_url)`
+- `manual_cache (url, status, last_seen)` and `manuals (id, url, sha256, ingested_at)`
+
+### Citation contract
+Every grounded answer must include `[source N]` markers and the engine response object's `citations` field must list the URLs/sections matching those markers.
+
+## Configuration
+| Var | Default | Purpose |
+|---|---|---|
+| `NEON_DATABASE_URL` | required | KB store |
+| `MIRA_TENANT_ID` | required | Tenant scope for retrieval and ingest |
+| `OLLAMA_BASE_URL` | `http://host.docker.internal:11434` | Embedding host |
+| `EMBED_MODEL` | `nomic-embed-text-v1.5` | 768-d embedder |
+| `USE_DOCLING` | `false` | OCR + semantic parsing |
+| `MIRA_RETRIEVAL_HYBRID_ENABLED` | `true` | Unit 6 hybrid kill switch |
+| `MIRA_RRF_K` | `60` | RRF constant (Cormack et al. 2009) |
+| `MIRA_HISTORY_LIMIT` | `20` | Conversation context cap |
+| `MAX_PDF_PAGES` | `300` | Skip enormous manuals |
+| `MIN_CHUNK_CHARS` | `80` | Drop micro-chunks |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| KB size | ~25,219 entries (2026-03-28) | grow continuously |
+| Retrieval recall@5 (golden cases) | tracked in `tests/eval/` | ≥ 0.80 |
+| Eval pass rate | 77 % (last recorded; stale) | ≥ 90 % |
+| Citation present rate | unmeasured | 100 % on industrial queries |
+| Hybrid uplift over vector-only | Unit 6 baseline | ≥ +5 pts recall@5 |
+| Tenant leakage | 0 | RLS / tenant-id assertion in every retrieval test |
+
+## Acceptance Criteria
+1. **Tenant isolation:** A retrieval call with tenant A never returns rows from tenant B (covered in `tests/eval/`).
+2. **Empty-KB fallback:** When `knowledge_entries` is empty, the engine still returns a non-empty answer with a "no sources" caveat — must not 5xx.
+3. **Hybrid kill switch:** Setting `MIRA_RETRIEVAL_HYBRID_ENABLED=false` falls back to pre-Unit-6 path without code change.
+4. **Citation markers:** Every grounded answer includes at least one `[source N]` and `citations` list entries match.
+5. **Embedding dimension:** Ingest aborts on a non-768-d vector rather than silently inserting.
+6. **Idempotent ingest:** Re-running `ingest_manuals.py` on the same URL inserts zero new chunks (sha256/url dedup).
+7. **Eval golden set:** `tests/eval/` has 39 golden cases that run offline; CI must keep ≥ 90 % pass.
+8. **No-LangChain invariant:** `grep -r "from langchain" .` returns zero hits; same for LlamaIndex.
+
+## Known Issues
+- pdfplumber loses table structure — flagged in `docs/architecture/rag-pipeline.md`.
+- Eval pass rate (77 %) is stale per memory `project_mira_state.md` — re-run after every prompt or retrieval change.
+- ChromaDB legacy data still lives in `mira-sidecar`; OEM migration to Open WebUI KB pending.
+- Sites that block bots silently underrepresent some OEMs in the KB.
+
+## Change Log
+- 2026-04 — Hybrid retrieval (Unit 6) shipped behind `MIRA_RETRIEVAL_HYBRID_ENABLED`.
+- 2026-03-28 — RAG architecture snapshot at v0.5.3 (`docs/architecture/rag-pipeline.md`).
+- 2026-03-27 — Fault code extraction added.

--- a/docs/specs/telegram-bot-spec.md
+++ b/docs/specs/telegram-bot-spec.md
@@ -1,0 +1,102 @@
+# Telegram Bot Specification
+**Version:** 1.0
+**Last Updated:** 2026-05-05
+**Owner:** Mike Harper / FactoryLM
+
+## Purpose
+The fastest field-tech surface for MIRA. A technician opens Telegram, sends a photo or short text ("contactor buzzing on line 3"), and gets a Guided Socratic Dialogue reply — typically inside 3 seconds. Telegram is **MIRA's primary chat surface** for inbound support today and the most-tested adapter against the shared engine. Voice work-orders, photo intake, and slash commands are first-class on this surface.
+
+## Scope
+**IN scope**
+- `mira-bots/telegram/` adapter container (`mira-bot-telegram`)
+- Slash commands for tech and ops users
+- Photo + voice handling
+- Polling-only operation (no webhook); singleton per bot token
+- Bridge to shared engine (`Supervisor`)
+
+**OUT of scope**
+- Telegram-side group admin features
+- Cross-platform message routing (handled at engine level)
+
+## Architecture
+- **Layer:** Adapter
+- **Library:** `python-telegram-bot 21.x`
+- **Mode:** Polling (`run_polling()`) — replaces the old VPS webhook gateway (March 2026 in `~/factorylm/CLUSTER.md`).
+- **Networks:** `bot-net`, `core-net`
+- **Singleton invariant:** Only one process may poll a given `TELEGRAM_BOT_TOKEN`. Stale pollers on Charlie are a documented incident pattern; agentic-OS self-healer enforces this.
+
+```
+Telegram ── HTTPS poll ─▶ mira-bot-telegram
+                              ├── strip_mentions, normalize chat_id (str)
+                              ├── photo? base64-encode → photo_b64
+                              ├── voice? Ollama whisper-style transcription
+                              └── Supervisor.process_full(chat_id, msg, photo_b64)
+                                          │
+                                          └── reply → telegram.send_message
+```
+
+## API Contract
+
+### Slash commands (canonical set)
+| Command | Args | Behavior |
+|---|---|---|
+| `/start` | — | Reset to IDLE, send onboarding message |
+| `/reset` | — | `Supervisor.reset(chat_id)` |
+| `/wo` | `<title>` (optional voice) | Create work order via `mira-mcp` `cmms_create_work_order` |
+| `/asset <tag>` | tag | Look up asset, set context, prompt for problem |
+| `/help` | — | Lists commands + escalation phone |
+| `/feedback <up\|down> [reason]` | — | `Supervisor.log_feedback` |
+
+### Inputs
+- **Text** ≤ 4 KB: forwarded as-is.
+- **Photo**: largest variant fetched, base64-encoded, passed as `photo_b64`.
+- **Voice**: ≤ 60 s, transcribed via Ollama; transcript becomes the user message; original audio is dropped after transcription.
+- **Document**: PDF ≤ 20 MB → forwarded to `mira-ingest /ingest/photo` (yes, name historical) or `mira-mcp /ingest/pdf` depending on type.
+
+### Output
+- Text replies sent in chunks ≤ 4096 chars.
+- Confidence "low" replies are prefixed with `⚠️ Low confidence:`.
+- Safety alerts use a dedicated red-bordered reply template.
+
+### `chat_id` mapping
+Telegram numeric `chat_id` is **always** cast to `str` before calling the engine.
+
+## Configuration
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `TELEGRAM_BOT_TOKEN` | yes | — | Bot token (Doppler) |
+| `MIRA_DB_PATH` | yes | `/data/mira.db` | Shared state |
+| `OPENWEBUI_BASE_URL` / `OPENWEBUI_API_KEY` | yes | — | KB retrieval |
+| `KNOWLEDGE_COLLECTION_ID` | yes | — | Open WebUI collection |
+| `INFERENCE_BACKEND` | yes | `cloud` | Cascade vs local |
+| `GROQ/CEREBRAS/GEMINI_API_KEY` | ≥ 1 | — | Cascade providers |
+| `MIRA_TENANT_ID` | yes | — | Tenant scope |
+| `LANGFUSE_*_KEY` | optional | — | Tracing |
+
+## Quality Standards
+| Metric | Current | Target |
+|---|---|---|
+| End-to-end p50 latency | ≤ 3 s (cloud cascade) | ≤ 2 s |
+| Test files | covered by shared 12 + adapter | maintain |
+| Singleton enforcement | self-healer-driven | regression test on competing-poller detection |
+| Photo handler robustness | EXIF-stripped via mira-ingest | maintain |
+| Voice transcription error rate | unmeasured | < 10 % WER on field audio |
+
+## Acceptance Criteria
+1. **Polling singleton:** Starting a second instance triggers either auto-shutdown (self-healer) or a clear startup error within 30 s; never two concurrent pollers.
+2. **Photo round-trip:** A 2 MB JPEG of a VFD nameplate produces an `ASSET_IDENTIFIED` state and a relevant first question.
+3. **Voice WO:** `/wo` followed by a voice note results in an Atlas work order created via `mira-mcp`; original audio is not persisted.
+4. **PDF cap:** A 25 MB PDF is rejected with a friendly message; ≤ 20 MB succeeds.
+5. **chat_id type:** No engine-side test ever observes an `int` chat_id from this adapter (cast invariant).
+6. **Safety bypass:** `"there's smoke from the cabinet"` returns the canned safety response immediately, regardless of FSM state.
+7. **Mention-strip:** `@MiraBot` and other Telegram entity tags are stripped before `Supervisor.process()`.
+8. **Reset:** `/reset` empties history and resets state.
+
+## Known Issues
+- Polling competes with any prior polling process on the same token (per CLAUDE.md gotcha + memory `project_mira_state`).
+- Voice transcription via Ollama has variable quality on noisy plant-floor audio.
+- Telegram entity tags can wrap user-typed text; `strip_mentions` handles known cases but is conservative on unknown entities.
+
+## Change Log
+- 2026-03 — Polling moved to Charlie (`run_polling()`); replaced VPS OpenClaw webhook gateway.
+- 2026-04 — Voice WO command (`/wo`) added.


### PR DESCRIPTION
## Summary
- 20 module specs under `docs/specs/` + `SPEC_INDEX.md` — source of truth for what each module does, its API contract, quality benchmarks, and acceptance criteria so future sessions can validate code against spec without re-explanation.
- 6-file `docs/context/` briefing the next session loads: `PROJECT_BRIEF`, `ARCHITECTURE`, `TECH_STACK`, `FILE_STRUCTURE`, `RULES`, `PROGRESS` (auto-updating).
- `.claude/hooks/stop.sh` — appends per-session entries between `<!-- BEGIN/END AUTOLOG -->` markers in `PROGRESS.md`. Wired via `.claude/settings.json` `hooks.Stop`.

Specs cover Core (mira-bots / -pipeline / -hub / -web / -mcp / -core), Data (crawler / KG / RAG / quality-gate / DST), Integrations (cmms / bridge / scan / ignition), Infra (agentic-os / auth-tenancy / deployment), Interfaces (telegram-bot / hub-mobile).

## Test plan
- [x] All spec files follow the canonical template (Purpose · Scope · Architecture · API Contract · Configuration · Quality Standards · Acceptance Criteria · Known Issues · Change Log).
- [x] `python3 -c "import json; json.load(open('.claude/settings.json'))"` valid JSON.
- [x] Stop hook smoke test — appends a well-formed entry between the AUTOLOG markers.
- [x] Pre-commit hook passes (shellcheck on `stop.sh`, no Python staged).
- [ ] Pre-existing CI failures expected — same baseline as `main`; this PR is docs-only and adds no executable code paths.