### PR TITLE
feat(kg): phase 3 — LLM relationship extractor

### DIFF
--- a/mira-hub/src/lib/knowledge-graph/__tests__/relationship-extractor.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/relationship-extractor.test.ts
@@ -1,0 +1,129 @@
+import { describe, test, expect } from "vitest";
+import {
+  buildExtractorPrompt,
+  parseAndValidate,
+  EXTRACTOR_ALLOWLIST,
+  HIGH_CONFIDENCE_THRESHOLD,
+} from "../relationship-extractor";
+
+describe("buildExtractorPrompt", () => {
+  test("system prompt declares the predicate allowlist", () => {
+    const { system } = buildExtractorPrompt("any text", []);
+    for (const p of EXTRACTOR_ALLOWLIST) expect(system).toContain(p);
+  });
+
+  test("user prompt includes the entity list and conversation", () => {
+    const { user } = buildExtractorPrompt(
+      "VFD-07 tripped due to bearing seizure",
+      [
+        { ref: "VFD-07", type: "equipment" },
+        { ref: "F004", type: "fault_code" },
+      ],
+    );
+    expect(user).toContain("VFD-07 (equipment)");
+    expect(user).toContain("F004 (fault_code)");
+    expect(user).toContain("VFD-07 tripped due to bearing seizure");
+  });
+
+  test("user prompt handles empty entity list cleanly", () => {
+    const { user } = buildExtractorPrompt("hello world", []);
+    expect(user).toContain("(none)");
+  });
+});
+
+describe("parseAndValidate", () => {
+  const known = new Set(["VFD-07", "F004", "BEARING_NDE", "MOTOR_M1"]);
+
+  test("accepts well-formed relationships", () => {
+    const json = JSON.stringify({
+      relationships: [
+        { source: "VFD-07", predicate: "had_fault", target: "F004", confidence: 0.9 },
+        { source: "F004", predicate: "caused_by", target: "BEARING_NDE", confidence: 0.7 },
+      ],
+    });
+    const out = parseAndValidate(json, known);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.predicate).toBe("had_fault");
+    expect(out[1]?.predicate).toBe("caused_by");
+  });
+
+  test("drops relationships referencing unknown entities (hallucination guard)", () => {
+    const json = JSON.stringify({
+      relationships: [
+        { source: "VFD-07", predicate: "caused_by", target: "GHOST_PUMP", confidence: 0.9 },
+        { source: "ALSO_FAKE", predicate: "had_fault", target: "F004", confidence: 0.9 },
+      ],
+    });
+    const out = parseAndValidate(json, known);
+    expect(out).toHaveLength(0);
+  });
+
+  test("drops predicates not in the extractor allowlist", () => {
+    const json = JSON.stringify({
+      relationships: [
+        { source: "VFD-07", predicate: "parent_of", target: "F004", confidence: 0.9 },
+        { source: "VFD-07", predicate: "located_at", target: "F004", confidence: 0.9 },
+        { source: "VFD-07", predicate: "fictional_predicate", target: "F004", confidence: 0.9 },
+      ],
+    });
+    const out = parseAndValidate(json, known);
+    expect(out).toHaveLength(0);
+  });
+
+  test("drops self-loops", () => {
+    const json = JSON.stringify({
+      relationships: [
+        { source: "VFD-07", predicate: "caused_by", target: "VFD-07", confidence: 0.9 },
+      ],
+    });
+    const out = parseAndValidate(json, known);
+    expect(out).toHaveLength(0);
+  });
+
+  test("clamps confidence to [0, 1]", () => {
+    const json = JSON.stringify({
+      relationships: [
+        { source: "VFD-07", predicate: "had_fault", target: "F004", confidence: 1.5 },
+        { source: "F004", predicate: "caused_by", target: "BEARING_NDE", confidence: -0.2 },
+      ],
+    });
+    const out = parseAndValidate(json, known);
+    expect(out).toHaveLength(2);
+    expect(out[0]?.confidence).toBe(1);
+    expect(out[1]?.confidence).toBe(0);
+  });
+
+  test("survives malformed JSON", () => {
+    expect(parseAndValidate("not json", known)).toEqual([]);
+    expect(parseAndValidate("", known)).toEqual([]);
+    expect(parseAndValidate('{"foo":"bar"}', known)).toEqual([]);
+    expect(parseAndValidate('{"relationships":"not an array"}', known)).toEqual([]);
+  });
+
+  test("survives missing fields", () => {
+    const json = JSON.stringify({
+      relationships: [
+        { predicate: "had_fault", target: "F004" },                  // missing source
+        { source: "VFD-07", target: "F004" },                          // missing predicate
+        { source: "VFD-07", predicate: "had_fault" },                  // missing target
+      ],
+    });
+    expect(parseAndValidate(json, known)).toHaveLength(0);
+  });
+
+  test("defaults confidence to 0.5 when missing", () => {
+    const json = JSON.stringify({
+      relationships: [
+        { source: "VFD-07", predicate: "had_fault", target: "F004" },
+      ],
+    });
+    const out = parseAndValidate(json, known);
+    expect(out[0]?.confidence).toBe(0.5);
+  });
+});
+
+describe("HIGH_CONFIDENCE_THRESHOLD", () => {
+  test("matches the spec-locked decision (0.6)", () => {
+    expect(HIGH_CONFIDENCE_THRESHOLD).toBe(0.6);
+  });
+});

