### PR TITLE
feat(kb): KB ingest hardening — spec + observability + fallbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,27 @@ jobs:
           # the other. Requires renaming one module to fix properly (tracked in
           # known-issues.md). Run locally with: pytest mira-bots/tests/test_email_adapter.py
 
+  kb-ingest-tests:
+    # Spec gate: docs/specs/kb-ingest-hardening-spec.md §12.3
+    # Runs on every PR that touches the ingest pipeline or its consumers.
+    name: KB Ingest Hardening Tests
+    runs-on: ubuntu-latest
+    needs: lint-and-type-check
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install minimal deps
+        # Pure-Python tests — no live Ollama / Docling / NeonDB.
+        # httpx + pyyaml are imported by kb_growth_cron at module load.
+        run: pip install pytest httpx pyyaml psycopg2-binary
+
+      - name: Run KB ingest hardening tests
+        run: pytest mira-crawler/tests/test_kb_ingest_hardening.py -v
+
   architecture-check:
     name: Architecture Check
     runs-on: ubuntu-latest

--- a/docs/migrations/006_pipeline_runs.sql
+++ b/docs/migrations/006_pipeline_runs.sql
@@ -1,0 +1,46 @@
+-- Migration 006: pipeline_runs
+-- Tracks every KB ingest pipeline invocation (kb_growth_cron, full_ingest_pipeline,
+-- and any future Celery-driven runs). One row per run; observability + alerting
+-- read from this table.
+--
+-- Spec: docs/specs/kb-ingest-hardening-spec.md §4.2
+-- Idempotent: safe to re-run.
+
+CREATE TABLE IF NOT EXISTS pipeline_runs (
+    id                UUID PRIMARY KEY,
+    tenant_id         TEXT NOT NULL DEFAULT 'mike',
+    pdf_url           TEXT NOT NULL,
+    manufacturer      TEXT,
+    model             TEXT,
+    doc_type          TEXT,
+    status            TEXT NOT NULL,             -- pending|running|ok|failed|partial
+    step_failed       TEXT,                      -- download|extract|chunk|embed|store|preflight|NULL
+    chunks_created    INTEGER NOT NULL DEFAULT 0,
+    bytes_downloaded  BIGINT,
+    error             TEXT,                      -- last error, truncated to 500 chars at write
+    started_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at      TIMESTAMPTZ,
+    duration_ms       INTEGER,
+    pipeline_version  TEXT NOT NULL,             -- git sha of pipeline at run time
+    metadata          JSONB DEFAULT '{}'::jsonb  -- step timings, retry counts, etc.
+);
+
+-- status + recency for the /api/kb/stats endpoint (latest runs first)
+CREATE INDEX IF NOT EXISTS pipeline_runs_status_idx
+    ON pipeline_runs (status, started_at DESC);
+
+-- tenant scoping
+CREATE INDEX IF NOT EXISTS pipeline_runs_tenant_idx
+    ON pipeline_runs (tenant_id, started_at DESC);
+
+-- Failure clustering ("which hosts are dying?")
+CREATE INDEX IF NOT EXISTS pipeline_runs_failed_idx
+    ON pipeline_runs (status, started_at DESC)
+    WHERE status IN ('failed', 'partial');
+
+COMMENT ON TABLE pipeline_runs IS
+    'KB ingest pipeline run history — see docs/specs/kb-ingest-hardening-spec.md';
+COMMENT ON COLUMN pipeline_runs.status IS
+    'pending=queued, running=in-flight, ok=success, failed=hard failure, partial=text extracted but embed/store deferred';
+COMMENT ON COLUMN pipeline_runs.pipeline_version IS
+    'Git SHA of the pipeline code at run time. Used to invalidate stale cache + correlate regressions.';

--- a/docs/runbooks/kb-ingest-ops.md
+++ b/docs/runbooks/kb-ingest-ops.md
@@ -1,0 +1,135 @@
+# KB Ingest Pipeline — Ops Runbook
+
+Companion to `docs/specs/kb-ingest-hardening-spec.md`. This is the playbook
+for the on-call human dealing with the cron when something goes sideways.
+
+---
+
+## 1. Doppler `OLLAMA_BASE_URL` rotation (KB-INGEST-8)
+
+The current value points at a node that does not exist (`100.72.2.99`).
+The correct value is Bravo on Tailscale (`100.86.236.11`).
+
+**Symptom that triggered this fix:** kb_growth_cron logs were silent on
+embed errors because `full_ingest_pipeline.py` swallows them. KB row count
+on Charlie was tracking +3–4 k/day from the Celery worker, but the cron's
+contribution was 0.
+
+**Apply (Mike — needs Doppler write access):**
+
+```bash
+# 1. Rotate the secret
+doppler secrets set OLLAMA_BASE_URL=http://100.86.236.11:11434 \
+  --project factorylm --config prd
+
+# 2. Verify
+doppler secrets get OLLAMA_BASE_URL --project factorylm --config prd --plain
+# expected:  http://100.86.236.11:11434
+
+# 3. Sanity-check Bravo is reachable from VPS
+ssh vps 'curl -s http://100.86.236.11:11434/api/tags | head -c 200'
+
+# 4. Restart cron + Celery
+ssh vps 'systemctl restart mira-celery; systemctl restart mira-kb-cron.timer || true'
+```
+
+**Verify:** the next cron tick should print a `preflight ok summary` JSON line
+and a `pipeline_runs` row should land with `status='ok'`. If you see
+`preflight failed` with `OLLAMA_BASE_URL=… unreachable`, rotate again — your
+shell environment was probably cached from the old value.
+
+The cron's preflight will refuse to do work if Ollama is unreachable, so a
+broken value can no longer silently rot the queue.
+
+---
+
+## 2. Apply the `pipeline_runs` migration
+
+NeonDB has a single instance. There is no transactional DDL drama.
+
+```bash
+# from the repo root, with NEON_DATABASE_URL exported
+psql "$NEON_DATABASE_URL" -f docs/migrations/006_pipeline_runs.sql
+# verify
+psql "$NEON_DATABASE_URL" -c "\d pipeline_runs"
+```
+
+Idempotent — safe to re-run.
+
+---
+
+## 3. Watching live ingestion
+
+```bash
+# Tail structured logs on VPS
+ssh vps 'tail -f /var/log/kb_growth.log | jq -c "{ts, step, status, error}"'
+
+# Last 24h of runs from NeonDB
+psql "$NEON_DATABASE_URL" -c "
+  SELECT started_at, status, manufacturer, model, chunks_created, error
+  FROM pipeline_runs
+  WHERE started_at > now() - interval '24 hours'
+  ORDER BY started_at DESC
+  LIMIT 50;"
+
+# Failure cluster (top hosts)
+psql "$NEON_DATABASE_URL" -c "
+  SELECT split_part(regexp_replace(pdf_url,'^https?://',''),'/',1) AS host,
+         COUNT(*) AS fails, MAX(started_at) AS last
+  FROM pipeline_runs
+  WHERE status IN ('failed','partial')
+    AND started_at > now() - interval '7 days'
+  GROUP BY host ORDER BY fails DESC LIMIT 10;"
+```
+
+---
+
+## 4. When the queue is stuck
+
+`pipeline_runs.status = 'running'` rows older than 30 minutes are reaped to
+`failed` automatically by the next cron preflight. If you still see a stuck
+row after one cron cycle:
+
+```bash
+psql "$NEON_DATABASE_URL" -c "
+  UPDATE pipeline_runs
+  SET status='failed', step_failed='manual-reap', completed_at=now()
+  WHERE status='running' AND started_at < now() - interval '1 hour';"
+```
+
+---
+
+## 5. URL allowlist additions
+
+Edit `mira-crawler/config/url_allowlist.yml`, commit, deploy. Subdomain
+matching is automatic — `foo.com` covers `cdn.foo.com`. PRs that try to
+download from non-allowlisted hosts fail at queue time, not at runtime.
+
+---
+
+## 6. Disabling ingest in an emergency
+
+```bash
+doppler secrets set KB_INGEST_ENABLED=false --project factorylm --config prd
+ssh vps 'systemctl restart mira-kb-cron.timer'
+```
+
+The cron will log `cron skipped reason=KB_INGEST_ENABLED=false` and exit 0.
+Nothing else changes — `knowledge_entries` queries still serve the existing
+80 k+ rows.
+
+---
+
+## 7. When Docling is down
+
+The pipeline will fall through to `pdfplumber` → `pypdf`. Quality drops; KB
+keeps growing. The structured log line will read
+`{"step": "extract", "method": "pdfplumber" }`.
+
+If Docling is down for more than a day, consider disabling ingest entirely
+(§6) until it's back — you'd rather pause growth than fill the KB with
+low-quality fallback extractions.
+
+---
+
+*Last updated: 2026-05-07*

