### PR TITLE
feat(kg): phase 4 — plan-vs-actual flagging

### DIFF
--- a/mira-hub/src/lib/knowledge-graph/__tests__/plan-vs-actual.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/plan-vs-actual.test.ts
@@ -1,0 +1,133 @@
+import { describe, test, expect } from "vitest";
+import { classifyMismatch, formatPmMismatchLine, type PmMismatch } from "../plan-vs-actual";
+import { formatMaintenanceContext } from "../context-builder";
+import type { MaintenanceContext } from "../traversal";
+
+describe("classifyMismatch", () => {
+  test("returns null below the minimum occurrence floor", () => {
+    expect(classifyMismatch(2, 30, 90)).toBeNull();
+    expect(classifyMismatch(1, 30, 90)).toBeNull();
+  });
+
+  test("returns null when MTBF or interval is missing", () => {
+    expect(classifyMismatch(5, null, 90)).toBeNull();
+    expect(classifyMismatch(5, 30, null)).toBeNull();
+  });
+
+  test("returns null when MTBF or interval is non-positive", () => {
+    expect(classifyMismatch(5, 0, 90)).toBeNull();
+    expect(classifyMismatch(5, 30, 0)).toBeNull();
+    expect(classifyMismatch(5, -1, 90)).toBeNull();
+  });
+
+  test("flags advisory when MTBF * 1.5 < interval but MTBF * 2 ≥ interval", () => {
+    // MTBF=50, interval=90 → 50*1.5=75 < 90 (advisory), 50*2=100 ≥ 90
+    expect(classifyMismatch(5, 50, 90)).toBe("advisory");
+  });
+
+  test("flags warning when MTBF * 2 < interval", () => {
+    // MTBF=30, interval=90 → 30*2=60 < 90 (warning)
+    expect(classifyMismatch(5, 30, 90)).toBe("warning");
+  });
+
+  test("returns null when reality matches or exceeds plan", () => {
+    expect(classifyMismatch(5, 90, 90)).toBeNull();
+    expect(classifyMismatch(5, 120, 90)).toBeNull();
+    // boundary: MTBF * 1.5 ≥ interval → not flagged
+    expect(classifyMismatch(5, 60, 90)).toBeNull();
+  });
+});
+
+describe("formatPmMismatchLine", () => {
+  const baseMismatch: PmMismatch = {
+    equipmentId: "VFD-07",
+    equipmentName: "PowerFlex 525",
+    faultCode: "F004",
+    occurrences: 5,
+    mtbfDays: 30,
+    pmTask: "bearing inspection",
+    pmIntervalDays: 90,
+    severity: "warning",
+  };
+
+  test("renders WARNING line with all key fields", () => {
+    const line = formatPmMismatchLine(baseMismatch);
+    expect(line).toContain("WARNING");
+    expect(line).toContain("F004");
+    expect(line).toContain("VFD-07");
+    expect(line).toContain("30d");
+    expect(line).toContain("5 occurrences");
+    expect(line).toContain("bearing inspection");
+    expect(line).toContain("90d");
+    expect(line).toContain("interval too long");
+  });
+
+  test("renders ADVISORY line for advisory severity", () => {
+    const line = formatPmMismatchLine({ ...baseMismatch, severity: "advisory", mtbfDays: 50 });
+    expect(line).toContain("ADVISORY");
+    expect(line).not.toContain("WARNING");
+  });
+});
+
+describe("formatMaintenanceContext — pmMismatches surface", () => {
+  function makeMc(): MaintenanceContext {
+    return {
+      equipment: {
+        id: "uuid-eq-1", tenantId: "t", entityType: "equipment", entityId: "VFD-07",
+        name: "PowerFlex 525", properties: {}, createdAt: new Date(), updatedAt: new Date(),
+      },
+      hierarchy: { plant: null, area: null, line: null },
+      components: [],
+      recentFaults: [],
+      recentWorkOrders: [],
+      knownParts: [],
+      manuals: [],
+      pmSchedule: [],
+      similarEquipment: [],
+      pmMismatches: [],
+    };
+  }
+
+  test("includes a Plan vs actual line when a mismatch is present", () => {
+    const mc = makeMc();
+    mc.pmMismatches = [
+      {
+        equipmentId: "VFD-07",
+        equipmentName: "PowerFlex 525",
+        faultCode: "F004",
+        occurrences: 4,
+        mtbfDays: 30,
+        pmTask: "bearing inspection",
+        pmIntervalDays: 90,
+        severity: "warning",
+      },
+    ];
+    const out = formatMaintenanceContext(mc);
+    expect(out).toContain("Plan vs actual");
+    expect(out).toContain("WARNING");
+    expect(out).toContain("F004");
+    expect(out).toContain("bearing inspection");
+  });
+
+  test("omits the line when there are no mismatches", () => {
+    const out = formatMaintenanceContext(makeMc());
+    expect(out).not.toContain("Plan vs actual");
+  });
+
+  test("caps mismatch lines at 3 to keep prompts compact", () => {
+    const mc = makeMc();
+    mc.pmMismatches = Array.from({ length: 6 }, (_, i) => ({
+      equipmentId: "VFD-07",
+      equipmentName: "PowerFlex 525",
+      faultCode: `F00${i}`,
+      occurrences: 3,
+      mtbfDays: 20,
+      pmTask: "PM",
+      pmIntervalDays: 90,
+      severity: "warning" as const,
+    }));
+    const out = formatMaintenanceContext(mc);
+    const lines = out.split("\n").filter((l) => l.includes("Plan vs actual"));
+    expect(lines.length).toBe(3);
+  });
+});

