### PR TITLE
fix(crawler): KB ingest folder_watcher + run.sh fixes (P0)

### DIFF
--- a/mira-crawler/run.sh
+++ b/mira-crawler/run.sh
@@ -5,10 +5,23 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# launchd plists set a minimal PATH that omits Homebrew. doppler is at
+# /opt/homebrew/bin on Apple Silicon and /usr/local/bin on Intel, so include
+# both. Without this, launchd restart after reboot fails with "doppler: not
+# found" — the failure mode that left mira-crawler offline silently in the
+# first place.
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+DOPPLER_BIN="$(command -v doppler || true)"
+if [ -z "$DOPPLER_BIN" ]; then
+  echo "$(date -u +%FT%TZ) [run.sh] FATAL: doppler not found on PATH ($PATH)" >&2
+  exit 127
+fi
+
 export CRAWLER_CACHE_DIR="$SCRIPT_DIR/data/cache"
 export DEDUP_DB_PATH="$SCRIPT_DIR/data/crawler_dedup.db"
 export INCOMING_WATCH_DIR="$SCRIPT_DIR/data/incoming"
 export OLLAMA_BASE_URL="http://localhost:11434"
 
-exec /usr/local/bin/doppler run --project factorylm --config prd -- \
+exec "$DOPPLER_BIN" run --project factorylm --config prd -- \
   .venv/bin/python main.py "$@"

--- a/mira-crawler/tests/test_watcher.py
+++ b/mira-crawler/tests/test_watcher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import time
 
 from watcher.folder_watcher import FolderWatcher
@@ -57,3 +58,58 @@ class TestFolderWatcher:
         watch_dir = tmp_path / "nonexistent" / "incoming"
         FolderWatcher(watch_dir=watch_dir, on_file=lambda p: None)
         assert watch_dir.exists()
+
+    def test_processes_existing_files_at_startup(self, tmp_path):
+        """Files already present when start() runs must be processed.
+
+        Regression: 16 PDFs sat in mira-crawler/data/incoming/ for 6 weeks
+        because the launchd-managed watcher only listened for on_created
+        events and never scanned what was already there. Backdate mtime so
+        the test simulates that scenario rather than relying on watchdog's
+        FSEvents quirk of picking up recent creations.
+        """
+        old_a = tmp_path / "preexisting_a.pdf"
+        old_b = tmp_path / "preexisting_b.pdf"
+        old_a.write_bytes(b"%PDF-1.4 a")
+        old_b.write_bytes(b"%PDF-1.4 b")
+        (tmp_path / "ignore_me.csv").write_text("a,b,c")
+
+        # 7 days ago — well beyond any FSEvents replay window
+        backdate = time.time() - 7 * 86400
+        os.utime(old_a, (backdate, backdate))
+        os.utime(old_b, (backdate, backdate))
+
+        received = []
+        watcher = FolderWatcher(
+            watch_dir=tmp_path,
+            on_file=lambda p: received.append(p),
+        )
+        watcher.start()
+        try:
+            time.sleep(0.5)
+            names = sorted(p.name for p in received)
+            assert names == ["preexisting_a.pdf", "preexisting_b.pdf"]
+        finally:
+            watcher.stop()
+
+    def test_existing_scan_does_not_double_process_new_files(self, tmp_path):
+        """A file present at startup AND a file dropped after must each fire once."""
+        old_pdf = tmp_path / "old.pdf"
+        old_pdf.write_bytes(b"%PDF-1.4 old")
+        backdate = time.time() - 7 * 86400
+        os.utime(old_pdf, (backdate, backdate))
+
+        received = []
+        watcher = FolderWatcher(
+            watch_dir=tmp_path,
+            on_file=lambda p: received.append(p.name),
+        )
+        watcher.start()
+        try:
+            time.sleep(0.5)
+            (tmp_path / "new.pdf").write_bytes(b"%PDF-1.4 new")
+            time.sleep(1.0)
+            counts = {n: received.count(n) for n in set(received)}
+            assert counts == {"old.pdf": 1, "new.pdf": 1}
+        finally:
+            watcher.stop()

--- a/mira-crawler/watcher/folder_watcher.py
+++ b/mira-crawler/watcher/folder_watcher.py
@@ -25,20 +25,30 @@ SUPPORTED_EXTENSIONS = {".pdf", ".docx", ".html", ".htm", ".txt", ".md"}
 class _IncomingHandler(FileSystemEventHandler):
     """Handle new files in the watched directory."""
 
