### PR TITLE
security(infra): Docker/nginx hardening bundle — closes #1142

### DIFF
--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -58,6 +58,10 @@ services:
       - '--storage.tsdb.retention.time=15d'
     networks:
       - core-net
+    deploy:
+      resources:
+        limits:
+          memory: 512M
 
   # ── Grafana — dashboards ──────────────────────────────────────────────────
   grafana:
@@ -78,6 +82,10 @@ services:
       - prometheus
     networks:
       - core-net
+    deploy:
+      resources:
+        limits:
+          memory: 512M
 
 networks:
   core-net:

--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -298,6 +298,12 @@ services:
       resources:
         limits:
           memory: 512M
+    healthcheck:
+      test: ["CMD", "sh", "-c", "cat /proc/1/cmdline | tr '\\0' ' ' | grep -q 'bot.py'"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
 
   mira-docling:
     image: quay.io/docling-project/docling-serve:v1.16.1
@@ -354,7 +360,7 @@ services:
     container_name: nango-db
     environment:
       POSTGRES_USER: nango
-      POSTGRES_PASSWORD: ${NANGO_DB_PASSWORD:-nango}
+      POSTGRES_PASSWORD: ${NANGO_DB_PASSWORD}
       POSTGRES_DB: nango
     volumes:
       - nango-db-data:/var/lib/postgresql/data
@@ -382,16 +388,16 @@ services:
       - NANGO_ENCRYPTION_KEY=${NANGO_ENCRYPTION_KEY}
       - NANGO_SECRET_KEY=${NANGO_SECRET_KEY}
       - NANGO_DB_USER=nango
-      - NANGO_DB_PASSWORD=${NANGO_DB_PASSWORD:-nango}
+      - NANGO_DB_PASSWORD=${NANGO_DB_PASSWORD}
       - NANGO_DB_HOST=nango-db
       - NANGO_DB_PORT=5432
       - NANGO_DB_NAME=nango
       - NANGO_DB_SSL=false
-      - RECORDS_DATABASE_URL=postgresql://nango:${NANGO_DB_PASSWORD:-nango}@nango-db:5432/nango
+      - RECORDS_DATABASE_URL=postgresql://nango:${NANGO_DB_PASSWORD}@nango-db:5432/nango
       - NANGO_SERVER_URL=${NANGO_SERVER_URL:-http://localhost:3003}
       - NANGO_PUBLIC_CONNECT_URL=${NANGO_PUBLIC_CONNECT_URL:-http://localhost:3009}
       - SERVER_PORT=3003
-      - FLAG_AUTH_ENABLED=${NANGO_DASHBOARD_AUTH_ENABLED:-false}
+      - FLAG_AUTH_ENABLED=${NANGO_DASHBOARD_AUTH_ENABLED:-true}
       - NANGO_DASHBOARD_USERNAME=${NANGO_DASHBOARD_USERNAME:-admin}
       - NANGO_DASHBOARD_PASSWORD=${NANGO_DASHBOARD_PASSWORD:-changeme}
       - FLAG_SERVE_CONNECT_UI=true

--- a/mira-bots/docker-compose.yml
+++ b/mira-bots/docker-compose.yml
@@ -45,8 +45,12 @@ services:
       - bot-net
       - core-net
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     healthcheck:
-      test: ["CMD", "python", "-c", "import os; exit(0)"]
+      test: ["CMD", "sh", "-c", "cat /proc/1/cmdline | tr '\\0' ' ' | grep -q 'bot.py'"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -66,8 +70,12 @@ services:
       - bot-net
       - core-net
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
     healthcheck:
-      test: ["CMD", "python", "-c", "import slack_bolt; exit(0)"]
+      test: ["CMD", "sh", "-c", "cat /proc/1/cmdline | tr '\\0' ' ' | grep -q 'bot.py'"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/mira-core/mira-ingest/Dockerfile
+++ b/mira-core/mira-ingest/Dockerfile
@@ -11,5 +11,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY main.py crawl_verifier.py route_fallback.py asset_tag.py crawl_routes.yaml ./
 COPY db/ db/
 
+RUN addgroup --system --gid 1001 mira && \
+    adduser --system --uid 1001 --ingroup mira mira
+
+USER mira
+
 ENV PYTHONUNBUFFERED=1
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/mira-crawler/docker-compose.yml
+++ b/mira-crawler/docker-compose.yml
@@ -23,6 +23,10 @@ services:
     depends_on:
       mira-redis:
         condition: service_healthy
+    deploy:
+      resources:
+        limits:
+          memory: 1G
     environment:
       - CELERY_BROKER_URL=redis://mira-redis:6379/0
       - CELERY_RESULT_BACKEND=redis://mira-redis:6379/1

--- a/mira-mcp/Dockerfile
+++ b/mira-mcp/Dockerfile
@@ -15,4 +15,9 @@ COPY schematic_intelligence.py .
 COPY cmms/ ./cmms/
 COPY context/ ./context/
 
+RUN addgroup --system --gid 1001 mira && \
+    adduser --system --uid 1001 --ingroup mira mira
+
+USER mira
+
 CMD ["python", "server.py"]

--- a/mira-pipeline/Dockerfile
+++ b/mira-pipeline/Dockerfile
@@ -19,6 +19,11 @@ COPY mira-pipeline/eval_api.py .
 COPY mira-pipeline/qr_bridge.py .
 COPY VERSION .
 
+RUN addgroup --system --gid 1001 mira && \
+    adduser --system --uid 1001 --ingroup mira mira
+
+USER mira
+
 ENV PYTHONUNBUFFERED=1
 EXPOSE 9099
 

--- a/mira-relay/Dockerfile
+++ b/mira-relay/Dockerfile
@@ -5,5 +5,10 @@ COPY pyproject.toml .
 RUN pip install --no-cache-dir starlette uvicorn[standard]
 COPY relay_server.py .
 
+RUN addgroup --system --gid 1001 mira && \
+    adduser --system --uid 1001 --ingroup mira mira
+
+USER mira
+
 EXPOSE 8765
 CMD ["python", "relay_server.py"]

--- a/mira-sidecar/Dockerfile
+++ b/mira-sidecar/Dockerfile
@@ -30,6 +30,12 @@ COPY mira-crawler/ingest/chunker.py /mira-crawler/ingest/chunker.py
 # Runtime directories (mounted as volumes in production)
 RUN mkdir -p /data/chroma /data/docs
 
+RUN addgroup --system --gid 1001 mira && \
+    adduser --system --uid 1001 --ingroup mira mira && \
+    chown -R mira:mira /data
+
+USER mira
+
 EXPOSE 5000
 
 HEALTHCHECK --interval=30s --timeout=10s --retries=3 --start-period=15s \

--- a/nginx-oracle-v2.conf
+++ b/nginx-oracle-v2.conf
@@ -8,8 +8,15 @@
 #
 # Deploy: scp nginx-oracle-v2.conf factorylm-prod:/etc/nginx/sites-enabled/mira && ssh factorylm-prod nginx -s reload
 
+# Rate-limiting zones (evaluated in http context via sites-enabled include)
+limit_req_zone $binary_remote_addr zone=api_v1:10m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=api_ingest:10m rate=5r/s;
+limit_req_zone $binary_remote_addr zone=api_agents:10m rate=10r/s;
+
 server {
     server_name app.factorylm.com;
+
+    server_tokens off;
 
     add_header X-Robots-Tag "noindex, nofollow" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
@@ -37,6 +44,7 @@ server {
 
     # Agent API
     location /api/agents/ {
+        limit_req zone=api_agents burst=20 nodelay;
         proxy_pass http://127.0.0.1:9099;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -48,6 +56,7 @@ server {
 
     # mira-pipeline OpenAI-compat API
     location /v1/ {
+        limit_req zone=api_v1 burst=20 nodelay;
         proxy_pass http://127.0.0.1:9099;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -87,6 +96,7 @@ server {
 
     # mira-ingest API
     location /api/ingest/ {
+        limit_req zone=api_ingest burst=10 nodelay;
         rewrite ^/api/ingest/(.*) /$1 break;
         proxy_pass http://127.0.0.1:8002;
         proxy_http_version 1.1;

--- a/nginx-oracle.conf
+++ b/nginx-oracle.conf
@@ -2,8 +2,15 @@
 # Deploy: scp nginx-oracle.conf factorylm-prod:/etc/nginx/sites-enabled/mira && ssh factorylm-prod nginx -s reload
 # TLS: sudo certbot --nginx -d app.factorylm.com
 
+# Rate-limiting zones (evaluated in http context via sites-enabled include)
+limit_req_zone $binary_remote_addr zone=api_v1:10m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=api_ingest:10m rate=5r/s;
+limit_req_zone $binary_remote_addr zone=api_agents:10m rate=10r/s;
+
 server {
     server_name app.factorylm.com;
+
+    server_tokens off;
 
     add_header X-Robots-Tag "noindex, nofollow" always;
     # Security response headers (web-review issue #616) — applied site-wide
@@ -25,6 +32,7 @@ server {
 
     # Agent API — proxied to mira-pipeline (includes public-status + authenticated endpoints)
     location /api/agents/ {
+        limit_req zone=api_agents burst=20 nodelay;
         proxy_pass http://127.0.0.1:9099;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -36,6 +44,7 @@ server {
 
     # mira-pipeline OpenAI-compat API + admin endpoints
     location /v1/ {
+        limit_req zone=api_v1 burst=20 nodelay;
         proxy_pass http://127.0.0.1:9099;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -115,6 +124,7 @@ server {
 
     # mira-ingest API
     location /api/ingest/ {
+        limit_req zone=api_ingest burst=10 nodelay;
         rewrite ^/api/ingest/(.*) /$1 break;
         proxy_pass http://127.0.0.1:8002;
         proxy_http_version 1.1;

--- a/nginx-phase2-live.conf
+++ b/nginx-phase2-live.conf
@@ -6,8 +6,15 @@
 # CRA-26 (308s on unknown paths) is handled by mira-hub's next.config trailingSlash —
 # the default_server for unmatched hosts already lives in factorylm-paths.
 
+# Rate-limiting zones (evaluated in http context via sites-enabled include)
+limit_req_zone $binary_remote_addr zone=api_v1:10m rate=10r/s;
+limit_req_zone $binary_remote_addr zone=api_ingest:10m rate=5r/s;
+limit_req_zone $binary_remote_addr zone=api_agents:10m rate=10r/s;
+
 server {
     server_name app.factorylm.com;
+
+    server_tokens off;
 
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
     add_header X-Content-Type-Options "nosniff" always;
@@ -40,6 +47,7 @@ server {
 
     # Agent API
     location /api/agents/ {
+        limit_req zone=api_agents burst=20 nodelay;
         proxy_pass http://127.0.0.1:9099;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -51,6 +59,7 @@ server {
 
     # mira-pipeline OpenAI-compat API
     location /v1/ {
+        limit_req zone=api_v1 burst=20 nodelay;
         proxy_pass http://127.0.0.1:9099;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -90,6 +99,7 @@ server {
 
     # mira-ingest API
     location /api/ingest/ {
+        limit_req zone=api_ingest burst=10 nodelay;
         rewrite ^/api/ingest/(.*) /$1 break;
         proxy_pass http://127.0.0.1:8002;
         proxy_http_version 1.1;


### PR DESCRIPTION
## Summary
7-item hardening bundle from the 2026-05-10 tech debt audit.

### Security
- **Non-root containers**: `USER mira` added to 5 Dockerfiles (pipeline, mcp, ingest, relay, sidecar) — matches mira-hub pattern
- **nginx rate limiting**: `limit_req_zone` + `limit_req` on `/v1/` (10r/s burst 20), `/api/ingest/` (5r/s burst 10), `/api/agents/` (10r/s burst 20) across all 3 nginx configs
- **`server_tokens off`**: added to all 3 nginx configs — hides nginx version from error pages
- **Postgres weak default removed**: `:-nango` fallback removed from `POSTGRES_PASSWORD` in saas.yml — requires explicit Doppler value
- **Nango dashboard auth default flipped**: `NANGO_DASHBOARD_AUTH_ENABLED` default changed to `true`

### Reliability
- **Real bot healthchecks**: replace `import os; exit(0)` with `cat /proc/1/cmdline | grep bot.py` — verifies the process is actually running
- **Memory limits**: 512M for telegram/slack bots + prometheus/grafana, 1G for celery worker

## Deploy note
The `USER mira` change requires that any host-mount directories (`/opt/mira/data`) are accessible by UID 1001. Verify permissions on VPS before restarting mira-mcp, mira-relay containers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)