--- a/mira-hub/src/lib/knowledge-graph/__tests__/traversal.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/traversal.test.ts
@@ -56,6 +56,7 @@ describe("formatMaintenanceContext", () => {
       manuals: [],
       pmSchedule: [],
       similarEquipment: [],
+      pmMismatches: [],
       ...overrides,
     };
   }

--- a/mira-hub/src/lib/knowledge-graph/context-builder.ts
+++ b/mira-hub/src/lib/knowledge-graph/context-builder.ts
@@ -365,6 +365,18 @@ export function formatMaintenanceContext(mc: MaintenanceContext): string {
     );
   }
 
+  // Phase 4 — plan vs actual mismatches surface inside the equipment block so
+  // the LLM sees them alongside the rest of the structured context.
+  if (mc.pmMismatches.length > 0) {
+    for (const m of mc.pmMismatches.slice(0, 3)) {
+      const tag = m.severity === "warning" ? "WARNING" : "ADVISORY";
+      lines.push(
+        `Plan vs actual [${tag}]: ${m.faultCode} every ~${m.mtbfDays.toFixed(0)}d ` +
+          `(${m.occurrences}x) but PM "${m.pmTask}" runs every ${m.pmIntervalDays}d → interval too long`,
+      );
+    }
+  }
+
   return lines.join("\n");
 }
 

