### PR TITLE
feat(hub): ICS calendar export + CSV export buttons (#1193, #1194)

### DIFF
--- a/mira-hub/src/app/(hub)/assets/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/page.tsx
@@ -7,7 +7,13 @@ import { useTranslations } from "next-intl";
 import {
   Search, QrCode, Wind, Zap, Cog, Thermometer, Droplets,
   Factory, Gauge, AlertCircle, CheckCircle2, AlertTriangle,
+<<<<<<< Updated upstream
   Plus, X, Loader2, Wrench, Printer,
+||||||| Stash base
+  Plus, X, Loader2, Wrench,
+=======
+  Plus, X, Loader2, Wrench, Download,
+>>>>>>> Stashed changes
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -462,6 +468,16 @@ function AssetsPageInner() {
         <div className="flex items-center justify-between mb-3">
           <h1 className="text-base font-semibold" style={{ color: "var(--foreground)" }}>{t("title")}</h1>
           <div className="flex items-center gap-2">
+            {/* Export CSV */}
+            <button
+              onClick={() => { window.location.href = `${API_BASE}/api/assets/export.csv`; }}
+              className="hidden md:flex items-center gap-1.5 h-8 px-3 rounded-lg text-xs font-medium border transition-colors hover:bg-[var(--surface-1)]"
+              style={{ borderColor: "var(--border)", color: "var(--foreground-muted)" }}
+              title="Export CSV"
+            >
+              <Download className="w-3.5 h-3.5" />
+              Export CSV
+            </button>
             {/* Desktop create button */}
             <button
               onClick={() => setShowCreate(true)}

--- a/mira-hub/src/app/(hub)/schedule/page.tsx
+++ b/mira-hub/src/app/(hub)/schedule/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Calendar, List, ChevronLeft, ChevronRight, Clock, User, RotateCcw, AlertCircle, X, Sparkles, Package, Wrench, ShieldAlert, BookOpen, Gauge } from "lucide-react";
+import { Calendar, List, ChevronLeft, ChevronRight, Clock, User, RotateCcw, AlertCircle, X, Sparkles, Package, Wrench, ShieldAlert, BookOpen, Gauge, Download } from "lucide-react";
 import { useToast } from "@/providers/toast-provider";
 import { Badge } from "@/components/ui/badge";
 import { API_BASE } from "@/lib/config";
@@ -142,6 +142,28 @@ export default function SchedulePage() {
                 <span className="text-[11px]" style={{ color: "var(--foreground-subtle)" }}>{t("upcomingCount", { count: scheduledCount })}</span>
               </div>
             </div>
+            {/* Export buttons */}
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => { window.location.href = `${API_BASE}/api/pm/export.ics`; }}
+                className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors hover:bg-[var(--surface-1)]"
+                style={{ borderColor: "var(--border)", color: "var(--foreground-muted)" }}
+                title="Export to Calendar (.ics)"
+              >
+                <Download className="w-3 h-3" />
+                <span className="hidden sm:inline">Calendar</span>
+              </button>
+              <button
+                onClick={() => { window.location.href = `${API_BASE}/api/pm/export.csv`; }}
+                className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors hover:bg-[var(--surface-1)]"
+                style={{ borderColor: "var(--border)", color: "var(--foreground-muted)" }}
+                title="Export CSV"
+              >
+                <Download className="w-3 h-3" />
+                <span className="hidden sm:inline">CSV</span>
+              </button>
+            </div>
+
             {/* View toggle */}
             <div className="flex rounded-lg overflow-hidden border" style={{ borderColor: "var(--border)" }}>
               <button onClick={() => setView("calendar")}

--- a/mira-hub/src/app/(hub)/workorders/page.tsx
+++ b/mira-hub/src/app/(hub)/workorders/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
-import { Search, Plus, User, Calendar as CalIcon, Bot, Sparkles, Loader2 } from "lucide-react";
+import { Search, Plus, User, Calendar as CalIcon, Bot, Sparkles, Loader2, Download } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -121,11 +121,22 @@ export default function WorkOrdersPage() {
                 )}
               </div>
             </div>
-            <Link href="/workorders/new">
-              <Button size="sm" className="gap-1.5">
-                <Plus className="w-3.5 h-3.5" />{tWO("new")}
-              </Button>
-            </Link>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => { window.location.href = `${API_BASE}/api/work-orders/export.csv`; }}
+                className="hidden md:flex items-center gap-1.5 h-8 px-3 rounded-lg text-xs font-medium border transition-colors hover:bg-[var(--surface-1)]"
+                style={{ borderColor: "var(--border)", color: "var(--foreground-muted)" }}
+                title="Export CSV"
+              >
+                <Download className="w-3.5 h-3.5" />
+                Export CSV
+              </button>
+              <Link href="/workorders/new">
+                <Button size="sm" className="gap-1.5">
+                  <Plus className="w-3.5 h-3.5" />{tWO("new")}
+                </Button>
+              </Link>
+            </div>
           </div>
 
           <div className="relative mb-3">

