### PR TITLE
test(bot): fix 5 pre-existing CI failures — closes CRA-85

### DIFF
--- a/mira-bots/tests/test_citation_gate.py
+++ b/mira-bots/tests/test_citation_gate.py
@@ -20,7 +20,10 @@ os.environ.setdefault("OPENWEBUI_BASE_URL", "http://localhost:8080")
 os.environ.setdefault("OPENWEBUI_API_KEY", "")
 os.environ.setdefault("KNOWLEDGE_COLLECTION_ID", "dummy")
 os.environ.setdefault("MIRA_DB_PATH", "/tmp/mira_citation_gate_test.db")
-os.environ.setdefault("MIRA_TENANT_ID", "test-tenant")
+# NOTE: do NOT setdefault MIRA_TENANT_ID at module scope — it pollutes env for
+# every other test in the pytest session (e.g. test_telegram_adapter expects
+# tenant_id to fall back to ""). Tests here that need a tenant should set it
+# locally via monkeypatch.
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 

--- a/mira-bots/tests/test_conversation_continuity.py
+++ b/mira-bots/tests/test_conversation_continuity.py
@@ -6,6 +6,11 @@ Covers: photo batching, session continuation, follow-up detection, deduplication
 import os
 import sys
 
+# Pre-import stdlib `email` BEFORE adding mira-bots/ to sys.path. The repo
+# contains a `mira-bots/email/` adapter directory that would otherwise shadow
+# the stdlib package via httpx → urllib.request → email.
+import email  # noqa: F401
+
 # Minimal env vars needed for shared module imports
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy-token-for-testing")
 os.environ.setdefault("OPENWEBUI_BASE_URL", "http://localhost:8080")
@@ -14,31 +19,41 @@ os.environ.setdefault("KNOWLEDGE_COLLECTION_ID", "dummy-collection")
 os.environ.setdefault("VISION_MODEL", "qwen2.5vl:7b")
 os.environ.setdefault("MIRA_DB_PATH", "/tmp/mira_test.db")
 
-# Allow importing from telegram/ directory
+# Allow importing from telegram/ directory and mira-bots/ root.
+# bot.py imports admin_commands → shared.tenant.invites, which needs
+# `mira-bots/` on sys.path so the `shared` package resolves.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "telegram"))
 
 
 def test_photo_buffer_groups_photos():
-    """PHOTO_BUFFER accumulates multiple photos for same chat_id."""
-    from bot import PHOTO_BUFFER, PHOTO_BUFFER_WINDOW
+    """_BURST_COLLECTOR accumulates multiple photos for same chat_id within
+    the 4-second burst window before they're routed to single/multi handlers.
+
+    The legacy in-memory ``PHOTO_BUFFER`` was replaced by a SQLite-backed
+    ``PhotoBatchQueue`` with a smaller ``_BURST_COLLECTOR`` pre-collector
+    (commit cbde671). This test pins the pre-collector behaviour the original
+    test was verifying.
+    """
+    from bot import _BURST_COLLECTOR
+    from shared.photo_batch_queue import BURST_WINDOW_SECONDS
 
     chat_id = 99991
-    PHOTO_BUFFER[chat_id] = {
+    _BURST_COLLECTOR[chat_id] = {
         "photos": ["b64_photo_1"],
         "raw_bytes_list": [b"bytes1"],
         "caption": "test equipment",
         "update": None,
         "task": None,
     }
-    PHOTO_BUFFER[chat_id]["photos"].append("b64_photo_2")
-    PHOTO_BUFFER[chat_id]["raw_bytes_list"].append(b"bytes2")
+    _BURST_COLLECTOR[chat_id]["photos"].append("b64_photo_2")
+    _BURST_COLLECTOR[chat_id]["raw_bytes_list"].append(b"bytes2")
 
-    assert len(PHOTO_BUFFER[chat_id]["photos"]) == 2
-    assert len(PHOTO_BUFFER[chat_id]["raw_bytes_list"]) == 2
-    assert PHOTO_BUFFER_WINDOW == 4.0
+    assert len(_BURST_COLLECTOR[chat_id]["photos"]) == 2
+    assert len(_BURST_COLLECTOR[chat_id]["raw_bytes_list"]) == 2
+    assert BURST_WINDOW_SECONDS == 4.0
 
-    # Cleanup
-    del PHOTO_BUFFER[chat_id]
+    del _BURST_COLLECTOR[chat_id]
 
 
 def test_non_industrial_continues_session():

--- a/mira-bots/tests/test_telegram_adapter_tenant.py
+++ b/mira-bots/tests/test_telegram_adapter_tenant.py
@@ -8,15 +8,30 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "telegram"))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-sys.modules.pop("chat_adapter", None)  # isolate from other bot adapters
 
 import pytest
-from chat_adapter import TelegramChatAdapter
+
+
+def _fresh_chat_adapter():
+    """Re-import chat_adapter so the patched module is the one whose globals
+    the TelegramChatAdapter class actually closes over.
+
+    Other tests in the suite (test_typing_indicator, test_image_downscale, etc.)
+    pop ``chat_adapter`` from ``sys.modules`` to avoid cross-adapter collisions,
+    which can leave this test's patched module out of sync with the class
+    instance imported at module scope. Re-importing inside each test removes
+    that ordering coupling.
+    """
+    sys.modules.pop("chat_adapter", None)
+    import chat_adapter  # noqa: PLC0415
+
+    return chat_adapter
 
 
 @pytest.mark.asyncio
 async def test_adapter_populates_tenant_id_from_resolver():
