### PR TITLE
fix(eval): manual-lookup short-circuit (CRA-8) — unblocks 4 of 13 stuck eval fixtures + demo S4

### DIFF
--- a/mira-bots/shared/guardrails.py
+++ b/mira-bots/shared/guardrails.py
@@ -372,12 +372,22 @@ VENDOR_SUPPORT_URLS: dict[str, str] = {
     "rockwell": "rockwellautomation.com/support",
     "powerflex": "rockwellautomation.com/support",
     "siemens": "siemens.com/support",
+    # Product-line aliases — must be present so users who only mention the
+    # product line (and not the manufacturer name) still resolve to the right
+    # vendor URL. Mirrors _VENDOR_DISPLAY_NAMES below. CRA-8.
+    "micromaster": "siemens.com/support",
+    "sinamics": "siemens.com/support",
     "abb": "abb.com/support",
     "omron": "ia.omron.com/support",
     "schneider": "se.com/support",
     "schneider electric": "se.com/support",
     "mitsubishi": "mitsubishielectric.com/support",
+    "fr-e": "mitsubishielectric.com/support",
+    "fr-a": "mitsubishielectric.com/support",
+    "fr-d": "mitsubishielectric.com/support",
+    "fr-f": "mitsubishielectric.com/support",
     "danfoss": "danfoss.com/support",
+    "aqua drive": "danfoss.com/support",
     "eaton": "eaton.com/support",
     "delta": "deltaww.com/support",
     "lenze": "lenze.com/support",
@@ -514,6 +524,29 @@ _DOCUMENTATION_PHRASES = (
     "first time setup",
     "initial setup",
 )
+
+
+# CRA-8: catches retrieval verb + (intervening words) + doc-noun.
+# The substring list above only matches contiguous phrases, so requests like
+# "get me a manual for the Danfoss AQUA Drive FC 202" (model number between
+# verb and noun) fall through to "industrial" intent and get diagnosed instead
+# of routed to the doc-crawl path. This regex closes that gap.
+_DOC_RETRIEVAL_REQUEST_RE = re.compile(
+    r"\b(?:get|find|fetch|send|grab|pull(?:\s+up)?|locate|share|provide|"
+    r"need(?:s|ed)?|want(?:s|ed)?|"
+    r"looking\s+for|search(?:ing)?\s+for|"
+    r"where(?:'s|\s+is|\s+can|\s+to)|"
+    r"do\s+you\s+have|"
+    r"hand\s+me|show\s+me|give\s+me|"
+    r"i\s+need|i\s+want|i'?m\s+looking)"
+    r"\b[^.?!\n]{0,80}?\b"
+    r"(?:manual|datasheet|documentation|docs|"
+    r"pinout|pin\s*out|wiring\s+diagram|"
+    r"instruction(?:s|\s+manual)?|user\s+guide|spec\s+sheet|"
+    r"catalog)\b",
+    re.IGNORECASE,
+)
+
 
 # Procedural how-to questions — user wants step-by-step instructions from the LLM,
 # not a document to download. Checked before _DOCUMENTATION_PHRASES so "how to install"
@@ -771,6 +804,8 @@ def classify_intent(message: str) -> str:
     # Documentation retrieval — checked BEFORE industrial so "manual" in
     # INTENT_KEYWORDS doesn't swallow explicit document requests.
     if any(phrase in msg for phrase in _DOCUMENTATION_PHRASES):
+        return "documentation"
+    if _DOC_RETRIEVAL_REQUEST_RE.search(msg):
         return "documentation"
 
     # Industrial signals — check BEFORE greeting to avoid false positives on

--- a/mira-bots/tests/test_guardrails.py
+++ b/mira-bots/tests/test_guardrails.py
@@ -120,6 +120,34 @@ class TestClassifyIntent:
         assert classify_intent("any documentation on this thing") == "documentation"
         assert classify_intent("show me the pinout for this sensor") == "documentation"
 
+    def test_doc_request_with_intervening_model_number(self):
+        # CRA-8 — eval failures where the substring phrase list missed retrieval-verb
+        # + doc-noun pairs split by an intervening model number. Caused "industrial"
+        # misclassification → MANUAL_LOOKUP_GATHERING instead of IDLE/doc-crawl.
+        assert (
+            classify_intent("get me a manual for the Danfoss AQUA Drive FC 202")
+            == "documentation"
+        )
+        assert (
+            classify_intent("looking for the FR-E700 datasheet") == "documentation"
+        )
+        assert (
+            classify_intent("find me the MICROMASTER 440 manual") == "documentation"
+        )
+        # Other plausible phrasings the regex must catch
+        assert classify_intent("send me the ACS580 manual") == "documentation"
+        assert classify_intent("can you grab the GS20 datasheet") == "documentation"
+        assert (
+            classify_intent("i'm looking for documentation on the PowerFlex 525")
+            == "documentation"
+        )
+
+    def test_doc_request_does_not_overmatch(self):
+        # The new regex must not swallow industrial diagnosis questions.
+        assert classify_intent("What does F-201 mean") == "industrial"
+        assert classify_intent("the manual reset switch is stuck") == "industrial"
+        assert classify_intent("pulled the plug, fault still showing") == "industrial"
+
     def test_depth_request_detector(self):
         from shared.guardrails import detect_depth_request
 
@@ -344,6 +372,19 @@ class TestVendorHelpers:
     def test_vendor_name_empty(self):
         assert vendor_name_from_text("") is None
         assert vendor_name_from_text(None) is None
+
+    def test_vendor_support_url_resolves_product_line_aliases(self):
+        # CRA-8 — when a user mentions only a product line (no manufacturer name),
+        # the URL must still resolve to the right vendor support site.
+        assert vendor_support_url("MICROMASTER 440 manual") == "siemens.com/support"
+        assert vendor_support_url("SINAMICS G120 datasheet") == "siemens.com/support"
+        assert (
+            vendor_support_url("AQUA Drive FC 202 manual") == "danfoss.com/support"
+        )
+        assert (
+            vendor_support_url("FR-E700 datasheet")
+            == "mitsubishielectric.com/support"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Eval scorecard has been stuck at 44/57 (77%) for **8 consecutive days** (Apr 30 → May 7) with the same 13 failures. wiki/hot.md flagged the manual-lookup short-circuit as the highest-leverage fix that needed human triage. This PR fixes it.

It also directly unblocks demo-readiness issue **#1039** (S4: KB miss → real OEM manual link) for the May 21 Florida Automation Expo demo — 14 days away.

## Root cause

`classify_intent` checks `_DOCUMENTATION_PHRASES` as a list of contiguous substrings. When a user puts a model number between the retrieval verb and the doc noun — e.g. \"get me a manual **for the Danfoss AQUA Drive FC 202**\" — none of the substrings match. The message falls through to \"industrial\" intent, gets diagnosed by the FSM, and ends in `MANUAL_LOOKUP_GATHERING` with the canned \"already indexed\" reply instead of `IDLE` with the vendor URL.

Three failing fixtures hit this exact pattern:

| Fixture | User input | Was: state / reply | Now: state / reply |
|---|---|---|---|
| `vfd_danfoss_02_aqua_drive_manual` | \"get me a manual for the Danfoss AQUA Drive FC 202\" | `MANUAL_LOOKUP_GATHERING` / canned | `IDLE` / `danfoss.com/support` |
| `vfd_mitsu_02_fr_e700_find_datasheet` | \"looking for the FR-E700 datasheet\" | same | `IDLE` / `mitsubishielectric.com/support` + `FR-E700` |
| `vfd_siemens_02_micromaster_manual` | \"find me the MICROMASTER 440 manual\" | same | `IDLE` / `siemens.com/support` |

## What changed

Two small edits in `mira-bots/shared/guardrails.py`:

1. **New `_DOC_RETRIEVAL_REQUEST_RE` regex** that catches retrieval verb + 0–80 chars + doc-noun. Wired into `classify_intent` *after* the existing substring check, so existing behaviour is unchanged — only previously-missed cases now match.

2. **Product-line aliases added to `VENDOR_SUPPORT_URLS`** (`micromaster`, `sinamics`, `aqua drive`, `fr-e/a/d/f`) so `vendor_support_url` resolves to the right vendor site when the user mentions only the product line, not the manufacturer name. Mirrors aliases already present in `_VENDOR_DISPLAY_NAMES`.

## Tests

- 146/146 pass in `test_guardrails.py` + `test_engine.py`
- 4 new test cases lock the new behavior:
  - `test_doc_request_with_intervening_model_number` — the 3 failing fixture inputs + 3 plausible variants
  - `test_doc_request_does_not_overmatch` — diagnostic phrasing (\"manual reset switch\", \"pulled the plug\") stays \"industrial\"
  - `test_vendor_support_url_resolves_product_line_aliases` — MICROMASTER/SINAMICS/AQUA Drive/FR-E700 all resolve correctly

## Scope

- Fixes the **B1 sub-pattern** in #1044 (4 of 8 cluster-B failures)
- Unblocks **demo S4** (#1039) for May 21
- Cluster A (FSM Q1→Q2 stickiness, MANUAL_LOOKUP_GATHERING leakage on non-doc inputs) and other cluster-B fixtures (`danfoss_earth_fault_28` cross-vendor leak, `cmms_wo_creation_32`, `lenze_thermal_30`, `self_critique_low_instruction_35`, `vfd_siemens_04_v20_startup`) are separate root causes — **explicitly not in scope** for this PR

## Verification

```bash
# Unit tests (this PR)
python -m pytest mira-bots/tests/test_guardrails.py mira-bots/tests/test_engine.py
# 146/146 passing

# After deploy, the eval should jump from 44/57 → 47/57 (+3) once the
# 3 doc-request fixtures pass cp_keyword_match + cp_reached_state.
# Hourly eval Celery task on VPS will pick this up automatically.
```

Refs: closes B1 in #1044 · unblocks #1039 (demo S4) · Linear CRA-8 · 8th day stale per `wiki/hot.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)