### PR TITLE
feat(ignition): ST parser + tag export endpoint (CRA-232, CRA-235)

### DIFF
--- a/ignition/tags_micro800.json
+++ b/ignition/tags_micro800.json
@@ -1,0 +1,573 @@
+{
+  "name": "default",
+  "tagType": "Provider",
+  "tags": [
+    {
+      "name": "Conveyor",
+      "tagType": "Folder",
+      "tags": [
+        {
+          "name": "ConveyorRunning",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C2",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Conveyor Running",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:conveyor_running",
+            "displayName": "ConveyorRunning",
+            "namespace": "LakeWales.Line1.Conveyor.ConveyorRunning",
+            "sourceVariable": "conveyor_running",
+            "modbusAddress": "COIL:2"
+          }
+        },
+        {
+          "name": "ConveyorSpeed",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400105",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "Conveyor Speed (feedback)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:conveyor_speed",
+            "displayName": "ConveyorSpeed(feedback)",
+            "namespace": "LakeWales.Line1.Conveyor.ConveyorSpeed",
+            "sourceVariable": "conveyor_speed",
+            "modbusAddress": "HR:105"
+          }
+        },
+        {
+          "name": "ConveyorSpeedCmd",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400113",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "Conveyor Speed Command (from Ignition)",
+          "writable": true,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:conveyor_speed_cmd",
+            "displayName": "ConveyorSpeedCommand(fromIgnition)",
+            "namespace": "LakeWales.Line1.Conveyor.ConveyorSpeedCmd",
+            "sourceVariable": "conveyor_speed_cmd",
+            "modbusAddress": "HR:113"
+          }
+        },
+        {
+          "name": "ConvState",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400114",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "Conveyor State (0=IDLE 1=STARTING 2=RUNNING 3=STOPPING 4=FAULT)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:conv_state",
+            "displayName": "ConveyorState(0=idle1=starting2=running3=stopping4=fault)",
+            "namespace": "LakeWales.Line1.Conveyor.ConvState",
+            "sourceVariable": "conv_state",
+            "modbusAddress": "HR:114"
+          }
+        },
+        {
+          "name": "DirFault",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C11",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Direction Fault (both wires active)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:dir_fault",
+            "displayName": "DirectionFault(bothWiresActive)",
+            "namespace": "LakeWales.Line1.Conveyor.DirFault",
+            "sourceVariable": "dir_fault",
+            "modbusAddress": "COIL:11"
+          }
+        },
+        {
+          "name": "DirFwd",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C7",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Direction Forward Decoded",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:dir_fwd",
+            "displayName": "DirectionForwardDecoded",
+            "namespace": "LakeWales.Line1.Conveyor.DirFwd",
+            "sourceVariable": "dir_fwd",
+            "modbusAddress": "COIL:7"
+          }
+        },
+        {
+          "name": "DirRev",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C8",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Direction Reverse Decoded",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:dir_rev",
+            "displayName": "DirectionReverseDecoded",
+            "namespace": "LakeWales.Line1.Conveyor.DirRev",
+            "sourceVariable": "dir_rev",
+            "modbusAddress": "COIL:8"
+          }
+        },
+        {
+          "name": "ErrorCode",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400106",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "Error Code (7=estop 8=dir_fault 9=vfd_comm)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:error_code",
+            "displayName": "ErrorCode(7=estop8=dirFault9=vfdComm)",
+            "namespace": "LakeWales.Line1.Conveyor.ErrorCode",
+            "sourceVariable": "error_code",
+            "modbusAddress": "HR:106"
+          }
+        },
+        {
+          "name": "EStopActive",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C6",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "E-stop Active",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:e_stop_active",
+            "displayName": "E-stopActive",
+            "namespace": "LakeWales.Line1.Conveyor.EStopActive",
+            "sourceVariable": "e_stop_active",
+            "modbusAddress": "COIL:6"
+          }
+        },
+        {
+          "name": "EstopWiringFault",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C10",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "E-stop Wiring Fault",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:estop_wiring_fault",
+            "displayName": "E-stopWiringFault",
+            "namespace": "LakeWales.Line1.Conveyor.EstopWiringFault",
+            "sourceVariable": "estop_wiring_fault",
+            "modbusAddress": "COIL:10"
+          }
+        },
+        {
+          "name": "FaultAlarm",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C3",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Fault Alarm Latched",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:fault_alarm",
+            "displayName": "FaultAlarmLatched",
+            "namespace": "LakeWales.Line1.Conveyor.FaultAlarm",
+            "sourceVariable": "fault_alarm",
+            "modbusAddress": "COIL:3"
+          }
+        },
+        {
+          "name": "Heartbeat",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C9",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Heartbeat (scan oscillator)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:heartbeat",
+            "displayName": "Heartbeat(scanOscillator)",
+            "namespace": "LakeWales.Line1.Conveyor.Heartbeat",
+            "sourceVariable": "heartbeat",
+            "modbusAddress": "COIL:9"
+          }
+        },
+        {
+          "name": "IoEmDi00",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C12",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Direction FWD Wire",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:_IO_EM_DI_00",
+            "displayName": "DirectionFwdWire",
+            "namespace": "LakeWales.Line1.Conveyor.IoEmDi00",
+            "sourceVariable": "_IO_EM_DI_00",
+            "modbusAddress": "COIL:12"
+          }
+        },
+        {
+          "name": "IoEmDi01",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C13",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Direction REV Wire",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:_IO_EM_DI_01",
+            "displayName": "DirectionRevWire",
+            "namespace": "LakeWales.Line1.Conveyor.IoEmDi01",
+            "sourceVariable": "_IO_EM_DI_01",
+            "modbusAddress": "COIL:13"
+          }
+        },
+        {
+          "name": "IoEmDi02",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C14",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "E-stop NC (healthy=TRUE)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:_IO_EM_DI_02",
+            "displayName": "E-stopNc(healthy=true)",
+            "namespace": "LakeWales.Line1.Conveyor.IoEmDi02",
+            "sourceVariable": "_IO_EM_DI_02",
+            "modbusAddress": "COIL:14"
+          }
+        },
+        {
+          "name": "IoEmDi03",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C15",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "E-stop NO (healthy=FALSE)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:_IO_EM_DI_03",
+            "displayName": "E-stopNo(healthy=false)",
+            "namespace": "LakeWales.Line1.Conveyor.IoEmDi03",
+            "sourceVariable": "_IO_EM_DI_03",
+            "modbusAddress": "COIL:15"
+          }
+        },
+        {
+          "name": "IoEmDi04",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C16",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Fault Reset Button",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:_IO_EM_DI_04",
+            "displayName": "FaultResetButton",
+            "namespace": "LakeWales.Line1.Conveyor.IoEmDi04",
+            "sourceVariable": "_IO_EM_DI_04",
+            "modbusAddress": "COIL:16"
+          }
+        },
+        {
+          "name": "IoEmDo00",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C17",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Green LED (Running)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:_IO_EM_DO_00",
+            "displayName": "GreenLed(running)",
+            "namespace": "LakeWales.Line1.Conveyor.IoEmDo00",
+            "sourceVariable": "_IO_EM_DO_00",
+            "modbusAddress": "COIL:17"
+          }
+        },
+        {
+          "name": "IoEmDo01",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C18",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Red LED (Fault)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:_IO_EM_DO_01",
+            "displayName": "RedLed(fault)",
+            "namespace": "LakeWales.Line1.Conveyor.IoEmDo01",
+            "sourceVariable": "_IO_EM_DO_01",
+            "modbusAddress": "COIL:18"
+          }
+        },
+        {
+          "name": "IoEmDo02",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C19",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Safety Contactor Q1",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:_IO_EM_DO_02",
+            "displayName": "SafetyContactorQ1",
+            "namespace": "LakeWales.Line1.Conveyor.IoEmDo02",
+            "sourceVariable": "_IO_EM_DO_02",
+            "modbusAddress": "COIL:19"
+          }
+        },
+        {
+          "name": "IoEmDo03",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C20",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "PB Run LED",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:_IO_EM_DO_03",
+            "displayName": "PbRunLed",
+            "namespace": "LakeWales.Line1.Conveyor.IoEmDo03",
+            "sourceVariable": "_IO_EM_DO_03",
+            "modbusAddress": "COIL:20"
+          }
+        },
+        {
+          "name": "ItemCount",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400111",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "Item Count (sensor_2 rising edges)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:item_count",
+            "displayName": "ItemCount(sensor2RisingEdges)",
+            "namespace": "LakeWales.Line1.Conveyor.ItemCount",
+            "sourceVariable": "item_count",
+            "modbusAddress": "HR:111"
+          }
+        },
+        {
+          "name": "MotorRunning",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C1",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "Motor Running",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:motor_running",
+            "displayName": "MotorRunning",
+            "namespace": "LakeWales.Line1.Conveyor.MotorRunning",
+            "sourceVariable": "motor_running",
+            "modbusAddress": "COIL:1"
+          }
+        },
+        {
+          "name": "MotorSpeed",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400101",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "Motor Speed (rpm or Modbus units)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:motor_speed",
+            "displayName": "MotorSpeed(rpmOrModbusUnits)",
+            "namespace": "LakeWales.Line1.Conveyor.MotorSpeed",
+            "sourceVariable": "motor_speed",
+            "modbusAddress": "HR:101"
+          }
+        },
+        {
+          "name": "SystemReady",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C5",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "System Ready",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:system_ready",
+            "displayName": "SystemReady",
+            "namespace": "LakeWales.Line1.Conveyor.SystemReady",
+            "sourceVariable": "system_ready",
+            "modbusAddress": "COIL:5"
+          }
+        },
+        {
+          "name": "UptimeSeconds",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400112",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "Uptime (seconds)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:uptime_seconds",
+            "displayName": "Uptime(seconds)",
+            "namespace": "LakeWales.Line1.Conveyor.UptimeSeconds",
+            "sourceVariable": "uptime_seconds",
+            "modbusAddress": "HR:112"
+          }
+        },
+        {
+          "name": "VfdCmdWord",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400115",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "VFD Command Word (1=STOP 18=FWD+RUN 20=REV+RUN)",
+          "writable": true,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:vfd_cmd_word",
+            "displayName": "VfdCommandWord(1=stop18=fwd+run20=rev+run)",
+            "namespace": "LakeWales.Line1.Conveyor.VfdCmdWord",
+            "sourceVariable": "vfd_cmd_word",
+            "modbusAddress": "HR:115"
+          }
+        },
+        {
+          "name": "VfdCommOk",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]C4",
+          "dataType": "Boolean",
+          "scanClass": "Default",
+          "tooltip": "VFD Comms OK",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:vfd_comm_ok",
+            "displayName": "VfdCommsOk",
+            "namespace": "LakeWales.Line1.Conveyor.VfdCommOk",
+            "sourceVariable": "vfd_comm_ok",
+            "modbusAddress": "COIL:4"
+          }
+        },
+        {
+          "name": "VfdCurrent",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400108",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "VFD Output Current (feedback)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:vfd_current",
+            "displayName": "VfdOutputCurrent(feedback)",
+            "namespace": "LakeWales.Line1.Conveyor.VfdCurrent",
+            "sourceVariable": "vfd_current",
+            "modbusAddress": "HR:108"
+          }
+        },
+        {
+          "name": "VfdDcBus",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400110",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "VFD DC Bus Voltage (feedback)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:vfd_dc_bus",
+            "displayName": "VfdDcBusVoltage(feedback)",
+            "namespace": "LakeWales.Line1.Conveyor.VfdDcBus",
+            "sourceVariable": "vfd_dc_bus",
+            "modbusAddress": "HR:110"
+          }
+        },
+        {
+          "name": "VfdFreqSetpoint",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400116",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "VFD Frequency Setpoint (x0.1 Hz, e.g. 300=30.0Hz)",
+          "writable": true,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:vfd_freq_setpoint",
+            "displayName": "VfdFrequencySetpoint(x0.1Hz,E.g.300=30.0hz)",
+            "namespace": "LakeWales.Line1.Conveyor.VfdFreqSetpoint",
+            "sourceVariable": "vfd_freq_setpoint",
+            "modbusAddress": "HR:116"
+          }
+        },
+        {
+          "name": "VfdFrequency",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400107",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "VFD Output Frequency (feedback, x0.1 Hz)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:vfd_frequency",
+            "displayName": "VfdOutputFrequency(feedback,X0.1Hz)",
+            "namespace": "LakeWales.Line1.Conveyor.VfdFrequency",
+            "sourceVariable": "vfd_frequency",
+            "modbusAddress": "HR:107"
+          }
+        },
+        {
+          "name": "VfdVoltage",
+          "tagType": "OpcTag",
+          "opcServer": "Ignition OPC-UA Server",
+          "opcItemPath": "ns=1;s=[Micro820_Conveyor]HR400109",
+          "dataType": "Int4",
+          "scanClass": "Default",
+          "tooltip": "VFD Output Voltage (feedback)",
+          "writable": false,
+          "i3x": {
+            "elementId": "urn:i3x:micro820:vfd_voltage",
+            "displayName": "VfdOutputVoltage(feedback)",
+            "namespace": "LakeWales.Line1.Conveyor.VfdVoltage",
+            "sourceVariable": "vfd_voltage",
+            "modbusAddress": "HR:109"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/mira-machine-logic-graph/.gitignore
+++ b/mira-machine-logic-graph/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+.env.local
+*.log

--- a/mira-machine-logic-graph/README.md
+++ b/mira-machine-logic-graph/README.md
@@ -1,0 +1,51 @@
+# mira-machine-logic-graph
+
+Parses Micro800 (CCW) Structured Text programs and exposes their variable
+graph as Ignition-importable tag JSON. Foundation for the future i3X
+facade — tag payloads already carry `i3x.elementId` / `i3x.namespace` /
+`i3x.displayName` metadata, ignored by Ignition Designer on import.
+
+## Run
+
+```bash
+bun install
+bun run dev               # http://localhost:8090
+bun test
+bun run tags:generate     # writes ../ignition/tags_micro800.json
+```
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| GET | `/health` | liveness |
+| GET | `/projects` | list registered PLC projects |
+| GET | `/projects/:id` | project metadata + Ignition device config |
+| GET | `/projects/:id/ignition-tags` | full Ignition tag export + i3X metadata (**CRA-235**) |
+
+## Projects
+
+Registered statically in `src/projects/registry.ts`. Today: one project,
+`micro820-conveyor`, pointing at `plc/Prog2.stf` +
+`research/variable-manifest.json`.
+
+## Why a separate service
+
+CCW stores the authoritative variable table in a binary `.accdb`. The
+`.stf` file references those variables but does not declare them. This
+service merges the two sources (ST identifier graph ∩ exported manifest)
+into a single Ignition-ready payload, so demos do not depend on hand
+maintenance of `tags.json`.
+
+## Tag emission
+
+For each variable that appears in the ST file **and** has a Modbus
+address in the manifest:
+
+- `COIL:N` → `ns=1;s=[<device>]C<N>` (`Boolean`)
+- `HR:N`   → `ns=1;s=[<device>]HR<400000+N>` (`Int4`)
+- `IR:N`   → `ns=1;s=[<device>]IR<300000+N>` (`Int4`)
+- `DI:N`   → `ns=1;s=[<device>]DI<N>` (`Boolean`)
+
+Tag names are PascalCase-mapped from the CCW global variable name. The
+original variable name is preserved on `i3x.sourceVariable`.

--- a/mira-machine-logic-graph/bun.lock
+++ b/mira-machine-logic-graph/bun.lock
@@ -1,0 +1,187 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "mira-machine-logic-graph",
+      "dependencies": {
+        "express": "^4.19.2",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.2.0",
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.12.0",
+        "typescript": "^5.4.5",
+      },
+    },
+  },
+  "packages": {
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/express": ["@types/express@4.17.25", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^4.17.33", "@types/qs": "*", "@types/serve-static": "^1" } }, "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@4.19.8", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
+
+    "@types/mime": ["@types/mime@1.3.5", "", {}, "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="],
+
+    "@types/node": ["@types/node@20.19.40", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q=="],
+
+    "@types/qs": ["@types/qs@6.15.1", "", {}, "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/send": ["@types/send@0.17.6", "", { "dependencies": { "@types/mime": "^1", "@types/node": "*" } }, "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og=="],
+
+    "@types/serve-static": ["@types/serve-static@1.15.10", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*", "@types/send": "<1" } }, "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw=="],
+
+    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
+    "array-flatten": ["array-flatten@1.1.1", "", {}, "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="],
+
+    "body-parser": ["body-parser@1.20.5", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.15.1", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@0.5.4", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.0.7", "", {}, "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA=="],
+
+    "debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "destroy": ["destroy@1.2.0", "", {}, "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "express": ["express@4.22.1", "", { "dependencies": { "accepts": "~1.3.8", "array-flatten": "1.1.1", "body-parser": "~1.20.3", "content-disposition": "~0.5.4", "content-type": "~1.0.4", "cookie": "~0.7.1", "cookie-signature": "~1.0.6", "debug": "2.6.9", "depd": "2.0.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "finalhandler": "~1.3.1", "fresh": "~0.5.2", "http-errors": "~2.0.0", "merge-descriptors": "1.0.3", "methods": "~1.1.2", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "path-to-regexp": "~0.1.12", "proxy-addr": "~2.0.7", "qs": "~6.14.0", "range-parser": "~1.2.1", "safe-buffer": "5.2.1", "send": "~0.19.0", "serve-static": "~1.16.2", "setprototypeof": "1.2.0", "statuses": "~2.0.1", "type-is": "~1.6.18", "utils-merge": "1.0.1", "vary": "~1.1.2" } }, "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g=="],
+
+    "finalhandler": ["finalhandler@1.3.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "on-finished": "~2.4.1", "parseurl": "~1.3.3", "statuses": "~2.0.2", "unpipe": "~1.0.0" } }, "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@0.5.2", "", {}, "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@0.3.0", "", {}, "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="],
+
+    "merge-descriptors": ["merge-descriptors@1.0.3", "", {}, "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ=="],
+
+    "methods": ["methods@1.1.2", "", {}, "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="],
+
+    "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-to-regexp": ["path-to-regexp@0.1.13", "", {}, "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.14.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@0.19.2", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "~0.5.2", "http-errors": "~2.0.1", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "~2.4.1", "range-parser": "~1.2.1", "statuses": "~2.0.2" } }, "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg=="],
+
+    "serve-static": ["serve-static@1.16.3", "", { "dependencies": { "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "parseurl": "~1.3.3", "send": "~0.19.1" } }, "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@1.6.18", "", { "dependencies": { "media-typer": "0.3.0", "mime-types": "~2.1.24" } }, "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "body-parser/qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "send/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+  }
+}

--- a/mira-machine-logic-graph/package.json
+++ b/mira-machine-logic-graph/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "mira-machine-logic-graph",
+  "version": "0.1.0",
+  "description": "Machine logic graph: parses Micro800 ST programs, exposes Ignition-compatible tag exports (and future i3X facade).",
+  "type": "module",
+  "scripts": {
+    "dev": "bun run --watch src/server.ts",
+    "start": "bun run src/server.ts",
+    "test": "bun test",
+    "tags:generate": "bun run scripts/generate-tags.ts"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.2.0",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.0",
+    "typescript": "^5.4.5"
+  },
+  "license": "Apache-2.0"
+}

--- a/mira-machine-logic-graph/scripts/generate-tags.ts
+++ b/mira-machine-logic-graph/scripts/generate-tags.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env bun
+/**
+ * CRA-232: generate ignition/tags_micro800.json from the Micro820
+ * conveyor project. Run from anywhere:
+ *
+ *   bun run scripts/generate-tags.ts [--project micro820-conveyor] [--out path]
+ */
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { findProject, PROJECTS } from "../src/projects/registry.ts";
+import { buildTagsForProject } from "../src/ignition/build-for-project.ts";
+
+function parseArgs(argv: string[]): { project: string; out: string } {
+  const args: { project: string; out: string } = {
+    project: "micro820-conveyor",
+    out: resolve(import.meta.dirname, "..", "..", "ignition", "tags_micro800.json"),
+  };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--project" && argv[i + 1]) args.project = argv[++i];
+    else if (argv[i] === "--out" && argv[i + 1]) args.out = resolve(argv[++i]);
+  }
+  return args;
+}
+
+const { project: projectId, out: outPath } = parseArgs(process.argv.slice(2));
+
+const project = findProject(projectId);
+if (!project) {
+  console.error(`Unknown project ${projectId}. Available: ${PROJECTS.map((p) => p.id).join(", ")}`);
+  process.exit(1);
+}
+
+const result = buildTagsForProject(project);
+
+mkdirSync(dirname(outPath), { recursive: true });
+writeFileSync(outPath, JSON.stringify(result.export, null, 2) + "\n", "utf8");
+
+console.log(`wrote ${outPath}`);
+console.log(`stats: ${JSON.stringify(result.stats)}`);

--- a/mira-machine-logic-graph/src/ignition/build-for-project.ts
+++ b/mira-machine-logic-graph/src/ignition/build-for-project.ts
@@ -1,0 +1,67 @@
+/**
+ * Glue layer: take a ProjectDef, load its ST file + manifest, run the
+ * parser, intersect with the manifest, hand to the tag builder.
+ */
+
+import { readFileSync } from "node:fs";
+import { parseStructuredText } from "../parser/st.ts";
+import { loadManifest, indexByName, type ManifestVariable } from "../parser/manifest.ts";
+import { buildIgnitionTags, type IgnitionTagExport } from "./tag-builder.ts";
+import type { ProjectDef } from "../projects/registry.ts";
+
+export interface BuildResult {
+  export: IgnitionTagExport;
+  stats: {
+    declaredInSt: number;
+    referencedInSt: number;
+    manifestSize: number;
+    tagsEmitted: number;
+    droppedNoAddress: number;
+    droppedUnsupportedType: number;
+  };
+}
+
+export function buildTagsForProject(project: ProjectDef): BuildResult {
+  const stSource = readFileSync(project.stPath, "utf8");
+  const parsed = parseStructuredText(stSource);
+  const manifest = loadManifest(project.manifestPath);
+  const idx = indexByName(manifest);
+
+  // Variables the ST file actually touches (either declared in a VAR
+  // block, or referenced as identifiers in the body). For CCW programs
+  // the declarations live in the project DB, so referencedIdentifiers
+  // is the load-bearing list.
+  const used = new Set<string>([
+    ...parsed.variables.map((v) => v.name),
+    ...parsed.referencedIdentifiers,
+  ]);
+
+  const variables: ManifestVariable[] = [];
+  let droppedNoAddress = 0;
+  for (const name of used) {
+    const v = idx.get(name);
+    if (!v) continue;
+    if (!v.modbusAddress) {
+      droppedNoAddress++;
+      continue;
+    }
+    variables.push(v);
+  }
+
+  const exp = buildIgnitionTags(variables, project.ignition);
+
+  const tagsEmitted = exp.tags.reduce((n, f) => n + f.tags.length, 0);
+  const droppedUnsupportedType = variables.length - tagsEmitted;
+
+  return {
+    export: exp,
+    stats: {
+      declaredInSt: parsed.variables.length,
+      referencedInSt: parsed.referencedIdentifiers.length,
+      manifestSize: manifest.variables.length,
+      tagsEmitted,
+      droppedNoAddress,
+      droppedUnsupportedType,
+    },
+  };
+}

--- a/mira-machine-logic-graph/src/ignition/tag-builder.ts
+++ b/mira-machine-logic-graph/src/ignition/tag-builder.ts
@@ -1,0 +1,159 @@
+/**
+ * Builds an Ignition Designer tag-import JSON for the Micro820 conveyor
+ * project from a parsed ST file + variable manifest.
+ *
+ * Output shape mirrors the existing ignition/tags/tags.json fixture so
+ * the file can be imported into Ignition Designer (Tag Browser →
+ * Import Tags) against the `Micro820_Conveyor` Modbus TCP device.
+ *
+ * Each tag also carries i3X-flavored metadata under `i3x`:
+ *   - elementId:   stable globally-unique handle
+ *   - displayName: human-friendly label
+ *   - namespace:   ISA-95-style path, e.g. "Site.Cell.Conveyor.MotorRunning"
+ *
+ * Ignition Designer ignores unknown keys on import, so these annotations
+ * are forward-compatible. They become the load-bearing fields once the
+ * i3X facade lands.
+ */
+
+import type { ManifestVariable } from "../parser/manifest.ts";
+
+export interface IgnitionTag {
+  name: string;
+  tagType: "OpcTag";
+  opcServer: string;
+  opcItemPath: string;
+  dataType: "Boolean" | "Int4" | "Int2" | "Float4" | "String";
+  scanClass: string;
+  tooltip?: string;
+  writable?: boolean;
+  i3x?: {
+    elementId: string;
+    displayName: string;
+    namespace: string;
+    sourceVariable: string;
+    modbusAddress: string | null;
+  };
+}
+
+export interface IgnitionFolder {
+  name: string;
+  tagType: "Folder";
+  tags: Array<IgnitionTag | IgnitionFolder>;
+}
+
+export interface IgnitionTagExport {
+  name: string;
+  tagType: "Provider";
+  tags: IgnitionFolder[];
+}
+
+export interface BuildOptions {
+  deviceName?: string;       // Ignition Modbus device name, default Micro820_Conveyor
+  providerName?: string;     // Provider name, default "default"
+  folderName?: string;       // Top folder, default "Conveyor"
+  site?: string;             // i3X namespace site, default "LakeWales"
+  cell?: string;             // i3X namespace cell, default "Line1"
+  writableNames?: Set<string>; // variable names that should be writable
+}
+
+const DEFAULT_WRITABLE = new Set([
+  "vfd_cmd_word",
+  "vfd_freq_setpoint",
+  "fault_reset_cmd",
+  "conveyor_speed_cmd",
+]);
+
+const BOOL_TYPES = new Set(["BOOL"]);
+const INT_TYPES = new Set(["INT", "DINT", "UINT", "UDINT", "WORD", "DWORD"]);
+
+function toPascalCase(name: string): string {
+  // _IO_EM_DI_00 -> IoEmDi00 ; motor_running -> MotorRunning
+  return name
+    .replace(/^_+/, "")
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1).toLowerCase())
+    .join("");
+}
+
+function ignitionAddress(deviceName: string, modbusAddr: string | null): string | null {
+  if (!modbusAddr) return null;
+  const m = modbusAddr.match(/^(COIL|HR|IR|DI):(\d+)$/i);
+  if (!m) return null;
+  const kind = m[1].toUpperCase();
+  const num = Number(m[2]);
+  if (kind === "COIL") return `ns=1;s=[${deviceName}]C${num}`;
+  if (kind === "DI") return `ns=1;s=[${deviceName}]DI${num}`;
+  if (kind === "IR") return `ns=1;s=[${deviceName}]IR${300000 + num}`;
+  if (kind === "HR") return `ns=1;s=[${deviceName}]HR${400000 + num}`;
+  return null;
+}
+
+function ignitionDataType(dataType: string): IgnitionTag["dataType"] | null {
+  const t = dataType.toUpperCase();
+  if (BOOL_TYPES.has(t)) return "Boolean";
+  if (INT_TYPES.has(t)) return "Int4";
+  if (t === "REAL") return "Float4";
+  if (t === "STRING") return "String";
+  return null;
+}
+
+export function buildIgnitionTags(
+  variables: ManifestVariable[],
+  opts: BuildOptions = {},
+): IgnitionTagExport {
+  const deviceName = opts.deviceName ?? "Micro820_Conveyor";
+  const providerName = opts.providerName ?? "default";
+  const folderName = opts.folderName ?? "Conveyor";
+  const site = opts.site ?? "LakeWales";
+  const cell = opts.cell ?? "Line1";
+  const writable = opts.writableNames ?? DEFAULT_WRITABLE;
+
+  const tags: IgnitionTag[] = [];
+
+  for (const v of variables) {
+    const opcItemPath = ignitionAddress(deviceName, v.modbusAddress);
+    const dataType = ignitionDataType(v.dataType);
+    if (!opcItemPath || !dataType) continue; // skip vars without a Modbus address or unsupported types
+
+    const displayName = toPascalCase(v.alias && v.alias.trim() ? v.alias : v.name);
+    const tagName = toPascalCase(v.name);
+
+    const tag: IgnitionTag = {
+      name: tagName,
+      tagType: "OpcTag",
+      opcServer: "Ignition OPC-UA Server",
+      opcItemPath,
+      dataType,
+      scanClass: "Default",
+      tooltip: v.alias ?? v.name,
+      // Manifest `direction` describes PLC data flow (PLC writes status
+      // out → field), not Ignition write permission. Only explicitly
+      // allowlisted setpoints are exposed as writable.
+      writable: writable.has(v.name),
+      i3x: {
+        elementId: `urn:i3x:micro820:${v.name}`,
+        displayName,
+        namespace: `${site}.${cell}.${folderName}.${tagName}`,
+        sourceVariable: v.name,
+        modbusAddress: v.modbusAddress,
+      },
+    };
+    tags.push(tag);
+  }
+
+  tags.sort((a, b) => a.name.localeCompare(b.name));
+
+  return {
+    name: providerName,
+    tagType: "Provider",
+    tags: [
+      {
+        name: folderName,
+        tagType: "Folder",
+        tags,
+      },
+    ],
+  };
+}

--- a/mira-machine-logic-graph/src/parser/manifest.ts
+++ b/mira-machine-logic-graph/src/parser/manifest.ts
@@ -1,0 +1,39 @@
+/**
+ * Cross-reference layer. Pairs ST identifiers with their declared
+ * type and Modbus address from research/variable-manifest.json, which
+ * is the authoritative export of the CCW Controller Variables table.
+ */
+
+import { readFileSync } from "node:fs";
+
+export interface ManifestVariable {
+  name: string;
+  dataType: string;
+  scope: string | null;
+  alias: string | null;
+  address: string | null;
+  modbusAddress: string | null;
+  retain: boolean;
+  terminalLabel: string | null;
+  sourceDevice: string | null;
+  direction: string | null;
+}
+
+export interface VariableManifest {
+  generatedAt: string;
+  sourceFiles: string[];
+  variables: ManifestVariable[];
+  notes?: string[];
+  gaps?: unknown[];
+}
+
+export function loadManifest(path: string): VariableManifest {
+  const raw = readFileSync(path, "utf8");
+  return JSON.parse(raw) as VariableManifest;
+}
+
+export function indexByName(manifest: VariableManifest): Map<string, ManifestVariable> {
+  const idx = new Map<string, ManifestVariable>();
+  for (const v of manifest.variables) idx.set(v.name, v);
+  return idx;
+}

--- a/mira-machine-logic-graph/src/parser/st.ts
+++ b/mira-machine-logic-graph/src/parser/st.ts
@@ -1,0 +1,126 @@
+/**
+ * Minimal Structured Text (ST / IEC 61131-3) parser scoped to what
+ * Micro820/CCW emits. We extract two things:
+ *
+ *   1. Declared variables from VAR_GLOBAL/VAR_INPUT/VAR_OUTPUT/VAR blocks
+ *      (CCW often omits VAR blocks from .stf because the declarations
+ *      live in PrjLibrary.accdb / the CCW Controller Variables table).
+ *   2. Referenced identifiers from program body — assignment targets
+ *      and right-hand-side reads. This is what we use when the .stf
+ *      has no VAR block: parse the body, then cross-reference with
+ *      an external manifest for type/address.
+ *
+ * Not a real ST parser. Tokenizer + regex pass. Sufficient for tag
+ * extraction; will be replaced when we need full semantic analysis.
+ */
+
+export type StScope =
+  | "VAR_GLOBAL"
+  | "VAR_INPUT"
+  | "VAR_OUTPUT"
+  | "VAR_IN_OUT"
+  | "VAR_EXTERNAL"
+  | "VAR";
+
+export interface ParsedStVariable {
+  name: string;
+  dataType: string;
+  scope: StScope;
+  initialValue: string | null;
+  comment: string | null;
+}
+
+export interface ParsedStFile {
+  programName: string | null;
+  variables: ParsedStVariable[];
+  referencedIdentifiers: string[];
+}
+
+const VAR_BLOCK_RE =
+  /\b(VAR_GLOBAL|VAR_INPUT|VAR_OUTPUT|VAR_IN_OUT|VAR_EXTERNAL|VAR)\b([\s\S]*?)\bEND_VAR\b/gi;
+
+const PROGRAM_RE = /\bPROGRAM\s+([A-Za-z_][A-Za-z0-9_]*)/i;
+
+const IDENT_RE = /[A-Za-z_][A-Za-z0-9_]*/g;
+
+const ST_KEYWORDS = new Set([
+  "AND", "OR", "NOT", "XOR", "MOD",
+  "IF", "THEN", "ELSE", "ELSIF", "END_IF",
+  "CASE", "OF", "END_CASE",
+  "FOR", "TO", "BY", "DO", "END_FOR",
+  "WHILE", "END_WHILE",
+  "REPEAT", "UNTIL", "END_REPEAT",
+  "RETURN", "EXIT", "CONTINUE",
+  "TRUE", "FALSE",
+  "BOOL", "INT", "DINT", "UINT", "UDINT", "REAL", "STRING", "TIME", "BYTE", "WORD", "DWORD",
+  "PROGRAM", "END_PROGRAM",
+  "FUNCTION", "END_FUNCTION",
+  "FUNCTION_BLOCK", "END_FUNCTION_BLOCK",
+  "VAR", "VAR_GLOBAL", "VAR_INPUT", "VAR_OUTPUT", "VAR_IN_OUT", "VAR_EXTERNAL", "END_VAR",
+  "RETAIN", "CONSTANT",
+]);
+
+function stripComments(src: string): string {
+  // Block comments (* ... *) — non-greedy, can span lines.
+  let out = src.replace(/\(\*[\s\S]*?\*\)/g, " ");
+  // Line comments // ...
+  out = out.replace(/\/\/[^\n]*/g, " ");
+  return out;
+}
+
+function parseVarBlock(scope: StScope, body: string): ParsedStVariable[] {
+  const vars: ParsedStVariable[] = [];
+  // Each declaration ends at a semicolon. Comments already stripped.
+  const lines = body.split(";");
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    // Pattern: name : TYPE [:= initial]
+    const m = line.match(
+      /^([A-Za-z_][A-Za-z0-9_]*)\s*:\s*([A-Za-z_][A-Za-z0-9_\[\]\.]*)(?:\s*:=\s*([^;]+?))?\s*$/,
+    );
+    if (!m) continue;
+    vars.push({
+      name: m[1],
+      dataType: m[2],
+      scope,
+      initialValue: m[3] ? m[3].trim() : null,
+      comment: null,
+    });
+  }
+  return vars;
+}
+
+export function parseStructuredText(source: string): ParsedStFile {
+  const stripped = stripComments(source);
+
+  const programMatch = stripped.match(PROGRAM_RE);
+  const programName = programMatch ? programMatch[1] : null;
+
+  const variables: ParsedStVariable[] = [];
+  let varBlocksText = "";
+  let m: RegExpExecArray | null;
+  // Reset lastIndex (regex has /g flag).
+  VAR_BLOCK_RE.lastIndex = 0;
+  while ((m = VAR_BLOCK_RE.exec(stripped)) !== null) {
+    const scope = m[1].toUpperCase() as StScope;
+    varBlocksText += m[0] + "\n";
+    variables.push(...parseVarBlock(scope, m[2]));
+  }
+
+  // Body = everything that wasn't inside a VAR..END_VAR block.
+  const body = stripped.replace(VAR_BLOCK_RE, " ");
+  const idents = new Set<string>();
+  const idMatches = body.match(IDENT_RE) || [];
+  for (const id of idMatches) {
+    if (ST_KEYWORDS.has(id.toUpperCase())) continue;
+    if (/^\d/.test(id)) continue;
+    idents.add(id);
+  }
+
+  return {
+    programName,
+    variables,
+    referencedIdentifiers: [...idents].sort(),
+  };
+}

--- a/mira-machine-logic-graph/src/projects/registry.ts
+++ b/mira-machine-logic-graph/src/projects/registry.ts
@@ -1,0 +1,43 @@
+/**
+ * Project registry. A "project" is a Micro800 / CCW program plus its
+ * variable manifest. Registered statically for now; a future revision
+ * will load from disk or a DB.
+ */
+
+import { resolve } from "node:path";
+
+export interface ProjectDef {
+  id: string;
+  name: string;
+  stPath: string;
+  manifestPath: string;
+  ignition: {
+    deviceName: string;
+    providerName: string;
+    folderName: string;
+    site: string;
+    cell: string;
+  };
+}
+
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
+
+export const PROJECTS: ProjectDef[] = [
+  {
+    id: "micro820-conveyor",
+    name: "Micro820 Conveyor (Lake Wales line 1)",
+    stPath: resolve(REPO_ROOT, "plc", "Prog2.stf"),
+    manifestPath: resolve(REPO_ROOT, "research", "variable-manifest.json"),
+    ignition: {
+      deviceName: "Micro820_Conveyor",
+      providerName: "default",
+      folderName: "Conveyor",
+      site: "LakeWales",
+      cell: "Line1",
+    },
+  },
+];
+
+export function findProject(id: string): ProjectDef | undefined {
+  return PROJECTS.find((p) => p.id === id);
+}

--- a/mira-machine-logic-graph/src/server.ts
+++ b/mira-machine-logic-graph/src/server.ts
@@ -1,0 +1,66 @@
+/**
+ * mira-machine-logic-graph Express API.
+ *
+ * Routes:
+ *   GET /health
+ *   GET /projects
+ *   GET /projects/:id
+ *   GET /projects/:id/ignition-tags   -- CRA-235
+ */
+
+import express from "express";
+import { PROJECTS, findProject } from "./projects/registry.ts";
+import { buildTagsForProject } from "./ignition/build-for-project.ts";
+
+export function createApp(): express.Express {
+  const app = express();
+
+  app.get("/health", (_req, res) => {
+    res.json({ ok: true, service: "mira-machine-logic-graph", version: "0.1.0" });
+  });
+
+  app.get("/projects", (_req, res) => {
+    res.json(PROJECTS.map((p) => ({ id: p.id, name: p.name })));
+  });
+
+  app.get("/projects/:id", (req, res) => {
+    const p = findProject(req.params.id);
+    if (!p) {
+      res.status(404).json({ error: "project_not_found", id: req.params.id });
+      return;
+    }
+    res.json({ id: p.id, name: p.name, ignition: p.ignition });
+  });
+
+  app.get("/projects/:id/ignition-tags", (req, res) => {
+    const p = findProject(req.params.id);
+    if (!p) {
+      res.status(404).json({ error: "project_not_found", id: req.params.id });
+      return;
+    }
+    try {
+      const result = buildTagsForProject(p);
+      res.json({
+        projectId: p.id,
+        generatedAt: new Date().toISOString(),
+        stats: result.stats,
+        export: result.export,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      res.status(500).json({ error: "build_failed", message });
+    }
+  });
+
+  return app;
+}
+
+// Run directly: `bun run src/server.ts`
+if (import.meta.main) {
+  const port = Number(process.env.PORT ?? 8090);
+  const app = createApp();
+  app.listen(port, () => {
+    // eslint-disable-next-line no-console
+    console.log(`mira-machine-logic-graph listening on :${port}`);
+  });
+}

--- a/mira-machine-logic-graph/tests/parser.test.ts
+++ b/mira-machine-logic-graph/tests/parser.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { parseStructuredText } from "../src/parser/st.ts";
+
+describe("parseStructuredText", () => {
+  test("parses PROGRAM name", () => {
+    const r = parseStructuredText("PROGRAM Prog2\n  x := 1;\nEND_PROGRAM");
+    expect(r.programName).toBe("Prog2");
+  });
+
+  test("parses a VAR_GLOBAL block", () => {
+    const src = `
+      VAR_GLOBAL
+        motor_running : BOOL := FALSE;
+        conv_state : INT := 0;
+      END_VAR
+    `;
+    const r = parseStructuredText(src);
+    expect(r.variables).toEqual([
+      { name: "motor_running", dataType: "BOOL", scope: "VAR_GLOBAL", initialValue: "FALSE", comment: null },
+      { name: "conv_state", dataType: "INT", scope: "VAR_GLOBAL", initialValue: "0", comment: null },
+    ]);
+  });
+
+  test("strips block and line comments before extracting identifiers", () => {
+    const src = `
+      PROGRAM Demo
+        (* hidden_var should not appear *)
+        motor_running := TRUE; // also_hidden
+      END_PROGRAM
+    `;
+    const r = parseStructuredText(src);
+    expect(r.referencedIdentifiers).toContain("motor_running");
+    expect(r.referencedIdentifiers).not.toContain("hidden_var");
+    expect(r.referencedIdentifiers).not.toContain("also_hidden");
+  });
+
+  test("excludes ST keywords from referenced identifiers", () => {
+    const src = `
+      IF motor_running AND NOT fault_alarm THEN
+        conv_state := 2;
+      END_IF
+    `;
+    const r = parseStructuredText(src);
+    expect(r.referencedIdentifiers).toContain("motor_running");
+    expect(r.referencedIdentifiers).toContain("fault_alarm");
+    expect(r.referencedIdentifiers).toContain("conv_state");
+    expect(r.referencedIdentifiers).not.toContain("IF");
+    expect(r.referencedIdentifiers).not.toContain("AND");
+    expect(r.referencedIdentifiers).not.toContain("NOT");
+    expect(r.referencedIdentifiers).not.toContain("THEN");
+  });
+});

--- a/mira-machine-logic-graph/tests/server.test.ts
+++ b/mira-machine-logic-graph/tests/server.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { createApp } from "../src/server.ts";
+
+async function pickPort(): Promise<number> {
+  return 8090 + Math.floor(Math.random() * 100);
+}
+
+describe("server", () => {
+  test("GET /projects returns the registered projects", async () => {
+    const app = createApp();
+    const port = await pickPort();
+    const server = app.listen(port);
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/projects`);
+      expect(r.status).toBe(200);
+      const body = (await r.json()) as Array<{ id: string }>;
+      expect(body.some((p) => p.id === "micro820-conveyor")).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("GET /projects/:id/ignition-tags returns a Provider export", async () => {
+    const app = createApp();
+    const port = await pickPort();
+    const server = app.listen(port);
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/projects/micro820-conveyor/ignition-tags`);
+      expect(r.status).toBe(200);
+      const body = (await r.json()) as {
+        export: { tagType: string; tags: Array<{ name: string; tags: unknown[] }> };
+        stats: { tagsEmitted: number };
+      };
+      expect(body.export.tagType).toBe("Provider");
+      expect(body.export.tags[0].name).toBe("Conveyor");
+      expect(body.stats.tagsEmitted).toBeGreaterThan(10);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("GET /projects/:id/ignition-tags returns 404 for unknown project", async () => {
+    const app = createApp();
+    const port = await pickPort();
+    const server = app.listen(port);
+    try {
+      const r = await fetch(`http://127.0.0.1:${port}/projects/nope/ignition-tags`);
+      expect(r.status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/mira-machine-logic-graph/tests/tag-builder.test.ts
+++ b/mira-machine-logic-graph/tests/tag-builder.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { buildIgnitionTags } from "../src/ignition/tag-builder.ts";
+import type { ManifestVariable } from "../src/parser/manifest.ts";
+
+const v = (over: Partial<ManifestVariable>): ManifestVariable => ({
+  name: "x",
+  dataType: "BOOL",
+  scope: "VAR",
+  alias: null,
+  address: null,
+  modbusAddress: null,
+  retain: false,
+  terminalLabel: null,
+  sourceDevice: null,
+  direction: null,
+  ...over,
+});
+
+describe("buildIgnitionTags", () => {
+  test("emits one folder with sorted tags", () => {
+    const out = buildIgnitionTags([
+      v({ name: "motor_running", modbusAddress: "COIL:1" }),
+      v({ name: "fault_alarm", modbusAddress: "COIL:3" }),
+    ]);
+    expect(out.tagType).toBe("Provider");
+    expect(out.tags).toHaveLength(1);
+    expect(out.tags[0].name).toBe("Conveyor");
+    const names = (out.tags[0].tags as { name: string }[]).map((t) => t.name);
+    expect(names).toEqual(["FaultAlarm", "MotorRunning"]);
+  });
+
+  test("maps COIL -> C, HR -> HR4000+addr", () => {
+    const out = buildIgnitionTags([
+      v({ name: "motor_running", modbusAddress: "COIL:1" }),
+      v({ name: "conv_state", dataType: "INT", modbusAddress: "HR:114" }),
+    ]);
+    const tags = out.tags[0].tags as { name: string; opcItemPath: string; dataType: string }[];
+    const motor = tags.find((t) => t.name === "MotorRunning")!;
+    const state = tags.find((t) => t.name === "ConvState")!;
+    expect(motor.opcItemPath).toBe("ns=1;s=[Micro820_Conveyor]C1");
+    expect(motor.dataType).toBe("Boolean");
+    expect(state.opcItemPath).toBe("ns=1;s=[Micro820_Conveyor]HR400114");
+    expect(state.dataType).toBe("Int4");
+  });
+
+  test("skips variables without a Modbus address or unsupported type", () => {
+    const out = buildIgnitionTags([
+      v({ name: "no_addr", modbusAddress: null }),
+      v({ name: "weird", dataType: "TON", modbusAddress: "HR:50" }),
+      v({ name: "ok", modbusAddress: "COIL:5" }),
+    ]);
+    const names = (out.tags[0].tags as { name: string }[]).map((t) => t.name);
+    expect(names).toEqual(["Ok"]);
+  });
+
+  test("attaches i3X metadata", () => {
+    const out = buildIgnitionTags([v({ name: "motor_running", modbusAddress: "COIL:1" })]);
+    const tag = (out.tags[0].tags as Array<{ i3x: { elementId: string; namespace: string } }>)[0];
+    expect(tag.i3x.elementId).toBe("urn:i3x:micro820:motor_running");
+    expect(tag.i3x.namespace).toBe("LakeWales.Line1.Conveyor.MotorRunning");
+  });
+
+  test("marks only allowlisted setpoints writable, regardless of manifest direction", () => {
+    const out = buildIgnitionTags([
+      v({ name: "vfd_cmd_word", dataType: "INT", modbusAddress: "HR:115", direction: "IN" }),
+      v({ name: "motor_running", modbusAddress: "COIL:1", direction: "OUT" }),
+      v({ name: "_IO_EM_DO_00", modbusAddress: "COIL:17", direction: "OUT" }),
+    ]);
+    const tags = out.tags[0].tags as { name: string; writable: boolean }[];
+    expect(tags.find((t) => t.name === "VfdCmdWord")!.writable).toBe(true);
+    expect(tags.find((t) => t.name === "MotorRunning")!.writable).toBe(false);
+    expect(tags.find((t) => t.name === "IoEmDo00")!.writable).toBe(false);
+  });
+});

--- a/mira-machine-logic-graph/tsconfig.json
+++ b/mira-machine-logic-graph/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "include": ["src/**/*", "scripts/**/*", "tests/**/*"]
+}

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -34,6 +34,12 @@ doppler run --project factorylm --config prd -- \
 - **Pipeline gap**: `build_video_v2.py` needs `--storyboard`, `--story`, `--recordings` flags added before user-recorded voice works. TTS mode works today via Option A (swap shots into storyboard_v2.yaml). See README for details.
 - **Hub login**: app.factorylm.com uses Google OAuth only — no password login; Playwright can't automate auth. Authenticated screenshots (chat, upload, QR chooser) still needed — capture manually.
 
+## eval-fixer run — 2026-05-11
+- Scorecard: 48/57 passing (84%) — `tests/eval/runs/2026-05-06T0833-offline-text.md`
+- Action: issue-filed (#1170 — added to Kanban)
+- 9 failures across 3 file clusters (engine.py×7, guardrails.py×3, prompts×3); multi-file span blocked autopatch
+- Dominant pattern: FSM stuck at Q-states / not advancing to DIAGNOSIS; also PowerFlex cross-vendor bleed + CMMS WO keyword miss
+
 ## eval-fixer run — 2026-05-10
 - Scorecard: 48/57 passing (84%) — `tests/eval/runs/2026-05-06T0833-offline-text.md`
 - Action: issue-filed (#1144 — added to Kanban)


### PR DESCRIPTION
## Summary
- New `mira-machine-logic-graph` module — Bun/TS
- ST parser for Micro820 .stf programs
- Generates `tags_micro800.json` for Ignition import
- HTTP endpoint for tag export (CRA-235)

## Linear
Closes CRA-232, CRA-235

## Test plan
- [ ] `bun run scripts/generate-tags.ts plc/Prog2.stf` produces valid Ignition JSON
- [ ] Import into Ignition Designer succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)