### PR TITLE
fix(hub): trailing-slash for asset API fetches (CRA-256)

### DIFF
--- a/mira-hub/src/app/(hub)/assets/[id]/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/[id]/page.tsx
@@ -116,10 +116,12 @@ export default function AssetDetailPage({ params }: { params: Promise<{ id: stri
     if (generatingQr || isQrBound) return;
     setGeneratingQr(true);
     try {
-      const res = await fetch(`/hub/api/assets/${id}/qr`, { method: "POST" });
+      // Trailing slash matches next.config trailingSlash:true — without it,
+      // Next.js issues a 308 redirect, fetch follows it, and res.redirected
+      // becomes true even though no auth-redirect happened.
+      const res = await fetch(`/hub/api/assets/${id}/qr/`, { method: "POST" });
       // Middleware redirects unauthenticated requests to /login, returning HTML.
-      // res.redirected captures that even after fetch follows the redirect.
-      if (res.redirected || res.url.includes("/login")) {
+      if (res.url.includes("/login")) {
         window.location.href = "/hub/login";
         return;
       }
@@ -132,7 +134,11 @@ export default function AssetDetailPage({ params }: { params: Promise<{ id: stri
         return;
       }
       if (res.ok && data.tag) {
-        setApiAsset((prev) => prev ? { ...prev, tag: data.tag!, qrGeneratedAt: data.qrGeneratedAt ?? null } : prev);
+        setApiAsset((prev) =>
+          prev
+            ? { ...prev, tag: data.tag!, qrGeneratedAt: data.qrGeneratedAt ?? null }
+            : prev,
+        );
         setShowQr(true);
       } else {
         console.error("[generate-qr] failed", res.status, data);
@@ -147,8 +153,8 @@ export default function AssetDetailPage({ params }: { params: Promise<{ id: stri
   }
 
   useEffect(() => {
-    fetch(`/hub/api/assets/${id}`)
-      .then(r => (r.ok && !r.redirected && !r.url.includes("/login")) ? r.json() : null)
+    fetch(`/hub/api/assets/${id}/`)
+      .then(r => (r.ok && !r.url.includes("/login")) ? r.json() : null)
       .then(data => { if (data && !data.error) setApiAsset(data); })
       .finally(() => setLoading(false));
   }, [id]);


### PR DESCRIPTION
## Summary
- Root cause of persistent QR Generate button bug: `next.config trailingSlash: true` causes 308 redirect on `/hub/api/assets/<id>/qr` → `/qr/`. fetch follows it, `res.redirected` becomes true, and c489eca3's auth-redirect check then bounces user to `/hub/login`.
- Same trap on the GET in useEffect — `apiAsset` stayed null so `isQrBound` was always false.
- Fix: request trailing-slash URLs directly + drop `res.redirected` from the auth check.

## Verification
```
curl -i POST /hub/api/assets/test-id/qr   → 308 → /qr/   (reproduces bug)
curl -i POST /hub/api/assets/test-id/qr/  → reaches route handler
```

## Test plan
- [ ] Deploy to CHARLIE VPS
- [ ] Log in as SR-SUMP-001 tenant user
- [ ] Click Generate QR on SR-SUMP-001 detail page
- [ ] Modal opens with valid QR

🤖 Generated with [Claude Code](https://claude.com/claude-code)