### PR TITLE
feat(web): activate hub_users on Stripe checkout / churn

### DIFF
--- a/mira-web/src/lib/__tests__/hub-user-activation.test.ts
+++ b/mira-web/src/lib/__tests__/hub-user-activation.test.ts
@@ -1,0 +1,90 @@
+/**
+ * hub-user-activation tests.
+ *
+ * We don't need a live NeonDB — we mock @neondatabase/serverless's `neon`
+ * to capture the SQL the helpers issue and assert the shape. The real
+ * SQL is exercised by the schema in mira-hub/src/lib/users.ts (status
+ * column, email_lower generated column).
+ */
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+
+let capturedQueries: Array<{ strings: TemplateStringsArray; values: unknown[] }>;
+let scriptedReturns: Array<unknown[]>;
+
+mock.module("@neondatabase/serverless", () => ({
+  neon: () => {
+    return (strings: TemplateStringsArray, ...values: unknown[]) => {
+      capturedQueries.push({ strings, values });
+      const next = scriptedReturns.shift() ?? [];
+      return Promise.resolve(next);
+    };
+  },
+}));
+
+beforeEach(() => {
+  capturedQueries = [];
+  scriptedReturns = [];
+  process.env.NEON_DATABASE_URL = "postgresql://fake:fake@fake/fake";
+});
+
+afterEach(() => {
+  delete process.env.NEON_DATABASE_URL;
+});
+
+describe("activateHubUserByEmail", () => {
+  test("returns matched=0 for empty email without touching DB", async () => {
+    const { activateHubUserByEmail } = await import("../hub-user-activation");
+    const out = await activateHubUserByEmail("   ");
+    expect(out.matched).toBe(0);
+    expect(capturedQueries.length).toBe(0);
+  });
+
+  test("issues an UPDATE that sets status to approved and clears trial_expires_at", async () => {
+    scriptedReturns = [[{ id: "user-123" }]];
+    const { activateHubUserByEmail } = await import("../hub-user-activation");
+    const out = await activateHubUserByEmail("Mike@Factorylm.com");
+    expect(out.matched).toBe(1);
+    expect(capturedQueries.length).toBe(1);
+    const sql = capturedQueries[0].strings.join("?");
+    expect(sql).toContain("UPDATE hub_users");
+    expect(sql).toContain("status = 'approved'");
+    expect(sql).toContain("trial_expires_at = NULL");
+    expect(sql).toContain("email_lower = LOWER(");
+    expect(capturedQueries[0].values).toEqual(["Mike@Factorylm.com"]);
+  });
+
+  test("returns matched=0 when no rows affected (user not yet on Hub)", async () => {
+    scriptedReturns = [[]];
+    const { activateHubUserByEmail } = await import("../hub-user-activation");
+    const out = await activateHubUserByEmail("nobody@example.com");
+    expect(out.matched).toBe(0);
+  });
+
+  test("throws when NEON_DATABASE_URL is unset", async () => {
+    delete process.env.NEON_DATABASE_URL;
+    const { activateHubUserByEmail } = await import("../hub-user-activation");
+    await expect(activateHubUserByEmail("a@b.com")).rejects.toThrow(
+      /NEON_DATABASE_URL/,
+    );
+  });
+});
+
+describe("expireHubUserByEmail", () => {
+  test("issues an UPDATE that sets status to expired", async () => {
+    scriptedReturns = [[{ id: "user-456" }]];
+    const { expireHubUserByEmail } = await import("../hub-user-activation");
+    const out = await expireHubUserByEmail("paid@x.com");
+    expect(out.matched).toBe(1);
+    const sql = capturedQueries[0].strings.join("?");
+    expect(sql).toContain("UPDATE hub_users");
+    expect(sql).toContain("status = 'expired'");
+    expect(sql).not.toContain("trial_expires_at"); // intentionally untouched
+  });
+
+  test("returns matched=0 for empty email", async () => {
+    const { expireHubUserByEmail } = await import("../hub-user-activation");
+    const out = await expireHubUserByEmail("");
+    expect(out.matched).toBe(0);
+    expect(capturedQueries.length).toBe(0);
+  });
+});