--- a/docs/specs/kb-ingest-hardening-spec.md
+++ b/docs/specs/kb-ingest-hardening-spec.md
@@ -1,0 +1,504 @@
+# KB Ingest Hardening — Production Spec
+
+**Status:** Draft → review by 2026-05-10 → lock by 2026-05-12 → ship by 2026-05-18 (demo prep)
+**Owner:** Mike Harper · **Branch:** `claude/xenodochial-murdock-d6e4f9`
+**Supersedes:** ad-hoc behavior in `mira-crawler/cron/kb_growth_cron.py` and `mira-crawler/tasks/full_ingest_pipeline.py`
+
+---
+
+## 0. TL;DR
+
+The MIRA KB ingest pipeline currently exists in two parallel and partially-overlapping systems:
+
+| System | Lives | Writes to | Status |
+| --- | --- | --- | --- |
+| Celery worker | `/opt/master_of_puppets/` (VPS) | `knowledge_entries` (80,789 rows, +3–4 k/day) | Real workload |
+| `kb_growth_cron.py` | this repo, run by VPS crontab | `knowledge_entries` (via `full_ingest_pipeline.py`) | Supplemental |
+| mira-hub UI | this repo (`mira-hub/src/app/api/*`) | reads `kb_chunks` (67 rows, demo stub) | **Wrong table** |
+
+Doppler `OLLAMA_BASE_URL` is set to `100.72.2.99` — there is no node at that address. Bravo (Ollama host) is `100.86.236.11`. Embeddings have been silently failing for an unknown duration; the pipeline's fault-tolerant design hid the failure.
+
+This spec defines the gold-standard the team will hold the pipeline to before MIRA goes in front of customers — across reliability, observability, data quality, security, fault tolerance, performance, monitoring, configuration, testing, and unification.
+
+It is **not aspirational**. Every requirement maps to a concrete gap with an issue, an owner, and a ship date.
+
+---
+
+## 1. Goals + Non-Goals
+
+### 1.1 Goals
+
+1. Single, well-instrumented ingest pipeline that the team can reason about end-to-end.
+2. Every PDF the pipeline touches is auditable: when, where from, how it processed, why it failed.
+3. The KB grows reliably (target: ≥ 100 PDFs/day) without hidden silent failures.
+4. UI surfaces (mira-hub, Telegram heartbeat) read from the same authoritative table.
+5. CI gate prevents regressions in the pipeline contract.
+
+### 1.2 Non-Goals (deferred)
+
+- Replacing Docling with a different extraction stack.
+- Migrating `mira-sidecar` ChromaDB; tracked separately in issue #195.
+- Real-time ingestion (current cadence: hourly cron is sufficient through demo window).
+- Multi-tenant ingest isolation beyond `tenant_id` scoping that already exists.
+- Cost tracking per ingest (nice-to-have, not in MVP critical path).
+
+---
+
+## 2. Architecture (target state)
+
+```
+                 ┌───────────────────────────────┐
+   PDF queue ──▶ │ kb_growth_cron.py             │
+  (manual_       │  · validates URL allowlist    │
+   queue.json)   │  · structured JSON logs       │
+                 │  · writes to pipeline_runs    │
+                 └───────────────┬───────────────┘
+                                 │
+                 ┌───────────────▼───────────────┐
+                 │ full_ingest_pipeline.py       │
+                 │  ┌─────────┬───────────────┐  │
+                 │  │ DOWNLOAD │ retry x3 EB  │  │
+                 │  ├─────────┼───────────────┤  │
+                 │  │ EXTRACT  │ Docling       │  │
+                 │  │          │  → fallback:  │  │
+                 │  │          │    pypdf/     │  │
+                 │  │          │    pdfplumber │  │
+                 │  ├─────────┼───────────────┤  │
+                 │  │ CHUNK    │ validate len  │  │
+                 │  ├─────────┼───────────────┤  │
+                 │  │ EMBED    │ batch x10     │  │
+                 │  │          │ Ollama Bravo  │  │
+                 │  ├─────────┼───────────────┤  │
+                 │  │ STORE    │ knowledge_    │  │
+                 │  │          │  entries      │  │
+                 │  ├─────────┼───────────────┤  │
+                 │  │ KG       │ entities +    │  │
+                 │  │          │  relationships│  │
+                 │  └─────────┴───────────────┘  │
+                 └───────────────┬───────────────┘
+                                 │
+                 ┌───────────────▼───────────────┐
+                 │ pipeline_runs (NeonDB)        │ ◀── /api/kb/stats
+                 │  + knowledge_entries          │ ◀── mira-hub UI
+                 │  + kg_entities                │ ◀── heartbeat
+                 │  + kg_relationships           │
+                 └───────────────────────────────┘
+```
+
+Authoritative table: **`knowledge_entries`**. `kb_chunks` is deprecated (see §11).
+
+---
+
+## 3. Reliability — Retry Logic
+
+### 3.1 Step boundaries
+
+The pipeline is decomposed into 5 idempotent steps, each with its own retry envelope:
+
+| Step | What | Idempotent? | Retry policy |
+| --- | --- | --- | --- |
+| 1. DOWNLOAD | HTTP GET PDF → local path | yes (re-download) | 3 retries, exponential backoff `1s, 4s, 16s` |
+| 2. EXTRACT | Docling sync OR fallback | yes | 2 retries on Docling, then drop to fallback |
+| 3. CHUNK | text → chunks (500–2000 chars) | yes (deterministic) | 0 retries (failure = code bug, not transient) |
+| 4. EMBED | Ollama batch embed | yes (per-chunk hash) | 3 retries per batch, exponential backoff |
+| 5. STORE | upsert into `knowledge_entries` | yes (UNIQUE index) | 3 retries on transient PG errors only |
+
+### 3.2 Error classification
+
+```python
+class IngestError(Exception):
+    transient: bool   # 5xx, timeout, connection-reset, PG deadlock
+    permanent: bool   # 404, 403, 4xx, schema mismatch, parse failure
+```
+
+- **Transient** → retry per policy above.
+- **Permanent** → mark step `failed`, write reason to `pipeline_runs`, do not retry.
+- The crawler's URL queue must move 403/404 entries to status `dead` after 1 attempt — they will not become 200 by waiting.
+
+### 3.3 Concrete defaults (no configuration knobs in v1)
+
+```python
+RETRY_MAX = 3
+BACKOFF_BASE_SECONDS = 1
+BACKOFF_FACTOR = 4
+DOWNLOAD_TIMEOUT = 60
+EMBED_BATCH_TIMEOUT = 120
+```
+
+---
+
+## 4. Observability — Metrics + Logging
+
+### 4.1 Structured logging (JSON)
+
+Every pipeline step emits one JSON line to stdout (so `journalctl` / `docker logs` / Promtail can pick it up):
+
+```json
+{
+  "ts": "2026-05-07T18:42:11Z",
+  "run_id": "9f6c0a…",
+  "step": "embed",
+  "pdf_url": "https://cdn.automationdirect.com/…",
+  "manufacturer": "Allen-Bradley",
+  "model": "1606-XLS",
+  "status": "ok",
+  "chunks": 47,
+  "duration_ms": 8412,
+  "error": null
+}
+```
+
+Required fields: `ts`, `run_id`, `step`, `status` (`ok|retry|failed`), `duration_ms`.
+Optional but expected: `pdf_url`, `manufacturer`, `model`, `chunks`, `error`, `bytes`.
+
+### 4.2 `pipeline_runs` table
+
+```sql
+CREATE TABLE pipeline_runs (
+    id              UUID PRIMARY KEY,
+    tenant_id       TEXT NOT NULL DEFAULT 'mike',
+    pdf_url         TEXT NOT NULL,
+    manufacturer    TEXT,
+    model           TEXT,
+    doc_type        TEXT,
+    status          TEXT NOT NULL,          -- pending|running|ok|failed|partial
+    step_failed     TEXT,                   -- which step failed (NULL if ok)
+    chunks_created  INTEGER NOT NULL DEFAULT 0,
+    bytes_downloaded BIGINT,
+    error           TEXT,                   -- last error message, truncated to 500 chars
+    started_at      TIMESTAMP NOT NULL DEFAULT now(),
+    completed_at    TIMESTAMP,
+    duration_ms     INTEGER,
+    pipeline_version TEXT NOT NULL          -- git sha of the pipeline at run time
+);
+
+CREATE INDEX pipeline_runs_status_idx ON pipeline_runs (status, started_at DESC);
+CREATE INDEX pipeline_runs_tenant_idx ON pipeline_runs (tenant_id, started_at DESC);
+```
+
+Every `kb_growth_cron.py` invocation **must** open a row before doing work and update it before exiting (success or failure). No hidden runs.
+
+### 4.3 Stats endpoint
+
+`GET /api/kb/stats` (mira-hub) returns:
+
+```json
+{
+  "total_entries": 80789,
+  "entries_today": 2847,
+  "entries_7d": 19204,
+  "success_rate_7d": 0.94,
+  "queue_depth": 17,
+  "top_failures": [
+    { "url_host": "manualslib.com", "count": 12, "last_error": "403" }
+  ],
+  "last_run_at": "2026-05-07T17:00:01Z",
+  "stale": false
+}
+```
+
+`stale: true` when `last_run_at` is older than 24h. The UI banner pulls from this.
+
+### 4.4 Alerting
+
+Telegram (`kb_growth` agent in `telegram_notify.py`) sends:
+
+| Trigger | Severity | Throttle |
+| --- | --- | --- |
+| Batch failure rate > 50% in last 10 runs | 🔴 critical | 1/hour |
+| No new `pipeline_runs` row in 24h | 🔴 critical | 1/day |
+| Docling health check fails | 🟡 warning | 1/hour |
+| Embedding failures > 30% in a batch | 🟡 warning | 1/hour |
+
+---
+
+## 5. Data Quality — Validation
+
+### 5.1 Chunk constraints
+
+| Rule | Limit | Action on violation |
+| --- | --- | --- |
+| Min length | 50 chars | drop chunk, log `dropped_short` |
+| Max length | 2000 chars | split on paragraph boundary, then sentence |
+| Content hash dedup | sha256(content + manufacturer + model) | skip insert, count `deduped` |
+| Manufacturer present | `metadata.manufacturer` non-null | drop chunk |
+| Embedding dim | 768 (matches `vector(768)` column) | reject, log `embed_dim_mismatch` |
+
+### 5.2 Required metadata
+
+Every row in `knowledge_entries` produced by this pipeline must have:
+
+- `manufacturer` (TEXT, non-null)
+- `model_number` (TEXT, may be `unknown`)
+- `equipment_type` or `chunk_type` (one of: `installation_manual`, `service_manual`, `parts_list`, `troubleshooting_guide`, `general`)
+- `metadata.source_url` (TEXT)
+- `metadata.chunk_index` (INTEGER)
+- `metadata.pipeline_version` (TEXT — git sha, supports cache invalidation)
+- `tenant_id` (`mike` for v1; the multi-tenant story is post-MVP)
+
+### 5.3 Backfill expectations
+
+Existing 80 k rows lack some of the above. **Do not** retroactively rewrite — backfill via tools/`kb_backfill_metadata.py` in a tracked migration job, not in the hot path.
+
+---
+
+## 6. Security — Input Validation
+
+### 6.1 URL allowlist
+
+PDFs may only be fetched from hosts in `mira-crawler/config/url_allowlist.yml`:
+
+```yaml
+oem_domains:
+  - cdn.automationdirect.com
+  - literature.rockwellautomation.com
+  - assets.omron.com
+distributors:
+  - automationdirect.com
+  - galco.com
+public_libraries:
+  - manualslib.com
+  - manualslib.us
+```
+
+Any host not on the list → reject at queue time with `dead`. No surprises.
+
+### 6.2 Content limits
+
+| Rule | Limit | Notes |
+| --- | --- | --- |
+| Max PDF size | 50 MB | larger → split job (v1: defer + alert; v2: auto-split) |
+| Content-Type | `application/pdf` | reject HTML pages dressed as PDFs |
+| Path traversal | strip `..`, `/`, `~` from manufacturer/model when forming local paths | already partially done in `full_ingest_pipeline.py`, formalize |
+| Docling rate limit | max 4 concurrent calls per worker | prevents resource exhaustion |
+
+### 6.3 Secret handling
+
+All config (Doppler `factorylm/prd`):
+
+- `NEON_DATABASE_URL`
+- `OLLAMA_BASE_URL` (the bug — see §10)
+- `DOCLING_URL`
+- `MIRA_TENANT_ID`
+- `TELEGRAM_BOT_TOKEN`
+- `TELEGRAM_CHAT_ID`
+
+Never read from `.env`. Never hardcoded. Never echoed to logs.
+
+---
+
+## 7. Fault Tolerance — Graceful Degradation
+
+| Dependency | Outage behavior |
+| --- | --- |
+| Docling down | Fall through to `pdfplumber` → `pypdf` chain. Quality drops; pipeline does not. Log `extract.method=fallback`. |
+| Ollama down | Persist extracted text to `pipeline_runs.staging_path` (or local file cache), mark run `partial`, retry embed step on next cron. **Do not** drop the work. |
+| NeonDB down | Buffer to `/var/lib/mira/kb_buffer/*.jsonl`, flush on next cron when DB returns. |
+| One PDF in batch fails | Continue; one bad PDF must never abort a batch run. |
+| Pipeline crash mid-run | `pipeline_runs.status='running'` rows older than 30 min get reaped to `failed` by next cron startup sweep. |
+
+The cron's design philosophy: **make forward progress every cycle, even if degraded.**
+
+---
+
+## 8. Performance — Throughput
+
+### 8.1 Targets
+
+| Metric | Target (v1) | Target (post-MVP) |
+| --- | --- | --- |
+| PDFs/day | ≥ 100 | ≥ 500 |
+| Median ingest end-to-end | < 90 s | < 30 s |
+| p95 ingest end-to-end | < 8 min | < 2 min |
+| Concurrent downloads | 3 | 8 |
+| Embed batch size | 10 chunks | 50 chunks |
+
+### 8.2 Concurrency model
+
+`kb_growth_cron.py` is single-process, single-PDF per invocation today. v1 of this spec stays there — the throughput bottleneck is Docling, not the cron. Parallelism is added by **invoking the cron more often**, not by threading inside it. Crontab cadence: every 30 min during business hours, hourly off-hours.
+
+If the queue exceeds 200 pending after 7 days, escalate to multi-worker design (post-MVP).
+
+---
+
+## 9. Monitoring — Alerting (operational)
+
+Heartbeat monitor (existing `mira-crawler/reporting/agent_report.py`) gains a KB section:
+
+```
+KB Growth Engine 📚
+  Total entries:   80,789
+  Today:           +247
+  Last 7d:         +18,940 (94% success)
+  Queue depth:     17 pending
+  Last run:        12 min ago ✅
+```
+
+If the daily `morning_brief` has the KB delta at zero for 2 days running → escalate to 🔴 in heartbeat.
+
+Weekly Telegram Pulse (Sunday 2 AM): KB growth + top contributing OEMs + top failure hosts.
+
+---
+
+## 10. Configuration — Environment
+
+### 10.1 Startup health check
+
+`kb_growth_cron.py` runs preflight checks before any work:
+
+```python
+def preflight() -> bool:
+    checks = [
+        ("ollama", f"{OLLAMA_URL}/api/tags"),
+        ("docling", f"{DOCLING_URL}/health"),
+        ("neon", neon_ping_query),
+    ]
+    # Fail-fast if any returns non-2xx for 5s.
+```
+
+Fail-fast policy: if Ollama is unreachable, exit non-zero, write `pipeline_runs` row with `status=failed, step_failed=preflight`. Do not silently queue.
+
+### 10.2 The Doppler bug
+
+**Current value (broken):** `OLLAMA_BASE_URL=http://100.72.2.99:11434`
+**Correct value:** `OLLAMA_BASE_URL=http://100.86.236.11:11434` (Bravo, Tailscale)
+
+Mike has authorized the fix. Rotation procedure:
+
+```bash
+doppler secrets set OLLAMA_BASE_URL=http://100.86.236.11:11434 \
+  --project factorylm --config prd
+# verify
+doppler secrets get OLLAMA_BASE_URL --project factorylm --config prd --plain
+# restart Celery + cron on VPS
+ssh vps 'systemctl restart mira-celery; systemctl restart mira-kb-cron.timer'
+```
+
+A regression test (§12) protects against re-breakage: cron preflight runs `ollama /api/tags` and fails the run if it returns 404 or connection-refused.
+
+### 10.3 Feature flags
+
+In env (Doppler) — defaults shown:
+
+| Flag | Default | Effect |
+| --- | --- | --- |
+| `KB_INGEST_ENABLED` | `true` | master switch |
+| `KB_INGEST_BATCH_SIZE` | `1` (one PDF per cron run) | tune up only after multi-worker |
+| `KB_INGEST_INTERVAL_MINUTES` | `30` | crontab cadence |
+| `KB_FALLBACK_EXTRACT_ENABLED` | `true` | turn off if pdfplumber output starts polluting KB |
+
+---
+
+## 11. Unification — Single Source of Truth
+
+### 11.1 Decision
+
+`knowledge_entries` is the authoritative table. Everything else reads from it.
+
+`kb_chunks` is **deprecated** as of this spec. It currently has 67 rows (all demo). It will be:
+
+1. Renamed to `kb_chunks_legacy_v1`.
+2. Backed up to NeonDB branch `backup-kb-chunks-2026-05-07` for forensic recovery.
+3. Removed from `mira-hub/src/lib/data-schema.ts` Phase-2 migration list.
+
+### 11.2 mira-hub UI changes
+
+Two endpoints currently reference `kb_chunks`. Both must be updated:
+
+- `mira-hub/src/app/api/usage/route.ts:60` → `SELECT COUNT(*) FROM knowledge_entries WHERE tenant_id = $1`
+- `mira-hub/src/app/api/knowledge/route.ts:22-26` → query `knowledge_entries` and project the same shape
+
+Field mapping:
+
+| `kb_chunks` field | `knowledge_entries` source |
+| --- | --- |
+| `system_category` | `metadata->>'system_category'` (NULL-tolerant) |
+| `subcategory` | `metadata->>'subcategory'` |
+| `manufacturer` | `manufacturer` (column) |
+| `product_family` | `metadata->>'product_family'` |
+| `doc_type` | `chunk_type` |
+| `source` | `metadata->>'source'` |
+| `quality_score` | `metadata->>'quality_score'` (NULL-tolerant; AVG over NULLs returns NULL — handle in code) |
+| `title` | `metadata->>'title'` |
+| `tenant_id` | `tenant_id` (column) |
+
+### 11.3 Authoritative-table contract
+
+A `docs/architecture/kb-tables.md` ADR will state the rule going forward: **any new feature that needs knowledge chunks reads from `knowledge_entries`. PRs that introduce a new chunks table fail review unless the PR description includes a migration plan to consolidate.**
+
+---
+
+## 12. Testing — CI Integration
+
+### 12.1 Unit tests (must exist)
+
+In `mira-crawler/tests/test_ingest_pipeline.py`:
+
+- `test_chunk_validation_min_length` — drops 49-char chunks, keeps 50-char.
+- `test_chunk_validation_max_length` — splits a 5000-char chunk into ≤ 2000-char pieces on paragraph boundaries.
+- `test_dedup_by_content_hash` — second insert of same content does not increment row count.
+- `test_retry_transient_then_succeed` — embed step retries 3× on 503 then commits.
+- `test_retry_permanent_then_dead` — download step on 404 marks `dead` after 1 attempt.
+- `test_fallback_pdfplumber_used_when_docling_down` — mock Docling 503 → pdfplumber path runs.
+- `test_url_allowlist_rejects_unknown_host` — `evil.com` is rejected before download.
+
+### 12.2 Integration test
+
+In `mira-crawler/tests/test_pipeline_e2e.py`, behind `pytest -m integration`:
+
+1. Stages a known small fixture PDF served by `pytest-httpserver`.
+2. Runs `full_ingest_pipeline.py` end to end against a NeonDB test branch.
+3. Asserts: ≥ 1 row in `knowledge_entries`, exactly 1 row in `pipeline_runs.status='ok'`, embedding column non-null.
+
+### 12.3 CI gate
+
+`.github/workflows/ci.yml` adds a `kb-ingest` job that runs §12.1 on every PR touching `mira-crawler/`, `mira-hub/src/app/api/*`, or this spec. Failing tests block merge.
+
+Mocked dependencies — no live Ollama / Docling / Neon hits in unit tests. Integration test runs nightly only (cost discipline).
+
+---
+
+## 13. Migration plan (ship order)
+
+| Step | Owner | Day | Issue |
+| --- | --- | --- | --- |
+| 1. Create `pipeline_runs` table migration | claude | day 1 | KB-INGEST-1 |
+| 2. Fix mira-hub `/api/usage` + `/api/knowledge` to read `knowledge_entries` | claude | day 1 | KB-INGEST-2 |
+| 3. Add `/api/kb/stats` endpoint | claude | day 1 | KB-INGEST-3 |
+| 4. Add structured JSON logging to `kb_growth_cron.py` | claude | day 2 | KB-INGEST-4 |
+| 5. Add Docling fallback path (pdfplumber) | claude | day 2 | KB-INGEST-5 |
+| 6. KB metrics in heartbeat monitor | claude | day 2 | KB-INGEST-6 |
+| 7. Unit tests + CI gate | claude | day 3 | KB-INGEST-7 |
+| 8. **Mike: rotate Doppler `OLLAMA_BASE_URL`** | Mike | day 3 | KB-INGEST-8 |
+| 9. Deploy to VPS, watch heartbeat for 48h | Mike | day 4–5 | KB-INGEST-9 |
+| 10. Demo prep — verify dashboard pulls real numbers | Mike | day 6 | — |
+
+Demo deadline: **2026-05-18**. All P0 issues closed by 2026-05-15 to leave 3 days of soak.
+
+---
+
+## 14. Acceptance criteria (Done = Done)
+
+A future engineer should be able to:
+
+1. Look at `mira-hub/dashboard` and see the same KB total as `SELECT COUNT(*) FROM knowledge_entries`.
+2. Watch a Telegram heartbeat and tell within 1 hour that ingest has stalled.
+3. Run `pytest mira-crawler/tests/` locally and have the suite pass without network.
+4. `git grep kb_chunks` and find only the deprecation notice + backup script.
+5. Submit a PR that breaks the `OLLAMA_BASE_URL` and have CI tell them within 5 min.
+6. Read `docs/specs/kb-ingest-hardening-spec.md` and understand the contract — without spelunking through Celery worker code on a different machine.
+
+If any of those six fail, the spec hasn't shipped.
+
+---
+
+## 15. Open questions / parking lot
+
+- Should the Celery worker on `/opt/master_of_puppets/` be merged into this repo? (Likely yes, post-demo. Keeps two-system split out of MVP scope.)
+- Do we want per-OEM ingest budgets (e.g. cap Allen-Bradley at 30% of KB)? Not now.
+- pgvector HNSW migration (`mira-core/scripts/migrate_to_hnsw.sql`) — separate track.
+- Quality scoring of chunks via LLM — separate track.
+
+---
+
+*Spec version: 1.0 · 2026-05-07 · Mike Harper*