--- a/mira-hub/src/lib/knowledge-graph/plan-vs-actual.ts
+++ b/mira-hub/src/lib/knowledge-graph/plan-vs-actual.ts
@@ -1,0 +1,180 @@
+/**
+ * Plan-vs-actual comparison (Phase 4 of KG multi-hop spec, #806).
+ *
+ * For every equipment that has both PM tasks (the plan) and recorded
+ * had_fault occurrences (the actual), compute MTBF over the lookback window
+ * and flag mismatches where reality is faster than the planned cadence.
+ *
+ * Mismatch rule: MTBF * 1.5 < pm_interval_days
+ *   — i.e. real failures happen ≥50% faster than the PM cycle.
+ *
+ * Noise filter: require ≥3 fault occurrences before flagging (otherwise the
+ * MTBF estimate is too noisy to be actionable).
+ */
+
+import pool from "@/lib/db";
+import type { PoolClient } from "pg";
+
+export interface PmMismatch {
+  equipmentId: string;            // kg entity_id, e.g. "VFD-07"
+  equipmentName: string;
+  faultCode: string;              // entity_id of the fault, e.g. "F004"
+  occurrences: number;            // count in the lookback window
+  mtbfDays: number;               // mean time between failures
+  pmTask: string;                 // name of the conflicting PM task
+  pmIntervalDays: number;
+  severity: "advisory" | "warning";
+}
+
+const MIN_OCCURRENCES = 3;
+const DEFAULT_LOOKBACK_DAYS = 365;
+const WARN_RATIO = 2.0;            // MTBF * 2 < interval → warning (vs advisory)
+
+async function withKgContext<T>(
+  tenantId: string,
+  fn: (client: PoolClient) => Promise<T>,
+): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("SET LOCAL ROLE factorylm_app");
+    await client.query("SELECT set_config('app.tenant_id', $1, true)", [tenantId]);
+    await client.query("SELECT set_config('app.current_tenant_id', $1, true)", [tenantId]);
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export interface FlagPmMismatchesOpts {
+  lookbackDays?: number;
+  /** Limit to a single equipment entity_id. */
+  equipmentEntityId?: string;
+}
+
+interface RawMismatchRow {
+  equipment_id: string;
+  equipment_name: string;
+  fault_code: string;
+  occurrences: string;
+  mtbf_days: string | null;
+  pm_task: string;
+  pm_interval_days: string | null;
+}
+
+/**
+ * Mismatch classification. Pulled out so the test suite can verify the rules
+ * without going to the database.
+ */
+export function classifyMismatch(
+  occurrences: number,
+  mtbfDays: number | null,
+  pmIntervalDays: number | null,
+): PmMismatch["severity"] | null {
+  if (occurrences < MIN_OCCURRENCES) return null;
+  if (mtbfDays == null || pmIntervalDays == null) return null;
+  if (mtbfDays <= 0 || pmIntervalDays <= 0) return null;
+  if (mtbfDays * WARN_RATIO < pmIntervalDays) return "warning";
+  if (mtbfDays * 1.5 < pmIntervalDays) return "advisory";
+  return null;
+}
+
+export async function flagPmMismatches(
+  tenantId: string,
+  opts: FlagPmMismatchesOpts = {},
+): Promise<PmMismatch[]> {
+  const lookback = opts.lookbackDays ?? DEFAULT_LOOKBACK_DAYS;
+
+  return withKgContext(tenantId, async (client) => {
+    // Per (equipment, fault_code) compute occurrences + MTBF in days.
+    // Cross-join with the equipment's PM tasks to expose any conflicting
+    // intervals; classification happens in TS so it stays testable.
+    const { rows } = await client.query<RawMismatchRow>(
+      `WITH faults AS (
+         SELECT
+           eq.id        AS equipment_uuid,
+           eq.entity_id AS equipment_id,
+           eq.name      AS equipment_name,
+           f.entity_id  AS fault_code,
+           COUNT(*)     AS occurrences,
+           CASE WHEN COUNT(*) >= 2
+                THEN EXTRACT(EPOCH FROM (
+                  MAX(COALESCE((r.properties->>'occurred_at')::timestamptz, r.created_at))
+                  - MIN(COALESCE((r.properties->>'occurred_at')::timestamptz, r.created_at))
+                )) / 86400.0 / NULLIF(COUNT(*) - 1, 0)
+                ELSE NULL
+           END AS mtbf_days
+         FROM kg_relationships r
+         JOIN kg_entities eq ON eq.id = r.source_id AND eq.tenant_id = r.tenant_id
+         JOIN kg_entities f  ON f.id  = r.target_id AND f.tenant_id  = r.tenant_id
+         WHERE r.tenant_id = $1
+           AND r.relationship_type = 'had_fault'
+           AND eq.entity_type = 'equipment'
+           AND f.entity_type  = 'fault_code'
+           AND COALESCE((r.properties->>'occurred_at')::timestamptz, r.created_at)
+               > now() - ($2 || ' days')::interval
+           ${opts.equipmentEntityId ? "AND eq.entity_id = $3" : ""}
+         GROUP BY eq.id, eq.entity_id, eq.name, f.entity_id
+       ),
+       pm AS (
+         SELECT
+           r.source_id AS equipment_uuid,
+           p.name      AS pm_task,
+           NULLIF(p.properties->>'interval_days','')::int AS pm_interval_days
+         FROM kg_relationships r
+         JOIN kg_entities p ON p.id = r.target_id AND p.tenant_id = r.tenant_id
+         WHERE r.tenant_id = $1
+           AND r.relationship_type = 'has_pm'
+           AND p.entity_type = 'pm_task'
+       )
+       SELECT
+         f.equipment_id,
+         f.equipment_name,
+         f.fault_code,
+         f.occurrences::text,
+         f.mtbf_days::text,
+         pm.pm_task,
+         pm.pm_interval_days::text
+       FROM faults f
+       JOIN pm ON pm.equipment_uuid = f.equipment_uuid
+       WHERE f.occurrences >= $${opts.equipmentEntityId ? "4" : "3"}`,
+      opts.equipmentEntityId
+        ? [tenantId, lookback, opts.equipmentEntityId, MIN_OCCURRENCES]
+        : [tenantId, lookback, MIN_OCCURRENCES],
+    );
+
+    const out: PmMismatch[] = [];
+    for (const r of rows) {
+      const occurrences = parseInt(r.occurrences, 10);
+      const mtbf = r.mtbf_days != null ? parseFloat(r.mtbf_days) : null;
+      const interval = r.pm_interval_days != null ? parseInt(r.pm_interval_days, 10) : null;
+      const severity = classifyMismatch(occurrences, mtbf, interval);
+      if (!severity) continue;
+      out.push({
+        equipmentId: r.equipment_id,
+        equipmentName: r.equipment_name,
+        faultCode: r.fault_code,
+        occurrences,
+        mtbfDays: mtbf!,
+        pmTask: r.pm_task,
+        pmIntervalDays: interval!,
+        severity,
+      });
+    }
+    return out;
+  });
+}
+
+export function formatPmMismatchLine(m: PmMismatch): string {
+  const tag = m.severity === "warning" ? "WARNING" : "ADVISORY";
+  return (
+    `${tag}: ${m.faultCode} on ${m.equipmentId} every ~${m.mtbfDays.toFixed(0)}d ` +
+    `(${m.occurrences} occurrences) but PM "${m.pmTask}" runs every ${m.pmIntervalDays}d ` +
+    `→ interval too long`
+  );
+}

