### PR TITLE
feat(hub): i3X external ID columns + python-multipart CVE bump

### DIFF
--- a/mira-core/mira-ingest/requirements.txt
+++ b/mira-core/mira-ingest/requirements.txt
@@ -3,7 +3,7 @@ uvicorn[standard]==0.44.*
 httpx==0.28.*
 Pillow>=10.0
 pillow-heif>=0.18
-python-multipart==0.0.27
+python-multipart==0.0.28
 pytest==9.*
 pytest-asyncio==1.3.*
 pytest-cov>=5.0

--- a/mira-hub/db/migrations/013_external_ids.sql
+++ b/mira-hub/db/migrations/013_external_ids.sql
@@ -1,0 +1,45 @@
+-- Migration 013: external ID columns on cmms_equipment for i3X interoperability
+--
+-- MIRA assets need to round-trip with adjacent systems (an existing CMMS,
+-- the PLC tag namespace, the SCADA historian, the UNS broker, the ERP
+-- spares catalog, the engineering drawing set). Each system has its own
+-- identifier for the same physical asset. We store those alongside the
+-- canonical MIRA row so we can:
+--
+--   * dedupe on import (e.g. MaintainX → Atlas sync uses cmms_id)
+--   * resolve tags coming off Ignition / SCADA streams to a MIRA asset
+--   * surface manufacturer part numbers in work-order parts lists
+--   * deep-link from a fault to the original drawing
+--
+-- All columns are nullable TEXT — empty is the normal state for assets
+-- that aren't yet cross-referenced. No indexes here: lookups are
+-- read-rare and tenant-scoped, so a full table scan is fine until the
+-- sync paths actually drive query traffic. Add indexes in a later
+-- migration once we have a real workload to size against.
+--
+-- CRA-258. Companion application changes:
+--   * mira-hub rowToAsset()  → exposes columns on /api/assets/by-tag
+--   * mira-hub /m/[tag] page → collapsible "External IDs" section
+--   * seed-stardust-racers   → populates demo values for SR-SUMP-001
+
+ALTER TABLE cmms_equipment
+  ADD COLUMN IF NOT EXISTS cmms_id                    TEXT,
+  ADD COLUMN IF NOT EXISTS plc_tag                    TEXT,
+  ADD COLUMN IF NOT EXISTS scada_path                 TEXT,
+  ADD COLUMN IF NOT EXISTS manufacturer_part_number   TEXT,
+  ADD COLUMN IF NOT EXISTS uns_topic_path             TEXT,
+  ADD COLUMN IF NOT EXISTS erp_asset_id               TEXT,
+  ADD COLUMN IF NOT EXISTS drawing_reference          TEXT;
+
+-- serial_number already exists on cmms_equipment (see seed-stardust-racers.ts
+-- which writes to it). Intentionally NOT re-added here.
+
+-- ─── Rollback notes ───────────────────────────────────────────────────────────
+-- ALTER TABLE cmms_equipment
+--   DROP COLUMN IF EXISTS cmms_id,
+--   DROP COLUMN IF EXISTS plc_tag,
+--   DROP COLUMN IF EXISTS scada_path,
+--   DROP COLUMN IF EXISTS manufacturer_part_number,
+--   DROP COLUMN IF EXISTS uns_topic_path,
+--   DROP COLUMN IF EXISTS erp_asset_id,
+--   DROP COLUMN IF EXISTS drawing_reference;

