### PR TITLE
fix(hub,nginx): allow /pricing in robots.txt + enable HTTP/2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,10 @@
 Extracted from CLAUDE.md to keep the build-state file within the ~200 line compliance budget.
 For current build state, see `CLAUDE.md` in project root.
 
+### mira-hub/v1.5.3 (2026-05-09) — Allow /pricing in robots.txt + nginx HTTP/2 (closes #1104, #1106)
+- **`mira-hub/src/app/robots.ts`** — Added `/pricing` to allow list so crawlers can index the pricing/conversion page.
+- **`nginx-phase2-live.conf`** — Added `http2` to both `listen 443 ssl` directives (app.factorylm.com + chat.factorylm.com). Estimated 1,440ms savings on login page LCP.
+
 ### v2.7.0 (2026-04-14) — Active learning loop: production 👎 → fixtures → draft PR (closes #219)
 - **`mira-bots/tools/active_learner.py`** — `ActiveLearner` class: scans `feedback_log` for `/bad` entries, reconstructs conversations from `interactions`, anonymizes via Claude (PII stripped, vendor/model preserved), infers eval pass criteria with confidence gate (default: 0.6), generates YAML fixtures matching existing eval schema.
 - **`tests/eval/active_learning_tasks.py`** — Celery `shared_task` `mira_active_learning.run_nightly` at 04:00 UTC. File-based lock (30-min stale timeout). Honors `ACTIVE_LEARNING_DISABLED=1` env var.

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/app/robots.ts
+++ b/mira-hub/src/app/robots.ts
@@ -7,7 +7,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: "*",
-        allow: ["/login", "/signup"],
+        allow: ["/login", "/signup", "/pricing"],
         disallow: ["/"],
       },
     ],

--- a/nginx-phase2-live.conf
+++ b/nginx-phase2-live.conf
@@ -239,7 +239,7 @@ server {
         add_header Cache-Control "no-store" always;
     }
 
-    listen 443 ssl;
+    listen 443 ssl http2;
     ssl_certificate /etc/letsencrypt/live/app.factorylm.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/app.factorylm.com/privkey.pem;
     include /etc/letsencrypt/options-ssl-nginx.conf;
@@ -264,7 +264,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 443 ssl http2;
     server_name chat.factorylm.com;
     client_max_body_size 100M;
 


### PR DESCRIPTION
## Summary

- **robots.ts**: add `/pricing` to the allow list — crawlers were blocked from indexing `app.factorylm.com/pricing` (the primary conversion surface)
- **nginx-phase2-live.conf**: add `http2` to `listen 443 ssl` on both `app.factorylm.com` and `chat.factorylm.com` vhosts — estimated 1,440ms savings on login page LCP
- **mira-hub v1.5.3** bumped per versioning discipline

Closes #1104, #1106

## Deploy

```bash
ssh root@165.245.138.91 "nginx -t && nginx -s reload"
# mira-hub container does NOT need rebuild — robots.ts is rendered dynamically at runtime
```

## Verification

```bash
curl -s https://app.factorylm.com/robots.txt | grep pricing
# → Allow: /pricing

curl -sI https://app.factorylm.com/login | head -1
# → HTTP/2 200
```

## Test plan

- [ ] `nginx -t` passes on VPS before reload
- [ ] `curl robots.txt` shows `/pricing` in Allow list
- [ ] `curl -sI` login page returns HTTP/2 header
- [ ] Lighthouse rerun on /pricing shows SEO score improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)