### PR TITLE
fix(scan): scope chat RAG to matched manufacturer (P0 demo blocker)

### DIFF
--- a/mira-scan-monday/.env.example
+++ b/mira-scan-monday/.env.example
@@ -3,10 +3,25 @@ OPENAI_API_KEY=
 OPENAI_BASE_URL=https://api.openai.com/v1
 VISION_MODEL=gpt-4o
 
-# MIRA RAG
+# MIRA RAG (mira-pipeline fallback path)
 MIRA_KB_BASE_URL=
 MIRA_KB_API_KEY=
 MIRA_KB_TIMEOUT=30
+
+# Manufacturer-scoped RAG (preferred when scan matches a known asset).
+# When enabled, the chat backend retrieves chunks from `knowledge_entries`
+# filtered by manufacturer and calls the LLM cascade directly. Requires
+# at least one of GROQ_API_KEY / CEREBRAS_API_KEY / GEMINI_API_KEY plus
+# NEON_DATABASE_URL. Falls back to MIRA_KB_BASE_URL if any piece is missing.
+GROQ_API_KEY=
+GROQ_MODEL=llama-3.3-70b-versatile
+CEREBRAS_API_KEY=
+CEREBRAS_MODEL=llama3.1-8b
+GEMINI_API_KEY=
+GEMINI_MODEL=gemini-2.5-flash
+VENDOR_RAG_TOP_K=5
+VENDOR_RAG_LLM_TIMEOUT=30
+MIRA_SHARED_TENANT_ID=78917b56-f85f-43bb-9a08-1bb98a6cd6c3
 
 # monday.com — server-side write fallback (used by the standalone
 # /scan/ path that doesn't run inside a Monday iframe). For the

--- a/mira-scan-monday/backend/mira_rag.py
+++ b/mira-scan-monday/backend/mira_rag.py
@@ -6,7 +6,7 @@ import re
 
 import httpx
 
-from . import db
+from . import db, vendor_rag
 from .known_equipment import get_equipment, match_equipment
 from .models import ChatSource, KBResult
 
@@ -145,6 +145,20 @@ async def chat(
     history: list[dict],
     asset_label: str | None = None,
 ) -> tuple[str, list[ChatSource]]:
