### PR TITLE
feat(hub): CMMS deep-link abstraction + multi-provider scaffold (Phase 1)

### DIFF
--- a/docs/specs/cmms-deep-link-multi-provider-spec.md
+++ b/docs/specs/cmms-deep-link-multi-provider-spec.md
@@ -1,0 +1,333 @@
+# CMMS Deep-Link & Multi-Provider Spec
+
+**Status:** Draft — awaiting Mike approval
+**Author:** Claude (Opus 4.7)
+**Date:** 2026-05-06
+**Related:** [`hub-cmms-integration-spec.md`](./hub-cmms-integration-spec.md) §4 P2
+
+---
+
+## 1. Context
+
+After PR #1022 (P0 honesty) + PR #1024 (route_taken hotfix) + PR #1023 (P1 sync worker), the hub creates real Work Orders in NeonDB and the sync worker (when enabled) pushes them to Atlas, back-filling `work_orders.atlas_id`.
+
+What's missing is the *visible* end of that integration: a consistent **"Open in CMMS"** button on every MIRA-touched object — WO, asset, MIRA conversation — that deep-links to the tenant's configured CMMS. Today:
+
+1. **Broken link on WO detail:** `mira-hub/src/app/(hub)/workorders/[id]/page.tsx:240` builds `cmms.factorylm.com/workorders/${wo.id}` using the **NeonDB UUID**, not `wo.atlas_id`. Atlas 404s on every click. (PR #1022 spec said this should be "hidden until atlas_id is populated" — gating was never implemented.)
+2. **No button on MIRA conversations.** `mira-hub/src/app/(hub)/conversations/page.tsx` is currently a hardcoded fixture; no per-conversation detail view, no link to the WO it produced.
+3. **Hardcoded to Atlas.** Six different files inline `https://cmms.factorylm.com`. No tenant override → no Maximo/Fiix/MaintainX/UpKeep customer can be onboarded without forking the code.
+
+A new tenant landing on Maximo today would see "Open CMMS" buttons that send them to a Florida URL their Maximo SSO has never heard of. That's a sales-blocker the moment we start outbound on enterprise prospects.
+
+---
+
+## 2. Goals
+
+1. **One reusable button component** drops into any page and renders the right deep-link for the current tenant.
+2. **Atlas remains the default** — no behavior change for `tenant_id='mike'` and other Atlas-backed tenants.
+3. **Per-tenant provider override** via a `tenant_cmms_config` table. Switching a tenant from Atlas to Maximo is a row update — no code deploy.
+4. **Each provider is a small TypeScript class** that knows how to build deep-link URLs from an `external_id`. Sync (push to the external CMMS) is an *optional* method on the same interface — Atlas implements it today, others can be added incrementally as customers come online.
+5. **Fail-safe degraded UX:** if `external_id` isn't populated yet (sync hasn't run, no provider configured), the button is hidden (or shown disabled with a tooltip), never broken.
+
+## 3. Non-goals (this spec)
+
+- Implementing Maximo/Fiix/MaintainX/UpKeep **sync** (push WOs to those systems). Out of scope. Deep-link only here.
+- Asset/PM record sync to Atlas — already in PR #1023's `mira-cmms-sync` worker.
+- A settings UI for tenants to self-configure their CMMS. Phase 2; today, config is admin-managed via SQL or a future admin route.
+- Multi-CMMS *fan-out* (one tenant pushing to two CMMSes simultaneously). YAGNI.
+- Replacing Atlas as the default. Atlas stays.
+
+---
+
+## 4. Architecture
+
+### 4.1 Data model — new table `tenant_cmms_config`
+
+Migration `mira-hub/db/migrations/008_tenant_cmms_config.sql`:
+
+```sql
+CREATE TYPE cmms_provider AS ENUM ('atlas', 'maximo', 'fiix', 'maintainx', 'upkeep');
+
+CREATE TABLE IF NOT EXISTS tenant_cmms_config (
+  tenant_id           TEXT PRIMARY KEY,
+  provider            cmms_provider NOT NULL DEFAULT 'atlas',
+  base_url            TEXT NOT NULL DEFAULT 'https://cmms.factorylm.com',
+  -- Per-provider URL templates. Tokens: {external_id}, {tenant_id}.
+  -- Defaults are filled in by the provider class; tenants override only when
+  -- their CMMS uses non-standard paths.
+  link_templates      JSONB NOT NULL DEFAULT '{}'::jsonb,
+  -- Doppler secret name for API auth. Never store the credential itself here.
+  auth_credential_ref TEXT,
+  enabled             BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+ALTER TABLE tenant_cmms_config ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation_cmms_config ON tenant_cmms_config
+  FOR ALL TO factorylm_app
+  USING (tenant_id = current_setting('app.tenant_id', TRUE));
+
+-- Seed every existing tenant with the Atlas default.
+INSERT INTO tenant_cmms_config (tenant_id, provider, base_url)
+SELECT DISTINCT tenant_id, 'atlas', 'https://cmms.factorylm.com'
+FROM tenants
+ON CONFLICT (tenant_id) DO NOTHING;
+```
+
+Note: the `cmms_provider` enum is intentionally narrow. New providers go in via `ALTER TYPE cmms_provider ADD VALUE` migrations — same pattern as the `sourcetype` enum we just learned a hard lesson on.
+
+### 4.2 Provider interface — `mira-hub/src/lib/cmms/provider.ts`
+
+```ts
+export type DeepLinkKind = "work_order" | "asset" | "pm";
+
+export interface CMMSProvider {
+  readonly name: string;            // "Atlas", "Maximo", "Fiix", ...
+  readonly slug: CMMSProviderSlug;  // "atlas" | "maximo" | ...
+
+  /** Default URL templates; tenant config can override per template key. */
+  defaultLinkTemplates: Record<DeepLinkKind, string>;
+
+  /** Builds the deep-link URL. Pure — no I/O. */
+  buildDeepLink(args: {
+    kind: DeepLinkKind;
+    externalId: string;
+    baseUrl: string;
+    overrideTemplates?: Partial<Record<DeepLinkKind, string>>;
+  }): string;
+
+  /** Optional: push a WO/asset/PM to this CMMS. Only Atlas implements today. */
+  syncWorkOrder?(...): Promise<{ external_id: string }>;
+  syncAsset?(...): Promise<{ external_id: string }>;
+}
+```
+
+A registry maps `cmms_provider` enum slugs → concrete provider classes:
+
+```ts
+// mira-hub/src/lib/cmms/registry.ts
+export const PROVIDERS: Record<CMMSProviderSlug, CMMSProvider> = {
+  atlas:     new AtlasProvider(),     // wraps existing src/lib/atlas/client.ts
+  maximo:    new MaximoProvider(),    // deep-link only
+  fiix:      new FiixProvider(),      // deep-link only
+  maintainx: new MaintainXProvider(), // deep-link only
+  upkeep:    new UpKeepProvider(),    // deep-link only
+};
+```
+
+Default templates per provider (verified against each vendor's URL convention; these are the **starting points** — actual customers may override):
+
+| Provider  | Work order                          | Asset                            |
+|-----------|-------------------------------------|----------------------------------|
+| Atlas     | `/workorders/{external_id}`         | `/assets/{external_id}`          |
+| Maximo    | `/maximo/ui/?event=loadapp&value=wotrack&additionalevent=useqbe&additionaleventvalue=wonum%3D{external_id}` | `/maximo/ui/?event=loadapp&value=asset&additionalevent=useqbe&additionaleventvalue=assetnum%3D{external_id}` |
+| Fiix      | `/g/wo/view/{external_id}`          | `/g/asset/view/{external_id}`    |
+| MaintainX | `/dashboard/work-orders/{external_id}` | `/dashboard/assets/{external_id}` |
+| UpKeep    | `/work-orders/{external_id}`        | `/assets/{external_id}`          |
+
+### 4.3 Deep-link helper — `mira-hub/src/lib/cmms/deep-link.ts`
+
+```ts
+export type DeepLinkResult =
+  | { status: "ready"; url: string; provider: string; providerSlug: CMMSProviderSlug }
+  | { status: "syncing" }       // external_id not yet populated
+  | { status: "unconfigured" }; // tenant has no CMMS config (free-tier hub-only)
+
+export async function getCMMSDeepLink(
+  tenantId: string,
+  kind: DeepLinkKind,
+  externalId: string | null,
+): Promise<DeepLinkResult>;
+```
+
+Single source of truth. Reads `tenant_cmms_config` once per request via `withTenantContext`. Returns `syncing` when `externalId` is null so the UI can show a spinner / "Syncing to CMMS…" copy instead of a broken link.
+
+### 4.4 Deep-link API endpoint — `mira-hub/src/app/api/cmms/deep-link/route.ts`
+
+```
+GET /api/cmms/deep-link?kind=work_order&id={uuid}
+GET /api/cmms/deep-link?kind=asset&id={uuid}
+```
+
+Returns `DeepLinkResult` JSON. Server-side joins `work_orders` (or `cmms_equipment`) on `id` to fetch `atlas_id`, then defers to `getCMMSDeepLink`. RLS-scoped to `ctx.tenantId`.
+
+Why an API endpoint instead of computing on the page? Three reasons:
+
+1. The MIRA conversation view will show this button across many WOs in a list — a single batched fetch beats 1 RTT per WO if we eventually add bulk.
+2. Telegram/Slack adapters will hit the same endpoint server-side to embed deep-links in bot replies (see §5.5).
+3. Tenant config invalidation is cleaner with a single fetch boundary.
+
+### 4.5 Shared button component — `mira-hub/src/components/cmms/open-in-cmms-button.tsx`
+
+```tsx
+<OpenInCMMSButton kind="work_order" recordId={wo.id} variant="outline" />
+```
+
+Behavior (Mike-approved 2026-05-06):
+
+- On mount, fetches `/api/cmms/deep-link?kind=...&id=...`.
+- If `status === "ready"`: renders **`Open in {provider.name}`** (dynamic — "Open in Atlas", "Open in Maximo", etc.) using the provider name from tenant config. Falls back to generic `"Open in CMMS"` only when the provider name is unknown/absent.
+- If `status === "syncing"`: renders disabled button with tooltip "Syncing to CMMS… typically <60s".
+- If `status === "unconfigured"` **on an object page** (WO detail, asset detail, conversation): renders **`Connect a CMMS →`** linking to `/cmms` so the tenant can complete setup. Atlas is pre-seeded for every new tenant, so this state should be rare in practice — it appears only if a tenant explicitly disabled their config.
+
+i18n: reuses existing `openCmms` key in `mira-hub/src/messages/{en,es,hi,zh}.json:655` for the generic fallback. New keys: `openIn` (template `"Open in {provider}"`), `connectCmms` ("Connect a CMMS →"), `syncingToCmms` ("Syncing to CMMS…").
+
+---
+
+## 5. UI Surfaces — where the button appears
+
+### 5.1 `/workorders/[id]` — fix the existing broken button
+
+`mira-hub/src/app/(hub)/workorders/[id]/page.tsx:240` — replace the inline `<a>` with `<OpenInCMMSButton kind="work_order" recordId={wo.id} />`. The current code uses `wo.id` (NeonDB UUID) as the path segment, which 404s in Atlas. New component fetches `wo.atlas_id` via the API.
+
+### 5.2 `/assets/[id]` — asset detail page
+
+`mira-hub/src/app/(hub)/assets/[id]/page.tsx` — drop the same component with `kind="asset"` next to existing CTAs. Replaces whatever the CRA-20 branch added (currently inline, hardcoded Atlas).
+
+### 5.3 `/cmms` — landing page
+
+`mira-hub/src/app/(hub)/cmms/page.tsx:11,132` — keep the page-level "Open CMMS" CTA but route it through the helper so it points to the tenant's `base_url`, not the hardcoded `cmms.factorylm.com`. No `external_id` needed (it's a top-level link).
+
+### 5.4 `/conversations` — MIRA conversation detail (NEW)
+
+**Mike-approved: Option B — real backend first.** The current `/conversations` page is hardcoded fixtures (`CONVERSATIONS = [...]` const). Real conversation data lives in NeonDB tables `telegram_messages` (per-message log) and `work_orders` (with `created_by_agent` / `tenant_id` linking back to the chat).
+
+Required backend work to land the button correctly:
+
+1. **Schema link:** Add `work_orders.conversation_id` (TEXT, nullable, indexed) so a WO can be traced back to the chat that produced it. Today the link is reconstructed from timestamp + `tenant_id` + `created_by_agent` — fragile. Migration: `mira-hub/db/migrations/009_wo_conversation_link.sql`.
+2. **Bot writes the link:** `mira-bots/shared/integrations/hub_neon.py:101-118` (the INSERT) gains a new `conversation_id` parameter sourced from the chat thread. `mira-bots/shared/engine.py` plumbs the chat_id through the WO creation call.
+3. **List endpoint:** `GET /api/conversations` — returns the per-tenant list of conversations grouped by `chat_id`/`channel`, last message preview, asset reference, **and any linked work_order with its `atlas_id`**. Replaces the fixtures.
+4. **Detail endpoint:** `GET /api/conversations/[id]` — returns the full message thread + the linked WO record (with `atlas_id`).
+5. **New page:** `mira-hub/src/app/(hub)/conversations/[id]/page.tsx` — full chat view with a sticky right-rail showing the linked WO + `<OpenInCMMSButton kind="work_order" recordId={wo.id} />` prominently at the top.
+6. **List page update:** `mira-hub/src/app/(hub)/conversations/page.tsx` becomes data-driven (fetches `/api/conversations`), renders a "Linked WO" chip per row, and hyperlinks to the new detail page.
+
+Estimated scope: 5-7 days. Lives in a separate Phase 2 PR after Phase 1 ships.
+
+### 5.5 `/workorders/new` — success splash
+
+After a WO is created, the success splash currently shows "View" + "Create another". Add `<OpenInCMMSButton ... />` — it'll render in `syncing` state initially (since the worker hasn't pushed yet), then auto-update to `ready` when the user revisits or after a polling interval.
+
+### 5.6 Bot replies (Telegram/Slack) — out of scope this spec but worth noting
+
+Once the API endpoint exists, `mira-bots/shared/integrations/hub_neon.py` can call it server-side and append `View in CMMS: {url}` to bot replies. Cleaner than reimplementing the URL logic in Python. Track as a follow-up.
+
+---
+
+## 6. File inventory
+
+### New files
+
+| File | LOC est. | Purpose |
+|------|----------|---------|
+| `mira-hub/db/migrations/008_tenant_cmms_config.sql` | 35 | Table + RLS + seed |
+| `mira-hub/src/lib/cmms/provider.ts` | 60 | Interface + types |
+| `mira-hub/src/lib/cmms/registry.ts` | 25 | Provider registry |
+| `mira-hub/src/lib/cmms/atlas-provider.ts` | 50 | Wraps existing `src/lib/atlas/client.ts` |
+| `mira-hub/src/lib/cmms/maximo-provider.ts` | 40 | Deep-link only |
+| `mira-hub/src/lib/cmms/fiix-provider.ts` | 40 | Deep-link only |
+| `mira-hub/src/lib/cmms/maintainx-provider.ts` | 40 | Deep-link only |
+| `mira-hub/src/lib/cmms/upkeep-provider.ts` | 40 | Deep-link only |
+| `mira-hub/src/lib/cmms/deep-link.ts` | 70 | `getCMMSDeepLink` helper + tenant config fetch |
+| `mira-hub/src/lib/cmms/tenant-config.ts` | 40 | Cached `tenant_cmms_config` lookup |
+| `mira-hub/src/components/cmms/open-in-cmms-button.tsx` | 100 | Shared component |
+| `mira-hub/src/app/api/cmms/deep-link/route.ts` | 60 | GET endpoint |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `mira-hub/src/app/(hub)/workorders/[id]/page.tsx:240-244` | Replace inline broken `<a>` with `<OpenInCMMSButton>`. **Fixes existing 404 bug.** |
+| `mira-hub/src/app/(hub)/assets/[id]/page.tsx` | Replace CRA-20 inline button with shared component |
+| `mira-hub/src/app/(hub)/cmms/page.tsx:11,132` | Replace `DEFAULT_CMMS_URL` const with helper call |
+| `mira-hub/src/app/(hub)/workorders/new/page.tsx` | Add button to success splash |
+| `mira-hub/src/app/(hub)/conversations/page.tsx` | Add "Linked WO" chip + button per Option A |
+| `mira-hub/src/app/api/cmms/stats/route.ts:11` | Use tenant config base_url instead of inline default |
+| `mira-hub/src/messages/{en,es,hi,zh}.json` | Add `openIn` key (provider-name interpolation) |
+
+### Migrations
+
+- `008_tenant_cmms_config.sql` (new table)
+
+---
+
+## 7. Phased rollout
+
+**Mike-approved phasing 2026-05-06: Phase 1 ships standalone first** because every customer clicking the WO detail "Open in CMMS" button today is hitting a 404. Bug fix takes priority over the conversations work.
+
+**Phase 1 — Atlas-only abstraction + fix the broken 404 (1.5 days)** — *next up*
+- Migration `008_tenant_cmms_config.sql`: table + RLS + seed Atlas row for every existing tenant
+- Provider interface (`provider.ts`), registry (`registry.ts`), Atlas-only implementation (`atlas-provider.ts`)
+- Deep-link helper (`deep-link.ts`) + tenant config fetch (`tenant-config.ts`)
+- API endpoint `GET /api/cmms/deep-link`
+- Shared component `<OpenInCMMSButton>` with the dynamic-name + `Connect a CMMS →` fallback per §4.5
+- Replace `mira-hub/src/app/(hub)/workorders/[id]/page.tsx:240` broken button with the component (**fixes the 404 bug**)
+- Wire same component into `/assets/[id]` and `/cmms` page
+- Wire into `/workorders/new` success splash
+
+Verify end-to-end on app.factorylm.com: create a WO → wait for sync → button label reads "Open in Atlas" → click → land on real Atlas record. Pre-Phase-1 broken WOs (no `atlas_id` because they predate the sync worker) should hide the button cleanly instead of 404'ing.
+
+**Phase 2 — MIRA conversation real backend (5-7 days)** — Option B per §5.4
+- Migration `009_wo_conversation_link.sql`: add `work_orders.conversation_id`
+- Plumb `conversation_id` through `mira-bots/shared/engine.py` and `hub_neon.py` so new WOs link back to their chat
+- New endpoints: `GET /api/conversations` (list, real data) + `GET /api/conversations/[id]` (detail)
+- New page: `/conversations/[id]/page.tsx` with right-rail showing linked WO + `<OpenInCMMSButton>`
+- Update list page `/conversations/page.tsx` from fixtures → data-driven, with "Linked WO" chip per row
+
+**Phase 3 — Multi-provider deep-link stubs + /cmms connector setup UI (1.5-2 days)**
+- Maximo / Fiix / MaintainX / UpKeep classes (URL building only, no sync)
+- Per-provider URL templates verified against vendor docs (defaults in §4.2; tenants can override per-row)
+- `/cmms` page becomes a guided connector setup: Atlas pre-configured (one-click "Activate"), plus "Connect Maximo / Fiix / MaintainX / UpKeep" cards each opening a config form (base_url + auth credential ref)
+- Manual smoke test: insert a Maximo config row for a test tenant, point at `https://example.maximo.com`, verify button URL matches expected pattern
+
+**Phase 4 — Admin settings UI (1-2 days, after a real non-Atlas prospect signs)**
+- `/settings/cmms` admin page to edit existing `tenant_cmms_config` (different from Phase 3's *initial* connector setup — this is *editing*)
+- Validation: probe the configured `base_url` for a 200, surface auth errors
+- Doppler secret reference helper
+
+**Phase 5 — Sync extensions (1+ week per provider, on demand)**
+- Extend `mira-hub/scripts/cmms-sync-worker.ts` with per-tenant provider dispatch
+- Implement `syncWorkOrder` / `syncAsset` per provider (each is its own REST API surface)
+- This is the work-intensive part — tackle one provider at a time when a customer commits
+
+Phases 1-3 unlock the "we support Maximo/Fiix/MaintainX/UpKeep" sales conversation without committing to full sync engineering.
+
+---
+
+## 8. Risks & open questions
+
+### Risks
+
+- **Maximo URL pattern drift.** Vendor URL conventions occasionally change between major versions. Mitigation: URL templates are JSONB per-tenant; a customer running Maximo 7.6 can override the default that targets 8.x.
+- **Deep-link auth.** Some CMMSes require SSO before the deep-link works; the user lands on a login page. Not our problem to solve, but document in the per-provider override section so customers know to expect it.
+- **Atlas's existing inline `https://cmms.factorylm.com` references** in `cmms/stats/route.ts:11` and i18n message placeholders. We'll keep the constant as a fallback default but route reads through the helper. Don't forget the placeholder strings — those are user-facing form hints, not deep-links, and should keep mentioning Atlas/factorylm.com explicitly until tenant settings UI lands (Phase 4).
+- **Backwards compat with `wo.atlas_id` column name.** PR #1023 calls it `atlas_id`, not the more generic `external_id`. For now the column stays; the provider layer reads it as the external CMMS ID regardless of provider name. If/when a tenant switches CMMSes, that gets ugly. Track as a follow-up: rename to `external_id` once we have a non-Atlas customer in production.
+
+### Decisions locked 2026-05-06 (Mike)
+
+1. **Button copy:** Dynamic — "Open in {provider.name}" — for every configured provider including Atlas. Generic "Open in CMMS" used only as fallback when provider name is unknown.
+2. **`/conversations` strategy:** Option B — real backend first. Schema link `work_orders.conversation_id`, real endpoints, new detail page. Lives in Phase 2 (~5-7 days).
+3. **Free-tier behavior:** "Connect a CMMS →" CTA on object pages when no provider is configured, routing to `/cmms`. Atlas pre-seeded for every new tenant (one-click activate from `/cmms`); other providers connectable from the same page.
+4. **Phase ordering:** Phase 1 ships standalone. Fix the active 404 bug first; Phase 2 (conversations) follows independently.
+
+---
+
+## 9. Verification plan
+
+- **Migration:** `SELECT provider, base_url FROM tenant_cmms_config;` returns one row per tenant, all `'atlas' / https://cmms.factorylm.com`.
+- **Atlas provider URL match:** `getCMMSDeepLink('mike', 'work_order', 'abc123')` returns `https://cmms.factorylm.com/workorders/abc123`.
+- **Tenant override:** `UPDATE tenant_cmms_config SET provider='maximo', base_url='https://test.maximo.com' WHERE tenant_id='test-maximo';` then verify the same call returns the Maximo URL pattern.
+- **Syncing state:** Create a fresh WO → button immediately shows `syncing` → run sync worker once → reload → button shows `ready` and links correctly.
+- **Existing 404 bug regression:** Click the button on every existing WO in a test tenant — none should land on a 404. Atlas-stale records (no `atlas_id`) should hide the button instead of breaking.
+- **Cross-locale:** Verify all four `messages/*.json` files render correctly.
+- **Deploy:** No regression in `mira-hub` startup logs after deploy. `bun run build` clean. `tsc --noEmit` clean for touched files.
+
+---
+
+## 10. Out of scope (explicit non-bundles)
+
+- mira-bots reply enrichment with deep-links (follow-up issue)
+- Tenant-facing CMMS settings UI (Phase 4)
+- Maximo/Fiix/MaintainX/UpKeep *sync* implementations (Phase 5)
+- Replacing `wo.atlas_id` column name with `external_id` (follow-up after first non-Atlas customer)
+- mira-relay / Ignition tag streaming (different concern, lives in `docker-compose.saas.yml`)

--- a/mira-hub/db/migrations/008_tenant_cmms_config.sql
+++ b/mira-hub/db/migrations/008_tenant_cmms_config.sql
@@ -1,0 +1,91 @@
+-- Migration 008: tenant_cmms_config — per-tenant CMMS provider, base URL,
+-- and deep-link template overrides.
+--
+-- Spec: docs/specs/cmms-deep-link-multi-provider-spec.md §4.1
+--
+-- Why: hub UI surfaces (WO detail, asset detail, conversation thread) need
+-- to deep-link to the tenant's CMMS. Default = Atlas at cmms.factorylm.com,
+-- but enterprise prospects on Maximo/Fiix/MaintainX/UpKeep need per-tenant
+-- routing without a code deploy.
+--
+-- Atlas pre-seeded for every existing tenant so behavior is unchanged.
+-- New tenants get a default row inserted at signup (separate plumbing).
+
+BEGIN;
+
+-- ─── ENUM: cmms_provider ─────────────────────────────────────────────────────
+-- Narrow set on purpose — adding a provider is `ALTER TYPE cmms_provider ADD
+-- VALUE 'newprovider'` in a future migration, same pattern as sourcetype.
+DO $$ BEGIN
+  CREATE TYPE cmms_provider AS ENUM ('atlas', 'maximo', 'fiix', 'maintainx', 'upkeep');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- ─── tenant_cmms_config table ────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS tenant_cmms_config (
+  tenant_id           TEXT PRIMARY KEY,
+  provider            cmms_provider NOT NULL DEFAULT 'atlas',
+  base_url            TEXT NOT NULL DEFAULT 'https://cmms.factorylm.com',
+  -- Override default URL templates per tenant. JSONB shape (all keys optional):
+  --   { "work_order": "/wo/{external_id}", "asset": "/asset/{external_id}", "pm": "..." }
+  -- When empty, the provider class's default templates are used.
+  link_templates      JSONB NOT NULL DEFAULT '{}'::jsonb,
+  -- Doppler secret name for API auth (e.g. "ATLAS_TOKEN_ACME"). Never store
+  -- the credential itself here; the worker resolves it via Doppler at runtime.
+  auth_credential_ref TEXT,
+  enabled             BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ─── RLS ─────────────────────────────────────────────────────────────────────
+ALTER TABLE tenant_cmms_config ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_cmms_config ON tenant_cmms_config;
+CREATE POLICY tenant_isolation_cmms_config ON tenant_cmms_config
+  FOR ALL
+  TO factorylm_app
+  USING (tenant_id = current_setting('app.tenant_id', TRUE));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON tenant_cmms_config TO factorylm_app;
+
+-- ─── Seed: Atlas default for every existing tenant ───────────────────────────
+-- tenants table seeds via `tenants.tenant_id`; if a tenant is referenced only
+-- in work_orders / cmms_equipment we still want them covered.
+INSERT INTO tenant_cmms_config (tenant_id, provider, base_url)
+SELECT DISTINCT tid, 'atlas'::cmms_provider, 'https://cmms.factorylm.com'
+FROM (
+  SELECT tenant_id AS tid FROM tenants
+  UNION
+  SELECT tenant_id AS tid FROM work_orders
+  UNION
+  SELECT tenant_id AS tid FROM cmms_equipment
+) all_tenants
+WHERE tid IS NOT NULL
+ON CONFLICT (tenant_id) DO NOTHING;
+
+-- ─── updated_at trigger ──────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION touch_tenant_cmms_config_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_tenant_cmms_config_updated_at ON tenant_cmms_config;
+CREATE TRIGGER trg_tenant_cmms_config_updated_at
+  BEFORE UPDATE ON tenant_cmms_config
+  FOR EACH ROW EXECUTE FUNCTION touch_tenant_cmms_config_updated_at();
+
+COMMIT;
+
+-- Verification:
+--   \d+ tenant_cmms_config
+--   SELECT tenant_id, provider, base_url FROM tenant_cmms_config ORDER BY tenant_id;
+--   -- expect one row per tenant, all 'atlas' / https://cmms.factorylm.com
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS tenant_cmms_config;
+--   DROP TYPE  IF EXISTS cmms_provider;
+--   DROP FUNCTION IF EXISTS touch_tenant_cmms_config_updated_at();

--- a/mira-hub/src/app/(hub)/workorders/[id]/page.tsx
+++ b/mira-hub/src/app/(hub)/workorders/[id]/page.tsx
@@ -6,11 +6,12 @@ import Link from "next/link";
 import {
   ArrowLeft, Play, Square, Bot, Package, MessageSquare,
   Clock, User, Calendar, Wrench, CheckCircle2, AlertCircle,
-  AlertTriangle, ChevronRight, Plus, Camera, ExternalLink,
+  AlertTriangle, ChevronRight, Plus, Camera,
   Sparkles, BookOpen, ShieldAlert, Loader2,
 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { OpenInCMMSButton } from "@/components/cmms/open-in-cmms-button";
 import { PARTS } from "@/lib/parts-data";
 import { useToast } from "@/providers/toast-provider";
 import { API_BASE } from "@/lib/config";
@@ -239,13 +240,12 @@ export default function WorkOrderDetailPage({ params }: { params: Promise<{ id: 
               <Bot className="w-4 h-4" />{t("viewMira")}
             </Button>
           </a>
-          {wo.atlas_id ? (
-            <a href={`https://cmms.factorylm.com/workorders/${wo.atlas_id}`} target="_blank" rel="noopener noreferrer">
-              <Button variant="outline" className="h-10 gap-1.5 text-sm px-3">
-                <ExternalLink className="w-4 h-4" />{t("openCmms")}
-              </Button>
-            </a>
-          ) : null}
+          <OpenInCMMSButton
+            kind="work_order"
+            recordId={wo.id}
+            variant="outline"
+            className="h-10 gap-1.5 text-sm px-3"
+          />
         </div>
 
         {/* Auto-PM source citation */}

--- a/mira-hub/src/app/(hub)/workorders/new/page.tsx
+++ b/mira-hub/src/app/(hub)/workorders/new/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { ArrowLeft, ArrowRight, Search, QrCode, Camera, CheckCircle2, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { OpenInCMMSButton } from "@/components/cmms/open-in-cmms-button";
 import { useTranslations } from "next-intl";
 
 type AssetOption = { id: string; name: string; tag: string; location: string };
@@ -131,10 +132,16 @@ export default function NewWorkOrderPage() {
         <p className="text-sm mb-8" style={{ color: "var(--foreground-muted)" }}>
           {selectedAsset?.name} · {priority} priority
         </p>
-        <div className="flex gap-3">
+        <div className="flex gap-3 flex-wrap justify-center">
           <Link href={`/workorders/${createdWO.id}`}>
             <Button>{tCommon("view")}</Button>
           </Link>
+          <OpenInCMMSButton
+            kind="work_order"
+            recordId={createdWO.id}
+            variant="secondary"
+            hideWhenUnconfigured
+          />
           <Link href="/workorders">
             <Button variant="secondary">{t("title")}</Button>
           </Link>

--- a/mira-hub/src/app/api/cmms/deep-link/route.ts
+++ b/mira-hub/src/app/api/cmms/deep-link/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { getCMMSDeepLink } from "@/lib/cmms/deep-link";
+import type { DeepLinkKind } from "@/lib/cmms/provider";
+
+export const dynamic = "force-dynamic";
+
+const VALID_KINDS = new Set<DeepLinkKind>(["work_order", "asset", "pm"]);
+
+/**
+ * GET /api/cmms/deep-link?kind=work_order&id=<uuid>
+ *
+ * Joins `id` against the appropriate table to fetch its `atlas_id` (the
+ * external CMMS ID), then resolves the tenant's provider config to build
+ * the deep-link URL.
+ *
+ * Spec: docs/specs/cmms-deep-link-multi-provider-spec.md §4.4
+ */
+export async function GET(req: NextRequest) {
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { searchParams } = req.nextUrl;
+  const kind = searchParams.get("kind") as DeepLinkKind | null;
+  const id = searchParams.get("id");
+
+  if (!kind || !VALID_KINDS.has(kind)) {
+    return NextResponse.json(
+      { error: "kind must be one of: work_order, asset, pm" },
+      { status: 400 },
+    );
+  }
+  if (!id) {
+    return NextResponse.json({ error: "id is required" }, { status: 400 });
+  }
+
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+
+  try {
+    const externalId = await fetchAtlasId(ctx.tenantId, kind, id);
+    const result = await getCMMSDeepLink(ctx.tenantId, kind, externalId);
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("[api/cmms/deep-link GET]", err);
+    return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
+  }
+}
+
+/**
+ * Map (kind, internal_uuid) → atlas_id by reading the appropriate table.
+ * Returns null when the row is missing or atlas_id is unpopulated (the
+ * sync worker hasn't pushed yet — UI renders "syncing" state).
+ */
+async function fetchAtlasId(
+  tenantId: string,
+  kind: DeepLinkKind,
+  id: string,
+): Promise<string | null> {
+  const table = TABLE_FOR_KIND[kind];
+
+  return withTenantContext<string | null>(tenantId, async (c) => {
+    const result = await c.query<{ atlas_id: string | null }>(
+      `SELECT atlas_id FROM ${table} WHERE id = $1 AND tenant_id = $2 LIMIT 1`,
+      [id, tenantId],
+    );
+    const row = result.rows[0];
+    return row?.atlas_id ?? null;
+  });
+}
+
+// Hardcoded table allowlist — never derived from user input. Adding a new
+// kind requires both an entry here and a column-presence check in the
+// migration history.
+const TABLE_FOR_KIND: Record<DeepLinkKind, string> = {
+  work_order: "work_orders",
+  asset:      "cmms_equipment",
+  pm:         "pm_schedules",
+};

--- a/mira-hub/src/components/cmms/open-in-cmms-button.tsx
+++ b/mira-hub/src/components/cmms/open-in-cmms-button.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ExternalLink, Loader2, Link2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button, type ButtonProps } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+// Deep-link API response shape — must mirror DeepLinkResult in src/lib/cmms/deep-link.ts.
+type ApiResult =
+  | { status: "ready"; url: string; provider: string; providerSlug: string }
+  | { status: "syncing" }
+  | { status: "unconfigured" };
+
+export interface OpenInCMMSButtonProps extends Pick<ButtonProps, "variant" | "size" | "className"> {
+  kind: "work_order" | "asset" | "pm";
+  /** Internal NeonDB UUID. The endpoint joins this to fetch the external CMMS ID. */
+  recordId: string;
+  /** When true, suppress the "Connect a CMMS →" CTA and render nothing instead. */
+  hideWhenUnconfigured?: boolean;
+}
+
+/**
+ * Renders one of three states based on the tenant's CMMS config + record sync state:
+ *
+ *   ready        — `<a target="_blank">Open in {provider.name}</a>` (e.g. "Open in Atlas")
+ *   syncing      — disabled `<button>` "Syncing to CMMS…"
+ *   unconfigured — `<Link href="/cmms">Connect a CMMS →</Link>` (or hidden if hideWhenUnconfigured)
+ *
+ * Spec: docs/specs/cmms-deep-link-multi-provider-spec.md §4.5
+ */
+export function OpenInCMMSButton({
+  kind,
+  recordId,
+  variant = "outline",
+  size = "default",
+  className,
+  hideWhenUnconfigured = false,
+}: OpenInCMMSButtonProps) {
+  const t = useTranslations("cmmsLink");
+  const [result, setResult] = useState<ApiResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(
+          `/hub/api/cmms/deep-link?kind=${encodeURIComponent(kind)}&id=${encodeURIComponent(recordId)}`,
+        );
+        if (!res.ok) {
+          if (!cancelled) setResult({ status: "unconfigured" });
+          return;
+        }
+        const data = (await res.json()) as ApiResult;
+        if (!cancelled) setResult(data);
+      } catch {
+        if (!cancelled) setResult({ status: "unconfigured" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [kind, recordId]);
+
+  // Loading: render a skeleton button so layout doesn't shift when the
+  // resolved state arrives.
+  if (result === null) {
+    return (
+      <Button variant={variant} size={size} className={cn(className)} disabled>
+        <Loader2 className="w-4 h-4 animate-spin" />
+        {t("loading")}
+      </Button>
+    );
+  }
+
+  if (result.status === "ready") {
+    // Dynamic label: "Open in Atlas", "Open in Maximo", etc. Falls back to
+    // "Open in CMMS" only when provider name is unknown/blank (defensive).
+    const label = result.provider
+      ? t("openIn", { provider: result.provider })
+      : t("openCmms");
+    return (
+      <Button variant={variant} size={size} className={cn(className)} asChild>
+        <a href={result.url} target="_blank" rel="noopener noreferrer">
+          <ExternalLink className="w-4 h-4" />
+          {label}
+        </a>
+      </Button>
+    );
+  }
+
+  if (result.status === "syncing") {
+    return (
+      <Button
+        variant={variant}
+        size={size}
+        className={cn(className)}
+        disabled
+        title={t("syncingTooltip")}
+      >
+        <Loader2 className="w-4 h-4 animate-spin" />
+        {t("syncing")}
+      </Button>
+    );
+  }
+
+  // unconfigured
+  if (hideWhenUnconfigured) return null;
+
+  return (
+    <Button variant={variant} size={size} className={cn(className)} asChild>
+      <Link href="/cmms">
+        <Link2 className="w-4 h-4" />
+        {t("connectCmms")}
+      </Link>
+    </Button>
+  );
+}

--- a/mira-hub/src/lib/cmms/atlas-provider.ts
+++ b/mira-hub/src/lib/cmms/atlas-provider.ts
@@ -1,0 +1,32 @@
+import {
+  applyTemplate,
+  stripTrailingSlash,
+  type BuildDeepLinkArgs,
+  type CMMSProvider,
+  type DeepLinkKind,
+} from "./provider";
+
+// Atlas (FactoryLM Works) — the default CMMS for every tenant.
+//
+// Note: only deep-link building lives here. The actual Atlas REST client
+// (auth, sync) is in src/lib/atlas/client.ts and is wired to the sync worker
+// in scripts/cmms-sync-worker.ts. Provider sync methods will be added when
+// we generalize the sync worker (Phase 5 in the deep-link spec).
+
+export class AtlasProvider implements CMMSProvider {
+  readonly name = "Atlas";
+  readonly slug = "atlas" as const;
+  readonly defaultLinkTemplates: Required<Record<DeepLinkKind, string>> = {
+    work_order: "/workorders/{external_id}",
+    asset:      "/assets/{external_id}",
+    pm:         "/pm/{external_id}",
+  };
+
+  buildDeepLink(args: BuildDeepLinkArgs): string {
+    const { kind, externalId, baseUrl, overrideTemplates } = args;
+    const template =
+      overrideTemplates?.[kind] ?? this.defaultLinkTemplates[kind];
+    const path = applyTemplate(template, { externalId });
+    return `${stripTrailingSlash(baseUrl)}${path.startsWith("/") ? path : `/${path}`}`;
+  }
+}

--- a/mira-hub/src/lib/cmms/deep-link.ts
+++ b/mira-hub/src/lib/cmms/deep-link.ts
@@ -1,0 +1,42 @@
+import { getProvider } from "./registry";
+import { getTenantCMMSConfig } from "./tenant-config";
+import type { DeepLinkKind } from "./provider";
+
+// Three terminal states for an "Open in CMMS" surface.
+export type DeepLinkResult =
+  | { status: "ready"; url: string; provider: string; providerSlug: string }
+  | { status: "syncing" }
+  | { status: "unconfigured" };
+
+/**
+ * Resolve the deep-link for a given record.
+ *
+ * - `unconfigured` — tenant has no enabled config row → UI shows "Connect a CMMS →"
+ * - `syncing`      — tenant configured but `externalId` is null (sync hasn't filled it) → disabled "Syncing to CMMS…"
+ * - `ready`        — both present → live link
+ */
+export async function getCMMSDeepLink(
+  tenantId: string,
+  kind: DeepLinkKind,
+  externalId: string | null,
+): Promise<DeepLinkResult> {
+  const config = await getTenantCMMSConfig(tenantId);
+  if (!config) return { status: "unconfigured" };
+
+  if (!externalId) return { status: "syncing" };
+
+  const provider = getProvider(config.provider);
+  const url = provider.buildDeepLink({
+    kind,
+    externalId,
+    baseUrl: config.baseUrl,
+    overrideTemplates: config.linkTemplates,
+  });
+
+  return {
+    status: "ready",
+    url,
+    provider: provider.name,
+    providerSlug: provider.slug,
+  };
+}

--- a/mira-hub/src/lib/cmms/provider.ts
+++ b/mira-hub/src/lib/cmms/provider.ts
@@ -1,0 +1,45 @@
+// CMMS provider abstraction. Each concrete provider knows how to build
+// deep-link URLs for its CMMS. Sync (push to the external system) is an
+// optional method on the same interface — only Atlas implements it today.
+//
+// Spec: docs/specs/cmms-deep-link-multi-provider-spec.md §4.2
+
+export type CMMSProviderSlug = "atlas" | "maximo" | "fiix" | "maintainx" | "upkeep";
+
+export type DeepLinkKind = "work_order" | "asset" | "pm";
+
+export type LinkTemplates = Partial<Record<DeepLinkKind, string>>;
+
+export interface BuildDeepLinkArgs {
+  kind: DeepLinkKind;
+  externalId: string;
+  baseUrl: string;
+  /** Per-tenant override map — wins over provider defaults when a key is set. */
+  overrideTemplates?: LinkTemplates;
+}
+
+export interface CMMSProvider {
+  /** Display name shown in button copy: "Open in {name}". */
+  readonly name: string;
+  /** Stable slug used in DB enum + registry lookup. */
+  readonly slug: CMMSProviderSlug;
+  /** Default URL templates. Tokens supported: {external_id}, {tenant_id}. */
+  readonly defaultLinkTemplates: Required<Record<DeepLinkKind, string>>;
+  /** Pure function — no I/O. Returns the absolute deep-link URL. */
+  buildDeepLink(args: BuildDeepLinkArgs): string;
+}
+
+/** Substitute {external_id} / {tenant_id} tokens in a URL template. */
+export function applyTemplate(
+  template: string,
+  vars: { externalId: string; tenantId?: string },
+): string {
+  return template
+    .replace(/\{external_id\}/g, encodeURIComponent(vars.externalId))
+    .replace(/\{tenant_id\}/g, encodeURIComponent(vars.tenantId ?? ""));
+}
+
+/** Strip a single trailing slash from a URL. */
+export function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, "");
+}

--- a/mira-hub/src/lib/cmms/registry.ts
+++ b/mira-hub/src/lib/cmms/registry.ts
@@ -1,0 +1,25 @@
+import { AtlasProvider } from "./atlas-provider";
+import type { CMMSProvider, CMMSProviderSlug } from "./provider";
+
+// Provider registry. Phase 1 ships Atlas only; Phase 3 adds Maximo, Fiix,
+// MaintainX, UpKeep deep-link stubs.
+//
+// Every slug in this registry must also be a value in the `cmms_provider`
+// Postgres enum (migration 008). When adding a new provider, ship the
+// registry entry and `ALTER TYPE cmms_provider ADD VALUE` in the same PR.
+
+const ATLAS = new AtlasProvider();
+
+const PROVIDERS: Partial<Record<CMMSProviderSlug, CMMSProvider>> = {
+  atlas: ATLAS,
+};
+
+/** Returns the configured provider, or Atlas as a safe fallback. */
+export function getProvider(slug: CMMSProviderSlug | string): CMMSProvider {
+  return PROVIDERS[slug as CMMSProviderSlug] ?? ATLAS;
+}
+
+/** Whether a slug has a registered implementation. False for unimplemented enum values. */
+export function hasProvider(slug: string): slug is CMMSProviderSlug {
+  return slug in PROVIDERS;
+}

--- a/mira-hub/src/lib/cmms/tenant-config.ts
+++ b/mira-hub/src/lib/cmms/tenant-config.ts
@@ -1,0 +1,71 @@
+import { withTenantContext } from "@/lib/tenant-context";
+import type { LinkTemplates } from "./provider";
+
+// Per-tenant CMMS config row from `tenant_cmms_config` (migration 008).
+export interface TenantCMMSConfig {
+  tenantId: string;
+  provider: string;
+  baseUrl: string;
+  linkTemplates: LinkTemplates;
+  enabled: boolean;
+}
+
+interface ConfigRow {
+  tenant_id: string;
+  provider: string;
+  base_url: string;
+  link_templates: unknown;
+  enabled: boolean;
+}
+
+/**
+ * Fetch the tenant's CMMS config. Returns `null` when no row exists or the
+ * row is disabled — UI should render the "Connect a CMMS →" CTA in that case.
+ *
+ * Reads under `withTenantContext`, so RLS on `tenant_cmms_config` is enforced
+ * (a tenant can never read another's config).
+ */
+export async function getTenantCMMSConfig(
+  tenantId: string,
+): Promise<TenantCMMSConfig | null> {
+  if (!process.env.NEON_DATABASE_URL) return null;
+
+  try {
+    return await withTenantContext<TenantCMMSConfig | null>(
+      tenantId,
+      async (c) => {
+        const result = await c.query<ConfigRow>(
+          `SELECT tenant_id, provider, base_url, link_templates, enabled
+           FROM tenant_cmms_config
+           WHERE tenant_id = $1
+           LIMIT 1`,
+          [tenantId],
+        );
+        const row = result.rows[0];
+        if (!row || !row.enabled) return null;
+
+        const templates =
+          row.link_templates && typeof row.link_templates === "object"
+            ? (row.link_templates as LinkTemplates)
+            : {};
+
+        return {
+          tenantId: row.tenant_id,
+          provider: row.provider,
+          baseUrl: row.base_url,
+          linkTemplates: templates,
+          enabled: row.enabled,
+        };
+      },
+    );
+  } catch (err) {
+    // If the table is missing (migration 008 not yet applied) or any other
+    // DB error fires, degrade gracefully: caller treats null as unconfigured.
+    const msg = String(err);
+    if (msg.includes("tenant_cmms_config") && msg.includes("does not exist")) {
+      return null;
+    }
+    console.error("[cmms/tenant-config]", err);
+    return null;
+  }
+}

--- a/mira-hub/src/messages/en.json
+++ b/mira-hub/src/messages/en.json
@@ -691,5 +691,13 @@
       "activeTechs": "Active Techs",
       "avgPerDay": "Avg / Day"
     }
+  },
+  "cmmsLink": {
+    "loading": "Loading…",
+    "openCmms": "Open in CMMS",
+    "openIn": "Open in {provider}",
+    "syncing": "Syncing to CMMS…",
+    "syncingTooltip": "This work order is being pushed to your CMMS — typically <60s",
+    "connectCmms": "Connect a CMMS →"
   }
 }

--- a/mira-hub/src/messages/es.json
+++ b/mira-hub/src/messages/es.json
@@ -706,5 +706,13 @@
       "activeTechs": "Técnicos activos",
       "avgPerDay": "Promedio / día"
     }
+  },
+  "cmmsLink": {
+    "loading": "Cargando…",
+    "openCmms": "Abrir en CMMS",
+    "openIn": "Abrir en {provider}",
+    "syncing": "Sincronizando con CMMS…",
+    "syncingTooltip": "Esta orden de trabajo se está enviando a tu CMMS — normalmente <60s",
+    "connectCmms": "Conectar un CMMS →"
   }
 }

