### PR TITLE
fix(web): a11y + console error fixes for factorylm.com (#1141)

### DIFF
--- a/mira-web/public/_dark-theme.css
+++ b/mira-web/public/_dark-theme.css
@@ -25,7 +25,7 @@ body {
   --fl-navy-700:  #e8eaf0;
   --fl-ink-900:   #e8eaf0;   /* body text */
   --fl-muted-600: rgba(232,234,240,.55); /* muted text */
-  --fl-orange-600:#f0a000;   /* primary accent — matches cartoon amber */
+  --fl-orange-600:#a06800;   /* primary accent — darkened for WCAG AA contrast with white text (#f0a000 fails at 2.15:1; #a06800 passes at 4.54:1) */
   --fl-orange-500:#ffb547;
   --fl-sky-100:   #0d1320;   /* hero gradient top — deep navy fade */
   --fl-good:      #00d4aa;   /* lifted from FactoryLM green for dark contrast */
@@ -34,6 +34,12 @@ body {
   color: var(--fl-ink-900);
   min-height: 100vh;
   margin: 0;
+}
+
+/* Safety / stop-card — lift border+text color for WCAG AA on dark card (#13141a).
+   #B5341E on #13141a = 3.04:1 (fail). #e05535 on #13141a ≈ 4.55:1 (pass). */
+body {
+  --fl-safety-border: #e05535;
 }
 
 /* Compare columns hard-code light pink / green in _components.css for the

--- a/mira-web/src/lib/head.ts
+++ b/mira-web/src/lib/head.ts
@@ -59,7 +59,7 @@ export function head(opts: HeadOpts, reqUrl?: string): string {
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="apple-mobile-web-app-title" content="FactoryLM">
   <link rel="apple-touch-icon" href="/public/icons/mira-192.png">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="icon" type="image/svg+xml" href="/public/icons/favicon.svg">
   <script src="/posthog-init.js"></script>
   <script src="/pwa-install.js" defer></script>
   <script>(function(){try{if(localStorage.getItem('fl_sun_mode')==='1')document.documentElement.classList.add('sun-pre');}catch(e){}})()</script>

--- a/mira-web/src/views/_topbar.ts
+++ b/mira-web/src/views/_topbar.ts
@@ -86,7 +86,7 @@ export function footer(opts: TopbarOpts = {}): string {
     <ul class="fl-footer-links">
 ${items}
     </ul>
-    <button type="button" id="fl-sun-toggle" class="fl-sun-toggle" aria-pressed="false" aria-label="Toggle high-contrast outdoor mode" data-cta="sun-toggle">&#9728; Sun-readable</button>
+    <button type="button" id="fl-sun-toggle" class="fl-sun-toggle" aria-pressed="false" aria-label="&#9728; Sun-readable" data-cta="sun-toggle">&#9728; Sun-readable</button>
   </div>
 </footer>`;
 }


### PR DESCRIPTION
## Summary
Fixes 4 of the 5 items from the 2026-05-10 Lighthouse audit (issue #1141). Item 4 (CSP) was already in place from a prior PR.

| Item | Fix |
|------|-----|
| CTA button contrast 2.15:1 → 4.54:1 | `--fl-orange-600` darkened `#f0a000 → #a06800` in `_dark-theme.css` |
| Alert card border contrast 3.04:1 → 4.55:1 | Added `--fl-safety-border: #e05535` to dark theme |
| aria-label/visible-text mismatch on Sun-toggle | `aria-label` now matches `"☀ Sun-readable"` exactly (WCAG 2.5.3) |
| Browser console 404 `/favicon.ico` error | `head.ts` favicon link corrected to `/public/icons/favicon.svg` |
| CSP on marketing nginx | Already present from PR #616 — no change needed |

Closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)