### PR TITLE
fix(seo): expand sitemap.xml + add app subdomain to robots.txt (CRA-27/28)

### DIFF
--- a/mira-web/public/robots.txt
+++ b/mira-web/public/robots.txt
@@ -1,5 +1,5 @@
 # FactoryLM robots.txt
-# Last updated: 2026-04-28
+# Last updated: 2026-05-12
 
 User-agent: *
 Allow: /
@@ -7,6 +7,7 @@ Disallow: /api/
 Disallow: /admin/
 Disallow: /demo/
 Sitemap: https://factorylm.com/sitemap.xml
+Sitemap: https://app.factorylm.com/sitemap.xml
 
 # AI crawlers — explicit allow
 # We want our content indexed and cited by ChatGPT, Claude, Perplexity, etc.

--- a/mira-web/public/sitemap.xml
+++ b/mira-web/public/sitemap.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://factorylm.com/cmms</loc>
-    <lastmod>2026-04-08</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>1.0</priority>
-  </url>
-</urlset>


### PR DESCRIPTION
## Summary

- **CRA-27**: Deleted stub `mira-web/public/sitemap.xml` (had only 1 URL). Dynamic route at `server.ts:306` now serves the full sitemap with 10+ URLs and correct priorities.
- **CRA-28**: Added `Sitemap: https://app.factorylm.com/sitemap.xml` to `mira-web/public/robots.txt`. Updated last-updated date.

## Test plan
- [ ] `curl https://app.factorylm.com/sitemap.xml` returns `<urlset>` with multiple URLs
- [ ] `curl https://app.factorylm.com/robots.txt` shows both Sitemap directives

🤖 Generated with [Claude Code](https://claude.com/claude-code)