### PR TITLE
feat(rag): agentic retrieval Component 1 — query decomposition

### DIFF
--- a/mira-bots/shared/agentic_retrieval.py
+++ b/mira-bots/shared/agentic_retrieval.py
@@ -1,0 +1,196 @@
+"""Agentic retrieval primitives — Component 1: query decomposition.
+
+Spec: docs/specs/agentic-rag-upgrade-spec.md (Component 1).
+
+Splits a complex user question into 2-4 focused sub-queries via a cheap
+Groq llama-3.1-8b-instant call so each concern hits the existing retrieval
+pipeline (`neon_recall.recall_knowledge`) independently. Per-sub-query
+results are merged via Reciprocal Rank Fusion (same RRF_K as
+`neon_recall._merge_results`) and deduplicated using the repo's existing
+key (`content[:100]`).
+
+Flag-gated by ``MIRA_QUERY_DECOMPOSE`` (default ``0``). Fail-open: any Groq
+or parse error returns ``[question]`` so callers behave identically to
+today.
+
+C2 (hybrid retrieval) and C3 (self-evaluation) are deferred to follow-up
+PRs per the spec rollout plan.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+GROQ_URL = "https://api.groq.com/openai/v1/chat/completions"
+GROQ_MODEL = os.getenv("MIRA_DECOMPOSE_MODEL", "llama-3.1-8b-instant")
+GROQ_TIMEOUT = float(os.getenv("MIRA_DECOMPOSE_TIMEOUT", "5"))
+
+MAX_SUBQUERIES = int(os.getenv("MIRA_DECOMPOSE_MAX_SUBQUERIES", "4"))
+MIN_TOKENS = int(os.getenv("MIRA_DECOMPOSE_MIN_TOKENS", "6"))
+
+RRF_K = int(os.getenv("MIRA_RRF_K", "60"))
+
+_SYSTEM_PROMPT = (
+    "You decompose industrial maintenance questions into focused sub-queries "
+    'for retrieval. Output JSON only: {"subqueries": ["...", "..."]}. '
+    "Rules:\n"
+    "- 2 to 4 sub-queries; each MUST be a self-contained search phrase.\n"
+    "- Preserve fault codes, model numbers, and manufacturer names verbatim.\n"
+    "- Cover distinct concerns (e.g. fault diagnosis, motor sizing, parameters).\n"
+    "- Do NOT invent details not present in the question.\n"
+    "- If the question is single-concern, return one entry equal to the question."
+)
+
+
+def is_decompose_enabled() -> bool:
+    return os.getenv("MIRA_QUERY_DECOMPOSE", "0") == "1"
+
+
+async def decompose_query(question: str) -> list[str]:
+    """Return 1-4 sub-queries for ``question``. Fail-open to ``[question]``.
+
+    Skip conditions (return ``[question]`` without an LLM call):
+      - flag ``MIRA_QUERY_DECOMPOSE`` is not set to ``1``
+      - ``GROQ_API_KEY`` missing
+      - question shorter than ``MIN_TOKENS`` whitespace tokens
+
+    The original question is always present in the returned list so worst-case
+    retrieval is identical to today.
+    """
+    q = (question or "").strip()
+    if not q:
+        return [question]
+
+    if not is_decompose_enabled():
+        return [question]
+
+    if len(q.split()) < MIN_TOKENS:
+        logger.debug("DECOMPOSE_SKIPPED reason=short_query tokens=%d", len(q.split()))
+        return [question]
+
+    groq_key = os.getenv("GROQ_API_KEY", "")
+    if not groq_key:
+        logger.debug("DECOMPOSE_SKIPPED reason=no_groq_key")
+        return [question]
+
+    try:
+        async with httpx.AsyncClient(timeout=GROQ_TIMEOUT) as client:
+            resp = await client.post(
+                GROQ_URL,
+                headers={"Authorization": f"Bearer {groq_key}"},
+                json={
+                    "model": GROQ_MODEL,
+                    "messages": [
+                        {"role": "system", "content": _SYSTEM_PROMPT},
+                        {"role": "user", "content": q},
+                    ],
+                    "temperature": 0.1,
+                    "max_tokens": 256,
+                    "response_format": {"type": "json_object"},
+                },
+            )
+            resp.raise_for_status()
+            content = resp.json()["choices"][0]["message"]["content"]
+    except Exception as exc:
+        logger.warning("DECOMPOSE_FAILED error=%s", str(exc)[:200])
+        return [question]
+
+    subqueries = _parse_subqueries(content)
+    if not subqueries:
+        logger.warning("DECOMPOSE_FAILED reason=parse_empty raw=%s", content[:200])
+        return [question]
+
+    # Always include the original question to bound worst-case quality.
+    if q not in subqueries:
+        subqueries.insert(0, q)
+
+    subqueries = subqueries[:MAX_SUBQUERIES]
+    logger.info("DECOMPOSE_OK n=%d", len(subqueries))
+    return subqueries
+
+
+def _parse_subqueries(raw: str) -> list[str]:
+    """Extract a clean list[str] of sub-queries from a model response."""
+    if not raw:
+        return []
+
+    candidate = raw.strip()
+    # Tolerate ```json ... ``` fences if the model ignores response_format.
+    fenced = re.search(r"\{.*\}", candidate, re.DOTALL)
+    if fenced:
+        candidate = fenced.group(0)
+
+    try:
+        data = json.loads(candidate)
+    except json.JSONDecodeError:
+        return []
+
+    if not isinstance(data, dict):
+        return []
+
+    raw_list = data.get("subqueries") or data.get("queries") or []
+    if not isinstance(raw_list, list):
+        return []
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in raw_list:
+        if not isinstance(item, str):
+            continue
+        s = item.strip()
+        if not s:
+            continue
+        key = s.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(s)
+    return out
+
+
+def _chunk_key(chunk: dict) -> str:
+    """Repo-canonical dedup key — matches ``neon_recall._merge_results``."""
+    return (chunk.get("content") or "")[:100]
+
+
+def merge_subquery_results(
+    per_subquery: list[list[dict]],
+    limit: int = 6,
+) -> list[dict]:
+    """Reciprocal Rank Fusion across per-sub-query result lists.
+
+    Dedup by ``content[:100]`` (matches ``neon_recall._merge_results``).
+    Each sub-query contributes ``1 / (RRF_K + rank_in_subquery)`` to a chunk's
+    score; chunks surfaced by multiple sub-queries dominate. The first
+    occurrence of a chunk wins for any non-score fields (manufacturer,
+    similarity, etc.).
+    """
+    scores: dict[str, float] = {}
+    best_row: dict[str, dict] = {}
+
+    for rows in per_subquery:
+        seen_in_stream: set[str] = set()
+        rank = 0
+        for row in rows:
+            key = _chunk_key(row)
+            if not key or key in seen_in_stream:
+                continue
+            seen_in_stream.add(key)
+            rank += 1
+            scores[key] = scores.get(key, 0.0) + 1.0 / (RRF_K + rank)
+            best_row.setdefault(key, row)
+
+    ordered = sorted(scores.keys(), key=lambda k: -scores[k])
+    merged: list[dict] = []
+    for key in ordered[:limit]:
+        row = dict(best_row[key])
+        row["rrf_score"] = round(scores[key], 6)
+        merged.append(row)
+    return merged

--- a/mira-bots/tests/test_agentic_retrieval.py
+++ b/mira-bots/tests/test_agentic_retrieval.py
@@ -1,0 +1,261 @@
+"""Tests for shared.agentic_retrieval — Component 1 (query decomposition).
+
+All Groq HTTP calls are mocked; offline-safe.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, "mira-bots")
+
+from shared.agentic_retrieval import (  # noqa: E402
+    _parse_subqueries,
+    decompose_query,
+    is_decompose_enabled,
+    merge_subquery_results,
+)
+
+
+def _mock_groq_response(content_obj: dict | str) -> MagicMock:
+    content_str = content_obj if isinstance(content_obj, str) else json.dumps(content_obj)
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value={"choices": [{"message": {"content": content_str}}]})
+    return resp
+
+
+def _patch_async_client(post_return=None, post_side_effect=None):
+    mock_client = patch("shared.agentic_retrieval.httpx.AsyncClient")
+    handle = mock_client.start()
+    instance = AsyncMock()
+    instance.__aenter__ = AsyncMock(return_value=instance)
+    instance.__aexit__ = AsyncMock(return_value=None)
+    if post_side_effect is not None:
+        instance.post = AsyncMock(side_effect=post_side_effect)
+    else:
+        instance.post = AsyncMock(return_value=post_return)
+    handle.return_value = instance
+    return mock_client, handle
+
+
+# ---------------------------------------------------------------------------
+# _parse_subqueries
+# ---------------------------------------------------------------------------
+
+
+class TestParseSubqueries:
+    def test_clean_json(self):
+        raw = json.dumps({"subqueries": ["fault code F004", "PowerFlex 525 trips on startup"]})
+        assert _parse_subqueries(raw) == [
+            "fault code F004",
+            "PowerFlex 525 trips on startup",
+        ]
+
+    def test_fenced_json(self):
+        raw = '```json\n{"subqueries": ["a", "b"]}\n```'
+        assert _parse_subqueries(raw) == ["a", "b"]
+
+    def test_dedupes_case_insensitive(self):
+        raw = json.dumps({"subqueries": ["Foo", "foo", "bar"]})
+        assert _parse_subqueries(raw) == ["Foo", "bar"]
+
+    def test_drops_blanks_and_non_strings(self):
+        raw = json.dumps({"subqueries": ["", "ok", 42, None, "  "]})
+        assert _parse_subqueries(raw) == ["ok"]
+
+    def test_garbage_returns_empty(self):
+        assert _parse_subqueries("not json") == []
+        assert _parse_subqueries("") == []
+        assert _parse_subqueries(json.dumps({"queries": "wrong type"})) == []
+
+    def test_accepts_alt_key(self):
+        raw = json.dumps({"queries": ["x", "y"]})
+        assert _parse_subqueries(raw) == ["x", "y"]
+
+
+# ---------------------------------------------------------------------------
+# is_decompose_enabled / skip paths
+# ---------------------------------------------------------------------------
+
+
+class TestSkipPaths:
+    @pytest.mark.asyncio
+    async def test_flag_off_returns_original(self, monkeypatch):
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "0")
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        with patch("shared.agentic_retrieval.httpx.AsyncClient") as mock_client:
+            out = await decompose_query("why does my PowerFlex 525 trip on overcurrent at startup")
+            assert out == ["why does my PowerFlex 525 trip on overcurrent at startup"]
+            mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_short_query_skipped(self, monkeypatch):
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "1")
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        with patch("shared.agentic_retrieval.httpx.AsyncClient") as mock_client:
+            out = await decompose_query("VFD trip")
+            assert out == ["VFD trip"]
+            mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_groq_key_skipped(self, monkeypatch):
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "1")
+        monkeypatch.setenv("GROQ_API_KEY", "")
+        with patch("shared.agentic_retrieval.httpx.AsyncClient") as mock_client:
+            out = await decompose_query("why does my PowerFlex 525 trip on overcurrent at startup")
+            assert out == ["why does my PowerFlex 525 trip on overcurrent at startup"]
+            mock_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_question_returns_input(self, monkeypatch):
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "1")
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        out = await decompose_query("")
+        assert out == [""]
+
+    def test_is_decompose_enabled(self, monkeypatch):
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "0")
+        assert is_decompose_enabled() is False
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "1")
+        assert is_decompose_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# decompose_query — happy path + failure
+# ---------------------------------------------------------------------------
+
+
+class TestDecomposeQuery:
+    @pytest.mark.asyncio
+    async def test_groq_success_returns_subqueries(self, monkeypatch):
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "1")
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        mock_resp = _mock_groq_response(
+            {
+                "subqueries": [
+                    "PowerFlex 525 fault code F004",
+                    "PowerFlex 525 motor sizing 10HP",
+                    "PowerFlex 525 acceleration time parameter",
+                ]
+            }
+        )
+        ctx, _ = _patch_async_client(post_return=mock_resp)
+        try:
+            q = "Why does my PowerFlex 525 trip on overcurrent at startup with a 10HP motor"
+            out = await decompose_query(q)
+        finally:
+            ctx.stop()
+
+        assert len(out) >= 3
+        # Original question is always included for safety.
+        assert q in out
+        # Spec subqueries preserved verbatim.
+        assert "PowerFlex 525 fault code F004" in out
+
+    @pytest.mark.asyncio
+    async def test_groq_already_includes_original(self, monkeypatch):
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "1")
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        q = "What does fault F004 mean on a PowerFlex 525"
+        mock_resp = _mock_groq_response({"subqueries": [q, "F004 overcurrent meaning"]})
+        ctx, _ = _patch_async_client(post_return=mock_resp)
+        try:
+            out = await decompose_query(q)
+        finally:
+            ctx.stop()
+        # Original not duplicated.
+        assert out.count(q) == 1
+
+    @pytest.mark.asyncio
+    async def test_max_cap_enforced(self, monkeypatch):
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "1")
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        monkeypatch.setenv("MIRA_DECOMPOSE_MAX_SUBQUERIES", "4")
+        # Reload module to pick up env override at import-time constant.
+        import importlib
+
+        from shared import agentic_retrieval
+
+        importlib.reload(agentic_retrieval)
+
+        mock_resp = _mock_groq_response({"subqueries": [f"sub{i}" for i in range(8)]})
+        ctx, _ = _patch_async_client(post_return=mock_resp)
+        try:
+            out = await agentic_retrieval.decompose_query(
+                "tell me everything about VFDs and motors and faults and parameters"
+            )
+        finally:
+            ctx.stop()
+        assert len(out) <= 4
+
+    @pytest.mark.asyncio
+    async def test_groq_failure_fails_open(self, monkeypatch):
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "1")
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        ctx, _ = _patch_async_client(post_side_effect=RuntimeError("network down"))
+        try:
+            q = "why does my PowerFlex 525 trip on overcurrent at startup"
+            out = await decompose_query(q)
+        finally:
+            ctx.stop()
+        assert out == [q]
+
+    @pytest.mark.asyncio
+    async def test_groq_returns_unparseable_fails_open(self, monkeypatch):
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "1")
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        mock_resp = _mock_groq_response("definitely not json {{{")
+        ctx, _ = _patch_async_client(post_return=mock_resp)
+        try:
+            q = "why does my PowerFlex 525 trip on overcurrent at startup"
+            out = await decompose_query(q)
+        finally:
+            ctx.stop()
+        assert out == [q]
+
+
+# ---------------------------------------------------------------------------
+# merge_subquery_results
+# ---------------------------------------------------------------------------
+
+
+class TestMergeSubqueryResults:
+    def test_dedup_by_content_prefix(self):
+        c1 = "PowerFlex 525 F004 overcurrent during acceleration ramp"
+        chunk = {"content": c1, "manufacturer": "AB", "similarity": 0.9}
+        per = [[chunk], [dict(chunk)]]
+        merged = merge_subquery_results(per, limit=10)
+        assert len(merged) == 1
+        # rrf_score reflects the chunk being seen twice.
+        assert merged[0]["rrf_score"] > 0
+
+    def test_cross_subquery_agreement_wins(self):
+        a = {"content": "A" * 120, "similarity": 0.5}
+        b = {"content": "B" * 120, "similarity": 0.9}
+        # `a` ranked #1 in two streams; `b` only in one.
+        per = [[a, b], [a]]
+        merged = merge_subquery_results(per, limit=10)
+        assert merged[0]["content"].startswith("A")
+
+    def test_limit_respected(self):
+        per = [
+            [{"content": f"chunk-{i}-" + "x" * 100} for i in range(5)],
+            [{"content": f"chunk-{i}-" + "y" * 100} for i in range(5, 10)],
+        ]
+        merged = merge_subquery_results(per, limit=3)
+        assert len(merged) == 3
+
+    def test_empty_input(self):
+        assert merge_subquery_results([], limit=6) == []
+        assert merge_subquery_results([[], []], limit=6) == []
+
+    def test_skips_empty_content(self):
+        per = [[{"content": ""}, {"content": "real chunk " + "x" * 100}]]
+        merged = merge_subquery_results(per, limit=6)
+        assert len(merged) == 1
+        assert merged[0]["content"].startswith("real chunk")


