### PR TITLE
fix(bots): defer annotations for Python 3.9 compat (CRA-77)

### DIFF
--- a/mira-bots/shared/benchmark_db.py
+++ b/mira-bots/shared/benchmark_db.py
@@ -9,6 +9,8 @@ Six tables:
   - prejudged_conversations: per-case transcripts + judge scores
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -1,5 +1,7 @@
 """MIRA Supervisor — Orchestrates workers, manages FSM state, routes intent."""
 
+from __future__ import annotations
+
 import asyncio
 import json
 import logging

--- a/mira-bots/shared/nemotron.py
+++ b/mira-bots/shared/nemotron.py
@@ -4,6 +4,8 @@ All methods fall back gracefully when NVIDIA_API_KEY is not set.
 Zero external dependencies beyond httpx (already installed).
 """
 
+from __future__ import annotations
+
 import json
 import logging
 import os

--- a/mira-bots/shared/neon_recall.py
+++ b/mira-bots/shared/neon_recall.py
@@ -18,6 +18,8 @@ This is the read-only recall path. The write path (ingest) lives in
 mira-core/mira-ingest/db/neon.py and is never called from bots.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import re

--- a/mira-bots/shared/telemetry.py
+++ b/mira-bots/shared/telemetry.py
@@ -5,6 +5,8 @@ are forwarded to a Langfuse instance.  Otherwise all calls silently no-op
 so the rest of the codebase never needs to guard imports.
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import uuid

--- a/mira-bots/shared/tts.py
+++ b/mira-bots/shared/tts.py
@@ -1,5 +1,7 @@
 """MIRA TTS — Kokoro ONNX local text-to-speech, returns OGG OPUS bytes."""
 
+from __future__ import annotations
+
 import io
 import logging
 import os

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -1,3 +1,8 @@
+## eval-fixer run — 2026-05-08
+- Scorecard: 44/57 passing (77%) — `tests/eval/runs/2026-04-29T0617.md` (same stale scorecard, 9 days old)
+- Action: issue-filed (#1074 — added to Kanban)
+- Hard-stop: 3 file_clusters keys (engine.py + guardrails.py + active.yaml). Identical 13 failures as 2026-05-04/05/06/07 runs. Prior issues #985, #1017, #1044 still open. Underlying scorecard hasn't been regenerated in 9 days — fresh judge eval is overdue, or one of the prior issues needs to land a fix before another run will produce signal.
+
 ## eval-fixer run — 2026-05-07
 - Scorecard: 44/57 passing (77%) — `tests/eval/runs/2026-04-29T0617.md` (same stale scorecard, 8 days old)
 - Action: issue-filed (#1044 — added to Kanban)


### PR DESCRIPTION
## Summary
- Bot eval harness on CHARLIE (Python 3.9.6) was failing on `X | Y` PEP-604 union annotations.
- Added `from __future__ import annotations` to 6 `mira-bots/shared/` modules so annotations are lazy strings instead of being evaluated at definition time.
- Files: `nemotron.py`, `engine.py`, `benchmark_db.py`, `neon_recall.py`, `tts.py`, `telemetry.py`. Other shared modules already had the future import.

## Verification
- `ast.parse` succeeds for all 6 files under Python 3.9.6.
- `tts`, `telemetry`, `benchmark_db`, `neon_recall` import cleanly under 3.9 in isolation.

Closes CRA-77.

## Test plan
- [ ] Bot eval harness runs on CHARLIE without `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)