--- a/mira-bots/agents/morning_brief_runner.py
+++ b/mira-bots/agents/morning_brief_runner.py
@@ -67,16 +67,73 @@ def _pm_section() -> str:
 
 
 def _kb_section() -> str:
-    """Read the latest KB growth report if available."""
+    """Live KB metrics from NeonDB (knowledge_entries + pipeline_runs).
+
+    Spec: docs/specs/kb-ingest-hardening-spec.md §9. Falls back to file-based
+    report if DB is unreachable so heartbeat never goes silent.
+    """
+    db_url = os.environ.get("NEON_DATABASE_URL", "")
+    if db_url:
+        try:
+            import psycopg2  # type: ignore
+            with psycopg2.connect(db_url, connect_timeout=5, sslmode="require") as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        SELECT
+                          COUNT(*)                                                          AS total,
+                          COUNT(*) FILTER (WHERE created_at > now() - interval '1 day')    AS today,
+                          COUNT(*) FILTER (WHERE created_at > now() - interval '7 days')   AS week
+                        FROM knowledge_entries
+                        """
+                    )
+                    row = cur.fetchone() or (0, 0, 0)
+                    total, today, week = row
+                    runs_today = runs_ok = runs_failed = 0
+                    last_run_at = None
+                    try:
+                        cur.execute(
+                            """
+                            SELECT
+                              COUNT(*)::int                                                   AS total,
+                              COUNT(*) FILTER (WHERE status = 'ok')::int                      AS ok,
+                              COUNT(*) FILTER (WHERE status IN ('failed','partial'))::int     AS failed,
+                              MAX(started_at)                                                 AS last_run_at
+                            FROM pipeline_runs
+                            WHERE started_at > now() - interval '1 day'
+                            """
+                        )
+                        run_row = cur.fetchone() or (0, 0, 0, None)
+                        runs_today, runs_ok, runs_failed, last_run_at = run_row
+                    except Exception:
+                        pass
+            stale = ""
+            if last_run_at is not None:
+                age = (datetime.now(timezone.utc) - last_run_at).total_seconds() / 3600
+                if age > 24:
+                    stale = " ⚠️ no runs in 24h"
+            success = (
+                f"  · {runs_today} runs today ({runs_ok}✓ / {runs_failed}✗){stale}"
+                if runs_today
+                else f"  · 0 runs today{stale}"
+            )
+            return (
+                f"• Total: *{int(total):,}* chunks\n"
+                f"• Today: *+{int(today):,}* (7d: +{int(week):,})\n"
+                f"{success}"
+            )
+        except Exception as exc:
+            logger.debug("KB DB query failed: %s — using file fallback", exc)
+
+    # File-based fallback (legacy report scraper)
     report_dir = Path("/opt/mira/reports/kb-growth-cron")
     if not report_dir.exists():
-        return "_No KB report available_"
+        return "_No KB metrics available_"
     reports = sorted(report_dir.glob("*.md"), reverse=True)
     if not reports:
-        return "_No KB report available_"
+        return "_No KB metrics available_"
     try:
         text = reports[0].read_text(encoding="utf-8")
-        # Extract first metric line
         for line in text.splitlines():
             if "| Done" in line or "PDFs Ingested" in line:
                 parts = [p.strip() for p in line.split("|") if p.strip()]

--- a/mira-crawler/config/url_allowlist.yml
+++ b/mira-crawler/config/url_allowlist.yml
@@ -1,0 +1,47 @@
+# KB ingest URL allowlist — see docs/specs/kb-ingest-hardening-spec.md §6.1
+#
+# Hosts on this list are eligible for download by kb_growth_cron.py.
+# Subdomain match: 'foo.com' allows 'cdn.foo.com', 'images.foo.com', etc.
+# Add new hosts here, then re-deploy. PRs that bypass the allowlist fail review.
+
+oem_domains:
+  - cdn.automationdirect.com
+  - automationdirect.com
+  - literature.rockwellautomation.com
+  - rockwellautomation.com
+  - assets.omron.com
+  - omron.com
+  - assets.schneider-electric.com
+  - se.com
+  - schneider-electric.com
+  - support.industry.siemens.com
+  - siemens.com
+  - mitsubishielectric.com
+  - support.fanuc.com
+  - fanuc.com
+  - allen-bradley.com
+  - downloads.eaton.com
+  - eaton.com
+  - downloads.banner-engineering.com
+  - bannerengineering.com
+  - downloads.parker.com
+  - parker.com
+  - sick.com
+  - balluff.com
+  - turck.com
+  - ifm.com
+
+distributors:
+  - automationdirect.com
+  - galco.com
+  - mcmaster.com
+  - grainger.com
+  - newark.com
+  - digikey.com
+  - mouser.com
+
+public_libraries:
+  - manualslib.com
+  - manualslib.us
+  - manualzz.com
+  - manualowl.com

--- a/mira-crawler/cron/kb_growth_cron.py
+++ b/mira-crawler/cron/kb_growth_cron.py
@@ -1,10 +1,12 @@
-"""
-KB Growth Cron — runs every 6 hours via crontab.
-Downloads one PDF from the queue, ingests it, logs the result.
-Dumb as an alarm clock. No frameworks. No dependencies beyond what's on the VPS.
+"""KB Growth Cron — runs every 30 min via crontab.
 
+Reads one PDF from manual_queue.json, ingests via full_ingest_pipeline.py,
+records the run in pipeline_runs (NeonDB), emits structured JSON logs.
+
+Spec: docs/specs/kb-ingest-hardening-spec.md
 Crontab entry (VPS):
-  0 */6 * * * cd /opt/mira && doppler run -- python3 mira-crawler/cron/kb_growth_cron.py >> /var/log/kb_growth.log 2>&1
+  */30 * * * * cd /opt/mira && doppler run -- python3 \
+    mira-crawler/cron/kb_growth_cron.py >> /var/log/kb_growth.log 2>&1
 """
 
 from __future__ import annotations
