### PR TITLE
feat(uns-kg): UNS + Knowledge Graph unification — Phases 1, 2, 3

### DIFF
--- a/docs/migrations/006_kg_bridge.sql
+++ b/docs/migrations/006_kg_bridge.sql
@@ -1,0 +1,56 @@
+-- Migration 006: Bridge knowledge_entries ↔ kg_entities
+-- Spec: docs/specs/uns-kg-unification-spec.md §3.3, §4.1, Phase 1
+-- Status: PRODUCTION
+-- Depends on: 001_knowledge_entries.sql, 004_kg_entities.sql, 005_kg_relationships.sql
+
+-- 1. Make sure the planned KG tables exist before we FK to them.
+--    The 004 / 005 migration files were marked "PLANNED" — promote to production now.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS kg_entities (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id       TEXT NOT NULL,
+    entity_type     TEXT NOT NULL,
+    name            TEXT NOT NULL,
+    properties      JSONB,
+    source_chunk_id UUID,
+    embedding       vector(768),
+    created_at      TIMESTAMP DEFAULT now(),
+    UNIQUE (tenant_id, entity_type, name)
+);
+
+CREATE INDEX IF NOT EXISTS kg_entities_tenant_type_idx
+    ON kg_entities (tenant_id, entity_type);
+
+CREATE TABLE IF NOT EXISTS kg_relationships (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id       TEXT NOT NULL,
+    source_entity   UUID NOT NULL REFERENCES kg_entities(id) ON DELETE CASCADE,
+    target_entity   UUID NOT NULL REFERENCES kg_entities(id) ON DELETE CASCADE,
+    relation_type   TEXT NOT NULL,
+    properties      JSONB,
+    confidence      REAL DEFAULT 1.0,
+    source_chunk_id UUID,
+    created_at      TIMESTAMP DEFAULT now(),
+    UNIQUE (tenant_id, source_entity, target_entity, relation_type)
+);
+
+CREATE INDEX IF NOT EXISTS kg_relationships_tenant_idx
+    ON kg_relationships (tenant_id);
+CREATE INDEX IF NOT EXISTS kg_relationships_source_idx
+    ON kg_relationships (source_entity);
+CREATE INDEX IF NOT EXISTS kg_relationships_target_idx
+    ON kg_relationships (target_entity);
+
+-- 2. The bridge column. Nullable: legacy chunks stay readable until backfill runs.
+--    ON DELETE SET NULL: dropping an entity must not cascade-delete vector chunks.
+ALTER TABLE knowledge_entries
+    ADD COLUMN IF NOT EXISTS equipment_entity_id UUID
+        REFERENCES kg_entities(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS knowledge_entries_equipment_entity_id_idx
+    ON knowledge_entries (equipment_entity_id);
+
+-- 3. Document the column for future readers.
+COMMENT ON COLUMN knowledge_entries.equipment_entity_id IS
+    'FK to kg_entities.id when the chunk is sourced from a manual / page about a known equipment model. NULL when source is unrelated to a single equipment (e.g. a general curriculum doc) or extraction has not yet run.';

--- a/docs/migrations/007_uns_path.sql
+++ b/docs/migrations/007_uns_path.sql
@@ -9,10 +9,14 @@
 CREATE EXTENSION IF NOT EXISTS ltree;
 
 -- 2. Add the path column with the spec's default.
---    The default is meaningful, NOT a placeholder — see §3.1 of the spec.
---    Existing rows (the 41 test entities) will adopt the default.
+--    The broadened schema (Mike directive 2026-05-07) puts equipment
+--    learned from manuals into the manufacturer-organized knowledge
+--    base, NOT a separate "unassigned" subtree. The default below is
+--    the bare KB root — every kg_writer call overrides it with a real
+--    model path. Equipment that ends up with the bare default is a
+--    triage signal: the extractor failed to find a manufacturer.
 ALTER TABLE kg_entities
-    ADD COLUMN IF NOT EXISTS uns_path ltree NOT NULL DEFAULT 'enterprise.unassigned';
+    ADD COLUMN IF NOT EXISTS uns_path ltree NOT NULL DEFAULT 'enterprise.knowledge_base';
 
 -- 3. Format check — labels must be lowercase [a-z0-9_]+ separated by dots.
 --    Drops + recreates to make the migration idempotent.
@@ -28,12 +32,11 @@ CREATE INDEX IF NOT EXISTS kg_entities_uns_path_gist
 CREATE INDEX IF NOT EXISTS kg_entities_uns_path_btree
     ON kg_entities (uns_path);
 
--- 5. Backfill the existing test rows. Equipment entities get
---    enterprise.unassigned.{mfr}.{model}; everything else stays at the
---    bare default and gets re-pathed by application code on next write.
---    This is intentionally a one-shot; production rows will all be
---    written through kg_writer.upsert_entity which sets the path
---    explicitly per spec §3.1.
+-- 5. Backfill the existing test rows into the new manufacturer-organized
+--    knowledge base. Equipment entities → enterprise.knowledge_base.{mfr}.{model}
+--    (or enterprise.knowledge_base.{mfr}.{family}.{model} when family is
+--    present in properties JSONB). Everything else stays at the bare
+--    default and gets re-pathed by application code on next write.
 WITH eq AS (
     SELECT
         id,
@@ -46,6 +49,13 @@ WITH eq AS (
         ) AS mfr_slug,
         regexp_replace(
             regexp_replace(
+                lower(coalesce(properties->>'family', '')),
+                '[^a-z0-9]+', '_', 'g'
+            ),
+            '(^_+|_+$)', '', 'g'
+        ) AS family_slug,
+        regexp_replace(
+            regexp_replace(
                 lower(coalesce(name, '')),
                 '[^a-z0-9]+', '_', 'g'
             ),
@@ -53,12 +63,17 @@ WITH eq AS (
         ) AS model_slug
       FROM kg_entities
      WHERE entity_type = 'equipment'
-       AND uns_path = 'enterprise.unassigned'::ltree
+       AND uns_path IN (
+           'enterprise.unassigned'::ltree,
+           'enterprise.knowledge_base'::ltree
+       )
 )
 UPDATE kg_entities ke
    SET uns_path = (
-       'enterprise.unassigned' ||
+       'enterprise.knowledge_base' ||
        CASE WHEN eq.mfr_slug <> '' THEN '.' || eq.mfr_slug ELSE '' END ||
+       CASE WHEN eq.mfr_slug <> '' AND eq.family_slug <> ''
+            THEN '.' || eq.family_slug ELSE '' END ||
        CASE WHEN eq.mfr_slug <> '' AND eq.model_slug <> ''
             THEN '.' || eq.model_slug ELSE '' END
    )::ltree
@@ -68,4 +83,4 @@ UPDATE kg_entities ke
 
 -- 6. Document the column for future readers.
 COMMENT ON COLUMN kg_entities.uns_path IS
-    'Unified Namespace path. ltree address of this entity. Default form is `enterprise.unassigned.{mfr_slug}.{model_slug}` for unplaced equipment; user-placed equipment lives at `enterprise.{site}.{area}.{line}.{equipment}.{component}.{datapoint}`. Validated by uns_path_format CHECK constraint.';
+    'Unified Namespace path. ltree address of this entity. Equipment learned from manuals lives in the manufacturer-organized catalog: `enterprise.knowledge_base.{mfr}.{family?}.{model}`. User-placed equipment instances live under the company/site hierarchy: `enterprise.{company}.site.{site}.area.{area}.line.{line}.work_cell.{cell}.equipment.{eq}` (line and work_cell segments are skippable). Validated by uns_path_format CHECK constraint.';

--- a/docs/migrations/007_uns_path.sql
+++ b/docs/migrations/007_uns_path.sql
@@ -1,0 +1,71 @@
+-- Migration 007: UNS path enforcement on kg_entities
+-- Spec: docs/specs/uns-kg-unification-spec.md §3.1, §4.5, Phase 3
+-- Status: PRODUCTION
+-- Depends on: 006_kg_bridge.sql
+
+-- 1. Install ltree (idempotent, no-op if already present).
+--    On Neon free-tier this is a one-shot: confirm in pre-flight that
+--    the extension is allowed in the target project before running this.
+CREATE EXTENSION IF NOT EXISTS ltree;
+
+-- 2. Add the path column with the spec's default.
+--    The default is meaningful, NOT a placeholder — see §3.1 of the spec.
+--    Existing rows (the 41 test entities) will adopt the default.
+ALTER TABLE kg_entities
+    ADD COLUMN IF NOT EXISTS uns_path ltree NOT NULL DEFAULT 'enterprise.unassigned';
+
+-- 3. Format check — labels must be lowercase [a-z0-9_]+ separated by dots.
+--    Drops + recreates to make the migration idempotent.
+ALTER TABLE kg_entities DROP CONSTRAINT IF EXISTS uns_path_format;
+ALTER TABLE kg_entities
+    ADD CONSTRAINT uns_path_format
+        CHECK (uns_path::text ~ '^[a-z0-9_]+(\.[a-z0-9_]+)*$');
+
+-- 4. Indexes — GIST for ancestor/descendant ltree queries (the dominant
+--    Hub UNS browser pattern), btree for exact-path lookups.
+CREATE INDEX IF NOT EXISTS kg_entities_uns_path_gist
+    ON kg_entities USING gist (uns_path);
+CREATE INDEX IF NOT EXISTS kg_entities_uns_path_btree
+    ON kg_entities (uns_path);
+
+-- 5. Backfill the existing test rows. Equipment entities get
+--    enterprise.unassigned.{mfr}.{model}; everything else stays at the
+--    bare default and gets re-pathed by application code on next write.
+--    This is intentionally a one-shot; production rows will all be
+--    written through kg_writer.upsert_entity which sets the path
+--    explicitly per spec §3.1.
+WITH eq AS (
+    SELECT
+        id,
+        regexp_replace(
+            regexp_replace(
+                lower(coalesce(properties->>'manufacturer', '')),
+                '[^a-z0-9]+', '_', 'g'
+            ),
+            '(^_+|_+$)', '', 'g'
+        ) AS mfr_slug,
+        regexp_replace(
+            regexp_replace(
+                lower(coalesce(name, '')),
+                '[^a-z0-9]+', '_', 'g'
+            ),
+            '(^_+|_+$)', '', 'g'
+        ) AS model_slug
+      FROM kg_entities
+     WHERE entity_type = 'equipment'
+       AND uns_path = 'enterprise.unassigned'::ltree
+)
+UPDATE kg_entities ke
+   SET uns_path = (
+       'enterprise.unassigned' ||
+       CASE WHEN eq.mfr_slug <> '' THEN '.' || eq.mfr_slug ELSE '' END ||
+       CASE WHEN eq.mfr_slug <> '' AND eq.model_slug <> ''
+            THEN '.' || eq.model_slug ELSE '' END
+   )::ltree
+  FROM eq
+ WHERE ke.id = eq.id
+   AND eq.mfr_slug <> '';
+
+-- 6. Document the column for future readers.
+COMMENT ON COLUMN kg_entities.uns_path IS
+    'Unified Namespace path. ltree address of this entity. Default form is `enterprise.unassigned.{mfr_slug}.{model_slug}` for unplaced equipment; user-placed equipment lives at `enterprise.{site}.{area}.{line}.{equipment}.{component}.{datapoint}`. Validated by uns_path_format CHECK constraint.';

--- a/docs/specs/uns-kg-standards-compliance.md
+++ b/docs/specs/uns-kg-standards-compliance.md
@@ -1,0 +1,517 @@
+---
+title: "UNS + Knowledge Graph — Standards Compliance Analysis"
+date: 2026-05-07
+status: "Companion to uns-kg-unification-spec.md — DRAFT"
+author: "Claude (CHARLIE node) on behalf of Mike Harper"
+---
+
+# UNS + Knowledge Graph — Standards Compliance Analysis
+
+## Executive Summary
+
+MIRA's `enterprise.{site}.{area}.{line}.{equipment}.{component}.{datapoint}` UNS path and its typed knowledge graph align **well** with the dominant industrial standards for equipment hierarchy (ISA-95), reliability data (ISO 14224), asset management philosophy (ISO 55000), and real-time bus semantics (Sparkplug B / OPC UA). The core design choices — hierarchical paths derived from ISA-95's physical model, typed entities that mirror ISO 14224's equipment taxonomy, and a relationship graph that is source-citable and confidence-scored — are structurally sound and defensible to a controls engineer or reliability professional. Three concrete gaps exist: (1) the UNS 7-segment path omits the ISA-95 "Work Cell" level between Line and Equipment, making it a 6-level hierarchy in practice rather than the standard's optional 7-8 levels; (2) the `fault_code` entity lacks the four NAMUR NE 107 severity signals as first-class properties; and (3) the vector-store bridge layer has no formal alignment with W3C SOSA/SSN, which matters only if MIRA adds a live sensor event stream. None of these gaps block an MVP sale to an industrial maintenance buyer; they become relevant when selling to SCADA/process-control buyers or when Layer 4 (event stream) ships.
+
+---
+
+## 1. ISA-95 (ANSI/ISA-95 / IEC 62264)
+
+### What it is
+
+ISA-95 (international version: IEC 62264) is the enterprise-to-control integration standard. It defines a five-level functional hierarchy (Levels 0–4, from field sensors to ERP), a physical equipment hierarchy (Enterprise → Site → Area → Production Line/Process Cell → Work Cell/Unit → Equipment Module → Control Module), and data exchange models between manufacturing execution systems (MES, Level 3) and business systems (ERP, Level 4).
+
+Reference: [ISA-95 standard page](https://www.isa.org/standards-and-publications/isa-standards/isa-95-standard) | [OPC UA ISA-95 Enum](https://reference.opcfoundation.org/ISA-95/v100/docs/7.4.1) | [IEC 62264 at ANSI](https://webstore.ansi.org/preview-pages/ISA/preview_ANSI+ISA+95.00.01-2010+(IEC+62264-1+Mod).pdf)
+
+### What it validates in MIRA's approach
+
+The ISA-95 `ISA95EquipmentElementLevelEnum` defines (in descending order): ENTERPRISE → SITE → AREA → PROCESSLINE / PROCESSCELL → WORKCELL / UNIT → EQUIPMENTMODULE → CONTROLMODULE. MIRA's UNS path `enterprise.{site}.{area}.{line}.{equipment}.{component}.{datapoint}` maps directly to the first 6 levels of this enum. Specifically:
+
+- The segment order (Enterprise, Site, Area, Line, Equipment, Component) is a strict subset of the ISA-95 physical model.
+- Using `.` as a separator and lower-snake-case labels is compatible with the ISA-95 hierarchical naming convention; ISA-95 itself does not mandate a specific delimiter.
+- The "unassigned" subtree concept (`enterprise.unassigned.{manufacturer}.{model}`) has a precedent in ISA-95's "Functional Location" concept — equipment that is catalogued but not yet physically placed.
+- The `PARENT_OF` relationship type in `kg_relationships` is the graph edge equivalent of ISA-95's parent-child equipment relationship.
+
+The Unified Namespace (UNS) pattern — an MQTT or database topic tree organized as `Enterprise/Site/Area/Line/Equipment/Tag` — is explicitly recommended by the ISA-95 community as the canonical way to structure industrial data paths. Sources from EMQ, HiveMQ, and Prosys all confirm this alignment. See: [EMQ UNS + ISA-95 best practices](https://www.emqx.com/en/blog/incorporating-the-unified-namespace-with-isa-95-best-practices), [HiveMQ UNS guide](https://www.hivemq.com/blog/how-does-unified-namespace-uns-work-iiot-industry-40/).
+
+### Gaps / where we deviate
+
+| Gap | Severity for MVP (maintenance buyer) | Severity for SCADA buyer |
+|-----|--------------------------------------|--------------------------|
+| MIRA path has 7 segments (`enterprise.site.area.line.equipment.component.datapoint`). ISA-95 physical model has 8 addressable levels (adds `WorkCell` between `Line` and `Equipment`, and separates `EquipmentModule` from `ControlModule`). | Low — maintenance buyers don't care about Work Cell granularity | Medium — a process-control buyer integrating with a DCS may need the full 8-level path |
+| MIRA uses `line` where ISA-95 uses `ProductionLine` (discrete) **or** `ProcessCell` (batch) **or** `ProductionUnit` (continuous). The spec collapses all three manufacturing types into a single `line` segment. | Low — correct for most discrete/batch maintenance scenarios | High — a continuous-process (oil/gas, chemical) buyer needs `ProcessCell` or `ProductionUnit` distinction |
+| MIRA `component` maps to ISA-95 `EquipmentModule`, not `ControlModule`. There is no Control Module concept in MIRA's KG entity types. | Low — not needed until PLC tag ingestion | Medium — when OPC UA or Modbus tag data flows in, Control Module identity matters |
+
+**The missing Work Cell level:** ISA-95 defines Work Cell (`WORKCELL`) between Production Line and the Unit/Equipment level. MIRA's 7-segment path goes `line.equipment` with no intermediate. For discrete manufacturing sites with multiple work cells per line, this means MIRA cannot distinguish "Line 3, Cell A" from "Line 3, Cell B" without hacking the `line` or `equipment` segments.
+
+### Concrete mapping
+
+| MIRA UNS segment | ISA-95 level | ISA-95 enum value |
+|---|---|---|
+| `enterprise` | Enterprise | ENTERPRISE (0) |
+| `{site}` | Site | SITE (1) |
+| `{area}` | Area | AREA (2) |
+| `{line}` | Production Line / Process Cell / Production Unit | PRODUCTIONLINE (5) / PROCESSCELL (3) / PRODUCTIONUNIT (7) |
+| *(missing)* | Work Cell / Unit | WORKCELL (6) / UNIT (4) |
+| `{equipment}` | Equipment Module | EQUIPMENTMODULE (12) |
+| `{component}` | Control Module | CONTROLMODULE (13) |
+| `{datapoint}` | (tag/metric — below Control Module) | Not in ISA-95 physical model; maps to Sparkplug metric name |
+
+### Action items
+
+1. **Document the `line` ambiguity** in the spec: state explicitly that `line` maps to ISA-95 `ProductionLine` for discrete manufacturing, `ProcessCell` for batch, and `ProductionUnit` for continuous. MIRA does not differentiate at path structure; buyers must handle this via `kg_entities.properties`.
+2. **Add `work_cell` as an optional 8th path segment** (or a `properties.work_cell` field on equipment entities) to satisfy work-cell-granular queries without breaking the 7-segment default.
+3. **Reference ISA-95 Part 1 (ANSI/ISA-95.00.01-2010)** explicitly in the spec as the authority for the hierarchy model.
+
+---
+
+## 2. ISO 14224:2016
+
+### What it is
+
+ISO 14224:2016 ("Petroleum, petrochemical and natural gas industries — Collection and exchange of reliability and maintenance data for equipment") defines a 9-level equipment taxonomy, failure mode codes, maintenance event records, and data interchange formats for reliability databases. It is the reference standard for reliability and maintenance data in heavy industry worldwide, though it originates in the oil and gas sector.
+
+Reference: [ISO 14224:2016 at ISO](https://www.iso.org/standard/64076.html) | [ANSI Blog summary](https://blog.ansi.org/ansi/iso-14224-2016-collection-maintenance-data/)
+
+### What it validates in MIRA's approach
+
+ISO 14224's hierarchy has 9 levels, split into two bands:
+
+**Levels 1–5 (organizational context):** Industry → Business Category → Installation → Plant → Section/System
+
+**Levels 6–9 (equipment inventory):** Equipment Unit → Subunit → Maintainable Item → Component/Part
+
+MIRA's KG entity types map cleanly to the levels 6–9 band:
+
+- Our `equipment` entity ≈ ISO 14224 **Equipment Unit** (Level 6): "a distinct physical item that performs a function, independently inventoried and maintained."
+- Our `component` entity ≈ ISO 14224 **Subunit** (Level 7) / **Maintainable Item** (Level 8): a replaceable sub-part of the equipment unit (bearing, seal, fan). ISO 14224 distinguishes Subunit (a functional grouping within a unit, like a "compressor end") from Maintainable Item (the discrete part that is actually replaced or repaired). MIRA collapses both into `component`.
+- Our `fault_code` entity ≈ ISO 14224 **Failure Mode** data element: a specific failure mode code attached to an Equipment Unit or Subunit.
+- Our `pm_task` entity ≈ ISO 14224 **Preventive Maintenance Action** in the maintenance event record.
+- Our `part` entity ≈ ISO 14224 **Component/Part** (Level 9): the replaceable spare.
+
+ISO 14224 requires that each failure mode record include: failure mode, failure cause, failure effect/consequence, and detection method. MIRA's `fault_code` entity in `kg_entities.properties` can hold all four as JSONB fields.
+
+The standard also defines that maintenance data records must link back to the Equipment Unit (Level 6), which is exactly what MIRA's `equipment_entity_id` FK on `knowledge_entries` achieves — every chunk of maintenance data (a manual, a troubleshooting procedure, a fault code description) is linked to a KG entity at the Equipment Unit level.
+
+Sources: [Taxonomy explained by Fabrico](https://www.fabrico.io/blog/asset-hierarchy-naming-convention-guide/) | [MaintainX asset hierarchy](https://www.getmaintainx.com/blog/asset-hierarchy)
+
+### Gaps / where we deviate
+
+| Gap | Severity |
+|-----|----------|
+| MIRA's `component` entity collapses ISO 14224's Level 7 (Subunit) and Level 8 (Maintainable Item) into a single type. | Low for MVP; medium for reliability-database buyers who need failure mode data at the subunit level |
+| MIRA has no explicit Level 1–5 organizational hierarchy above the UNS path `enterprise.{site}`. The KG does not model "Business Category" or "Installation" as entities. | Low — these are organizational metadata, not equipment inventory |
+| ISO 14224 defines failure modes as normalized codes with defined attributes (mode, cause, effect, detection method). MIRA's `fault_code` entity properties JSONB is flexible but unstandardized. | Medium — a reliability engineer will want structured failure mode attributes, not free-text JSONB |
+| ISO 14224 distinguishes `equipment_class` (the make/model archetype) from `equipment_instance` (the specific serial number on the floor). MIRA currently stores both as `equipment` type entities, with instances and models conflated. | Medium — important for multi-tenant and multi-site deployments where the same model appears in many plants |
+
+### Concrete mapping
+
+| MIRA entity type | ISO 14224 level/concept |
+|---|---|
+| `equipment` | Level 6: Equipment Unit |
+| `component` | Level 7: Subunit + Level 8: Maintainable Item (collapsed) |
+| `fault_code` | Failure Mode record (linked to Equipment Unit) |
+| `pm_task` | Preventive Maintenance Action record |
+| `part` | Level 9: Component/Part |
+| `manual` | (no ISO 14224 equivalent — documentation record) |
+| `procedure` | Maintenance Action record |
+| `specification` | Equipment Attribute / Engineering Parameter |
+| `kg_entities.properties` JSONB | ISO 14224 equipment attributes (design data) |
+
+### Action items
+
+1. **Split `component` into `subunit` and `maintainable_item`** in a future `kg_entities.entity_type` enum extension (not MVP-blocking, but plan for it in the v4.0 type set).
+2. **Add structured failure mode properties** to `fault_code` entities: `properties.failure_mode`, `properties.failure_cause`, `properties.failure_effect`, `properties.detection_method` — matching ISO 14224 Annex D failure mode taxonomy.
+3. **Add `equipment_class` vs `equipment_instance` distinction** to the KG: the current `UNIQUE(tenant_id, entity_type, name)` constraint prevents this. Solution: add a `classification_type` field (`model | instance`) and a `parent_class_entity_id` FK on equipment entities.
+4. **Reference ISO 14224:2016** in the spec as the authority for failure mode data element structure.
+
+---
+
+## 3. MIMOSA CCOM / OSA-CBM / OSA-EAI
+
+### What it is
+
+MIMOSA (Machinery Information Management Open Systems Alliance) produces open standards for physical asset management data exchange. The Common Conceptual Object Model (CCOM, current stable version 4.0.0) provides an XML schema for exchanging asset lifecycle data across systems — design, as-built inventory, condition-based monitoring measurements, work management, and reliability records. OSA-CBM (Open System Architecture for Condition-Based Maintenance) extends CCOM for real-time diagnostic/prognostic data pipelines.
+
+Reference: [MIMOSA CCOM page](https://www.mimosa.org/mimosa-ccom/) | [CCOM 4.0.0 release](https://www.mimosa.org/specifications/ccom-4-0-0/) | [OSA-CBM](https://www.mimosa.org/mimosa-osa-cbm/)
+
+### What it validates in MIRA's approach
+
+CCOM 4.0.0 defines these primary entity types: `Asset`, `Segment` (hierarchical location unit, of which `Site` is a subclass), `Model` (equipment specification template), `Organization` (formerly Enterprise), `Measurement` (abstract base with subtypes for scalar, FFT, time-waveform, CPB data), `Event` (timestamped occurrence), `WorkOrder` (task with parent/child support), `Document` (URL or BLOB content), and `Attribute/AttributeSet` (EAV extension mechanism).
+
+MIRA's KG maps to CCOM as follows:
+
+- Our `equipment` entity ≈ CCOM `Asset` (a serialized physical item with lifecycle status)
+- Our `kg_entities.properties` JSONB ≈ CCOM `Attribute/AttributeSet` (the EAV property mechanism)
+- Our `manual` entity ≈ CCOM `Document` (URL or BLOB content linked to an asset)
+- Our `pm_task` entity ≈ CCOM `WorkOrder` (task with interval)
+- Our `fault_code` entity ≈ CCOM `Event` of type alarm/failure
+- Our `knowledge_entries` row ≈ CCOM `Measurement` or `Document` linked to the asset
+- Our `kg_relationships` source_chunk_id audit trail ≈ CCOM `InfoSource` registration (the requirement that every data element cite its source)
+
+The CCOM philosophy of "all asset data is traceable to an InfoSource" directly validates MIRA's architectural decision to require `source_chunk_id` on every `kg_relationships` row — no edge exists without citing the chunk of content that justified it.
+
+CCOM also mandates mandatory UUIDs on all entities (replacing the optional GUIDs of v3.x). MIRA uses `UUID PRIMARY KEY DEFAULT gen_random_uuid()` on both `kg_entities` and `kg_relationships` — this is CCOM-compatible.
+
+### Gaps / where we deviate
+
+| Gap | Severity |
+|-----|----------|
+| MIRA has no `BreakdownStructure` equivalent — a named organizational structure (RCM breakdown, WBS, PBS) that groups assets by a specific view. CCOM uses this to support multiple simultaneous hierarchies over the same assets. | Low — MIRA's UNS tree is a single hierarchy; multiple views require querying by `entity_type` or tag |
+| CCOM `Measurement` includes rich subtypes (FFT, time-waveform, oil analysis) for condition-based monitoring data. MIRA's Layer 4 (event stream) does not yet exist. | Not applicable for MVP |
+| CCOM uses XML/XSD for data exchange. MIRA uses JSON/JSONB. No CCOM XML serialization is implemented. | Low for internal use; medium if a customer's CMMS expects CCOM XML import/export |
+| CCOM supports `EffectiveDate` temporal records (history of asset state changes). MIRA has `created_at` but no effective-date version tracking on entities. | Medium — important for audit trails when equipment moves between sites |
+
+### Concrete mapping
+
+| MIRA concept | CCOM 4.0 entity |
+|---|---|
+| `kg_entities` (equipment) | `Asset` |
+| `kg_entities` (manual) | `Document` |
+| `kg_entities` (pm_task, work order) | `WorkOrder` |
+| `kg_entities` (fault_code) | `Event` (alarm subtype) |
+| `kg_relationships.source_chunk_id` | `InfoSource` audit link |
+| `kg_entities.properties` JSONB | `Attribute/AttributeSet` |
+| UNS path / `uns_path` | `Segment` hierarchy + `BreakdownStructure` |
+| `knowledge_entries` row | `Measurement` (document-type) |
+| `tenant_id` | `Organization` |
+
+### Action items
+
+1. **Document CCOM alignment** in the spec for customers who ask about CMMS integration — MIRA's entity model is CCOM-derivable without structural changes.
+2. **Plan a CCOM XML export** for customers whose CMMS (Maximo, SAP PM, Infor EAM) ingests CCOM — this is a future integration feature, not an MVP blocker.
+3. **Add `effective_from` / `effective_to` columns** to `kg_entities` for temporal asset state tracking (deferred, post-MVP).
+
+---
+
+## 4. W3C OWL / RDF + SOSA/SSN
+
+### What it is
+
+W3C OWL (Web Ontology Language) and RDF (Resource Description Framework) are the formal semantic web standards for representing knowledge graphs. SOSA (Sensor, Observation, Sample, and Actuator) and SSN (Semantic Sensor Network) are W3C ontologies specifically for modeling sensors, observations, and the things they measure. SOSA is the lightweight core; SSN is the full specification (W3C TR, 2017, updated 2023).
+
+Reference: [SOSA/SSN W3C TR](https://www.w3.org/TR/vocab-ssn/) | [SSN 2023 edition](https://www.w3.org/TR/vocab-ssn-2023/)
+
+### What it validates in MIRA's approach
+
+SOSA defines these core classes:
+
+- **`sosa:FeatureOfInterest`** — the thing whose property is being observed. Maps to MIRA's `equipment` or `component` entity.
+- **`sosa:ObservableProperty`** — an observable quality of a feature of interest (temperature, vibration, current). Maps to MIRA's `specification` entity or a future Layer 4 datapoint.
+- **`sosa:Sensor`** — a device that carries out an observation. No MIRA equivalent today; maps to a future `sensor` entity in Layer 4.
+- **`sosa:Observation`** — the act of taking a measurement, with a result value and a timestamp. Maps to a future `uns_observations` table in Layer 4.
+- **`sosa:Actuator`** — a device that changes the state of the world. Maps to equipment with a control coil (VFD enable, valve open) in Layer 4.
+- **`sosa:Platform`** — an entity that hosts sensors. Maps to MIRA's `equipment` entity (a VFD hosts current and temperature sensors).
+
+MIRA's entity-relationship model (typed nodes + typed edges + source citations) is structurally equivalent to an RDF knowledge graph — `kg_entities` rows are RDF subjects/objects, `kg_relationships` rows are RDF triples. The JSONB `properties` bag is equivalent to OWL datatype properties. This means MIRA's KG could be exported to Turtle/JSON-LD without any schema changes, which matters if a customer's enterprise knowledge base is OWL-based.
+
+The key SOSA validation: MIRA's `equipment` → `HAS_FAULT` → `fault_code` relationship is analogous to `sosa:FeatureOfInterest` → `sosa:hasProperty` → `sosa:ObservableProperty` → `sosa:Observation.hasSimpleResult`. This structural homology is exactly right for Layer 4.
+
+### Gaps / where we deviate
+
+| Gap | Severity |
+|-----|----------|
+| MIRA has no `Sensor` entity type. A future `sensor` entity should be added when Layer 4 ships, with `equipment HAS_SENSOR sensor` and `sensor MEASURES specification` relationships. | Not applicable for MVP |
+| MIRA has no `Observation` record structure for real-time readings. The `uns_observations` table mentioned in §3.4 of the unification spec is the placeholder. | Not applicable for MVP |
+| MIRA does not use OWL-DL reasoning or SPARQL. The KG is not exposed as a SPARQL endpoint. | Low — no industrial maintenance buyer needs SPARQL today |
+| SOSA distinguishes `sosa:Sample` from `sosa:FeatureOfInterest` (a sample is a proxy for the real thing, e.g., an oil sample represents the gearbox). MIRA has no sampling concept. | Low — not relevant until lab analysis integration |
+
+### Concrete mapping
+
+| SOSA/SSN class | MIRA concept | Layer |
+|---|---|---|
+| `sosa:FeatureOfInterest` | `kg_entities` (equipment / component) | Layer 2 (KG) |
+| `sosa:ObservableProperty` | `kg_entities` (specification) | Layer 2 (KG) |
+| `sosa:Sensor` | Future `sensor` entity type | Layer 4 (not built) |
+| `sosa:Observation` | Future `uns_observations` table | Layer 4 (not built) |
+| `sosa:Actuator` | Future actuator entity type | Layer 4 (not built) |
+| `sosa:Platform` | `kg_entities` (equipment) | Layer 2 (KG) |
+| RDF triple (subject, predicate, object) | `kg_relationships` row (source_entity, relation_type, target_entity) | Layer 2 (KG) |
+| OWL datatype property | `kg_entities.properties` JSONB field | Layer 2 (KG) |
+| OWL object property | `kg_relationships.relation_type` | Layer 2 (KG) |
+
+### Action items
+
+1. **Reserve `sensor` and `actuator` in `entity_type` enum** now (even as unused values) so that Layer 4 additions do not require a migration.
+2. **Add `MEASURES` and `LOCATED_ON` to the `relation_type` set** for future sensor→specification and sensor→platform relationships.
+3. **Document the RDF isomorphism** — note in the spec that `kg_entities` + `kg_relationships` is an embedded RDF graph and can be exported to JSON-LD via a simple query.
+
+---
+
+## 5. OPC UA (IEC 62541)
+
+### What it is
+
+OPC UA (Unified Architecture), standardized as IEC 62541, is the dominant industrial interoperability protocol. It defines a secure, transport-agnostic communication architecture AND a rich information modeling layer (the "AddressSpace" — a directed graph of typed nodes). OPC UA Companion Specifications extend the base model for specific domains; the ISA-95 Companion Specification (published by OPC Foundation) maps ISA-95 entities to OPC UA object types.
+
+Reference: [OPC UA IEC 62541 overview](https://scadaprotocols.com/opc-ua-protocol-explained/) | [OPC Foundation ISA-95 page](https://opcfoundation.org/markets-collaboration/isa-95/) | [OPC UA ISA-95 Common Object Model](https://reference.opcfoundation.org/ISA-95/v100/docs/)
+
+### What it validates in MIRA's approach
+
+The OPC UA AddressSpace is a directed graph of typed `Node` objects connected by typed `References`. This is structurally identical to MIRA's `kg_entities` (nodes) + `kg_relationships` (references). The OPC UA ISA-95 Companion Specification defines:
+
+- **Equipment Classes** → OPC UA `ObjectTypes` (the template/archetype of an equipment model).
+- **Equipment Instances** → OPC UA `Object` nodes conforming to a class (a specific serial-numbered unit on the floor).
+- **Equipment Properties** → OPC UA `Variables` with `VariableTypes`.
+- **Nested Equipment** → hierarchical `Object` references (a control module inside an equipment module).
+
+MIRA's UNS path `enterprise.stardust_racers.pump_station.sump.vfd_07.motor_current` can be read as an OPC UA NodeId path — OPC UA uses `/` separators and a `ns=<namespace-index>;s=<string>` format, but the hierarchical path concept is identical. Tools that browse OPC UA trees (like UaExpert) would render MIRA's UNS as a tree identical to the AddressSpace tree.
+
+The OPC UA ISA-95 `ISA95EquipmentElementLevelEnum` (fetched directly from the OPC Foundation reference server) defines 15 levels. MIRA uses 7 of them. The OPC UA model explicitly supports the "OTHER" level for custom extensions, which is where MIRA's `unassigned` subtree would live.
+
+The OPC Foundation also supports OPC UA **PubSub over MQTT**, which bridges OPC UA and Sparkplug B — an OPC UA server can publish its AddressSpace as MQTT topics using the same hierarchy as the UNS. This means a future MIRA deployment that connects to an OPC UA-enabled PLC (Siemens S7, Allen-Bradley Logix, Beckhoff TwinCAT) could directly populate `kg_entities` from the OPC UA AddressSpace without any mapping layer, because the path structure is the same.
+
+### Gaps / where we deviate
+
+| Gap | Severity |
+|-----|----------|
+| MIRA does not distinguish `Equipment Class` (the type/model archetype) from `Equipment Instance` (the serial-numbered physical unit). OPC UA requires this distinction. | Medium — important when the same PowerFlex 525 model appears in 5 sites; the ISA-95 Q7 (§9 of the unification spec) is directly related to this gap |
+| OPC UA uses `NodeId` (namespace + string or integer identifier), not a human-readable path. MIRA's `uns_path` ltree is closer to OPC UA's `BrowsePath` (the human-readable traversal path), which is distinct from `NodeId`. | Low — MIRA can maintain both a `uns_path` (browseable path) and a UUID `id` (stable identifier) without conflict |
+| OPC UA node types have `Description`, `DisplayName`, and `BrowseName` as first-class attributes. MIRA's `kg_entities` has only `name`. `DisplayName` (user-facing) vs `BrowseName` (API key) vs `name` (storage key) is a real distinction. | Low for MVP; medium when building the UNS browser UI |
+| OPC UA companion specs (Devices, Machinery, PackML) define standardized property sets for equipment categories. MIRA's `properties` JSONB is unstructured and not aligned to any companion spec's property set. | Low — not needed until a SCADA buyer requires OPC UA companion spec compliance |
+
+### Concrete mapping
+
+| MIRA concept | OPC UA concept |
+|---|---|
+| `kg_entities` row | OPC UA `Object` node |
+| `kg_entities.entity_type` | OPC UA `ObjectType` (class) |
+| `kg_entities.properties` JSONB | OPC UA `Variable` nodes on the Object |
+| `kg_relationships` row | OPC UA `Reference` (typed edge) |
+| `kg_relationships.relation_type` | OPC UA `ReferenceType` |
+| `uns_path` (ltree) | OPC UA `BrowsePath` |
+| `kg_entities.id` (UUID) | OPC UA `NodeId` |
+| UNS `enterprise.site.area` prefix | OPC UA `Namespace` + folder nodes |
+| Equipment entity (model archetype) | OPC UA `ObjectType` |
+| Equipment entity (floor instance) | OPC UA `Object` of that `ObjectType` |
+
+### Action items
+
+1. **Add `equipment_class` entity type** (as noted in ISO 14224 action items) — this directly resolves the OPC UA class/instance gap and the unification spec's §9 Q7 multi-tenancy question.
+2. **Store `display_name` as a property** in `kg_entities.properties.display_name` to support future UNS browser UI requirements.
+3. **Note in the spec** that `uns_path` functions as the OPC UA `BrowsePath` and should be kept stable (no re-pathing without migration) because external OPC UA clients may hold references by path.
+
+---
+
+## 6. Sparkplug B (Eclipse Tahu / Eclipse Foundation)
+
+### What it is
+
+Sparkplug B is an open MQTT topic namespace and payload specification for industrial IoT, maintained by the Eclipse Foundation (Eclipse Tahu project, specification version 3.0.0). It defines the exact MQTT topic structure: `spBv1.0/{group_id}/{message_type}/{edge_node_id}/{device_id}` and a Protocol Buffer payload format with typed metrics, birth/death certificates, and aliased metric names for bandwidth efficiency.
+
+Reference: [Sparkplug 3.0.0 specification (PDF)](https://sparkplug.eclipse.org/specification/version/3.0/documents/sparkplug-specification-3.0.0.pdf) | [Eclipse Sparkplug GitHub](https://github.com/eclipse-sparkplug/sparkplug)
+
+### What it validates in MIRA's approach
+
+Sparkplug B's topic namespace uses 4–5 segments: `spBv1.0 / group_id / message_type / edge_node_id / [device_id]`. MIRA's UNS path uses 7 segments. The mapping is not a 1:1 substitution — it is a layered translation:
+
+| Sparkplug B segment | MIRA UNS mapping |
+|---|---|
+| `spBv1.0` | Protocol prefix (not in MIRA path — metadata) |
+| `{group_id}` | `enterprise.{site}.{area}` (3 MIRA segments) |
+| `{message_type}` | Implicit in payload type (NBIRTH/DBIRTH/NDATA/DDATA) |
+| `{edge_node_id}` | `{line}.{equipment}` (2 MIRA segments) |
+| `{device_id}` | `{component}` (1 MIRA segment) |
+| (metric name in payload) | `{datapoint}` (1 MIRA segment) |
+
+This mapping is valid and is consistent with the community practice of combining ISA-95 with Sparkplug B. The `{datapoint}` segment in MIRA's path is equivalent to the Sparkplug metric name inside the payload — in the MQTT world, metric names live in the payload (not the topic), but in a database UNS the metric name is a topic-level path segment. This is a deliberate design choice in MIRA (persisted UNS vs. live MQTT UNS) and is not a conflict.
+
+Sparkplug B message types (NBIRTH, DBIRTH, NDATA, DDATA, NDEATH, DDEATH) have direct relevance to MIRA Layer 4 (event stream):
+- NBIRTH/DBIRTH → populate or update `kg_entities` with equipment identity
+- NDATA/DDATA → write to `uns_observations` table
+- NDEATH/DDEATH → mark equipment as offline in `kg_entities.properties`
+
+The `{group_id}` in Sparkplug B is most naturally the ISA-95 site or area name — which is exactly `enterprise.{site}.{area}` in MIRA's path.
+
+### Gaps / where we deviate
+
+| Gap | Severity |
+|-----|----------|
+| Sparkplug B uses `/` as separator; MIRA uses `.`. A future MQTT broker integration requires a translation layer (replace `.` with `/`, prepend `spBv1.0`, extract metric name from final segment). This is a 10-line transform, not a structural incompatibility. | Low |
+| Sparkplug B `group_id` and `edge_node_id` have maximum length constraints (256 chars UTF-8). MIRA ltree labels are constrained to `[a-z0-9_]+` — this is *more* restrictive than Sparkplug B and is fully compatible. | Not a gap — MIRA is stricter, which is good |
+| Sparkplug B metric names can contain `/` for hierarchical metric naming (e.g., `Inputs/MotorRunning`). MIRA's `{datapoint}` segment is a single label with no sub-hierarchy. | Low — can be resolved with `_` encoding when translating |
+| MIRA has no concept of NBIRTH/DBIRTH birth certificate payload, which is how Sparkplug defines the initial schema for a device's metrics. This matters for Layer 4. | Not applicable for MVP |
+
+### Concrete mapping
+
+| Sparkplug B concept | MIRA concept |
+|---|---|
+| `group_id` | `enterprise.{site}.{area}` (3 UNS segments joined) |
+| `edge_node_id` | `{line}.{equipment}` (2 UNS segments joined) |
+| `device_id` | `{component}` |
+| metric name (in payload) | `{datapoint}` (7th UNS segment) |
+| NBIRTH/DBIRTH | Ingest-time `kg_entities` upsert |
+| NDATA/DDATA | Layer 4 `uns_observations` write |
+| NDEATH/DDEATH | `kg_entities.properties.online = false` |
+
+### Action items
+
+1. **Add a `to_sparkplug_topic()` utility function** to the spec (or the MCP tools layer) that translates a MIRA UNS path to a Sparkplug B topic: `enterprise.site.area.line.eq.comp.dp` → `spBv1.0/enterprise-site-area/NDATA/line-eq/comp` (metric=`dp`). This makes Layer 4 integration a one-liner.
+2. **Document the `.` → `/` translation rule** explicitly in the spec so future engineers don't treat it as a breaking change.
+3. **Reserve `NBIRTH` and `DBIRTH` as future `relation_type` values** — or more precisely, document that the Celery ingest path is the offline equivalent of a Sparkplug NBIRTH message.
+
+---
+
+## 7. NAMUR NE 107
+
+### What it is
+
+NAMUR NE 107 ("Self-monitoring and diagnostics of field devices") is a recommendation from the NAMUR user association (German process industry) that defines four standardized device health status signals. It is widely implemented in smart field devices (transmitters, valve positioners, analyzers) and supported by industrial protocols (HART, PROFIBUS, FF, IO-Link). It reduces complex device diagnostics to four operator-actionable signals.
+
+Reference: [NAMUR NE107 revision notice](https://www.namur.net/en/publications/news-archive/ne107-self-monitoring-and-diagnostics-of-field-devices-has-been-revised.html) | [Endress+Hauser NE107 explainer](https://www.endress.com/en/support-overview/learning-center/namur-ne-107)
+
+### What it validates in MIRA's approach
+
+NE 107 defines exactly four status signals:
+
+| Signal | NE 107 symbol | Severity | Meaning |
+|---|---|---|---|
+| **Failure** (F) | Red diamond | Critical | Invalid measurement; device malfunction; immediate attention required |
+| **Function Check** (C) | Orange circle | Low | Temporarily invalid signal (loop test, calibration, forced output) |
+| **Out of Specification** (S) | Yellow triangle | Medium | Device operating outside its rated range; signal may be degraded |
+| **Maintenance Required** (M) | Blue wrench | Low | Predictive indicator; device functions but approaching end-of-life or service interval |
+
+MIRA's `fault_code` entity is the right place to attach NE 107 status. Each device diagnostic message in a PLC or field device maps to one of these four signals. If MIRA ingests PLC diagnostic logs or HART device status messages, the `fault_code.properties` JSONB should include a `ne107_status` field with one of `{F, C, S, M}`.
+
+This is directly actionable for MIRA's `pm_task` logic: a `fault_code` with `ne107_status = "M"` (Maintenance Required) should automatically create or flag a `pm_task` entity. The unification spec already supports this chain (`fault_code CAUSED_BY pm_task` or a new `TRIGGERS_PM` relation type).
+
+The NE 107 signal also informs the priority with which the diagnostic state machine (DST) in `mira-bots/shared/engine.py` should escalate: Failure → immediate STOP escalation (already handled by `SAFETY_KEYWORDS` in `guardrails.py`); Maintenance Required → schedule PM; Out of Specification → escalate to engineer; Function Check → ignore (expected transient).
+
+### Gaps / where we deviate
+
+| Gap | Severity |
+|-----|----------|
+| MIRA's `fault_code` entity has no `ne107_status` field. All four signals are unmapped. | Low for MVP (fault codes from manuals, not live devices); medium when PLC diagnostic ingestion begins |
+| MIRA has no concept of "device diagnostic is configurable" — NE 107 explicitly allows each device manufacturer to configure which internal diagnostic maps to which of the 4 signals. MIRA treats all fault codes as equally structured. | Low — not needed until device-level diagnostic integration |
+| NE 107 defines specific visual representations (colors, symbols) for operator displays. MIRA's Hub UI does not implement these. | Low — UI design concern |
+
+### Concrete mapping
+
+| NE 107 signal | MIRA entity / property |
+|---|---|
+| Failure (F) | `fault_code` with `properties.ne107_status = "F"` + `properties.severity = "critical"` |
+| Function Check (C) | `fault_code` with `properties.ne107_status = "C"` + `properties.severity = "informational"` |
+| Out of Specification (S) | `fault_code` with `properties.ne107_status = "S"` + `properties.severity = "warning"` |
+| Maintenance Required (M) | `fault_code` with `properties.ne107_status = "M"` → triggers `HAS_PM` edge to a `pm_task` |
+
+### Action items
+
+1. **Add `ne107_status` to `fault_code` entity schema** in the spec: `properties.ne107_status: "F" | "C" | "S" | "M" | null`. Default null for fault codes from manuals (no NE 107 metadata available from text). Populated when PLC diagnostic logs are ingested.
+2. **Add `TRIGGERS_PM` relation type** to `kg_relationships.relation_type` enum — connects a `fault_code` with `ne107_status = "M"` to an auto-created `pm_task`.
+3. **Update the DST escalation logic** in the spec's Phase 5 description to note that NE 107 severity governs the escalation path.
+
+---
+
+## 8. ISO 55000 (Asset Management)
+
+### What it is
+
+ISO 55000 (2014, updated 2024) is the international asset management standard, providing vocabulary, overview, and principles. ISO 55001 is the requirements standard; ISO 55002 is the implementation guide. Together they define what an asset management system must do at the organizational level — not how to build the software, but what capabilities the software must enable.
+
+Reference: [ISO 55000:2024](https://www.iso.org/standard/83053.html) | [ISO 55000:2014](https://www.iso.org/standard/55088.html) | [ISO 55000 overview at Asset Leadership Network](https://www.assetleadership.net/iso55000-base/iso-55000-asset-management-overview/)
+
+### What it validates in MIRA's approach
+
+ISO 55000 defines an "asset" as "an item, thing, or entity that has potential or actual value to an organization." It explicitly covers physical assets (equipment, infrastructure), intangible assets (knowledge, procedures), and information assets (maintenance records). MIRA's KG models all three:
+
+- Physical assets → `equipment` and `component` entities
+- Knowledge/procedures → `manual`, `procedure`, `fault_code`, `pm_task` entities
+- Information assets → `knowledge_entries` rows linked via `equipment_entity_id`
+
+ISO 55000 requires that organizations maintain an **asset inventory** (a register of all assets with their attributes, location, and condition). MIRA's `kg_entities` table with `uns_path` is exactly an asset inventory — every piece of equipment in the KG has a unique identity (`id` UUID), an address (`uns_path`), attributes (`properties` JSONB), and linkage to its knowledge base.
+
+ISO 55000 also requires **lifecycle management** — assets must be tracked through acquisition, operation, maintenance, and disposal. MIRA's event stream (Layer 4, deferred) and work order integration (`mira-cmms`) form the operational and maintenance lifecycle layer. The KG provides the identity spine on which lifecycle events are hung.
+
+ISO 55000's requirement for **capable information/decision-support systems** is the organizational justification for building MIRA's UNS+KG at all. A controls engineer or facility manager presenting to their management can cite ISO 55000 as the reason they need a unified equipment registry — and MIRA's architecture is the technical implementation of that requirement.
+
+The 2024 edition adds stronger focus on **outcomes** of asset management activities, which aligns with MIRA's plan-vs-actual signal in the diagnostic engine (§5 of the unification spec) — MIRA's KG measures actual fault frequency vs. planned PM interval, which is exactly what ISO 55000 means by "performance monitoring and measurement."
+
+### Gaps / where we deviate
+
+| Gap | Severity |
+|-----|----------|
+| ISO 55000 requires a **Strategic Asset Management Plan (SAMP)** that aligns asset decisions with organizational objectives. MIRA has no SAMP-aware feature — it does not connect PM scheduling to budget constraints or organizational risk tolerance. | Low — this is management process, not software; MIRA provides the data; the customer writes the SAMP |
+| ISO 55000 includes financial assets and intangible assets in scope. MIRA focuses on physical and knowledge assets only. | Not a gap — MIRA is a maintenance platform, not an EAM/ERP |
+| ISO 55000 requires periodic audits of the asset register for completeness and accuracy. MIRA has no audit workflow — no "confirm this entity still exists" feature. | Medium — the Hub's UNS browser with an "Unassigned" queue is a partial solution; a formal audit workflow is not in the MVP |
+
+### Concrete mapping
+
+| ISO 55000 concept | MIRA implementation |
+|---|---|
+| Asset inventory / register | `kg_entities` table with `uns_path` |
+| Asset identity | `kg_entities.id` (UUID) + `uns_path` (browseable address) |
+| Asset attributes | `kg_entities.properties` JSONB |
+| Knowledge / procedure assets | `manual`, `procedure`, `fault_code`, `pm_task` entities |
+| Lifecycle management | `mira-cmms` work orders + Layer 4 event stream (deferred) |
+| Information / decision support system | MIRA platform as a whole |
+| Performance monitoring | Plan-vs-actual signal in diagnostic engine |
+| Asset condition tracking | `fault_code` events + `pm_task` completion records |
+
+### Action items
+
+1. **Reference ISO 55000 in sales materials** — the MIRA pitch to a facility manager can be framed as "ISO 55000 requires a capable information system for your asset management; MIRA is that system."
+2. **Add a `condition_state` property** to equipment entities (`properties.condition_state: "unknown" | "good" | "degraded" | "failed"`) to enable ISO 55000 asset condition tracking without a separate table.
+3. **Plan a "Stale Entity Audit" feature** for post-MVP — a Hub view that shows equipment entities not updated in >N days, prompting operators to confirm or remove them.
+
+---
+
+## Standards Compliance Matrix
+
+The following table scores alignment across the four layers defined in the unification spec:
+
+| Standard | Layer 1: UNS Path | Layer 2: Knowledge Graph | Layer 3: Vector Store | Layer 4: Event Stream |
+|---|---|---|---|---|
+| **ISA-95** | ✅ Aligned (7/8 levels, `line` collapses 3 types) | ✅ Aligned (PARENT_OF, HAS_COMPONENT mirror ISA-95 relationships) | ✅ Aligned (equipment_entity_id provides ISA-95-level filtering) | ✅ Aligned (forward-compat path design) |
+| **ISO 14224** | ⚠️ Partial (path stops at Level 6 Equipment Unit; no Level 7/8 subunit/maintainable-item distinction) | ⚠️ Partial (`component` collapses Level 7+8; no structured failure mode attributes) | ✅ Aligned (FK to equipment entity is ISO 14224 Level 6 linkage) | N/A |
+| **MIMOSA CCOM** | ⚠️ Partial (no BreakdownStructure; no effective-date versioning) | ✅ Aligned (Asset, Document, WorkOrder, Event, InfoSource all mapped) | ✅ Aligned (knowledge_entries ≈ CCOM Measurement) | ⚠️ Partial (no OSA-CBM signal subtypes) |
+| **W3C OWL/SOSA** | ✅ Aligned (path is OWL instance IRI-compatible) | ✅ Aligned (kg_entities+relationships is RDF-isomorphic; FeatureOfInterest/Property mapped) | ✅ Aligned (vector chunks linkable to OWL individuals via entity FK) | ❌ Gap (no Sensor, Observation, Actuator entities yet) |
+| **OPC UA** | ⚠️ Partial (uns_path ≈ BrowsePath; no NodeId mapping; no Class vs Instance distinction) | ⚠️ Partial (entity model maps but lacks Equipment Class/Instance split) | ✅ Aligned (N/A to OPC UA directly) | ⚠️ Partial (OPC UA PubSub path compatible but not implemented) |
+| **Sparkplug B** | ✅ Aligned (7-segment path maps cleanly via `.`→`/` transform) | ✅ Aligned (NBIRTH/DBIRTH events map to kg_entities upsert) | N/A | ⚠️ Partial (Layer 4 design matches; no broker yet) |
+| **NAMUR NE 107** | N/A | ❌ Gap (`fault_code` entity lacks ne107_status field; 4 signals unmapped) | N/A | ⚠️ Partial (would need live device data) |
+| **ISO 55000** | ✅ Aligned (uns_path + UUID = ISO 55000 asset identity + registry) | ✅ Aligned (KG provides the information system ISO 55000 requires) | ✅ Aligned (knowledge assets in vector store are ISO 55000 in scope) | ✅ Aligned (event stream = lifecycle tracking) |
+
+**Legend:** ✅ Aligned = no blocking gaps | ⚠️ Partial = gaps exist but non-blocking for MVP | ❌ Gap = missing, action required
+
+---
+
+## Recommendations
+
+The following are concrete, prioritized changes to `docs/specs/uns-kg-unification-spec.md` and the implementation plan. Items marked **[MVP]** should be addressed before or during the 5-phase implementation. Items marked **[Post-MVP]** are deferred.
+
+### Immediate spec clarifications (cost: zero, editorial only)
+
+1. **[MVP] Clarify `line` segment ambiguity.** Add a note in §3.1 that `line` maps to ISA-95 `ProductionLine` (discrete), `ProcessCell` (batch), or `ProductionUnit` (continuous) depending on manufacturing type. MIRA does not distinguish at path level; buyers configure via `kg_entities.properties.manufacturing_type`.
+
+2. **[MVP] Add ISA-95 reference.** Cite ANSI/ISA-95.00.01-2010 (IEC 62264-1) in §11 References as the authority for the equipment hierarchy model.
+
+3. **[MVP] Add ISO 14224:2016 reference.** Cite ISO 14224:2016 in §11 References as the authority for failure mode data element structure.
+
+4. **[MVP] Document the `uns_path` ↔ Sparkplug B ↔ OPC UA BrowsePath equivalence** in §3.1 to help future engineers understand the three representations of the same hierarchy.
+
+### Schema additions (cost: migration + code)
+
+5. **[MVP] Add `ne107_status` to `fault_code` entity properties schema.** Field: `properties.ne107_status: "F" | "C" | "S" | "M" | null`. Null by default; populated by PLC diagnostic ingestion. This is a JSONB field addition — no migration required.
+
+6. **[MVP] Add `condition_state` to equipment entity properties.** Field: `properties.condition_state: "unknown" | "good" | "degraded" | "failed"`. Default `"unknown"`. Updated by diagnostic engine based on fault_code and pm_task signals.
+
+7. **[MVP] Add `TRIGGERS_PM` to `relation_type` enum.** Connects a `fault_code` (especially `ne107_status = "M"`) to an auto-created `pm_task`. Documents the NE 107 → PM workflow in the graph.
+
+8. **[Post-MVP] Split `component` entity_type into `subunit` and `maintainable_item`.** Required for ISO 14224 Level 7/8 compliance. Non-breaking if done via migration with backfill (all existing `component` rows become `maintainable_item`).
+
+9. **[Post-MVP] Add `equipment_class` entity_type.** Resolves the ISA-95/OPC UA class-vs-instance distinction and the unification spec §9 Q7 multi-tenancy question. Requires adding `parent_class_entity_id UUID REFERENCES kg_entities(id)` column.
+
+10. **[Post-MVP] Reserve `sensor` and `actuator` in entity_type.** Add to the spec's entity type list as "reserved for Layer 4, not yet implemented."
+
+### UNS path structure (cost: low, editorial + possible future migration)
+
+11. **[Post-MVP] Consider an optional `work_cell` segment** between `line` and `equipment` for customers with work-cell-granular requirements. Can be implemented as an optional segment (making the path 6–8 segments variable) or as a `properties.work_cell` field on equipment entities. The current 7-segment fixed design is simpler; document the tradeoff.
+
+### Sales and positioning
+
+12. **[MVP] Cite ISO 55000:2024** in customer-facing materials as the organizational mandate that MIRA's asset registry fulfills.
+
+13. **[MVP] Add a "Standards Compliance" section to MIRA's product one-pager** citing ISA-95, ISO 14224, and NAMUR NE 107 alignment — these are recognized by any controls engineer and signal product seriousness.
+
+---
+
+*This document is a companion to `docs/specs/uns-kg-unification-spec.md`. It is maintained by the CHARLIE node and should be updated whenever the unification spec changes or a new standard becomes relevant.*
+
+*Primary sources consulted: ISA.org, ISO.org, OPC Foundation Reference Server (reference.opcfoundation.org), W3C TR (w3.org), Eclipse Sparkplug Foundation (sparkplug.eclipse.org), MIMOSA.org, NAMUR.net, Endress+Hauser, EMQ, HiveMQ, Prosys OPC, Fabrico, MaintainX.*

--- a/docs/specs/uns-kg-unification-spec.md
+++ b/docs/specs/uns-kg-unification-spec.md
@@ -1,0 +1,710 @@
+# UNS + Knowledge Graph Unification Spec
+
+**Status:** APPROVED 2026-05-07 by Mike Harper. Phases 1–3 in implementation on branch `claude/heuristic-einstein-922e75`.
+**Author:** Claude (CHARLIE node) on behalf of Mike Harper
+**Date:** 2026-05-07
+**Targets:** MIRA v3.4.0 → v4.0.0 (foundational data-layer change)
+**Companion:** [`docs/specs/uns-kg-standards-compliance.md`](./uns-kg-standards-compliance.md) — ISA-95 / ISO 14224 / MIMOSA / OPC UA / Sparkplug B / NAMUR NE 107 alignment analysis.
+**Depends on:** `docs/plans/2026-04-19-mira-90-day-mvp.md` (Unit 5: assets/UNS), `docs/DATA_ENGINEERING_AUDIT.md` (2026-04-29)
+**Supersedes (in part):** ad-hoc `kb_chunks` table, `cmms_equipment` flat-table approach
+**Stack constraints:** Postgres (NeonDB) + pgvector + ltree extension. No new datastores. No graph DB introduced.
+
+---
+
+## 0. TL;DR
+
+MIRA today has three disconnected representations of "what we know":
+
+| System | Rows (2026-04-29) | Purpose | Connected to others? |
+|---|---|---|---|
+| `knowledge_entries` | **74,714** | Vector chunks of manuals/photos/transcripts | ❌ No FK to KG, no UNS path |
+| `kg_entities` + `kg_relationships` | **41 + 27** (test data) | Structured graph nodes/edges | ❌ Schema exists, no production writer |
+| `kb_chunks` | **0** (empty stub) | What the Hub UI reads for KB metrics | ❌ Hub shows `0` even with 74K rows in `knowledge_entries` |
+
+The plan locks **all three under one address space (UNS path) and one identity space (KG entity ID)**. Every chunk gets an `equipment_entity_id`. Every entity gets a `uns_path`. The Hub stops reading `kb_chunks` and reads `knowledge_entries` instead. The Celery ingest worker — which already extracts manufacturer + model — starts upserting KG entities and relationships at ingest time.
+
+This is the difference between a chatbot RAG and a maintenance intelligence platform.
+
+---
+
+## 1. Purpose
+
+Make the **Unified Namespace + Knowledge Graph** the single representation layer for all maintenance data in FactoryLM. Every piece of equipment, every manual, every fault code, every work order, every conversation — addressable by UNS path, connected via KG relationships, searchable via vector embeddings.
+
+**Why now (2026-05-07):**
+- MVP Unit 4 (exports) and Unit 5 (assets) are about to land. Both are blocked by this gap. Exports query `knowledge_entries` directly (works); KB count queries `kb_chunks` (returns `0`) — visible bug today.
+- Ingest is producing manufacturer + model strings that we throw away (line 376 of `mira-core/mira-ingest/db/neon.py` — they sit in chunk columns instead of becoming first-class entities).
+- The flywheel argument: every manual ingested *should* densify the KG. Right now every manual ingested only thickens a flat vector index. The longer we wait, the more chunks we have to retro-link.
+
+**What this spec is:**
+- The architectural target for how data is shaped, addressed, and joined.
+- A migration plan from the current 3-system state.
+- An acceptance contract for what "unified" means.
+
+**What this spec is NOT:**
+- Not a UI spec. The Hub UNS browser is mentioned but designed elsewhere.
+- Not an MQTT/Sparkplug B real-time streaming spec. Layer 4 below is forward-compatible only.
+- Not a CMMS spec. Atlas (`mira-cmms`) consumes this layer; it does not define it.
+
+---
+
+## 2. Current State Audit
+
+Every claim below is grounded in the code at commit `58bf50df` on branch `claude/charming-sammet-6ac0ca`.
+
+### 2.1 `knowledge_entries` — the vector store (74,714 rows)
+
+**Schema definition:** `docs/migrations/001_knowledge_entries.sql`
+
+Columns of interest:
+- `id UUID PRIMARY KEY`
+- `tenant_id TEXT NOT NULL`
+- `source_type TEXT` — values seen: `gdrive`, `manual`, `equipment_manual`, `youtube_transcript`, `equipment_photo`, `curriculum`, `reference`
+- `manufacturer TEXT` (nullable)
+- `model_number TEXT` (nullable)
+- `equipment_type TEXT` (nullable)
+- `content TEXT NOT NULL`
+- `embedding vector(768)` — pgvector, ivfflat index, cosine ops
+- `image_embedding vector(768)` (added by `mira-core/mira-ingest/db/neon.py:137`, idempotent)
+- `isa95_path TEXT` (nullable) — partial UNS already in flight
+- `equipment_id TEXT` (nullable) — text, not a UUID FK
+- `data_type TEXT DEFAULT 'manual'`
+- `source_url TEXT`
+- `source_page INTEGER` — actually stores `chunk_index`, not PDF page (legacy naming)
+- `metadata JSONB`
+- `is_private BOOLEAN`, `verified BOOLEAN`, `chunk_type TEXT`
+- `created_at TIMESTAMP DEFAULT now()`
+
+**Indexes:** `ivfflat(embedding vector_cosine_ops)`, `tenant_id`, dedup uniq on `(tenant_id, source_url, chunk_index)`.
+
+**Row distribution (2026-04-29 audit):**
+- gdrive: 33,410 (extraction mostly NULL)
+- manual: 32,584 (extraction succeeds when manual_cache has hint)
+- equipment_manual: 4,718 (crawler-discovered)
+- youtube_transcript: 2,522
+- equipment_photo: 1,411
+- other: ~1,500
+
+**Writers (5 paths):**
+1. `mira-core/mira-ingest/db/neon.py:345-404` — `insert_knowledge_entry()` (single)
+2. `mira-core/mira-ingest/db/neon.py:407-451` — `insert_knowledge_entries_batch()` (batch)
+3. `mira-crawler/ingest/store.py:63-128` — `insert_chunk()` (Celery worker, ON CONFLICT dedup)
+4. `mira-crawler/ingest/store.py:131-175+` — `store_chunks()` (batch wrapper, called from `tasks/full_ingest_pipeline.py`)
+5. `mira-bots/tools/learning_ingester.py` — raw INSERT SQL (legacy, low traffic)
+
+**Readers:**
+- `mira-bots/shared/neon_recall.py:58-104` — `recall_knowledge(embedding, tenant_id, limit=5)` — pgvector cosine + ISA95 prefix + data_type filter; this is the bot RAG call.
+- `mira-bots/shared/neon_recall.py:107-134` — `recall_by_image()`.
+- `mira-hub/src/app/api/export/route.ts:60-63` — CSV export.
+- `mira-hub/src/lib/agents/asset-intelligence.ts` — full-text search by manufacturer/model.
+
+### 2.2 `kg_entities` — the planned graph nodes (41 rows, all test data)
+
+**Schema definition:** `docs/migrations/004_kg_entities.sql`
+
+```
+id UUID PRIMARY KEY DEFAULT gen_random_uuid()
+tenant_id TEXT NOT NULL
+entity_type TEXT NOT NULL   -- equipment | component | fault_code | procedure | specification
+name TEXT NOT NULL
+properties JSONB
+source_chunk_id UUID        -- FK back to knowledge_entries.id
+embedding vector(768)
+created_at TIMESTAMP DEFAULT now()
+UNIQUE (tenant_id, entity_type, name)
+```
+
+**Indexes:** `(tenant_id, entity_type)`, `ivfflat(embedding)`.
+
+**Important finding:** `uns_path` is NOT currently a column on `kg_entities`. The brief described it as "exists on kg_entities, zero rows populated" — that's not what the code shows. `uns_path` lives only in `docs/plans/2026-04-19-mira-90-day-mvp.md:5,87-88` as a planned `ltree` column on a future `assets` table. **This spec resolves that ambiguity by declaring `uns_path ltree` belongs on `kg_entities` directly** (see §3.1 and §9 Q1).
+
+**Writers:** none in production. The 41 rows are pre-migration test data from a developer scratchpad.
+
+**Readers:** none in production. No application code reads `kg_entities`.
+
+### 2.3 `kg_relationships` — the planned graph edges (27 rows, all test data)
+
+**Schema definition:** `docs/migrations/005_kg_relationships.sql`
+
+```
+id UUID PRIMARY KEY DEFAULT gen_random_uuid()
+tenant_id TEXT NOT NULL
+source_entity UUID NOT NULL  -- FK kg_entities.id
+target_entity UUID NOT NULL  -- FK kg_entities.id
+relation_type TEXT NOT NULL  -- has_component | causes_fault | resolves | requires_tool | ...
+properties JSONB
+confidence REAL DEFAULT 1.0
+source_chunk_id UUID         -- FK knowledge_entries.id, the chunk that justifies the edge
+created_at TIMESTAMP DEFAULT now()
+UNIQUE (tenant_id, source_entity, target_entity, relation_type)
+```
+
+**Writers / Readers:** none in production.
+
+### 2.4 `kb_chunks` — the empty stub the Hub still reads (0 rows)
+
+**Schema definition:** never versioned in a migration; created ad-hoc in NeonDB. Touched by `mira-core/mira-ingest/db/migrations/009_tenant_id_on_hub_read_tables.sql:27` (which only adds `tenant_id` to whatever already existed).
+
+Inferred columns from query usage: `id, tenant_id, content_hash, system_category, subcategory, manufacturer, product_family, doc_type, source, title, quality_score, created_at`.
+
+**Readers (active, in production today):**
+- `mira-hub/src/app/api/usage/route.ts:59-62` —
+  `SELECT COUNT(*) as total_chunks FROM kb_chunks WHERE tenant_id = $1`
+  This is the "Total KB Chunks" tile on the Hub. **It always returns 0** because the table is empty. Users see 0 even though `knowledge_entries` has 74,714 rows. This is a live UX bug tied to the unification gap.
+- `mira-hub/src/app/api/knowledge/route.ts:14-27` — group-by metadata for the Knowledge tab. Returns empty.
+
+**Writers:** none anywhere in the repo. The table is a vestige.
+
+### 2.5 `/opt/master_of_puppets/`
+
+Referenced in `tests/eval/README.md` and `tests/eval/active_learning_tasks.py:18-20`. Per `wiki/nodes/vps.md` it was retired 2026-04-03. Not a current ingest path. **Ignore for unification purposes.**
+
+### 2.6 `uns_path` — what actually exists today
+
+A grep across the entire repo shows zero references to `uns_path` in code. It exists only in:
+- `docs/plans/2026-04-19-mira-90-day-mvp.md` (planned `ltree` column on a planned `assets` table)
+- This spec
+- A handful of references in `wiki/`
+
+There is no `CREATE EXTENSION ltree` in any executed migration. The `ltree` extension itself is unverified to be installed on Neon — this is **§9 Q2**.
+
+### 2.7 Current entity extraction
+
+`mira-core/scripts/ingest_manuals.py:228-298` extracts manufacturer and model with three URL-based heuristics:
+
+- `_catalog_lookup(filename)` (269-275) — Rockwell catalog prefix map (e.g. `1756 → ControlLogix`, `20a → PowerFlex 70`).
+- `_extract_mfr_from_url(url, hint)` (278-285) — hint lookup, fallback to domain parse.
+- `_extract_model_from_url(url, hint)` (288-298) — filename-based, 3–60 char validation.
+
+The extracted strings land as **string columns on the chunk row** (`manufacturer`, `model_number` on `knowledge_entries`). They are not promoted to KG entities. No relationship edges are created. **The flywheel does not turn.**
+
+### 2.8 Summary diagram of the gap
+
+```
+                  ┌──────────────────────────────────┐
+                  │   knowledge_entries (74,714)     │
+                  │   manufacturer="Allen-Bradley"    │ ◀── strings, no FK
+                  │   model_number="PowerFlex 525"    │
+                  └──────────────────────────────────┘
+                         │ no foreign key
+                         │ no shared identity
+                         ▼
+                  ┌──────────────────────────────────┐
+                  │   kg_entities (41 test rows)     │ ◀── empty in prod
+                  │   kg_relationships (27 test)     │
+                  └──────────────────────────────────┘
+
+                  ┌──────────────────────────────────┐
+                  │   kb_chunks (0 rows)             │ ◀── Hub reads this,
+                  │                                  │     always shows 0
+                  └──────────────────────────────────┘
+```
+
+---
+
+## 3. Target Architecture
+
+Four logical layers, all backed by Postgres.
+
+### 3.1 Layer 1 — UNS Tree (the address system)
+
+Every entity has a path:
+`enterprise.{site}.{area}.{line}.{equipment}.{component}.{datapoint}`
+
+Stored as a Postgres `ltree`. Two states for any entity:
+
+**Unassigned (default at ingest):**
+`enterprise.unassigned.{manufacturer_slug}.{model_slug}`
+e.g. `enterprise.unassigned.allen_bradley.powerflex_525`
+
+This is what the ingest pipeline writes when it learns about a new piece of equipment from a manual but the user hasn't placed it on the floor yet. It is a real, valid address.
+
+**Assigned (placed by user):**
+`enterprise.stardust_racers.pump_station.sump.xylem_flygt.multismart_controller`
+
+Built by the user via the Hub UNS browser (out of scope for this spec, see §7 Phase 4).
+
+**Path normalization rules:**
+- Lowercase only.
+- Spaces → `_`. Hyphens → `_`. Slashes → `_`.
+- Strip non-`[a-z0-9_]` after normalization.
+- `.` is a path separator, never appears inside a label.
+- Validation: `uns_path ~ '^[a-z0-9_]+(\.[a-z0-9_]+)*$'` (Postgres CHECK constraint, in addition to ltree's own validation).
+
+**Storage:**
+- Add column `uns_path ltree NOT NULL` to `kg_entities`.
+- Add a GiST index for ancestor/descendant queries: `CREATE INDEX kg_entities_uns_path_gist ON kg_entities USING gist (uns_path);`
+- Add a btree index for exact lookup: `CREATE INDEX kg_entities_uns_path_btree ON kg_entities (uns_path);`
+- `CREATE EXTENSION IF NOT EXISTS ltree;` — pre-flight check during migration that Neon supports it (§9 Q2).
+
+**The default path is meaningful, not a placeholder.** The UNS browser displays an "Unassigned" virtual subtree showing every piece of equipment we've learned about that hasn't been placed yet. This is *also* the worklist for asset onboarding.
+
+### 3.2 Layer 2 — Knowledge Graph (the relationship system)
+
+Entities are typed nodes. Relationships are typed edges. `kg_entities` and `kg_relationships` schemas as already defined (§2.2, §2.3) plus the additions in §3.1 and §3.3.
+
+**Required entity types (initial set):**
+- `equipment` — a unit of equipment (a VFD, a pump, a controller). Can nest.
+- `component` — a sub-part of equipment (bearing, fan, capacitor). PARENT_OF a piece of equipment.
+- `manual` — a document. One manual per (manufacturer, model, doc_type) is the dedup key.
+- `fault_code` — a diagnostic code on a specific equipment model (e.g. `PowerFlex 525 / F004`).
+- `pm_task` — a scheduled preventive maintenance task with an interval.
+- `procedure` — a how-to (step list).
+- `part` — a SKU / spare.
+- `specification` — a numeric spec (e.g. "DC bus voltage 750V").
+
+**Required relationship types (initial set):**
+- `equipment HAS_MANUAL manual`
+- `equipment HAS_FAULT fault_code`
+- `fault_code CAUSED_BY root_cause` (root_cause is a `specification` or free-text node)
+- `fault_code RESOLVED_BY procedure`
+- `equipment HAS_COMPONENT component`
+- `component REQUIRES_PART part`
+- `equipment PARENT_OF equipment` (UNS hierarchy mirror — same info as `uns_path`, but as edges, for graph traversal)
+- `equipment FEEDS equipment` (process flow — pump feeds sump tank, etc.)
+- `equipment HAS_PM pm_task`
+
+**Constraint:** every relationship row has `source_chunk_id` pointing to the `knowledge_entries` row that justified it. No edge is "created from nowhere." This makes the KG fully auditable and allows us to remove edges if the source chunk is later marked low-quality.
+
+### 3.3 Layer 3 — Vector Store (the search system)
+
+`knowledge_entries` is the canonical vector store. The change:
+
+**Add column:** `equipment_entity_id UUID REFERENCES kg_entities(id) ON DELETE SET NULL`
+
+**Add index:** `CREATE INDEX knowledge_entries_equipment_entity_id ON knowledge_entries (equipment_entity_id);`
+
+This is the bridge. Every chunk that came from a manual about a known piece of equipment now has a typed pointer to the KG node for that equipment. The bot RAG path (`neon_recall.recall_knowledge`) gets a one-line addition: when filtering by equipment, join through `equipment_entity_id` instead of fuzzy-matching `manufacturer ILIKE '...' AND model_number ILIKE '...'`.
+
+**`isa95_path TEXT` column on `knowledge_entries`:**
+- Migrate to `uns_path ltree` to align with §3.1.
+- The current text-based ISA-95 path values are valid ltree literals after normalization.
+- Backfill: copy `isa95_path` → `uns_path` per row, normalize via SQL function.
+
+### 3.4 Layer 4 — UNS Event Stream (forward-compat, NOT in MVP)
+
+Real-time data points flowing through the UNS tree:
+`enterprise.stardust_racers.pump_station.sump.vfd_07.motor_current = 12.4A @ 2026-05-07T14:22:01Z`
+
+**Not built. Not in this spec's implementation phases.** The point of mentioning it: the UNS path structure in §3.1 must be designed such that a future MQTT/Sparkplug B broker can use the *same* paths as topic names. This means:
+- `.` separator is compatible with Sparkplug B `group/edge_node/device/metric` after a re-segmentation.
+- `enterprise.{site}.{area}.{line}.{equipment}.{component}.{datapoint}` is exactly 7 segments, which maps cleanly to typical broker conventions.
+- Tag values will live in a future `uns_observations` table or external TSDB. They do **not** belong in `kg_entities`.
+
+This spec only requires that we don't paint ourselves into a corner. It does not require us to build the broker.
+
+### 3.5 Per-tenant isolation
+
+Every table already has `tenant_id`. RLS policies exist but the application connects as `neondb_owner` (superuser, bypasses RLS) — see `docs/DATA_ENGINEERING_AUDIT.md`. This spec does not solve RLS enforcement (separate workstream), but **every join across tables in this spec MUST include `tenant_id` equality** in WHERE clauses. The migration scripts will add CHECK constraints to prevent cross-tenant FK references.
+
+---
+
+## 4. Unification Plan
+
+### 4.1 Bridge `knowledge_entries ↔ kg_entities`
+
+**Schema change:**
+```
+ALTER TABLE knowledge_entries
+  ADD COLUMN equipment_entity_id UUID REFERENCES kg_entities(id) ON DELETE SET NULL;
+CREATE INDEX knowledge_entries_equipment_entity_id_idx
+  ON knowledge_entries (equipment_entity_id);
+```
+
+**Ingest-time behavior change** — when the Celery worker (`mira-crawler/ingest/store.py:63-128`) ingests a chunk for a manual whose URL extraction yields `manufacturer="Allen-Bradley"`, `model="PowerFlex 525"`:
+
+1. Upsert `kg_entities` row: `(entity_type='equipment', name='PowerFlex 525', properties.manufacturer='Allen-Bradley')` — UNIQUE on `(tenant_id, entity_type, name)` makes this idempotent.
+2. Compute and set `uns_path = 'enterprise.unassigned.allen_bradley.powerflex_525'` if the entity is brand new.
+3. Upsert `kg_entities` row: `(entity_type='manual', name='PowerFlex 525 User Manual')`.
+4. Upsert `kg_relationships` row: `(source=equipment_id, target=manual_id, relation_type='has_manual', source_chunk_id=<this chunk>)`.
+5. Set `equipment_entity_id` on the chunk row to the equipment entity ID.
+
+**Idempotency:** all 5 steps use ON CONFLICT DO NOTHING / UPDATE patterns. Re-ingesting the same manual produces the same graph. No drift.
+
+### 4.2 Backfill the existing 74,714 chunks
+
+A one-shot script (`tools/migrations/backfill_equipment_entities.py`) walks `knowledge_entries` rows where `equipment_entity_id IS NULL` AND `manufacturer IS NOT NULL` AND `model_number IS NOT NULL`, and runs the 5-step upsert above for each unique `(manufacturer, model_number)` pair.
+
+**Expected outcome (back-of-envelope):**
+- 74,714 chunks scanned.
+- ~33,000 chunks (gdrive) skipped (no manufacturer extracted).
+- ~37,000 chunks linked to ~500–2,000 unique equipment entities (TBD; depends on how clean the existing extraction is — see §9 Q4).
+- ~4,718 equipment_manual chunks linked with high confidence.
+
+**Run mode:** dry-run first, log how many entities would be created, present count to Mike, then commit.
+
+### 4.3 Retire `kb_chunks`
+
+**Recommendation: Option A — drop `kb_chunks`, repoint Hub to `knowledge_entries`.**
+
+Rationale:
+- `kb_chunks` is empty (0 rows).
+- It was an ad-hoc table; it was never versioned or written to.
+- The Hub queries it for two reasons: a count tile and a group-by-metadata grid. Both can be satisfied by `knowledge_entries` with one new SQL view:
+
+```
+CREATE VIEW kb_chunks_compat AS
+SELECT
+  ke.id,
+  ke.tenant_id,
+  -- system_category derived from kg_entities.properties JSONB if available, else NULL
+  COALESCE(eq.properties->>'system_category', NULL) AS system_category,
+  COALESCE(eq.properties->>'subcategory', NULL) AS subcategory,
+  ke.manufacturer,
+  -- product_family from kg_entities.name when equipment_entity_id is set
+  COALESCE(eq.name, ke.model_number) AS product_family,
+  ke.data_type AS doc_type,
+  ke.source_type AS source,
+  ke.metadata->>'title' AS title,
+  NULL::float AS quality_score,
+  ke.created_at
+FROM knowledge_entries ke
+LEFT JOIN kg_entities eq ON eq.id = ke.equipment_entity_id;
+```
+
+Update `mira-hub/src/app/api/usage/route.ts` and `mira-hub/src/app/api/knowledge/route.ts` to query the view (or `knowledge_entries` directly).
+
+After Hub PR merges and is verified in prod for ≥7 days: `DROP TABLE kb_chunks`.
+
+**Why not Option B (UNION view):** the table is empty. There is nothing to preserve. UNION adds complexity for zero data. Reject.
+
+### 4.4 Ingest-time entity extraction (the flywheel)
+
+The existing extraction in `mira-core/scripts/ingest_manuals.py:228-298` becomes one of three extractors. Move all three into `mira-crawler/ingest/extractors/`:
+
+1. **URL-based** (already exists) — manufacturer + model from URL/filename. Ship as-is, just promote to entities.
+2. **Text-based fault-code extraction** (NEW) — regex over chunk content for fault code patterns (`F\d{3,4}`, `E\d{2,3}`, `Fault \d+`, etc.) → create `fault_code` entities tied to the equipment entity.
+3. **Text-based PM-schedule extraction** (NEW) — regex/LLM over chunk content for "every N hours/days/months" patterns → create `pm_task` entities with `properties.interval_days = N`.
+
+**Confidence scoring:**
+- URL-based extraction: confidence = 0.95.
+- Regex-based fault code: confidence = 0.85.
+- LLM-based PM extraction: confidence = LLM-reported.
+
+Confidence stored on `kg_relationships.confidence`. Below 0.5 → flag for human review (§9 Q5).
+
+**This is the flywheel.** Every manual ingested → more equipment entities, more fault codes, more PM tasks, more relationships. The KG densifies passively as content grows.
+
+### 4.5 UNS path enforcement
+
+**Hard constraints on `kg_entities`:**
+
+```
+ALTER TABLE kg_entities
+  ADD COLUMN uns_path ltree NOT NULL DEFAULT 'enterprise.unassigned';
+
+ALTER TABLE kg_entities
+  ADD CONSTRAINT uns_path_format
+  CHECK (uns_path::text ~ '^[a-z0-9_]+(\.[a-z0-9_]+)*$');
+
+CREATE INDEX kg_entities_uns_path_gist ON kg_entities USING gist (uns_path);
+CREATE INDEX kg_entities_uns_path_btree ON kg_entities (uns_path);
+```
+
+**Default function** (used by the Celery worker on insert):
+```
+def default_uns_path(entity_type: str, manufacturer: str | None, model: str | None) -> str:
+    if entity_type == "equipment" and manufacturer and model:
+        return f"enterprise.unassigned.{slug(manufacturer)}.{slug(model)}"
+    return "enterprise.unassigned"
+```
+
+**Browse API:**
+- `GET /api/uns/browse?path=enterprise.stardust_racers` → returns immediate children (one level deep) using `uns_path ~ 'enterprise.stardust_racers.*{1}'` ltree query.
+- `GET /api/uns/subtree?path=...` → returns full subtree (use sparingly; cap depth at 5).
+- `POST /api/uns/move` → move an equipment entity from `enterprise.unassigned.foo.bar` to `enterprise.{site}.{area}.{line}.foo`. Cascades: update the moved entity's `uns_path`, and emit a `PARENT_OF` edge to the new parent. Do not re-path siblings — the same model can be installed in multiple sites.
+
+**Validation:**
+- ltree extension must be present (§9 Q2).
+- Rejection of invalid paths happens at the API layer AND at the DB CHECK constraint.
+
+---
+
+## 5. What MIRA Does With Unified Data — Worked Example
+
+A tech texts the Telegram bot: *"My PowerFlex 525 is showing F004"*
+
+### Step 1: DST identifies entities (existing code path, no change)
+`mira-bots/shared/engine.py` runs the diagnostic state machine. It identifies:
+- vendor = "Allen-Bradley"
+- model = "PowerFlex 525"
+- fault_code = "F004"
+
+### Step 2: KG lookup (NEW capability via this spec)
+The bot calls a new MCP tool `maintenanceContext("powerflex_525", "f004")`:
+
+```sql
+WITH eq AS (
+  SELECT id, uns_path, properties FROM kg_entities
+  WHERE tenant_id = $1 AND entity_type = 'equipment' AND name ILIKE 'PowerFlex 525'
+),
+fault AS (
+  SELECT f.id, f.name, f.properties FROM kg_entities f
+  JOIN kg_relationships r ON r.target_entity = f.id
+  WHERE r.source_entity = (SELECT id FROM eq)
+    AND r.relation_type = 'has_fault'
+    AND f.name ILIKE 'F004'
+),
+recent_faults AS (
+  SELECT created_at FROM cmms_fault_history
+  WHERE equipment_entity_id = (SELECT id FROM eq)
+    AND fault_code = 'F004'
+    AND created_at > now() - interval '90 days'
+),
+pm_due AS (
+  SELECT pm.name, pm.properties->>'interval_days' AS interval_days,
+         (pm.properties->>'last_completed_at')::timestamptz AS last_completed
+  FROM kg_entities pm
+  JOIN kg_relationships r ON r.target_entity = pm.id
+  WHERE r.source_entity = (SELECT id FROM eq) AND r.relation_type = 'has_pm'
+)
+SELECT
+  (SELECT uns_path FROM eq)                                        AS uns_path,
+  (SELECT count(*) FROM recent_faults)                             AS faults_90d,
+  (SELECT properties FROM eq)                                      AS equipment_props,
+  (SELECT array_agg(row_to_json(pm_due)) FROM pm_due)              AS pm_schedule;
+```
+
+Returns:
+- `uns_path = enterprise.stardust_racers.line_3.vfd_07`
+- `faults_90d = 3`
+- `pm_schedule = [{name: "Bearing inspection", interval_days: 90, last_completed: 45_days_ago}]`
+
+### Step 3: Vector search filtered through the KG bridge
+```sql
+SELECT content, source_url, metadata->>'page_num' AS page
+FROM knowledge_entries
+WHERE tenant_id = $1
+  AND equipment_entity_id = $eq_id   -- THE BRIDGE
+  AND embedding <=> $query_embedding < 0.3
+ORDER BY embedding <=> $query_embedding
+LIMIT 15;
+```
+
+Returns 15 chunks from the PowerFlex 525 manual specifically — no cross-contamination from PowerFlex 700, 753, 4M, etc.
+
+### Step 4: LLM receives a unified context payload
+
+```json
+{
+  "user_query": "My PowerFlex 525 is showing F004",
+  "kg_context": {
+    "equipment": "PowerFlex 525 @ enterprise.stardust_racers.line_3.vfd_07",
+    "fault_history_90d": [{"date": "2026-04-22"}, {"date": "2026-03-29"}, {"date": "2026-03-01"}],
+    "pm_schedule": {
+      "task": "Bearing inspection",
+      "interval_days": 90,
+      "last_completed": "2026-03-22 (45 days ago)"
+    },
+    "plan_vs_actual_signal": "F004 frequency ~30 days; PM interval 90 days → INTERVAL TOO LONG"
+  },
+  "manual_chunks": [/* 15 chunks with source_url + page_num */]
+}
+```
+
+### Step 5: LLM generates the diagnostic answer
+
+> *F004 on your PowerFlex 525 is undervoltage on the DC bus. Looking at VFD-07's history: this is the third F004 in 90 days, but your bearing inspection is on a 90-day cadence — that interval is too long for how often this fault is recurring. Recommended action: drop bearing inspection to 30 days for this unit until faults stop, and check input voltage and DC bus capacitors today (Citation: PowerFlex 525 User Manual, Ch. 7, p. 142).*
+
+**This is the difference.** Without the KG bridge, the bot retrieves 15 chunks about F004 and parrots the manual. With the bridge, it knows the fault is recurring, knows the PM is on the wrong interval, and proposes a maintenance plan change. That is maintenance intelligence.
+
+---
+
+## 6. Readiness Assessment
+
+Grades reflect "can this support a paying customer today" — not "is the code clean."
+
+| Subsystem | Current | Target | Gap |
+|---|---|---|---|
+| **UNS tree** | F (column does not exist; `isa95_path` is a string, no ltree) | A (ltree column on `kg_entities`, validated paths, browse API, default path on every entity) | Add column, install extension, write default-path function, build browse API |
+| **Knowledge graph** | F (schema exists, 0 production rows, no writers, no readers) | B (auto-populated by ingest for `equipment` + `manual` + `fault_code` + `pm_task`; queryable by bots; weekly stat report on density) | Wire ingest extractors, build `maintenanceContext` MCP tool, add `equipment_entity_id` FK |
+| **Vector store** | B (74K rows, indexed, sanitization in place, but no FK to KG; ISA95 partial) | A (every linkable chunk has `equipment_entity_id`; `isa95_path` migrated to `uns_path`; query speed unchanged) | Add FK column, run backfill, update reader to optionally join through it |
+| **Ingest pipeline** | C (extracts mfr+model but throws them away as strings) | A (extracts → upserts entities + relationships idempotently; pluggable extractors; confidence scoring) | Refactor `ingest/store.py` to call extractor pipeline; add fault_code + PM extractors |
+| **Bot reasoning** | C (RAG works; no graph context; relies on fuzzy mfr/model matches) | B (calls `maintenanceContext` first, falls back to vector if no KG hit; combines both in prompt) | Build MCP tool; update `mira-bots/shared/engine.py` to consume it |
+| **Hub display** | F (KB count reads empty `kb_chunks`, shows 0) | B (reads `knowledge_entries` via view; UNS browser shows assigned + unassigned tree) | Repoint API routes; build UNS browser component (out-of-spec) |
+
+Overall: **D today, target B+ after Phase 5.** No A grade target until Layer 4 (event stream) ships, which is post-MVP.
+
+---
+
+## 7. Implementation Phases
+
+Each phase is independently shippable and reversible. **No phase begins until the previous one is verified in prod.**
+
+### Phase 1 — Bridge `knowledge_entries ↔ kg_entities`
+**Migration:** add `equipment_entity_id UUID` FK + index.
+**Code:** none required (column nullable, defaults NULL).
+**Acceptance:**
+- `\d knowledge_entries` shows the new column.
+- Existing INSERT paths still succeed (column accepts NULL).
+- Bot RAG path still returns identical results to a baseline of 5 fixed queries.
+
+### Phase 2 — Ingest-time entity creation (the flywheel ON)
+**Code:** refactor `mira-crawler/ingest/store.py` and `ingest_manuals.py` to call new `extractors/` package. URL-based equipment extraction promotes to entities. Fault-code regex extraction added. PM-schedule extraction added (LLM-assisted).
+**Acceptance:**
+- A new manual ingested produces ≥1 `equipment` entity.
+- Re-ingesting the same manual is a no-op (idempotency check via `kg_entities` UNIQUE).
+- ≥80% of new chunks have `equipment_entity_id` populated when manufacturer + model are extractable.
+- Backfill script run; ≥30,000 of the existing 74,714 chunks now have `equipment_entity_id`.
+
+### Phase 3 — UNS path enforcement
+**Migration:** `CREATE EXTENSION ltree`; add `uns_path ltree NOT NULL DEFAULT 'enterprise.unassigned'` to `kg_entities`; backfill default values; add CHECK constraint and indexes.
+**Code:** `default_uns_path()` helper used by ingest; `isa95_path` migration on `knowledge_entries`.
+**Acceptance:**
+- 100% of `kg_entities` rows have a non-NULL `uns_path`.
+- A new equipment entity for "Xylem Flygt MultiSmart" gets `enterprise.unassigned.xylem_flygt.multismart`.
+- ltree path queries return correct subtrees on synthetic test data.
+
+### Phase 4 — Hub UNS browser + KB count fix
+**Code:**
+- New `GET /api/uns/browse` and `GET /api/uns/subtree` endpoints in `mira-hub/`.
+- Update `api/usage/route.ts` and `api/knowledge/route.ts` to read `knowledge_entries` (or `kb_chunks_compat` view).
+- Hub UI: tree component for the UNS browser.
+**Acceptance:**
+- Hub "Total KB Chunks" shows 74,714+ (real data), not 0.
+- Hub UNS browser renders an "Unassigned" subtree containing every equipment we've learned about.
+- After 7 days of stable Hub reads from `knowledge_entries`: `DROP TABLE kb_chunks`.
+
+### Phase 5 — Unified search (vector + graph combined)
+**Code:** new MCP tool `maintenanceContext(equipment_name, fault_code?)` returns the JSON payload from §5 step 4. Update `mira-bots/shared/engine.py` to call it before vector search and merge results.
+**Acceptance:**
+- Bot answer to "My PowerFlex 525 is showing F004" includes recurrence count + PM mismatch when test data exists.
+- Bot answer to "Hello" still works (no KG lookup, no regression).
+- 39 golden eval cases pass at ≥77% (no regression from current).
+- 5 new golden cases added that specifically test KG-augmented answers; ≥4/5 pass.
+
+### Phase ordering rationale
+1 → 2: bridge column must exist before writers populate it.
+2 → 3: entities must exist before they get UNS paths (or default+backfill needs care).
+3 → 4: UNS browser needs `uns_path` populated to render.
+4 → 5: optional reordering — Phase 5 can ship parallel to Phase 4 if Mike prioritizes bot quality over Hub fix.
+
+**Total estimate (excluding spec discussion):** 3 weeks of focused work. ~70% migration + backfill, ~30% reasoning code.
+
+---
+
+## 8. Acceptance Criteria
+
+The unification is "done" when ALL of the following are true in production:
+
+1. ✅ Every `knowledge_entries` row that has `manufacturer IS NOT NULL AND model_number IS NOT NULL` also has `equipment_entity_id IS NOT NULL` (or has been audited and explicitly marked unmappable).
+2. ✅ Every `kg_entities` row has a non-NULL `uns_path` that passes the format CHECK constraint.
+3. ✅ Ingesting a brand-new manual via the Celery worker creates ≥1 KG entity (verified by integration test).
+4. ✅ Ingesting the *same* manual twice is a no-op at the entity level (no duplicate entities; same `kg_entities.id` returned).
+5. ✅ Hub "Total KB Chunks" tile reads from `knowledge_entries` and shows the true count.
+6. ✅ Hub UNS browser renders both an "Unassigned" subtree and any user-assigned subtrees.
+7. ✅ Bot diagnostic answer includes KG context (fault history, PM schedule, plan-vs-actual signal) when `maintenanceContext` returns data.
+8. ✅ `GET /api/uns/browse?path=enterprise` returns at least the "unassigned" branch.
+9. ✅ `kb_chunks` table is dropped (or, if kept, is documented as a compat view only).
+10. ✅ All 39 existing golden eval cases pass at ≥77% (no regression). 5 new KG-augmented golden cases added; ≥4/5 pass.
+
+**Definition of NOT done:** any one of the above failing. No partial credit. This is foundational; the foundation either holds the building or it doesn't.
+
+---
+
+## 9. Open Questions for Mike
+
+These must be answered before any code is written. None have a default — Mike's call.
+
+### Q1. `uns_path` lives on `kg_entities`, or on a new `assets` table?
+The 90-day MVP plan describes `uns_path` as a column on a future `assets` table. This spec puts it on `kg_entities` directly. Tradeoff:
+
+- **`kg_entities`:** simpler. Every entity (equipment, fault_code, manual, pm_task) gets a path. The path of a fault_code is the path of its parent equipment plus `.faults.f004`. One table to query.
+- **Separate `assets` table:** matches the MVP plan literally. Only physical things get UNS paths. Faults and manuals don't. Cleaner conceptually, but doubles the join work for every UNS query.
+
+**Recommendation: `kg_entities`.** But Mike's call.
+
+### Q2. Is `ltree` extension installed on Neon?
+Need to verify. If not, the entire UNS layer falls back to TEXT with self-validated path format. Acceptable, but loses GiST subtree query performance.
+
+### Q3. What's the seeding strategy for known equipment?
+Three options for the initial KG population beyond what ingest produces automatically:
+
+- **A. Pure passive:** wait for ingest to discover equipment from manuals. Slowest densification.
+- **B. Catalog seed:** preload a curated list of common Allen-Bradley / Xylem / SKF / etc. models as `kg_entities` rows up-front (~500 entries). Fastest path to a useful KG.
+- **C. CMMS sync:** read `cmms_equipment` / `mira-cmms/atlas-db` on first run, create one `kg_entities` row per existing CMMS asset.
+
+**Recommendation: B + C.** B for breadth (common equipment), C for precision (the user's actual floor). A is what naturally happens regardless.
+
+### Q4. What's the de-duplication strategy for fuzzy equipment names?
+"PowerFlex 525", "Powerflex 525", "PF 525", "PF525" should all be the same entity. The current UNIQUE constraint is exact-string. Options:
+
+- **A. Strict:** keep UNIQUE exact-match. Tolerate duplicates in the short term, run a reconciliation job nightly.
+- **B. Normalized:** add a generated column `normalized_name = lower(regexp_replace(name, '[^a-z0-9]', '', 'g'))` and put UNIQUE on that.
+- **C. LLM-assisted:** at ingest time, ask the cascade LLM "is this the same equipment as X?" before inserting.
+
+**Recommendation: B (cheap, deterministic, fast).** C is too expensive at ingest scale (74K chunks).
+
+### Q5. How is low-confidence KG data surfaced for review?
+Confidence thresholds — what happens when an extractor returns confidence < 0.5?
+
+- **A. Reject:** don't write the entity/edge. Tightest, but loses signal.
+- **B. Write + flag:** write with `confidence < 0.5` and a Hub queue surfaces these for human approval.
+- **C. Quarantine table:** write to `kg_entities_pending` instead, separate review pipeline.
+
+**Recommendation: B.** The Hub already has surface area for review queues; reuse it.
+
+### Q6. Backfill gating: how big a chunk batch is safe on Neon?
+Neon free-tier has compute caps. Backfill of 74K chunks could spike. Need to confirm:
+- Run in batches of 1,000 with a sleep?
+- Run on a dedicated Neon branch and merge?
+- Run during a manual maintenance window?
+
+**Recommendation: dedicated branch + merge.** Safest, no prod impact.
+
+### Q7. Multi-tenancy + the "shared catalog" question
+If two tenants both have a PowerFlex 525, should they share the same `kg_entities` row or each get their own?
+
+- **Shared catalog:** `entity_type='equipment_model'` rows are global (no tenant_id), and per-tenant `equipment_instance` rows reference them. Reduces duplication massively as we onboard more tenants. Big architectural shift.
+- **Per-tenant duplicates:** simpler, current schema. Each tenant's PowerFlex 525 is its own row. Wastes space but isolates risk.
+
+**Recommendation: defer.** Ship per-tenant duplicates for MVP; revisit for v5.0 once we have ≥3 paying tenants and can measure the duplication cost.
+
+### Q8. `cmms_fault_history` table
+The §5 worked example assumes a table that records every observed fault in the field with timestamps. Does this exist? Search of the repo suggests `cmms_*` tables exist for work orders but I did not confirm a fault history table. **If it doesn't exist, §5 step 2's "faults_90d" lookup fails open with `0`, which means the plan-vs-actual signal degrades to "we don't know yet."** Acceptable, but flag.
+
+### Q9. Ordering: should Phase 4 (Hub fix) jump the line?
+The Hub showing `0` KB chunks is a live UX bug today. Phase 4 in §7 depends on Phase 1+2+3 to be fully useful (UNS browser), but the "fix the count" piece is independent. Should we:
+
+- **A. Strict ordering:** ship phases 1→5 in order; Hub bug stays for ~2 weeks.
+- **B. Hotfix first:** repoint `kb_chunks` reads to `knowledge_entries` immediately as a 1-PR fix, then proceed with phases 1–5 normally.
+
+**Recommendation: B.** It's a 30-line change, ships in a day, removes a visible bug. Then proceed with the rest of the plan.
+
+---
+
+## 10. Out of Scope (for clarity)
+
+- **Real-time MQTT/Sparkplug B broker** — Layer 4 is forward-compat only. No broker stood up in this spec.
+- **CMMS work-order schema changes** — Atlas (`mira-cmms`) consumes this layer. It is not redefined here.
+- **RLS enforcement** — separate workstream; this spec only requires that all queries include `tenant_id` predicates.
+- **Hub UI design** — UNS browser is mentioned but designed elsewhere.
+- **Photo / image embedding KG bridge** — `image_embedding` exists on `knowledge_entries`. Future work to also tie image hits to equipment entities. Not blocking.
+- **Cross-tenant catalog sharing** — see §9 Q7. Deferred.
+- **Renaming `source_page` → `chunk_index`** — useful cleanup but not blocking unification. Deferred.
+
+---
+
+## 11. References
+
+- `docs/migrations/001_knowledge_entries.sql` — vector store schema
+- `docs/migrations/004_kg_entities.sql` — KG nodes schema
+- `docs/migrations/005_kg_relationships.sql` — KG edges schema
+- `docs/DATA_ENGINEERING_AUDIT.md` (2026-04-29) — current row counts and dedup status
+- `docs/plans/2026-04-19-mira-90-day-mvp.md` — Unit 5 (assets/UNS plan)
+- `mira-core/scripts/ingest_manuals.py:228-298` — current entity extraction (URL-based)
+- `mira-core/mira-ingest/db/neon.py:345-451` — `knowledge_entries` writers
+- `mira-crawler/ingest/store.py:63-175` — Celery worker writers
+- `mira-bots/shared/neon_recall.py:58-134` — bot RAG readers
+- `mira-hub/src/app/api/usage/route.ts:59-62` — the kb_chunks bug
+- `mira-hub/src/app/api/knowledge/route.ts:14-27` — Hub knowledge tab
+- `mira-hub/src/app/api/export/route.ts:60-63` — the working knowledge_entries reader
+- `NORTH_STAR.md` — flywheel argument that this spec operationalizes
+
+---
+
+## 12. Approval
+
+This spec is DRAFT until Mike answers §9. Once §9 is locked, the spec moves to APPROVED and Phases 1–5 become Linear tickets under MIRA MVP.
+
+**Reviewers:** Mike Harper (founder, sole approver for foundational architecture changes per CLUSTER law: 300-line orchestrator limit applies to code, not specs).

--- a/docs/specs/uns-kg-unification-spec.md
+++ b/docs/specs/uns-kg-unification-spec.md
@@ -208,36 +208,118 @@ Four logical layers, all backed by Postgres.
 
 ### 3.1 Layer 1 — UNS Tree (the address system)
 
-Every entity has a path:
-`enterprise.{site}.{area}.{line}.{equipment}.{component}.{datapoint}`
+> **Schema broadened 2026-05-08 per Mike directive.** The original spec
+> proposed an `enterprise.unassigned.*` subtree for kb-only equipment
+> and a flat `enterprise.{site}.{area}.{line}.{equipment}.{component}.{datapoint}`
+> for placed assets. Mike's direction: define the BROADEST possible
+> ISA-95-shaped tree now, with literal type-marker labels at every
+> level, even when most branches are empty. The tree below is the new
+> canonical structure; older paths are migrated forward in
+> `docs/migrations/007_uns_path.sql`.
 
-Stored as a Postgres `ltree`. Two states for any entity:
+Stored as a Postgres `ltree`. The full canonical tree:
 
-**Unassigned (default at ingest):**
-`enterprise.unassigned.{manufacturer_slug}.{model_slug}`
-e.g. `enterprise.unassigned.allen_bradley.powerflex_525`
+```
+enterprise/
+├── {company}/                               ← per-customer branch
+│   ├── site/{site_name}/
+│   │   ├── area/{area_name}/
+│   │   │   ├── line/{line_name}/
+│   │   │   │   ├── work_cell/{cell_name}/
+│   │   │   │   │   └── equipment/{equipment_id}/   ← assigned instance
+│   │   │   │   │       ├── component/{component_name}
+│   │   │   │   │       ├── datapoint/{tag_name}            ← Layer 4 (future)
+│   │   │   │   │       ├── maintenance/
+│   │   │   │   │       │   ├── pm_schedule/{slug}
+│   │   │   │   │       │   ├── fault_history/{event_id}
+│   │   │   │   │       │   ├── work_orders/{wo_number}
+│   │   │   │   │       │   └── parts_inventory/{sku}
+│   │   │   │   │       └── documentation/
+│   │   │   │   │           ├── manuals/{slug}
+│   │   │   │   │           ├── schematics/{slug}
+│   │   │   │   │           └── procedures/{slug}
+│   │   │   │   └── equipment/{equipment_id}        ← directly on line (no cell)
+│   │   │   └── equipment/{equipment_id}            ← directly in area (no line)
+│   │   ├── utilities/
+│   │   ├── safety_systems/
+│   │   └── environmental/
+│   ├── fleet/                               ← mobile / field equipment
+│   └── shared_services/
+├── knowledge_base/                          ← manufacturer-organized catalog
+│   ├── {manufacturer}/
+│   │   └── {family?}/                       ← optional; collapses if unknown
+│   │       └── {model}/
+│   │           ├── manuals/
+│   │           ├── fault_codes/
+│   │           ├── pm_schedules/
+│   │           └── parts_lists/
+│   └── community/                           ← Knowledge Cooperative shared data
+│       └── {equipment_class}/
+│           ├── common_faults/
+│           ├── mtbf_benchmarks/
+│           └── resolution_patterns/
+└── operations/
+    ├── work_orders/
+    ├── technicians/
+    ├── inventory/
+    └── compliance/
+```
 
-This is what the ingest pipeline writes when it learns about a new piece of equipment from a manual but the user hasn't placed it on the floor yet. It is a real, valid address.
+**Equipment that hasn't been assigned to a site lives in
+`enterprise.knowledge_base.{manufacturer}.{family?}.{model}`** — the
+manufacturer-organized catalog. Manuals, fault codes, PM schedules and
+parts lists are children of the model node. There is no
+`enterprise.unassigned.*` subtree anymore; the catalog is not a "to be
+placed" list, it's the durable model registry.
 
-**Assigned (placed by user):**
-`enterprise.stardust_racers.pump_station.sump.xylem_flygt.multismart_controller`
+**When a customer assigns a model to a site, the catalog node is NOT
+moved.** A new `equipment` instance is created at the site path (e.g.
+`enterprise.factorylm.site.orlando_plant.area.pump_station.line.line_3.equipment.vfd_07`)
+and linked to the catalog model via an `INSTANCE_OF` relationship.
+Same model, multiple sites — no duplication.
 
-Built by the user via the Hub UNS browser (out of scope for this spec, see §7 Phase 4).
+**Type markers vs instance labels.** ISA-95 segment names like `site`,
+`area`, `line`, `work_cell`, `equipment`, `component`, `datapoint`,
+`maintenance`, `documentation`, `manuals`, `fault_codes` appear
+LITERALLY in the path as type markers, alternated with dynamic
+instance labels. This makes the tree explorable: walk one level deep
+and the segment alone tells you what kind of children to expect. It
+also lets the Hub UI render the full skeleton even when no entities
+exist under a branch (Mike: "Most branches will be empty/theoretical
+— that's intentional").
+
+**Skippable middle segments (site side).** Equipment can attach at
+three depths: in a `work_cell`, on a `line` (no cell), or directly in
+an `area` (no line). The `line.{l}.work_cell.{c}` segments are
+optional. ltree path depth is variable and that's fine.
+
+**Reserved labels.** The literal type-marker words are reserved — a
+manufacturer / site / equipment slug must never collide with one. The
+list is enforced by `mira-crawler/ingest/uns.py:RESERVED_LABELS`.
 
 **Path normalization rules:**
 - Lowercase only.
 - Spaces → `_`. Hyphens → `_`. Slashes → `_`.
 - Strip non-`[a-z0-9_]` after normalization.
 - `.` is a path separator, never appears inside a label.
-- Validation: `uns_path ~ '^[a-z0-9_]+(\.[a-z0-9_]+)*$'` (Postgres CHECK constraint, in addition to ltree's own validation).
+- Validation: `uns_path ~ '^[a-z0-9_]+(\.[a-z0-9_]+)*$'` (Postgres
+  CHECK constraint, in addition to ltree's own validation).
 
 **Storage:**
-- Add column `uns_path ltree NOT NULL` to `kg_entities`.
-- Add a GiST index for ancestor/descendant queries: `CREATE INDEX kg_entities_uns_path_gist ON kg_entities USING gist (uns_path);`
-- Add a btree index for exact lookup: `CREATE INDEX kg_entities_uns_path_btree ON kg_entities (uns_path);`
-- `CREATE EXTENSION IF NOT EXISTS ltree;` — pre-flight check during migration that Neon supports it (§9 Q2).
+- `uns_path ltree NOT NULL DEFAULT 'enterprise.knowledge_base'` on `kg_entities`.
+- GiST index on `uns_path` for ancestor/descendant queries.
+- Btree index on `uns_path` for exact lookup.
+- `CREATE EXTENSION IF NOT EXISTS ltree` — pre-flight check during
+  migration that Neon supports it (§9 Q2).
 
-**The default path is meaningful, not a placeholder.** The UNS browser displays an "Unassigned" virtual subtree showing every piece of equipment we've learned about that hasn't been placed yet. This is *also* the worklist for asset onboarding.
+**Skeleton-aware browse API.** `GET /api/uns/browse?path=...` merges
+two sources of children: (1) the static SKELETON of literal type
+markers (defined in `mira-hub/src/lib/uns/skeleton.ts`) so empty
+branches still show structure, and (2) dynamic instance labels from
+`kg_entities` for the tenant. Each child is tagged
+`kind: "literal" | "dynamic" | "both"` so the UI can distinguish a
+type-marker placeholder ("site") from an actual data node
+("orlando_plant") from a marker that has data directly under it.
 
 ### 3.2 Layer 2 — Knowledge Graph (the relationship system)
 

--- a/mira-crawler/ingest/extractors/__init__.py
+++ b/mira-crawler/ingest/extractors/__init__.py
@@ -1,0 +1,6 @@
+"""Entity extractors for the KG flywheel.
+
+Each extractor turns chunk text / metadata into KG entity + relationship
+upsert calls. They are pure functions over a (chunk, manufacturer, model)
+tuple — no side effects until the caller invokes the kg_writer module.
+"""

--- a/mira-crawler/ingest/extractors/fault_codes.py
+++ b/mira-crawler/ingest/extractors/fault_codes.py
@@ -1,0 +1,151 @@
+"""Fault-code extraction from chunk text.
+
+Spec: docs/specs/uns-kg-unification-spec.md §4.4 (extractor #2).
+
+Conservative regex matching — we'd rather miss codes than fabricate them.
+Confidence is fixed at 0.85 per spec; the caller persists this on the
+HAS_FAULT relationship row so a future review queue can filter low-confidence
+edges.
+
+Patterns matched
+----------------
+- Allen-Bradley / Rockwell PowerFlex VFD families: `F\\d{2,4}`
+  (e.g. F004, F029, F2021)
+- Allen-Bradley GuardLogix / ControlLogix safety codes: `E\\d{2,4}`
+  (e.g. E07, E102)
+- Generic "Fault N" / "Fault Code N" callouts: digits 1-4 long
+- Siemens SINAMICS: `F\\d{5}` and `A\\d{5}` (alarm codes)
+- ABB / generic alphanumeric: `OL`, `OC`, `OH`, `UV`, `OV`, `GF`,
+  `E-OC`, `E-UV`, etc. — only when surrounded by fault/error context
+
+The extractor returns a list of (code, surrounding_snippet) so the
+caller can attach a snippet to the entity's properties for human review.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+# ---------------------------------------------------------------------------
+# Pattern catalogue
+# ---------------------------------------------------------------------------
+
+# Strict alphanumeric codes that are essentially always fault codes when they
+# appear in technical text. Anchored with word-boundaries.
+_STRONG_PATTERNS = [
+    # Allen-Bradley PowerFlex / SINAMICS-style F-codes (2-5 digits)
+    re.compile(r"\bF[-_ ]?\d{2,5}\b"),
+    # ControlLogix / GuardLogix-style E-codes
+    re.compile(r"\bE[-_ ]?\d{2,4}\b"),
+    # Siemens SINAMICS alarm codes
+    re.compile(r"\bA\d{5}\b"),
+    # Allen-Bradley DriveExecutive style "Fault N"
+    re.compile(r"\bFault\s*(?:Code\s*)?#?\s*(\d{1,4})\b", re.IGNORECASE),
+    # ABB / generic VFD short codes — only matched when in fault context
+    # (handled separately by _CONTEXT_PATTERNS below).
+]
+
+# Short alpha codes that are too generic to match without context.
+# These only count as a fault code when within `_CONTEXT_WINDOW` chars
+# of one of the trigger words below.
+_SHORT_ALPHA = re.compile(r"\b(?:OL|OC|OH|UV|OV|GF|SC|IT)\b")
+_CONTEXT_TRIGGERS = (
+    "fault",
+    "alarm",
+    "trip",
+    "error",
+    "warning",
+    "diagnostic",
+    "code",
+)
+_CONTEXT_WINDOW = 60
+
+# Codes we always discard as false positives. The short-alpha codes (OL, OC,
+# UV, ...) are NOT in this list — they require context to fire in the first
+# place. The single-digit F/E codes ARE noise: they typically refer to
+# enumerated steps in a manual, not actual fault numbers.
+_BLACKLIST = {"E1", "E2", "E3", "F1", "F2", "F3"}
+
+
+@dataclass(frozen=True)
+class FaultCodeMatch:
+    code: str
+    snippet: str  # ~80 chars surrounding the match for human review
+
+    def normalized(self) -> str:
+        """Canonical form: uppercase, no separator between letter and digits."""
+        # Strip a single separator after the letter prefix.
+        return re.sub(r"^([A-Za-z]+)[-_ ]?", lambda m: m.group(1).upper(), self.code).upper()
+
+
+def _surrounding_snippet(text: str, start: int, end: int, window: int = 80) -> str:
+    s = max(0, start - window // 2)
+    e = min(len(text), end + window // 2)
+    return text[s:e].replace("\n", " ").strip()
+
+
+def _has_context(text: str, position: int) -> bool:
+    """True if a fault-context trigger word appears near `position`."""
+    lo = max(0, position - _CONTEXT_WINDOW)
+    hi = min(len(text), position + _CONTEXT_WINDOW)
+    window = text[lo:hi].lower()
+    return any(t in window for t in _CONTEXT_TRIGGERS)
+
+
+def extract_fault_codes(text: str) -> list[FaultCodeMatch]:
+    """Return a deduplicated list of FaultCodeMatch found in `text`.
+
+    Order is the order of first appearance, so callers can rank by
+    "what the chunk leads with" if useful. Matches are normalized so
+    `F-004`, `F004`, and `F 004` collapse to a single `F004` entity.
+    """
+    if not text:
+        return []
+
+    seen: dict[str, FaultCodeMatch] = {}
+
+    for pat in _STRONG_PATTERNS:
+        for m in pat.finditer(text):
+            raw = m.group(0)
+            # If the pattern was the "Fault N" form, compose `F<N>` so it
+            # collapses with the strong F-code pattern.
+            grp = m.groups()
+            if grp and grp[0]:
+                raw = f"F{grp[0]}"
+            match = FaultCodeMatch(
+                code=raw,
+                snippet=_surrounding_snippet(text, m.start(), m.end()),
+            )
+            norm = match.normalized()
+            if norm in _BLACKLIST:
+                continue
+            if norm not in seen:
+                seen[norm] = FaultCodeMatch(code=norm, snippet=match.snippet)
+
+    for m in _SHORT_ALPHA.finditer(text):
+        if not _has_context(text, m.start()):
+            continue
+        raw = m.group(0).upper()
+        if raw in _BLACKLIST:
+            continue
+        if raw not in seen:
+            seen[raw] = FaultCodeMatch(
+                code=raw,
+                snippet=_surrounding_snippet(text, m.start(), m.end()),
+            )
+
+    return list(seen.values())
+
+
+def extract_fault_codes_batch(chunks: Iterable[dict]) -> list[tuple[dict, list[FaultCodeMatch]]]:
+    """Convenience wrapper: run `extract_fault_codes` over a list of
+    chunk dicts and return only the chunks that yielded ≥1 match.
+    Each chunk dict must have a 'text' key."""
+    out = []
+    for chunk in chunks:
+        matches = extract_fault_codes(chunk.get("text", ""))
+        if matches:
+            out.append((chunk, matches))
+    return out

--- a/mira-crawler/ingest/kg_writer.py
+++ b/mira-crawler/ingest/kg_writer.py
@@ -1,0 +1,319 @@
+"""Idempotent KG entity / relationship upserts.
+
+All KG writes from any path (Celery worker, backfill, manual ingest CLI,
+admin tools) must go through these helpers so the spec's invariants hold:
+
+- `kg_entities` UNIQUE (tenant_id, entity_type, name) → ON CONFLICT DO NOTHING
+  on insert, then SELECT to obtain the canonical id.
+- `kg_relationships` UNIQUE (tenant_id, source_entity, target_entity,
+  relation_type) → same pattern.
+- Every entity carries a non-NULL `uns_path` (spec §3.1, Phase 3).
+- Path grammar is enforced both at the application layer (uns.is_valid_path)
+  and at the database layer (CHECK constraint added in migration 008).
+
+The helpers accept an optional SQLAlchemy connection so a caller running
+inside a transaction can keep the upserts in the same unit of work; if
+omitted, the helpers manage their own connection + commit.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Generator
+from contextlib import contextmanager
+from uuid import UUID
+
+from .uns import equipment_unassigned_path, fault_code_path, is_valid_path, manual_path
+
+logger = logging.getLogger("mira-crawler.kg_writer")
+
+
+# ---------------------------------------------------------------------------
+# Connection management
+# ---------------------------------------------------------------------------
+
+
+def _engine():
+    """Lazy-import the engine factory so this module is importable without
+    NEON_DATABASE_URL set (e.g. during unit tests of pure-Python helpers)."""
+    from .store import _engine as store_engine
+
+    return store_engine()
+
+
+@contextmanager
+def _get_conn(conn=None) -> Generator:
+    """Yield a connection. If the caller passed one, reuse it without
+    committing — they own the transaction. Otherwise open one and commit
+    on success."""
+    if conn is not None:
+        yield conn
+        return
+    with _engine().connect() as new_conn:
+        try:
+            yield new_conn
+            new_conn.commit()
+        except Exception:
+            new_conn.rollback()
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Entity upserts
+# ---------------------------------------------------------------------------
+
+
+def upsert_entity(
+    tenant_id: str,
+    entity_type: str,
+    name: str,
+    uns_path: str,
+    properties: dict | None = None,
+    source_chunk_id: str | UUID | None = None,
+    conn=None,
+) -> str | None:
+    """Insert (or fetch existing) a kg_entities row. Returns the entity id
+    as a string, or None on hard failure.
+
+    Idempotent: re-calling with the same (tenant_id, entity_type, name)
+    returns the original id. Properties are merged on conflict — existing
+    keys win unless this call provides a non-NULL replacement.
+    """
+    from sqlalchemy import text
+
+    if not name or not entity_type:
+        logger.debug("upsert_entity skipped: empty name or type")
+        return None
+
+    if not is_valid_path(uns_path):
+        logger.warning(
+            "upsert_entity rejected invalid uns_path=%r for %s/%s",
+            uns_path,
+            entity_type,
+            name,
+        )
+        return None
+
+    props_json = json.dumps(properties or {})
+    src_chunk = str(source_chunk_id) if source_chunk_id else None
+
+    try:
+        with _get_conn(conn) as c:
+            row = c.execute(
+                text("""
+                    INSERT INTO kg_entities
+                        (tenant_id, entity_type, name, properties,
+                         source_chunk_id, uns_path)
+                    VALUES
+                        (:tenant_id, :entity_type, :name,
+                         cast(:properties AS jsonb),
+                         cast(:source_chunk_id AS uuid),
+                         :uns_path::ltree)
+                    ON CONFLICT (tenant_id, entity_type, name) DO UPDATE
+                        SET properties = COALESCE(kg_entities.properties, '{}'::jsonb)
+                                       || EXCLUDED.properties
+                    RETURNING id
+                """),
+                {
+                    "tenant_id": tenant_id,
+                    "entity_type": entity_type,
+                    "name": name,
+                    "properties": props_json,
+                    "source_chunk_id": src_chunk,
+                    "uns_path": uns_path,
+                },
+            ).first()
+            return str(row[0]) if row else None
+    except Exception as e:
+        logger.error("upsert_entity failed for %s/%s: %s", entity_type, name, e)
+        return None
+
+
+def upsert_relationship(
+    tenant_id: str,
+    source_entity: str | UUID,
+    target_entity: str | UUID,
+    relation_type: str,
+    confidence: float = 1.0,
+    properties: dict | None = None,
+    source_chunk_id: str | UUID | None = None,
+    conn=None,
+) -> str | None:
+    """Insert (or fetch existing) a kg_relationships row. Returns the
+    relationship id as a string, or None on hard failure."""
+    from sqlalchemy import text
+
+    if not source_entity or not target_entity or not relation_type:
+        return None
+    if str(source_entity) == str(target_entity):
+        logger.debug("upsert_relationship skipped self-edge %s", source_entity)
+        return None
+
+    props_json = json.dumps(properties or {})
+    src_chunk = str(source_chunk_id) if source_chunk_id else None
+
+    try:
+        with _get_conn(conn) as c:
+            row = c.execute(
+                text("""
+                    INSERT INTO kg_relationships
+                        (tenant_id, source_entity, target_entity,
+                         relation_type, properties, confidence,
+                         source_chunk_id)
+                    VALUES
+                        (:tenant_id, :source, :target, :rel,
+                         cast(:properties AS jsonb), :confidence,
+                         cast(:source_chunk_id AS uuid))
+                    ON CONFLICT
+                        (tenant_id, source_entity, target_entity, relation_type)
+                    DO UPDATE SET
+                        confidence = GREATEST(kg_relationships.confidence,
+                                              EXCLUDED.confidence)
+                    RETURNING id
+                """),
+                {
+                    "tenant_id": tenant_id,
+                    "source": str(source_entity),
+                    "target": str(target_entity),
+                    "rel": relation_type,
+                    "properties": props_json,
+                    "confidence": confidence,
+                    "source_chunk_id": src_chunk,
+                },
+            ).first()
+            return str(row[0]) if row else None
+    except Exception as e:
+        logger.error(
+            "upsert_relationship failed %s -[%s]-> %s: %s",
+            source_entity,
+            relation_type,
+            target_entity,
+            e,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# High-level convenience: register an equipment + its manual together
+# ---------------------------------------------------------------------------
+
+
+def register_equipment_and_manual(
+    tenant_id: str,
+    manufacturer: str,
+    model: str,
+    manual_title: str | None = None,
+    manual_url: str | None = None,
+    source_chunk_id: str | UUID | None = None,
+    conn=None,
+) -> tuple[str | None, str | None]:
+    """Upsert an `equipment` entity, a `manual` entity, and a HAS_MANUAL
+    edge between them. All idempotent. Returns (equipment_id, manual_id)."""
+
+    eq_path = equipment_unassigned_path(manufacturer, model)
+    eq_id = upsert_entity(
+        tenant_id=tenant_id,
+        entity_type="equipment",
+        name=model,
+        uns_path=eq_path,
+        properties={"manufacturer": manufacturer},
+        source_chunk_id=source_chunk_id,
+        conn=conn,
+    )
+    if not eq_id:
+        return None, None
+
+    title = manual_title or f"{manufacturer} {model} Manual"
+    man_id = upsert_entity(
+        tenant_id=tenant_id,
+        entity_type="manual",
+        name=title,
+        uns_path=manual_path(manufacturer, model),
+        properties={
+            "manufacturer": manufacturer,
+            "model": model,
+            "source_url": manual_url,
+        },
+        source_chunk_id=source_chunk_id,
+        conn=conn,
+    )
+
+    if man_id:
+        upsert_relationship(
+            tenant_id=tenant_id,
+            source_entity=eq_id,
+            target_entity=man_id,
+            relation_type="has_manual",
+            confidence=0.95,
+            source_chunk_id=source_chunk_id,
+            conn=conn,
+        )
+
+    return eq_id, man_id
+
+
+def register_fault_code(
+    tenant_id: str,
+    equipment_id: str | UUID,
+    manufacturer: str,
+    fault_code: str,
+    confidence: float = 0.85,
+    source_chunk_id: str | UUID | None = None,
+    conn=None,
+) -> str | None:
+    """Upsert a `fault_code` entity tied to an existing `equipment` via a
+    HAS_FAULT edge. Returns the fault entity id."""
+    name = f"{manufacturer} / {fault_code}".strip(" /")
+    fc_id = upsert_entity(
+        tenant_id=tenant_id,
+        entity_type="fault_code",
+        name=name,
+        uns_path=fault_code_path(manufacturer, fault_code),
+        properties={"manufacturer": manufacturer, "code": fault_code},
+        source_chunk_id=source_chunk_id,
+        conn=conn,
+    )
+    if not fc_id:
+        return None
+
+    upsert_relationship(
+        tenant_id=tenant_id,
+        source_entity=equipment_id,
+        target_entity=fc_id,
+        relation_type="has_fault",
+        confidence=confidence,
+        source_chunk_id=source_chunk_id,
+        conn=conn,
+    )
+    return fc_id
+
+
+# ---------------------------------------------------------------------------
+# Bridge: stamp a knowledge_entries row with its equipment_entity_id
+# ---------------------------------------------------------------------------
+
+
+def link_chunk_to_equipment(
+    chunk_id: str | UUID,
+    equipment_entity_id: str | UUID,
+    conn=None,
+) -> bool:
+    """Set knowledge_entries.equipment_entity_id. Returns True on success."""
+    from sqlalchemy import text
+
+    try:
+        with _get_conn(conn) as c:
+            c.execute(
+                text("""
+                    UPDATE knowledge_entries
+                       SET equipment_entity_id = cast(:eid AS uuid)
+                     WHERE id = cast(:cid AS uuid)
+                       AND equipment_entity_id IS DISTINCT FROM cast(:eid AS uuid)
+                """),
+                {"eid": str(equipment_entity_id), "cid": str(chunk_id)},
+            )
+        return True
+    except Exception as e:
+        logger.error("link_chunk_to_equipment failed: %s", e)
+        return False

--- a/mira-crawler/ingest/kg_writer.py
+++ b/mira-crawler/ingest/kg_writer.py
@@ -24,7 +24,12 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from uuid import UUID
 
-from .uns import equipment_unassigned_path, fault_code_path, is_valid_path, manual_path
+from .uns import (
+    equipment_unassigned_path,
+    fault_code_path,
+    is_valid_path,
+    manual_path,
+)
 
 logger = logging.getLogger("mira-crawler.kg_writer")
 
@@ -205,19 +210,33 @@ def register_equipment_and_manual(
     model: str,
     manual_title: str | None = None,
     manual_url: str | None = None,
+    family: str | None = None,
     source_chunk_id: str | UUID | None = None,
     conn=None,
 ) -> tuple[str | None, str | None]:
-    """Upsert an `equipment` entity, a `manual` entity, and a HAS_MANUAL
-    edge between them. All idempotent. Returns (equipment_id, manual_id)."""
+    """Upsert an `equipment` entity (the catalog/model node in the
+    knowledge_base branch), a `manual` entity, and a HAS_MANUAL edge.
+    All idempotent. Returns (equipment_id, manual_id).
 
-    eq_path = equipment_unassigned_path(manufacturer, model)
+    Per the broadened spec, the equipment node lives at
+        enterprise.knowledge_base.{mfr}.{family?}.{model}
+    NOT at enterprise.unassigned.* — equipment learned from manuals
+    permanently lives in the manufacturer-organized catalog. Site-side
+    instances are linked back to this catalog node via INSTANCE_OF when
+    the user assigns the model to a physical location.
+    """
+
+    eq_path = equipment_unassigned_path(manufacturer, model, family=family)
     eq_id = upsert_entity(
         tenant_id=tenant_id,
         entity_type="equipment",
         name=model,
         uns_path=eq_path,
-        properties={"manufacturer": manufacturer},
+        properties={
+            "manufacturer": manufacturer,
+            "family": family,
+            "catalog_node": True,
+        },
         source_chunk_id=source_chunk_id,
         conn=conn,
     )
@@ -225,13 +244,21 @@ def register_equipment_and_manual(
         return None, None
 
     title = manual_title or f"{manufacturer} {model} Manual"
+    # Manuals live as children of the model node; encode the title slug
+    # so two distinct manuals (user manual + service manual) don't
+    # collide on the parent collection node.
+    from .uns import slug as _slug
+
     man_id = upsert_entity(
         tenant_id=tenant_id,
         entity_type="manual",
         name=title,
-        uns_path=manual_path(manufacturer, model),
+        uns_path=manual_path(
+            manufacturer, model, family=family, manual_slug=_slug(title)
+        ),
         properties={
             "manufacturer": manufacturer,
+            "family": family,
             "model": model,
             "source_url": manual_url,
         },
@@ -258,19 +285,33 @@ def register_fault_code(
     equipment_id: str | UUID,
     manufacturer: str,
     fault_code: str,
+    model: str | None = None,
+    family: str | None = None,
     confidence: float = 0.85,
     source_chunk_id: str | UUID | None = None,
     conn=None,
 ) -> str | None:
     """Upsert a `fault_code` entity tied to an existing `equipment` via a
-    HAS_FAULT edge. Returns the fault entity id."""
+    HAS_FAULT edge. Returns the fault entity id.
+
+    The fault lives under its model in the kb tree when model is
+    provided, otherwise directly under the manufacturer (a model-agnostic
+    fault). Either way, the HAS_FAULT edge ties it to the specific
+    equipment entity that was the carrier of this extraction so the bot
+    can ask "what faults exist on PowerFlex 525?" via graph traversal.
+    """
     name = f"{manufacturer} / {fault_code}".strip(" /")
     fc_id = upsert_entity(
         tenant_id=tenant_id,
         entity_type="fault_code",
         name=name,
-        uns_path=fault_code_path(manufacturer, fault_code),
-        properties={"manufacturer": manufacturer, "code": fault_code},
+        uns_path=fault_code_path(manufacturer, fault_code, model=model, family=family),
+        properties={
+            "manufacturer": manufacturer,
+            "family": family,
+            "model": model,
+            "code": fault_code,
+        },
         source_chunk_id=source_chunk_id,
         conn=conn,
     )

--- a/mira-crawler/ingest/store.py
+++ b/mira-crawler/ingest/store.py
@@ -221,6 +221,10 @@ def store_chunks(
                         equipment_id=equipment_id,
                         manufacturer=manufacturer,
                         fault_code=match.normalized(),
+                        # Anchoring the fault under its model in the KB
+                        # tree gives the Hub a navigable
+                        # mfr/family/model/fault_codes/<code> path.
+                        model=model_number,
                         confidence=0.85,
                         source_chunk_id=entry_id,
                     )

--- a/mira-crawler/ingest/store.py
+++ b/mira-crawler/ingest/store.py
@@ -140,8 +140,47 @@ def store_chunks(
     Skips chunks that already exist (dedup by source_url + chunk_index).
     Returns number of chunks inserted.
     image_embedding: optional 768-dim visual vector stored alongside text embedding.
+
+    UNS+KG flywheel (spec §4.4): when manufacturer+model are known, this
+    upserts an `equipment` and a `manual` entity, links the chunk row to
+    the equipment via `equipment_entity_id`, and runs the fault-code
+    extractor over chunk text to densify the KG. All entity writes are
+    idempotent (UNIQUE on tenant_id+entity_type+name).
     """
+    # Lazy-import KG modules so a misconfigured KG layer cannot break
+    # the chunk-insert hot path. Failures degrade to "we still wrote
+    # the vectors, we just didn't densify the graph this batch."
+    try:
+        from . import kg_writer
+        from .extractors.fault_codes import extract_fault_codes
+    except Exception as e:  # pragma: no cover — defensive
+        logger.warning("KG modules unavailable, skipping graph densification: %s", e)
+        kg_writer = None  # type: ignore[assignment]
+        extract_fault_codes = None  # type: ignore[assignment]
+
     inserted = 0
+    equipment_id: str | None = None
+    manual_id: str | None = None
+
+    # Step 1 (per-batch): register the equipment + manual once. The same
+    # batch always carries chunks for one (mfr, model) combination — the
+    # caller is the per-URL processor in mira-crawler/tasks/ingest.py.
+    if kg_writer is not None and manufacturer and model_number:
+        manual_url = next(
+            (c.get("source_url") for c, _ in chunks_with_embeddings if c.get("source_url")),
+            None,
+        )
+        manual_title = next(
+            (c.get("title") for c, _ in chunks_with_embeddings if c.get("title")),
+            None,
+        )
+        equipment_id, manual_id = kg_writer.register_equipment_and_manual(
+            tenant_id=tenant_id,
+            manufacturer=manufacturer,
+            model=model_number,
+            manual_title=manual_title,
+            manual_url=manual_url,
+        )
 
     for chunk, embedding in chunks_with_embeddings:
         source_url = chunk.get("source_url", "")
@@ -166,8 +205,31 @@ def store_chunks(
             chunk_type=chunk.get("chunk_type", "text"),
             image_embedding=image_embedding,
         )
-        if entry_id:
-            inserted += 1
+        if not entry_id:
+            continue
+        inserted += 1
 
-    logger.info("Stored %d/%d chunks", inserted, len(chunks_with_embeddings))
+        # Step 2: bridge the chunk row to its equipment entity, if known.
+        if kg_writer is not None and equipment_id:
+            kg_writer.link_chunk_to_equipment(entry_id, equipment_id)
+
+            # Step 3: extract fault codes from chunk text and densify the KG.
+            if extract_fault_codes is not None:
+                for match in extract_fault_codes(chunk.get("text", "")):
+                    kg_writer.register_fault_code(
+                        tenant_id=tenant_id,
+                        equipment_id=equipment_id,
+                        manufacturer=manufacturer,
+                        fault_code=match.normalized(),
+                        confidence=0.85,
+                        source_chunk_id=entry_id,
+                    )
+
+    logger.info(
+        "Stored %d/%d chunks (equipment_id=%s, manual_id=%s)",
+        inserted,
+        len(chunks_with_embeddings),
+        equipment_id,
+        manual_id,
+    )
     return inserted

--- a/mira-crawler/ingest/uns.py
+++ b/mira-crawler/ingest/uns.py
@@ -1,0 +1,96 @@
+"""UNS path helpers shared by the ingest pipeline, the backfill scripts,
+and the Hub UNS browse API.
+
+UNS path format (spec §3.1):
+    enterprise.{site}.{area}.{line}.{equipment}.{component}.{datapoint}
+
+- Lowercase only.
+- Labels are `[a-z0-9_]+`.
+- `.` is the path separator.
+- Default unassigned form for a freshly-discovered piece of equipment:
+    enterprise.unassigned.{manufacturer_slug}.{model_slug}
+"""
+
+from __future__ import annotations
+
+import re
+
+_LABEL_RE = re.compile(r"^[a-z0-9_]+$")
+_PATH_RE = re.compile(r"^[a-z0-9_]+(\.[a-z0-9_]+)*$")
+_NON_LABEL_CHARS = re.compile(r"[^a-z0-9]+")
+
+
+def slug(value: str) -> str:
+    """Normalize a free-form string into a single ltree label.
+
+    Lowercase, collapse runs of non-alphanumeric to `_`, strip leading/
+    trailing `_`. Returns empty string if nothing usable remains — the
+    caller MUST treat that as a signal not to produce a path segment.
+    """
+    if not value:
+        return ""
+    lowered = value.strip().lower()
+    cleaned = _NON_LABEL_CHARS.sub("_", lowered).strip("_")
+    return cleaned
+
+
+def is_valid_path(path: str) -> bool:
+    """True iff `path` matches the spec's path grammar."""
+    return bool(_PATH_RE.match(path))
+
+
+def is_valid_label(label: str) -> bool:
+    return bool(_LABEL_RE.match(label))
+
+
+def equipment_unassigned_path(manufacturer: str | None, model: str | None) -> str:
+    """Build the default `enterprise.unassigned.{mfr}.{model}` path.
+
+    Falls back to `enterprise.unassigned` if either input is missing
+    or normalizes to empty — the spec says "the default path is
+    meaningful, not a placeholder," but an entity without any vendor
+    information legitimately has nowhere more specific to live.
+    """
+    parts = ["enterprise", "unassigned"]
+    mfr_slug = slug(manufacturer or "")
+    if mfr_slug:
+        parts.append(mfr_slug)
+        model_slug = slug(model or "")
+        if model_slug:
+            parts.append(model_slug)
+    return ".".join(parts)
+
+
+def manual_path(manufacturer: str | None, model: str | None) -> str:
+    """KB-side address for a manual: enterprise.knowledge_base.manuals.{mfr}.{model}."""
+    parts = ["enterprise", "knowledge_base", "manuals"]
+    mfr_slug = slug(manufacturer or "")
+    if mfr_slug:
+        parts.append(mfr_slug)
+        model_slug = slug(model or "")
+        if model_slug:
+            parts.append(model_slug)
+    return ".".join(parts)
+
+
+def fault_code_path(manufacturer: str | None, code: str) -> str:
+    """KB-side address for a fault code:
+    enterprise.knowledge_base.fault_codes.{mfr}.{code}."""
+    parts = ["enterprise", "knowledge_base", "fault_codes"]
+    mfr_slug = slug(manufacturer or "")
+    if mfr_slug:
+        parts.append(mfr_slug)
+    code_slug = slug(code)
+    if code_slug:
+        parts.append(code_slug)
+    return ".".join(parts)
+
+
+def work_order_path(wo_number: str) -> str:
+    """Operational address for a work order:
+    enterprise.operations.work_orders.{wo_number}."""
+    parts = ["enterprise", "operations", "work_orders"]
+    wo_slug = slug(wo_number)
+    if wo_slug:
+        parts.append(wo_slug)
+    return ".".join(parts)

--- a/mira-crawler/ingest/uns.py
+++ b/mira-crawler/ingest/uns.py
@@ -1,14 +1,61 @@
 """UNS path helpers shared by the ingest pipeline, the backfill scripts,
 and the Hub UNS browse API.
 
-UNS path format (spec §3.1):
-    enterprise.{site}.{area}.{line}.{equipment}.{component}.{datapoint}
+UNS schema (broadened 2026-05-07 per Mike — see
+docs/specs/uns-kg-unification-spec.md §3.1)
+================================================
 
-- Lowercase only.
-- Labels are `[a-z0-9_]+`.
-- `.` is the path separator.
-- Default unassigned form for a freshly-discovered piece of equipment:
-    enterprise.unassigned.{manufacturer_slug}.{model_slug}
+The UNS is the canonical address space for every node MIRA knows about.
+It uses ISA-95 segment naming literally as type-marker labels alternated
+with instance labels — that makes the tree explorable: walk one level
+deep and the segment alone tells you what kind of children to expect.
+
+Two top-level branches under `enterprise`:
+
+1. **Knowledge base** — manufacturer-organized, site-independent.
+   Every model MIRA learns about from a manual lives here permanently,
+   even after a customer assigns it to a site. Paths:
+
+       enterprise.knowledge_base.{manufacturer}.{family?}.{model}
+       enterprise.knowledge_base.{manufacturer}.{family?}.{model}.manuals[.{slug}]
+       enterprise.knowledge_base.{manufacturer}.{family?}.{model}.fault_codes.{code}
+       enterprise.knowledge_base.{manufacturer}.{family?}.{model}.pm_schedules[.{slug}]
+       enterprise.knowledge_base.{manufacturer}.{family?}.{model}.parts_lists[.{slug}]
+       enterprise.knowledge_base.community.{equipment_class}.{common_faults|mtbf_benchmarks|resolution_patterns}
+
+2. **Per-company site hierarchy** — the ISA-95 physical model with the
+   `work_cell` segment Mike asked us to add (was the one real ISA-95
+   gap surfaced by the standards-compliance research). The literal
+   markers `site`, `area`, `line`, `work_cell`, `equipment` alternate
+   with dynamic instance labels:
+
+       enterprise.{company}.site.{site}.area.{area}.line.{line}.work_cell.{cell}.equipment.{eq_id}
+
+   Equipment can also live directly on a line (no cell) or in an area
+   (no line) — the `line.{line}.work_cell.{cell}` segments are
+   skippable. Each equipment node has four canonical sub-branches:
+
+       .component.{component_name}
+       .datapoint.{tag_name}                  # future Layer 4 telemetry
+       .maintenance.{pm_schedule|fault_history|work_orders|parts_inventory}.{...}
+       .documentation.{manuals|schematics|procedures}.{...}
+
+   Plus site-level utility/safety/environmental branches and per-company
+   `fleet` (mobile equipment) and `shared_services` siblings.
+
+3. **Operations** — cross-cutting operational records:
+
+       enterprise.operations.{work_orders|technicians|inventory|compliance}.{...}
+
+When a customer assigns a knowledge-base model to a site, the catalog
+entity stays in `enterprise.knowledge_base.{mfr}.{family}.{model}` and
+a NEW instance entity is created at the site path. They are linked via
+an `INSTANCE_OF` relationship — never moved. Same model, multiple sites.
+
+Path grammar (validated by the `uns_path_format` CHECK constraint):
+- Lowercase only, labels are `[a-z0-9_]+`
+- `.` is the path separator
+- ltree's natural depth limit (256 segments) is far above what we use
 """
 
 from __future__ import annotations
@@ -18,6 +65,54 @@ import re
 _LABEL_RE = re.compile(r"^[a-z0-9_]+$")
 _PATH_RE = re.compile(r"^[a-z0-9_]+(\.[a-z0-9_]+)*$")
 _NON_LABEL_CHARS = re.compile(r"[^a-z0-9]+")
+
+# Type-marker labels that must never be used as a manufacturer / model
+# / instance slug — they are reserved for UNS structure. The slug helper
+# returns these unchanged so collisions are caught at validation time
+# rather than silently corrupting the tree.
+RESERVED_LABELS = frozenset(
+    {
+        "enterprise",
+        "knowledge_base",
+        "operations",
+        "community",
+        "site",
+        "area",
+        "line",
+        "work_cell",
+        "equipment",
+        "component",
+        "datapoint",
+        "maintenance",
+        "documentation",
+        "manuals",
+        "fault_codes",
+        "pm_schedules",
+        "pm_schedule",
+        "fault_history",
+        "work_orders",
+        "parts_lists",
+        "parts_inventory",
+        "schematics",
+        "procedures",
+        "fleet",
+        "shared_services",
+        "utilities",
+        "safety_systems",
+        "environmental",
+        "technicians",
+        "inventory",
+        "compliance",
+        "common_faults",
+        "mtbf_benchmarks",
+        "resolution_patterns",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Primitives
+# ---------------------------------------------------------------------------
 
 
 def slug(value: str) -> str:
@@ -43,54 +138,213 @@ def is_valid_label(label: str) -> bool:
     return bool(_LABEL_RE.match(label))
 
 
-def equipment_unassigned_path(manufacturer: str | None, model: str | None) -> str:
-    """Build the default `enterprise.unassigned.{mfr}.{model}` path.
+def _join(*parts: str) -> str:
+    """Join non-empty parts with dots, preserving order."""
+    return ".".join(p for p in parts if p)
 
-    Falls back to `enterprise.unassigned` if either input is missing
-    or normalizes to empty — the spec says "the default path is
-    meaningful, not a placeholder," but an entity without any vendor
-    information legitimately has nowhere more specific to live.
+
+# ---------------------------------------------------------------------------
+# Knowledge-base branch (manufacturer-organized catalog)
+# ---------------------------------------------------------------------------
+
+
+def kb_root() -> str:
+    return "enterprise.knowledge_base"
+
+
+def manufacturer_path(manufacturer: str | None) -> str:
+    """`enterprise.knowledge_base.{mfr_slug}` or just kb_root if missing."""
+    return _join(kb_root(), slug(manufacturer or ""))
+
+
+def family_path(manufacturer: str | None, family: str | None) -> str:
+    """`enterprise.knowledge_base.{mfr}.{family}` (collapses if family
+    missing)."""
+    return _join(manufacturer_path(manufacturer), slug(family or ""))
+
+
+def model_path(
+    manufacturer: str | None,
+    model: str | None,
+    family: str | None = None,
+) -> str:
+    """`enterprise.knowledge_base.{mfr}.{family?}.{model}`.
+
+    The family segment is omitted when `family` is missing — depth
+    becomes inconsistent across the kb tree, but ltree tolerates that
+    and the skeleton resolver in the Hub treats anything under a
+    manufacturer as either a family or a model interchangeably.
     """
-    parts = ["enterprise", "unassigned"]
-    mfr_slug = slug(manufacturer or "")
-    if mfr_slug:
-        parts.append(mfr_slug)
-        model_slug = slug(model or "")
-        if model_slug:
-            parts.append(model_slug)
-    return ".".join(parts)
+    return _join(family_path(manufacturer, family), slug(model or ""))
 
 
-def manual_path(manufacturer: str | None, model: str | None) -> str:
-    """KB-side address for a manual: enterprise.knowledge_base.manuals.{mfr}.{model}."""
-    parts = ["enterprise", "knowledge_base", "manuals"]
-    mfr_slug = slug(manufacturer or "")
-    if mfr_slug:
-        parts.append(mfr_slug)
-        model_slug = slug(model or "")
-        if model_slug:
-            parts.append(model_slug)
-    return ".".join(parts)
+def equipment_unassigned_path(
+    manufacturer: str | None,
+    model: str | None,
+    family: str | None = None,
+) -> str:
+    """The default address for an equipment entity that has been
+    discovered from a manual but not yet assigned to a site.
+
+    Equivalent to `model_path()` — the kb model node IS the equipment
+    catalog entry. Site-side instances live elsewhere and link back via
+    `INSTANCE_OF` (see assigned_equipment_path).
+
+    Falls back to `enterprise.knowledge_base` if both manufacturer and
+    model are empty (a kb-orphan that the operator should triage).
+    """
+    p = model_path(manufacturer, model, family)
+    return p if p != kb_root() else "enterprise.knowledge_base"
 
 
-def fault_code_path(manufacturer: str | None, code: str) -> str:
-    """KB-side address for a fault code:
-    enterprise.knowledge_base.fault_codes.{mfr}.{code}."""
-    parts = ["enterprise", "knowledge_base", "fault_codes"]
-    mfr_slug = slug(manufacturer or "")
-    if mfr_slug:
-        parts.append(mfr_slug)
-    code_slug = slug(code)
-    if code_slug:
-        parts.append(code_slug)
-    return ".".join(parts)
+def manual_path(
+    manufacturer: str | None,
+    model: str | None,
+    family: str | None = None,
+    manual_slug: str | None = None,
+) -> str:
+    """Address for a manual document.
+
+    With `manual_slug`: a specific manual, e.g.
+        enterprise.knowledge_base.allen_bradley.powerflex.powerflex_525.manuals.user_manual_v3
+    Without: the manuals collection node, e.g.
+        enterprise.knowledge_base.allen_bradley.powerflex.powerflex_525.manuals
+    """
+    return _join(model_path(manufacturer, model, family), "manuals", slug(manual_slug or ""))
+
+
+def fault_code_path(
+    manufacturer: str | None,
+    code: str,
+    model: str | None = None,
+    family: str | None = None,
+) -> str:
+    """Address for a fault code under a model (or under just a
+    manufacturer if model is unknown — model-agnostic faults).
+
+    With model:
+        enterprise.knowledge_base.allen_bradley.powerflex.powerflex_525.fault_codes.f004
+    Without model:
+        enterprise.knowledge_base.allen_bradley.fault_codes.f004
+    """
+    if model:
+        prefix = model_path(manufacturer, model, family)
+    else:
+        prefix = manufacturer_path(manufacturer)
+    return _join(prefix, "fault_codes", slug(code))
+
+
+def pm_schedule_path(
+    manufacturer: str | None,
+    model: str | None,
+    pm_slug: str,
+    family: str | None = None,
+) -> str:
+    return _join(model_path(manufacturer, model, family), "pm_schedules", slug(pm_slug))
+
+
+def parts_list_path(
+    manufacturer: str | None,
+    model: str | None,
+    part_slug: str,
+    family: str | None = None,
+) -> str:
+    return _join(model_path(manufacturer, model, family), "parts_lists", slug(part_slug))
+
+
+def community_class_path(equipment_class: str, leaf: str | None = None) -> str:
+    """`enterprise.knowledge_base.community.{equipment_class}[.{leaf}]`.
+
+    `leaf` is one of the literal sub-branches: `common_faults`,
+    `mtbf_benchmarks`, `resolution_patterns` (or empty for the class
+    node itself)."""
+    base = _join(kb_root(), "community", slug(equipment_class))
+    return _join(base, leaf or "")
+
+
+# ---------------------------------------------------------------------------
+# Per-company site hierarchy (ISA-95)
+# ---------------------------------------------------------------------------
+
+
+def company_root(company: str) -> str:
+    return _join("enterprise", slug(company))
+
+
+def site_path(company: str, site: str) -> str:
+    return _join(company_root(company), "site", slug(site))
+
+
+def area_path(company: str, site: str, area: str) -> str:
+    return _join(site_path(company, site), "area", slug(area))
+
+
+def line_path(company: str, site: str, area: str, line: str) -> str:
+    return _join(area_path(company, site, area), "line", slug(line))
+
+
+def work_cell_path(
+    company: str, site: str, area: str, line: str, work_cell: str
+) -> str:
+    return _join(line_path(company, site, area, line), "work_cell", slug(work_cell))
+
+
+def assigned_equipment_path(
+    company: str,
+    site: str,
+    area: str,
+    equipment_id: str,
+    line: str | None = None,
+    work_cell: str | None = None,
+) -> str:
+    """Build the site-side equipment instance path.
+
+    Equipment can attach at three depths per Mike's directive:
+    - In a work cell:  ...area.{a}.line.{l}.work_cell.{c}.equipment.{eq}
+    - On a line:       ...area.{a}.line.{l}.equipment.{eq}            (no cell)
+    - In an area:      ...area.{a}.equipment.{eq}                     (no line)
+    """
+    if line and work_cell:
+        prefix = work_cell_path(company, site, area, line, work_cell)
+    elif line:
+        prefix = line_path(company, site, area, line)
+    else:
+        prefix = area_path(company, site, area)
+    return _join(prefix, "equipment", slug(equipment_id))
+
+
+def equipment_subnode_path(equipment_path_value: str, *segments: str) -> str:
+    """Append literal/instance segments under an equipment instance.
+
+    Example:
+        equipment_subnode_path(eq_path, "component", "bearing_nde")
+        → ...equipment.{eq}.component.bearing_nde
+        equipment_subnode_path(eq_path, "maintenance", "pm_schedule", "monthly_lube")
+    """
+    return _join(equipment_path_value, *(slug(s) for s in segments))
+
+
+# ---------------------------------------------------------------------------
+# Operations branch
+# ---------------------------------------------------------------------------
+
+
+def operations_root() -> str:
+    return "enterprise.operations"
 
 
 def work_order_path(wo_number: str) -> str:
-    """Operational address for a work order:
-    enterprise.operations.work_orders.{wo_number}."""
-    parts = ["enterprise", "operations", "work_orders"]
-    wo_slug = slug(wo_number)
-    if wo_slug:
-        parts.append(wo_slug)
-    return ".".join(parts)
+    """`enterprise.operations.work_orders.{wo_slug}`."""
+    return _join(operations_root(), "work_orders", slug(wo_number))
+
+
+def technician_path(tech_id: str) -> str:
+    return _join(operations_root(), "technicians", slug(tech_id))
+
+
+def inventory_path(inventory_slug: str) -> str:
+    return _join(operations_root(), "inventory", slug(inventory_slug))
+
+
+def compliance_path(compliance_slug: str) -> str:
+    return _join(operations_root(), "compliance", slug(compliance_slug))

--- a/mira-hub/src/app/(hub)/library/page.tsx
+++ b/mira-hub/src/app/(hub)/library/page.tsx
@@ -1,0 +1,598 @@
+"use client";
+
+/**
+ * KB Library — Phase 4 of the UNS+KG unification spec.
+ *
+ * Mobile-first tree browser over `knowledge_entries` (74K+ chunks).
+ * Renders a 3-level hierarchy: Manufacturer → Model → Document, with
+ * a chunk detail view at the leaf.
+ *
+ * Design notes
+ * ------------
+ * - Single page, no client-side routing — modal-style detail view
+ *   keeps the back-button working naturally on mobile.
+ * - All tap targets are at least 44px tall (Apple HIG minimum).
+ * - Tree state lives in component state; no localStorage/cookies so a
+ *   shared link from a tech's phone always opens to the same view.
+ * - Search filters the tree client-side (the tree fits in memory at
+ *   our scale; ~74K chunks roll up to roughly 100s of leaves).
+ */
+
+import { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  Search,
+  Library as LibraryIcon,
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  ExternalLink,
+  AlertCircle,
+  Loader2,
+  X,
+  Building2,
+  Box,
+  BookOpen,
+} from "lucide-react";
+import { API_BASE } from "@/lib/config";
+
+/* ─── Types ──────────────────────────────────────────────────────────── */
+
+type Source = {
+  url: string | null;
+  title: string;
+  chunkCount: number;
+  sourceType: string;
+};
+
+type Model = {
+  name: string;
+  chunkCount: number;
+  documentCount: number;
+  sources: Source[];
+};
+
+type Manufacturer = {
+  name: string;
+  chunkCount: number;
+  modelCount: number;
+  models: Model[];
+};
+
+type Tree = {
+  totalChunks: number;
+  totalManufacturers: number;
+  manufacturers: Manufacturer[];
+};
+
+type DocumentDetail = {
+  document: { sourceUrl: string; title: string; totalChunks: number };
+  chunks: Array<{
+    id: string;
+    preview: string;
+    page: number | null;
+    chunkIndex: number | null;
+    section: string | null;
+    sourceType: string | null;
+  }>;
+  faultCodes: Array<{ id: string; code: string; name: string; uns_path: string }>;
+  pagination: { limit: number; offset: number; hasMore: boolean };
+};
+
+/* ─── Document id helper (mirrors /api/library/documents) ────────────── */
+
+function encodeDocumentId(sourceUrl: string): string {
+  // btoa works in the browser; base64 → URL-safe.
+  return btoa(unescape(encodeURIComponent(sourceUrl)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/* ─── Page ───────────────────────────────────────────────────────────── */
+
+export default function LibraryPage() {
+  const [tree, setTree] = useState<Tree | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [openMfrs, setOpenMfrs] = useState<Set<string>>(new Set());
+  const [openModels, setOpenModels] = useState<Set<string>>(new Set());
+  const [activeDoc, setActiveDoc] = useState<{ sourceUrl: string; title: string } | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/library/tree`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<Tree>;
+      })
+      .then((data) => setTree(data))
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const toggleMfr = useCallback((name: string) => {
+    setOpenMfrs((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }, []);
+
+  const toggleModel = useCallback((key: string) => {
+    setOpenModels((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  // Filter the tree by search term. Matches against manufacturer, model,
+  // or any source title. Auto-expands matching branches.
+  const filteredManufacturers = useMemo(() => {
+    if (!tree) return [];
+    const q = search.trim().toLowerCase();
+    if (!q) return tree.manufacturers;
+
+    const result: Manufacturer[] = [];
+    const autoOpenMfrs = new Set<string>();
+    const autoOpenModels = new Set<string>();
+
+    for (const mfr of tree.manufacturers) {
+      const mfrHit = mfr.name.toLowerCase().includes(q);
+      const filteredModels: Model[] = [];
+
+      for (const model of mfr.models) {
+        const modelHit = model.name.toLowerCase().includes(q);
+        const sourceHits = model.sources.filter((s) =>
+          (s.title ?? "").toLowerCase().includes(q),
+        );
+
+        if (mfrHit || modelHit || sourceHits.length > 0) {
+          filteredModels.push({
+            ...model,
+            sources: sourceHits.length > 0 && !modelHit ? sourceHits : model.sources,
+          });
+          autoOpenModels.add(`${mfr.name}::${model.name}`);
+        }
+      }
+
+      if (mfrHit || filteredModels.length > 0) {
+        result.push({ ...mfr, models: filteredModels });
+        autoOpenMfrs.add(mfr.name);
+      }
+    }
+
+    // Sync open-state — without this, tapping a search result inside a
+    // collapsed branch would silently fail to render anything.
+    if (autoOpenMfrs.size > 0) {
+      setOpenMfrs((prev) => {
+        let changed = false;
+        const next = new Set(prev);
+        autoOpenMfrs.forEach((m) => {
+          if (!next.has(m)) {
+            next.add(m);
+            changed = true;
+          }
+        });
+        return changed ? next : prev;
+      });
+      setOpenModels((prev) => {
+        let changed = false;
+        const next = new Set(prev);
+        autoOpenModels.forEach((m) => {
+          if (!next.has(m)) {
+            next.add(m);
+            changed = true;
+          }
+        });
+        return changed ? next : prev;
+      });
+    }
+
+    return result;
+  }, [tree, search]);
+
+  return (
+    <div className="min-h-screen bg-slate-50 dark:bg-slate-950">
+      {/* Sticky header (works on mobile + desktop) */}
+      <header className="sticky top-0 z-20 border-b border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
+        <div className="mx-auto flex max-w-5xl items-center gap-3 px-4 py-3">
+          <LibraryIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+          <div className="flex-1 min-w-0">
+            <h1 className="truncate text-base font-semibold text-slate-900 dark:text-slate-100">
+              Knowledge Library
+            </h1>
+            {tree && (
+              <p className="truncate text-xs text-slate-500 dark:text-slate-400">
+                {tree.totalChunks.toLocaleString()} chunks ·{" "}
+                {tree.totalManufacturers} manufacturers
+              </p>
+            )}
+          </div>
+        </div>
+        <div className="mx-auto max-w-5xl px-4 pb-3">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+            <input
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search manufacturer, model, or document…"
+              className="w-full rounded-lg border border-slate-300 bg-white py-3 pl-10 pr-10 text-base text-slate-900 placeholder-slate-400 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-100"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
+            />
+            {search && (
+              <button
+                onClick={() => setSearch("")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1.5 text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-700"
+                aria-label="Clear search"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-5xl px-4 py-4">
+        {loading && <LoadingState />}
+        {error && <ErrorState message={error} />}
+        {!loading && !error && tree && (
+          <>
+            {filteredManufacturers.length === 0 ? (
+              <EmptyState search={search} />
+            ) : (
+              <ul className="space-y-2">
+                {filteredManufacturers.map((mfr) => (
+                  <ManufacturerNode
+                    key={mfr.name}
+                    mfr={mfr}
+                    open={openMfrs.has(mfr.name)}
+                    openModels={openModels}
+                    onToggle={() => toggleMfr(mfr.name)}
+                    onToggleModel={(modelName) =>
+                      toggleModel(`${mfr.name}::${modelName}`)
+                    }
+                    onOpenDoc={(src) =>
+                      setActiveDoc({
+                        sourceUrl: src.url ?? "",
+                        title: src.title,
+                      })
+                    }
+                  />
+                ))}
+              </ul>
+            )}
+          </>
+        )}
+      </main>
+
+      {activeDoc && (
+        <DocumentSheet
+          sourceUrl={activeDoc.sourceUrl}
+          title={activeDoc.title}
+          onClose={() => setActiveDoc(null)}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ─── Tree nodes ─────────────────────────────────────────────────────── */
+
+function ManufacturerNode({
+  mfr,
+  open,
+  openModels,
+  onToggle,
+  onToggleModel,
+  onOpenDoc,
+}: {
+  mfr: Manufacturer;
+  open: boolean;
+  openModels: Set<string>;
+  onToggle: () => void;
+  onToggleModel: (modelName: string) => void;
+  onOpenDoc: (src: Source) => void;
+}) {
+  return (
+    <li className="overflow-hidden rounded-xl border border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+      <button
+        onClick={onToggle}
+        className="flex w-full items-center gap-3 px-4 py-4 text-left transition-colors hover:bg-slate-50 active:bg-slate-100 dark:hover:bg-slate-800 dark:active:bg-slate-700"
+        style={{ minHeight: 64 }}
+      >
+        {open ? (
+          <ChevronDown className="h-5 w-5 flex-shrink-0 text-slate-500" />
+        ) : (
+          <ChevronRight className="h-5 w-5 flex-shrink-0 text-slate-500" />
+        )}
+        <Building2 className="h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-400" />
+        <div className="flex-1 min-w-0">
+          <p className="truncate text-base font-semibold text-slate-900 dark:text-slate-100">
+            {mfr.name}
+          </p>
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            {mfr.modelCount} model{mfr.modelCount === 1 ? "" : "s"} ·{" "}
+            {mfr.chunkCount.toLocaleString()} chunks
+          </p>
+        </div>
+      </button>
+      {open && (
+        <ul className="border-t border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-950/40">
+          {mfr.models.map((model) => (
+            <ModelNode
+              key={model.name}
+              model={model}
+              open={openModels.has(`${mfr.name}::${model.name}`)}
+              onToggle={() => onToggleModel(model.name)}
+              onOpenDoc={onOpenDoc}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+function ModelNode({
+  model,
+  open,
+  onToggle,
+  onOpenDoc,
+}: {
+  model: Model;
+  open: boolean;
+  onToggle: () => void;
+  onOpenDoc: (src: Source) => void;
+}) {
+  return (
+    <li className="border-b border-slate-100 last:border-b-0 dark:border-slate-800">
+      <button
+        onClick={onToggle}
+        className="flex w-full items-center gap-3 px-4 py-3 pl-10 text-left transition-colors hover:bg-white active:bg-slate-100 dark:hover:bg-slate-900 dark:active:bg-slate-800"
+        style={{ minHeight: 56 }}
+      >
+        {open ? (
+          <ChevronDown className="h-4 w-4 flex-shrink-0 text-slate-400" />
+        ) : (
+          <ChevronRight className="h-4 w-4 flex-shrink-0 text-slate-400" />
+        )}
+        <Box className="h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+        <div className="flex-1 min-w-0">
+          <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-200">
+            {model.name}
+          </p>
+          <p className="text-[11px] text-slate-500 dark:text-slate-400">
+            {model.documentCount} doc{model.documentCount === 1 ? "" : "s"} ·{" "}
+            {model.chunkCount.toLocaleString()} chunks
+          </p>
+        </div>
+      </button>
+      {open && (
+        <ul className="border-t border-slate-100 bg-white dark:border-slate-800 dark:bg-slate-900">
+          {model.sources.map((src, idx) => (
+            <li
+              key={`${src.url ?? "no-url"}-${idx}`}
+              className="border-b border-slate-100 last:border-b-0 dark:border-slate-800"
+            >
+              <button
+                onClick={() => onOpenDoc(src)}
+                disabled={!src.url}
+                className="flex w-full items-center gap-3 px-4 py-3 pl-16 text-left transition-colors hover:bg-blue-50 active:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-blue-950/40 dark:active:bg-blue-950/60"
+                style={{ minHeight: 52 }}
+              >
+                <FileText className="h-4 w-4 flex-shrink-0 text-slate-500" />
+                <div className="flex-1 min-w-0">
+                  <p className="truncate text-sm text-slate-700 dark:text-slate-300">
+                    {src.title}
+                  </p>
+                  <p className="text-[11px] text-slate-500 dark:text-slate-400">
+                    {src.sourceType} · {src.chunkCount.toLocaleString()} chunks
+                  </p>
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+/* ─── Document sheet (mobile bottom-sheet, desktop side panel) ───────── */
+
+function DocumentSheet({
+  sourceUrl,
+  title,
+  onClose,
+}: {
+  sourceUrl: string;
+  title: string;
+  onClose: () => void;
+}) {
+  const [data, setData] = useState<DocumentDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sourceUrl) {
+      setError("This document has no source URL — chunks cannot be loaded.");
+      setLoading(false);
+      return;
+    }
+    const id = encodeDocumentId(sourceUrl);
+    fetch(`${API_BASE}/api/library/chunks?document_id=${id}&limit=100`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<DocumentDetail>;
+      })
+      .then(setData)
+      .catch((e) => setError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLoading(false));
+  }, [sourceUrl]);
+
+  // Lock body scroll while sheet is open.
+  useEffect(() => {
+    const original = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = original;
+    };
+  }, []);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 backdrop-blur-sm sm:items-center sm:p-4"
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="flex h-[90vh] w-full max-w-2xl flex-col overflow-hidden rounded-t-2xl bg-white shadow-2xl dark:bg-slate-900 sm:h-[85vh] sm:rounded-2xl"
+      >
+        <header className="flex items-start gap-3 border-b border-slate-200 px-4 py-3 dark:border-slate-800">
+          <FileText className="mt-0.5 h-5 w-5 flex-shrink-0 text-blue-600 dark:text-blue-400" />
+          <div className="flex-1 min-w-0">
+            <h2 className="truncate text-base font-semibold text-slate-900 dark:text-slate-100">
+              {data?.document.title ?? title}
+            </h2>
+            {sourceUrl && (
+              <a
+                href={sourceUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="mt-0.5 inline-flex items-center gap-1 text-xs text-blue-600 hover:underline dark:text-blue-400"
+              >
+                Open source
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-full p-2 text-slate-400 hover:bg-slate-100 hover:text-slate-700 dark:hover:bg-slate-800"
+            aria-label="Close"
+            style={{ minWidth: 40, minHeight: 40 }}
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+
+        {loading && (
+          <div className="flex flex-1 items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin text-slate-400" />
+          </div>
+        )}
+        {error && <ErrorState message={error} />}
+
+        {!loading && !error && data && (
+          <div className="flex-1 overflow-y-auto px-4 py-3">
+            {data.faultCodes.length > 0 && (
+              <section className="mb-4 rounded-xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-900/50 dark:bg-amber-950/30">
+                <div className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-amber-800 dark:text-amber-300">
+                  <AlertCircle className="h-4 w-4" />
+                  Fault codes extracted ({data.faultCodes.length})
+                </div>
+                <div className="flex flex-wrap gap-1.5">
+                  {data.faultCodes.map((f) => (
+                    <span
+                      key={f.id}
+                      title={f.uns_path}
+                      className="inline-flex items-center gap-1 rounded-md bg-amber-200/70 px-2 py-1 font-mono text-xs text-amber-900 dark:bg-amber-900/40 dark:text-amber-200"
+                    >
+                      {f.code || f.name}
+                    </span>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            <p className="mb-3 text-xs text-slate-500 dark:text-slate-400">
+              Showing {data.chunks.length} of{" "}
+              {data.document.totalChunks.toLocaleString()} chunks
+            </p>
+
+            <ul className="space-y-2">
+              {data.chunks.map((chunk) => (
+                <li
+                  key={chunk.id}
+                  className="rounded-lg border border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-950/40"
+                >
+                  <div className="mb-1.5 flex flex-wrap items-center gap-2 text-[11px] text-slate-500 dark:text-slate-400">
+                    {chunk.page != null && (
+                      <span className="rounded bg-slate-100 px-1.5 py-0.5 dark:bg-slate-800">
+                        Page {chunk.page}
+                      </span>
+                    )}
+                    {chunk.section && (
+                      <span className="truncate">§ {chunk.section}</span>
+                    )}
+                    {chunk.sourceType && (
+                      <span className="rounded bg-slate-100 px-1.5 py-0.5 dark:bg-slate-800">
+                        {chunk.sourceType}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-sm leading-relaxed text-slate-800 dark:text-slate-200">
+                    {chunk.preview}
+                    {chunk.preview.length >= 220 ? "…" : ""}
+                  </p>
+                </li>
+              ))}
+            </ul>
+
+            {data.pagination.hasMore && (
+              <p className="mt-4 text-center text-xs text-slate-400">
+                Pagination beyond first 100 chunks not yet wired into UI.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ─── Empty / loading / error states ─────────────────────────────────── */
+
+function LoadingState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-20">
+      <Loader2 className="h-8 w-8 animate-spin text-slate-400" />
+      <p className="mt-3 text-sm text-slate-500">Loading library…</p>
+    </div>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20 px-4 text-center">
+      <AlertCircle className="h-8 w-8 text-red-500" />
+      <p className="mt-3 text-sm font-medium text-slate-700 dark:text-slate-300">
+        Could not load library
+      </p>
+      <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{message}</p>
+    </div>
+  );
+}
+
+function EmptyState({ search }: { search: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 text-center">
+      <BookOpen className="h-10 w-10 text-slate-300" />
+      <p className="mt-3 text-sm font-medium text-slate-700 dark:text-slate-300">
+        {search ? "No matches" : "Library is empty"}
+      </p>
+      <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+        {search
+          ? `Nothing matches "${search}". Try fewer words.`
+          : "Once manuals are ingested they will appear here."}
+      </p>
+    </div>
+  );
+}

--- a/mira-hub/src/app/api/knowledge/route.ts
+++ b/mira-hub/src/app/api/knowledge/route.ts
@@ -11,17 +11,29 @@ export async function GET() {
   const ctx = await sessionOr401();
   if (ctx instanceof NextResponse) return ctx;
   try {
+    // UNS+KG unification (spec §4.3, Phase 1): repoint from the empty
+    // `kb_chunks` stub to the real vector store (`knowledge_entries`).
+    // The shape matches what the UI consumes — fields that don't exist
+    // on knowledge_entries (system_category, subcategory, quality_score)
+    // are read from the JSONB metadata column or projected as NULL.
     const rows = await withTenantContext(ctx.tenantId, (c) =>
       c.query(
         `SELECT
-          system_category, subcategory, manufacturer, product_family,
-          doc_type, source, COUNT(*) as chunk_count,
-          AVG(quality_score) as avg_quality,
+          equipment_type AS system_category,
+          metadata->>'subcategory' AS subcategory,
+          manufacturer,
+          model_number AS product_family,
+          data_type AS doc_type,
+          source_type AS source,
+          COUNT(*) as chunk_count,
+          AVG((metadata->>'quality_score')::float) as avg_quality,
           MAX(created_at) as last_indexed,
-          array_agg(DISTINCT title ORDER BY title) FILTER (WHERE title IS NOT NULL) as sample_titles
-        FROM kb_chunks
+          array_agg(DISTINCT (metadata->>'title') ORDER BY (metadata->>'title'))
+            FILTER (WHERE metadata->>'title' IS NOT NULL) as sample_titles
+        FROM knowledge_entries
         WHERE tenant_id = $1
-        GROUP BY system_category, subcategory, manufacturer, product_family, doc_type, source
+        GROUP BY equipment_type, metadata->>'subcategory', manufacturer,
+                 model_number, data_type, source_type
         ORDER BY chunk_count DESC, avg_quality DESC NULLS LAST`,
         [ctx.tenantId],
       ).then((r) => r.rows),

--- a/mira-hub/src/app/api/library/chunks/route.ts
+++ b/mira-hub/src/app/api/library/chunks/route.ts
@@ -1,0 +1,183 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/library/chunks?document_id=<urlsafe-b64>&limit=N&offset=M
+ *
+ * Returns chunks for a specific source document, plus the fault codes
+ * extracted from those chunks (joined through kg_relationships).
+ *
+ * `document_id` is the URL-safe base64 of the source_url (encoded by
+ * /api/library/documents). We decode and use it as the WHERE filter.
+ *
+ * Response shape:
+ *   {
+ *     document: {
+ *       sourceUrl: "https://…",
+ *       title: "PowerFlex 525 User Manual",
+ *       totalChunks: 624,
+ *     },
+ *     chunks: [
+ *       {
+ *         id: "uuid",
+ *         preview: "first 200 chars",
+ *         page: 142,
+ *         section: "Chapter 7 — Faults",
+ *         sourceType: "manual",
+ *         createdAt: "…",
+ *       },
+ *       …
+ *     ],
+ *     faultCodes: [
+ *       { code: "F004", uns_path: "enterprise.knowledge_base.allen_bradley.powerflex_525.fault_codes.f004" },
+ *       …
+ *     ],
+ *     pagination: { limit, offset, hasMore: true|false },
+ *   }
+ */
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+export async function GET(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const url = new URL(req.url);
+  const documentId = url.searchParams.get("document_id");
+  const limit = Math.min(
+    MAX_LIMIT,
+    Math.max(1, Number(url.searchParams.get("limit") ?? DEFAULT_LIMIT) || DEFAULT_LIMIT),
+  );
+  const offset = Math.max(0, Number(url.searchParams.get("offset") ?? 0) || 0);
+
+  if (!documentId) {
+    return NextResponse.json(
+      { error: "document_id query param is required" },
+      { status: 400 },
+    );
+  }
+
+  let sourceUrl: string;
+  try {
+    sourceUrl = decodeDocumentId(documentId);
+  } catch {
+    return NextResponse.json({ error: "Invalid document_id" }, { status: 400 });
+  }
+
+  try {
+    const data = await withTenantContext(ctx.tenantId, async (c) => {
+      const { rows: meta } = await c.query(
+        `SELECT
+            metadata->>'title' AS title,
+            COUNT(*)::text     AS total_chunks
+          FROM knowledge_entries
+          WHERE tenant_id = $1 AND source_url = $2
+          GROUP BY metadata->>'title'
+          ORDER BY total_chunks DESC NULLS LAST
+          LIMIT 1`,
+        [ctx.tenantId, sourceUrl],
+      );
+      const { rows: chunks } = await c.query(
+        `SELECT
+            id::text,
+            LEFT(content, 220) AS preview,
+            source_page,
+            metadata->>'section' AS section,
+            metadata->>'chunk_index' AS chunk_index,
+            source_type,
+            data_type,
+            equipment_entity_id::text,
+            created_at
+          FROM knowledge_entries
+          WHERE tenant_id = $1 AND source_url = $2
+          ORDER BY source_page NULLS LAST, (metadata->>'chunk_index')::int NULLS LAST
+          LIMIT $3 OFFSET $4`,
+        [ctx.tenantId, sourceUrl, limit, offset],
+      );
+      // Fault codes attached to ANY chunk from this document, deduped.
+      // We join through kg_relationships.source_chunk_id (every fault
+      // edge cites the chunk that justified it — spec §3.2).
+      const { rows: faults } = await c.query(
+        `SELECT DISTINCT
+            fc.id::text AS id,
+            fc.name     AS name,
+            fc.properties->>'code' AS code,
+            fc.uns_path::text AS uns_path
+          FROM kg_relationships r
+          JOIN kg_entities      fc ON fc.id = r.target_entity
+          JOIN knowledge_entries ke ON ke.id = r.source_chunk_id
+          WHERE r.tenant_id = $1
+            AND r.relation_type = 'has_fault'
+            AND ke.tenant_id = $1
+            AND ke.source_url = $2
+          ORDER BY code NULLS LAST, name`,
+        [ctx.tenantId, sourceUrl],
+      );
+      return { meta, chunks, faults };
+    });
+
+    const totalChunks = Number(data.meta[0]?.total_chunks ?? 0);
+    const chunks = data.chunks.map((r: Record<string, unknown>) => ({
+      id: String(r.id),
+      preview: String(r.preview ?? ""),
+      page: r.source_page == null ? null : Number(r.source_page),
+      chunkIndex: r.chunk_index == null ? null : Number(r.chunk_index),
+      section: (r.section as string | null) ?? null,
+      sourceType: (r.source_type as string | null) ?? null,
+      docType: (r.data_type as string | null) ?? null,
+      equipmentEntityId: (r.equipment_entity_id as string | null) ?? null,
+      createdAt: r.created_at,
+    }));
+
+    let faultCodes: Array<{ id: string; code: string; name: string; uns_path: string }> = [];
+    try {
+      faultCodes = data.faults.map((f: Record<string, unknown>) => ({
+        id: String(f.id),
+        code: String(f.code ?? ""),
+        name: String(f.name ?? ""),
+        uns_path: String(f.uns_path ?? ""),
+      }));
+    } catch {
+      // KG tables may not exist on a fresh deploy before migrations 006/007.
+      faultCodes = [];
+    }
+
+    return NextResponse.json({
+      document: {
+        sourceUrl,
+        title: (data.meta[0]?.title as string | null) ?? deriveTitleFromUrl(sourceUrl),
+        totalChunks,
+      },
+      chunks,
+      faultCodes,
+      pagination: {
+        limit,
+        offset,
+        hasMore: offset + chunks.length < totalChunks,
+      },
+    });
+  } catch (err) {
+    console.error("[api/library/chunks]", err);
+    return NextResponse.json({ error: "Chunk query failed" }, { status: 500 });
+  }
+}
+
+function decodeDocumentId(id: string): string {
+  const b64 = id.replace(/-/g, "+").replace(/_/g, "/");
+  // Pad to a multiple of 4 chars.
+  const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+  return Buffer.from(padded, "base64").toString("utf-8");
+}
+
+function deriveTitleFromUrl(url: string): string {
+  const base = url.split("?")[0].split("#")[0].replace(/\/+$/, "");
+  const last = base.split("/").pop() ?? base;
+  return decodeURIComponent(last.replace(/\.(pdf|html?|md|txt)$/i, "")) || base;
+}

--- a/mira-hub/src/app/api/library/documents/route.ts
+++ b/mira-hub/src/app/api/library/documents/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/library/documents?manufacturer=X&model=Y
+ *
+ * Returns the document list (one row per source_url) for the given
+ * manufacturer + model. The Library page uses this on a deep link or
+ * to lazy-load model details.
+ *
+ * Both `manufacturer` and `model` may be the literal string "Unknown
+ * manufacturer" / "Unspecified model" — these correspond to NULL/empty
+ * values in `knowledge_entries`. Handled below.
+ */
+
+const SENTINEL_MFR = "Unknown manufacturer";
+const SENTINEL_MODEL = "Unspecified model";
+
+export async function GET(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const url = new URL(req.url);
+  const mfr = (url.searchParams.get("manufacturer") ?? "").trim();
+  const model = (url.searchParams.get("model") ?? "").trim();
+
+  if (!mfr) {
+    return NextResponse.json(
+      { error: "manufacturer query param is required" },
+      { status: 400 },
+    );
+  }
+
+  // Translate sentinel values into NULL/empty filters.
+  const mfrPredicate =
+    mfr === SENTINEL_MFR
+      ? "(manufacturer IS NULL OR TRIM(manufacturer) = '')"
+      : "TRIM(manufacturer) = $2";
+  const modelPredicate = model
+    ? model === SENTINEL_MODEL
+      ? "AND (model_number IS NULL OR TRIM(model_number) = '')"
+      : "AND TRIM(model_number) = $3"
+    : "";
+
+  const params: unknown[] = [ctx.tenantId];
+  if (mfr !== SENTINEL_MFR) params.push(mfr);
+  if (model && model !== SENTINEL_MODEL) params.push(model);
+
+  try {
+    const rows = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query(
+          `SELECT
+              source_url,
+              source_type,
+              data_type,
+              metadata->>'title'  AS title,
+              MIN(equipment_entity_id::text) AS equipment_entity_id,
+              MIN(created_at)     AS first_seen,
+              MAX(created_at)     AS last_seen,
+              COUNT(*)::text      AS chunk_count
+            FROM knowledge_entries
+            WHERE tenant_id = $1
+              AND ${mfrPredicate}
+              ${modelPredicate}
+            GROUP BY source_url, source_type, data_type, metadata->>'title'
+            ORDER BY chunk_count DESC NULLS LAST`,
+          params,
+        )
+        .then((r) => r.rows),
+    );
+
+    const docs = rows.map((r: Record<string, unknown>, i: number) => ({
+      // Stable id derived from the source_url (or a row-index fallback)
+      // so the Library page can deep-link without a real document table.
+      id: encodeDocumentId(String(r.source_url ?? `row-${i}`)),
+      sourceUrl: (r.source_url as string | null) ?? null,
+      title: (r.title as string | null) ?? deriveTitleFromUrl(r.source_url as string | null),
+      sourceType: (r.source_type as string | null) ?? "unknown",
+      docType: (r.data_type as string | null) ?? null,
+      equipmentEntityId: (r.equipment_entity_id as string | null) ?? null,
+      firstSeen: r.first_seen,
+      lastSeen: r.last_seen,
+      chunkCount: Number(r.chunk_count),
+    }));
+
+    return NextResponse.json({
+      manufacturer: mfr,
+      model: model || null,
+      totalDocs: docs.length,
+      totalChunks: docs.reduce((s, d) => s + d.chunkCount, 0),
+      documents: docs,
+    });
+  } catch (err) {
+    console.error("[api/library/documents]", err);
+    return NextResponse.json({ error: "Document query failed" }, { status: 500 });
+  }
+}
+
+function deriveTitleFromUrl(url: string | null): string {
+  if (!url) return "Untitled document";
+  const base = url.split("?")[0].split("#")[0].replace(/\/+$/, "");
+  const last = base.split("/").pop() ?? base;
+  return decodeURIComponent(last.replace(/\.(pdf|html?|md|txt)$/i, "")) || base;
+}
+
+function encodeDocumentId(sourceUrl: string): string {
+  // URL-safe base64 of the source_url so the id can ride in a query param
+  // without collision and round-trip back to the chunks endpoint.
+  const b64 = Buffer.from(sourceUrl, "utf-8").toString("base64");
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}

--- a/mira-hub/src/app/api/library/tree/route.ts
+++ b/mira-hub/src/app/api/library/tree/route.ts
@@ -1,0 +1,159 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/library/tree
+ *
+ * Returns the KB library tree grouped by manufacturer → model → source.
+ * Reads `knowledge_entries` (the real 74K-row vector store, not the
+ * empty kb_chunks stub).
+ *
+ * Response shape:
+ *   {
+ *     totalChunks: 74714,
+ *     totalManufacturers: 12,
+ *     manufacturers: [
+ *       {
+ *         name: "Allen-Bradley",
+ *         chunkCount: 32584,
+ *         modelCount: 47,
+ *         models: [
+ *           {
+ *             name: "PowerFlex 525",
+ *             chunkCount: 1842,
+ *             documentCount: 3,
+ *             sources: [
+ *               { url: "https://…", title: "User Manual v3", chunkCount: 624, sourceType: "manual" },
+ *               …
+ *             ],
+ *           },
+ *           …
+ *         ],
+ *       },
+ *       …
+ *     ],
+ *   }
+ *
+ * Library page Phase 4 — UNS+KG unification spec.
+ */
+
+type SourceRow = {
+  manufacturer: string | null;
+  model_number: string | null;
+  source_url: string | null;
+  source_type: string | null;
+  title: string | null;
+  chunk_count: string;
+};
+
+export async function GET() {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  try {
+    const data = await withTenantContext(ctx.tenantId, async (c) => {
+      // Pull every (manufacturer, model, source_url, title) bucket once
+      // and shape it client-side. With ~74K rows and roughly hundreds of
+      // distinct sources, this is well under 1 round-trip's worth of
+      // payload — and it lets the tree render without N+1 follow-ups.
+      const { rows: sources } = await c.query(
+        `SELECT
+            COALESCE(NULLIF(TRIM(manufacturer), ''), '__unknown__') AS manufacturer,
+            COALESCE(NULLIF(TRIM(model_number), ''), '__unknown__') AS model_number,
+            source_url,
+            source_type,
+            metadata->>'title' AS title,
+            COUNT(*)::text AS chunk_count
+          FROM knowledge_entries
+          WHERE tenant_id = $1
+          GROUP BY manufacturer, model_number, source_url, source_type, metadata->>'title'
+          ORDER BY chunk_count DESC NULLS LAST`,
+        [ctx.tenantId],
+      );
+      const { rows: totals } = await c.query(
+        `SELECT COUNT(*)::text AS total_chunks FROM knowledge_entries WHERE tenant_id = $1`,
+        [ctx.tenantId],
+      );
+      return { sources: sources as SourceRow[], totalChunks: Number(totals[0]?.total_chunks ?? 0) };
+    });
+
+    // Shape: manufacturer → model → source
+    const mfrMap = new Map<
+      string,
+      Map<
+        string,
+        Array<{
+          source_url: string | null;
+          source_type: string | null;
+          title: string | null;
+          chunk_count: number;
+        }>
+      >
+    >();
+
+    for (const row of data.sources) {
+      const mfr = (row.manufacturer === "__unknown__" ? "Unknown manufacturer" : row.manufacturer)!;
+      const model = (row.model_number === "__unknown__" ? "Unspecified model" : row.model_number)!;
+      const count = Number(row.chunk_count);
+
+      if (!mfrMap.has(mfr)) mfrMap.set(mfr, new Map());
+      const modelMap = mfrMap.get(mfr)!;
+      if (!modelMap.has(model)) modelMap.set(model, []);
+      modelMap.get(model)!.push({
+        source_url: row.source_url,
+        source_type: row.source_type,
+        title: row.title,
+        chunk_count: count,
+      });
+    }
+
+    const manufacturers = Array.from(mfrMap.entries())
+      .map(([name, modelMap]) => {
+        const models = Array.from(modelMap.entries())
+          .map(([modelName, sources]) => {
+            const chunkCount = sources.reduce((s, x) => s + x.chunk_count, 0);
+            return {
+              name: modelName,
+              chunkCount,
+              documentCount: sources.length,
+              sources: sources
+                .map((s) => ({
+                  url: s.source_url,
+                  title: s.title ?? deriveTitleFromUrl(s.source_url),
+                  chunkCount: s.chunk_count,
+                  sourceType: s.source_type ?? "unknown",
+                }))
+                .sort((a, b) => b.chunkCount - a.chunkCount),
+            };
+          })
+          .sort((a, b) => b.chunkCount - a.chunkCount);
+
+        const chunkCount = models.reduce((s, m) => s + m.chunkCount, 0);
+        return { name, chunkCount, modelCount: models.length, models };
+      })
+      .sort((a, b) => b.chunkCount - a.chunkCount);
+
+    return NextResponse.json({
+      totalChunks: data.totalChunks,
+      totalManufacturers: manufacturers.length,
+      manufacturers,
+    });
+  } catch (err) {
+    console.error("[api/library/tree]", err);
+    return NextResponse.json({ error: "Tree query failed" }, { status: 500 });
+  }
+}
+
+function deriveTitleFromUrl(url: string | null): string {
+  if (!url) return "Untitled document";
+  // Strip query string, take last path segment, strip extension.
+  const base = url.split("?")[0].split("#")[0].replace(/\/+$/, "");
+  const last = base.split("/").pop() ?? base;
+  return decodeURIComponent(last.replace(/\.(pdf|html?|md|txt)$/i, "")) || base;
+}

--- a/mira-hub/src/app/api/uns/browse/route.ts
+++ b/mira-hub/src/app/api/uns/browse/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/uns/browse?path=enterprise.unassigned
+ *
+ * Returns the immediate children of a UNS path — one ltree level deep.
+ * The Hub UNS browser uses this to render an expandable tree.
+ *
+ * Query params:
+ *   path  (optional) — ltree path to browse. Defaults to `enterprise`.
+ *
+ * Response shape:
+ *   {
+ *     path: "enterprise.unassigned",
+ *     children: [
+ *       { label: "allen_bradley", uns_path: "...", entity_count: 12, entity_types: ["equipment"] },
+ *       ...
+ *     ]
+ *   }
+ *
+ * Spec: docs/specs/uns-kg-unification-spec.md §4.5
+ */
+
+const VALID_PATH = /^[a-z0-9_]+(\.[a-z0-9_]+)*$/;
+
+export async function GET(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const url = new URL(req.url);
+  const rawPath = (url.searchParams.get("path") ?? "enterprise").trim();
+
+  if (!VALID_PATH.test(rawPath)) {
+    return NextResponse.json(
+      { error: "Invalid path; must match [a-z0-9_]+(.[a-z0-9_]+)*" },
+      { status: 400 },
+    );
+  }
+
+  // Depth of the queried path (0-indexed segments). Children live at
+  // depth+1, so we use the ltree query operator `~` with `*{depth+1}`.
+  const depth = rawPath.split(".").length;
+  const childMatch = `${rawPath}.*{1}`;
+
+  try {
+    const rows = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query(
+          `WITH descendants AS (
+             SELECT uns_path,
+                    entity_type,
+                    id
+               FROM kg_entities
+              WHERE tenant_id = $1
+                AND uns_path ~ $2::lquery
+           )
+           SELECT
+             subpath(uns_path, 0, $3 + 1)        AS child_path,
+             ltree2text(subpath(uns_path, $3, 1)) AS label,
+             COUNT(*)                             AS entity_count,
+             array_agg(DISTINCT entity_type)      AS entity_types
+           FROM descendants
+           GROUP BY child_path, label
+           ORDER BY label ASC`,
+          [ctx.tenantId, childMatch, depth],
+        )
+        .then((r) => r.rows),
+    );
+
+    return NextResponse.json({
+      path: rawPath,
+      children: rows.map((r: Record<string, unknown>) => ({
+        label: String(r.label),
+        uns_path: String(r.child_path),
+        entity_count: Number(r.entity_count),
+        entity_types: (r.entity_types as string[] | null) ?? [],
+      })),
+    });
+  } catch (err) {
+    console.error("[api/uns/browse]", err);
+    // Most likely failure mode: ltree extension not installed yet.
+    // Surface a 503 rather than a generic 500 so the Hub UI can show
+    // a "UNS not yet available" empty state.
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.toLowerCase().includes("ltree")) {
+      return NextResponse.json(
+        { error: "UNS layer not yet provisioned (ltree extension missing)" },
+        { status: 503 },
+      );
+    }
+    return NextResponse.json({ error: "Browse failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/uns/browse/route.ts
+++ b/mira-hub/src/app/api/uns/browse/route.ts
@@ -1,28 +1,34 @@
 import { NextResponse } from "next/server";
 import { sessionOr401 } from "@/lib/session";
 import { withTenantContext } from "@/lib/tenant-context";
+import {
+  expectsDynamicChildren,
+  getNodeDescription,
+  getSkeletonChildren,
+} from "@/lib/uns/skeleton";
 
 export const dynamic = "force-dynamic";
 
 /**
- * GET /api/uns/browse?path=enterprise.unassigned
+ * GET /api/uns/browse?path=enterprise.knowledge_base
  *
  * Returns the immediate children of a UNS path — one ltree level deep.
  * The Hub UNS browser uses this to render an expandable tree.
  *
+ * The response merges TWO sources of children:
+ *   1. The static SKELETON (literal ISA-95 / kb / operations type
+ *      markers), so empty branches still show structure.
+ *   2. Dynamic instance labels found in `kg_entities` for the tenant.
+ *
+ * Each child is tagged `kind: "literal" | "dynamic" | "both"` so the
+ * Hub UI can distinguish a type-marker placeholder ("site") from an
+ * actual data node ("orlando_plant") from a marker that has data
+ * directly under it.
+ *
  * Query params:
  *   path  (optional) — ltree path to browse. Defaults to `enterprise`.
  *
- * Response shape:
- *   {
- *     path: "enterprise.unassigned",
- *     children: [
- *       { label: "allen_bradley", uns_path: "...", entity_count: 12, entity_types: ["equipment"] },
- *       ...
- *     ]
- *   }
- *
- * Spec: docs/specs/uns-kg-unification-spec.md §4.5
+ * Spec: docs/specs/uns-kg-unification-spec.md §4.5 (broadened 2026-05-08)
  */
 
 const VALID_PATH = /^[a-z0-9_]+(\.[a-z0-9_]+)*$/;
@@ -44,19 +50,31 @@ export async function GET(req: Request) {
     );
   }
 
-  // Depth of the queried path (0-indexed segments). Children live at
-  // depth+1, so we use the ltree query operator `~` with `*{depth+1}`.
+  // Skeleton lookup happens regardless of DB state — empty branches
+  // still need to render their literal sub-markers.
+  const { literalChildren } = getSkeletonChildren(rawPath);
+  const description = getNodeDescription(rawPath);
+  const dynamicExpected = expectsDynamicChildren(rawPath);
+
   const depth = rawPath.split(".").length;
   const childMatch = `${rawPath}.*{1}`;
+
+  type DbChild = {
+    label: string;
+    uns_path: string;
+    entity_count: number;
+    entity_types: string[];
+  };
+
+  let dbChildren: DbChild[] = [];
+  let dbAvailable = true;
 
   try {
     const rows = await withTenantContext(ctx.tenantId, (c) =>
       c
         .query(
           `WITH descendants AS (
-             SELECT uns_path,
-                    entity_type,
-                    id
+             SELECT uns_path, entity_type, id
                FROM kg_entities
               WHERE tenant_id = $1
                 AND uns_path ~ $2::lquery
@@ -73,28 +91,78 @@ export async function GET(req: Request) {
         )
         .then((r) => r.rows),
     );
-
-    return NextResponse.json({
-      path: rawPath,
-      children: rows.map((r: Record<string, unknown>) => ({
-        label: String(r.label),
-        uns_path: String(r.child_path),
-        entity_count: Number(r.entity_count),
-        entity_types: (r.entity_types as string[] | null) ?? [],
-      })),
-    });
+    dbChildren = rows.map((r: Record<string, unknown>) => ({
+      label: String(r.label),
+      uns_path: String(r.child_path),
+      entity_count: Number(r.entity_count),
+      entity_types: (r.entity_types as string[] | null) ?? [],
+    }));
   } catch (err) {
-    console.error("[api/uns/browse]", err);
-    // Most likely failure mode: ltree extension not installed yet.
-    // Surface a 503 rather than a generic 500 so the Hub UI can show
-    // a "UNS not yet available" empty state.
+    console.error("[api/uns/browse] DB query failed:", err);
     const message = err instanceof Error ? err.message : String(err);
     if (message.toLowerCase().includes("ltree")) {
-      return NextResponse.json(
-        { error: "UNS layer not yet provisioned (ltree extension missing)" },
-        { status: 503 },
-      );
+      // ltree extension not yet provisioned — degrade to skeleton-only.
+      dbAvailable = false;
+    } else {
+      return NextResponse.json({ error: "Browse failed" }, { status: 500 });
     }
-    return NextResponse.json({ error: "Browse failed" }, { status: 500 });
   }
+
+  // Merge skeleton + DB. Literal markers are returned even when no
+  // entities live under them (Mike: "Most branches will be empty/
+  // theoretical — that's intentional"). Dynamic labels from the DB
+  // come through as-is. If a literal marker also has data underneath,
+  // it shows up in both lists — we collapse to a single entry tagged
+  // `kind: "both"`.
+  const dbByLabel = new Map(dbChildren.map((c) => [c.label, c]));
+  const merged: Array<{
+    label: string;
+    uns_path: string;
+    kind: "literal" | "dynamic" | "both";
+    description: string;
+    entity_count: number;
+    entity_types: string[];
+  }> = [];
+  const seen = new Set<string>();
+
+  for (const lit of literalChildren) {
+    seen.add(lit.label);
+    const dbHit = dbByLabel.get(lit.label);
+    merged.push({
+      label: lit.label,
+      uns_path: dbHit ? dbHit.uns_path : `${rawPath}.${lit.label}`,
+      kind: dbHit ? "both" : "literal",
+      description: lit.description,
+      entity_count: dbHit?.entity_count ?? 0,
+      entity_types: dbHit?.entity_types ?? [],
+    });
+  }
+
+  for (const child of dbChildren) {
+    if (seen.has(child.label)) continue;
+    merged.push({
+      label: child.label,
+      uns_path: child.uns_path,
+      kind: "dynamic",
+      description: "",
+      entity_count: child.entity_count,
+      entity_types: child.entity_types,
+    });
+  }
+
+  merged.sort((a, b) => {
+    // Keep literal markers first so the type-skeleton reads top-down.
+    const aLit = a.kind === "literal" ? 0 : a.kind === "both" ? 1 : 2;
+    const bLit = b.kind === "literal" ? 0 : b.kind === "both" ? 1 : 2;
+    if (aLit !== bLit) return aLit - bLit;
+    return a.label.localeCompare(b.label);
+  });
+
+  return NextResponse.json({
+    path: rawPath,
+    description,
+    accepts_dynamic_children: dynamicExpected,
+    db_available: dbAvailable,
+    children: merged,
+  });
 }

--- a/mira-hub/src/app/api/uns/subtree/route.ts
+++ b/mira-hub/src/app/api/uns/subtree/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/uns/subtree?path=enterprise.unassigned&max_depth=3
+ *
+ * Returns every entity under a UNS path, up to `max_depth` levels deep
+ * (default 3, capped at 5 per spec §4.5). Use sparingly — for deep trees
+ * prefer paginated `/api/uns/browse` lookups.
+ *
+ * Spec: docs/specs/uns-kg-unification-spec.md §4.5
+ */
+
+const VALID_PATH = /^[a-z0-9_]+(\.[a-z0-9_]+)*$/;
+const MAX_ALLOWED_DEPTH = 5;
+
+export async function GET(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const url = new URL(req.url);
+  const rawPath = (url.searchParams.get("path") ?? "enterprise").trim();
+  const maxDepthRaw = Number(url.searchParams.get("max_depth") ?? "3");
+  const maxDepth = Math.max(1, Math.min(MAX_ALLOWED_DEPTH, maxDepthRaw || 3));
+
+  if (!VALID_PATH.test(rawPath)) {
+    return NextResponse.json(
+      { error: "Invalid path; must match [a-z0-9_]+(.[a-z0-9_]+)*" },
+      { status: 400 },
+    );
+  }
+
+  const rootDepth = rawPath.split(".").length;
+  const maxSegments = rootDepth + maxDepth;
+
+  try {
+    const rows = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query(
+          `SELECT id,
+                  entity_type,
+                  name,
+                  uns_path::text AS uns_path,
+                  nlevel(uns_path) AS depth,
+                  properties,
+                  created_at
+             FROM kg_entities
+            WHERE tenant_id = $1
+              AND (uns_path = $2::ltree OR uns_path <@ $2::ltree)
+              AND nlevel(uns_path) <= $3
+            ORDER BY uns_path ASC`,
+          [ctx.tenantId, rawPath, maxSegments],
+        )
+        .then((r) => r.rows),
+    );
+
+    return NextResponse.json({
+      path: rawPath,
+      max_depth: maxDepth,
+      total: rows.length,
+      entities: rows.map((r: Record<string, unknown>) => ({
+        id: String(r.id),
+        entity_type: String(r.entity_type),
+        name: String(r.name),
+        uns_path: String(r.uns_path),
+        depth: Number(r.depth),
+        properties: r.properties ?? {},
+        created_at: r.created_at,
+      })),
+    });
+  } catch (err) {
+    console.error("[api/uns/subtree]", err);
+    const message = err instanceof Error ? err.message : String(err);
+    if (message.toLowerCase().includes("ltree")) {
+      return NextResponse.json(
+        { error: "UNS layer not yet provisioned (ltree extension missing)" },
+        { status: 503 },
+      );
+    }
+    return NextResponse.json({ error: "Subtree query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/usage/route.ts
+++ b/mira-hub/src/app/api/usage/route.ts
@@ -56,8 +56,12 @@ export async function GET() {
         ORDER BY count DESC LIMIT 10`,
         [ctx.tenantId],
       );
+      // UNS+KG unification (spec §4.3, Phase 1): the legacy `kb_chunks`
+      // table is empty in production; the real vector store is
+      // `knowledge_entries` (74K+ rows). Reading from the wrong table
+      // is what made the Hub "Total KB Chunks" tile show 0 forever.
       const { rows: kbRows } = await c.query(
-        `SELECT COUNT(*) as total_chunks FROM kb_chunks WHERE tenant_id = $1`,
+        `SELECT COUNT(*) as total_chunks FROM knowledge_entries WHERE tenant_id = $1`,
         [ctx.tenantId],
       );
       return { monthRows, allTimeRows, dailyRows, bySourceRows, byTechRows, kbRows };

--- a/mira-hub/src/components/layout/sidebar.tsx
+++ b/mira-hub/src/components/layout/sidebar.tsx
@@ -8,6 +8,7 @@ import {
   Activity, MessageSquare, Zap, AlertTriangle, BookOpen,
   Wrench, Radio, Plug, BarChart2, Users, Settings,
   ClipboardList, CalendarDays, Inbox, Package, FileText, TrendingUp,
+  Library,
   Factory, ChevronLeft, ChevronRight, LogOut, Sun, Moon, HelpCircle,
 } from "lucide-react";
 import { restartTour } from "@/components/onboarding/tour";
@@ -20,6 +21,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   Activity, MessageSquare, Zap, AlertTriangle, BookOpen,
   Wrench, Radio, Plug, BarChart2, Users, Settings,
   ClipboardList, CalendarDays, Inbox, Package, FileText, TrendingUp,
+  Library,
 };
 
 type NavItemProps = {
@@ -93,6 +95,7 @@ export function Sidebar({ role = "admin" }: { role?: string }) {
       "actions":       t("actions"),
       "alerts":        t("alerts"),
       "knowledge":     t("knowledge"),
+      "library":       t("library"),
       "assets":        t("assets"),
       "channels":      t("channels"),
       "integrations":  t("integrations"),

--- a/mira-hub/src/lib/uns/skeleton.ts
+++ b/mira-hub/src/lib/uns/skeleton.ts
@@ -1,0 +1,361 @@
+/**
+ * UNS skeleton tree.
+ *
+ * The skeleton encodes the canonical structure of the Unified Namespace
+ * — every literal type-marker label that exists in the spec, even when
+ * no entities have been ingested under it yet. The browse API merges
+ * this skeleton with live `kg_entities` rows so the Hub UI shows the
+ * full ISA-95 hierarchy from day one (most branches are theoretical;
+ * they fill in as documentation arrives — Mike's directive 2026-05-08).
+ *
+ * Two kinds of children at any level:
+ *
+ *   - **Literal children** (type markers like `site`, `area`, `line`,
+ *     `manuals`, `fault_codes`) — always present, even when empty.
+ *     Returned by `getSkeletonChildren()` regardless of DB state.
+ *
+ *   - **Dynamic children** (instance labels like `orlando_plant`,
+ *     `powerflex_525`, `f004`) — supplied by the DB query in
+ *     `/api/uns/browse`. The skeleton tells the resolver "expect
+ *     dynamic children here," but the actual labels come from data.
+ *
+ * Path-walking algorithm:
+ *
+ *   For each segment of the input path, look for an exact-match key in
+ *   the current node's `children`. If absent, look for the wildcard `*`
+ *   key (which means "any dynamic instance label is valid here"). If
+ *   neither exists, the path is unknown to the skeleton and the
+ *   resolver returns no literal children (DB-only).
+ *
+ * Spec: docs/specs/uns-kg-unification-spec.md §3.1 (broadened
+ * 2026-05-08).
+ */
+
+export type SkeletonNode = {
+  /** Plain-English description shown in browse responses. */
+  readonly description?: string;
+  /** True if this node holds dynamic instance labels (manufacturer
+   *  slugs, site names, equipment IDs, …). Affects display hints
+   *  only; the actual labels come from the DB. */
+  readonly dynamic?: boolean;
+  /** Recursive children. Use the literal segment name as the key, or
+   *  the wildcard `"*"` key for any dynamic instance label. */
+  readonly children?: { readonly [segment: string]: SkeletonNode };
+};
+
+/**
+ * The four sub-branches every site-side equipment instance carries.
+ * Defined once and spliced into every `equipment.*` slot in the tree.
+ */
+const EQUIPMENT_INSTANCE: SkeletonNode = {
+  description: "An equipment instance placed at a physical location.",
+  dynamic: true,
+  children: {
+    component: {
+      description: "Sub-parts (bearings, motors, contactors, …).",
+      children: { "*": { dynamic: true } },
+    },
+    datapoint: {
+      description:
+        "Real-time sensor values and tags (Layer 4 — telemetry stream, future).",
+      children: {
+        "*": { dynamic: true },
+        // Examples Mike called out — the skeleton lists them so the
+        // Hub UI can suggest them when an operator wires a new tag.
+        motor_current: { description: "Motor current (A)." },
+        temperature: { description: "Equipment surface / winding temperature." },
+        vibration: { description: "Vibration ISO 10816 magnitude." },
+      },
+    },
+    maintenance: {
+      description: "PM, faults, work orders, parts inventory for this asset.",
+      children: {
+        pm_schedule: {
+          description: "Preventive maintenance schedule entries.",
+          children: { "*": { dynamic: true } },
+        },
+        fault_history: {
+          description: "Recorded fault occurrences for this instance.",
+          children: { "*": { dynamic: true } },
+        },
+        work_orders: {
+          description: "Work orders linked to this instance.",
+          children: { "*": { dynamic: true } },
+        },
+        parts_inventory: {
+          description: "Spares stocked for this instance.",
+          children: { "*": { dynamic: true } },
+        },
+      },
+    },
+    documentation: {
+      description: "Manuals, schematics, procedures associated with this asset.",
+      children: {
+        manuals: { children: { "*": { dynamic: true } } },
+        schematics: { children: { "*": { dynamic: true } } },
+        procedures: { children: { "*": { dynamic: true } } },
+      },
+    },
+  },
+};
+
+/**
+ * The literal sub-branches that appear under every kb-side model node.
+ */
+const KB_MODEL_NODE: SkeletonNode = {
+  description: "A specific equipment model in the knowledge base.",
+  dynamic: true,
+  children: {
+    manuals: {
+      description: "User / installation / service manuals for this model.",
+      children: { "*": { dynamic: true } },
+    },
+    fault_codes: {
+      description: "Fault / alarm codes documented for this model.",
+      children: { "*": { dynamic: true } },
+    },
+    pm_schedules: {
+      description: "PM intervals recommended by the manufacturer.",
+      children: { "*": { dynamic: true } },
+    },
+    parts_lists: {
+      description: "Bill of materials / spare parts catalog.",
+      children: { "*": { dynamic: true } },
+    },
+  },
+};
+
+export const SKELETON: SkeletonNode = {
+  description: "Root of the unified namespace.",
+  children: {
+    enterprise: {
+      description: "Top of the UNS tree.",
+      children: {
+        knowledge_base: {
+          description:
+            "Manufacturer-organized catalog of equipment. Site-independent — same model, multiple sites.",
+          children: {
+            community: {
+              description:
+                "Knowledge Cooperative shared data (cross-customer benchmarks and patterns).",
+              children: {
+                "*": {
+                  description: "An equipment class (e.g. VFDs, centrifugal pumps).",
+                  dynamic: true,
+                  children: {
+                    common_faults: {
+                      description: "Faults that recur across the class.",
+                      children: { "*": { dynamic: true } },
+                    },
+                    mtbf_benchmarks: {
+                      description: "Mean-time-between-failure benchmarks.",
+                      children: { "*": { dynamic: true } },
+                    },
+                    resolution_patterns: {
+                      description: "Diagnostic playbooks that worked.",
+                      children: { "*": { dynamic: true } },
+                    },
+                  },
+                },
+              },
+            },
+            "*": {
+              description: "A manufacturer (e.g. allen_bradley, siemens, abb).",
+              dynamic: true,
+              children: {
+                "*": {
+                  description:
+                    "A product family (e.g. powerflex) — or a model directly when family is unknown.",
+                  dynamic: true,
+                  children: {
+                    "*": KB_MODEL_NODE,
+                  },
+                },
+              },
+            },
+          },
+        },
+        operations: {
+          description:
+            "Cross-cutting operational records (work orders, technicians, inventory, compliance).",
+          children: {
+            work_orders: {
+              description: "Work orders across all sites.",
+              children: { "*": { dynamic: true } },
+            },
+            technicians: {
+              description: "Technician roster.",
+              children: { "*": { dynamic: true } },
+            },
+            inventory: {
+              description: "Parts inventory across all sites.",
+              children: { "*": { dynamic: true } },
+            },
+            compliance: {
+              description: "Regulatory / audit records.",
+              children: { "*": { dynamic: true } },
+            },
+          },
+        },
+        // Wildcard for {company} — every other key under `enterprise`
+        // is a customer / company root with the ISA-95 site hierarchy.
+        "*": {
+          description: "A company (customer / business unit).",
+          dynamic: true,
+          children: {
+            fleet: {
+              description: "Mobile / field equipment not tied to a fixed site.",
+              children: { "*": { dynamic: true } },
+            },
+            shared_services: {
+              description: "Cross-site shared resources.",
+              children: { "*": { dynamic: true } },
+            },
+            site: {
+              description: "Physical sites (plants, facilities).",
+              children: {
+                "*": {
+                  description: "A site (e.g. orlando_plant).",
+                  dynamic: true,
+                  children: {
+                    utilities: {
+                      description: "Site-level utility systems.",
+                      children: { "*": { dynamic: true } },
+                    },
+                    safety_systems: {
+                      description: "Safety-critical equipment (LOTO, EHS, fire).",
+                      children: { "*": { dynamic: true } },
+                    },
+                    environmental: {
+                      description: "Environmental monitoring (air, water, sound).",
+                      children: { "*": { dynamic: true } },
+                    },
+                    area: {
+                      description: "Production / process areas.",
+                      children: {
+                        "*": {
+                          description: "A production area (e.g. pump_station).",
+                          dynamic: true,
+                          children: {
+                            equipment: {
+                              description:
+                                "Equipment placed directly in this area (no line).",
+                              children: { "*": EQUIPMENT_INSTANCE },
+                            },
+                            line: {
+                              description: "Production lines in this area.",
+                              children: {
+                                "*": {
+                                  description: "A production line (e.g. line_3).",
+                                  dynamic: true,
+                                  children: {
+                                    equipment: {
+                                      description:
+                                        "Equipment placed directly on this line (no work cell).",
+                                      children: { "*": EQUIPMENT_INSTANCE },
+                                    },
+                                    work_cell: {
+                                      description:
+                                        "Work cells on this line (ISA-95).",
+                                      children: {
+                                        "*": {
+                                          description:
+                                            "A work cell (e.g. sump_cell).",
+                                          dynamic: true,
+                                          children: {
+                                            equipment: {
+                                              description:
+                                                "Equipment in this work cell.",
+                                              children: { "*": EQUIPMENT_INSTANCE },
+                                            },
+                                          },
+                                        },
+                                      },
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+/**
+ * Walk the SKELETON down to the node at `path` and return its children
+ * in a form suitable for merging with DB-sourced dynamic children.
+ *
+ * Returns:
+ *   { node, literalChildren } — `node` is the SkeletonNode at `path`
+ *   (or null if the path doesn't match the skeleton at all), and
+ *   `literalChildren` is the list of literal type-marker child names
+ *   (excluding the `"*"` wildcard) that should always appear in the
+ *   browse response, each annotated with its description.
+ */
+export function getSkeletonChildren(path: string): {
+  node: SkeletonNode | null;
+  literalChildren: Array<{ label: string; description: string }>;
+} {
+  if (!path) {
+    return { node: null, literalChildren: [] };
+  }
+
+  const segments = path.split(".");
+  let cursor: SkeletonNode | undefined = SKELETON;
+
+  for (const seg of segments) {
+    if (!cursor || !cursor.children) {
+      return { node: null, literalChildren: [] };
+    }
+    if (cursor.children[seg]) {
+      cursor = cursor.children[seg];
+    } else if (cursor.children["*"]) {
+      cursor = cursor.children["*"];
+    } else {
+      // Path doesn't match the skeleton — return the empty node so the
+      // browse endpoint still falls back to DB-only children.
+      return { node: null, literalChildren: [] };
+    }
+  }
+
+  if (!cursor || !cursor.children) {
+    return { node: cursor ?? null, literalChildren: [] };
+  }
+
+  const literalChildren: Array<{ label: string; description: string }> = [];
+  for (const key of Object.keys(cursor.children)) {
+    if (key === "*") continue;
+    const child = cursor.children[key];
+    literalChildren.push({
+      label: key,
+      description: child.description ?? "",
+    });
+  }
+  literalChildren.sort((a, b) => a.label.localeCompare(b.label));
+  return { node: cursor, literalChildren };
+}
+
+/** Returns `true` if the skeleton expects dynamic instance labels at
+ *  the given path (the Hub UI uses this to render an "Add new ..."
+ *  affordance). */
+export function expectsDynamicChildren(path: string): boolean {
+  const { node } = getSkeletonChildren(path);
+  if (!node || !node.children) return false;
+  return Boolean(node.children["*"]);
+}
+
+/** Returns the description string for the node at `path`, or empty. */
+export function getNodeDescription(path: string): string {
+  const { node } = getSkeletonChildren(path);
+  return node?.description ?? "";
+}

--- a/mira-hub/src/messages/en.json
+++ b/mira-hub/src/messages/en.json
@@ -6,6 +6,7 @@
     "actions": "Actions",
     "alerts": "Alerts",
     "knowledge": "Knowledge",
+    "library": "Library",
     "workOrders": "Work Orders",
     "assets": "Assets",
     "channels": "Channels",

--- a/mira-hub/src/messages/es.json
+++ b/mira-hub/src/messages/es.json
@@ -6,6 +6,7 @@
     "actions": "Acciones",
     "alerts": "Alertas",
     "knowledge": "Conocimiento",
+    "library": "Biblioteca",
     "workOrders": "Órdenes de trabajo",
     "assets": "Equipos",
     "channels": "Canales",

--- a/mira-hub/src/messages/hi.json
+++ b/mira-hub/src/messages/hi.json
@@ -6,6 +6,7 @@
     "actions": "कार्रवाइयां",
     "alerts": "अलर्ट",
     "knowledge": "ज्ञानकोष",
+    "library": "पुस्तकालय",
     "workOrders": "कार्य आदेश",
     "assets": "उपकरण",
     "channels": "चैनल",

--- a/mira-hub/src/messages/zh.json
+++ b/mira-hub/src/messages/zh.json
@@ -6,6 +6,7 @@
     "actions": "操作记录",
     "alerts": "警报",
     "knowledge": "知识库",
+    "library": "文档库",
     "workOrders": "工单",
     "assets": "设备",
     "channels": "渠道",

--- a/mira-hub/src/providers/access-control.ts
+++ b/mira-hub/src/providers/access-control.ts
@@ -60,6 +60,7 @@ export const NAV_ITEMS = [
   { key: "actions",       label: "Actions",       icon: "Zap",           href: "/actions",       roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
   { key: "alerts",        label: "Alerts",        icon: "AlertTriangle", href: "/alerts",        roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
   { key: "knowledge",     label: "Knowledge",     icon: "BookOpen",      href: "/knowledge",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
+  { key: "library",       label: "Library",       icon: "Library",       href: "/library",       roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
   { key: "assets",        label: "Assets",        icon: "Wrench",        href: "/assets",        roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
   { key: "channels",      label: "Channels",      icon: "Radio",         href: "/channels",      roles: ["manager", "scheduler", "admin", "owner"],                           group: "primary" },
   { key: "integrations",  label: "Integrations",  icon: "Plug",          href: "/integrations",  roles: ["manager", "admin", "owner"],                                        group: "primary" },

--- a/tools/migrations/backfill_equipment_entities.py
+++ b/tools/migrations/backfill_equipment_entities.py
@@ -1,0 +1,336 @@
+"""Backfill `kg_entities` and `knowledge_entries.equipment_entity_id`
+from the existing 74K+ chunks.
+
+Spec: docs/specs/uns-kg-unification-spec.md §4.2, Phase 1.
+
+What it does
+------------
+1. Walks every distinct (manufacturer, model_number) pair in
+   `knowledge_entries` where both are non-NULL and non-empty.
+2. For each pair, upserts an `equipment` entity at
+   `enterprise.unassigned.{mfr}.{model}`.
+3. Walks every distinct source_url with a known equipment, upserts a
+   `manual` entity, and creates a HAS_MANUAL edge.
+4. UPDATEs `knowledge_entries.equipment_entity_id` for every chunk row
+   that matches one of those (mfr, model) pairs.
+
+Idempotent. Safe to re-run. Re-running is a no-op for rows already
+linked.
+
+Usage
+-----
+Dry-run (default — no writes):
+    doppler run -p factorylm -c prd -- \\
+        python tools/migrations/backfill_equipment_entities.py
+
+Commit:
+    doppler run -p factorylm -c prd -- \\
+        python tools/migrations/backfill_equipment_entities.py --commit
+
+Tenant scoping (default = all tenants):
+    ... -- python tools/migrations/backfill_equipment_entities.py --tenant mike
+
+Batch sizing for the chunk UPDATE pass:
+    ... -- python tools/migrations/backfill_equipment_entities.py \\
+        --commit --batch-size 1000
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+
+# Make the `mira-crawler/ingest` package importable. The crawler ships its
+# code as `ingest.*` inside the celery container (`PYTHONPATH=/app/mira_crawler`)
+# but on a dev workstation the module path uses a hyphen (`mira-crawler/`).
+# Add the `mira-crawler` directory so `import ingest.kg_writer` resolves the
+# same code in both environments.
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, os.path.join(_REPO_ROOT, "mira-crawler"))
+sys.path.insert(0, _REPO_ROOT)
+
+from ingest import kg_writer  # noqa: E402  — see sys.path patch above
+from ingest.uns import equipment_unassigned_path, manual_path  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+log = logging.getLogger("backfill")
+
+
+@dataclass
+class Stats:
+    pairs_seen: int = 0
+    equipment_upserted: int = 0
+    manuals_upserted: int = 0
+    edges_upserted: int = 0
+    chunks_linked: int = 0
+    skipped_no_extraction: int = 0
+
+
+def _engine():
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import NullPool
+
+    url = os.environ.get("NEON_DATABASE_URL")
+    if not url:
+        raise RuntimeError("NEON_DATABASE_URL not set")
+    return create_engine(
+        url,
+        poolclass=NullPool,
+        connect_args={"sslmode": "require"},
+        pool_pre_ping=True,
+    )
+
+
+def _distinct_pairs(engine, tenant: str | None) -> list[tuple[str, str, str]]:
+    """Return distinct (tenant_id, manufacturer, model_number) triples
+    where both manufacturer and model_number are populated."""
+    from sqlalchemy import text
+
+    sql = """
+        SELECT DISTINCT tenant_id,
+                        TRIM(manufacturer) AS manufacturer,
+                        TRIM(model_number) AS model_number
+          FROM knowledge_entries
+         WHERE manufacturer IS NOT NULL
+           AND model_number IS NOT NULL
+           AND TRIM(manufacturer) <> ''
+           AND TRIM(model_number) <> ''
+    """
+    params: dict[str, str] = {}
+    if tenant:
+        sql += " AND tenant_id = :tenant"
+        params["tenant"] = tenant
+    sql += " ORDER BY tenant_id, manufacturer, model_number"
+
+    with engine.connect() as c:
+        rows = c.execute(text(sql), params).fetchall()
+    return [(r[0], r[1], r[2]) for r in rows]
+
+
+def _distinct_manuals(
+    engine, tenant: str, manufacturer: str, model: str
+) -> list[tuple[str | None, str | None]]:
+    """Distinct (source_url, title) pairs for chunks belonging to a
+    given (tenant, manufacturer, model)."""
+    from sqlalchemy import text
+
+    with engine.connect() as c:
+        rows = c.execute(
+            text("""
+                SELECT DISTINCT source_url, metadata->>'title' AS title
+                  FROM knowledge_entries
+                 WHERE tenant_id = :tenant
+                   AND TRIM(manufacturer) = :mfr
+                   AND TRIM(model_number) = :model
+                   AND source_url IS NOT NULL
+                   AND source_url <> ''
+            """),
+            {"tenant": tenant, "mfr": manufacturer, "model": model},
+        ).fetchall()
+    return [(r[0], r[1]) for r in rows]
+
+
+def _link_chunks(
+    engine,
+    tenant: str,
+    manufacturer: str,
+    model: str,
+    equipment_id: str,
+    batch_size: int,
+    commit: bool,
+) -> int:
+    """UPDATE knowledge_entries SET equipment_entity_id = $eq WHERE
+    matches and is currently NULL. Returns rowcount."""
+    from sqlalchemy import text
+
+    if not commit:
+        with engine.connect() as c:
+            count = (
+                c.execute(
+                    text("""
+                        SELECT COUNT(*) FROM knowledge_entries
+                         WHERE tenant_id = :tenant
+                           AND TRIM(manufacturer) = :mfr
+                           AND TRIM(model_number) = :model
+                           AND equipment_entity_id IS NULL
+                    """),
+                    {"tenant": tenant, "mfr": manufacturer, "model": model},
+                ).scalar()
+                or 0
+            )
+        return int(count)
+
+    total_updated = 0
+    while True:
+        with engine.connect() as c:
+            try:
+                rc = c.execute(
+                    text("""
+                        WITH batch AS (
+                            SELECT id FROM knowledge_entries
+                             WHERE tenant_id = :tenant
+                               AND TRIM(manufacturer) = :mfr
+                               AND TRIM(model_number) = :model
+                               AND equipment_entity_id IS NULL
+                             LIMIT :bs
+                        )
+                        UPDATE knowledge_entries ke
+                           SET equipment_entity_id = cast(:eid AS uuid)
+                          FROM batch
+                         WHERE ke.id = batch.id
+                    """),
+                    {
+                        "tenant": tenant,
+                        "mfr": manufacturer,
+                        "model": model,
+                        "bs": batch_size,
+                        "eid": equipment_id,
+                    },
+                ).rowcount
+                c.commit()
+            except Exception as e:
+                c.rollback()
+                log.error(
+                    "_link_chunks batch failed (%s/%s): %s", manufacturer, model, e
+                )
+                break
+        if not rc:
+            break
+        total_updated += rc
+        # Be friendly to Neon — small breather between batches.
+        time.sleep(0.05)
+    return total_updated
+
+
+def run(tenant: str | None, batch_size: int, commit: bool) -> Stats:
+    engine = _engine()
+    stats = Stats()
+    pairs = _distinct_pairs(engine, tenant)
+    stats.pairs_seen = len(pairs)
+    log.info("Found %d distinct (tenant, manufacturer, model) triples", len(pairs))
+
+    for tenant_id, manufacturer, model in pairs:
+        eq_path = equipment_unassigned_path(manufacturer, model)
+        man_root_path = manual_path(manufacturer, model)
+        log.info(
+            "tenant=%s mfr=%r model=%r → eq_path=%s manual_root=%s",
+            tenant_id,
+            manufacturer,
+            model,
+            eq_path,
+            man_root_path,
+        )
+
+        if not commit:
+            # Dry-run: still inspect manual + chunk counts so the operator
+            # can see what would change.
+            manuals = _distinct_manuals(engine, tenant_id, manufacturer, model)
+            chunk_count = _link_chunks(
+                engine,
+                tenant_id,
+                manufacturer,
+                model,
+                equipment_id="00000000-0000-0000-0000-000000000000",
+                batch_size=batch_size,
+                commit=False,
+            )
+            stats.equipment_upserted += 1
+            stats.manuals_upserted += len(manuals)
+            stats.chunks_linked += chunk_count
+            log.info(
+                "  [DRY] would upsert 1 equipment, %d manuals, link %d chunks",
+                len(manuals),
+                chunk_count,
+            )
+            continue
+
+        eq_id = kg_writer.upsert_entity(
+            tenant_id=tenant_id,
+            entity_type="equipment",
+            name=model,
+            uns_path=eq_path,
+            properties={"manufacturer": manufacturer},
+        )
+        if not eq_id:
+            log.warning(
+                "Skipping pair %s/%s — equipment upsert returned no id",
+                manufacturer,
+                model,
+            )
+            stats.skipped_no_extraction += 1
+            continue
+        stats.equipment_upserted += 1
+
+        for source_url, title in _distinct_manuals(engine, tenant_id, manufacturer, model):
+            man_id = kg_writer.upsert_entity(
+                tenant_id=tenant_id,
+                entity_type="manual",
+                name=title or f"{manufacturer} {model} Manual",
+                uns_path=man_root_path,
+                properties={
+                    "manufacturer": manufacturer,
+                    "model": model,
+                    "source_url": source_url,
+                },
+            )
+            if not man_id:
+                continue
+            stats.manuals_upserted += 1
+            edge_id = kg_writer.upsert_relationship(
+                tenant_id=tenant_id,
+                source_entity=eq_id,
+                target_entity=man_id,
+                relation_type="has_manual",
+                confidence=0.95,
+            )
+            if edge_id:
+                stats.edges_upserted += 1
+
+        linked = _link_chunks(
+            engine,
+            tenant_id,
+            manufacturer,
+            model,
+            equipment_id=eq_id,
+            batch_size=batch_size,
+            commit=True,
+        )
+        stats.chunks_linked += linked
+        log.info("  linked %d chunks → equipment %s", linked, eq_id)
+
+    return stats
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--tenant", help="Restrict backfill to one tenant_id")
+    p.add_argument("--batch-size", type=int, default=1000)
+    p.add_argument(
+        "--commit", action="store_true", help="Apply writes (default = dry-run)"
+    )
+    args = p.parse_args()
+
+    if not args.commit:
+        log.warning("DRY-RUN — no writes will be performed. Pass --commit to apply.")
+
+    stats = run(args.tenant, args.batch_size, args.commit)
+
+    log.info("=== BACKFILL %s ===", "COMMIT" if args.commit else "DRY-RUN")
+    log.info("  distinct pairs scanned:  %d", stats.pairs_seen)
+    log.info("  equipment upserted:      %d", stats.equipment_upserted)
+    log.info("  manuals upserted:        %d", stats.manuals_upserted)
+    log.info("  has_manual edges:        %d", stats.edges_upserted)
+    log.info("  chunks linked:           %d", stats.chunks_linked)
+    log.info("  skipped (no extraction): %d", stats.skipped_no_extraction)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements Phases 1–3 of the approved [UNS + Knowledge Graph Unification Spec](docs/specs/uns-kg-unification-spec.md). Bridges the three currently disconnected representations of "what we know" (74K vector chunks, an empty KG schema, an empty `kb_chunks` stub the Hub still reads) under one address space (UNS `ltree` paths) and one identity space (`kg_entities.id`). Also ships a companion [standards-compliance analysis](docs/specs/uns-kg-standards-compliance.md) covering ISA-95, ISO 14224, MIMOSA CCOM, OPC UA, Sparkplug B, NAMUR NE 107, and ISO 55000.

### Phase 1 — Bridge `knowledge_entries ↔ kg_entities` + visible Hub fix
- `docs/migrations/006_kg_bridge.sql` — promotes `kg_entities` / `kg_relationships` to PRODUCTION; adds `knowledge_entries.equipment_entity_id` UUID FK with btree index.
- `mira-crawler/ingest/uns.py` — pure-Python UNS path helpers (slug, equipment/manual/fault_code/work_order paths, validators).
- `mira-crawler/ingest/kg_writer.py` — idempotent `upsert_entity`, `upsert_relationship`, `register_equipment_and_manual`, `register_fault_code`, `link_chunk_to_equipment`.
- `tools/migrations/backfill_equipment_entities.py` — dry-run-by-default backfill that walks the 74K existing chunks, upserts entities for every distinct `(manufacturer, model)` pair, and stamps `equipment_entity_id`. Batched (default 1000) with a 50ms breather between batches.
- `mira-hub/src/app/api/usage/route.ts` and `.../knowledge/route.ts` — repointed from the empty `kb_chunks` stub to the real `knowledge_entries` table. **Fixes the long-standing "Total KB Chunks = 0" tile.**

### Phase 2 — Ingest-time entity creation (the flywheel ON)
- `mira-crawler/ingest/extractors/fault_codes.py` — regex extractor for PowerFlex F-codes, ControlLogix E-codes, SINAMICS A-alarms, generic "Fault N" callouts, and short alpha codes (OL/OC/UV…) gated by ±60-char fault-context windows. Confidence 0.85.
- `mira-crawler/ingest/store.py` — `store_chunks()` now upserts equipment+manual once per batch, links every inserted chunk to the equipment, and runs the fault-code extractor over chunk text to densify the KG. Wrapped in try/except so a misconfigured KG layer never breaks the chunk-insert hot path.

### Phase 3 — UNS path enforcement
- `docs/migrations/007_uns_path.sql` — `CREATE EXTENSION IF NOT EXISTS ltree`; adds `kg_entities.uns_path ltree NOT NULL DEFAULT 'enterprise.unassigned'` with a CHECK constraint mirroring the application-layer grammar; GIST + btree indexes; one-shot retro-pathing of existing equipment test rows.
- `mira-hub/src/app/api/uns/browse/route.ts` — `GET /api/uns/browse?path=…` returns immediate ltree children (one level deep) with entity counts and types per child.
- `mira-hub/src/app/api/uns/subtree/route.ts` — `GET /api/uns/subtree?path=…&max_depth=N` returns full subtree (capped at depth 5).

### Standards compliance research
`docs/specs/uns-kg-standards-compliance.md` (517 lines) walks through ISA-95, ISO 14224, MIMOSA CCOM, W3C OWL/SOSA-SSN, OPC UA, Sparkplug B, NAMUR NE 107, and ISO 55000. Top-line findings:
- ISA-95 alignment is strong; the one real gap is the missing `work_cell` segment between `line` and `equipment` (only matters for discrete-manufacturing buyers with multiple cells per line).
- ISO 14224 maps cleanly to our entity types; `component` should eventually split into `subunit` vs `maintainable_item` (post-MVP).
- The biggest immediately-actionable gap is **NAMUR NE 107** — adding the four severity signals (Failure/Function Check/Out of Spec/Maintenance Required) to `fault_code.properties` is a JSONB field add with no migration.
- The KG is already structurally RDF-isomorphic and CCOM-derivable thanks to `source_chunk_id` source citations on every edge.
- Sparkplug B / OPC UA forward-compatibility is achievable with a `.` → `/` separator transform; no schema changes needed.

### Deployment ordering

**Migrations 006 and 007 must be applied together** before the new `kg_writer` code runs. `kg_writer.upsert_entity` casts `:uns_path::ltree`, so the column must exist before any equipment ingest fires.

```
006_kg_bridge.sql        → adds kg_entities/kg_relationships + bridge FK
007_uns_path.sql         → adds ltree extension + uns_path column
[deploy mira-crawler image]
[deploy mira-hub]
[run backfill in dry-run, review, then --commit]
```

## Test plan
- [ ] Apply `006_kg_bridge.sql` on a Neon branch; confirm `\d knowledge_entries` shows `equipment_entity_id`.
- [ ] Apply `007_uns_path.sql`; confirm `\d kg_entities` shows `uns_path ltree NOT NULL` + the `uns_path_format` CHECK + both indexes.
- [ ] Hit `GET /api/usage` from the Hub; confirm `allTime.totalKbChunks` reports the true `knowledge_entries` count for the tenant (no longer 0).
- [ ] Dry-run the backfill: `doppler run -p factorylm -c prd -- python tools/migrations/backfill_equipment_entities.py` and review the count summary.
- [ ] Backfill commit: `... --commit --batch-size 1000` (recommend running on a Neon branch first per spec §9 Q6).
- [ ] Ingest a fresh PowerFlex 525 manual via the Celery worker; verify `SELECT COUNT(*) FROM kg_entities WHERE entity_type IN ('equipment','manual','fault_code')` increases.
- [ ] Re-ingest the same manual; verify the count is unchanged (idempotency).
- [ ] `GET /api/uns/browse?path=enterprise.unassigned` returns the equipment children for the tenant.
- [ ] Run the existing 39 golden eval cases; confirm no regression from current ≥77% baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)