### PR TITLE
fix(deploy): rm bare container names in pre-deploy cleanup

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -67,7 +67,10 @@ jobs:
           # has lost track of, we hit `Error: container name already in use` and the deploy
           # bails out (exact failure mode of run 25264673954, 2026-05-02).
           for svc in $TARGETS; do
+            # container_name in saas.yml is sometimes bare (mira-hub,
+            # mira-bot-telegram), sometimes -saas suffixed. Try both.
             docker rm -f "${svc}-saas" 2>/dev/null || true
+            docker rm -f "${svc}" 2>/dev/null || true
           done
 
           echo "=== Rebuild containers ==="


### PR DESCRIPTION
Unblocks deploys targeting services whose `container_name` in `docker-compose.saas.yml` is bare (no `-saas` suffix) — `mira-hub`, `mira-bot-telegram`.

Run [25737604039](https://github.com/Mikecranesync/MIRA/actions/runs/25737604039) failed at:
```
Container mira-bot-telegram Error response from daemon: Conflict.
The container name "/mira-bot-telegram" is already in use…
```
because the cleanup loop only `docker rm -f`'d `${svc}-saas`.

Adds a second `docker rm -f "${svc}"` so both naming conventions are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)