-    def __init__(self, on_file: callable) -> None:
+    def __init__(self, on_file: callable, seen: set[str]) -> None:
         super().__init__()
         self.on_file = on_file
+        # Shared with FolderWatcher so the startup scan and the FSEvents
+        # observer don't double-fire on the same path. macOS replays recent
+        # creates when the observer attaches, which would re-trigger ingest
+        # for every file already handled by _scan_existing.
+        self.seen = seen
 
     def on_created(self, event):
         if event.is_directory:
             return
         path = Path(event.src_path)
-        if path.suffix.lower() in SUPPORTED_EXTENSIONS:
-            logger.info("New file detected: %s", path.name)
-            try:
-                self.on_file(path)
-            except Exception as e:
-                logger.error("Error processing %s: %s", path.name, e)
+        if path.suffix.lower() not in SUPPORTED_EXTENSIONS:
+            return
+        key = str(path.resolve())
+        if key in self.seen:
+            return
+        self.seen.add(key)
+        logger.info("New file detected: %s", path.name)
+        try:
+            self.on_file(path)
+        except Exception as e:
+            logger.error("Error processing %s: %s", path.name, e)
 
 
 class FolderWatcher:
@@ -53,12 +63,36 @@ class FolderWatcher:
         self.watch_dir.mkdir(parents=True, exist_ok=True)
         self.on_file = on_file
         self._observer: Observer | None = None
+        self._seen: set[str] = set()
+
+    def _scan_existing(self) -> None:
+        """Process files already present in watch_dir before the observer attaches.
+
+        Without this, files dropped while the watcher was offline are stranded
+        until something modifies them — the bug that left 16 PDFs untouched in
+        data/incoming/ for six weeks.
+        """
+        for path in sorted(self.watch_dir.iterdir()):
+            if not path.is_file():
+                continue
+            if path.suffix.lower() not in SUPPORTED_EXTENSIONS:
+                continue
+            key = str(path.resolve())
+            if key in self._seen:
+                continue
+            self._seen.add(key)
+            logger.info("Existing file at startup: %s", path.name)
+            try:
+                self.on_file(path)
+            except Exception as e:
+                logger.error("Error processing %s: %s", path.name, e)
 
     def start(self) -> None:
         """Start watching (non-blocking — runs in background thread)."""
         if self._observer is not None:
             return
-        handler = _IncomingHandler(on_file=self.on_file)
+        self._scan_existing()
+        handler = _IncomingHandler(on_file=self.on_file, seen=self._seen)
         self._observer = Observer()
         self._observer.schedule(handler, str(self.watch_dir), recursive=False)
         self._observer.start()


### PR DESCRIPTION
## Summary

P0 — KB ingest pipeline was silently dead for ~31 days. Two bugs in mira-crawler:

1. **folder_watcher.py** only handled `on_created` — files dropped while the watcher was offline (or any file pre-dating the last restart) were stranded. Confirmed: 16 PDFs in data/incoming/ untouched since 2026-03-26. Now scans existing files at startup and tracks a per-watcher seen-set so macOS FSEvents replay can't double-fire.

2. **run.sh** hardcoded `/usr/local/bin/doppler` and inherited launchd's minimal PATH. On Apple Silicon Bravo where doppler lives at `/opt/homebrew/bin/doppler`, this silently failed launchd restart after reboot. Now exports the merged PATH and resolves doppler via `command -v` with a clear early error if missing.

This cherry-picks the focused KB fix from BRAVO's `chore/claude-code-v21-and-kb-fixes-2026-05-07` branch (which was 30+ commits behind main and would have deleted ~32k lines of merged work — KG multi-hop phases 1-5, mira-mcp dockerfile, demo readiness, etc.). The v2.1 settings/docs portion was dropped to keep scope tight.

## Test plan
- [x] 6 watcher tests pass locally (BRAVO verified)
- [x] ruff clean
- [ ] After merge: redeploy crawler on VPS, verify 16 stranded PDFs get picked up
- [ ] After merge: trace full ingest pipeline end-to-end on VPS

## Backlog this unblocks
- 16 stranded PDFs in mira-crawler/data/incoming/ (process on next restart)
- 263 manual_cache rows pending ingest_manuals.py (separate drain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>