@@ -13,11 +15,26 @@ import json
 import os
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+# pipeline_runs (DB-tracked observability) lives next to this file
+_HERE = Path(__file__).parent.resolve()
+sys.path.insert(0, str(_HERE))
+from pipeline_runs import (  # noqa: E402  (path bootstrap above)
+    open_run,
+    close_run,
+    reap_stuck_runs,
+    PipelineRun,
+)
 
 # Reporting + notifications (optional — degrades gracefully)
-_REPO_ROOT = Path(__file__).parent.parent.parent
+_REPO_ROOT = _HERE.parent.parent
 try:
     from mira_crawler.reporting.agent_report import AgentReport
     from mira_crawler.reporting.telegram_notify import notify as _tg_notify
@@ -33,20 +50,57 @@ except ImportError:
         def _tg_notify(*_: object) -> bool: return False  # type: ignore[misc]
 
 # ─── paths ────────────────────────────────────────────────────────────────────
-_HERE = Path(__file__).parent.resolve()
 _REPO = _HERE.parent.parent
 QUEUE_FILE = _HERE / "manual_queue.json"
 PIPELINE = _REPO / "mira-crawler" / "tasks" / "full_ingest_pipeline.py"
+ALLOWLIST_FILE = _REPO / "mira-crawler" / "config" / "url_allowlist.yml"
 LOG_FILE = Path("/var/log/kb_growth.log")
+
+# ─── config ───────────────────────────────────────────────────────────────────
+OLLAMA_URL = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+DOCLING_URL = os.getenv("DOCLING_URL", "http://localhost:5001")
+PIPELINE_TIMEOUT = int(os.getenv("KB_INGEST_TIMEOUT", "900"))
+INGEST_ENABLED = os.getenv("KB_INGEST_ENABLED", "true").lower() != "false"
+
+
+# ─── structured logging ───────────────────────────────────────────────────────
 
 
 def _ts() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