### PR DESCRIPTION
## Summary

Implements Component 1 of `docs/specs/agentic-rag-upgrade-spec.md` — query decomposition. Adds `mira-bots/shared/agentic_retrieval.py` with two functions:

- `decompose_query(question)` — splits a complex maintenance question into 2–4 focused sub-queries via a Groq `llama-3.1-8b-instant` call. Each sub-query is meant to hit the existing `neon_recall.recall_knowledge` pipeline independently.
- `merge_subquery_results(per_subquery, limit)` — Reciprocal Rank Fusion across per-sub-query result lists, deduplicated by `content[:100]` (matches `neon_recall._merge_results`).

Flag-gated by `MIRA_QUERY_DECOMPOSE` (default `0` — off). Fail-open: Groq error, missing key, parse failure, or short query all return `[question]` so callers behave byte-identically to today. The original question is always included in the returned list to bound worst-case retrieval quality.

C2 (hybrid retrieval flag-exposure) and C3 (self-evaluation + retry) are deferred to follow-up PRs per spec §5 rollout plan. No `RAGWorker.process` integration in this PR — Component 1 is wired up in a follow-up once benchmarked.

**No new dependencies.** Reuses existing `httpx` direct-Groq pattern from `shared/dialogue_acts.py` and `shared/conversation_router.py`.

## Test plan

- [x] 21 offline-safe pytest tests covering parse, skip paths, happy path, fail-open on Groq error, fail-open on unparseable response, max-subqueries cap, RRF dedup, cross-subquery agreement, limit enforcement.
- [ ] CI Unit Tests pass.
- [ ] Ruff lint + format clean.
- [ ] No regression in existing eval suite (component is flag-OFF by default — should be no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)