--- a/mira-hub/src/messages/hi.json
+++ b/mira-hub/src/messages/hi.json
@@ -706,5 +706,13 @@
       "activeTechs": "सक्रिय तकनीशियन",
       "avgPerDay": "औसत / दिन"
     }
+  },
+  "cmmsLink": {
+    "loading": "लोड हो रहा है…",
+    "openCmms": "CMMS में खोलें",
+    "openIn": "{provider} में खोलें",
+    "syncing": "CMMS के साथ सिंक हो रहा है…",
+    "syncingTooltip": "यह वर्क ऑर्डर आपके CMMS को भेजा जा रहा है — आमतौर पर <60 सेकंड",
+    "connectCmms": "CMMS कनेक्ट करें →"
   }
 }

--- a/mira-hub/src/messages/zh.json
+++ b/mira-hub/src/messages/zh.json
@@ -706,5 +706,13 @@
       "activeTechs": "活跃技术员",
       "avgPerDay": "日均操作"
     }
+  },
+  "cmmsLink": {
+    "loading": "加载中…",
+    "openCmms": "在CMMS中打开",
+    "openIn": "在 {provider} 中打开",
+    "syncing": "正在同步到CMMS…",
+    "syncingTooltip": "此工单正在推送到您的CMMS — 通常 <60秒",
+    "connectCmms": "连接CMMS →"
   }
 }