-def _log(msg: str) -> None:
-    line = f"[{_ts()}] {msg}"
-    print(line, flush=True)
+def jlog(
+    step: str,
+    status: str,
+    *,
+    run: Optional[PipelineRun] = None,
+    duration_ms: Optional[int] = None,
+    error: Optional[str] = None,
+    **fields: Any,
+) -> None:
+    """Emit one structured JSON log line. See spec §4.1."""
+    record: dict[str, Any] = {
+        "ts": _ts(),
+        "step": step,
+        "status": status,
+    }
+    if run is not None:
+        record["run_id"] = run.id
+        record["pdf_url"] = run.pdf_url
+        if run.manufacturer:
+            record["manufacturer"] = run.manufacturer
+        if run.model:
+            record["model"] = run.model
+    if duration_ms is not None:
+        record["duration_ms"] = duration_ms
+    if error:
+        record["error"] = error[:500]
+    record.update(fields)
+    print(json.dumps(record, default=str), flush=True)
+
+
+# ─── queue ────────────────────────────────────────────────────────────────────
 
 
 def load_queue() -> list[dict]:
@@ -59,8 +113,96 @@ def save_queue(queue: list[dict]) -> None:
         json.dump(queue, f, indent=2)
 
 
-def run_pipeline(entry: dict) -> tuple[bool, str]:
-    """Run full_ingest_pipeline.py for one entry. Returns (success, output_tail)."""
+# ─── url allowlist ────────────────────────────────────────────────────────────
+
+
+def _load_allowlist() -> Optional[set[str]]:
+    """Read allowlist from YAML. Returns None if file missing (allow all — dev mode)."""
+    if not ALLOWLIST_FILE.exists():
+        return None
+    try:
+        import yaml  # type: ignore
+        with open(ALLOWLIST_FILE) as f:
+            data = yaml.safe_load(f) or {}
+        hosts: set[str] = set()
+        for key in ("oem_domains", "distributors", "public_libraries"):
+            for h in data.get(key, []) or []:
+                hosts.add(h.strip().lower())
+        return hosts
+    except Exception as exc:
+        jlog("allowlist", "warning", error=f"failed to load: {exc}")
+        return None
+
+
+def _host_allowed(url: str, allowlist: Optional[set[str]]) -> bool:
+    if allowlist is None:
+        return True
+    try:
+        host = (urlparse(url).hostname or "").lower()
+    except Exception:
+        return False
+    if not host:
+        return False
+    # exact match or any suffix-match (e.g. 'cdn.foo.com' allowed by 'foo.com')
+    if host in allowlist:
+        return True
+    return any(host.endswith("." + h) for h in allowlist)
+
+
+# ─── preflight ────────────────────────────────────────────────────────────────
+
+
+def _http_ok(url: str, timeout: float = 5.0) -> tuple[bool, str]:
+    try:
+        r = httpx.get(url, timeout=timeout)
+        if r.status_code < 400:
+            return True, f"{r.status_code}"
+        return False, f"{r.status_code}"
+    except Exception as exc:
+        return False, type(exc).__name__
+
+
+def preflight() -> bool:
+    """Validate critical deps before any work. Spec §10.1."""
+    t0 = time.monotonic()
+    checks = [
+        ("ollama", f"{OLLAMA_URL.rstrip('/')}/api/tags"),
+        ("docling", f"{DOCLING_URL.rstrip('/')}/health"),
+    ]
+    all_ok = True
+    for name, url in checks:
+        ok, info = _http_ok(url)
+        jlog(
+            "preflight",
+            "ok" if ok else "failed",
+            check=name,
+            url=url,
+            result=info,
+        )
+        if not ok and name == "ollama":
+            # Ollama is hard-required — embeddings will fail without it.
+            all_ok = False
+
+    # Reap any stuck `running` rows from earlier crashed runs.
+    reaped = reap_stuck_runs(max_age_minutes=30)
+    if reaped:
+        jlog("preflight", "warning", check="reap", reaped=reaped)
+
+    jlog(
+        "preflight",
+        "ok" if all_ok else "failed",
+        check="summary",
+        duration_ms=int((time.monotonic() - t0) * 1000),
+    )
+    return all_ok
+
+
+# ─── pipeline subprocess ──────────────────────────────────────────────────────
+
+
+def run_pipeline(entry: dict) -> tuple[bool, str, int]:
+    """Run full_ingest_pipeline.py for one entry.
+    Returns (success, output_tail, chunks_created)."""
     cmd = [
         sys.executable,
         str(PIPELINE),
@@ -77,59 +219,120 @@ def run_pipeline(entry: dict) -> tuple[bool, str]:
         cmd,
         capture_output=True,
         text=True,
-        timeout=900,
+        timeout=PIPELINE_TIMEOUT,
         env=env,
     )
     output = (result.stdout + result.stderr).strip()
-    tail = "\n".join(output.splitlines()[-20:])  # last 20 lines for log
-    return result.returncode == 0, tail
+    tail = "\n".join(output.splitlines()[-20:])
+
+    # Best-effort: parse chunk count from full_ingest_pipeline output line
+    # (e.g. "  kb_chunks: 47").
+    chunks = 0
+    for line in output.splitlines():
+        if "kb_chunks" in line:
+            for tok in line.split():
+                if tok.isdigit():
+                    chunks = int(tok)
+                    break
+    return result.returncode == 0, tail, chunks
 
 
-def main() -> None:
-    _log("KB growth cron starting")
+# ─── main ─────────────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    jlog("cron", "start")
+
+    if not INGEST_ENABLED:
+        jlog("cron", "skipped", reason="KB_INGEST_ENABLED=false")
+        return 0
 
     if not QUEUE_FILE.exists():
-        _log(f"ERROR: queue file not found: {QUEUE_FILE}")
-        sys.exit(1)
+        jlog("cron", "failed", error=f"queue file not found: {QUEUE_FILE}")
+        return 1
 
     if not PIPELINE.exists():
-        _log(f"ERROR: pipeline not found: {PIPELINE}")
-        sys.exit(1)
+        jlog("cron", "failed", error=f"pipeline not found: {PIPELINE}")
+        return 1
+
+    if not preflight():
+        # Open a run row for this failed preflight so heartbeat sees it.
+        run = open_run(pdf_url="(preflight)", tenant_id=os.getenv("MIRA_TENANT_ID", "mike"))
+        close_run(run, status="failed", step_failed="preflight",
+                  error=f"OLLAMA_BASE_URL={OLLAMA_URL} unreachable")
+        jlog("cron", "failed", error="preflight failed — see preflight log lines above")
+        return 2
 
     queue = load_queue()
-    pending = [i for i, e in enumerate(queue) if e.get("status") == "pending"]
+    pending_indices = [i for i, e in enumerate(queue) if e.get("status") == "pending"]
 
-    if not pending:
-        _log("Queue empty — nothing to ingest. Add PDFs to manual_queue.json.")
+    if not pending_indices:
         done = sum(1 for e in queue if e.get("status") == "done")
         failed = sum(1 for e in queue if e.get("status") == "failed")
-        _log(f"Queue stats: {done} done, {failed} failed, 0 pending")
-        sys.exit(0)
+        jlog("cron", "idle", done=done, failed=failed, pending=0)
+        return 0
 
-    idx = pending[0]
+    allowlist = _load_allowlist()
+
+    idx = pending_indices[0]
     entry = queue[idx]
-    _log(f"Processing [{idx+1}/{len(queue)}]: {entry['manufacturer']} {entry['model']} — {entry['url'][:80]}")
+    url = entry["url"]
 
+    if not _host_allowed(url, allowlist):
+        entry["status"] = "dead"
+        entry["failed_at"] = _ts()
+        entry["error"] = "host not on URL allowlist"
+        queue[idx] = entry
+        save_queue(queue)
+        run = open_run(
+            pdf_url=url,
+            manufacturer=entry["manufacturer"],
+            model=entry["model"],
+            doc_type=entry.get("type"),
+        )
+        close_run(run, status="failed", step_failed="allowlist",
+                  error="host not on URL allowlist")
+        jlog("allowlist", "rejected", run=run, host=urlparse(url).hostname)
+        return 0
+
+    run = open_run(
+        pdf_url=url,
+        manufacturer=entry["manufacturer"],
+        model=entry["model"],
+        doc_type=entry.get("type", "installation_manual"),
+    )
+    jlog("ingest", "start", run=run, queue_index=idx, queue_total=len(queue))
+
+    t0 = time.monotonic()
     try:
-        success, tail = run_pipeline(entry)
+        success, tail, chunks = run_pipeline(entry)
     except subprocess.TimeoutExpired:
         success = False
-        tail = "TIMEOUT after 900s"
+        tail = f"TIMEOUT after {PIPELINE_TIMEOUT}s"
+        chunks = 0
     except Exception as exc:
         success = False
         tail = str(exc)
+        chunks = 0
+    duration_ms = int((time.monotonic() - t0) * 1000)
 
     if success:
         entry["status"] = "done"
         entry["done_at"] = _ts()
-        _log(f"SUCCESS: {entry['manufacturer']} {entry['model']}")
+        entry["chunks_created"] = chunks
+        close_run(run, status="ok", chunks_created=chunks)
+        jlog("ingest", "ok", run=run, chunks=chunks, duration_ms=duration_ms)
     else:
         entry["status"] = "failed"
         entry["failed_at"] = _ts()
-        entry["error"] = tail[-200:]  # cap stored error
-        _log(f"FAILED: {entry['manufacturer']} {entry['model']}")
-
-    _log(f"Pipeline output (tail):\n{tail}")
+        entry["error"] = tail[-200:]
+        close_run(
+            run,
+            status="failed",
+            step_failed="pipeline",
+            error=tail,
+        )
+        jlog("ingest", "failed", run=run, error=tail[-300:], duration_ms=duration_ms)
 
     queue[idx] = entry
     save_queue(queue)
@@ -137,10 +340,10 @@ def main() -> None:
     remaining = sum(1 for e in queue if e.get("status") == "pending")
     done = sum(1 for e in queue if e.get("status") == "done")
     failed = sum(1 for e in queue if e.get("status") == "failed")
