### PR TITLE
fix(hub,scan): CRA-130/CRA-134 demo blockers — Atlas data flow + RAG mfr scoping

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -474,12 +474,17 @@ services:
       - CEREBRAS_MODEL=${CEREBRAS_MODEL:-llama3.1-8b}
       - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - GEMINI_MODEL=${GEMINI_MODEL:-gemini-2.5-flash}
-      # Atlas CMMS live stats (public URL — mira-hub is not on cmms-ext network)
-      - HUB_CMMS_API_URL=${HUB_CMMS_API_URL:-https://cmms.factorylm.com}
+      # Atlas CMMS live stats — internal docker URL via shared cmms network.
+      # Public cmms.factorylm.com nginx only proxies /auth/ + /api/ + /license/
+      # to the Spring backend; /work-orders/*, /assets/*, /preventive-maintenances/*
+      # fall through to the SPA and 405 on POST. Direct backend access bypasses
+      # nginx. (Re-applies fix dc10a10f, regressed by 08db78e0.)
+      - HUB_CMMS_API_URL=${HUB_CMMS_API_URL:-http://cmms-backend:8080}
       - ATLAS_API_USER=${ATLAS_API_USER:-}
       - ATLAS_API_PASSWORD=${ATLAS_API_PASSWORD:-}
     networks:
       - mira-net
+      - cmms-ext
     restart: unless-stopped
     deploy:
       resources:
@@ -505,7 +510,7 @@ services:
     container_name: mira-cmms-sync
     environment:
       - NEON_DATABASE_URL=${NEON_DATABASE_URL:-}
-      - HUB_CMMS_API_URL=${HUB_CMMS_API_URL:-https://cmms.factorylm.com}
+      - HUB_CMMS_API_URL=${HUB_CMMS_API_URL:-http://cmms-backend:8080}
       - ATLAS_API_USER=${ATLAS_API_USER:-}
       - ATLAS_API_PASSWORD=${ATLAS_API_PASSWORD:-}
       - CMMS_SYNC_ENABLED=${CMMS_SYNC_ENABLED:-false}
@@ -514,6 +519,7 @@ services:
     command: ["bun", "run", "scripts/cmms-sync-worker.ts", "--interval-ms", "${CMMS_SYNC_INTERVAL_MS:-60000}"]
     networks:
       - mira-net
+      - cmms-ext
     restart: unless-stopped
     depends_on:
       - mira-hub

--- a/mira-hub/src/app/api/cmms/stats/route.ts
+++ b/mira-hub/src/app/api/cmms/stats/route.ts
@@ -26,7 +26,7 @@ async function getToken(): Promise<{ token: string | null; reason?: string }> {
     const res = await fetch(`${atlasBase()}/auth/signin`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: user, password: pass }),
+      body: JSON.stringify({ email: user, password: pass, type: "CLIENT" }),
       signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {

--- a/mira-hub/src/lib/knowledge-graph/cmms-sync.ts
+++ b/mira-hub/src/lib/knowledge-graph/cmms-sync.ts
@@ -39,7 +39,7 @@ async function atlasAdminToken(): Promise<string | null> {
     const res = await fetch(`${ATLAS_URL}/auth/signin`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: user, password: pass }),
+      body: JSON.stringify({ email: user, password: pass, type: "CLIENT" }),
       signal: AbortSignal.timeout(8_000),
     });
     if (!res.ok) return null;

--- a/mira-scan-monday/backend/mira_rag.py
+++ b/mira-scan-monday/backend/mira_rag.py
@@ -119,6 +119,20 @@ def _split_sources(content: str) -> tuple[str, list[ChatSource]]:
     return reply, sources
 
 
+def _split_make_model(label: str | None, asset_id: str | None) -> tuple[str | None, str | None]:
+    """Best-effort split of a label like 'Allen-Bradley PowerFlex 525' into
+    (make, model). Falls back to splitting the slugified asset_id."""
+    src = (label or "").strip()
+    if not src and asset_id:
+        src = asset_id.replace("-", " ").strip()
+    if not src:
+        return None, None
+    parts = src.split(None, 1)
+    if len(parts) == 1:
+        return parts[0], None
+    return parts[0], parts[1]
+
+
 def _system_prompt(asset_id: str | None, asset_label: str | None) -> str:
     base = (
         "You are MIRA, an industrial-maintenance diagnostic assistant. "
@@ -132,11 +146,24 @@ def _system_prompt(asset_id: str | None, asset_label: str | None) -> str:
             label = eq["label"]
     if not label:
         return base
-    return (
-        f"{base} The user is asking about a {label}. "
-        "Scope all retrieval and reasoning to that equipment unless the "
-        "user explicitly asks otherwise."
+    make, _ = _split_make_model(label, asset_id)
+    constraint = (
+        f"The user is asking about a {label}. "
+        f"Answer ONLY about the {label}. "
     )
+    if make:
+        constraint += (
+            f"Use ONLY documentation, parameter codes, and terminology from {make}. "
+            f"Do NOT reference, compare to, or cite documentation from other manufacturers "
+            f"(e.g. Yaskawa, ABB, Siemens, Automation Direct, Danfoss, Mitsubishi, Fuji) "
+            f"unless the user explicitly asks. "
+        )
+    constraint += (
+        "If the question cannot be answered from the OEM manual for this exact equipment, "
+        "say 'I don't have the relevant section of the manual for this' rather than guessing "
+        "from a similar product."
+    )
+    return f"{base} {constraint}"
 
 
 async def chat(


### PR DESCRIPTION
## Summary
Fixes for two Florida Expo demo blockers (May 21 deadline, May 16/17 sub-deadlines).

### CRA-134 — Hub CMMS panel was 503-ing
Three stacked regressions:
1. `docker-compose.saas.yml`: `HUB_CMMS_API_URL` reverted to public URL by 08db78e0 (file-rewrite merge clobbered dc10a10f). Public nginx only proxies `/auth/`+`/api/`+`/license/` — the hub's `/work-orders/search` etc. fell through to the SPA → 405.
2. `mira-hub` was on `mira-net` only; not on `factorylm-cmms_default`. Added `cmms-ext` external network.
3. `/api/cmms/stats` and `cmms-sync.ts` POSTed `/auth/signin` without the required `type: "CLIENT"` — backend returns 400 Validation failed. (atlas/client.ts already had it; aligned the two stragglers.)

**Verified post-deploy:** hub→cmms-backend signin returns 203-char token; WO search returns real content; full stats flow returns `{open:25, inprogress:25, complete:25, assets:0, pms:0}`.

### CRA-130 — Scan chat returned wrong-OEM content
`mira-scan-monday/backend/mira_rag.py` system prompt only said "user is asking about a {label}" — too soft. PowerFlex 525 question came back with GS10 (different drive, different OEM) content.

Tightened the system prompt to:
- Require ONLY-this-equipment + ONLY-this-manufacturer documentation
- Explicit cross-vendor disallowlist (Yaskawa, ABB, Siemens, Automation Direct, Danfoss, Mitsubishi, Fuji)
- "Say I don't know" instead of guessing from a similar product

**Partial fix.** The LLM is more constrained but mira-pipeline still isn't doing manufacturer-scoped RAG retrieval (`sources: []` persists). Pipeline-side scoping is follow-up.

## Test plan
- [x] `docker exec mira-hub` signin via internal URL → token returned
- [x] `docker exec mira-hub` POST /work-orders/search → real WO data
- [x] `/chat/message` for PowerFlex 525 — LLM no longer says "GS10 drive"
- [ ] `/api/cmms/stats` end-to-end via authenticated browser session — needs UI check
- [ ] CRA-130 demo flow E2E with real photo — needs manual QA before May 16

🤖 Generated with [Claude Code](https://claude.com/claude-code)