### PR TITLE
feat(hub): CMMS deep-link integration Phase 1

### DIFF
--- a/mira-hub/db/migrations/008_tenant_cmms_config.sql
+++ b/mira-hub/db/migrations/008_tenant_cmms_config.sql
@@ -1,0 +1,65 @@
+-- Migration 008: tenant CMMS config for deep-link integration
+--
+-- Stores per-tenant CMMS provider configuration. Phase 1 of the deep-link
+-- integration: when a tenant has a row here AND an entity carries an atlas_id
+-- (or other provider-specific external id) the OpenInCMMSButton can resolve a
+-- canonical deep link via the provider abstraction.
+--
+-- Atlas is the default provider for all existing tenants — every hub_tenants
+-- row gets a seed config pointing at https://cmms.factorylm.com.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS tenant_cmms_config (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id       UUID        NOT NULL,
+  provider        TEXT        NOT NULL,                 -- 'atlas' | 'maintainx' | 'fiix' | ...
+  base_url        TEXT        NOT NULL,                 -- e.g. 'https://cmms.factorylm.com'
+  display_name    TEXT        NOT NULL,                 -- shown on the OpenInCMMSButton ('Atlas', 'MaintainX')
+  config          JSONB       NOT NULL DEFAULT '{}',    -- provider-specific knobs (route templates, api hints)
+  enabled         BOOLEAN     NOT NULL DEFAULT TRUE,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Phase 1 invariant: at most one enabled CMMS per tenant. A future migration can
+-- relax this once we support multi-CMMS routing.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tenant_cmms_config_one_enabled
+  ON tenant_cmms_config (tenant_id) WHERE enabled = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_tenant_cmms_config_tenant
+  ON tenant_cmms_config (tenant_id);
+
+-- RLS: tenants see only their own config (matches asset_enrichment pattern in 004).
+ALTER TABLE tenant_cmms_config ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_cmms_config_tenant ON tenant_cmms_config;
+CREATE POLICY tenant_cmms_config_tenant ON tenant_cmms_config
+  AS PERMISSIVE FOR ALL
+  USING (tenant_id = (current_setting('app.tenant_id', TRUE))::uuid);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON tenant_cmms_config TO factorylm_app;
+
+-- ─── Atlas-default seed ──────────────────────────────────────────────────────
+-- Every existing tenant gets a default Atlas configuration pointing at the
+-- shared cmms.factorylm.com instance. Self-hosted tenants override base_url
+-- via the /cmms settings page later.
+--
+-- hub_tenants.id is TEXT but always stores UUID-formatted values
+-- (gen_random_uuid()::text), so the cast is safe.
+INSERT INTO tenant_cmms_config (tenant_id, provider, base_url, display_name)
+SELECT
+  hub_tenants.id::uuid,
+  'atlas',
+  'https://cmms.factorylm.com',
+  'Atlas'
+FROM hub_tenants
+WHERE NOT EXISTS (
+  SELECT 1 FROM tenant_cmms_config tcc
+  WHERE tcc.tenant_id = hub_tenants.id::uuid
+);
+
+COMMIT;
+
+-- ─── Rollback ────────────────────────────────────────────────────────────────
+-- DROP TABLE IF EXISTS tenant_cmms_config;

--- a/mira-hub/src/app/(hub)/assets/[id]/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { AssetChat } from "@/components/AssetChat";
 import { AssetIntelligencePanel } from "@/components/AssetIntelligencePanel";