-    _log(f"Queue: {done} done, {failed} failed, {remaining} pending")
-    _log("KB growth cron done")
+    jlog("cron", "done", done=done, failed=failed, pending=remaining)
 
-    _emit_report(entry, success, done, failed, remaining)
+    _emit_report(entry, success, done, failed, remaining, chunks)
+    return 0
 
 
 def _emit_report(
@@ -149,26 +352,26 @@ def _emit_report(
     done: int,
     failed: int,
     remaining: int,
+    chunks: int,
 ) -> None:
     name = f"{entry['manufacturer']} {entry['model']}"
 
-    # Telegram notification
     try:
         if success:
             _tg_notify(
                 "kb_growth",
-                f"✅ Ingested *{name}*\nQueue: {done} done · {failed} failed · {remaining} remaining",
+                f"✅ Ingested *{name}* ({chunks} chunks)\n"
+                f"Queue: {done} done · {failed} failed · {remaining} remaining",
             )
         else:
-            err = entry.get("error", "unknown error")[:120]
+            err = (entry.get("error") or "unknown error")[:120]
             _tg_notify(
                 "kb_growth",
                 f"❌ Failed: *{name}*\n`{err}`\nWill retry next cycle",
             )
     except Exception as exc:
-        _log(f"Telegram notify failed (non-fatal): {exc}")
+        jlog("notify", "failed", error=str(exc))
 
-    # HTML/Markdown report
     if not _REPORT_AVAILABLE:
         return
     try:
@@ -180,22 +383,23 @@ def _emit_report(
             .add_metric("Done", done, "PDFs", trend="up")
             .add_metric("Failed", failed, "PDFs", trend="flat" if failed == 0 else "down")
             .add_metric("Remaining", remaining, "PDFs")
+            .add_metric("Chunks (this run)", chunks, "chunks")
         )
         if success:
-            report.add_alert("ok", f"Ingested: {name}")
+            report.add_alert("ok", f"Ingested: {name} ({chunks} chunks)")
         else:
             report.add_alert(
                 "warning",
-                f"Failed: {name} — {entry.get('error', '')[:120]}",
+                f"Failed: {name} — {(entry.get('error') or '')[:120]}",
             )
         if remaining > 0:
             report.add_action(f"Review {remaining} pending PDFs in manual_queue.json")
         if failed > 0:
             report.add_action(f"Investigate {failed} failed PDF(s) and re-queue or remove")
-        report.save(telegram=False)  # Telegram already sent above
+        report.save(telegram=False)
     except Exception as exc:
-        _log(f"Report generation failed (non-fatal): {exc}")
+        jlog("report", "failed", error=str(exc))
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/mira-crawler/cron/pipeline_runs.py
+++ b/mira-crawler/cron/pipeline_runs.py
@@ -1,0 +1,241 @@
+"""pipeline_runs — DB helper for KB ingest observability.
+
+Each cron invocation opens a row before any work, updates it on completion.
+No silent runs. See docs/specs/kb-ingest-hardening-spec.md §4.2.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import uuid
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+try:
+    import psycopg2
+    _HAVE_PG = True
+except ImportError:
+    _HAVE_PG = False
+
+
+def _git_sha() -> str:
+    """Return short git SHA of the current pipeline. 'unknown' if not in a repo."""
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--short=12", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5,
+        ).strip()
+        return out or "unknown"
+    except Exception:
+        return os.getenv("PIPELINE_VERSION", "unknown")
+
+
+_PIPELINE_VERSION = _git_sha()
+
+
+@dataclass
+class PipelineRun:
+    """One row in pipeline_runs. Mutable until close()."""
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    tenant_id: str = "mike"
+    pdf_url: str = ""
+    manufacturer: Optional[str] = None
+    model: Optional[str] = None
+    doc_type: Optional[str] = None
+    status: str = "pending"
+    step_failed: Optional[str] = None
+    chunks_created: int = 0
+    bytes_downloaded: Optional[int] = None
+    error: Optional[str] = None
+    started_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    completed_at: Optional[datetime] = None
+    duration_ms: Optional[int] = None
+    pipeline_version: str = _PIPELINE_VERSION
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def _conn_string() -> Optional[str]:
+    return os.getenv("NEON_DATABASE_URL") or os.getenv("DATABASE_URL")
+
+
+def _connect():
+    if not _HAVE_PG:
+        return None
+    url = _conn_string()
+    if not url:
+        return None
+    try:
+        return psycopg2.connect(url, connect_timeout=10, sslmode="require")
+    except Exception:
+        return None
+
+
+def open_run(
+    pdf_url: str,
+    manufacturer: Optional[str] = None,
+    model: Optional[str] = None,
+    doc_type: Optional[str] = None,
+    tenant_id: str = "mike",
+) -> PipelineRun:
+    """Insert a row in `running` state. Always returns a PipelineRun (DB-down safe)."""
+    run = PipelineRun(
+        tenant_id=tenant_id,
+        pdf_url=pdf_url,
+        manufacturer=manufacturer,
+        model=model,
+        doc_type=doc_type,
+        status="running",
+    )
+    conn = _connect()
+    if conn is None:
+        return run
+    try:
+        with conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO pipeline_runs
+                    (id, tenant_id, pdf_url, manufacturer, model, doc_type,
+                     status, started_at, pipeline_version, metadata)
+                VALUES
+                    (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    run.id, run.tenant_id, run.pdf_url, run.manufacturer,
+                    run.model, run.doc_type, run.status, run.started_at,
+                    run.pipeline_version, json.dumps(run.metadata),
+                ),
+            )
+    except Exception:
+        # DB unreachable — caller still gets a local run object so logs are coherent.
+        pass
+    finally:
+        conn.close()
+    return run
+
+
+def close_run(
+    run: PipelineRun,
+    status: str,
+    chunks_created: int = 0,
+    step_failed: Optional[str] = None,
+    error: Optional[str] = None,
+    bytes_downloaded: Optional[int] = None,
+    metadata_extra: Optional[dict[str, Any]] = None,
+) -> None:
+    """Finalize a run row. Truncates error to 500 chars per the spec."""
+    run.status = status
+    run.chunks_created = chunks_created
+    run.step_failed = step_failed
+    run.error = (error or "")[:500] if error else None
+    run.bytes_downloaded = bytes_downloaded
+    run.completed_at = datetime.now(timezone.utc)
+    run.duration_ms = int(
+        (run.completed_at - run.started_at).total_seconds() * 1000
+    )
+    if metadata_extra:
+        run.metadata.update(metadata_extra)
+
+    conn = _connect()
+    if conn is None:
+        return
+    try:
+        with conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE pipeline_runs
+                SET status = %s,
+                    step_failed = %s,
+                    chunks_created = %s,
+                    bytes_downloaded = %s,
+                    error = %s,
+                    completed_at = %s,
+                    duration_ms = %s,
+                    metadata = %s
+                WHERE id = %s
+                """,
+                (
+                    run.status, run.step_failed, run.chunks_created,
+                    run.bytes_downloaded, run.error, run.completed_at,
+                    run.duration_ms, json.dumps(run.metadata), run.id,
+                ),
+            )
+    except Exception:
+        pass
+    finally:
+        conn.close()
+
+
+def reap_stuck_runs(max_age_minutes: int = 30) -> int:
+    """Mark runs stuck in `running` for >max_age_minutes as `failed`.
+    Called from preflight on cron startup. Returns count reaped.
+    """
+    conn = _connect()
+    if conn is None:
+        return 0
+    try:
+        with conn, conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE pipeline_runs
+                SET status = 'failed',
+                    step_failed = COALESCE(step_failed, 'reaped'),
+                    error = COALESCE(error, 'reaped: stuck in running >' || %s::text || ' min'),
+                    completed_at = now(),
+                    duration_ms = EXTRACT(EPOCH FROM (now() - started_at))::int * 1000
+                WHERE status = 'running'
+                  AND started_at < now() - (%s || ' minutes')::interval
+                RETURNING id
+                """,
+                (max_age_minutes, max_age_minutes),
+            )
+            return cur.rowcount
+    except Exception:
+        return 0
+    finally:
+        conn.close()
+
+
+@contextmanager
+def tracked_run(
+    pdf_url: str,
+    manufacturer: Optional[str] = None,
+    model: Optional[str] = None,
+    doc_type: Optional[str] = None,
+    tenant_id: str = "mike",
+) -> Generator[PipelineRun, None, None]:
+    """Context manager: opens a run, marks it failed on exception, ok on clean exit.
+
+    Caller is expected to set run.chunks_created / run.bytes_downloaded /
+    run.step_failed before yielding back — see kb_growth_cron.py for usage.
+    """
+    run = open_run(pdf_url, manufacturer, model, doc_type, tenant_id)
+    try:
+        yield run
+    except Exception as exc:
+        close_run(
+            run,
+            status="failed",
+            step_failed=run.step_failed or "unknown",
+            error=str(exc),
+        )
+        raise
+    else:
+        # Caller sets status via run.status before exiting normally.
+        if run.status in ("running", "pending"):
+            run.status = "ok"
+        close_run(
+            run,
+            status=run.status,
+            chunks_created=run.chunks_created,
+            step_failed=run.step_failed,
+            error=run.error,
+            bytes_downloaded=run.bytes_downloaded,
+            metadata_extra=run.metadata,
+        )

--- a/mira-crawler/tasks/extract_fallback.py
+++ b/mira-crawler/tasks/extract_fallback.py
@@ -1,0 +1,82 @@
+"""Fallback PDF text extraction — runs when Docling is down.
+
+Quality is lower (no layout, no table reconstruction, no markdown structure),
+but the pipeline keeps moving. See docs/specs/kb-ingest-hardening-spec.md §7.
+
+Order of preference:
+  1. pdfplumber  — best layout fidelity of the pure-python options
+  2. pypdf       — fallback when pdfplumber not installed
+  3. (give up)   — caller treats as docling=failed and skips the doc
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("mira.extract_fallback")
+
+
+def _try_pdfplumber(path: Path) -> Optional[str]:
+    try:
+        import pdfplumber  # type: ignore
+    except ImportError:
+        return None
+    try:
+        out: list[str] = []
+        with pdfplumber.open(str(path)) as pdf:
+            for page in pdf.pages:
+                txt = page.extract_text() or ""
+                if txt.strip():
+                    out.append(txt)
+        return "\n\n".join(out).strip() or None
+    except Exception as exc:
+        logger.warning("pdfplumber failed: %s", exc)
+        return None
+
+
+def _try_pypdf(path: Path) -> Optional[str]:
+    try:
+        import pypdf  # type: ignore
+    except ImportError:
+        return None
+    try:
+        reader = pypdf.PdfReader(str(path))
+        out: list[str] = []
+        for page in reader.pages:
+            try:
+                txt = page.extract_text() or ""
+            except Exception:
+                txt = ""
+            if txt.strip():
+                out.append(txt)
+        return "\n\n".join(out).strip() or None
+    except Exception as exc:
+        logger.warning("pypdf failed: %s", exc)
+        return None
+
+
+def fallback_extract(pdf_path: Path) -> tuple[str, str]:
+    """Extract text without Docling. Returns (text, method_label).
+
+    method_label is one of: 'pdfplumber', 'pypdf', 'fallback_failed'.
+    Empty text means all fallbacks failed — caller should treat as a hard miss.
+    """
+    if not pdf_path.exists() or pdf_path.stat().st_size == 0:
+        return "", "fallback_failed"
+
+    # 1. pdfplumber
+    txt = _try_pdfplumber(pdf_path)
+    if txt:
+        logger.info("Fallback: pdfplumber extracted %d chars", len(txt))
+        return txt, "pdfplumber"
+
+    # 2. pypdf
+    txt = _try_pypdf(pdf_path)
+    if txt:
+        logger.info("Fallback: pypdf extracted %d chars", len(txt))
+        return txt, "pypdf"
+
+    logger.error("All fallback extractors failed for %s", pdf_path.name)
+    return "", "fallback_failed"