--- a/mira-web/src/lib/hub-user-activation.ts
+++ b/mira-web/src/lib/hub-user-activation.ts
@@ -1,0 +1,82 @@
+/**
+ * Bridge mira-web's Stripe webhook to the mira-hub `hub_users` table.
+ *
+ * Until this existed, a successful checkout flipped `plg_tenants.tier` to
+ * "active" but left the matching `hub_users.status` at "trial" (or, for
+ * legacy users, "pending"). The Hub middleware
+ * (`mira-hub/src/middleware.ts`) therefore kept routing paying customers
+ * to `/pending-approval` or `/upgrade` after their 7-day trial expired.
+ *
+ * Both apps share the same NeonDB, so we update `hub_users` directly.
+ * The UPDATE is idempotent and silently affects 0 rows when the user
+ * hasn't registered on the Hub yet (e.g. they paid first, then signed
+ * up via magic link). The corresponding hub_users row, when created
+ * later via `ensureUserAndTenant`, defaults to "trial" — at that point
+ * we'd need a backfill, but for the PLG self-serve flow the user
+ * almost always registers first.
+ *
+ * `status = 'approved'` is in the `UserStatus` enum
+ * (`mira-hub/src/lib/users.ts`) and bypasses every middleware gate
+ * (no `pending` redirect, no `expired` redirect, no `trial` expiry
+ * check). Clearing `trial_expires_at` keeps that gate from re-firing
+ * if status ever changes back to `trial`.
+ */
+
+import { neon } from "@neondatabase/serverless";
+
+function sql() {
+  const url = process.env.NEON_DATABASE_URL;
+  if (!url) throw new Error("NEON_DATABASE_URL not set");
+  return neon(url);
+}
+
+export interface HubActivationResult {
+  matched: number;
+}
+
+/**
+ * Mark the hub_users row for `email` as approved. Returns the number
+ * of rows affected (0 if the user hasn't registered yet on the Hub).
+ *
+ * Throws only on connection / SQL errors — callers should catch and
+ * log so a transient hub-DB blip doesn't cause Stripe to retry the
+ * whole webhook (idempotent activation logic upstream handles that).
+ */
+export async function activateHubUserByEmail(
+  email: string,
+): Promise<HubActivationResult> {
+  const trimmed = email.trim();
+  if (!trimmed) return { matched: 0 };
+  const db = sql();
+  const rows = (await db`
+    UPDATE hub_users
+       SET status = 'approved',
+           trial_expires_at = NULL,
+           updated_at = NOW()
+     WHERE email_lower = LOWER(${trimmed})
+     RETURNING id
+  `) as Array<{ id: string }>;
+  return { matched: rows.length };
+}
+
+/**
+ * Inverse of activateHubUserByEmail — flip back to 'expired' so the
+ * Hub middleware redirects the user to /upgrade. Used on
+ * `customer.subscription.deleted` so churned customers can resubscribe
+ * but lose access until they do.
+ */
+export async function expireHubUserByEmail(
+  email: string,
+): Promise<HubActivationResult> {
+  const trimmed = email.trim();
+  if (!trimmed) return { matched: 0 };
+  const db = sql();
+  const rows = (await db`
+    UPDATE hub_users
+       SET status = 'expired',
+           updated_at = NOW()
+     WHERE email_lower = LOWER(${trimmed})
+     RETURNING id
+  `) as Array<{ id: string }>;
+  return { matched: rows.length };
+}

--- a/mira-web/src/server.ts
+++ b/mira-web/src/server.ts
@@ -95,6 +95,10 @@ import {
   createPortalSession,
   constructWebhookEvent,
 } from "./lib/stripe.js";
