### PR TITLE
fix(scan-monday): cap chat history at 20 turns to prevent token cost runaway (closes #1085)

### DIFF
--- a/mira-scan-monday/backend/main.py
+++ b/mira-scan-monday/backend/main.py
@@ -325,9 +325,7 @@ async def queue_search_now(
 
 
 @app.post("/chat/message", response_model=ChatMessageResponse)
-async def chat_message(
-    req: ChatMessageRequest, request: Request
-) -> ChatMessageResponse:
+async def chat_message(req: ChatMessageRequest, request: Request) -> ChatMessageResponse:
     if not req.message.strip():
         raise HTTPException(status_code=400, detail="message is required")
     # Chat is downstream of scan — bump last_seen so we know the install
@@ -335,11 +333,13 @@ async def chat_message(
     account_id = session.account_id_from_headers(request.headers)
     if account_id:
         await oauth.touch_last_seen(account_id)
+    _max_turns = int(os.getenv("MIRA_MAX_CHAT_HISTORY_TURNS", "20"))
+    trimmed_history = (req.history or [])[-_max_turns:]
     reply, sources = await mira_rag.chat(
         message=req.message,
         asset_id=req.asset_id,
         asset_label=req.asset_label,
-        history=req.history,
+        history=trimmed_history,
     )
     return ChatMessageResponse(reply=reply, sources=sources)
 


### PR DESCRIPTION
## Problem

`/chat/message` passes `req.history` directly to `mira_rag.chat()` with no length cap. A runaway client that echoes the full history on every request will push increasingly large payloads to the LLM cascade, inflating latency and token cost with each turn.

## Fix

Trim history to the most recent `MIRA_MAX_CHAT_HISTORY_TURNS` turns (default 20, matching GSDEngine's `MIRA_HISTORY_LIMIT`) before forwarding downstream:

```python
_max_turns = int(os.getenv("MIRA_MAX_CHAT_HISTORY_TURNS", "20"))
trimmed_history = (req.history or [])[-_max_turns:]
```

Closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)