### PR TITLE
fix(infra): tech debt P0s + P1 memory limits (#1138, #1139, #1140)

### DIFF
--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -3,7 +3,6 @@ services:
     build:
       context: ./mira-hub
       dockerfile: Dockerfile
-    image: mira-hub:latest
     container_name: mira-hub
     restart: unless-stopped
     ports:

--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -61,9 +61,11 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     environment:
-      - LLM_PROVIDER=anthropic
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - LLM_MODEL_ANTHROPIC=claude-sonnet-4-6
+      # PRD §4: No Anthropic — sidecar is legacy (sunset pending, ADR-0008).
+      # Local Ollama covers any residual /rag callers; active chat path is
+      # mira-pipeline, not this service.
+      - LLM_PROVIDER=ollama
+      - LLM_MODEL_OLLAMA=${LLM_MODEL_OLLAMA:-llama3}
       - EMBEDDING_PROVIDER=ollama
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       - OLLAMA_EMBED_MODEL=nomic-embed-text
@@ -77,6 +79,10 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/status')"]
       interval: 30s
@@ -106,6 +112,10 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')"]
       interval: 30s
@@ -176,6 +186,10 @@ services:
       - mira-net
       - cmms-ext
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
       interval: 30s
@@ -321,6 +335,10 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/health')"]
       interval: 30s
@@ -343,6 +361,10 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U nango"]
       interval: 10s
@@ -384,6 +406,10 @@ services:
       nango-db:
         condition: service_healthy
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3003/health"]
       interval: 30s
@@ -521,6 +547,10 @@ services:
       - mira-net
       - cmms-ext
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
     depends_on:
       - mira-hub
 

--- a/mira-hub/src/lib/agents/asset-intelligence.ts
+++ b/mira-hub/src/lib/agents/asset-intelligence.ts
@@ -100,7 +100,7 @@ function equipmentTypeToCorpus(type: string): string {
 }
 
 async function getOllamaEmbedding(text: string): Promise<number[] | null> {
-  const base = process.env.OLLAMA_BASE_URL ?? "http://192.168.1.11:11434";
+  const base = process.env.OLLAMA_BASE_URL ?? "http://100.86.236.11:11434";
   try {
     const resp = await fetch(`${base}/api/embeddings`, {
       method: "POST",


### PR DESCRIPTION
## Summary

Fixes 3 P0s + 1 P1 from the 2026-05-10 tech debt audit (`docs/audits/2026-05-10-tech-debt-audit.md`).

### P0s
- **#1138** Remove `ANTHROPIC_API_KEY` from `docker-compose.saas.yml` (PRD §4 compliance). mira-sidecar (legacy, sunset pending) was the last Anthropic caller; switched its `LLM_PROVIDER` to `ollama` — embedding was already ollama, active chat path is mira-pipeline.
- **#1139** Drop `mira-hub:latest` tag from `docker-compose.hub.yml`. The `build:` directive covers it; the stale `image:` line shadowed fresh builds. Matches `docker-compose.saas.yml` convention.
- **#1140** Replace hardcoded `192.168.1.11` in `mira-hub/src/lib/agents/asset-intelligence.ts:103` with Bravo's Tailscale IP (`100.86.236.11`). `OLLAMA_BASE_URL` env still takes precedence.

### P1
- **Memory limits** added to services in `docker-compose.saas.yml` that were missing them: mira-sidecar 1G, mira-ingest 1G, mira-web 512M, mira-relay 256M, nango-db 512M, nango-server 1G, mira-cmms-sync 256M.

### P1s skipped (already compliant)
- **console.log scan**: 7 hits, all legitimate (logger module, ops status logs, dev-only fallback when `RESEND_API_KEY` absent).
- **`restart: always`**: zero hits across all compose files.
- **TODO/FIXME scan**: 2 hits, both reference issue #578.

## Test plan
- [x] `docker compose -f docker-compose.saas.yml config --quiet` — no errors
- [x] `docker compose -f docker-compose.hub.yml config --quiet` — no errors
- [x] `grep ANTHROPIC docker-compose.saas.yml` — no matches
- [ ] Deploy to VPS and confirm mira-sidecar starts under ollama provider (sidecar is sunset-pending, low risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)