### PR TITLE
fix(security): CRA-226/227/228 + feat(graph) CRA-236 live troubleshoot

### DIFF
--- a/docs/superpowers/specs/2026-05-11-cra-236-live-troubleshoot-design.md
+++ b/docs/superpowers/specs/2026-05-11-cra-236-live-troubleshoot-design.md
@@ -1,0 +1,115 @@
+# CRA-236 — Live Troubleshoot Endpoint (Ignition tags + MIRA reasoning)
+
+**Status:** in-flight
+**Owner:** Mike / Claude
+**Service:** `mira-machine-logic-graph`
+**Branch:** `claude/happy-saha-632958`
+
+## Goal
+
+Add `POST /projects/:id/live-troubleshoot` to mira-machine-logic-graph. The
+endpoint pulls live tag values from an Ignition gateway, merges them with the
+project's static graph context (parsed ST + manifest), and asks a Groq-cascade
+LLM to produce a grounded troubleshooting answer that cites the live tag
+values it used.
+
+## Non-goals
+
+- Writing tags back to Ignition (read-only).
+- Multi-turn conversation state — single-shot Q&A.
+- Replacing the diagnostic Supervisor in mira-bots/shared. This endpoint is
+  the PLC-grounded read path; the Supervisor remains the conversation path.
+- Anthropic. PRD §4 — Groq → Cerebras → Gemini cascade only.
+
+## API
+
+```
+POST /projects/:id/live-troubleshoot
+Body: {
+  "question": "Why won't Conveyor_B16_Run turn on?",
+  "ignitionUrl": "http://localhost:8088",
+  "tagPrefix": "[default]MIRA_PLC"
+}
+
+200 OK
+{
+  "answer": "...grounded answer citing live values...",
+  "tags_read": [
+    { "path": "[default]MIRA_PLC/motor_running", "value": false, "quality": "Good", "timestamp": "2026-05-11T..." }
+  ],
+  "context_used": [
+    "variable:motor_running (BOOL, %M1.0)",
+    "variable:e_stop_active (BOOL, %I0.0)"
+  ],
+  "provider": "groq"
+}
+
+404  project_not_found
+502  ignition_unreachable | llm_unavailable
+500  build_failed
+```
+
+## Data flow
+
+1. `findProject(:id)` — resolve project, 404 if missing.
+2. `buildTagsForProject(project)` — get parsed ST + manifest + tag export.
+   The variable list is the graph context.
+3. **Ignition read:** `POST {ignitionUrl}/data/tag/read` with Basic auth from
+   `IGNITION_USER` / `IGNITION_PASSWORD` envs. Body = `{ paths: [...] }` built
+   from each manifest variable: `{tagPrefix}/{variable.name}`.
+4. **Prompt construction** — system + user. System constrains the LLM to:
+   - Only cite tag values present in `tags_read`.
+   - Mark each tag value `[live]` in the answer.
+   - Refuse to invent tags or values.
+5. **LLM call** — Groq cascade via fetch. Order: Groq → Cerebras → Gemini.
+   First success wins. All three providers speak the OpenAI chat-completions
+   shape. 502 if all three fail.
+6. Return structured response.
+
+## Environment
+
+| Var | Required | Default | Purpose |
+|---|---|---|---|
+| `GROQ_API_KEY` | one of | — | Primary LLM |
+| `CEREBRAS_API_KEY` | one of | — | Fallback |
+| `GEMINI_API_KEY` | one of | — | Fallback |
+| `GROQ_MODEL` | no | `llama-3.3-70b-versatile` | |
+| `CEREBRAS_MODEL` | no | `llama3.1-8b` | |
+| `GEMINI_MODEL` | no | `gemini-2.0-flash` | |
+| `IGNITION_USER` | no | `admin` | Basic auth |
+| `IGNITION_PASSWORD` | no | `password` | Basic auth |
+| `IGNITION_TIMEOUT_MS` | no | `5000` | |
+
+At least one LLM key required; otherwise 502.
+
+## Files
+
+- `src/api/live-troubleshoot.ts` — handler + helpers (Ignition read, LLM cascade).
+- `src/server.ts` — mount the route.
+- `tests/live-troubleshoot.test.ts` — endpoint tests using injected `fetch`
+  doubles (the global `fetch` is monkey-patched per test, no real network).
+
+## Test plan
+
+- **404** for unknown project id.
+- **400** for missing `question`, `ignitionUrl`, or `tagPrefix`.
+- **502** when Ignition returns non-2xx.
+- **502** when no LLM provider key is set.
+- **200** happy path: Ignition fetch and LLM fetch both return canned 200,
+  response includes `answer`, `tags_read`, `context_used`, `provider`.
+- **Fallback**: Groq returns 500, Cerebras returns 200 → response
+  `provider: "cerebras"`.
+
+## Risks
+
+- Real Ignition latency. Bound by `IGNITION_TIMEOUT_MS` via `AbortSignal.timeout`.
+- LLM hallucinating tag values. Mitigation: system prompt + only pass values
+  from `tags_read`; answer cites live values verbatim.
+- Manifest may be larger than the LLM context window. Mitigation: cap context
+  at first 64 variables (covers Micro820 line 1; revisit when projects grow).
+
+## Out of scope (next ticket)
+
+- Caching tag reads.
+- Streaming responses.
+- Multi-turn carryover.