--- a/mira-hub/src/app/api/assets/export.csv/route.ts
+++ b/mira-hub/src/app/api/assets/export.csv/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { toCsv, csvResponse } from "@/lib/csv-export";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  try {
+    const rows = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query(
+          `SELECT
+            id,
+            equipment_number AS tag,
+            COALESCE(description, manufacturer || ' ' || COALESCE(model_number, '')) AS name,
+            manufacturer,
+            model_number AS model,
+            serial_number,
+            equipment_type AS type,
+            location,
+            department,
+            criticality,
+            work_order_count,
+            total_downtime_hours,
+            last_maintenance_date,
+            last_work_order_at,
+            last_reported_fault,
+            created_at
+          FROM cmms_equipment
+          WHERE tenant_id = $1
+          ORDER BY last_work_order_at DESC NULLS LAST, created_at DESC
+          LIMIT 1000`,
+          [ctx.tenantId],
+        )
+        .then((r) => r.rows),
+    );
+
+    return csvResponse(toCsv(rows), "assets.csv");
+  } catch (err) {
+    console.error("[api/assets/export.csv GET]", err);
+    return NextResponse.json({ error: "Export failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/pm/export.csv/route.ts
+++ b/mira-hub/src/app/api/pm/export.csv/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { toCsv, csvResponse } from "@/lib/csv-export";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  try {
+    const rows = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query(
+          `SELECT
+            id,
+            COALESCE(manufacturer, '') || ' ' || COALESCE(model_number, '') AS asset,
+            task AS title,
+            interval_value,
+            interval_unit,
+            estimated_duration_minutes,
+            criticality,
+            COALESCE(trigger_type, 'calendar') AS trigger_type,
+            meter_type,
+            meter_threshold,
+            COALESCE(meter_current, 0) AS meter_current,
+            next_due_at,
+            last_completed_at,
+            auto_extracted,
+            source_citation,
+            parts_needed,
+            tools_needed,
+            safety_requirements,
+            created_at
+          FROM pm_schedules
+          WHERE tenant_id = $1
+          ORDER BY next_due_at ASC NULLS LAST
+          LIMIT 1000`,
+          [ctx.tenantId],
+        )
+        .then((r) => r.rows),
+    );
+
+    return csvResponse(toCsv(rows), "pm-schedule.csv");
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("pm_schedules") && msg.includes("does not exist")) {
+      return csvResponse("", "pm-schedule.csv");
+    }
+    console.error("[api/pm/export.csv GET]", err);
+    return NextResponse.json({ error: "Export failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/pm/export.ics/route.ts
+++ b/mira-hub/src/app/api/pm/export.ics/route.ts
@@ -1,0 +1,123 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { buildICS, type PMTask } from "@/lib/ics-export";
+
+export const dynamic = "force-dynamic";
+
+function pmStatus(
+  nextDueAt: string | null,
+  lastCompletedAt: string | null,
+): "scheduled" | "overdue" | "completed" {
+  if (lastCompletedAt) {
+    const completed = new Date(lastCompletedAt);
+    const now = new Date();
+    if (now.getTime() - completed.getTime() < 7 * 24 * 60 * 60 * 1000) {
+      return "completed";
+    }
+  }
+  if (!nextDueAt) return "scheduled";
+  return new Date(nextDueAt) < new Date() ? "overdue" : "scheduled";
+}
+
+function intervalToRecur(value: number, unit: string): string {
+  const unitMap: Record<string, string> = {
+    hours: "hr",
+    days: value === 1 ? "Daily" : `${value}d`,
+    weeks: value === 1 ? "Weekly" : `${value}w`,
+    months:
+      value === 1
+        ? "Monthly"
+        : value === 3
+          ? "Quarterly"
+          : value === 6
+            ? "Semi-annual"
+            : `${value}mo`,
+    years: value === 1 ? "Annual" : `${value}yr`,
+    cycles: `${value} cycles`,
+  };
+  return unitMap[unit] ?? `${value} ${unit}`;
+}
+
+function rowToPMTask(r: Record<string, unknown>): PMTask {
+  const nextDueAt = r.next_due_at ? String(r.next_due_at) : null;
+  const lastCompletedAt = r.last_completed_at ? String(r.last_completed_at) : null;
+  const durationMin =
+    typeof r.estimated_duration_minutes === "number" ? r.estimated_duration_minutes : null;
+  const dueDate = nextDueAt ? nextDueAt.slice(0, 10) : new Date().toISOString().slice(0, 10);
+  const assetLabel =
+    [r.manufacturer, r.model_number].filter(Boolean).join(" ") || "Unknown asset";
+
+  return {
+    id: String(r.id),
+    title: String(r.task),
+    asset: assetLabel,
+    date: dueDate,
+    tech: "—",
+    recur: intervalToRecur(Number(r.interval_value), String(r.interval_unit)),
+    durationH: durationMin ? Math.max(1, Math.round(durationMin / 60)) : 1,
+    status: pmStatus(nextDueAt, lastCompletedAt),
+    criticality: r.criticality ? String(r.criticality) : "medium",
+    parts_needed: Array.isArray(r.parts_needed) ? (r.parts_needed as string[]) : [],
+    tools_needed: Array.isArray(r.tools_needed) ? (r.tools_needed as string[]) : [],
+    safety_requirements: Array.isArray(r.safety_requirements)
+      ? (r.safety_requirements as string[])
+      : [],
+    source_citation: r.source_citation ? String(r.source_citation) : null,
+  };
+}
+
+export async function GET() {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  try {
+    const rows = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query(
+          `SELECT
+            id, manufacturer, model_number,
+            task, interval_value, interval_unit,
+            parts_needed, tools_needed, estimated_duration_minutes,
+            safety_requirements, criticality, source_citation,
+            next_due_at, last_completed_at
+          FROM pm_schedules
+          WHERE tenant_id = $1
+          ORDER BY next_due_at ASC NULLS LAST
+          LIMIT 500`,
+          [ctx.tenantId],
+        )
+        .then((r) => r.rows),
+    );
+
+    const tasks: PMTask[] = rows.map(rowToPMTask);
+    const icsContent = buildICS(tasks, "MIRA PM Schedule");
+
+    return new Response(icsContent, {
+      headers: {
+        "Content-Type": "text/calendar; charset=utf-8",
+        "Content-Disposition": 'attachment; filename="pm-schedule.ics"',
+        "Cache-Control": "no-store",
+      },
+    });
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("pm_schedules") && msg.includes("does not exist")) {
+      // Return an empty-but-valid calendar when the table hasn't been created yet
+      const emptyIcs = buildICS([], "MIRA PM Schedule");
+      return new Response(emptyIcs, {
+        headers: {
+          "Content-Type": "text/calendar; charset=utf-8",
+          "Content-Disposition": 'attachment; filename="pm-schedule.ics"',
+          "Cache-Control": "no-store",
+        },
+      });
+    }
+    console.error("[api/pm/export.ics GET]", err);
+    return NextResponse.json({ error: "Export failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/work-orders/export.csv/route.ts
+++ b/mira-hub/src/app/api/work-orders/export.csv/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { toCsv, csvResponse } from "@/lib/csv-export";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  try {
+    const rows = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query(
+          `SELECT
+            id,
+            work_order_number,
+            title,
+            COALESCE(manufacturer, '') || ' ' || COALESCE(model_number, '') AS asset,
+            manufacturer,
+            model_number,
+            status,
+            priority,
+            source,
+            suggested_actions,
+            safety_warnings,
+            description,
+            created_at,
+            updated_at
+          FROM work_orders
+          WHERE tenant_id = $1
+          ORDER BY
+            CASE status WHEN 'open' THEN 0 WHEN 'in_progress' THEN 1 ELSE 2 END,
+            CASE priority WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 ELSE 3 END,
+            created_at DESC
+          LIMIT 1000`,
+          [ctx.tenantId],
+        )
+        .then((r) => r.rows),
+    );
+
+    return csvResponse(toCsv(rows), "work-orders.csv");
+  } catch (err) {
+    const msg = String(err);
+    if (msg.includes("work_orders") && msg.includes("does not exist")) {
+      return csvResponse("", "work-orders.csv");
+    }
+    console.error("[api/work-orders/export.csv GET]", err);
+    return NextResponse.json({ error: "Export failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/lib/csv-export.ts
+++ b/mira-hub/src/lib/csv-export.ts
@@ -1,0 +1,45 @@
+/**
+ * Lightweight CSV serialiser — no external dependencies.
+ * Follows RFC 4180 quoting: fields containing commas, double-quotes,
+ * or newlines are wrapped in double-quotes; embedded double-quotes are
+ * doubled.
+ */
+
+/**
+ * Escape a single cell value for CSV output.
+ */
+export function csvEscape(value: unknown): string {
+  const s = value == null ? "" : Array.isArray(value) ? value.join("; ") : String(value);
+  if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/**
+ * Serialise an array of flat objects to a CSV string.
+ * The column order follows the keys of the first row.
+ * Returns an empty string for an empty array.
+ */
+export function toCsv(rows: Record<string, unknown>[]): string {
+  if (rows.length === 0) return "";
+  const headers = Object.keys(rows[0]);
+  const lines = [
+    headers.join(","),
+    ...rows.map((r) => headers.map((h) => csvEscape(r[h])).join(",")),
+  ];
+  return lines.join("\n");
+}
+
+/**
+ * Build a Response with the correct CSV headers.
+ */
+export function csvResponse(content: string, filename: string): Response {
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Cache-Control": "no-store",
+    },
+  });
+}

--- a/mira-hub/src/lib/ics-export.ts
+++ b/mira-hub/src/lib/ics-export.ts
@@ -1,0 +1,137 @@
+/**
+ * RFC 5545 ICS generation for PM schedules.
+ * No external dependencies — pure string construction.
+ */
+
+export interface PMTask {
+  id: string;
+  title: string;
+  asset: string;
+  date: string;       // YYYY-MM-DD (all-day event)
+  tech: string;
+  recur: string;
+  durationH: number;
+  status: string;
+  criticality?: string;
+  parts_needed?: string[];
+  tools_needed?: string[];
+  safety_requirements?: string[];
+  source_citation?: string | null;
+}
+
+/**
+ * Fold long lines to 75 octets per RFC 5545 §3.1.
+ * Continuation lines begin with a single space.
+ */
+function foldLine(line: string): string {
+  if (line.length <= 75) return line;
+  const chunks: string[] = [];
+  // First chunk: 75 chars; continuation chunks: 74 chars (1 leading space)
+  chunks.push(line.slice(0, 75));
+  let offset = 75;
+  while (offset < line.length) {
+    chunks.push(" " + line.slice(offset, offset + 74));
+    offset += 74;
+  }
+  return chunks.join("\r\n");
+}
+
+/**
+ * Escape TEXT-value special characters per RFC 5545 §3.3.11.
+ */
+function escapeText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,")
+    .replace(/\n/g, "\\n");
+}
+
+/**
+ * Produce a DTSTART/DTEND pair for an all-day event from a YYYY-MM-DD string.
+ * All-day events use DATE value type (no time component).
+ */
+function allDayDate(dateStr: string): { dtstart: string; dtend: string } {
+  // Parse the date and build the end date (next day for all-day events)
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const end = new Date(y, m - 1, d + 1); // next day
+  const pad = (n: number) => String(n).padStart(2, "0");
+  const endStr = `${end.getFullYear()}${pad(end.getMonth() + 1)}${pad(end.getDate())}`;
+  const startStr = `${y}${pad(m)}${pad(d)}`;
+  return {
+    dtstart: `DTSTART;VALUE=DATE:${startStr}`,
+    dtend: `DTEND;VALUE=DATE:${endStr}`,
+  };
+}
+
+/**
+ * Build a DESCRIPTION string from PM task fields.
+ */
+function buildDescription(pm: PMTask): string {
+  const lines: string[] = [
+    `Asset: ${pm.asset}`,
+    `Status: ${pm.status}`,
+    `Recurrence: ${pm.recur}`,
+    `Duration: ${pm.durationH}h`,
+    `Technician: ${pm.tech}`,
+  ];
+
+  if (pm.criticality) lines.push(`Criticality: ${pm.criticality}`);
+  if (pm.parts_needed?.length) lines.push(`Parts needed: ${pm.parts_needed.join(", ")}`);
+  if (pm.tools_needed?.length) lines.push(`Tools needed: ${pm.tools_needed.join(", ")}`);
+  if (pm.safety_requirements?.length) lines.push(`Safety: ${pm.safety_requirements.join(", ")}`);
+  if (pm.source_citation) lines.push(`Manual ref: ${pm.source_citation}`);
+
+  return lines.join("\\n");
+}
+
+/**
+ * Generate a VEVENT block for a single PM task.
+ */
+function toVEvent(pm: PMTask, prodId: string): string {
+  const { dtstart, dtend } = allDayDate(pm.date);
+  const dtstamp = new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d+Z$/, "Z");
+  const uid = `${pm.id}@${prodId}`;
+  const summary = escapeText(pm.title);
+  const description = buildDescription(pm);
+
+  const lines = [
+    "BEGIN:VEVENT",
+    foldLine(`UID:${uid}`),
+    `DTSTAMP:${dtstamp}`,
+    dtstart,
+    dtend,
+    foldLine(`SUMMARY:${summary}`),
+    foldLine(`DESCRIPTION:${description}`),
+    "END:VEVENT",
+  ];
+
+  return lines.join("\r\n");
+}
+
+/**
+ * Convert an array of PM tasks to a complete RFC 5545 VCALENDAR string.
+ *
+ * @param tasks  Array of PM task objects
+ * @param calName  Optional calendar display name (X-WR-CALNAME)
+ * @returns  Complete .ics file content as a string
+ */
+export function buildICS(tasks: PMTask[], calName = "PM Schedule"): string {
+  const prodId = "factorylm.com";
+
+  const header = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    `PRODID:-//FactoryLM//MIRA PM Schedule//EN`,
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    `X-WR-CALNAME:${escapeText(calName)}`,
+    "X-WR-TIMEZONE:UTC",
+  ];
+
+  const events = tasks.map((t) => toVEvent(t, prodId));
+
+  const footer = ["END:VCALENDAR"];
+
+  return [...header, ...events, ...footer].join("\r\n") + "\r\n";
+}


### PR DESCRIPTION
## Summary
- Add **Export to Calendar** button on PM Schedule page → downloads `.ics` (RFC 5545) with all scheduled PM tasks as all-day calendar events
- Add **Export CSV** buttons on PM Schedule, Assets, and Work Orders pages → downloads typed CSV files
- 4 new API routes: `GET /api/pm/export.ics`, `GET /api/pm/export.csv`, `GET /api/assets/export.csv`, `GET /api/work-orders/export.csv`
- 2 new pure utility modules: `src/lib/ics-export.ts` (RFC 5545, no dependencies), `src/lib/csv-export.ts` (RFC 4180 quoting)

Closes #1193, #1194

## Test plan
- [ ] PM Schedule: click "Calendar" button → file download named `pm-schedule.ics` opens in calendar app with all PM tasks
- [ ] PM Schedule: click "CSV" button → file with headers + one row per task
- [ ] Assets: click "Export CSV" → file with asset tag, name, manufacturer, model columns
- [ ] Work Orders: click "Export CSV" → file with WO id, title, status, asset columns
- [ ] Empty tables: downloads produce header-only CSV (no error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)