### PR TITLE
fix(hub): CRA-17 — wire /upgrade button to mira-web Stripe Checkout

### DIFF
--- a/docs/specs/mira-hub-full-platform-spec.md
+++ b/docs/specs/mira-hub-full-platform-spec.md
@@ -709,10 +709,15 @@ This is the to-do list. Work top-down. Update this list when items are done.
     - Confirm Doppler `NEXTAUTH_URL=https://app.factorylm.com/api/auth` (no `/hub/`)
     - Confirm Google authorized redirect URIs include the matching callback path
     - **Acceptance:** Google sign-in completes without `redirect_uri_mismatch`
-17. **Wire `/upgrade` to mira-web Stripe Checkout**
-    - Either: redirect "Upgrade" CTA to `https://app.factorylm.com/pricing` (mira-web)
-    - Or: proxy a `/api/checkout` call from hub through to mira-web
-    - **Acceptance:** Clicking "Upgrade" actually opens Stripe Checkout
+17. ~~**Wire `/upgrade` to mira-web Stripe Checkout**~~ — **DONE 2026-05-06**
+    - `mira-hub/src/app/(hub)/upgrade/page.tsx` now redirects to
+      `/pricing?from=hub-upgrade&plan=<id>`. nginx phase-2 routes `/pricing` and
+      `/api/checkout/*` to mira-web :3200, so the hub no longer needs its own
+      Stripe wiring.
+    - **Follow-up:** Hub plan list ($20 / $499) doesn't match mira-web's live
+      Stripe tiers ($97 / $297). Either reconcile the hub PLANS array to the
+      real prices, or have mira-web's `/pricing` accept a `plan=` hint to
+      pre-select. Filed as a separate item.
 
 ### P2 — Polish (visible quality, not blocking)
 

--- a/mira-hub/src/app/(hub)/upgrade/page.tsx
+++ b/mira-hub/src/app/(hub)/upgrade/page.tsx
@@ -42,8 +42,14 @@ const PLANS = [
 
 export default function UpgradePage() {
   function handleUpgrade(planId: string) {
-    // Stripe checkout — placeholder until Stripe is wired
-    window.open(`mailto:mike@factorylm.com?subject=FactoryLM%20${planId}%20plan%20signup`, "_blank");
+    // mira-web owns the Stripe billing surface (see deployment/nginx-phase2-live.conf
+    // — `/pricing` and `/api/checkout/*` both proxy to mira-web :3200). Sending the
+    // user to /pricing lets them pick a plan that matches the live Stripe price IDs;
+    // sending them to /api/checkout/session bypasses pricing and opens Stripe directly.
+    // We use /pricing because the hub plan list ($20 / $499) doesn't yet match the
+    // canonical mira-web tiers ($97 / $297) — defer the tier reconciliation to a
+    // follow-up. `planId` is logged via the query string so we can analyze drop-off.
+    window.location.href = `/pricing?from=hub-upgrade&plan=${encodeURIComponent(planId)}`;
   }
 
   return (


### PR DESCRIPTION
## Summary

Closes spec §11 P1 #17. Replaces the `mailto:` placeholder in
`mira-hub/src/app/(hub)/upgrade/page.tsx` with a redirect to
`/pricing?from=hub-upgrade&plan=<id>`.

nginx-phase2-live.conf:164 and :192 already proxy `/pricing` and
`/api/checkout/*` from `app.factorylm.com` to mira-web :3200, so the
hub doesn't need to own a Stripe wiring layer.

## Why /pricing instead of /api/checkout/session

`/api/checkout/session` would jump the user straight to Stripe — fewer
clicks. But the hub's plan list ($20 Individual / $499 Facility) does
**not** match mira-web's live Stripe tiers ($97 / $297). Sending the
user through `/pricing` lets them land on the actually-purchasable
price. The tier mismatch itself is a follow-up.

## Test plan

- [x] One-line redirect change in upgrade/page.tsx
- [x] Spec §11 row flipped DONE; follow-up noted
- [ ] CI green
- [ ] Manual: click "Start Individual Plan" on /upgrade in prod after
      deploy — should land on /pricing with `from=hub-upgrade&plan=individual`

Refs CRA-17.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>