--- a/mira-hub/src/lib/knowledge-graph/extractor.ts
+++ b/mira-hub/src/lib/knowledge-graph/extractor.ts
@@ -7,6 +7,7 @@
 
 import pool from "@/lib/db";
 import type { PoolClient } from "pg";
+import { extractRelationships, type EntityRef, type ExtractionStats } from "./relationship-extractor";
 
 // ── Regex patterns ─────────────────────────────────────────────────────────
 
@@ -170,6 +171,17 @@ export interface ExtractionResult {
   actions: number;
   relationships: number;
   triples: number;
+  /** Phase 3: stats from the LLM relationship extractor pass. null if disabled. */
+  llmRelationships: ExtractionStats | null;
+}
+
+export interface ExtractAndStoreOpts {
+  /**
+   * Run Pass 2 (LLM relationship extractor) after the regex pass. Defaults
+   * to true when KG_LLM_EXTRACTOR_DISABLED is unset and any cascade key is
+   * available. Caller can force off (e.g. eval / offline tests).
+   */
+  llmRelationships?: boolean;
 }
 
 export async function extractAndStore(
@@ -177,6 +189,7 @@ export async function extractAndStore(
   assetId: string,
   conversationText: string,
   conversationId: string | null,
+  opts: ExtractAndStoreOpts = {},
 ): Promise<ExtractionResult> {
   const extracted = extractEntitiesFromText(conversationText);
 
@@ -220,12 +233,34 @@ export async function extractAndStore(
     }
   });
 
+  // Pass 2: LLM relationship extractor. Fire-and-forget — failures here must
+  // not break the regex-pass result. Skipped when KG_LLM_EXTRACTOR_DISABLED
+  // is set or when caller passes opts.llmRelationships === false.
+  const runLlm =
+    opts.llmRelationships !== false && process.env.KG_LLM_EXTRACTOR_DISABLED !== "1";
+  let llmStats: ExtractionStats | null = null;
+  if (runLlm) {
+    const refs: EntityRef[] = [
+      { ref: assetId, type: "equipment" },
+      ...extracted.equipment.map((e) => ({ ref: e, type: "equipment_tag" })),
+      ...extracted.faultCodes.map((f) => ({ ref: f, type: "fault_code" })),
+      ...extracted.parts.map((p) => ({ ref: p, type: "part" })),
+    ];
+    try {
+      llmStats = await extractRelationships(tenantId, conversationText, refs, conversationId);
+    } catch (err) {
+      // never break regex-pass results because Pass 2 misbehaved
+      console.warn("[kg-extractor] LLM Pass 2 failed:", err);
+    }
+  }
+
   return {
     equipment: extracted.equipment.length,
     faultCodes: extracted.faultCodes.length,
     parts: extracted.parts.length,
     actions: extracted.actions.length,
-    relationships: relCount,
-    triples: tripleCount,
+    relationships: relCount + (llmStats?.storedRelationships ?? 0),
+    triples: tripleCount + (llmStats?.storedTriples ?? 0),
+    llmRelationships: llmStats,
   };
 }

