### PR TITLE
fix(engine): KB pre-check reply includes model name for multi-token products (closes #1086)

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -3532,6 +3532,20 @@ class Supervisor:
             # CRA-8 Cluster A: include the model token (and the literal word "manual")
             # so vendor-specific manual requests don't fall through the keyword check.
             model_hint = model_override or _looks_like_model_number(combined) or ""
+            if not model_hint:
+                # Fallback for models where alpha and digit are separate tokens
+                # (e.g. "MICROMASTER 440", "AQUA Drive FC 202").
+                _skip = {"VFD", "ASK", "MANUAL", "FIND", "GET", "THE", "ME",
+                         "FOR", "DRIVE", "MOTOR", "INVERTER", "CONTROLLER", "PLC",
+                         "A", "AN", "MY", "IS", "IN", "OF", "ON", "AT"}
+                if mfr:
+                    _skip.add(mfr.upper())
+                _caps = [w for w in re.findall(r'\b[A-Z]{2,}\b', combined)
+                         if w not in _skip]
+                _nums = re.findall(r'\b\d{2,}\b', combined)
+                _parts = _caps[:2] + (_nums[:1] if _nums else [])
+                if _parts:
+                    model_hint = " ".join(_parts)
             if mfr and model_hint:
                 reply = f"I have the {mfr} {model_hint} manual indexed."
             elif mfr:

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -3535,14 +3535,33 @@ class Supervisor:
             if not model_hint:
                 # Fallback for models where alpha and digit are separate tokens
                 # (e.g. "MICROMASTER 440", "AQUA Drive FC 202").
-                _skip = {"VFD", "ASK", "MANUAL", "FIND", "GET", "THE", "ME",
-                         "FOR", "DRIVE", "MOTOR", "INVERTER", "CONTROLLER", "PLC",
-                         "A", "AN", "MY", "IS", "IN", "OF", "ON", "AT"}
+                _skip = {
+                    "VFD",
+                    "ASK",
+                    "MANUAL",
+                    "FIND",
+                    "GET",
+                    "THE",
+                    "ME",
+                    "FOR",
+                    "DRIVE",
+                    "MOTOR",
+                    "INVERTER",
+                    "CONTROLLER",
+                    "PLC",
+                    "A",
+                    "AN",
+                    "MY",
+                    "IS",
+                    "IN",
+                    "OF",
+                    "ON",
+                    "AT",
+                }
                 if mfr:
                     _skip.add(mfr.upper())
-                _caps = [w for w in re.findall(r'\b[A-Z]{2,}\b', combined)
-                         if w not in _skip]
-                _nums = re.findall(r'\b\d{2,}\b', combined)
+                _caps = [w for w in re.findall(r"\b[A-Z]{2,}\b", combined) if w not in _skip]
+                _nums = re.findall(r"\b\d{2,}\b", combined)
                 _parts = _caps[:2] + (_nums[:1] if _nums else [])
                 if _parts:
                     model_hint = " ".join(_parts)


### PR DESCRIPTION
## Problem

`_looks_like_model_number()` requires alpha AND digit in the **same token**, so product names like `MICROMASTER 440` (letters + separate number) and `AQUA Drive FC 202` return `""`. The `KB_PRE_CHECK_HIT` path then replies with only the manufacturer name, failing the eval keyword checks for `MICROMASTER`, `440`, `AQUA`, and `FC 202`.

## Fix

Added a fallback inside `_do_documentation_lookup` that runs when `_looks_like_model_number` returns empty:
- Finds uppercase words (2+ chars) not in a stop-word set
- Finds standalone numbers (2+ digits)
- Combines up to 2 caps tokens + the first number

Results:
- `"MICROMASTER 440"` → `"I have the Siemens MICROMASTER 440 manual indexed."`
- `"AQUA Drive FC 202"` → `"I have the Danfoss AQUA FC 202 manual indexed."`

All four expected keywords pass: `MICROMASTER`, `440`, `AQUA`, `FC 202`.

## Verification

```
python -c "..."  # outputs show all keywords present (verified locally)
```

Eval fixtures that now pass:
- `vfd_siemens_02_micromaster_manual`
- `vfd_danfoss_02_aqua_drive_manual`

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)