### PR TITLE
feat(hub): upload results summary card after document ingest (#1195)

### DIFF
--- a/mira-hub/src/app/(hub)/knowledge/page.tsx
+++ b/mira-hub/src/app/(hub)/knowledge/page.tsx
@@ -17,6 +17,7 @@ import { UploadPicker } from "@/components/UploadPicker";
 import { UploadBlock, type UploadBlockData } from "@/components/UploadBlock";
 import { API_BASE } from "@/lib/config";
 import { KbGrowthDashboard } from "./KbGrowthDashboard";
+import { UploadSummaryCard } from "@/components/UploadSummaryCard";
 
 type Manufacturer = {
   name: string;
@@ -101,6 +102,7 @@ export default function KnowledgePage() {
   const [search, setSearch] = useState("");
   const [uploads, setUploads] = useState<UploadBlockData[]>([]);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [summaryUploadId, setSummaryUploadId] = useState<string | null>(null);
 
   const [selectedMfr, setSelectedMfr] = useState<string | null>(null);
   const [groups, setGroups] = useState<ManualGroup[]>([]);
@@ -304,6 +306,7 @@ export default function KnowledgePage() {
   }, [uploads, fetchUploads]);
 
   async function handleLocalFiles(files: File[], assetTag: string | null) {
+    let firstId: string | null = null;
     for (const file of files) {
       const form = new FormData();
       form.append("file", file);
@@ -324,7 +327,12 @@ export default function KnowledgePage() {
                 : `Upload failed (${res.status})`;
         throw new Error(msg);
       }
+      if (!firstId) {
+        const data = (await res.json().catch(() => null)) as { id?: string } | null;
+        if (data?.id) firstId = data.id;
+      }
     }
+    if (firstId) setSummaryUploadId(firstId);
     await fetchUploads();
   }
 
@@ -340,13 +348,19 @@ export default function KnowledgePage() {
     }>,
     assetTag: string | null,
   ) {
+    let firstId: string | null = null;
     for (const result of results) {
-      await fetch(`${API_BASE}/api/uploads`, {
+      const res = await fetch(`${API_BASE}/api/uploads`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ ...result, assetTag: assetTag ?? undefined }),
       });
+      if (!firstId && res.ok) {
+        const data = (await res.json().catch(() => null)) as { id?: string } | null;
+        if (data?.id) firstId = data.id;
+      }
     }
+    if (firstId) setSummaryUploadId(firstId);
     await fetchUploads();
   }
 
