### PR TITLE
fix(web): WCAG AA contrast + tap-target fixes on pricing + legal pages (closes #1117 #1107)

### DIFF
--- a/mira-web/public/pricing.html
+++ b/mira-web/public/pricing.html
@@ -28,7 +28,7 @@
       --border-hi: rgba(255,255,255,0.14);
       --text: #e8eaf0;
       --text-dim: rgba(255,255,255,0.55);
-      --text-faint: rgba(255,255,255,0.28);
+      --text-faint: rgba(255,255,255,0.48);
       --amber: #f0a000;
       --amber-dim: rgba(240,160,0,0.12);
       --teal: #00d4aa;
@@ -71,13 +71,17 @@
     }
     .nav-logo svg { width: 22px; height: 22px; }
     .nav-links { display: flex; gap: 28px; list-style: none; }
-    .nav-links a { font-size: 14px; color: rgba(255,255,255,0.6); text-decoration: none; }
+    .nav-links a {
+      font-size: 14px; color: rgba(255,255,255,0.6); text-decoration: none;
+      display: flex; align-items: center; min-height: 44px; padding: 0 6px;
+    }
     .nav-links a:hover { color: var(--text); }
     .nav-cta {
       font-size: 13px; font-weight: 700; color: #0a0a08;
       background: linear-gradient(180deg, #f0a030 0%, #d4880a 100%);
       border: 1px solid rgba(255,255,255,0.12);
-      border-radius: 6px; padding: 7px 14px; text-decoration: none;
+      border-radius: 6px; padding: 11px 14px; text-decoration: none;
+      min-height: 44px; display: flex; align-items: center;
     }
     @media (max-width: 640px) { .nav-links { display: none; } }
 
@@ -157,7 +161,8 @@
     }
 
     .card-cta {
-      display: block; text-align: center;
+      display: flex; align-items: center; justify-content: center;
+      min-height: 44px; text-align: center;
       padding: 12px 20px; border-radius: 6px;
       font-size: 14px; font-weight: 600; text-decoration: none;
       transition: opacity 150ms;

--- a/mira-web/public/privacy.html
+++ b/mira-web/public/privacy.html
@@ -28,7 +28,7 @@
       --border-hi: rgba(255,255,255,0.14);
       --text: #e8eaf0;
       --text-dim: rgba(255,255,255,0.55);
-      --text-faint: rgba(255,255,255,0.28);
+      --text-faint: rgba(255,255,255,0.48);
       --amber: #f0a000;
       --amber-dim: rgba(240,160,0,0.12);
       --font: 'Inter', sans-serif;

--- a/mira-web/public/terms.html
+++ b/mira-web/public/terms.html
@@ -28,7 +28,7 @@
       --border-hi: rgba(255,255,255,0.14);
       --text: #e8eaf0;
       --text-dim: rgba(255,255,255,0.55);
-      --text-faint: rgba(255,255,255,0.28);
+      --text-faint: rgba(255,255,255,0.48);
       --amber: #f0a000;
       --amber-dim: rgba(240,160,0,0.12);
       --font: 'Inter', sans-serif;

--- a/mira-web/public/trust.html
+++ b/mira-web/public/trust.html
@@ -28,7 +28,7 @@
       --border-hi: rgba(255,255,255,0.14);
       --text: #e8eaf0;
       --text-dim: rgba(255,255,255,0.55);
-      --text-faint: rgba(255,255,255,0.28);
+      --text-faint: rgba(255,255,255,0.48);
       --amber: #f0a000;
       --amber-dim: rgba(240,160,0,0.12);
       --green: #4ade80;


### PR DESCRIPTION
## Summary
- **Color contrast** (`--text-faint`): `rgba(255,255,255,0.28)` → `rgba(255,255,255,0.48)` on pricing/privacy/terms/trust pages (~2.9:1 → ~5.2:1 on dark `#0d0e11` background). Fixes WCAG 1.4.3 AA for hero eyebrow, card footnotes, footer links, FAQ chevron
- **Tap targets**: Nav links and CTA buttons bumped to `min-height: 44px` using flexbox alignment. Fixes WCAG 2.5.5 for 12 desktop / 7 mobile small targets on /pricing

## Files changed
- `mira-web/public/pricing.html` — contrast + tap target
- `mira-web/public/privacy.html` — contrast only
- `mira-web/public/terms.html` — contrast only
- `mira-web/public/trust.html` — contrast only

## Test plan
- [ ] Lighthouse a11y on `/pricing` — color-contrast score > 0
- [ ] Lighthouse a11y on `/pricing` — tap-targets score > 0
- [ ] Footer links and card footnotes are readable on dark background
- [ ] CTA buttons remain visually centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)