### PR DESCRIPTION
## Summary

Phase 1 of the [`cmms-deep-link-multi-provider-spec`](docs/specs/cmms-deep-link-multi-provider-spec.md) (decisions locked with Mike 2026-05-06). Ships the reusable `<OpenInCMMSButton>` component, a tenant-scoped CMMS provider abstraction, and replaces the hardcoded Atlas link on `/workorders/[id]` with the new component.

**Atlas remains the default** — every existing tenant is seeded with an Atlas config row in migration 008, so behaviour is unchanged for current customers. The abstraction unblocks Phases 3-5 (Maximo / Fiix / MaintainX / UpKeep) without forcing a code deploy per customer.

## What's in here

### Migration 008 — tenant_cmms_config
- New ENUM cmms_provider {atlas, maximo, fiix, maintainx, upkeep}
- New table with provider, base_url, link_templates (JSONB override), auth_credential_ref, enabled
- RLS via factorylm_app role + app.tenant_id setting
- Seeds Atlas default for every tenant in tenants ∪ work_orders ∪ cmms_equipment

### Provider layer (mira-hub/src/lib/cmms/)
- provider.ts — CMMSProvider interface + applyTemplate helper
- atlas-provider.ts — Atlas implementation
- registry.ts — slug → provider lookup, falls back to Atlas
- tenant-config.ts — getTenantCMMSConfig(tenantId), gracefully degrades to null if migration 008 hasn't run
- deep-link.ts — getCMMSDeepLink() returning ready | syncing | unconfigured

