### PR TITLE
feat(hub): QR codes, mobile asset landing, auth fixture, apex redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ mira-hud/vision_backend/logs/
 *.session
 *.session-journal
 
+# Playwright auth fixtures — contain logged-in session cookies
+mira-hub/tests/e2e/fixtures/storageState.json
+
 # Python
 __pycache__/
 *.pyc

--- a/mira-hub/src/app/(hub)/assets/[id]/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { AssetChat } from "@/components/AssetChat";
 import { AssetIntelligencePanel } from "@/components/AssetIntelligencePanel";
+import { QrCodeImage } from "@/components/qr-code";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
@@ -102,6 +103,7 @@ export default function AssetDetailPage({ params }: { params: Promise<{ id: stri
   const t = useTranslations("assets");
   const { id } = use(params);
   const [activeTab, setActiveTab] = useState("overview");
+  const [showQr, setShowQr] = useState(false);
   const [apiAsset, setApiAsset] = useState<ApiAsset | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -140,7 +142,7 @@ export default function AssetDetailPage({ params }: { params: Promise<{ id: stri
                 <Badge variant="outline" className="text-[10px]">{t("criticalityLabel", { level: asset.criticality })}</Badge>
               </div>
             </div>
-            <Button size="sm" variant="ghost">
+            <Button size="sm" variant="ghost" onClick={() => setShowQr(true)} aria-label="Show QR code">
               <QrCode className="w-4 h-4" />
             </Button>
           </div>
@@ -190,6 +192,34 @@ export default function AssetDetailPage({ params }: { params: Promise<{ id: stri
           {activeTab === "documents"     && <DocumentsTab />}
           {activeTab === "parts"         && <PartsTab />}
           {activeTab === "intelligence"  && <AssetIntelligencePanel assetId={id} />}
+        </div>
+      )}
+
+      {showQr && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Asset QR code"
+          onClick={() => setShowQr(false)}
+        >
+          <div
+            className="bg-white rounded-lg shadow-xl max-w-sm w-full p-6 text-center"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="text-xs font-mono uppercase tracking-wide text-slate-500 mb-1">{asset.tag}</div>
+            <h2 className="text-lg font-semibold mb-4">{asset.name}</h2>
+            <div className="flex justify-center mb-4">
+              <QrCodeImage
+                value={typeof window !== "undefined" ? `${window.location.origin}/m/${asset.tag}` : `/m/${asset.tag}`}
+                size={224}
+              />
+            </div>
+            <p className="text-xs text-slate-500 mb-4">
+              Scan to open the mobile asset page. Print and post on the equipment.
+            </p>
+            <Button variant="outline" size="sm" onClick={() => setShowQr(false)}>Close</Button>
+          </div>
         </div>
       )}
     </div>

--- a/mira-hub/src/app/(hub)/assets/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/page.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from "next-intl";
 import {
   Search, QrCode, Wind, Zap, Cog, Thermometer, Droplets,
   Factory, Gauge, AlertCircle, CheckCircle2, AlertTriangle,
-  Plus, X, Loader2, Wrench,
+  Plus, X, Loader2, Wrench, Printer,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -471,6 +471,14 @@ function AssetsPageInner() {
               <Plus className="w-4 h-4" />
               New Asset
             </button>
+            <Link
+              href="/assets/print-qr"
+              className="hidden md:inline-flex items-center gap-1.5 h-8 px-3 rounded-lg text-sm font-medium border transition-colors hover:bg-slate-50"
+              style={{ borderColor: "var(--border)", color: "var(--foreground)" }}
+            >
+              <Printer className="w-3.5 h-3.5" />
+              Print QR Labels
+            </Link>
             <Button size="sm" className="gap-1.5">
               <QrCode className="w-3.5 h-3.5" />
               {tCommon("scanQr")}

--- a/mira-hub/src/app/(hub)/assets/print-qr/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/print-qr/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Loader2, Printer } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { QrCodeImage } from "@/components/qr-code";
+import { API_BASE } from "@/lib/config";
+
+type Asset = {
+  id: string;
+  tag: string;
+  name: string;
+  manufacturer: string | null;
+  model: string | null;
+  location: string | null;
+};
+
+export default function PrintQrPage() {
+  const [assets, setAssets] = useState<Asset[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`${API_BASE}/api/assets`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data: Asset[]) => {
+        if (cancelled) return;
+        setAssets(data);
+        setSelected(new Set(data.map((a) => a.id)));
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const origin = typeof window !== "undefined" ? window.location.origin : "";
+  const visible = useMemo(
+    () => assets.filter((a) => selected.has(a.id)),
+    [assets, selected],
+  );
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  }
+
+  function selectAll() {
+    setSelected(new Set(assets.map((a) => a.id)));
+  }
+  function clear() {
+    setSelected(new Set());
+  }
+
+  return (
+    <div className="min-h-screen p-6 print:p-0" style={{ backgroundColor: "var(--background)" }}>
+      {/* Toolbar — hidden on print */}
+      <div className="print:hidden max-w-5xl mx-auto mb-6 flex items-center justify-between gap-3 flex-wrap">
+        <Link
+          href="/assets"
+          className="inline-flex items-center gap-1.5 text-sm"
+          style={{ color: "var(--brand-blue)" }}
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to assets
+        </Link>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={selectAll}>Select all</Button>
+          <Button variant="ghost" size="sm" onClick={clear}>Clear</Button>
+          <Button size="sm" onClick={() => window.print()} disabled={visible.length === 0}>
+            <Printer className="w-4 h-4 mr-1.5" />
+            Print {visible.length} label{visible.length === 1 ? "" : "s"}
+          </Button>
+        </div>
+      </div>
+
+      {/* Selection list — hidden on print */}
+      {!loading && !error && assets.length > 0 ? (
+        <div className="print:hidden max-w-5xl mx-auto mb-6 rounded-lg border bg-white p-4">
+          <div className="text-sm font-medium mb-2">Assets to print</div>
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-2 text-sm">
+            {assets.map((a) => (
+              <label key={a.id} className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={selected.has(a.id)}
+                  onChange={() => toggle(a.id)}
+                />
+                <span className="font-mono text-xs">{a.tag}</span>
+                <span className="text-slate-600 truncate">{a.name}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-slate-500" />
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="max-w-md mx-auto rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          Failed to load assets: {error}
+        </div>
+      ) : null}
+
+      {/* Label sheet — visible on screen and print */}
+      <div className="max-w-5xl mx-auto grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 print:grid-cols-3 print:gap-2">
+        {visible.map((a) => (
+          <div
+            key={a.id}
+            className="border rounded p-3 flex flex-col items-center text-center bg-white print:break-inside-avoid"
+            style={{ borderColor: "var(--border)" }}
+          >
+            <QrCodeImage value={`${origin}/m/${a.tag}`} size={144} />
+            <div className="mt-2 font-mono text-xs">{a.tag}</div>
+            <div className="text-xs font-medium leading-tight mt-1 line-clamp-2">{a.name}</div>
+            {a.location ? (
+              <div className="text-[10px] text-slate-500 leading-tight mt-1 line-clamp-1">{a.location}</div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+
+      {!loading && visible.length === 0 && !error ? (
+        <div className="text-center text-sm text-slate-500 py-12 print:hidden">
+          No assets selected.
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/mira-hub/src/app/api/assets/by-tag/[tag]/route.ts
+++ b/mira-hub/src/app/api/assets/by-tag/[tag]/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+function rowToAsset(r: Record<string, unknown>) {
+  return {
+    id: r.id,
+    tag: r.equipment_number ?? r.id,
+    name: (r.description as string) || [r.manufacturer, r.model_number, r.equipment_type].filter(Boolean).join(" "),
+    manufacturer: r.manufacturer ?? null,
+    model: r.model_number ?? null,
+    serialNumber: r.serial_number ?? null,
+    type: r.equipment_type ?? null,
+    location: r.location ?? null,
+    department: r.department ?? null,
+    criticality: r.criticality ?? "medium",
+    workOrderCount: r.work_order_count ?? 0,
+    downtimeHours: r.total_downtime_hours ?? 0,
+    lastMaintenance: r.last_maintenance_date ?? null,
+    lastWorkOrder: r.last_work_order_at ?? null,
+    lastFault: r.last_reported_fault ?? null,
+    description: r.description ?? null,
+    installDate: r.installation_date ?? null,
+    createdAt: r.created_at ?? null,
+  };
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ tag: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { tag: rawTag } = await params;
+  const tag = decodeURIComponent(rawTag).trim();
+  if (!tag || !/^[A-Za-z0-9_-]{1,64}$/.test(tag)) {
+    return NextResponse.json({ error: "invalid tag" }, { status: 400 });
+  }
+
+  try {
+    const row = await withTenantContext(ctx.tenantId, (c) =>
+      c.query(
+        `SELECT
+          id, equipment_number, manufacturer, model_number, serial_number,
+          equipment_type, location, department, criticality,
+          work_order_count, total_downtime_hours,
+          last_maintenance_date, last_work_order_at,
+          last_reported_fault, description, installation_date, created_at
+        FROM cmms_equipment
+        WHERE equipment_number = $1 AND tenant_id = $2
+        LIMIT 1`,
+        [tag, ctx.tenantId],
+      ).then((r) => r.rows[0] ?? null),
+    );
+
+    if (!row) {
+      return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(rowToAsset(row));
+  } catch (err) {
+    console.error("[api/assets/by-tag/[tag] GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/m/[assetTag]/page.tsx
+++ b/mira-hub/src/app/m/[assetTag]/page.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { use, useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  AlertCircle,
+  Bot,
+  Calendar,
+  Loader2,
+  MapPin,
+  Package,
+  Wrench,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { QrCodeImage } from "@/components/qr-code";
+import { API_BASE } from "@/lib/config";
+
+type Asset = {
+  id: string;
+  tag: string;
+  name: string;
+  manufacturer: string | null;
+  model: string | null;
+  serialNumber: string | null;
+  type: string | null;
+  location: string | null;
+  criticality: string;
+  lastWorkOrder: string | null;
+  lastMaintenance: string | null;
+};
+
+const TELEGRAM_BOT = process.env.NEXT_PUBLIC_TELEGRAM_BOT_USERNAME ?? "MiraFactoryBot";
+
+export default function MobileAssetPage({
+  params,
+}: {
+  params: Promise<{ assetTag: string }>;
+}) {
+  const { assetTag: rawTag } = use(params);
+  const assetTag = decodeURIComponent(rawTag);
+
+  const [asset, setAsset] = useState<Asset | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [shareUrl, setShareUrl] = useState("");
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      setShareUrl(`${window.location.origin}/m/${assetTag}`);
+    }
+  }, [assetTag]);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`${API_BASE}/api/assets/by-tag/${encodeURIComponent(assetTag)}`)
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+        return res.json();
+      })
+      .then((data) => {
+        if (!cancelled) setAsset(data);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [assetTag]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen p-6">
+        <Loader2 className="h-6 w-6 animate-spin text-slate-500" />
+      </div>
+    );
+  }
+
+  if (error || !asset) {
+    return (
+      <div className="max-w-md mx-auto p-6 pt-12">
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 flex gap-3">
+          <AlertCircle className="h-5 w-5 text-red-600 shrink-0" />
+          <div>
+            <h1 className="font-semibold text-red-900">Asset not found</h1>
+            <p className="text-sm text-red-800 mt-1">
+              No asset matches tag <code className="font-mono">{assetTag}</code>{error ? ` (${error})` : ""}.
+            </p>
+            <Link href="/assets" className="text-sm text-red-700 underline mt-2 inline-block">
+              Browse all assets
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const tgDeepLink = `https://t.me/${TELEGRAM_BOT}?start=asset_${encodeURIComponent(asset.tag)}`;
+  const newWoUrl = `/workorders/new?assetId=${encodeURIComponent(String(asset.id))}&assetTag=${encodeURIComponent(asset.tag)}`;
+
+  return (
+    <div className="max-w-md mx-auto px-4 pt-6 pb-12">
+      {/* Asset header */}
+      <div className="mb-4">
+        <div className="text-xs font-mono uppercase tracking-wide text-slate-500">
+          {asset.tag}
+        </div>
+        <h1 className="text-2xl font-semibold leading-tight mt-1">{asset.name}</h1>
+        {asset.criticality && asset.criticality !== "medium" ? (
+          <div className="mt-2 inline-block text-xs font-medium px-2 py-0.5 rounded bg-amber-100 text-amber-900 capitalize">
+            {asset.criticality} criticality
+          </div>
+        ) : null}
+      </div>
+
+      {/* Specs card */}
+      <div className="rounded-lg border bg-white p-4 space-y-3 text-sm">
+        {asset.manufacturer || asset.model ? (
+          <Row icon={<Package className="h-4 w-4" />} label="Make / Model">
+            {[asset.manufacturer, asset.model].filter(Boolean).join(" • ") || "—"}
+          </Row>
+        ) : null}
+        {asset.location ? (
+          <Row icon={<MapPin className="h-4 w-4" />} label="Location">
+            {asset.location}
+          </Row>
+        ) : null}
+        {asset.lastWorkOrder ? (
+          <Row icon={<Wrench className="h-4 w-4" />} label="Last work order">
+            {new Date(asset.lastWorkOrder).toLocaleDateString()}
+          </Row>
+        ) : null}
+        {asset.lastMaintenance ? (
+          <Row icon={<Calendar className="h-4 w-4" />} label="Last maintenance">
+            {new Date(asset.lastMaintenance).toLocaleDateString()}
+          </Row>
+        ) : null}
+      </div>
+
+      {/* Actions */}
+      <div className="mt-4 grid gap-2">
+        <Button asChild size="lg" className="w-full">
+          <a href={tgDeepLink} target="_blank" rel="noopener noreferrer">
+            <Bot className="h-4 w-4 mr-2" />
+            Chat with MIRA about this equipment
+          </a>
+        </Button>
+        <Button asChild size="lg" variant="outline" className="w-full">
+          <Link href={newWoUrl}>
+            <Wrench className="h-4 w-4 mr-2" />
+            Create Work Order
+          </Link>
+        </Button>
+        <Button asChild size="lg" variant="ghost" className="w-full">
+          <Link href={`/assets/${asset.id}`}>Open full asset detail</Link>
+        </Button>
+      </div>
+
+      {/* QR for sharing this page */}
+      {shareUrl ? (
+        <div className="mt-8 flex flex-col items-center text-center text-xs text-slate-500">
+          <QrCodeImage value={shareUrl} size={144} />
+          <div className="mt-2 font-mono">{asset.tag}</div>
+          <div>Scan to share this asset</div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function Row({
+  icon,
+  label,
+  children,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="text-slate-400 mt-0.5">{icon}</div>
+      <div className="flex-1 min-w-0">
+        <div className="text-xs uppercase tracking-wide text-slate-500">{label}</div>
+        <div className="text-slate-900">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/mira-hub/src/app/m/layout.tsx
+++ b/mira-hub/src/app/m/layout.tsx
@@ -1,0 +1,12 @@
+// Minimal layout for mobile QR landing pages.
+// No sidebar, no bottom tabs — just a clean full-bleed mobile view
+// for technicians scanning a QR code in the field.
+export const dynamic = "force-dynamic";
+
+export default function MLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen" style={{ backgroundColor: "var(--background)" }}>
+      {children}
+    </div>
+  );
+}

--- a/mira-hub/src/components/qr-code.tsx
+++ b/mira-hub/src/components/qr-code.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import QRCode from "qrcode";
+
+type Props = {
+  value: string;
+  size?: number;
+  className?: string;
+  alt?: string;
+};
+
+export function QrCodeImage({ value, size = 192, className, alt }: Props) {
+  const [dataUrl, setDataUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    QRCode.toDataURL(value, {
+      width: size,
+      margin: 1,
+      errorCorrectionLevel: "M",
+    })
+      .then((url) => {
+        if (!cancelled) setDataUrl(url);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "QR generation failed");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [value, size]);
+
+  if (error) {
+    return (
+      <div
+        className={className}
+        style={{ width: size, height: size }}
+        role="img"
+        aria-label={`QR code error: ${error}`}
+      >
+        <span className="text-xs text-red-600">QR error</span>
+      </div>
+    );
+  }
+
+  if (!dataUrl) {
+    return (
+      <div
+        className={className}
+        style={{ width: size, height: size, background: "#f1f5f9" }}
+        aria-busy="true"
+      />
+    );
+  }
+
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={dataUrl}
+      width={size}
+      height={size}
+      alt={alt ?? `QR code for ${value}`}
+      className={className}
+    />
+  );
+}

--- a/mira-hub/tests/e2e/fixtures/create-auth-state.ts
+++ b/mira-hub/tests/e2e/fixtures/create-auth-state.ts
@@ -1,0 +1,51 @@
+/* eslint-disable no-console */
+/**
+ * Interactive helper that opens a real Chromium window, lets you log in
+ * to app.factorylm.com, then saves cookies + localStorage to a JSON file
+ * Playwright can reuse via `storageState`.
+ *
+ * Run once per environment when the magic-link / Google OAuth session
+ * expires:
+ *   bun run tests/e2e/fixtures/create-auth-state.ts
+ *
+ * Output: tests/e2e/fixtures/storageState.json (gitignored).
+ *
+ * Then in playwright.config.ts (or per-test):
+ *   use: { storageState: "tests/e2e/fixtures/storageState.json" }
+ */
+import { chromium } from "@playwright/test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const STATE_PATH = resolve(__dirname, "storageState.json");
+const TARGET_URL = process.env.AUTH_TARGET_URL ?? "https://app.factorylm.com/login";
+const POST_LOGIN_MARKER =
+  process.env.AUTH_POST_LOGIN_MARKER ?? "/feed";
+
+async function main() {
+  const browser = await chromium.launch({ headless: false });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  console.log(`\n→ Opening ${TARGET_URL}`);
+  console.log("  Log in (magic-link / Google OAuth) in the browser window.");
+  console.log(
+    `  Once you land on a page whose URL contains "${POST_LOGIN_MARKER}",`,
+  );
+  console.log("  this script will save the session and exit.\n");
+
+  await page.goto(TARGET_URL);
+  await page.waitForURL((url) => url.pathname.includes(POST_LOGIN_MARKER), {
+    timeout: 10 * 60 * 1000, // 10 minutes — magic-link can take a while
+  });
+
+  await context.storageState({ path: STATE_PATH });
+  console.log(`✓ Session saved to ${STATE_PATH}`);
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/apply-apex-login-redirects.sh
+++ b/scripts/apply-apex-login-redirects.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Apply apex /login + /signup → app.factorylm.com redirects on the VPS.
+#
+# Idempotent: skips if the redirect blocks already exist.
+# Run from a machine that can SSH to the VPS as root (or a user with
+# sudo nginx access).
+#
+# Usage:
+#   scripts/apply-apex-login-redirects.sh           # apply
+#   DRY_RUN=1 scripts/apply-apex-login-redirects.sh # diff only
+set -euo pipefail
+
+VPS_HOST="${VPS_HOST:-root@100.68.120.99}"
+NGINX_CONF="${NGINX_CONF:-/etc/nginx/sites-enabled/factorylm-landing}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# Marker — used both as the "already applied?" sentinel and as the anchor
+# we splice the new lines below. The apex factorylm.com 443 block lives
+# in factorylm-landing (verified 2026-05-09).
+MARKER='server_name factorylm.com www.factorylm.com;'
+NEW_BLOCK=$'    # apex login/signup → app subdomain (added 2026-05-09)\n    location = /login  { return 301 https://app.factorylm.com/login; }\n    location = /signup { return 301 https://app.factorylm.com/signup; }'
+
+remote_apply() {
+  ssh "$VPS_HOST" bash -se <<'REMOTE'
+set -euo pipefail
+NGINX_CONF="${NGINX_CONF:-/etc/nginx/sites-enabled/factorylm-landing}"
+
+if [[ ! -f "$NGINX_CONF" ]]; then
+  echo "ERROR: $NGINX_CONF not found on VPS" >&2
+  exit 1
+fi
+
+if grep -q 'apex login/signup → app subdomain' "$NGINX_CONF"; then
+  echo "✓ Redirects already present in $NGINX_CONF — nothing to do."
+  exit 0
+fi
+
+cp "$NGINX_CONF" "${NGINX_CONF}.bak.$(date +%Y%m%d-%H%M%S)"
+
+# Insert the new block AFTER the FIRST apex server_name line (the 443 block).
+awk '
+  /server_name factorylm\.com www\.factorylm\.com;/ && !inserted {
+    print
+    print "    # apex login/signup → app subdomain (added 2026-05-09)"
+    print "    location = /login  { return 301 https://app.factorylm.com/login; }"
+    print "    location = /signup { return 301 https://app.factorylm.com/signup; }"
+    inserted = 1
+    next
+  }
+  { print }
+' "$NGINX_CONF" > "${NGINX_CONF}.new"
+
+mv "${NGINX_CONF}.new" "$NGINX_CONF"
+
+nginx -t
+systemctl reload nginx
+echo "✓ Reloaded nginx with apex /login + /signup redirects."
+REMOTE
+}
+
+verify() {
+  for path in /login /signup; do
+    code=$(curl -sI -o /dev/null -w '%{http_code}' "https://factorylm.com${path}" || true)
+    loc=$(curl -sI "https://factorylm.com${path}" | awk -F': ' 'tolower($1)=="location"{print $2}' | tr -d '\r')
+    printf 'GET https://factorylm.com%-8s → %s  Location: %s\n' "$path" "$code" "${loc:-<none>}"
+  done
+}
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  echo "DRY RUN — would SSH to $VPS_HOST and edit $NGINX_CONF"
+  echo "Block to insert:"
+  echo "$NEW_BLOCK"
+  exit 0
+fi
+
+remote_apply
+echo
+echo "Verifying:"
+verify

--- a/scripts/apply-apex-login-redirects.sh
+++ b/scripts/apply-apex-login-redirects.sh
@@ -14,10 +14,9 @@ VPS_HOST="${VPS_HOST:-root@100.68.120.99}"
 NGINX_CONF="${NGINX_CONF:-/etc/nginx/sites-enabled/factorylm-landing}"
 DRY_RUN="${DRY_RUN:-0}"
 
-# Marker — used both as the "already applied?" sentinel and as the anchor
-# we splice the new lines below. The apex factorylm.com 443 block lives
-# in factorylm-landing (verified 2026-05-09).
-MARKER='server_name factorylm.com www.factorylm.com;'
+# The apex factorylm.com 443 block lives in factorylm-landing (verified
+# 2026-05-09). The remote awk in remote_apply() anchors on its
+# `server_name factorylm.com www.factorylm.com;` line.
 NEW_BLOCK=$'    # apex login/signup → app subdomain (added 2026-05-09)\n    location = /login  { return 301 https://app.factorylm.com/login; }\n    location = /signup { return 301 https://app.factorylm.com/signup; }'
 
 remote_apply() {


### PR DESCRIPTION
## Summary

- **QR codes** — new `QrCodeImage` component (uses existing `qrcode` dep), a Show-QR overlay on the asset detail page, and a `/assets/print-qr` printable label sheet with per-asset checkboxes.
- **`/m/[assetTag]` mobile landing page** — minimal layout (no sidebar/tabs), looks up asset by tag via new `/api/assets/by-tag/[tag]` endpoint, shows make/model/location/last-WO, plus actions: Chat with MIRA via Telegram deep link, Create Work Order, Open full asset detail. Self-share QR at the bottom.
- **Playwright auth fixture** — `tests/e2e/fixtures/create-auth-state.ts` opens a real browser, lets the operator log in, saves `storageState.json` (gitignored) for reuse in e2e specs.
- **Apex login/signup redirects** — `scripts/apply-apex-login-redirects.sh` idempotently patches the VPS `factorylm-landing` nginx config. **Already applied and verified live**: `factorylm.com/login` and `factorylm.com/signup` now `301 → app.factorylm.com/...`.

## Files

| File | What |
|---|---|
| `mira-hub/src/components/qr-code.tsx` | client QR component |
| `mira-hub/src/app/m/[assetTag]/page.tsx` + `layout.tsx` | mobile QR landing |
| `mira-hub/src/app/api/assets/by-tag/[tag]/route.ts` | tag → equipment lookup (tenant-scoped) |
| `mira-hub/src/app/(hub)/assets/[id]/page.tsx` | wires Show-QR overlay |
| `mira-hub/src/app/(hub)/assets/page.tsx` | adds Print-QR-Labels button |
| `mira-hub/src/app/(hub)/assets/print-qr/page.tsx` | printable sheet |
| `mira-hub/tests/e2e/fixtures/create-auth-state.ts` | interactive login → storageState.json |
| `scripts/apply-apex-login-redirects.sh` | nginx redirect patch (idempotent) |
| `.gitignore` | gitignores `storageState.json` |

## Test plan

- [x] `curl -sI https://factorylm.com/login` → `301` → `https://app.factorylm.com/login` (verified live)
- [x] `curl -sI https://factorylm.com/signup` → `301` → `https://app.factorylm.com/signup` (verified live)
- [ ] After deploy: scan a printed QR for an existing asset → lands on `/m/<tag>` and shows asset card
- [ ] Asset detail → Show QR overlay → QR encodes correct `/m/<tag>` URL
- [ ] `/assets/print-qr` → select-all + print → label sheet renders one QR per asset, page-break-friendly
- [ ] Run `bun run tests/e2e/fixtures/create-auth-state.ts`, log in, confirm `storageState.json` is generated and gitignored

## Notes

- QR encodes `${origin}/m/<asset_tag>` — works in dev (`localhost`) and prod automatically.
- `/m/*` is auth-gated by the existing `withAuth` middleware (no allowlist change). Technicians scanning will be redirected to `/login` on first scan, then to the asset page.
- The nginx script targets `factorylm-landing` (the apex 443 block), not `mira` — discovered during the deploy that the apex lives in a different file than the `app.`/`chat.` subdomains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)