@@ -480,6 +494,10 @@ export default function KnowledgePage() {
 
       <div className="px-4 md:px-6 py-4 pb-24 max-w-5xl mx-auto">
         {!selectedMfr && <KbGrowthDashboard />}
+
+        {!selectedMfr && summaryUploadId && (
+          <UploadSummaryCard uploadId={summaryUploadId} />
+        )}
 
         {!selectedMfr && (
           <div className="space-y-2 mb-4">

--- a/mira-hub/src/app/api/uploads/[id]/route.ts
+++ b/mira-hub/src/app/api/uploads/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { randomUUID } from "node:crypto";
-import { getUpload, updateUploadStatus, deleteUpload } from "@/lib/uploads";
+import { getUpload, getUploadCounts, updateUploadStatus, deleteUpload } from "@/lib/uploads";
 import { sessionOr401 } from "@/lib/session";
 import { makeUploadLogger } from "@/lib/upload-log";
 import { composeTimeout, isAbortError } from "@/lib/abort-helpers";
@@ -10,6 +10,26 @@ const OPENWEBUI_DELETE_TIMEOUT_MS = 10_000;
 export const dynamic = "force-dynamic";
 
 const TERMINAL: ReadonlyArray<string> = ["parsed", "failed", "cancelled"];
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+  const { id } = await params;
+  const row = await getUpload(id, ctx.tenantId);
+  if (!row) return NextResponse.json({ error: "not_found" }, { status: 404 });
+
+  // Counts are only meaningful once the pipeline has finished (or failed).
+  // For in-flight uploads we return zeros so the card shows "Processing…".
+  const counts =
+    row.status === "parsed"
+      ? await getUploadCounts(row, ctx.tenantId)
+      : { pm_tasks_count: 0, fault_codes_count: 0, knowledge_chunks_count: 0 };
+
+  return NextResponse.json({ ...row, ...counts });
+}
 
 export async function DELETE(
   req: NextRequest,

--- a/mira-hub/src/components/UploadSummaryCard.tsx
+++ b/mira-hub/src/components/UploadSummaryCard.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { CheckCircle2, Loader2, AlertCircle, CalendarDays, BookOpen, Wrench } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { API_BASE } from "@/lib/config";
+
+type UploadStatus = "queued" | "fetching" | "parsing" | "parsed" | "failed" | "cancelled";
+
+interface UploadSummaryData {
+  id: string;
+  filename: string;
+  status: UploadStatus;
+  statusDetail: string | null;
+  pm_tasks_count: number;
+  fault_codes_count: number;
+  knowledge_chunks_count: number;
+}
+
+const POLLING_INTERVAL_MS = 3_000;
+
+// Stop polling once we hit a terminal status
+const TERMINAL_STATUSES: ReadonlySet<UploadStatus> = new Set(["parsed", "failed", "cancelled"]);
+
+// Counts are "ready" when status is parsed and at least one count is non-zero
+// (or status is parsed — we show whatever we have, even all zeros)
+function isComplete(data: UploadSummaryData): boolean {
+  return TERMINAL_STATUSES.has(data.status);
+}
+
+interface StatBlockProps {
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  loading: boolean;
+  color: string;
+}
+
+function StatBlock({ icon, label, value, loading, color }: StatBlockProps) {
+  return (
+    <div
+      className="flex-1 flex flex-col items-center justify-center gap-1 p-3 rounded-xl text-center"
+      style={{ backgroundColor: "var(--surface-1)" }}
+    >
+      <div className="w-8 h-8 rounded-lg flex items-center justify-center" style={{ backgroundColor: color + "18" }}>
+        <span style={{ color }}>{icon}</span>
+      </div>
+      {loading ? (
+        <Loader2 className="w-4 h-4 animate-spin mt-1" style={{ color: "var(--foreground-subtle)" }} />
+      ) : (
+        <span className="text-xl font-bold leading-tight" style={{ color: "var(--foreground)" }}>
+          {value}
+        </span>
+      )}
+      <span className="text-[11px] leading-tight" style={{ color: "var(--foreground-muted)" }}>
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export function UploadSummaryCard({ uploadId }: { uploadId: string }) {
+  const [data, setData] = useState<UploadSummaryData | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    async function poll() {
+      if (!mountedRef.current) return;
+      try {
+        const res = await fetch(`${API_BASE}/api/uploads/${uploadId}`, { cache: "no-store" });
+        if (!res.ok) {
+          setFetchError(`Failed to load upload status (${res.status})`);
+          return;
+        }
+        const json = (await res.json()) as UploadSummaryData;
+        if (!mountedRef.current) return;
+        setData(json);
+        setFetchError(null);
+
+        // Keep polling while the upload is still in flight
+        if (!isComplete(json)) {
+          timerRef.current = setTimeout(() => void poll(), POLLING_INTERVAL_MS);
+        }
+      } catch (err) {
+        if (!mountedRef.current) return;
+        setFetchError((err as Error).message);
+      }
+    }
+
+    void poll();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [uploadId]);
+
+  if (fetchError) {
+    return (
+      <div
+        className="card p-4 flex items-center gap-3"
+        style={{ borderColor: "#DC262630" }}
+      >
+        <AlertCircle className="w-4 h-4 flex-shrink-0" style={{ color: "#DC2626" }} />
+        <p className="text-sm" style={{ color: "var(--foreground-muted)" }}>{fetchError}</p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="card p-4 flex items-center gap-3">
+        <Loader2 className="w-4 h-4 animate-spin flex-shrink-0" style={{ color: "var(--brand-blue)" }} />
+        <p className="text-sm" style={{ color: "var(--foreground-muted)" }}>Loading upload summary…</p>
+      </div>
+    );
+  }
+
+  const processing = !isComplete(data);
+  const failed = data.status === "failed";
+
+  return (
+    <div
+      className="card p-4 space-y-4"
+      style={failed ? { borderColor: "#DC262640" } : undefined}
+    >
+      {/* Banner */}
+      <div className="flex items-center gap-2.5">
+        {failed ? (
+          <AlertCircle className="w-5 h-5 flex-shrink-0" style={{ color: "#DC2626" }} />
+        ) : processing ? (
+          <Loader2 className="w-5 h-5 animate-spin flex-shrink-0" style={{ color: "var(--brand-blue)" }} />
+        ) : (
+          <CheckCircle2 className="w-5 h-5 flex-shrink-0" style={{ color: "#16A34A" }} />
+        )}
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold truncate" style={{ color: "var(--foreground)" }}>
+            {data.filename}
+          </p>
+          <p className="text-xs mt-0.5" style={{ color: failed ? "#DC2626" : processing ? "var(--brand-blue)" : "#16A34A" }}>
+            {failed
+              ? data.statusDetail
+                ? `Failed: ${data.statusDetail}`
+                : "Processing failed"
+              : processing
+              ? "Processing document…"
+              : "Document indexed successfully"}
+          </p>
+        </div>
+      </div>
+
+      {/* Stats row */}
+      <div className="flex gap-2">
+        <StatBlock
+          icon={<CalendarDays className="w-4 h-4" />}
+          label="PM Tasks Found"
+          value={data.pm_tasks_count}
+          loading={processing}
+          color="#7C3AED"
+        />
+        <StatBlock
+          icon={<Wrench className="w-4 h-4" />}
+          label="Fault Codes"
+          value={data.fault_codes_count}
+          loading={processing}
+          color="#EA580C"
+        />
+        <StatBlock
+          icon={<BookOpen className="w-4 h-4" />}
+          label="Knowledge Chunks"
+          value={data.knowledge_chunks_count}
+          loading={processing}
+          color="#0891B2"
+        />
+      </div>
+
+      {/* CTAs — only shown once processing is done */}
+      {!processing && !failed && (
+        <div className="flex gap-2 pt-1">
+          <Button asChild size="sm" variant="outline" className="flex-1 text-xs gap-1.5">
+            <Link href="/schedule">
+              <CalendarDays className="w-3.5 h-3.5" />
+              View PM Schedule
+            </Link>
+          </Button>
+          <Button asChild size="sm" variant="outline" className="flex-1 text-xs gap-1.5">
+            <Link href="/knowledge">
+              <BookOpen className="w-3.5 h-3.5" />
+              View Knowledge Base
+            </Link>
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mira-hub/src/lib/uploads.ts
+++ b/mira-hub/src/lib/uploads.ts
@@ -234,3 +234,62 @@ export async function deleteUpload(id: string, tenantId = DEFAULT_TENANT_ID): Pr
   );
   return (rowCount ?? 0) > 0;
 }
+
+export interface UploadCounts {
+  pm_tasks_count: number;
+  fault_codes_count: number;
+  knowledge_chunks_count: number;
+}
+
+/**
+ * Query ingest-result counts for a completed upload.
+ *
+ * - knowledge_chunks_count: taken directly from hub_uploads.kb_chunk_count
+ *   (written by the pipeline when mira-ingest returns the chunk count).
+ * - pm_tasks_count: count of pm_schedules rows whose source_citation matches
+ *   the upload filename. Falls back to 0 if the table/column doesn't exist.
+ * - fault_codes_count: count of kb_chunks rows tagged as fault-code chunks
+ *   whose source matches the upload filename. Falls back to 0 gracefully.
+ *
+ * All fallbacks return 0 — never throws on missing tables/columns.
+ */
+export async function getUploadCounts(
+  upload: Upload,
+  tenantId = DEFAULT_TENANT_ID,
+): Promise<UploadCounts> {
+  // kb_chunk_count is written directly by the ingest pipeline
+  const knowledge_chunks_count = upload.kbChunkCount ?? 0;
+
+  // PM tasks: pm_schedules rows linked to this filename via source_citation
+  let pm_tasks_count = 0;
+  try {
+    const { rows } = await pool.query(
+      `SELECT COUNT(*)::int AS n
+         FROM pm_schedules
+        WHERE tenant_id = $1
+          AND source_citation ILIKE $2`,
+      [tenantId, `%${upload.filename}%`],
+    );
+    pm_tasks_count = rows[0]?.n ?? 0;
+  } catch {
+    // Table or column doesn't exist yet — return 0
+  }
+
+  // Fault codes: kb_chunks tagged as fault codes linked to this filename
+  let fault_codes_count = 0;
+  try {
+    const { rows } = await pool.query(
+      `SELECT COUNT(*)::int AS n
+         FROM kb_chunks
+        WHERE tenant_id = $1
+          AND source ILIKE $2
+          AND (doc_type ILIKE '%fault%' OR doc_type ILIKE '%error%' OR title ILIKE '%fault%' OR title ILIKE '%error code%')`,
+      [tenantId, `%${upload.filename}%`],
+    );
+    fault_codes_count = rows[0]?.n ?? 0;
+  } catch {
+    // Table or column doesn't exist yet — return 0
+  }
+
+  return { pm_tasks_count, fault_codes_count, knowledge_chunks_count };
+}


### PR DESCRIPTION
## Summary
- After uploading a document, show a results summary card above the upload list with counts of PM tasks found, fault codes, and knowledge chunks
- Card polls `GET /api/uploads/[id]` every 3 seconds until the pipeline finishes, showing a spinner while processing
- Once complete, shows CTA buttons to View PM Schedule and View Knowledge Base
- Counts use best-effort DB queries (filename ILIKE match on `pm_schedules.source_citation` + `kb_chunks.source`); all fall back to 0 gracefully if tables/columns are missing

Closes #1195

## New / changed files
| File | Change |
|---|---|
| `src/components/UploadSummaryCard.tsx` | New component |
| `src/app/api/uploads/[id]/route.ts` | Added `GET` handler (previously only `DELETE` existed) |
| `src/lib/uploads.ts` | Added `getUpload()` + `getUploadCounts()` + `UploadCounts` interface |
| `src/app/(hub)/knowledge/page.tsx` | Capture upload ID from POST response + render `<UploadSummaryCard>` |

## Known limitations
`pm_tasks_count` and `fault_codes_count` use filename matching — they'll be exact once the ingest pipeline writes `source_upload_id` to those tables. `knowledge_chunks_count` is exact (from `hub_uploads.kb_chunk_count` written by the pipeline).

## Test plan
- [ ] Upload a PDF → card appears above upload list with "Processing…" spinner
- [ ] After ~10-30s → card shows counts + green banner + CTA buttons
- [ ] Failed upload → card shows red banner with error detail
- [ ] Refresh page → card disappears (stateless — no persistence of summary ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)