### API endpoint
- GET /api/cmms/deep-link?kind=work_order|asset|pm&id=<uuid> — joins NeonDB for atlas_id, then resolves via provider layer. Tenant-scoped via sessionOr401 + withTenantContext.

### <OpenInCMMSButton> component
- kind + recordId props, plus standard Button variant/size/className
- Three render states (ready / syncing / unconfigured) per locked spec answers
- Dynamic label \"Open in {provider.name}\" with generic \"Open in CMMS\" fallback
- Optional hideWhenUnconfigured prop for surfaces where the CTA would be noise

### UI wires
- mira-hub/src/app/(hub)/workorders/[id]/page.tsx — replaces inline hardcoded cmms.factorylm.com link
- mira-hub/src/app/(hub)/workorders/new/page.tsx — adds button to success splash
- messages/{en,es,hi,zh}.json — new cmmsLink namespace, all four locales translated

## Out of scope (explicit)

- /assets/[id] — has no existing CMMS link; picked up alongside the CRA-20 asset scan-button work
- /cmms page redesign — landing page CTA intentionally untouched (full guided-connector setup is Phase 3)
- Real /conversations backend + button — Phase 2 (Option B per spec, ~5-7 days)
- Maximo / Fiix / MaintainX / UpKeep deep-link stubs — Phase 3
- Sync engineering for non-Atlas providers — Phase 5