--- a/mira-crawler/tasks/full_ingest_pipeline.py
+++ b/mira-crawler/tasks/full_ingest_pipeline.py
@@ -266,9 +266,29 @@ def step_extract(pdf_path: Path, report: PipelineReport) -> str:
         return md
 
     except Exception as exc:
-        report.docling_method = "failed"
+        logger.error("Docling failed: %s — attempting fallback extractor", exc)
         report.errors.append(f"Docling: {exc}")
-        logger.error("Docling failed: %s", exc)
+        # Fallback path — pdfplumber → pypdf. Spec §7.
+        if os.getenv("KB_FALLBACK_EXTRACT_ENABLED", "true").lower() != "false":
+            try:
+                try:
+                    from tasks.extract_fallback import fallback_extract
+                except ImportError:
+                    from mira_crawler.tasks.extract_fallback import fallback_extract  # type: ignore[no-redef]
+                fb_text, fb_method = fallback_extract(pdf_path)
+                if fb_text:
+                    report.docling_method = fb_method
+                    report.docling_chars = len(fb_text)
+                    report.docling_pages = max(1, fb_text.count("\f") + 1)
+                    logger.warning("Fallback extractor used: %s (%d chars)",
+                                   fb_method, len(fb_text))
+                    return fb_text
+                report.docling_method = "fallback_failed"
+                return ""
+            except Exception as fb_exc:
+                logger.error("Fallback extractor errored: %s", fb_exc)
+                report.errors.append(f"Fallback: {fb_exc}")
+        report.docling_method = "failed"
         return ""
 
 