+    # Manufacturer-scoped path: when the scan matched a known asset, we
+    # retrieve from `knowledge_entries` filtered by manufacturer and call
+    # the LLM cascade directly. This stops cross-vendor leakage where
+    # mira-pipeline would otherwise pull (e.g.) Yaskawa chunks into a
+    # PowerFlex 525 conversation.
+    vendor_result = await vendor_rag.vendor_chat(
+        message=message,
+        asset_id=asset_id,
+        asset_label=asset_label,
+        history=history,
+    )
+    if vendor_result is not None:
+        return vendor_result
+
     if not MIRA_KB_BASE_URL:
         return (
             "MIRA knowledge base is not configured. Set MIRA_KB_BASE_URL to enable grounded chat.",

--- a/mira-scan-monday/backend/tests/test_vendor_rag.py
+++ b/mira-scan-monday/backend/tests/test_vendor_rag.py
@@ -1,0 +1,147 @@
+"""Unit tests for the manufacturer-scoped chat path.
+
+Run from `mira-scan-monday/`:
+
+    python -m pytest backend/tests/test_vendor_rag.py -v
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend import vendor_rag
+from backend.models import ChatSource
+
+
+def test_manufacturer_patterns_powerflex_525():
+    pats = vendor_rag.manufacturer_patterns("ab-powerflex-525")
+    # Curated entry has allen-bradley, allen bradley, rockwell, ab.
+    assert "%allen-bradley%" in pats
+    assert "%rockwell%" in pats
+
+
+def test_manufacturer_patterns_unknown_asset():
+    assert vendor_rag.manufacturer_patterns("not-a-real-id") == []
+    assert vendor_rag.manufacturer_patterns(None) == []
+
+
+def test_chunks_to_sources_dedupes_by_url_and_page():
+    chunks = [
+        {
+            "manufacturer": "Allen-Bradley",
+            "model_number": "PowerFlex 525",
+            "source_url": "https://ex/manual.pdf",
+            "source_page": 12,
+            "content": "x",
+        },
+        {
+            "manufacturer": "Allen-Bradley",
+            "model_number": "PowerFlex 525",
+            "source_url": "https://ex/manual.pdf",
+            "source_page": 12,
+            "content": "y",
+        },
+        {
+            "manufacturer": "Allen-Bradley",
+            "model_number": "PowerFlex 525",
+            "source_url": "https://ex/manual.pdf",
+            "source_page": 13,
+            "content": "z",
+        },
+    ]
+    sources = vendor_rag.chunks_to_sources(chunks)
+    assert len(sources) == 2
+    assert all(isinstance(s, ChatSource) for s in sources)
+    assert sources[0].page == 12 and sources[1].page == 13
+
+
+def test_build_grounded_messages_includes_citations_and_label():
+    chunks = [
+        {
+            "manufacturer": "Allen-Bradley",
+            "model_number": "PowerFlex 525",
+            "source_url": "https://ex/m.pdf",
+            "source_page": 7,
+            "content": "P035 sets motor mode.",
+        }
+    ]
+    msgs = vendor_rag.build_grounded_messages(
+        chunks,
+        asset_label="Allen-Bradley PowerFlex 525",
+        history=[{"role": "user", "content": "hi"}],
+        user_message="What is P035?",
+    )
+    assert msgs[0]["role"] == "system"
+    sys = msgs[0]["content"]
+    assert "Allen-Bradley PowerFlex 525" in sys
+    assert "[1]" in sys
+    assert "P035 sets motor mode." in sys
+    assert msgs[-1] == {"role": "user", "content": "What is P035?"}
+
+
+@pytest.mark.asyncio
+async def test_vendor_chat_returns_none_when_no_patterns():
+    # No asset_id → no patterns → fast fallback.
+    result = await vendor_rag.vendor_chat(
+        message="What is P035?",
+        asset_id=None,
+        asset_label=None,
+        history=[],
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_vendor_chat_filters_by_manufacturer(monkeypatch):
+    """The retrieval SQL must restrict by manufacturer ILIKE — never
+    return chunks from unrelated vendors. We assert by inspecting the
+    params passed to db.fetch_all (the full query) and feeding back a
+    canned chunk-set; the LLM call is also stubbed.
+    """
+    captured: dict[str, object] = {}
+
+    async def fake_fetch_all(sql: str, params):
+        captured["sql"] = sql
+        captured["params"] = params
+        # Pretend NeonDB returned one PowerFlex chunk.
+        return [
+            (
+                "Parameter P035 [Motor NP Volts] sets nameplate voltage.",
+                "Allen-Bradley",
+                "PowerFlex 525",
+                "https://ex/pf525.pdf",
+                42,
+                {"chunk_index": 3},
+                0.81,
+            )
+        ]
+
+    async def fake_call(messages):  # noqa: ARG001 — signature parity
+        return "P035 sets the motor nameplate voltage [1]."
+
+    monkeypatch.setattr(vendor_rag.db, "fetch_all", fake_fetch_all)
+    monkeypatch.setattr(vendor_rag, "call_llm_cascade", fake_call)
+    monkeypatch.setattr(
+        vendor_rag,
+        "_providers",
+        lambda: [{"name": "stub", "url": "x", "key": "x", "model": "x"}],
+    )
+
+    result = await vendor_rag.vendor_chat(
+        message="What is P035?",
+        asset_id="ab-powerflex-525",
+        asset_label="Allen-Bradley PowerFlex 525",
+        history=[],
+    )
+    assert result is not None
+    reply, sources = result
+    assert "P035" in reply
+    assert sources and sources[0].url == "https://ex/pf525.pdf"
+
+    # Verify the SQL really restricts by manufacturer.
+    sql = str(captured["sql"])
+    assert "manufacturer ILIKE" in sql
+    assert "content_tsv @@ plainto_tsquery" in sql
+    # Patterns must include allen-bradley alias from the curated entry.
+    params = list(captured["params"])  # type: ignore[arg-type]
+    assert "%allen-bradley%" in params

--- a/mira-scan-monday/backend/vendor_rag.py
+++ b/mira-scan-monday/backend/vendor_rag.py
@@ -1,0 +1,273 @@
+"""Manufacturer-scoped RAG for the scan chat path.
+
+Bypasses mira-pipeline (which retrieves across all manufacturers) and
+queries `knowledge_entries` directly with a manufacturer ILIKE filter so
+a PowerFlex 525 chat never sees Yaskawa or AutomationDirect chunks.
+
+Retrieval = Postgres BM25 via `content_tsv @@ plainto_tsquery(...)`
+(no embeddings needed — the GIN index is already populated by the
+crawler ingest pipeline). Chunks become the LLM's grounded context;
+the LLM cascade (Groq → Cerebras → Gemini) is called directly.
+
+Falls back to mira_rag.chat()'s existing mira-pipeline path when:
+- the asset isn't in the curated allowlist (no manufacturer patterns),
+- NeonDB is unavailable,
+- or all LLM providers fail.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+from . import db
+from .known_equipment import get_equipment
+from .models import ChatSource
+
+logger = logging.getLogger("mira-scan.vendor_rag")
+
+SHARED_TENANT_ID = os.getenv(
+    "MIRA_SHARED_TENANT_ID", "78917b56-f85f-43bb-9a08-1bb98a6cd6c3"
+)
+VENDOR_RAG_TOP_K = int(os.getenv("VENDOR_RAG_TOP_K", "5"))
+VENDOR_RAG_LLM_TIMEOUT = float(os.getenv("VENDOR_RAG_LLM_TIMEOUT", "30"))
+
+
+def manufacturer_patterns(asset_id: str | None) -> list[str]:
+    """Return ILIKE patterns for the manufacturer column.
+
+    Curated entries already enumerate the manufacturer aliases that
+    appear in scanner output AND in `knowledge_entries.manufacturer`
+    (Allen-Bradley vs Rockwell, ABB vs Baldor-Reliance, etc.). Reusing
+    them here means the same source of truth governs both directions.
+    """
+    if not asset_id:
+        return []
+    entry = get_equipment(asset_id)
+    if not entry:
+        return []
+    return [f"%{tok}%" for tok in entry.get("make", []) if tok]
+
+
+async def retrieve_vendor_chunks(
+    patterns: list[str], query: str, top_k: int = VENDOR_RAG_TOP_K
+) -> list[dict[str, Any]]:
+    """BM25-rank chunks restricted to the given manufacturer patterns.
+
+    Returns [] on empty inputs or any DB error so the caller can fall
+    back without raising.
+    """
+    if not patterns or not query.strip():
+        return []
+
+    # Build N OR'd ILIKE clauses with positional params to avoid string
+    # interpolation. Order: $1 = query, $2..$N+1 = patterns, last = limit.
+    mfr_clauses = " OR ".join("manufacturer ILIKE %s" for _ in patterns)
+    sql = f"""
+        SELECT content,
+               manufacturer,
+               model_number,
+               source_url,
+               source_page,
+               metadata,
+               ts_rank_cd(content_tsv, plainto_tsquery('english', %s)) AS rank
+          FROM knowledge_entries
+         WHERE ({mfr_clauses})
+           AND content_tsv @@ plainto_tsquery('english', %s)
+         ORDER BY rank DESC
+         LIMIT %s
+    """
+    params: tuple[Any, ...] = (query, *patterns, query, top_k)
+    try:
+        rows = await db.fetch_all(sql, params)
+    except db.DBUnavailable:
+        return []
+    except Exception:
+        logger.exception("vendor RAG retrieval failed (patterns=%r)", patterns)
+        return []
+
+    chunks: list[dict[str, Any]] = []
+    for row in rows:
+        chunks.append(
+            {
+                "content": row[0] or "",
+                "manufacturer": row[1] or "",
+                "model_number": row[2] or "",
+                "source_url": row[3] or "",
+                "source_page": row[4],
+                "metadata": row[5] or {},
+                "rank": float(row[6] or 0.0),
+            }
+        )
+    return chunks
+
+
+def build_grounded_messages(
+    chunks: list[dict[str, Any]],
+    asset_label: str | None,
+    history: list[dict],
+    user_message: str,
+) -> list[dict[str, str]]:
+    """Assemble the system+history+user messages with [n] citation markers
+    so the LLM can reference sources by index."""
+    label = asset_label or "the equipment"
+    blocks: list[str] = []
+    for i, c in enumerate(chunks, start=1):
+        head_bits = [b for b in (c.get("manufacturer"), c.get("model_number")) if b]
+        head = " ".join(head_bits) or "OEM doc"
+        page = c.get("source_page")
+        page_str = f", p.{page}" if page else ""
+        url = c.get("source_url") or ""
+        url_str = f" — {url}" if url else ""
+        blocks.append(f"[{i}] {head}{page_str}{url_str}\n{c.get('content', '')}")
+    context = "\n\n---\n\n".join(blocks) if blocks else "(no documentation found)"
+
+    system = (
+        f"You are MIRA, an industrial maintenance diagnostic assistant answering "
+        f"about {label}. Use ONLY the documentation below to answer. Cite sources "
+        f"with [n] markers matching the numbered blocks. If the documentation does "
+        f"not cover the question, say so plainly — never guess or invent values.\n\n"
+        f"Documentation:\n{context}"
+    )
+
+    messages: list[dict[str, str]] = [{"role": "system", "content": system}]
+    for h in history or []:
+        role = h.get("role")
+        content = h.get("content")
+        if role in {"user", "assistant"} and isinstance(content, str) and content:
+            messages.append({"role": role, "content": content})
+    messages.append({"role": "user", "content": user_message})
+    return messages
+
+
+_PROVIDERS: list[dict[str, str]] = []
+
+
+def _providers() -> list[dict[str, str]]:
+    """Lazy-build the cascade so tests can monkey-patch env vars."""
+    global _PROVIDERS  # noqa: PLW0603
+    if _PROVIDERS:
+        return _PROVIDERS
+    out: list[dict[str, str]] = []
+    if (k := os.getenv("GROQ_API_KEY", "")):
+        out.append(
+            {
+                "name": "groq",
+                "url": "https://api.groq.com/openai/v1/chat/completions",
+                "key": k,
+                "model": os.getenv("GROQ_MODEL", "llama-3.3-70b-versatile"),
+            }
+        )
+    if (k := os.getenv("CEREBRAS_API_KEY", "")):
+        out.append(
+            {
+                "name": "cerebras",
+                "url": "https://api.cerebras.ai/v1/chat/completions",
+                "key": k,
+                "model": os.getenv("CEREBRAS_MODEL", "llama3.1-8b"),
+            }
+        )
+    if (k := os.getenv("GEMINI_API_KEY", "")):
+        out.append(
+            {
+                "name": "gemini",
+                "url": (
+                    "https://generativelanguage.googleapis.com/v1beta/openai/"
+                    "chat/completions"
+                ),
+                "key": k,
+                "model": os.getenv("GEMINI_MODEL", "gemini-2.5-flash"),
+            }
+        )
+    _PROVIDERS = out
+    return out
+
+
+async def call_llm_cascade(messages: list[dict[str, str]]) -> str:
+    """Try Groq → Cerebras → Gemini; return first non-empty completion."""
+    for p in _providers():
+        try:
+            async with httpx.AsyncClient(timeout=VENDOR_RAG_LLM_TIMEOUT) as client:
+                resp = await client.post(
+                    p["url"],
+                    json={
+                        "model": p["model"],
+                        "messages": messages,
+                        "temperature": 0.2,
+                    },
+                    headers={
+                        "Authorization": f"Bearer {p['key']}",
+                        "Content-Type": "application/json",
+                    },
+                )
+                resp.raise_for_status()
+                data = resp.json()
+            content = data["choices"][0]["message"]["content"] or ""
+            if content.strip():
+                logger.info("vendor RAG LLM=%s ok", p["name"])
+                return content
+        except Exception as exc:
+            logger.warning("vendor RAG LLM=%s failed: %s", p["name"], exc)
+            continue
+    return ""
+
+
+def chunks_to_sources(chunks: list[dict[str, Any]]) -> list[ChatSource]:
+    sources: list[ChatSource] = []
+    seen: set[tuple[str, int | None]] = set()
+    for c in chunks:
+        url = c.get("source_url") or ""
+        page = c.get("source_page")
+        key = (url, page)
+        if key in seen:
+            continue
+        seen.add(key)
+        title_bits = [
+            b for b in (c.get("manufacturer"), c.get("model_number")) if b
+        ]
+        title = " ".join(title_bits) or (url or "OEM document")
+        sources.append(
+            ChatSource(title=title, url=url or None, page=page if page else None)
+        )
+    return sources
+
+
+async def vendor_chat(
+    message: str,
+    asset_id: str | None,
+    asset_label: str | None,
+    history: list[dict],
+) -> tuple[str, list[ChatSource]] | None:
+    """Run the manufacturer-scoped chat path.
+
+    Returns (reply, sources) on success, or None if this path can't
+    serve the request (no patterns, no chunks, no LLM) — caller then
+    falls back to mira-pipeline.
+    """
+    patterns = manufacturer_patterns(asset_id)
+    if not patterns:
+        return None
+
+    chunks = await retrieve_vendor_chunks(patterns, message)
+    if not chunks:
+        logger.info(
+            "vendor RAG: no chunks for asset=%s patterns=%r — falling back",
+            asset_id,
+            patterns,
+        )
+        return None
+
+    if not _providers():
+        logger.warning(
+            "vendor RAG: no LLM providers configured — falling back to mira-pipeline"
+        )
+        return None
+
+    messages = build_grounded_messages(chunks, asset_label, history, message)
+    reply = await call_llm_cascade(messages)
+    if not reply.strip():
+        return None
+    return reply, chunks_to_sources(chunks)


### PR DESCRIPTION
## Summary
- Scan chat was returning Yaskawa / AutomationDirect chunks for a PowerFlex 525 because mira-pipeline retrieves across all 83K+ \`knowledge_entries\` with no manufacturer filter.
- New \`vendor_rag\` path queries NeonDB directly with a manufacturer ILIKE filter derived from the curated allowlist, then calls the LLM cascade (Groq → Cerebras → Gemini) directly with grounded context.
- Falls back to the existing mira-pipeline path when no asset matches, no chunks come back, or no LLM provider is configured — no behavior regression for the unmatched flow.

## What changed
- \`mira-scan-monday/backend/vendor_rag.py\` (new) — pattern derivation, BM25 retrieval over \`content_tsv\`, LLM cascade, source builder.
- \`mira-scan-monday/backend/mira_rag.py\` — calls \`vendor_rag.vendor_chat\` first; original mira-pipeline path is the fallback.
- \`mira-scan-monday/.env.example\` — documents \`GROQ_API_KEY\` / \`CEREBRAS_API_KEY\` / \`GEMINI_API_KEY\` and tunables.

## Test plan
- [x] \`pytest backend/tests/\` — 33/33 passing (6 new tests)
- [x] \`ruff check\` clean on changed files
- [ ] Deploy to VPS, set provider keys via Doppler, verify with curl: \`POST /chat/message\` for \`asset_id=ab-powerflex-525\` should return Allen-Bradley citations only
- [ ] Smoke-test a Siemens device to confirm cross-vendor scoping
- [ ] Verify fallback path: chat without an \`asset_id\` still hits mira-pipeline

## Notes
- Manufacturer aliases come from the same \`KNOWN_EQUIPMENT\` table that drives asset matching, so Allen-Bradley / Rockwell / AB stay aligned both directions.
- LLM env vars match the existing mira-bots router naming so Doppler keys can be reused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)