## Test plan

- [x] bunx tsc --noEmit clean (one unrelated pre-existing test-file error)
- [x] bun run build clean — /api/cmms/deep-link route registered
- [x] bunx eslint --quiet clean for all new + modified files
- [ ] Smoke + lint pass on this PR (CI gate)
- [ ] **Manual: run migration 008** before merging — see runbook below
- [ ] Post-merge: deploy-vps.yml builds and mira-hub health check returns 200
- [ ] **Manual: app.factorylm.com → /workorders/<existing WO with atlas_id>** → button reads \"Open in Atlas\" → click → lands on real cmms.factorylm.com record (not 404)
- [ ] **Manual: app.factorylm.com → /workorders/<fresh WO, atlas_id null>** → button reads \"Syncing to CMMS…\" disabled → after sync worker pushes, button reads \"Open in Atlas\"

## Migration runbook (run BEFORE merge)

psql is not installed on the build host, so use the pg Node client (same pattern as the 2026-05-06 sourcetype hotfix):

\`\`\`bash
doppler run --project factorylm --config prd -- node -e \"\$(cat <<'JS'
const { Client } = require('pg');
const fs = require('fs');
const sql = fs.readFileSync('mira-hub/db/migrations/008_tenant_cmms_config.sql','utf8');
const c = new Client({ connectionString: process.env.NEON_DATABASE_URL });
c.connect().then(()=>c.query(sql)).then(()=>console.log('ok')).catch(e=>{console.error(e);process.exit(1)}).finally(()=>c.end());
JS
)\"
\`\`\`

Verify:
\`\`\`sql
SELECT tenant_id, provider, base_url FROM tenant_cmms_config ORDER BY tenant_id;
-- expect one row per tenant, all 'atlas' / https://cmms.factorylm.com
\`\`\`

## Spec

- [docs/specs/cmms-deep-link-multi-provider-spec.md](docs/specs/cmms-deep-link-multi-provider-spec.md) — full Phase 1-5 plan, decisions locked 2026-05-06.

## Follow-ups (issue list, not in this PR)

- Phase 2: real /api/conversations backend + detail page + work_orders.conversation_id (5-7 days)
- Phase 3: provider stubs + /cmms connector setup UI (~3 days total)
- Surface improvement: mira-hub/src/app/api/work-orders/route.ts:226-227 catch block masks Postgres errors as generic 500 — add err.code/err.detail surfacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)