--- a/mira-hub/src/lib/knowledge-graph/traversal.ts
+++ b/mira-hub/src/lib/knowledge-graph/traversal.ts
@@ -15,6 +15,7 @@
 import pool from "@/lib/db";
 import type { PoolClient } from "pg";
 import type { KGEntity } from "./types";
+import { flagPmMismatches, type PmMismatch } from "./plan-vs-actual";
 
 // ── Shared transaction helper ──────────────────────────────────────────────
 
@@ -310,6 +311,7 @@ export interface MaintenanceContext {
   manuals: KGEntity[];
   pmSchedule: PmScheduleSummary[];
   similarEquipment: KGEntity[];
+  pmMismatches: PmMismatch[];
 }
 
 export interface MaintenanceContextOpts {
@@ -448,6 +450,20 @@ export async function maintenanceContext(
         : Promise.resolve({ rows: [] as EntityRow[] }),
     ]);
 
+    // Phase 4: plan-vs-actual mismatches scoped to this equipment.
+    // Cheap follow-up query — no second transaction needed because we're
+    // already inside withKgContext via the outer caller. We do call into
+    // flagPmMismatches which opens its own context, which is fine
+    // (independent transaction, same RLS settings).
+    let pmMismatches: PmMismatch[] = [];
+    try {
+      pmMismatches = await flagPmMismatches(tenantId, {
+        equipmentEntityId: equipment.entityId,
+      });
+    } catch {
+      pmMismatches = [];
+    }
+
     return {
       equipment,
       hierarchy: {
@@ -474,6 +490,7 @@ export async function maintenanceContext(
         };
       }),
       similarEquipment: similar.rows.map(rowToEntity),
+      pmMismatches,
     };
   });
 }


### PR DESCRIPTION
## Summary
- Plan-vs-actual analysis: compare planned PM steps vs actual diagnostic resolution
- Flagging logic for divergence
- Tests for flagging rules

Phase 4 of KG multi-hop reasoning rollout. Builds on phase 3 (PR #1062).

## Test plan
- [x] Unit tests pass for plan-vs-actual logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)