--- a/mira-hub/src/lib/knowledge-graph/relationship-extractor.ts
+++ b/mira-hub/src/lib/knowledge-graph/relationship-extractor.ts
@@ -1,0 +1,300 @@
+/**
+ * LLM-based relationship extraction (Phase 3 of KG multi-hop spec, #806).
+ *
+ * Pass 1 (existing regex extractor) gives us entities. This module is Pass 2:
+ * given the conversation text + the entity list, ask the LLM cascade to
+ * surface causal / resolution / dependency relationships.
+ *
+ * Hard guards:
+ *  - Predicate must be in the EXTRACTOR_ALLOWLIST (subset of full schema —
+ *    only the predicates the LLM is allowed to emit).
+ *  - Endpoints must reference an entity from the supplied list. Any
+ *    relationship referencing an unknown entity is dropped.
+ *  - confidence < HIGH_CONFIDENCE_THRESHOLD goes to triples log only.
+ *  - confidence >= HIGH_CONFIDENCE_THRESHOLD is also written as a structured
+ *    relationship (kg_relationships).
+ *
+ * Cost: per-conversation, fire-and-forget after the diagnostic conversation
+ * closes (resolved decision §12 #5). Uses the same cascade as chat.
+ */
+
+import pool from "@/lib/db";
+import type { PoolClient } from "pg";
+import { cascadeComplete } from "@/lib/llm/cascade";
+import { isRelationshipType } from "./types";
+
+// Subset of relationship types the LLM is allowed to emit. We deliberately
+// leave hierarchical types (parent_of, has_component) and located_at out —
+// those come from CMMS / hand-authored hierarchy, not free-text inference.
+export const EXTRACTOR_ALLOWLIST = [
+  "caused_by",
+  "resolved_by",
+  "feeds",
+  "requires_part",
+  "triggered_pm",
+  "had_fault",
+] as const;
+
+export type ExtractorPredicate = (typeof EXTRACTOR_ALLOWLIST)[number];
+
+export const HIGH_CONFIDENCE_THRESHOLD = 0.6;
+
+// ── Prompt construction ────────────────────────────────────────────────────
+
+export interface EntityRef {
+  /** Stable external identifier we expect the LLM to echo back, e.g. "VFD-07". */
+  ref: string;
+  /** entity_type (equipment, fault_code, part, ...). */
+  type: string;
+}
+
+export interface RawRelationship {
+  source: string;
+  predicate: string;
+  target: string;
+  confidence?: number;
+}
+
+const SYSTEM_PROMPT = `You extract maintenance relationships from technician conversations.
+Return ONLY a JSON object of the form {"relationships":[{"source":"...","predicate":"...","target":"...","confidence":0.0}]}.
+
+Rules:
+- predicate must be one of: ${EXTRACTOR_ALLOWLIST.join(", ")}
+- source and target MUST be from the provided entity list — do not invent new ones
+- confidence is a number 0.0–1.0 reflecting how clearly the conversation states the relationship
+- if no relationships are present, return {"relationships":[]}
+- never include explanatory text outside the JSON
+- caused_by means: source's failure was caused by target ("X tripped because Y")
+- resolved_by means: source's issue was fixed by target action/part ("replaced bearing — runs now")
+- feeds means: source supplies / drives target ("conveyor 3 feeds packer 1")
+- requires_part means: source needs target as a replacement part
+- triggered_pm means: source fault should bump the PM cadence on target
+- had_fault means: source equipment exhibited the target fault code in this conversation`;
+
+export function buildExtractorPrompt(
+  conversationText: string,
+  entities: EntityRef[],
+): { system: string; user: string } {
+  const entityList = entities.map((e) => `${e.ref} (${e.type})`).join("\n");
+  const user =
+    `Entities present in this conversation:\n${entityList || "(none)"}\n\n` +
+    `Conversation:\n${conversationText}\n\n` +
+    `Return the JSON object now.`;
+  return { system: SYSTEM_PROMPT, user };
+}
+
+// ── Output validation ──────────────────────────────────────────────────────
+
+export interface ValidatedRelationship {
+  source: string;
+  predicate: ExtractorPredicate;
+  target: string;
+  confidence: number;
+}
+
+export function parseAndValidate(
+  rawJson: string,
+  knownRefs: Set<string>,
+): ValidatedRelationship[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawJson);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object" || !("relationships" in parsed)) return [];
+  const list = (parsed as { relationships?: unknown }).relationships;
+  if (!Array.isArray(list)) return [];
+
+  const out: ValidatedRelationship[] = [];
+  for (const item of list) {
+    if (!item || typeof item !== "object") continue;
+    const r = item as Record<string, unknown>;
+    const source = typeof r.source === "string" ? r.source : null;
+    const predicate = typeof r.predicate === "string" ? r.predicate : null;
+    const target = typeof r.target === "string" ? r.target : null;
+    let confidence = typeof r.confidence === "number" ? r.confidence : 0.5;
+    if (!source || !predicate || !target) continue;
+    if (source === target) continue;
+    // Predicate must be in extractor allowlist AND in the global relationship type allowlist
+    if (!(EXTRACTOR_ALLOWLIST as readonly string[]).includes(predicate)) continue;
+    if (!isRelationshipType(predicate)) continue;
+    // Both endpoints must reference known entities — kill hallucinations
+    if (!knownRefs.has(source) || !knownRefs.has(target)) continue;
+    confidence = Math.max(0, Math.min(1, confidence));
+    out.push({ source, predicate: predicate as ExtractorPredicate, target, confidence });
+  }
+  return out;
+}
+
+// ── Storage ────────────────────────────────────────────────────────────────
+
+async function withKgContext<T>(
+  tenantId: string,
+  fn: (client: PoolClient) => Promise<T>,
+): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("SET LOCAL ROLE factorylm_app");
+    await client.query("SELECT set_config('app.tenant_id', $1, true)", [tenantId]);
+    await client.query("SELECT set_config('app.current_tenant_id', $1, true)", [tenantId]);
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+interface KgIdLookup {
+  ref: string;
+  id: string;
+  entity_type: string;
+}
+
+async function lookupKgIds(
+  client: PoolClient,
+  tenantId: string,
+  refs: string[],
+): Promise<Map<string, KgIdLookup>> {
+  if (refs.length === 0) return new Map();
+  const { rows } = await client.query<KgIdLookup>(
+    `SELECT entity_id AS ref, id, entity_type
+       FROM kg_entities
+       WHERE tenant_id = $1 AND entity_id = ANY($2)`,
+    [tenantId, refs],
+  );
+  const map = new Map<string, KgIdLookup>();
+  for (const r of rows) map.set(r.ref, r);
+  return map;
+}
+
+export interface ExtractionStats {
+  emitted: number;
+  validated: number;
+  storedRelationships: number;
+  storedTriples: number;
+  unknownEndpoints: number;
+  llmProvider: string | null;
+  durationMs: number;
+}
+
+/**
+ * Pass 2: run the LLM relationship extractor against a conversation chunk,
+ * validate, and persist. Caller has already run the regex pass and supplies
+ * the resulting entity list (with refs that map to entity_id in kg_entities).
+ *
+ * Caller is responsible for tenancy of the entities — we trust the supplied
+ * list. We refuse to invent entities; relationships that reference unknown
+ * refs are silently dropped.
+ *
+ * Safe to call when no API keys are set — returns stats with zeros.
+ */
+export async function extractRelationships(
+  tenantId: string,
+  conversationText: string,
+  entities: EntityRef[],
+  conversationId: string | null,
+): Promise<ExtractionStats> {
+  const start = Date.now();
+  const knownRefs = new Set(entities.map((e) => e.ref));
+
+  const { system, user } = buildExtractorPrompt(conversationText, entities);
+  const result = await cascadeComplete(
+    [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    { jsonMode: true, temperature: 0.0, maxTokens: 600 },
+  );
+
+  if (!result) {
+    return {
+      emitted: 0,
+      validated: 0,
+      storedRelationships: 0,
+      storedTriples: 0,
+      unknownEndpoints: 0,
+      llmProvider: null,
+      durationMs: Date.now() - start,
+    };
+  }
+
+  const validated = parseAndValidate(result.content, knownRefs);
+  // Re-parse without the knownRefs guard to count hallucinations for telemetry
+  let unknownEndpoints = 0;
+  try {
+    const probe = JSON.parse(result.content) as { relationships?: unknown };
+    if (Array.isArray(probe.relationships)) {
+      for (const item of probe.relationships) {
+        if (!item || typeof item !== "object") continue;
+        const r = item as Record<string, unknown>;
+        const s = typeof r.source === "string" ? r.source : null;
+        const t = typeof r.target === "string" ? r.target : null;
+        if ((s && !knownRefs.has(s)) || (t && !knownRefs.has(t))) unknownEndpoints++;
+      }
+    }
+  } catch {
+    /* already handled by parseAndValidate */
+  }
+
+  let storedRelationships = 0;
+  let storedTriples = 0;
+
+  if (validated.length > 0) {
+    await withKgContext(tenantId, async (client) => {
+      const refs = [...new Set(validated.flatMap((v) => [v.source, v.target]))];
+      const kgIds = await lookupKgIds(client, tenantId, refs);
+
+      for (const v of validated) {
+        const src = kgIds.get(v.source);
+        const tgt = kgIds.get(v.target);
+
+        // Always log a triple for the audit trail
+        await client.query(
+          `INSERT INTO kg_triples_log
+             (tenant_id, conversation_id, subject, predicate, object, confidence, source)
+           VALUES ($1, $2, $3, $4, $5, $6, 'llm_relationship_extraction')`,
+          [tenantId, conversationId, v.source, v.predicate, v.target, v.confidence],
+        );
+        storedTriples++;
+
+        // Promote to structured relationship only above the threshold AND
+        // when both endpoints actually exist in the KG.
+        if (v.confidence >= HIGH_CONFIDENCE_THRESHOLD && src && tgt) {
+          await client.query(
+            `INSERT INTO kg_relationships
+               (tenant_id, source_id, target_id, relationship_type,
+                confidence, source_conversation_id, properties)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)
+             ON CONFLICT DO NOTHING`,
+            [
+              tenantId,
+              src.id,
+              tgt.id,
+              v.predicate,
+              v.confidence,
+              conversationId,
+              JSON.stringify({ extractor: "llm", llm_provider: result.provider }),
+            ],
+          );
+          storedRelationships++;
+        }
+      }
+    });
+  }
+
+  return {
+    emitted: validated.length + unknownEndpoints,
+    validated: validated.length,
+    storedRelationships,
+    storedTriples,
+    unknownEndpoints,
+    llmProvider: result.provider,
+    durationMs: Date.now() - start,
+  };
+}

--- a/mira-hub/src/lib/llm/cascade.ts
+++ b/mira-hub/src/lib/llm/cascade.ts
@@ -1,0 +1,115 @@
+/**
+ * Cascade LLM client (non-streaming) for internal classifiers and extractors.
+ *
+ * Mirrors the Groq → Cerebras → Gemini cascade used by /api/assets/[id]/chat
+ * but returns the full completion as a string. Designed for short structured
+ * outputs (JSON-mode classifications), not long-form chat.
+ *
+ * Cluster law (CLUSTER.md / global memory): no Anthropic, no LangChain,
+ * always cascade.
+ */
+
+interface CascadeProvider {
+  name: string;
+  url: string;
+  key: string | undefined;
+  model: string;
+}
+
+function defaultProviders(): CascadeProvider[] {
+  return [
+    {
+      name: "Groq",
+      url: "https://api.groq.com/openai/v1/chat/completions",
+      key: process.env.GROQ_API_KEY,
+      // 8B preferred for short structured tasks; the 70B used in chat is
+      // overkill for relationship extraction.
+      model: process.env.GROQ_CLASSIFIER_MODEL ?? process.env.GROQ_MODEL ?? "llama-3.1-8b-instant",
+    },
+    {
+      name: "Cerebras",
+      url: "https://api.cerebras.ai/v1/chat/completions",
+      key: process.env.CEREBRAS_API_KEY,
+      model: process.env.CEREBRAS_CLASSIFIER_MODEL ?? process.env.CEREBRAS_MODEL ?? "llama3.1-8b",
+    },
+    {
+      name: "Gemini",
+      url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+      key: process.env.GEMINI_API_KEY,
+      model: process.env.GEMINI_CLASSIFIER_MODEL ?? process.env.GEMINI_MODEL ?? "gemini-2.5-flash",
+    },
+  ];
+}
+
+export interface CascadeMessage {
+  role: "system" | "user" | "assistant";
+  content: string;
+}
+
+export interface CascadeResult {
+  provider: string;
+  content: string;
+  durationMs: number;
+}
+
+export interface CascadeOpts {
+  maxTokens?: number;
+  temperature?: number;
+  jsonMode?: boolean;
+  timeoutMs?: number;
+  providers?: CascadeProvider[];
+}
+
+async function callOne(
+  provider: CascadeProvider,
+  messages: CascadeMessage[],
+  opts: CascadeOpts,
+): Promise<string | null> {
+  if (!provider.key) return null;
+  const body: Record<string, unknown> = {
+    model: provider.model,
+    messages,
+    max_tokens: opts.maxTokens ?? 600,
+    temperature: opts.temperature ?? 0.0,
+    stream: false,
+  };
+  if (opts.jsonMode) body.response_format = { type: "json_object" };
+
+  let res: Response;
+  try {
+    res = await fetch(provider.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${provider.key}`,
+      },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 15_000),
+    });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  let parsed: { choices?: { message?: { content?: string } }[] };
+  try {
+    parsed = (await res.json()) as { choices?: { message?: { content?: string } }[] };
+  } catch {
+    return null;
+  }
+  return parsed.choices?.[0]?.message?.content ?? null;
+}
+
+export async function cascadeComplete(
+  messages: CascadeMessage[],
+  opts: CascadeOpts = {},
+): Promise<CascadeResult | null> {
+  const providers = opts.providers ?? defaultProviders();
+  const start = Date.now();
+  for (const p of providers) {
+    const content = await callOne(p, messages, opts);
+    if (content) {
+      return { provider: p.name, content, durationMs: Date.now() - start };
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- LLM-based relationship extractor over manual chunks
- Cascade-backed (Groq → Cerebras → Gemini)
- Tests: extraction prompt + parser

Phase 3 of KG multi-hop reasoning rollout. Builds on phase 2 (PR #1061).

## Test plan
- [x] Unit tests pass for extractor
- [x] Cascade fallback verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)