### PR TITLE
fix(hub): drop invalid 'Hub' literal from POST /api/work-orders (prod hotfix)

### DIFF
--- a/mira-hub/src/app/api/work-orders/route.ts
+++ b/mira-hub/src/app/api/work-orders/route.ts
@@ -195,7 +195,7 @@ export async function POST(req: NextRequest) {
             $2, $3, $4,
             $5, $6, $7,
             ARRAY[]::TEXT[], ARRAY[]::TEXT[],
-            'open'::workorderstatus, $8::prioritylevel, 'Hub',
+            'open'::workorderstatus, $8::prioritylevel, NULL,
             $9, $10, NOW(), NOW()
           )
           RETURNING id, work_order_number, source, created_by_agent,


### PR DESCRIPTION
## Summary

Second enum bug in P0.1 (PR #1022). The hub WO insert hardcodes `route_taken = 'Hub'`, but the `routetype` enum is `{A, B, C, D, PM}` — there is no `'Hub'` value. Every hub WO submit was failing with:

```
invalid input value for enum routetype: "Hub"
```

This shadowed the `sourcetype` `'hub_ui'` bug Mike spotted earlier today (hotfix already applied to NeonDB; codified in `006_add_hub_ui_source.sql` on the P1 branch). After the sourcetype fix landed, my verifier `INSERT` caught this one.

## Fix

`route_taken NULL` for hub-created WOs. `route_taken` tracks the diagnostic flowchart path used by the Telegram engine (A/B/C/D) or the auto-PM generator (PM). Hub WOs go through neither, so NULL is semantically correct (and 25 of the 77 existing rows already have NULL).

One-line change at `mira-hub/src/app/api/work-orders/route.ts:198`:

```diff
-            'open'::workorderstatus, $8::prioritylevel, 'Hub',
+            'open'::workorderstatus, $8::prioritylevel, NULL,
```

## Verification

End-to-end DB-layer verify on prod NeonDB (after this fix):

```
[verify] using tenant=mike equipment=2164e0c5-...
INSERT INTO work_orders (...) VALUES (..., 'hub_ui', ..., NULL, ...)
  → PASS, source=hub_ui, route_taken=null
DELETE → row removed
```

`bun run build` clean, `tsc --noEmit` clean for the touched file.

## Test plan

- [x] DB-layer INSERT with the fixed query succeeds against prod NeonDB
- [x] `bun run build` clean
- [ ] Smoke + lint pass on this PR (CI gate)
- [ ] Post-merge: deploy-vps.yml rebuilds mira-hub on the VPS
- [ ] **Mike: click through `/workorders/new` on https://app.factorylm.com** — should land on the success splash with a real `WO-XXXXXXXX` number, and the WO should appear in `/workorders` afterwards

## Related

- PR #1022 — P0.1 introduced both enum bugs (hub_ui + Hub)
- PR #1023 — P1 sync branch carries `006_add_hub_ui_source.sql` (codified sourcetype hotfix) + renumbered `007_atlas_sync_cols.sql`. P1 will pick up this fix when it merges main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)