### PR TITLE
chore(dx): Warp terminal config — workflows + MCP setup

### DIFF
--- a/.warp/MCP_SETUP.md
+++ b/.warp/MCP_SETUP.md
@@ -1,0 +1,36 @@
+# Warp MCP Setup — mira-mcp
+
+Add mira-mcp as a local MCP server so Warp's Oz agent has access to MIRA's
+equipment diagnostic tools and CMMS integration.
+
+## Prerequisites
+
+- mira-mcp container running (`bash install/up.sh`)
+- Doppler secret `MCP_REST_API_KEY` value handy: `doppler secrets get MCP_REST_API_KEY --project factorylm --config prd --plain`
+
+## Steps
+
+1. Open Warp → **Settings** → **AI** → **MCP Servers** → **Add Server**
+2. Choose **SSE** connection type
+3. Fill in:
+   - **Name:** `mira-mcp`
+   - **URL:** `http://localhost:8009/sse`
+   - **Headers:** `Authorization: Bearer <value of MCP_REST_API_KEY>`
+4. Save. Restart Warp agent if prompted.
+
+## Verify
+
+In Warp agent mode, ask: *"What MCP tools are available?"*
+Should list MIRA's diagnostic + CMMS tools.
+
+Or test the SSE endpoint directly:
+```bash
+curl -s http://localhost:8009/sse -H "Authorization: Bearer $(doppler secrets get MCP_REST_API_KEY --project factorylm --config prd --plain)"
+```
+
+## Port Reference
+
+| Host port | Container port | What |
+|-----------|---------------|------|
+| 8009 (default, or $MCP_SSE_PORT) | 8000 | FastMCP SSE — used by Warp |
+| 8001 | 8001 | REST health + API |

