### PR TITLE
feat(rag): agentic RAG components 2 + 3 — self-eval + wiring

### DIFF
--- a/mira-bots/shared/agentic_retrieval.py
+++ b/mira-bots/shared/agentic_retrieval.py
@@ -219,9 +219,8 @@ async def evaluate_retrieval(
     if not sample:
         return (True, 0.5, None)
 
-    user_msg = (
-        f"Question: {q}\n\nChunks:\n"
-        + "\n---\n".join(f"[{i + 1}] {t}" for i, t in enumerate(sample))
+    user_msg = f"Question: {q}\n\nChunks:\n" + "\n---\n".join(
+        f"[{i + 1}] {t}" for i, t in enumerate(sample)
     )
 
     try:
@@ -298,11 +297,7 @@ async def _reformulate_query(
     equipment_context: str | None,
     groq_key: str,
 ) -> str | None:
-    ctx_line = (
-        f"Equipment context: {equipment_context}\n"
-        if equipment_context
-        else ""
-    )
+    ctx_line = f"Equipment context: {equipment_context}\n" if equipment_context else ""
     user_msg = f"{ctx_line}Original question: {question}"
     try:
         async with httpx.AsyncClient(timeout=GROQ_TIMEOUT) as client:

--- a/mira-bots/shared/agentic_retrieval.py
+++ b/mira-bots/shared/agentic_retrieval.py
@@ -1,20 +1,17 @@
-"""Agentic retrieval primitives — Component 1: query decomposition.
+"""Agentic retrieval primitives — Components 1 + 2.
 
-Spec: docs/specs/agentic-rag-upgrade-spec.md (Component 1).
+Spec: docs/specs/agentic-rag-upgrade-spec.md.
 
-Splits a complex user question into 2-4 focused sub-queries via a cheap
-Groq llama-3.1-8b-instant call so each concern hits the existing retrieval
-pipeline (`neon_recall.recall_knowledge`) independently. Per-sub-query
-results are merged via Reciprocal Rank Fusion (same RRF_K as
-`neon_recall._merge_results`) and deduplicated using the repo's existing
-key (`content[:100]`).
+C1 (``decompose_query``): splits a complex question into 2-4 focused
+sub-queries via Groq llama-3.1-8b-instant; per-sub-query results merged
+via RRF in ``merge_subquery_results``. Flag-gated by
+``MIRA_QUERY_DECOMPOSE`` (default ``0``). Fail-open to ``[question]``.
 
-Flag-gated by ``MIRA_QUERY_DECOMPOSE`` (default ``0``). Fail-open: any Groq
-or parse error returns ``[question]`` so callers behave identically to
-today.
-
-C2 (hybrid retrieval) and C3 (self-evaluation) are deferred to follow-up
-PRs per the spec rollout plan.
+C2 (``evaluate_retrieval``): scores retrieved chunks 1-10 for relevance
+to the question via Groq; below threshold, returns a reformulated query
+the caller can retry with (1 retry max). Flag-gated by
+``MIRA_RAG_SELF_EVAL`` (default ``0``). Fail-open to
+``(True, 5.0, None)`` so retrieval is never blocked on Groq errors.
 """
 
 from __future__ import annotations
@@ -158,6 +155,194 @@ def _parse_subqueries(raw: str) -> list[str]:
 def _chunk_key(chunk: dict) -> str:
     """Repo-canonical dedup key — matches ``neon_recall._merge_results``."""
     return (chunk.get("content") or "")[:100]
+
+
+# ---------------------------------------------------------------------------
+# Component 2 — retrieval self-evaluation
+# ---------------------------------------------------------------------------
+
+SELF_EVAL_THRESHOLD = float(os.getenv("MIRA_RAG_SELF_EVAL_THRESHOLD", "0.4"))
+SELF_EVAL_CHUNKS = int(os.getenv("MIRA_RAG_SELF_EVAL_CHUNKS", "5"))
+SELF_EVAL_CHUNK_CHARS = int(os.getenv("MIRA_RAG_SELF_EVAL_CHARS", "500"))
+
+_EVAL_SYSTEM_PROMPT = (
+    "You rate how relevant retrieved document chunks are to an industrial "
+    "maintenance question. Output JSON only: "
+    '{"score": <1-10 integer>, "reason": "<short>"}. '
+    "10 = chunks directly answer the question. 1 = chunks are unrelated. "
+    "Be strict: chunks about a different manufacturer or unrelated equipment "
+    "score below 4."
+)
+
+_REFORMULATE_SYSTEM_PROMPT = (
+    "You rewrite an industrial maintenance question into a better search "
+    "query, using equipment context when provided. Output JSON only: "
+    '{"query": "<rewritten search phrase>"}. '
+    "Rules: keep manufacturer, model, and fault codes verbatim; use specific "
+    "technical terms; produce a single self-contained search phrase."
+)
+
+
+def is_self_eval_enabled() -> bool:
+    return os.getenv("MIRA_RAG_SELF_EVAL", "0") == "1"
+
+
+async def evaluate_retrieval(
+    question: str,
+    chunks: list[dict],
+    threshold: float = SELF_EVAL_THRESHOLD,
+    equipment_context: str | None = None,
+) -> tuple[bool, float, str | None]:
+    """Score retrieved chunks 1-10 (normalized to 0-1) for relevance.
+
+    Returns ``(is_relevant, normalized_score, reformulated_query_or_None)``.
+
+    Fail-open: any Groq/parse error returns ``(True, 0.5, None)`` so the
+    caller proceeds with the original chunks. When ``score < threshold`` and
+    Groq successfully proposes a reformulation, the third tuple element is
+    the new query; otherwise ``None``.
+    """
+    q = (question or "").strip()
+    if not q or not chunks:
+        return (True, 0.5, None)
+
+    groq_key = os.getenv("GROQ_API_KEY", "")
+    if not groq_key:
+        logger.debug("SELF_EVAL_SKIPPED reason=no_groq_key")
+        return (True, 0.5, None)
+
+    sample = []
+    for c in chunks[:SELF_EVAL_CHUNKS]:
+        text = (c.get("content") or "")[:SELF_EVAL_CHUNK_CHARS]
+        if text:
+            sample.append(text)
+    if not sample:
+        return (True, 0.5, None)
+
+    user_msg = (
+        f"Question: {q}\n\nChunks:\n"
+        + "\n---\n".join(f"[{i + 1}] {t}" for i, t in enumerate(sample))
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=GROQ_TIMEOUT) as client:
+            resp = await client.post(
+                GROQ_URL,
+                headers={"Authorization": f"Bearer {groq_key}"},
+                json={
+                    "model": GROQ_MODEL,
+                    "messages": [
+                        {"role": "system", "content": _EVAL_SYSTEM_PROMPT},
+                        {"role": "user", "content": user_msg},
+                    ],
+                    "temperature": 0.1,
+                    "max_tokens": 128,
+                    "response_format": {"type": "json_object"},
+                },
+            )
+            resp.raise_for_status()
+            content = resp.json()["choices"][0]["message"]["content"]
+    except Exception as exc:
+        logger.warning("SELF_EVAL_FAILED error=%s", str(exc)[:200])
+        return (True, 0.5, None)
+
+    raw_score = _parse_eval_score(content)
+    if raw_score is None:
+        logger.warning("SELF_EVAL_PARSE_FAILED raw=%s", content[:200])
+        return (True, 0.5, None)
+
+    normalized = max(0.0, min(1.0, raw_score / 10.0))
+    is_relevant = normalized >= threshold
+    logger.info(
+        "SELF_EVAL score=%.2f relevant=%s threshold=%.2f",
+        normalized,
+        is_relevant,
+        threshold,
+    )
+
+    if is_relevant:
+        return (True, normalized, None)
+
+    reformulated = await _reformulate_query(q, equipment_context, groq_key)
+    return (False, normalized, reformulated)
+
+
+def _parse_eval_score(raw: str) -> float | None:
+    if not raw:
+        return None
+    candidate = raw.strip()
+    fenced = re.search(r"\{.*\}", candidate, re.DOTALL)
+    if fenced:
+        candidate = fenced.group(0)
+    try:
+        data = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    score = data.get("score")
+    if isinstance(score, bool):
+        return None
+    if isinstance(score, (int, float)):
+        return float(score)
+    if isinstance(score, str):
+        try:
+            return float(score)
+        except ValueError:
+            return None
+    return None
+
+
+async def _reformulate_query(
+    question: str,
+    equipment_context: str | None,
+    groq_key: str,
+) -> str | None:
+    ctx_line = (
+        f"Equipment context: {equipment_context}\n"
+        if equipment_context
+        else ""
+    )
+    user_msg = f"{ctx_line}Original question: {question}"
+    try:
+        async with httpx.AsyncClient(timeout=GROQ_TIMEOUT) as client:
+            resp = await client.post(
+                GROQ_URL,
+                headers={"Authorization": f"Bearer {groq_key}"},
+                json={
+                    "model": GROQ_MODEL,
+                    "messages": [
+                        {"role": "system", "content": _REFORMULATE_SYSTEM_PROMPT},
+                        {"role": "user", "content": user_msg},
+                    ],
+                    "temperature": 0.1,
+                    "max_tokens": 128,
+                    "response_format": {"type": "json_object"},
+                },
+            )
+            resp.raise_for_status()
+            content = resp.json()["choices"][0]["message"]["content"]
+    except Exception as exc:
+        logger.warning("REFORMULATE_FAILED error=%s", str(exc)[:200])
+        return None
+
+    candidate = content.strip()
+    fenced = re.search(r"\{.*\}", candidate, re.DOTALL)
+    if fenced:
+        candidate = fenced.group(0)
+    try:
+        data = json.loads(candidate)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    new_q = data.get("query")
+    if not isinstance(new_q, str):
+        return None
+    new_q = new_q.strip()
+    if not new_q or new_q.lower() == question.lower():
+        return None
+    return new_q
 
 
 def merge_subquery_results(

--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -13,7 +13,9 @@ import yaml
 from .. import neon_recall as _neon_recall
 from ..agentic_retrieval import (
     decompose_query,
+    evaluate_retrieval,
     is_decompose_enabled,
+    is_self_eval_enabled,
     merge_subquery_results,
 )
 from ..guardrails import rewrite_question, vendor_name_from_text, vendor_support_url
@@ -355,6 +357,38 @@ class RAGWorker:
                                     effective_tenant,
                                     query_text=embed_query,
                                 )
+
+                        if is_self_eval_enabled() and neon_chunks:
+                            try:
+                                eq_ctx = state.get("asset_identified") or None
+                                is_rel, score, reformulated = await evaluate_retrieval(
+                                    embed_query,
+                                    neon_chunks,
+                                    equipment_context=eq_ctx,
+                                )
+                                logger.info(
+                                    "RAG_SELF_EVAL score=%.2f relevant=%s reformulated=%s",
+                                    score,
+                                    is_rel,
+                                    bool(reformulated),
+                                )
+                                if not is_rel and reformulated:
+                                    retry_emb = await self._embed_ollama(reformulated)
+                                    if retry_emb:
+                                        retry_chunks = _neon_recall.recall_knowledge(
+                                            retry_emb,
+                                            effective_tenant,
+                                            query_text=reformulated,
+                                        )
+                                        if retry_chunks:
+                                            logger.info(
+                                                "RAG_SELF_EVAL_RETRY n_chunks=%d query=%r",
+                                                len(retry_chunks),
+                                                reformulated[:80],
+                                            )
+                                            neon_chunks = retry_chunks
+                            except Exception as exc:
+                                logger.warning("SELF_EVAL_CALL_FAILED %s", exc)
 
             # Extract chunk texts for reranking / telemetry
             chunk_texts = [c["content"] for c in neon_chunks]

--- a/mira-bots/tests/test_agentic_retrieval.py
+++ b/mira-bots/tests/test_agentic_retrieval.py
@@ -14,9 +14,12 @@ import pytest
 sys.path.insert(0, "mira-bots")
 
 from shared.agentic_retrieval import (  # noqa: E402
+    _parse_eval_score,
     _parse_subqueries,
     decompose_query,
+    evaluate_retrieval,
     is_decompose_enabled,
+    is_self_eval_enabled,
     merge_subquery_results,
 )
 
@@ -259,3 +262,229 @@ class TestMergeSubqueryResults:
         merged = merge_subquery_results(per, limit=6)
         assert len(merged) == 1
         assert merged[0]["content"].startswith("real chunk")
+
+
+# ---------------------------------------------------------------------------
+# Component 2 — _parse_eval_score
+# ---------------------------------------------------------------------------
+
+
+class TestParseEvalScore:
+    def test_clean_int(self):
+        assert _parse_eval_score(json.dumps({"score": 8, "reason": "x"})) == 8.0
+
+    def test_clean_float(self):
+        assert _parse_eval_score(json.dumps({"score": 7.5})) == 7.5
+
+    def test_string_score(self):
+        assert _parse_eval_score(json.dumps({"score": "6"})) == 6.0
+
+    def test_fenced(self):
+        assert _parse_eval_score('```json\n{"score": 3}\n```') == 3.0
+
+    def test_invalid_returns_none(self):
+        assert _parse_eval_score("not json") is None
+        assert _parse_eval_score("") is None
+        assert _parse_eval_score(json.dumps({"score": True})) is None
+        assert _parse_eval_score(json.dumps({"score": "abc"})) is None
+        assert _parse_eval_score(json.dumps({})) is None
+
+
+# ---------------------------------------------------------------------------
+# Component 2 — evaluate_retrieval
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateRetrieval:
+    @pytest.mark.asyncio
+    async def test_relevant_chunks_high_score(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        mock_resp = _mock_groq_response({"score": 9, "reason": "directly answers"})
+        ctx, _ = _patch_async_client(post_return=mock_resp)
+        try:
+            chunks = [{"content": "PowerFlex 525 fault F004 means overcurrent on accel"}]
+            is_rel, score, reformulated = await evaluate_retrieval(
+                "what does F004 mean on a PowerFlex 525", chunks
+            )
+        finally:
+            ctx.stop()
+        assert is_rel is True
+        assert score == pytest.approx(0.9)
+        assert reformulated is None
+
+    @pytest.mark.asyncio
+    async def test_irrelevant_chunks_low_score_triggers_reformulation(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        eval_resp = _mock_groq_response({"score": 2, "reason": "wrong manufacturer"})
+        reform_resp = _mock_groq_response(
+            {"query": "PowerFlex 525 F004 overcurrent fault accel time"}
+        )
+        ctx, _ = _patch_async_client(post_side_effect=[eval_resp, reform_resp])
+        try:
+            chunks = [{"content": "Siemens G120 motor controller user manual chapter 3"}]
+            is_rel, score, reformulated = await evaluate_retrieval(
+                "what does F004 mean on a PowerFlex 525",
+                chunks,
+                equipment_context="Allen-Bradley PowerFlex 525",
+            )
+        finally:
+            ctx.stop()
+        assert is_rel is False
+        assert score == pytest.approx(0.2)
+        assert reformulated == "PowerFlex 525 F004 overcurrent fault accel time"
+
+    @pytest.mark.asyncio
+    async def test_groq_failure_fails_open(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        ctx, _ = _patch_async_client(post_side_effect=RuntimeError("network down"))
+        try:
+            is_rel, score, reformulated = await evaluate_retrieval(
+                "any question", [{"content": "any chunk"}]
+            )
+        finally:
+            ctx.stop()
+        assert is_rel is True
+        assert score == 0.5
+        assert reformulated is None
+
+    @pytest.mark.asyncio
+    async def test_no_chunks_fails_open(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        with patch("shared.agentic_retrieval.httpx.AsyncClient") as mock_client:
+            is_rel, score, reformulated = await evaluate_retrieval("question", [])
+            mock_client.assert_not_called()
+        assert is_rel is True
+        assert score == 0.5
+        assert reformulated is None
+
+    @pytest.mark.asyncio
+    async def test_no_groq_key_fails_open(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "")
+        with patch("shared.agentic_retrieval.httpx.AsyncClient") as mock_client:
+            is_rel, score, reformulated = await evaluate_retrieval(
+                "question", [{"content": "chunk"}]
+            )
+            mock_client.assert_not_called()
+        assert is_rel is True
+        assert score == 0.5
+        assert reformulated is None
+
+    @pytest.mark.asyncio
+    async def test_unparseable_score_fails_open(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        bad_resp = _mock_groq_response("not json {{{")
+        ctx, _ = _patch_async_client(post_return=bad_resp)
+        try:
+            is_rel, score, reformulated = await evaluate_retrieval(
+                "question", [{"content": "chunk"}]
+            )
+        finally:
+            ctx.stop()
+        assert is_rel is True
+        assert score == 0.5
+        assert reformulated is None
+
+    @pytest.mark.asyncio
+    async def test_low_score_no_reformulation_when_groq_fails_second_call(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        eval_resp = _mock_groq_response({"score": 1, "reason": "irrelevant"})
+        ctx, _ = _patch_async_client(
+            post_side_effect=[eval_resp, RuntimeError("reformulate failed")]
+        )
+        try:
+            is_rel, score, reformulated = await evaluate_retrieval(
+                "what does F004 mean", [{"content": "unrelated"}]
+            )
+        finally:
+            ctx.stop()
+        assert is_rel is False
+        assert score == pytest.approx(0.1)
+        assert reformulated is None
+
+    @pytest.mark.asyncio
+    async def test_threshold_boundary_relevant(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        # score=4 -> normalized=0.4 -> >= threshold 0.4 -> relevant, no reformulation call.
+        mock_resp = _mock_groq_response({"score": 4})
+        ctx, _ = _patch_async_client(post_return=mock_resp)
+        try:
+            is_rel, score, reformulated = await evaluate_retrieval(
+                "q", [{"content": "c"}], threshold=0.4
+            )
+        finally:
+            ctx.stop()
+        assert is_rel is True
+        assert score == pytest.approx(0.4)
+        assert reformulated is None
+
+    @pytest.mark.asyncio
+    async def test_chunk_content_truncated_in_prompt(self, monkeypatch):
+        """Long chunks get truncated to keep the eval prompt small."""
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        mock_resp = _mock_groq_response({"score": 8})
+        ctx, handle = _patch_async_client(post_return=mock_resp)
+        try:
+            big = "x" * 10_000
+            await evaluate_retrieval("q", [{"content": big}])
+            instance = handle.return_value
+            call = instance.post.call_args
+            sent = call.kwargs["json"]["messages"][1]["content"]
+        finally:
+            ctx.stop()
+        # 500 char default + framing must be far smaller than the input.
+        assert len(sent) < 1000
+
+    @pytest.mark.asyncio
+    async def test_reformulation_skipped_when_identical(self, monkeypatch):
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        eval_resp = _mock_groq_response({"score": 2})
+        reform_resp = _mock_groq_response({"query": "same question"})
+        ctx, _ = _patch_async_client(post_side_effect=[eval_resp, reform_resp])
+        try:
+            is_rel, _, reformulated = await evaluate_retrieval(
+                "same question", [{"content": "c"}]
+            )
+        finally:
+            ctx.stop()
+        assert is_rel is False
+        assert reformulated is None
+
+
+class TestSelfEvalFlag:
+    def test_flag_default_off(self, monkeypatch):
+        monkeypatch.delenv("MIRA_RAG_SELF_EVAL", raising=False)
+        assert is_self_eval_enabled() is False
+
+    def test_flag_on(self, monkeypatch):
+        monkeypatch.setenv("MIRA_RAG_SELF_EVAL", "1")
+        assert is_self_eval_enabled() is True
+
+    def test_flag_other_value(self, monkeypatch):
+        monkeypatch.setenv("MIRA_RAG_SELF_EVAL", "true")
+        assert is_self_eval_enabled() is False
+
+
+class TestDecomposeAndEvaluateTogether:
+    """C1 + C2 work independently (each behind its own flag) and together."""
+
+    @pytest.mark.asyncio
+    async def test_decompose_then_evaluate_high_score(self, monkeypatch):
+        monkeypatch.setenv("MIRA_QUERY_DECOMPOSE", "1")
+        monkeypatch.setenv("GROQ_API_KEY", "k")
+        decompose_resp = _mock_groq_response(
+            {"subqueries": ["F004 fault meaning", "PowerFlex 525 overcurrent accel"]}
+        )
+        eval_resp = _mock_groq_response({"score": 8})
+        ctx, _ = _patch_async_client(post_side_effect=[decompose_resp, eval_resp])
+        try:
+            q = "Why does my PowerFlex 525 throw F004 on accel with a 10HP motor"
+            subs = await decompose_query(q)
+            chunks = [{"content": "PowerFlex 525 manual chapter 4: F004 overcurrent"}]
+            is_rel, score, reformulated = await evaluate_retrieval(q, chunks)
+        finally:
+            ctx.stop()
+        assert q in subs
+        assert len(subs) >= 2
+        assert is_rel is True
+        assert score == pytest.approx(0.8)
+        assert reformulated is None

--- a/mira-bots/tests/test_agentic_retrieval.py
+++ b/mira-bots/tests/test_agentic_retrieval.py
@@ -441,9 +441,7 @@ class TestEvaluateRetrieval:
         reform_resp = _mock_groq_response({"query": "same question"})
         ctx, _ = _patch_async_client(post_side_effect=[eval_resp, reform_resp])
         try:
-            is_rel, _, reformulated = await evaluate_retrieval(
-                "same question", [{"content": "c"}]
-            )
+            is_rel, _, reformulated = await evaluate_retrieval("same question", [{"content": "c"}])
         finally:
             ctx.stop()
         assert is_rel is False


### PR DESCRIPTION
## Summary

Completes the agentic RAG upgrade (C1 was #1135 + #1136).

- **Component 2 — `evaluate_retrieval()`** (`mira-bots/shared/agentic_retrieval.py`): scores retrieved chunks 1-10 for relevance via Groq llama-3.1-8b-instant; below threshold (default 0.4 normalized) asks Groq to reformulate the query using equipment context from FSM state. Returns `(is_relevant, score, reformulated_or_None)`. Fail-open on any error to `(True, 0.5, None)` — retrieval is never blocked.
- **Component 3 — wiring** (`mira-bots/shared/workers/rag_worker.py`): self-eval runs after the existing text-path retrieval; on a low score with a non-trivial reformulation it retries once via `_embed_ollama` + `recall_knowledge`. C1 (decompose) and C2 (self-eval) flags are independent — both off, either alone, or both together.

Flags (default OFF):
- `MIRA_QUERY_DECOMPOSE=1` — C1
- `MIRA_RAG_SELF_EVAL=1` — C2
- `MIRA_RAG_SELF_EVAL_THRESHOLD=0.4` — tunable
- `MIRA_RAG_SELF_EVAL_CHUNKS=5`, `MIRA_RAG_SELF_EVAL_CHARS=500` — prompt size caps

## Test plan

- [x] 18 new tests added (40 total in `test_agentic_retrieval.py`); all green offline
  - `_parse_eval_score`: clean int / float / string / fenced / invalid (5)
  - `evaluate_retrieval`: high score, low + reformulate, Groq fail, no chunks, no key, unparseable, second-call fail, threshold boundary, prompt truncation, identical-reformulation skip (10)
  - flag enablement defaults (3)
  - C1+C2 combined wiring (1)
  - bonus parse-related (rest)
- [x] Existing C1 tests unchanged — still pass
- [ ] CI checks