--- a/mira-crawler/tests/test_kb_ingest_hardening.py
+++ b/mira-crawler/tests/test_kb_ingest_hardening.py
@@ -1,0 +1,180 @@
+"""Tests for KB ingest hardening — the contract from
+docs/specs/kb-ingest-hardening-spec.md must hold.
+
+These tests are pure-Python and require no live Ollama / Docling / NeonDB.
+They cover §6 (URL allowlist), §7 (fallback extraction), and the
+pipeline_runs helper used by §4 observability.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ─── path bootstrap so tests can import the cron module ──────────────────────
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CRON_DIR = _REPO_ROOT / "mira-crawler" / "cron"
+_TASKS_DIR = _REPO_ROOT / "mira-crawler" / "tasks"
+for p in (str(_CRON_DIR), str(_TASKS_DIR)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+# ─── §6 URL allowlist ─────────────────────────────────────────────────────────
+
+
+class TestUrlAllowlist:
+    """Spec §6.1 — only allowlisted hosts may be downloaded."""
+
+    def _import_host_allowed(self):
+        from kb_growth_cron import _host_allowed
+        return _host_allowed
+
+    def test_exact_host_allowed(self):
+        host_allowed = self._import_host_allowed()
+        allowlist = {"automationdirect.com", "manualslib.com"}
+        assert host_allowed("https://automationdirect.com/manuals/x.pdf", allowlist) is True
+
+    def test_subdomain_allowed_via_suffix(self):
+        host_allowed = self._import_host_allowed()
+        allowlist = {"automationdirect.com"}
+        assert host_allowed(
+            "https://cdn.automationdirect.com/manuals/x.pdf", allowlist
+        ) is True
+
+    def test_unknown_host_rejected(self):
+        host_allowed = self._import_host_allowed()
+        allowlist = {"automationdirect.com"}
+        assert host_allowed("https://evil.com/x.pdf", allowlist) is False
+
+    def test_lookalike_domain_not_matched_by_substring(self):
+        """Spec §6.1: 'foo.com' allows 'cdn.foo.com' but NOT 'fakefoo.com'."""
+        host_allowed = self._import_host_allowed()
+        allowlist = {"foo.com"}
+        assert host_allowed("https://fakefoo.com/x.pdf", allowlist) is False
+        assert host_allowed("https://foo.com.evil.com/x.pdf", allowlist) is False
+
+    def test_empty_allowlist_means_open(self):
+        """When no allowlist file exists (None), all URLs pass — dev mode."""
+        host_allowed = self._import_host_allowed()
+        assert host_allowed("https://anything.com/x.pdf", None) is True
+
+    def test_malformed_url_rejected(self):
+        host_allowed = self._import_host_allowed()
+        allowlist = {"automationdirect.com"}
+        assert host_allowed("not-a-url", allowlist) is False
+        assert host_allowed("", allowlist) is False
+
+
+# ─── §7 fallback extraction ───────────────────────────────────────────────────
+
+
+class TestFallbackExtract:
+    """Spec §7 — when Docling is down, pdfplumber/pypdf must keep the pipeline alive."""
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        from extract_fallback import fallback_extract
+        text, method = fallback_extract(tmp_path / "does-not-exist.pdf")
+        assert text == ""
+        assert method == "fallback_failed"
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        from extract_fallback import fallback_extract
+        empty = tmp_path / "empty.pdf"
+        empty.write_bytes(b"")
+        text, method = fallback_extract(empty)
+        assert text == ""
+        assert method == "fallback_failed"
+
+    def test_pdfplumber_used_when_available(self, tmp_path):
+        """If pdfplumber returns text, fallback_extract uses it (preferred path)."""
+        from extract_fallback import fallback_extract
+
+        fake_pdf = tmp_path / "ok.pdf"
+        fake_pdf.write_bytes(b"%PDF-1.4 stub")
+
+        class FakePage:
+            def extract_text(self):
+                return "fallback page text"
+
+        class FakePdf:
+            pages = [FakePage(), FakePage()]
+            def __enter__(self):
+                return self
+            def __exit__(self, *_):
+                return False
+
+        fake_module = type("FakeModule", (), {"open": lambda _: FakePdf()})
+        with patch.dict(sys.modules, {"pdfplumber": fake_module}):
+            text, method = fallback_extract(fake_pdf)
+
+        assert "fallback page text" in text
+        assert method == "pdfplumber"
+
+
+# ─── pipeline_runs helper (§4) ────────────────────────────────────────────────
+
+
+class TestPipelineRunsHelper:
+    """Helper must remain DB-down safe — never raise to caller."""
+
+    def test_open_run_returns_object_when_db_unreachable(self, monkeypatch):
+        from pipeline_runs import open_run
+        monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        run = open_run(pdf_url="https://x.com/a.pdf", manufacturer="Test", model="X")
+        assert run.pdf_url == "https://x.com/a.pdf"
+        assert run.manufacturer == "Test"
+        assert run.status == "running"
+        assert run.id  # uuid string
+
+    def test_close_run_truncates_long_errors(self, monkeypatch):
+        from pipeline_runs import open_run, close_run
+        monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        run = open_run(pdf_url="https://x.com/a.pdf")
+        long_err = "x" * 5000
+        close_run(run, status="failed", step_failed="embed", error=long_err)
+        assert run.error is not None
+        assert len(run.error) <= 500
+        assert run.duration_ms is not None and run.duration_ms >= 0
+
+    def test_close_run_preserves_chunks_count(self, monkeypatch):
+        from pipeline_runs import open_run, close_run
+        monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        run = open_run(pdf_url="https://x.com/a.pdf")
+        close_run(run, status="ok", chunks_created=42)
+        assert run.chunks_created == 42
+        assert run.status == "ok"
+
+
+# ─── §4.1 structured logging ─────────────────────────────────────────────────
+
+
+class TestStructuredLogging:
+    def test_jlog_emits_valid_json_with_required_fields(self, capsys):
+        import json as _json
+        from kb_growth_cron import jlog
+        jlog("ingest", "ok", duration_ms=1234, chunks=10)
+        out = capsys.readouterr().out.strip()
+        rec = _json.loads(out)
+        assert rec["step"] == "ingest"
+        assert rec["status"] == "ok"
+        assert rec["duration_ms"] == 1234
+        assert rec["chunks"] == 10
+        assert "ts" in rec  # spec §4.1 — every record has a timestamp
+
+    def test_jlog_truncates_error(self, capsys):
+        import json as _json
+        from kb_growth_cron import jlog
+        jlog("download", "failed", error="x" * 1000)
+        rec = _json.loads(capsys.readouterr().out.strip())
+        assert len(rec["error"]) <= 500
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/mira-hub/src/app/api/kb/stats/route.ts
+++ b/mira-hub/src/app/api/kb/stats/route.ts
@@ -1,0 +1,106 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/kb/stats
+ * KB ingest dashboard endpoint. See docs/specs/kb-ingest-hardening-spec.md §4.3.
+ *
+ * Returns growth, success rate, queue depth, and the most recent failure cluster
+ * so the UI can show "stale" / "healthy" badges without fanning out queries.
+ */
+export async function GET() {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  try {
+    const data = await withTenantContext(ctx.tenantId, async (c) => {
+      // Total + recent KB rows (authoritative table)
+      const totals = await c.query(
+        `SELECT
+           COUNT(*)                                         AS total_entries,
+           COUNT(*) FILTER (WHERE created_at > now() - interval '1 day')  AS entries_today,
+           COUNT(*) FILTER (WHERE created_at > now() - interval '7 days') AS entries_7d
+         FROM knowledge_entries
+         WHERE tenant_id = $1`,
+        [ctx.tenantId],
+      );
+
+      // Pipeline run health (table created in 006_pipeline_runs.sql).
+      // Wrap in a try so an old DB without the table still returns 0s.
+      let runs = { rows: [{ total: 0, ok: 0, failed: 0, last_run_at: null }] } as {
+        rows: Array<{ total: number; ok: number; failed: number; last_run_at: string | null }>;
+      };
+      try {
+        runs = await c.query(
+          `SELECT
+             COUNT(*)::int                                                 AS total,
+             COUNT(*) FILTER (WHERE status = 'ok')::int                    AS ok,
+             COUNT(*) FILTER (WHERE status IN ('failed','partial'))::int   AS failed,
+             MAX(started_at)                                               AS last_run_at
+           FROM pipeline_runs
+           WHERE tenant_id = $1
+             AND started_at > now() - interval '7 days'`,
+          [ctx.tenantId],
+        );
+      } catch {
+        // pipeline_runs table not yet deployed — degrade gracefully.
+      }
+
+      let topFailures: Array<{ url_host: string; count: number; last_error: string | null }> = [];
+      try {
+        const fails = await c.query(
+          `SELECT
+             split_part(regexp_replace(pdf_url, '^https?://', ''), '/', 1) AS url_host,
+             COUNT(*)::int                                                  AS count,
+             (array_agg(error ORDER BY started_at DESC))[1]                AS last_error
+           FROM pipeline_runs
+           WHERE tenant_id = $1
+             AND status IN ('failed','partial')
+             AND started_at > now() - interval '7 days'
+           GROUP BY url_host
+           ORDER BY count DESC
+           LIMIT 5`,
+          [ctx.tenantId],
+        );
+        topFailures = fails.rows;
+      } catch {
+        // pipeline_runs not yet deployed
+      }
+
+      return { totals: totals.rows[0], runs: runs.rows[0], topFailures };
+    });
+
+    const t = data.totals as Record<string, unknown>;
+    const r = data.runs as Record<string, unknown>;
+
+    const total = Number(r.total ?? 0);
+    const ok = Number(r.ok ?? 0);
+    const successRate = total > 0 ? ok / total : null;
+
+    const lastRunAt = r.last_run_at ? new Date(String(r.last_run_at)) : null;
+    const stale = !lastRunAt
+      ? true
+      : Date.now() - lastRunAt.getTime() > 24 * 60 * 60 * 1000;
+
+    return NextResponse.json({
+      total_entries: Number(t.total_entries ?? 0),
+      entries_today: Number(t.entries_today ?? 0),
+      entries_7d: Number(t.entries_7d ?? 0),
+      pipeline_runs_7d: total,
+      success_rate_7d: successRate,
+      queue_depth: null, // populated when manual_queue.json is exposed via API
+      top_failures: data.topFailures,
+      last_run_at: lastRunAt?.toISOString() ?? null,
+      stale,
+    });
+  } catch (err) {
+    console.error("[api/kb/stats]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/knowledge/route.ts
+++ b/mira-hub/src/app/api/knowledge/route.ts
@@ -11,17 +11,31 @@ export async function GET() {
   const ctx = await sessionOr401();
   if (ctx instanceof NextResponse) return ctx;
   try {
+    // Authoritative table: `knowledge_entries` (kb_chunks deprecated).
+    // Field mapping in docs/specs/kb-ingest-hardening-spec.md §11.2.
     const rows = await withTenantContext(ctx.tenantId, (c) =>
       c.query(
         `SELECT
-          system_category, subcategory, manufacturer, product_family,
-          doc_type, source, COUNT(*) as chunk_count,
-          AVG(quality_score) as avg_quality,
-          MAX(created_at) as last_indexed,
-          array_agg(DISTINCT title ORDER BY title) FILTER (WHERE title IS NOT NULL) as sample_titles
-        FROM kb_chunks
+          metadata->>'system_category' AS system_category,
+          metadata->>'subcategory'     AS subcategory,
+          manufacturer                  AS manufacturer,
+          metadata->>'product_family'  AS product_family,
+          chunk_type                    AS doc_type,
+          metadata->>'source'          AS source,
+          COUNT(*)                      AS chunk_count,
+          AVG((metadata->>'quality_score')::float) AS avg_quality,
+          MAX(created_at)               AS last_indexed,
+          array_agg(DISTINCT metadata->>'title' ORDER BY metadata->>'title')
+            FILTER (WHERE metadata->>'title' IS NOT NULL)  AS sample_titles
+        FROM knowledge_entries
         WHERE tenant_id = $1
-        GROUP BY system_category, subcategory, manufacturer, product_family, doc_type, source
+        GROUP BY
+          metadata->>'system_category',
+          metadata->>'subcategory',
+          manufacturer,
+          metadata->>'product_family',
+          chunk_type,
+          metadata->>'source'
         ORDER BY chunk_count DESC, avg_quality DESC NULLS LAST`,
         [ctx.tenantId],
       ).then((r) => r.rows),

--- a/mira-hub/src/app/api/usage/route.ts
+++ b/mira-hub/src/app/api/usage/route.ts
@@ -56,8 +56,10 @@ export async function GET() {
         ORDER BY count DESC LIMIT 10`,
         [ctx.tenantId],
       );
+      // KB total — authoritative table is `knowledge_entries`.
+      // See docs/specs/kb-ingest-hardening-spec.md §11.
       const { rows: kbRows } = await c.query(
-        `SELECT COUNT(*) as total_chunks FROM kb_chunks WHERE tenant_id = $1`,
+        `SELECT COUNT(*) as total_chunks FROM knowledge_entries WHERE tenant_id = $1`,
         [ctx.tenantId],
       );
       return { monthRows, allTimeRows, dailyRows, bySourceRows, byTechRows, kbRows };

--- a/mira-hub/src/lib/data-schema.ts
+++ b/mira-hub/src/lib/data-schema.ts
@@ -11,11 +11,12 @@ let dataSchemaReady: Promise<void> | null = null;
 export function ensureDataSchema(): Promise<void> {
   if (dataSchemaReady) return dataSchemaReady;
   dataSchemaReady = (async () => {
+    // kb_chunks deprecated — see docs/specs/kb-ingest-hardening-spec.md §11.
+    // Authoritative table is `knowledge_entries` (managed by mira-pipeline).
     const pipelineTables = [
       "work_orders",
       "pm_schedules",
       "cmms_equipment",
-      "kb_chunks",
       "telegram_messages",
     ] as const;
 


### PR DESCRIPTION
## Summary

- New spec `docs/specs/kb-ingest-hardening-spec.md` defines the production contract for the KB ingest pipeline across 10 dimensions (reliability, observability, data quality, security, fault tolerance, performance, monitoring, configuration, testing, unification).
- Code changes implement the immediate gaps so the pipeline becomes auditable, fault-tolerant, and unified ahead of the **2026-05-18** demo.
- `mira-hub` UI now reads `knowledge_entries` (80k+ rows) instead of the demo `kb_chunks` stub (67 rows).
- New `pipeline_runs` table + helpers expose ingest health to mira-hub `/api/kb/stats` and the Telegram morning brief.
- Docling fallback (pdfplumber → pypdf) keeps the pipeline alive when Docling is down.

Tracking: [#1071](https://github.com/Mikecranesync/MIRA/issues/1071) · Linear parent: [CRA-86](https://linear.app/cranesync/issue/CRA-86)

## Files changed

| Concern | Files |
|---|---|
| Spec / runbook | `docs/specs/kb-ingest-hardening-spec.md`, `docs/runbooks/kb-ingest-ops.md` |
| Migration | `docs/migrations/006_pipeline_runs.sql` |
| Cron + tracker | `mira-crawler/cron/{kb_growth_cron,pipeline_runs}.py`, `mira-crawler/config/url_allowlist.yml` |
| Fallback extract | `mira-crawler/tasks/{extract_fallback.py,full_ingest_pipeline.py}` |
| mira-hub UI cutover | `mira-hub/src/app/api/{usage,knowledge,kb/stats}/route.ts`, `mira-hub/src/lib/data-schema.ts` |
| Heartbeat | `mira-bots/agents/morning_brief_runner.py` |
| Tests + CI | `mira-crawler/tests/test_kb_ingest_hardening.py`, `.github/workflows/ci.yml` |

## Test plan

- [x] `pytest mira-crawler/tests/test_kb_ingest_hardening.py` — 14/14 green locally
- [x] CI new job `kb-ingest-tests` runs on every PR
- [ ] Mike: apply `006_pipeline_runs.sql` on NeonDB ([CRA-87](https://linear.app/cranesync/issue/CRA-87))
- [ ] Mike: rotate Doppler `OLLAMA_BASE_URL` to `100.86.236.11` ([CRA-94](https://linear.app/cranesync/issue/CRA-94)) — see runbook §1
- [ ] Mike: deploy + 48h soak before demo ([CRA-95](https://linear.app/cranesync/issue/CRA-95))
- [ ] Verify spec §14 acceptance criteria post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)