--- a/.warp/README.md
+++ b/.warp/README.md
@@ -1,0 +1,37 @@
+# MIRA Warp Configuration
+
+Warp terminal config for the MIRA project. All nodes that clone this repo get these automatically.
+
+## Workflows
+
+`workflows/` — 12 searchable command snippets. Open with `Ctrl-Shift-R` in Warp or search from the command palette.
+
+| Workflow | What |
+|----------|------|
+| `mira-stack-up` | Start full stack via `install/up.sh` |
+| `mira-stack-down` | Stop all containers |
+| `mira-rebuild-service` | Rebuild single container (parameterized) |
+| `mira-logs` | Tail container logs (parameterized) |
+| `mira-smoke-test` | Smoke test localhost |
+| `mira-smoke-remote` | Smoke test remote node (parameterized IP) |
+| `mira-tests` | Full offline pytest suite |
+| `mira-eval` | Golden eval cases only |
+| `mira-enum-drift` | Enum drift check |
+| `mira-pr-review` | PR self-fix script (parameterized PR#) |
+| `plc-health` | PLC API health check |
+| `cluster-ssh` | SSH to cluster node (parameterized) |
+
+## MCP Setup
+
+See `MCP_SETUP.md` to connect mira-mcp to Warp's local AI agent.
+This gives Warp's Oz agent access to MIRA's equipment diagnostic tools.
+
+## Claude Code in Warp
+
+Run `claude` inside Warp to get:
+- Rich multi-line input editor (`Ctrl-G`)
+- Desktop notifications when Claude pauses for input
+- Inline code review sidebar
+- Remote Control (steer from another node via Tailscale)
+
+One-time notification setup: `claude /install-github-app` → follow Warp plugin prompt.

--- a/.warp/workflows/cluster-ssh.yaml
+++ b/.warp/workflows/cluster-ssh.yaml
@@ -1,0 +1,8 @@
+---
+name: SSH to cluster node
+command: ssh {{node}}
+tags: [cluster, ssh, ops]
+description: SSH into a FactoryLM cluster node
+arguments:
+  - name: node
+    description: "Node alias: factorylm@100.107.140.12 (Alpha), bravonode@100.86.236.11 (Bravo)"

--- a/.warp/workflows/mira-enum-drift.yaml
+++ b/.warp/workflows/mira-enum-drift.yaml
@@ -1,0 +1,5 @@
+---
+name: MIRA check enum drift
+command: cd /Users/charlienode/MIRA && python scripts/check_enum_drift.py
+tags: [mira, lint, ci]
+description: Detect enum drift between Python source and DB schema

--- a/.warp/workflows/mira-eval.yaml
+++ b/.warp/workflows/mira-eval.yaml
@@ -1,0 +1,5 @@
+---
+name: MIRA eval (golden cases)
+command: cd /Users/charlienode/MIRA && python -m pytest tests/eval/ -v --tb=short
+tags: [mira, test, eval]
+description: Run 39 golden eval cases against the diagnostic engine

--- a/.warp/workflows/mira-logs.yaml
+++ b/.warp/workflows/mira-logs.yaml
@@ -1,0 +1,8 @@
+---
+name: MIRA service logs
+command: doppler run --project factorylm --config prd -- docker compose logs -f {{service}}
+tags: [mira, docker, debug]
+description: Tail logs for a MIRA container
+arguments:
+  - name: service
+    description: "Container name: mira-pipeline, mira-bot-telegram, mira-bot-slack, mira-mcp, atlas-api, mira-web, mira-bridge, mira-ingest"

--- a/.warp/workflows/mira-pr-review.yaml
+++ b/.warp/workflows/mira-pr-review.yaml
@@ -1,0 +1,8 @@
+---
+name: MIRA trigger PR self-fix
+command: bash scripts/pr_self_fix.sh {{pr_number}}
+tags: [mira, ci, github]
+description: Run automated self-fix loop on a PR (reads 🔴 IMPORTANT review comments, applies patches, pushes)
+arguments:
+  - name: pr_number
+    description: "GitHub PR number to fix (e.g. 1082)"

--- a/.warp/workflows/mira-rebuild-service.yaml
+++ b/.warp/workflows/mira-rebuild-service.yaml
@@ -1,0 +1,8 @@
+---
+name: MIRA rebuild service
+command: doppler run --project factorylm --config prd -- docker compose up -d --build {{service}}
+tags: [mira, docker, ops]
+description: Rebuild and restart a single MIRA container without touching others
+arguments:
+  - name: service
+    description: "Container name: mira-pipeline, mira-bot-telegram, mira-mcp, atlas-api, mira-web, etc."

--- a/.warp/workflows/mira-smoke-remote.yaml
+++ b/.warp/workflows/mira-smoke-remote.yaml
@@ -1,0 +1,8 @@
+---
+name: MIRA smoke test (remote node)
+command: MIRA_SERVER_BASE_URL=http://{{node_ip}} bash install/smoke_test.sh
+tags: [mira, test, ops]
+description: Run smoke tests against a remote cluster node
+arguments:
+  - name: node_ip
+    description: "Node IP or Tailscale IP (e.g. 100.107.140.12 for Alpha, 100.86.236.11 for Bravo)"

--- a/.warp/workflows/mira-smoke-test.yaml
+++ b/.warp/workflows/mira-smoke-test.yaml
@@ -1,0 +1,5 @@
+---
+name: MIRA smoke test
+command: bash install/smoke_test.sh
+tags: [mira, test, ops]
+description: Run smoke tests against localhost (set MIRA_SERVER_BASE_URL=http://IP for remote node)

--- a/.warp/workflows/mira-stack-down.yaml
+++ b/.warp/workflows/mira-stack-down.yaml
@@ -1,0 +1,5 @@
+---
+name: MIRA stack down
+command: doppler run --project factorylm --config prd -- docker compose down
+tags: [mira, docker, ops]
+description: Stop all MIRA containers

--- a/.warp/workflows/mira-stack-up.yaml
+++ b/.warp/workflows/mira-stack-up.yaml
@@ -1,0 +1,5 @@
+---
+name: MIRA stack up
+command: bash install/up.sh
+tags: [mira, docker, ops]
+description: Start full MIRA stack (creates networks + doppler-injected compose up)

--- a/.warp/workflows/mira-tests.yaml
+++ b/.warp/workflows/mira-tests.yaml
@@ -1,0 +1,5 @@
+---
+name: MIRA run tests
+command: cd /Users/charlienode/MIRA && python -m pytest tests/ -v --tb=short
+tags: [mira, test, pytest]
+description: Run full offline test suite (76 tests, no containers required)

--- a/.warp/workflows/plc-health.yaml
+++ b/.warp/workflows/plc-health.yaml
@@ -1,0 +1,5 @@
+---
+name: PLC API health check
+command: curl -s localhost:8001/api/health | jq .
+tags: [plc, modbus, health]
+description: Check PLC Modbus bridge health endpoint


### PR DESCRIPTION
## Summary

- Adds `.warp/workflows/` with 12 parameterized YAML workflows (stack ops, rebuild, logs, smoke test local/remote, pytest, eval, enum drift, PR self-fix, PLC health, cluster SSH)
- Adds `.warp/MCP_SETUP.md` — steps to wire `mira-mcp` SSE (`:8009`) into Warp's Oz local agent for equipment diagnostic tool access
- Adds `.warp/README.md` — quick reference for all workflows and setup

Workflows are auto-discovered by Warp from `.warp/workflows/` when the repo is open. All nodes (Alpha/Bravo/Charlie) get them on next `git pull`.

## Test plan

- [ ] Install Warp: `brew install --cask warp`
- [ ] Open MIRA repo in Warp, hit `Ctrl-Shift-R` — verify workflows appear under "Repository Workflows"
- [ ] Run `mira-stack-up` workflow, confirm stack starts
- [ ] Run `mira-smoke-test` workflow, confirm pass
- [ ] Follow `.warp/MCP_SETUP.md` to add mira-mcp as MCP server, verify tools listed in Oz agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)