+import {
+  activateHubUserByEmail,
+  expireHubUserByEmail,
+} from "./lib/hub-user-activation.js";
 import { FAULT_CODES } from "./data/fault-codes.js";
 import { BLOG_POSTS } from "./data/blog-posts.js";
 import {
@@ -1146,6 +1150,21 @@ app.post("/api/stripe/webhook", async (c) => {
         break;
       }
 
+      // Bridge to mira-hub: flip hub_users.status → 'approved' so the Hub
+      // middleware stops redirecting paying customers to /pending-approval
+      // or /upgrade. Idempotent UPDATE — silently 0 rows if the user
+      // hasn't registered on the Hub yet.
+      try {
+        const result = await activateHubUserByEmail(tenant.email);
+        console.log(
+          "[stripe-webhook] Hub user activation: matched=%d email=%s",
+          result.matched,
+          tenant.email,
+        );
+      } catch (err) {
+        console.error("[stripe-webhook] Hub user activation failed:", err);
+      }
+
       const result = await finalizeActivation(tenant, {
         signupUser,
         updateTenantAtlas,
@@ -1185,8 +1204,11 @@ app.post("/api/stripe/webhook", async (c) => {
     case "customer.subscription.deleted": {
       const sub = event.data.object;
       const tenantId = sub.metadata?.tenant_id;
+      let churnedTenantEmail: string | null = null;
       if (tenantId) {
         await updateTenantTier(tenantId, "churned");
+        const t = await findTenantById(tenantId);
+        churnedTenantEmail = t?.email ?? null;
         console.log("[stripe-webhook] Tenant churned:", tenantId);
         void recordAuditEvent({
           tenantId,
@@ -1204,6 +1226,7 @@ app.post("/api/stripe/webhook", async (c) => {
           const tenant = await findTenantByStripeCustomerId(customerId);
           if (tenant) {
             await updateTenantTier(tenant.id, "churned");
+            churnedTenantEmail = tenant.email;
             console.log("[stripe-webhook] Tenant churned (by customer):", tenant.id);
             void recordAuditEvent({
               tenantId: tenant.id,
@@ -1214,6 +1237,19 @@ app.post("/api/stripe/webhook", async (c) => {
               metadata: { matched_via: "customer_id" },
             });
           }
+        }
+      }
+      // Mirror churn into mira-hub so middleware redirects them to /upgrade.
+      if (churnedTenantEmail) {
+        try {
+          const result = await expireHubUserByEmail(churnedTenantEmail);
+          console.log(
+            "[stripe-webhook] Hub user expired: matched=%d email=%s",
+            result.matched,
+            churnedTenantEmail,
+          );
+        } catch (err) {
+          console.error("[stripe-webhook] Hub user expiry failed:", err);
         }
       }
       break;


### PR DESCRIPTION
Closes #1192. Gap 2 from `docs/specs/manual-intelligence-self-serve-spec.md`.

## Why
Until now mira-web's Stripe webhook flipped `plg_tenants.tier` to `active` but left `hub_users.status` at `trial`. After 7 days the Hub middleware redirected paying customers to `/upgrade`. Legacy users at `status='pending'` were stuck on `/pending-approval` forever.

## What
- **`mira-web/src/lib/hub-user-activation.ts`** — `activateHubUserByEmail` / `expireHubUserByEmail`. Idempotent, tenant-scoped UPDATE on `hub_users` (matched by `email_lower`). Both apps share the same NeonDB.
- **`mira-web/src/server.ts`** — webhook handler now calls these helpers in `checkout.session.completed` and `customer.subscription.deleted`. Errors are caught + logged so Stripe doesn't retry.

`'approved'` is already in `UserStatus` (mira-hub/src/lib/users.ts) — middleware passes it through every gate. No migration.

## Tests
6 `bun:test` cases — happy path, empty email no-op, no-rows match, missing `NEON_DATABASE_URL`. All pass.

## Test plan
- [x] Unit tests pass (`bun test src/lib/__tests__/hub-user-activation.test.ts` → 6 pass)
- [ ] Post-deploy: trigger a test Stripe webhook (or a real test-mode checkout), confirm Hub user goes from `trial` → `approved` in NeonDB
- [ ] Post-deploy: a fresh login with the activated user lands on `/feed`, not `/pending-approval` or `/upgrade`

🤖 Generated with [Claude Code](https://claude.com/claude-code)