### PR TITLE
fix(mira-web): redirect /login and /signup to app.factorylm.com (#1132 #1133)

### DIFF
--- a/mira-web/src/server.ts
+++ b/mira-web/src/server.ts
@@ -1756,6 +1756,14 @@ app.get("/api/connect/status", requireActive, async (c) => {
 });
 
 // ---------------------------------------------------------------------------
+// Apex-domain redirects — funnel URLs that only exist on app.factorylm.com
+// closes #1132, #1133
+// ---------------------------------------------------------------------------
+
+app.get("/login", (c) => c.redirect("https://app.factorylm.com/login", 301));
+app.get("/signup", (c) => c.redirect("https://app.factorylm.com/signup", 301));
+
+// ---------------------------------------------------------------------------
 // 404 — custom page with home link (CRA-109)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `factorylm.com/login` and `factorylm.com/signup` both returned HTTP 404. The hub (and its auth flows) live at `app.factorylm.com`.
- External links, marketing emails, and social posts commonly target the apex domain. Without redirects, they dead-end.
- Added 301 permanent redirects in `mira-web/src/server.ts` just before the `app.notFound` handler.

## Changes

```ts
app.get("/login", (c) => c.redirect("https://app.factorylm.com/login", 301));
app.get("/signup", (c) => c.redirect("https://app.factorylm.com/signup", 301));
```

## Test plan

- [ ] `curl -sI https://factorylm.com/login` → `HTTP/2 301` + `location: https://app.factorylm.com/login`
- [ ] `curl -sI https://factorylm.com/signup` → `HTTP/2 301` + `location: https://app.factorylm.com/signup`
- [ ] Deploy `mira-web` to VPS, recheck

Also: **#1102** (404 page no back link) is already fixed — `server.ts:1681` has `<a class="home" href="/">Back to home</a>`. Closing that issue as a duplicate resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)