--- a/mira-hub/scripts/seed-stardust-racers.ts
+++ b/mira-hub/scripts/seed-stardust-racers.ts
@@ -34,6 +34,11 @@ const SR_SUMP = {
   department: "Ride Maintenance",
   criticality: "high",
   last_reported_fault: "Lead pump nuisance trip on overload — investigate motor current and seal water",
+  // External IDs (CRA-258) — demonstrates i3X cross-system interop.
+  plc_tag: "SUMP_001",
+  manufacturer_part_number: "CR-15-3-A-F-A-E-HQQE",
+  scada_path: "Site/StardustRacers/PitB/SumpPanel/SUMP_001",
+  uns_topic_path: "factorylm/stardust-racers/pit-b/sump-panel/sump-001",
 };
 
 async function main() {
@@ -61,25 +66,33 @@ async function main() {
       `INSERT INTO cmms_equipment
          (id, tenant_id, equipment_number, description, manufacturer, model_number,
           serial_number, equipment_type, location, department, criticality,
-          last_reported_fault, qr_generated_at)
-       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::criticalitylevel,$12,NOW())
+          last_reported_fault, qr_generated_at,
+          plc_tag, manufacturer_part_number, scada_path, uns_topic_path)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::criticalitylevel,$12,NOW(),
+               $13,$14,$15,$16)
        ON CONFLICT (id) DO UPDATE SET
-         equipment_number     = EXCLUDED.equipment_number,
-         description          = EXCLUDED.description,
-         manufacturer         = EXCLUDED.manufacturer,
-         model_number         = EXCLUDED.model_number,
-         serial_number        = EXCLUDED.serial_number,
-         equipment_type       = EXCLUDED.equipment_type,
-         location             = EXCLUDED.location,
-         department           = EXCLUDED.department,
-         criticality          = EXCLUDED.criticality,
-         last_reported_fault  = EXCLUDED.last_reported_fault,
-         qr_generated_at      = COALESCE(cmms_equipment.qr_generated_at, EXCLUDED.qr_generated_at)`,
+         equipment_number          = EXCLUDED.equipment_number,
+         description               = EXCLUDED.description,
+         manufacturer              = EXCLUDED.manufacturer,
+         model_number              = EXCLUDED.model_number,
+         serial_number             = EXCLUDED.serial_number,
+         equipment_type            = EXCLUDED.equipment_type,
+         location                  = EXCLUDED.location,
+         department                = EXCLUDED.department,
+         criticality               = EXCLUDED.criticality,
+         last_reported_fault       = EXCLUDED.last_reported_fault,
+         qr_generated_at           = COALESCE(cmms_equipment.qr_generated_at, EXCLUDED.qr_generated_at),
+         plc_tag                   = EXCLUDED.plc_tag,
+         manufacturer_part_number  = EXCLUDED.manufacturer_part_number,
+         scada_path                = EXCLUDED.scada_path,
+         uns_topic_path            = EXCLUDED.uns_topic_path`,
       [
         SR_SUMP.id, SYNTH_TENANT_ID, SR_SUMP.equipment_number, SR_SUMP.description,
         SR_SUMP.manufacturer, SR_SUMP.model_number, SR_SUMP.serial_number,
         SR_SUMP.equipment_type, SR_SUMP.location, SR_SUMP.department,
         SR_SUMP.criticality, SR_SUMP.last_reported_fault,
+        SR_SUMP.plc_tag, SR_SUMP.manufacturer_part_number,
+        SR_SUMP.scada_path, SR_SUMP.uns_topic_path,
       ],
     );
 

--- a/mira-hub/src/app/api/assets/by-tag/[tag]/route.ts
+++ b/mira-hub/src/app/api/assets/by-tag/[tag]/route.ts
@@ -26,6 +26,15 @@ function rowToAsset(r: Record<string, unknown>) {
     createdAt: r.created_at ?? null,
     parentAssetId: r.parent_asset_id ?? null,
     qrGeneratedAt: r.qr_generated_at ?? null,
+    externalIds: {
+      cmmsId: (r.cmms_id as string | null) ?? null,
+      plcTag: (r.plc_tag as string | null) ?? null,
+      scadaPath: (r.scada_path as string | null) ?? null,
+      manufacturerPartNumber: (r.manufacturer_part_number as string | null) ?? null,
+      unsTopicPath: (r.uns_topic_path as string | null) ?? null,
+      erpAssetId: (r.erp_asset_id as string | null) ?? null,
+      drawingReference: (r.drawing_reference as string | null) ?? null,
+    },
   };
 }
 
@@ -54,7 +63,9 @@ export async function GET(
           work_order_count, total_downtime_hours,
           last_maintenance_date, last_work_order_at,
           last_reported_fault, description, installation_date, created_at,
-          parent_asset_id, qr_generated_at
+          parent_asset_id, qr_generated_at,
+          cmms_id, plc_tag, scada_path, manufacturer_part_number,
+          uns_topic_path, erp_asset_id, drawing_reference
         FROM cmms_equipment
         WHERE equipment_number = $1 AND tenant_id = $2
         LIMIT 1`,

--- a/mira-hub/src/app/m/[assetTag]/page.tsx
+++ b/mira-hub/src/app/m/[assetTag]/page.tsx
@@ -24,16 +24,28 @@ type ChildAsset = {
   model: string | null;
 };
 
+type ExternalIds = {
+  cmmsId: string | null;
+  plcTag: string | null;
+  scadaPath: string | null;
+  manufacturerPartNumber: string | null;
+  unsTopicPath: string | null;
+  erpAssetId: string | null;
+  drawingReference: string | null;
+};
+
 type AssetView = {
   id: string;
   tag: string;
   name: string;
   manufacturer: string | null;
   model: string | null;
+  serialNumber: string | null;
   type: string | null;
   location: string | null;
   criticality: string;
   qrGeneratedAt: string | null;
+  externalIds?: ExternalIds;
   children?: ChildAsset[];
 };
 
@@ -240,6 +252,41 @@ export default function MobileAssetPage({
         ) : null}
       </div>
 
+      {/* External IDs (i3X interop) — collapsed by default, shown only when populated */}
+      {asset.externalIds && Object.values(asset.externalIds).some(Boolean) ? (
+        <details className="mt-4 rounded-lg border bg-white">
+          <summary className="cursor-pointer px-4 py-3 text-xs uppercase tracking-wide text-slate-500 select-none">
+            External IDs
+          </summary>
+          <dl className="px-4 pb-3 space-y-2 text-sm">
+            {asset.externalIds.cmmsId ? (
+              <ExtId label="CMMS ID" value={asset.externalIds.cmmsId} />
+            ) : null}
+            {asset.externalIds.plcTag ? (
+              <ExtId label="PLC Tag" value={asset.externalIds.plcTag} />
+            ) : null}
+            {asset.externalIds.scadaPath ? (
+              <ExtId label="SCADA Path" value={asset.externalIds.scadaPath} />
+            ) : null}
+            {asset.serialNumber ? (
+              <ExtId label="Serial Number" value={asset.serialNumber} />
+            ) : null}
+            {asset.externalIds.manufacturerPartNumber ? (
+              <ExtId label="Mfr Part #" value={asset.externalIds.manufacturerPartNumber} />
+            ) : null}
+            {asset.externalIds.unsTopicPath ? (
+              <ExtId label="UNS Topic" value={asset.externalIds.unsTopicPath} />
+            ) : null}
+            {asset.externalIds.erpAssetId ? (
+              <ExtId label="ERP Asset ID" value={asset.externalIds.erpAssetId} />
+            ) : null}
+            {asset.externalIds.drawingReference ? (
+              <ExtId label="Drawing Ref" value={asset.externalIds.drawingReference} />
+            ) : null}
+          </dl>
+        </details>
+      ) : null}
+
       {/* Three primary actions — large, thumb-friendly */}
       <div className="mt-5 grid gap-3">
         <Button
@@ -334,6 +381,15 @@ export default function MobileAssetPage({
           ← Back to dashboard
         </Link>
       </footer>
+    </div>
+  );
+}
+
+function ExtId({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-baseline sm:gap-3">
+      <dt className="text-xs uppercase tracking-wide text-slate-500 sm:w-32 shrink-0">{label}</dt>
+      <dd className="font-mono text-slate-900 break-all">{value}</dd>
     </div>
   );
 }

--- a/mira-mcp/requirements.txt
+++ b/mira-mcp/requirements.txt
@@ -3,7 +3,7 @@ uvicorn==0.44.0
 starlette==0.52.1
 openviking==0.3.9
 pdfplumber==0.11.9
-python-multipart==0.0.27  # CVE-2026-42561 (HIGH)
+python-multipart==0.0.28  # CVE-2026-42561 (HIGH) — fixed in 0.0.28 (boundary length cap)
 httpx==0.28.*
 openpyxl==3.1.5
 PyJWT>=2.12.0,<3.0  # 2.10/2.11 have CVE-2026-32597 (HIGH); 2.12.0 fixes


### PR DESCRIPTION
## Summary
- Adds \`external_id\` columns on \`cmms_equipment\` for i3X/MaintainX interop (migration 013)
- Bumps python-multipart 0.0.27 → 0.0.28 (CVE-2026-42561) across mira-ingest + mira-mcp
- Seed script for Stardust Racers demo
- Updates by-tag asset API + mobile asset page

## Test plan
- [ ] Migration 013 applies cleanly
- [ ] CVE scan clean
- [ ] Asset by-tag lookup works with external IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)