### PR TITLE
fix(hub): drop tenant filter — KB is universal

### DIFF
--- a/mira-hub/src/app/api/knowledge/manufacturer/route.ts
+++ b/mira-hub/src/app/api/knowledge/manufacturer/route.ts
@@ -10,6 +10,9 @@ export const fetchCache = "force-no-store";
 // Manufacturer name is matched case-insensitively to handle case variants
 // in the legacy data ('siemens' vs 'Siemens', 'Yaskawa' vs 'Yaskawa Electric Corporation').
 // 'Uncategorized' matches NULL or empty manufacturer rows.
+//
+// No tenant filter — KB is universal (see /api/knowledge/route.ts comment).
+// Auth still enforced via sessionOr401 so anonymous callers cannot reach data.
 export async function GET(req: NextRequest) {
   if (!process.env.NEON_DATABASE_URL) {
     return NextResponse.json({ error: "DB not configured" }, { status: 503 });
@@ -26,10 +29,9 @@ export async function GET(req: NextRequest) {
     const isUncategorized = name.toLowerCase() === "uncategorized";
     const mfrFilter = isUncategorized
       ? "(manufacturer IS NULL OR TRIM(manufacturer) = '')"
-      : "LOWER(TRIM(COALESCE(manufacturer, ''))) = LOWER($2)";
+      : "LOWER(TRIM(COALESCE(manufacturer, ''))) = LOWER($1)";
 
-    const params: (string | number)[] = [ctx.tenantId];
-    if (!isUncategorized) params.push(name);
+    const params: string[] = isUncategorized ? [] : [name];
 
     const { rows } = await pool.query(
       `SELECT
@@ -41,8 +43,7 @@ export async function GET(req: NextRequest) {
          MAX(created_at) AS last_indexed,
          MAX(metadata->>'title') AS title
        FROM knowledge_entries
-       WHERE tenant_id = $1
-         AND ${mfrFilter}
+       WHERE ${mfrFilter}
        GROUP BY source_url
        ORDER BY chunk_count DESC
        LIMIT 500`,

--- a/mira-hub/src/app/api/knowledge/route.ts
+++ b/mira-hub/src/app/api/knowledge/route.ts
@@ -7,10 +7,15 @@ export const revalidate = 0;
 export const fetchCache = "force-no-store";
 
 // Returns the knowledge library rolled up by manufacturer.
-// Queries knowledge_entries directly (bypasses RLS via neondb_owner) with an
-// explicit tenant_id filter — factorylm_app lacks SELECT on this legacy table,
-// and the table's RLS policy reads app.current_tenant_id which withTenantContext
-// does not set. Programmatic tenant filter preserves isolation.
+// Queries knowledge_entries directly (bypasses RLS via neondb_owner) with no
+// tenant filter — OEM manuals, datasheets, and reference documentation are
+// UNIVERSAL: every authenticated user sees the full corpus regardless of
+// session tenant. The legacy ingest pipeline tagged rows with whatever
+// MIRA_TENANT_ID was set in env (typically literal 'mike'), which does not
+// match the per-user UUID tenantIds minted by the multi-tenant signup flow
+// (migration 008). Filtering by ctx.tenantId returned 0 rows of 83K+ ingested
+// chunks. If per-tenant private docs are added later, switch to filtering on
+// is_private rather than tenant_id.
 //
 // LIVE — no server-side cache (force-dynamic + force-no-store + revalidate=0).
 // Each request hits Neon directly so newly-ingested chunks from the Celery
@@ -34,19 +39,15 @@ export async function GET() {
            COUNT(DISTINCT source_url)::bigint AS doc_count,
            MAX(created_at) AS last_indexed
          FROM knowledge_entries
-         WHERE tenant_id = $1
          GROUP BY 1
          ORDER BY chunk_count DESC`,
-        [ctx.tenantId],
       ),
       pool.query(
         `SELECT
            COUNT(*)::bigint AS total_chunks,
            COUNT(DISTINCT source_url)::bigint AS total_docs,
            MAX(created_at) AS last_ingested
-         FROM knowledge_entries
-         WHERE tenant_id = $1`,
-        [ctx.tenantId],
+         FROM knowledge_entries`,
       ),
     ]);
 


### PR DESCRIPTION
## Summary
- Knowledge page still rendered no manufacturer cards after #1076 because `WHERE tenant_id = \$1` filters by the per-user UUID session tenantId, but the 83K+ rows in `knowledge_entries` were ingested with the literal `MIRA_TENANT_ID` env value (typically `'mike'`) — the values don't match → 0 rows returned.
- OEM manuals / datasheets are universal reference material. Drop the tenant filter on both `/api/knowledge` and `/api/knowledge/manufacturer`.
- Auth is still enforced via `sessionOr401`, and queries continue to use `pool` (neondb_owner) which bypasses RLS.

## Test plan
- [ ] Deploy to VPS
- [ ] `curl http://localhost:3101/api/knowledge` returns >0 manufacturers and totalChunks ≈ 83K
- [ ] Knowledge page renders manufacturer cards in the browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)