+import { OpenInCMMSButton } from "@/components/OpenInCMMSButton";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
@@ -79,6 +80,8 @@ type ApiAsset = {
   model: string | null; serialNumber: string | null; type: string | null;
   location: string | null; criticality: string; workOrderCount: number;
   lastMaintenance: string | null; lastFault: string | null; installDate: string | null;
+  /** External CMMS id used by OpenInCMMSButton; null until sync populates it. */
+  atlasId?: string | null;
 };
 
 function apiToDisplay(a: ApiAsset): typeof ASSETS["1"] {
@@ -140,9 +143,12 @@ export default function AssetDetailPage({ params }: { params: Promise<{ id: stri
                 <Badge variant="outline" className="text-[10px]">{t("criticalityLabel", { level: asset.criticality })}</Badge>
               </div>
             </div>
-            <Button size="sm" variant="ghost">
-              <QrCode className="w-4 h-4" />
-            </Button>
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <OpenInCMMSButton entityType="asset" atlasId={apiAsset?.atlasId} size="sm" />
+              <Button size="sm" variant="ghost">
+                <QrCode className="w-4 h-4" />
+              </Button>
+            </div>
           </div>
 
           {/* Tabs */}

--- a/mira-hub/src/app/(hub)/cmms/page.tsx
+++ b/mira-hub/src/app/(hub)/cmms/page.tsx
@@ -5,6 +5,7 @@ import { Database, ExternalLink, CheckCircle2, ClipboardList, Wrench, Calendar, 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { OpenInCMMSButton } from "@/components/OpenInCMMSButton";
 import { useToast } from "@/providers/toast-provider";
 import { useTranslations } from "next-intl";
 
@@ -86,11 +87,7 @@ export default function CMMSPage() {
               </p>
             </div>
             {configured && (
-              <a href={config.url} target="_blank" rel="noopener noreferrer">
-                <Button size="sm" className="h-8 gap-1.5 text-xs">
-                  <ExternalLink className="w-3.5 h-3.5" />{t("openAtlas")}
-                </Button>
-              </a>
+              <OpenInCMMSButton entityType="home" size="sm" variant="default" />
             )}
           </div>
         </div>

--- a/mira-hub/src/app/(hub)/workorders/[id]/page.tsx
+++ b/mira-hub/src/app/(hub)/workorders/[id]/page.tsx
@@ -6,11 +6,12 @@ import Link from "next/link";
 import {
   ArrowLeft, Play, Square, Bot, Package, MessageSquare,
   Clock, User, Calendar, Wrench, CheckCircle2, AlertCircle,
-  AlertTriangle, ChevronRight, Plus, Camera, ExternalLink,
+  AlertTriangle, ChevronRight, Plus, Camera,
   Sparkles, BookOpen, ShieldAlert, Loader2,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { OpenInCMMSButton } from "@/components/OpenInCMMSButton";
 import { PARTS } from "@/lib/parts-data";
 import { useToast } from "@/providers/toast-provider";
 import { API_BASE } from "@/lib/config";
@@ -46,6 +47,8 @@ type WO = {
   manufacturer: string | null;
   model_number: string | null;
   equipment_id: string | null;
+  /** External CMMS id (atlas_id, etc.). Null until the CMMS sync populates it. */
+  atlas_id: string | null;
   status: string;
   priority: string;
   source: string;
@@ -237,11 +240,7 @@ export default function WorkOrderDetailPage({ params }: { params: Promise<{ id: 
               <Bot className="w-4 h-4" />{t("viewMira")}
             </Button>
           </a>
-          <a href={`https://cmms.factorylm.com/workorders/${wo.id}`} target="_blank" rel="noopener noreferrer">
-            <Button variant="outline" className="h-10 gap-1.5 text-sm px-3">
-              <ExternalLink className="w-4 h-4" />{t("openCmms")}
-            </Button>
-          </a>
+          <OpenInCMMSButton entityType="work_order" atlasId={wo.atlas_id} />
         </div>
 
         {/* Auto-PM source citation */}

--- a/mira-hub/src/app/(hub)/workorders/new/page.tsx
+++ b/mira-hub/src/app/(hub)/workorders/new/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { ArrowLeft, ArrowRight, Search, QrCode, Camera, CheckCircle2, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { OpenInCMMSButton } from "@/components/OpenInCMMSButton";
 import { useTranslations } from "next-intl";
 
 /* ─── Mock asset search results ─────────────────────────────────────── */
@@ -67,6 +68,12 @@ export default function NewWorkOrderPage() {
           <Button onClick={() => { setStep(1); setSubmitted(false); setSelectedAsset(null); setDescription(""); setPriority("Medium"); setAssetQuery(""); }}>
             {tCommon("create")}
           </Button>
+        </div>
+        {/* Deep-link to CMMS or "Connect a CMMS" CTA. atlasId is unset on a freshly
+            created WO — sync hasn't run yet — so when the tenant has CMMS configured
+            this button hides; tenants without CMMS see the connect CTA. */}
+        <div className="mt-4">
+          <OpenInCMMSButton entityType="work_order" atlasId={null} size="sm" />
         </div>
       </div>
     );

--- a/mira-hub/src/app/api/assets/[id]/route.ts
+++ b/mira-hub/src/app/api/assets/[id]/route.ts
@@ -24,6 +24,8 @@ function rowToAsset(r: Record<string, unknown>) {
     description: r.description ?? null,
     installDate: r.installation_date ?? null,
     createdAt: r.created_at ?? null,
+    // External CMMS id consumed by OpenInCMMSButton. Null until sync populates it.
+    atlasId: r.atlas_id ? String(r.atlas_id) : null,
   };
 }
 

--- a/mira-hub/src/app/api/cmms/deep-link/route.ts
+++ b/mira-hub/src/app/api/cmms/deep-link/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { resolveDeepLink } from "@/lib/cmms/deep-link";
+import type { CMMSEntityType } from "@/lib/cmms/provider";
+
+export const dynamic = "force-dynamic";
+
+const VALID_ENTITY_TYPES = new Set<CMMSEntityType>(["work_order", "asset", "pm_schedule"]);
+
+/**
+ * GET /api/cmms/deep-link?entity_type=work_order&entity_id=ATLAS-EXT-ID
+ *
+ * `entity_id` is the EXTERNAL CMMS id (atlas_id, maintainx_id, etc.) — not
+ * the hub's canonical id. Callers fetch the entity first and pass its
+ * external id here. Empty/missing entity_id is allowed: it lets the client
+ * discover whether the tenant has any CMMS configured at all (so it can
+ * render the "Connect a CMMS" CTA when there's nothing to link to yet).
+ *
+ * Response shape mirrors DeepLinkResolution from lib/cmms/deep-link.ts:
+ *   { state: "linked",       url, providerName, provider }
+ *   { state: "unconfigured" }
+ *   { state: "unlinked",     providerName, provider }
+ */
+export async function GET(req: NextRequest) {
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const url = new URL(req.url);
+  const entityType = url.searchParams.get("entity_type") as CMMSEntityType | null;
+  const entityId = url.searchParams.get("entity_id");
+
+  if (!entityType || !VALID_ENTITY_TYPES.has(entityType)) {
+    return NextResponse.json(
+      { error: "Invalid or missing entity_type. Expected: work_order | asset | pm_schedule" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const resolution = await resolveDeepLink({
+      tenantId: ctx.tenantId,
+      entityType,
+      externalId: entityId,
+    });
+    return NextResponse.json(resolution);
+  } catch (err) {
+    console.error("[api/cmms/deep-link]", err);
+    return NextResponse.json({ error: "Resolution failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/work-orders/[id]/route.ts
+++ b/mira-hub/src/app/api/work-orders/[id]/route.ts
@@ -54,6 +54,9 @@ function rowToWO(r: Record<string, unknown>) {
     manufacturer: r.manufacturer ?? null,
     model_number: r.model_number ?? null,
     equipment_id: r.equipment_id ? String(r.equipment_id) : null,
+    // External CMMS id used by OpenInCMMSButton for deep-linking. Null until
+    // the CMMS sync populates the column (added in a follow-up migration).
+    atlas_id: r.atlas_id ? String(r.atlas_id) : null,
     status: String(r.status ?? "open"),
     priority: String(r.priority ?? "medium"),
     source,

--- a/mira-hub/src/components/OpenInCMMSButton.tsx
+++ b/mira-hub/src/components/OpenInCMMSButton.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ExternalLink, Link2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { CMMSEntityType } from "@/lib/cmms/provider";
+
+interface Props {
+  entityType: CMMSEntityType;
+  /**
+   * External CMMS id on the entity (e.g. atlas_id). Pass null/undefined when
+   * the entity hasn't been synced yet — the button will hide itself.
+   */
+  atlasId?: string | null;
+  /** Optional className appended to the rendered button. */
+  className?: string;
+  /** Override visual variant. Defaults to outline (matches existing CMMS link buttons). */
+  variant?: "default" | "outline" | "ghost";
+  size?: "default" | "sm" | "lg" | "icon";
+}
+
+type Resolution =
+  | { state: "linked"; url: string; providerName: string; provider: string }
+  | { state: "unconfigured" }
+  | { state: "unlinked"; providerName: string; provider: string };
+
+interface ResolutionCacheEntry {
+  promise: Promise<Resolution | null>;
+  fetchedAt: number;
+}
+
+const CACHE_TTL_MS = 60_000;
+const cache = new Map<string, ResolutionCacheEntry>();
+
+function fetchResolution(entityType: CMMSEntityType, atlasId: string | null | undefined): Promise<Resolution | null> {
+  const key = `${entityType}::${atlasId ?? ""}`;
+  const cached = cache.get(key);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) return cached.promise;
+
+  const params = new URLSearchParams({ entity_type: entityType });
+  if (atlasId) params.set("entity_id", atlasId);
+
+  const promise = fetch(`/hub/api/cmms/deep-link?${params.toString()}`)
+    .then(async (r) => {
+      if (!r.ok) return null;
+      return (await r.json()) as Resolution;
+    })
+    .catch(() => null);
+
+  cache.set(key, { promise, fetchedAt: Date.now() });
+  return promise;
+}
+
+/**
+ * Renders one of three states:
+ *   - tenant has CMMS + entity has atlas_id  → "Open in {ProviderName}" linking out
+ *   - tenant has no CMMS configured          → "Connect a CMMS →" linking to /cmms
+ *   - tenant has CMMS but entity has no id   → renders nothing (sync hasn't run)
+ *
+ * Lazy: doesn't render anything until the resolution returns. Cache is per
+ * (entityType, atlasId) for 60s so repeated mounts don't refetch.
+ */
+export function OpenInCMMSButton({
+  entityType,
+  atlasId,
+  className,
+  variant = "outline",
+  size = "default",
+}: Props) {
+  const [resolution, setResolution] = useState<Resolution | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchResolution(entityType, atlasId).then((r) => {
+      if (!cancelled) setResolution(r);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [entityType, atlasId]);
+
+  if (!resolution) return null;
+
+  if (resolution.state === "linked") {
+    return (
+      <a href={resolution.url} target="_blank" rel="noopener noreferrer" className={className}>
+        <Button variant={variant} size={size} className="gap-1.5">
+          <ExternalLink className="w-4 h-4" />
+          Open in {resolution.providerName}
+        </Button>
+      </a>
+    );
+  }
+
+  if (resolution.state === "unconfigured") {
+    return (
+      <Link href="/cmms" className={className}>
+        <Button variant={variant} size={size} className="gap-1.5">
+          <Link2 className="w-4 h-4" />
+          Connect a CMMS →
+        </Button>
+      </Link>
+    );
+  }
+
+  // resolution.state === "unlinked": tenant has CMMS but this entity hasn't synced.
+  return null;
+}

--- a/mira-hub/src/lib/cmms/atlas-provider.ts
+++ b/mira-hub/src/lib/cmms/atlas-provider.ts
@@ -1,0 +1,34 @@
+import type { CMMSProvider, CMMSProviderConfig, CMMSEntityType } from "./provider";
+
+/**
+ * Atlas (cmms.factorylm.com) deep-link provider.
+ *
+ * Route map (matches the Atlas Next.js app):
+ *   /workorders/:id  — work order detail
+ *   /assets/:id      — asset / equipment detail
+ *   /schedule/:id    — PM schedule detail
+ *   home             — base URL only, no path
+ */
+const ROUTE: Record<CMMSEntityType, (id: string) => string> = {
+  work_order:  (id) => `/workorders/${encodeURIComponent(id)}`,
+  asset:       (id) => `/assets/${encodeURIComponent(id)}`,
+  pm_schedule: (id) => `/schedule/${encodeURIComponent(id)}`,
+  home:        ()   => "",
+};
+
+function trimTrailingSlash(s: string): string {
+  return s.replace(/\/+$/, "");
+}
+
+export const atlasProvider: CMMSProvider = {
+  id: "atlas",
+
+  deepLink(entityType, externalId, config: CMMSProviderConfig): string | null {
+    const route = ROUTE[entityType];
+    if (!route) return null;
+    // "home" doesn't need an externalId — every other entity type does.
+    if (entityType !== "home" && !externalId) return null;
+    const base = trimTrailingSlash(config.baseUrl);
+    return `${base}${route(externalId ?? "")}`;
+  },
+};

--- a/mira-hub/src/lib/cmms/deep-link.ts
+++ b/mira-hub/src/lib/cmms/deep-link.ts
@@ -1,0 +1,62 @@
+import { getProvider } from "./registry";
+import { getTenantCMMSConfig, type TenantCMMSConfig } from "./tenant-config";
+import type { CMMSEntityType } from "./provider";
+
+/**
+ * Result of resolveDeepLink — distinguishes the three render states the
+ * OpenInCMMSButton needs to handle:
+ *   - linked     : tenant has CMMS + entity has external id → show "Open in {name}"
+ *   - unconfigured: tenant has no CMMS config              → show "Connect a CMMS →"
+ *   - unlinked   : tenant has CMMS but entity has no external id → button hidden
+ */
+export type DeepLinkResolution =
+  | { state: "linked"; url: string; providerName: string; provider: string }
+  | { state: "unconfigured" }
+  | { state: "unlinked"; providerName: string; provider: string };
+
+export interface ResolveDeepLinkInput {
+  tenantId: string;
+  entityType: CMMSEntityType;
+  /** External CMMS id on the entity, e.g. atlas_id. Null/undefined = entity not synced yet. */
+  externalId: string | null | undefined;
+}
+
+/**
+ * Resolve a deep link for an entity from the tenant's configured CMMS.
+ * Pure read — does not write anything. Used by both the API route and
+ * server components that want to render the link inline.
+ */
+export async function resolveDeepLink(
+  input: ResolveDeepLinkInput,
+): Promise<DeepLinkResolution> {
+  const config = await getTenantCMMSConfig(input.tenantId);
+  if (!config) return { state: "unconfigured" };
+
+  // "home" is a special pseudo-entity that doesn't need an externalId — every
+  // other entity type requires one (returns "unlinked" so the UI can hide).
+  if (input.entityType !== "home" && !input.externalId) {
+    return { state: "unlinked", providerName: config.displayName, provider: config.provider };
+  }
+
+  const provider = getProvider(config.provider);
+  if (!provider) {
+    // Tenant has a config row but the provider isn't registered (e.g. removed
+    // a connector). Treat as unconfigured so the UI nudges them to reconnect.
+    return { state: "unconfigured" };
+  }
+
+  const url = provider.deepLink(input.entityType, input.externalId ?? "", {
+    baseUrl: config.baseUrl,
+    displayName: config.displayName,
+    options: config.options,
+  });
+
+  if (!url) {
+    return { state: "unlinked", providerName: config.displayName, provider: config.provider };
+  }
+
+  return { state: "linked", url, providerName: config.displayName, provider: config.provider };
+}
+
+/** Re-exported for callers that already have a config in hand. */
+export type { TenantCMMSConfig };

--- a/mira-hub/src/lib/cmms/provider.ts
+++ b/mira-hub/src/lib/cmms/provider.ts
@@ -1,0 +1,41 @@
+/**
+ * CMMS provider abstraction.
+ *
+ * A CMMSProvider knows how to translate canonical entity references (work_order
+ * by atlas_id, asset by atlas_id, ...) into provider-specific deep links.
+ * Phase 1 ships the Atlas provider; MaintainX/Fiix/Limble plug in by
+ * implementing this interface and registering themselves in registry.ts.
+ *
+ * Implementations must be pure: no DB calls, no fetches, no side effects.
+ * Tenant-specific config (base_url, display_name) is passed in by the caller.
+ */
+
+/**
+ * "home" is a pseudo-entity that resolves to the CMMS base URL — useful for
+ * "Open in Atlas" CTAs on the /cmms hub page or in marketing surfaces.
+ */
+export type CMMSEntityType = "work_order" | "asset" | "pm_schedule" | "home";
+
+export interface CMMSProviderConfig {
+  /** Per-tenant base URL, e.g. "https://cmms.factorylm.com" or a self-hosted host. */
+  baseUrl: string;
+  /** Human-readable label shown on the button: "Atlas", "MaintainX". */
+  displayName: string;
+  /** Free-form provider-specific knobs from tenant_cmms_config.config. */
+  options?: Record<string, unknown>;
+}
+
+export interface CMMSProvider {
+  /** Stable identifier matching tenant_cmms_config.provider ('atlas', 'maintainx', ...). */
+  readonly id: string;
+
+  /**
+   * Build a deep link to the entity inside this CMMS.
+   * Returns null if the provider can't represent this entity type.
+   */
+  deepLink(
+    entityType: CMMSEntityType,
+    externalId: string,
+    config: CMMSProviderConfig,
+  ): string | null;
+}

--- a/mira-hub/src/lib/cmms/registry.ts
+++ b/mira-hub/src/lib/cmms/registry.ts
@@ -1,0 +1,21 @@
+import type { CMMSProvider } from "./provider";
+import { atlasProvider } from "./atlas-provider";
+
+/**
+ * Registry of CMMS providers, keyed by their id (matches tenant_cmms_config.provider).
+ *
+ * To add a new provider: implement CMMSProvider, import it here, add it to the
+ * map. tenant_cmms_config.provider values that aren't in this map fall through
+ * to "no CMMS configured" — the OpenInCMMSButton renders the connect-CTA fallback.
+ */
+const PROVIDERS: Record<string, CMMSProvider> = {
+  [atlasProvider.id]: atlasProvider,
+};
+
+export function getProvider(id: string): CMMSProvider | null {
+  return PROVIDERS[id] ?? null;
+}
+
+export function listProviders(): CMMSProvider[] {
+  return Object.values(PROVIDERS);
+}

--- a/mira-hub/src/lib/cmms/tenant-config.ts
+++ b/mira-hub/src/lib/cmms/tenant-config.ts
@@ -1,0 +1,77 @@
+import { withTenantContext } from "@/lib/tenant-context";
+
+/**
+ * Per-tenant CMMS configuration loaded from the tenant_cmms_config table.
+ * Returned by getTenantCMMSConfig() when the tenant has an enabled config.
+ */
+export interface TenantCMMSConfig {
+  provider: string;
+  baseUrl: string;
+  displayName: string;
+  options: Record<string, unknown>;
+}
+
+interface CacheEntry {
+  config: TenantCMMSConfig | null;
+  loadedAt: number;
+}
+
+const CACHE_TTL_MS = 60_000;
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Fetch the active CMMS config for a tenant. Returns null if the tenant has
+ * no enabled config (the UI then renders a "Connect a CMMS" fallback).
+ *
+ * Cached for 60 seconds per tenant — config changes are infrequent and the
+ * deep-link path is hit on every WO/asset detail render.
+ */
+export async function getTenantCMMSConfig(tenantId: string): Promise<TenantCMMSConfig | null> {
+  const cached = cache.get(tenantId);
+  if (cached && Date.now() - cached.loadedAt < CACHE_TTL_MS) {
+    return cached.config;
+  }
+
+  if (!process.env.NEON_DATABASE_URL) {
+    return null;
+  }
+
+  try {
+    const row = await withTenantContext(tenantId, (c) =>
+      c
+        .query<{
+          provider: string;
+          base_url: string;
+          display_name: string;
+          config: Record<string, unknown> | null;
+        }>(
+          `SELECT provider, base_url, display_name, config
+           FROM tenant_cmms_config
+           WHERE tenant_id = $1::uuid AND enabled = TRUE
+           LIMIT 1`,
+          [tenantId],
+        )
+        .then((r) => r.rows[0] ?? null),
+    );
+
+    const config: TenantCMMSConfig | null = row
+      ? {
+          provider: row.provider,
+          baseUrl: row.base_url,
+          displayName: row.display_name,
+          options: row.config ?? {},
+        }
+      : null;
+
+    cache.set(tenantId, { config, loadedAt: Date.now() });
+    return config;
+  } catch (err) {
+    console.error("[cmms/tenant-config] load failed", err);
+    return null;
+  }
+}
+
+/** Drop a tenant's cached config — call after writes to tenant_cmms_config. */
+export function invalidateTenantCMMSConfig(tenantId: string): void {
+  cache.delete(tenantId);
+}


### PR DESCRIPTION
## Summary

Foundation for tenant-scoped CMMS deep-linking. Phase 1 of the spec Mike approved in a prior session.

- **Migration 008** — `tenant_cmms_config` table (RLS, one enabled provider per tenant) + Atlas-default seed for every existing `hub_tenants` row
- **Provider abstraction** — `lib/cmms/{provider,registry,atlas-provider}.ts` ready for MaintainX/Fiix/Limble plug-ins via the registry; `"home"` pseudo-entity for base-URL CTAs
- **Deep-link resolver** + per-tenant config loader (60s in-memory cache) consumed by the new `GET /api/cmms/deep-link?entity_type=…&entity_id=…` endpoint
- **Shared `<OpenInCMMSButton>`** — three render states:
  - tenant has CMMS configured + entity has `atlas_id` → **Open in {ProviderName}**
  - tenant has no CMMS configured → **Connect a CMMS →** linking to `/cmms`
  - tenant has CMMS configured but entity has no `atlas_id` yet → button hidden (sync hasn't run)
- **Fixes the 404** at `workorders/[id]/page.tsx:240` — the hardcoded `cmms.factorylm.com/workorders/${wo.id}` link that used the hub's canonical UUID instead of the Atlas id
- Wires the button into `/assets/[id]` header, the `/cmms` page top-of-page CTA, and the `/workorders/new` success splash
- Exposes `atlas_id` / `atlasId` on the WO and asset API responses (always `null` in Phase 1 — populated by a follow-up sync migration)

LOC: ~490 in 14 files (under the 600 budget).

## Manual migration command

The migration is **not** auto-applied. Run from a CHARLIE/macOS shell with `NEON_DATABASE_URL` exported (Doppler `factorylm/prd`):

```bash
psql "$NEON_DATABASE_URL" -f mira-hub/db/migrations/008_tenant_cmms_config.sql
```

To roll back:
```bash
psql "$NEON_DATABASE_URL" -c "DROP TABLE IF EXISTS tenant_cmms_config;"
```

## Build / typecheck

- `bun run build` ✓ (Next 16.2.4, Turbopack, all routes compiled)
- `bunx tsc --noEmit` ✓ (one pre-existing error in `rls-deny.integration.test.ts` is untouched)
- `bun run lint` — no new errors on the touched paths; pre-existing setState-in-effect warnings elsewhere

## Test plan

- [ ] Apply migration 008 against a NeonDB branch and verify `tenant_cmms_config` has one Atlas row per `hub_tenants`
- [ ] Curl `GET /hub/api/cmms/deep-link?entity_type=home` → expect `{ state: "linked", url: "https://cmms.factorylm.com", providerName: "Atlas", provider: "atlas" }`
- [ ] Curl `GET /hub/api/cmms/deep-link?entity_type=work_order&entity_id=ABC` → expect `linked` with `https://cmms.factorylm.com/workorders/ABC`
- [ ] Visit `/workorders/{id}` — button should render but stay hidden (atlas_id is null in Phase 1) and **the previous 404 link is gone**
- [ ] Visit `/assets/{id}` — button hidden in the same state
- [ ] Visit `/cmms` — top button reads "Open in Atlas" and links to the resolved base URL
- [ ] Delete the tenant's row in `tenant_cmms_config`, refresh `/workorders/{id}` — button should now read "Connect a CMMS →" and link to `/cmms`

## Out of scope (follow-ups)

- Adding `atlas_id` columns to `work_orders` / `cmms_equipment` and the sync that populates them
- `/cmms` settings UI for editing `tenant_cmms_config` (currently rendered from local component state — the page is mock-y)
- Multi-CMMS routing per tenant (the schema already lifts the unique-by-tenant constraint to "where enabled = TRUE", so this is a pure UI/registry change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)