--- a/mira-core/docker-compose.yml
+++ b/mira-core/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       # RAG embedding: nomic-embed-text via Ollama (matches mira-ingest NeonDB embeddings)
       # Default all-MiniLM-L6-v2 truncates at 256 tokens; nomic handles 8192
       - RAG_EMBEDDING_ENGINE=ollama
-      - RAG_EMBEDDING_MODEL=nomic-embed-text:latest
+      - RAG_EMBEDDING_MODEL=nomic-embed-text:v1.5
       - RAG_CHUNK_SIZE=1000
       - RAG_CHUNK_OVERLAP=100
       # Pipeline connection — MIRA Diagnostic model via mira-pipeline

--- a/mira-hub/src/lib/agents/asset-intelligence.ts
+++ b/mira-hub/src/lib/agents/asset-intelligence.ts
@@ -100,7 +100,8 @@ function equipmentTypeToCorpus(type: string): string {
 }
 
 async function getOllamaEmbedding(text: string): Promise<number[] | null> {
-  const base = process.env.OLLAMA_BASE_URL ?? "http://100.86.236.11:11434";
+  const base = process.env.OLLAMA_BASE_URL;
+  if (!base) throw new Error("OLLAMA_BASE_URL not set");
   try {
     const resp = await fetch(`${base}/api/embeddings`, {
       method: "POST",

--- a/mira-machine-logic-graph/src/api/live-troubleshoot.ts
+++ b/mira-machine-logic-graph/src/api/live-troubleshoot.ts
@@ -1,0 +1,300 @@
+/**
+ * POST /projects/:id/live-troubleshoot
+ *
+ * Pulls live tag values from an Ignition gateway, merges them with the
+ * project's static graph context (parsed ST + manifest), and asks a Groq
+ * cascade LLM to produce a grounded troubleshooting answer.
+ *
+ * Spec: docs/superpowers/specs/2026-05-11-cra-236-live-troubleshoot-design.md
+ * PRD §4: no Anthropic. Groq -> Cerebras -> Gemini only.
+ */
+
+import { readFileSync } from "node:fs";
+import type { Request, Response } from "express";
+import { findProject, type ProjectDef } from "../projects/registry.ts";
+import { parseStructuredText } from "../parser/st.ts";
+import {
+  indexByName,
+  loadManifest,
+  type ManifestVariable,
+} from "../parser/manifest.ts";
+
+const CONTEXT_VAR_LIMIT = 64;
+
+export interface LiveTagRead {
+  path: string;
+  value: unknown;
+  quality: string;
+  timestamp: string;
+}
+
+interface IgnitionTagReadResponse {
+  // Ignition WebDev tag/read returns either an array of rows or an object
+  // with a `results` key, depending on the WebDev script. Be tolerant.
+  results?: Array<{
+    path?: string;
+    value?: unknown;
+    quality?: string | { name?: string };
+    timestamp?: string;
+  }>;
+}
+
+export interface LiveTroubleshootBody {
+  question?: string;
+  ignitionUrl?: string;
+  tagPrefix?: string;
+}
+
+interface LlmProvider {
+  name: "groq" | "cerebras" | "gemini";
+  url: string;
+  apiKey: string;
+  model: string;
+}
+
+function llmProviders(): LlmProvider[] {
+  const providers: LlmProvider[] = [];
+  const groq = process.env.GROQ_API_KEY;
+  if (groq) {
+    providers.push({
+      name: "groq",
+      url: "https://api.groq.com/openai/v1/chat/completions",
+      apiKey: groq,
+      model: process.env.GROQ_MODEL ?? "llama-3.3-70b-versatile",
+    });
+  }
+  const cerebras = process.env.CEREBRAS_API_KEY;
+  if (cerebras) {
+    providers.push({
+      name: "cerebras",
+      url: "https://api.cerebras.ai/v1/chat/completions",
+      apiKey: cerebras,
+      model: process.env.CEREBRAS_MODEL ?? "llama3.1-8b",
+    });
+  }
+  const gemini = process.env.GEMINI_API_KEY;
+  if (gemini) {
+    // Gemini exposes an OpenAI-compatible endpoint under /v1beta/openai/.
+    providers.push({
+      name: "gemini",
+      url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+      apiKey: gemini,
+      model: process.env.GEMINI_MODEL ?? "gemini-2.0-flash",
+    });
+  }
+  return providers;
+}
+
+function graphVariablesForProject(project: ProjectDef): ManifestVariable[] {
+  // Mirrors buildTagsForProject's intersection logic but returns the raw
+  // ManifestVariable rows (build-for-project transforms them into Ignition
+  // tags with Pascal-cased names, which would lose the original identifier).
+  const stSource = readFileSync(project.stPath, "utf8");
+  const parsed = parseStructuredText(stSource);
+  const manifest = loadManifest(project.manifestPath);
+  const idx = indexByName(manifest);
+  const used = new Set<string>([
+    ...parsed.variables.map((v) => v.name),
+    ...parsed.referencedIdentifiers,
+  ]);
+  const out: ManifestVariable[] = [];
+  for (const name of used) {
+    const v = idx.get(name);
+    if (!v) continue;
+    if (!v.modbusAddress) continue;
+    out.push(v);
+  }
+  return out;
+}
+
+async function readIgnitionTags(
+  ignitionUrl: string,
+  paths: string[],
+): Promise<LiveTagRead[]> {
+  const user = process.env.IGNITION_USER ?? "admin";
+  const password = process.env.IGNITION_PASSWORD ?? "password";
+  const auth = "Basic " + Buffer.from(`${user}:${password}`).toString("base64");
+  const timeoutMs = Number(process.env.IGNITION_TIMEOUT_MS ?? 5000);
+
+  const url = `${ignitionUrl.replace(/\/$/, "")}/data/tag/read`;
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: auth,
+    },
+    body: JSON.stringify({ paths }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!resp.ok) {
+    throw new Error(`ignition_${resp.status}`);
+  }
+  const data = (await resp.json()) as IgnitionTagReadResponse | LiveTagRead[];
+  const rows = Array.isArray(data) ? data : (data.results ?? []);
+  return rows.map((r, i) => {
+    const quality =
+      typeof r.quality === "string"
+        ? r.quality
+        : (r.quality?.name ?? "Unknown");
+    return {
+      path: r.path ?? paths[i] ?? "",
+      value: r.value ?? null,
+      quality,
+      timestamp: r.timestamp ?? new Date().toISOString(),
+    };
+  });
+}
+
+function buildPrompt(
+  question: string,
+  variables: ManifestVariable[],
+  liveTags: LiveTagRead[],
+): { system: string; user: string } {
+  const system = [
+    "You are a PLC troubleshooting assistant for industrial maintenance technicians.",
+    "Answer ONLY from the live tag values and graph context provided below.",
+    "Cite each tag value you use as `name = value [live]`.",
+    "If the answer is not derivable from the provided data, say so plainly — do not invent tags or values.",
+    "Be terse: 3-6 sentences max. Lead with the diagnosis.",
+  ].join(" ");
+
+  const ctxLines = variables.slice(0, CONTEXT_VAR_LIMIT).map((v) => {
+    const addr = v.modbusAddress ?? v.address ?? "n/a";
+    return `- ${v.name} (${v.dataType}, addr=${addr}${v.direction ? `, dir=${v.direction}` : ""})`;
+  });
+
+  const liveLines = liveTags.map(
+    (t) => `- ${t.path} = ${JSON.stringify(t.value)} [quality=${t.quality}, ts=${t.timestamp}]`,
+  );
+
+  const user = [
+    `Question: ${question}`,
+    "",
+    "Graph context (variables, types, addresses):",
+    ctxLines.join("\n"),
+    "",
+    "Live tag values from Ignition:",
+    liveLines.join("\n"),
+  ].join("\n");
+
+  return { system, user };
+}
+
+interface LlmResult {
+  answer: string;
+  provider: string;
+}
+
+async function callLlmCascade(
+  system: string,
+  user: string,
+): Promise<LlmResult> {
+  const providers = llmProviders();
+  if (providers.length === 0) {
+    throw new Error("llm_unavailable");
+  }
+  const messages = [
+    { role: "system", content: system },
+    { role: "user", content: user },
+  ];
+  let lastError = "";
+  for (const p of providers) {
+    try {
+      const resp = await fetch(p.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${p.apiKey}`,
+        },
+        body: JSON.stringify({
+          model: p.model,
+          messages,
+          temperature: 0.2,
+          max_tokens: 512,
+        }),
+        signal: AbortSignal.timeout(30000),
+      });
+      if (!resp.ok) {
+        lastError = `${p.name}_${resp.status}`;
+        continue;
+      }
+      const data = (await resp.json()) as {
+        choices?: Array<{ message?: { content?: string } }>;
+      };
+      const answer = data.choices?.[0]?.message?.content?.trim();
+      if (!answer) {
+        lastError = `${p.name}_empty`;
+        continue;
+      }
+      return { answer, provider: p.name };
+    } catch (err) {
+      lastError = `${p.name}_${err instanceof Error ? err.message : "error"}`;
+      continue;
+    }
+  }
+  throw new Error(`llm_cascade_failed:${lastError}`);
+}
+
+export async function handleLiveTroubleshoot(
+  req: Request<{ id: string }, unknown, LiveTroubleshootBody>,
+  res: Response,
+): Promise<void> {
+  const project = findProject(req.params.id);
+  if (!project) {
+    res.status(404).json({ error: "project_not_found", id: req.params.id });
+    return;
+  }
+
+  const { question, ignitionUrl, tagPrefix } = req.body ?? {};
+  if (!question || !ignitionUrl || !tagPrefix) {
+    res.status(400).json({
+      error: "bad_request",
+      message: "question, ignitionUrl, and tagPrefix are required",
+    });
+    return;
+  }
+
+  let variables: ManifestVariable[];
+  try {
+    variables = graphVariablesForProject(project);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.status(500).json({ error: "build_failed", message });
+    return;
+  }
+
+  const prefix = tagPrefix.replace(/\/$/, "");
+  const paths = variables.map((v) => `${prefix}/${v.name}`);
+
+  let tagsRead: LiveTagRead[];
+  try {
+    tagsRead = await readIgnitionTags(ignitionUrl, paths);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.status(502).json({ error: "ignition_unreachable", message });
+    return;
+  }
+
+  const { system, user } = buildPrompt(question, variables, tagsRead);
+
+  let llm: LlmResult;
+  try {
+    llm = await callLlmCascade(system, user);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const code = message.startsWith("llm_unavailable") ? "llm_unavailable" : "llm_cascade_failed";
+    res.status(502).json({ error: code, message });
+    return;
+  }
+
+  const contextUsed = variables
+    .slice(0, CONTEXT_VAR_LIMIT)
+    .map((v) => `variable:${v.name} (${v.dataType}, ${v.modbusAddress ?? v.address ?? "no-addr"})`);
+
+  res.json({
+    answer: llm.answer,
+    tags_read: tagsRead,
+    context_used: contextUsed,
+    provider: llm.provider,
+  });
+}

--- a/mira-machine-logic-graph/src/server.ts
+++ b/mira-machine-logic-graph/src/server.ts
@@ -11,9 +11,11 @@
 import express from "express";
 import { PROJECTS, findProject } from "./projects/registry.ts";
 import { buildTagsForProject } from "./ignition/build-for-project.ts";
+import { handleLiveTroubleshoot } from "./api/live-troubleshoot.ts";
 
 export function createApp(): express.Express {
   const app = express();
+  app.use(express.json({ limit: "1mb" }));
 
   app.get("/health", (_req, res) => {
     res.json({ ok: true, service: "mira-machine-logic-graph", version: "0.1.0" });
@@ -30,6 +32,10 @@ export function createApp(): express.Express {
       return;
     }
     res.json({ id: p.id, name: p.name, ignition: p.ignition });
+  });
+
+  app.post("/projects/:id/live-troubleshoot", (req, res) => {
+    void handleLiveTroubleshoot(req, res);
   });
 
   app.get("/projects/:id/ignition-tags", (req, res) => {

--- a/mira-machine-logic-graph/tests/live-troubleshoot.test.ts
+++ b/mira-machine-logic-graph/tests/live-troubleshoot.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createApp } from "../src/server.ts";
+
+function pickPort(): number {
+  return 8200 + Math.floor(Math.random() * 200);
+}
+
+// We swap the global fetch per-test. Outbound calls in the handler are
+// either Ignition (matched by /data/tag/read) or LLM provider endpoints
+// (matched by host). Local supertest calls go through Express's listener,
+// not through fetch, so they're unaffected.
+const realFetch = globalThis.fetch;
+
+interface MockResponse {
+  status: number;
+  body: unknown;
+}
+
+function installFetchMock(
+  router: (url: string, init: RequestInit | undefined) => MockResponse,
+): void {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    // Let the test's own localhost calls fall through to the real fetch
+    // so they actually hit the Express server.
+    if (url.includes("127.0.0.1") || url.includes("localhost:8")) {
+      // Only fall through for local Express server (ports 8200-8399 here).
+      const m = url.match(/:(\d+)/);
+      if (m && Number(m[1]) >= 8200 && Number(m[1]) < 8400) {
+        return realFetch(input as RequestInfo, init);
+      }
+    }
+    const mock = router(url, init);
+    return new Response(JSON.stringify(mock.body), {
+      status: mock.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+beforeEach(() => {
+  process.env.GROQ_API_KEY = "test-groq-key";
+  delete process.env.CEREBRAS_API_KEY;
+  delete process.env.GEMINI_API_KEY;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  delete process.env.GROQ_API_KEY;
+  delete process.env.CEREBRAS_API_KEY;
+  delete process.env.GEMINI_API_KEY;
+});
+
+describe("POST /projects/:id/live-troubleshoot", () => {
+  test("404 for unknown project", async () => {
+    const app = createApp();
+    const port = pickPort();
+    const server = app.listen(port);
+    try {
+      const r = await fetch(
+        `http://127.0.0.1:${port}/projects/nope/live-troubleshoot`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            question: "x",
+            ignitionUrl: "http://ignition",
+            tagPrefix: "[default]MIRA_PLC",
+          }),
+        },
+      );
+      expect(r.status).toBe(404);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("400 when required fields missing", async () => {
+    const app = createApp();
+    const port = pickPort();
+    const server = app.listen(port);
+    try {
+      const r = await fetch(
+        `http://127.0.0.1:${port}/projects/micro820-conveyor/live-troubleshoot`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ question: "x" }),
+        },
+      );
+      expect(r.status).toBe(400);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("502 when Ignition is unreachable", async () => {
+    installFetchMock((url) => {
+      if (url.includes("/data/tag/read")) {
+        return { status: 500, body: { error: "ignition_down" } };
+      }
+      return { status: 200, body: {} };
+    });
+    const app = createApp();
+    const port = pickPort();
+    const server = app.listen(port);
+    try {
+      const r = await fetch(
+        `http://127.0.0.1:${port}/projects/micro820-conveyor/live-troubleshoot`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            question: "why is conveyor stopped?",
+            ignitionUrl: "http://fake-ignition:8088",
+            tagPrefix: "[default]MIRA_PLC",
+          }),
+        },
+      );
+      expect(r.status).toBe(502);
+      const body = (await r.json()) as { error: string };
+      expect(body.error).toBe("ignition_unreachable");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("502 when no LLM provider key is set", async () => {
+    delete process.env.GROQ_API_KEY;
+    installFetchMock((url) => {
+      if (url.includes("/data/tag/read")) {
+        return {
+          status: 200,
+          body: { results: [{ path: "x", value: false, quality: "Good" }] },
+        };
+      }
+      return { status: 500, body: {} };
+    });
+    const app = createApp();
+    const port = pickPort();
+    const server = app.listen(port);
+    try {
+      const r = await fetch(
+        `http://127.0.0.1:${port}/projects/micro820-conveyor/live-troubleshoot`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            question: "why?",
+            ignitionUrl: "http://fake-ignition:8088",
+            tagPrefix: "[default]MIRA_PLC",
+          }),
+        },
+      );
+      expect(r.status).toBe(502);
+      const body = (await r.json()) as { error: string };
+      expect(body.error).toBe("llm_unavailable");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("200 happy path returns grounded answer", async () => {
+    installFetchMock((url) => {
+      if (url.includes("/data/tag/read")) {
+        return {
+          status: 200,
+          body: {
+            results: [
+              {
+                path: "[default]MIRA_PLC/motor_running",
+                value: false,
+                quality: "Good",
+                timestamp: "2026-05-11T10:00:00Z",
+              },
+            ],
+          },
+        };
+      }
+      if (url.includes("api.groq.com")) {
+        return {
+          status: 200,
+          body: {
+            choices: [
+              {
+                message: {
+                  content:
+                    "motor_running = false [live]. Likely cause: e_stop_active = true [live].",
+                },
+              },
+            ],
+          },
+        };
+      }
+      return { status: 500, body: {} };
+    });
+
+    const app = createApp();
+    const port = pickPort();
+    const server = app.listen(port);
+    try {
+      const r = await fetch(
+        `http://127.0.0.1:${port}/projects/micro820-conveyor/live-troubleshoot`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            question: "why won't the motor run?",
+            ignitionUrl: "http://fake-ignition:8088",
+            tagPrefix: "[default]MIRA_PLC",
+          }),
+        },
+      );
+      expect(r.status).toBe(200);
+      const body = (await r.json()) as {
+        answer: string;
+        tags_read: unknown[];
+        context_used: string[];
+        provider: string;
+      };
+      expect(body.answer).toContain("[live]");
+      expect(body.provider).toBe("groq");
+      expect(Array.isArray(body.tags_read)).toBe(true);
+      expect(body.context_used.length).toBeGreaterThan(0);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("falls back to cerebras when groq fails", async () => {
+    process.env.CEREBRAS_API_KEY = "test-cerebras-key";
+    installFetchMock((url) => {
+      if (url.includes("/data/tag/read")) {
+        return {
+          status: 200,
+          body: { results: [{ path: "x", value: true, quality: "Good" }] },
+        };
+      }
+      if (url.includes("api.groq.com")) {
+        return { status: 500, body: { error: "groq_down" } };
+      }
+      if (url.includes("api.cerebras.ai")) {
+        return {
+          status: 200,
+          body: {
+            choices: [{ message: { content: "fallback answer [live]" } }],
+          },
+        };
+      }
+      return { status: 500, body: {} };
+    });
+
+    const app = createApp();
+    const port = pickPort();
+    const server = app.listen(port);
+    try {
+      const r = await fetch(
+        `http://127.0.0.1:${port}/projects/micro820-conveyor/live-troubleshoot`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            question: "why?",
+            ignitionUrl: "http://fake-ignition:8088",
+            tagPrefix: "[default]MIRA_PLC",
+          }),
+        },
+      );
+      expect(r.status).toBe(200);
+      const body = (await r.json()) as { provider: string };
+      expect(body.provider).toBe("cerebras");
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- CRA-227: pin nomic-embed-text Docker image to v1.5
- CRA-228: remove hardcoded Bravo LAN IP from asset-intelligence
- CRA-236: live troubleshoot endpoint — Ignition tags + Groq cascade

## Test plan
- [ ] 18 tests pass per branch description