-    adapter = TelegramChatAdapter(bot_token="dummy")
+    chat_adapter = _fresh_chat_adapter()
+    adapter = chat_adapter.TelegramChatAdapter(bot_token="dummy")
     raw = {
         "update_id": 1,
         "message": {
@@ -26,15 +41,19 @@ async def test_adapter_populates_tenant_id_from_resolver():
             "text": "hello",
         },
     }
-    with patch("chat_adapter.chat_tenant_resolve", return_value="t_acme"):
+    with patch.object(chat_adapter, "chat_tenant_resolve", return_value="t_acme"):
         evt = await adapter.normalize_incoming(raw)
     assert evt.tenant_id == "t_acme"
     assert evt.external_user_id == "555"
 
 
 @pytest.mark.asyncio
-async def test_adapter_empty_tenant_when_resolver_returns_empty():
-    adapter = TelegramChatAdapter(bot_token="dummy")
+async def test_adapter_empty_tenant_when_resolver_returns_empty(monkeypatch):
+    # Clear MIRA_TENANT_ID so the env-var fallback inside the real resolver
+    # cannot leak a value if the patch itself fails.
+    monkeypatch.delenv("MIRA_TENANT_ID", raising=False)
+    chat_adapter = _fresh_chat_adapter()
+    adapter = chat_adapter.TelegramChatAdapter(bot_token="dummy")
     raw = {
         "update_id": 2,
         "message": {
@@ -44,6 +63,6 @@ async def test_adapter_empty_tenant_when_resolver_returns_empty():
             "text": "stranger",
         },
     }
-    with patch("chat_adapter.chat_tenant_resolve", return_value=""):
+    with patch.object(chat_adapter, "chat_tenant_resolve", return_value=""):
         evt = await adapter.normalize_incoming(raw)
     assert evt.tenant_id == ""

--- a/mira-bots/tests/test_unit2_citations.py
+++ b/mira-bots/tests/test_unit2_citations.py
@@ -33,7 +33,10 @@ os.environ.setdefault("OPENWEBUI_BASE_URL", "http://localhost:8080")
 os.environ.setdefault("OPENWEBUI_API_KEY", "")
 os.environ.setdefault("KNOWLEDGE_COLLECTION_ID", "dummy")
 os.environ.setdefault("MIRA_DB_PATH", "/tmp/mira_unit2_citations_test.db")
-os.environ.setdefault("MIRA_TENANT_ID", "test-tenant")
+# NOTE: do NOT setdefault MIRA_TENANT_ID at module scope — it pollutes env for
+# every other test in the pytest session (e.g. test_telegram_adapter expects
+# tenant_id to fall back to ""). Tests here that need a tenant should set it
+# locally via monkeypatch.
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 


### PR DESCRIPTION
## Summary

Three independent stale-test problems were causing 5 CI failures on every PR. All are local-only test fixes; no production code changes.

## What was broken

| # | Test | Root cause |
|---|---|---|
| 1 | `test_photo_buffer_groups_photos` | Asserted against `PHOTO_BUFFER` global removed in cbde671 (replaced with `_BURST_COLLECTOR` + SQLite-backed `PhotoBatchQueue`). |
| 2 | `test_normalize_incoming_text_message`, `test_normalize_incoming_group_message` | `test_citation_gate.py` and `test_unit2_citations.py` called `os.environ.setdefault("MIRA_TENANT_ID", "test-tenant")` at module scope, leaking into every later test that expected the tenant fallback to be empty. |
| 3 | `test_adapter_populates_tenant_id_from_resolver`, `test_adapter_empty_tenant_when_resolver_returns_empty` | Tests imported `chat_adapter` at module scope but other tests (`test_typing_indicator`, `test_image_downscale`, etc.) pop it from `sys.modules`. By the time these tests ran, the class instance's `__globals__` no longer matched the module `mock.patch` resolved → patch silently no-op'd and real resolver returned the polluted env value. |

## What's in the diff

- **test_conversation_continuity.py**: pin to new `_BURST_COLLECTOR` + `BURST_WINDOW_SECONDS` API. Pre-import stdlib `email` before adding `mira-bots/` to sys.path (the repo's `mira-bots/email/` adapter would otherwise shadow it via `httpx → urllib.request`).
- **test_citation_gate.py + test_unit2_citations.py**: drop the `MIRA_TENANT_ID` setdefault. Neither file needs it at import time.
- **test_telegram_adapter_tenant.py**: re-import `chat_adapter` inside each test via a `_fresh_chat_adapter()` helper, patch via `patch.object()` on the same module instance, and `monkeypatch.delenv("MIRA_TENANT_ID")` for defence in depth.

## Verification

```
$ pytest mira-bots/tests/ \
    --ignore=mira-bots/tests/test_slack_relay.py \
    --ignore=mira-bots/tests/test_email_adapter.py \
    --ignore=mira-bots/tests/test_teams_adapter.py \
    --ignore=mira-bots/tests/test_gchat_adapter.py
================= 614 passed, 8 skipped, 45 warnings in 1.15s ==================
```

Before: `5 failed, 609 passed`.

## Test plan

- [ ] CI "Unit Tests" job goes green on this PR
- [ ] Subsequent merges to main no longer carry these 5 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)