### PR TITLE
feat(scan-monday): per-account chat quota gate — 200 msg/month free tier (closes #1083)

### DIFF
--- a/mira-scan-monday/backend/db.py
+++ b/mira-scan-monday/backend/db.py
@@ -204,6 +204,13 @@ async def ensure_account_usage_table() -> None:
                   ON account_usage_daily (usage_date DESC)
                 """
             )
+            # Idempotent migration: add chat_count column for /chat/message quota gate.
+            await cur.execute(
+                """
+                ALTER TABLE account_usage_daily
+                  ADD COLUMN IF NOT EXISTS chat_count integer NOT NULL DEFAULT 0
+                """
+            )
         _ENSURED_USAGE = True
         logger.info("account_usage_daily table is ready")
     except Exception:

--- a/mira-scan-monday/backend/main.py
+++ b/mira-scan-monday/backend/main.py
@@ -333,6 +333,20 @@ async def chat_message(req: ChatMessageRequest, request: Request) -> ChatMessage
     account_id = session.account_id_from_headers(request.headers)
     if account_id:
         await oauth.touch_last_seen(account_id)
+        used = await usage.month_chat_count(account_id)
+        if used >= usage.FREE_TIER_MONTHLY_CHAT_CAP:
+            raise HTTPException(
+                status_code=429,
+                detail={
+                    "error": "quota_exceeded",
+                    "used": used,
+                    "cap": usage.FREE_TIER_MONTHLY_CHAT_CAP,
+                    "message": (
+                        f"Free-tier limit of {usage.FREE_TIER_MONTHLY_CHAT_CAP} "
+                        "AI messages/month reached."
+                    ),
+                },
+            )
     _max_turns = int(os.getenv("MIRA_MAX_CHAT_HISTORY_TURNS", "20"))
     trimmed_history = (req.history or [])[-_max_turns:]
     reply, sources = await mira_rag.chat(
@@ -341,6 +355,8 @@ async def chat_message(req: ChatMessageRequest, request: Request) -> ChatMessage
         asset_label=req.asset_label,
         history=trimmed_history,
     )
+    if account_id:
+        await usage.bump_chat_count(account_id)
     return ChatMessageResponse(reply=reply, sources=sources)
 
 

--- a/mira-scan-monday/backend/usage.py
+++ b/mira-scan-monday/backend/usage.py
@@ -96,6 +96,54 @@ async def month_scan_count(account_id: str) -> int:
     return int(row[0]) if row and row[0] is not None else 0
 
 
+FREE_TIER_MONTHLY_CHAT_CAP = int(os.getenv("MIRA_FREE_TIER_MONTHLY_CHAT_CAP", "200"))
+
+
+async def bump_chat_count(account_id: str) -> None:
+    """Increment today's chat_count for an account. Best-effort no-op on failure."""
+    if not account_id:
+        return
+    sql = """
+        INSERT INTO account_usage_daily
+            (account_id, usage_date, chat_count, last_seen_at)
+        VALUES (%s, CURRENT_DATE, 1, NOW())
+        ON CONFLICT (account_id, usage_date) DO UPDATE
+            SET chat_count   = account_usage_daily.chat_count + 1,
+                last_seen_at = NOW()
+    """
+    try:
+        await db.execute(sql, (account_id,))
+    except db.DBUnavailable:
+        return
+    except Exception:
+        logger.exception("usage.bump_chat_count failed for account_id=%s", account_id)
+
+
+async def month_chat_count(account_id: str) -> int:
+    """Sum chat_count over the trailing 30 days for an account.
+
+    Returns 0 on empty account_id, DB unavailability, or no activity.
+    Never raises — callers must fail-open so a DB outage never locks out
+    a legitimate user.
+    """
+    if not account_id:
+        return 0
+    sql = """
+        SELECT COALESCE(SUM(chat_count), 0)::integer
+          FROM account_usage_daily
+         WHERE account_id = %s
+           AND usage_date >= CURRENT_DATE - INTERVAL '30 days'
+    """
+    try:
+        row = await db.fetch_one(sql, (account_id,))
+    except db.DBUnavailable:
+        return 0
+    except Exception:
+        logger.exception("usage.month_chat_count failed for account_id=%s", account_id)
+        return 0
+    return int(row[0]) if row and row[0] is not None else 0
+
+
 async def days_summary(account_id: str, days: int = 30) -> list[dict]:
     """Return up to N most-recent days of scan_count for an account.
 


### PR DESCRIPTION
## Problem

`/chat/message` had no per-account quota — a single free Monday install could send unlimited AI messages, each burning Groq/Cerebras/Gemini free-tier capacity. `/scan/extract` already had a 50-scan/month gate; chat had nothing.

## Fix

Adds the same pattern scan uses:

1. **Schema** (`db.py`): idempotent `ALTER TABLE account_usage_daily ADD COLUMN IF NOT EXISTS chat_count integer NOT NULL DEFAULT 0` — runs at startup.

2. **Usage helpers** (`usage.py`): `bump_chat_count(account_id)` and `month_chat_count(account_id)` — exact mirrors of the scan pair. Fail-open on DB error.

3. **Gate** (`main.py`): before calling `mira_rag.chat()`, check `month_chat_count`. If over cap, return HTTP 429 with `{error: "quota_exceeded", used, cap, message}` — same shape as the scan gate so the frontend `UpsellCTA` component can reuse it. Bump on success.

**Default cap:** 200 messages/month (`MIRA_FREE_TIER_MONTHLY_CHAT_CAP` env var).

**Unauthenticated calls** (no account_id from headers) bypass the gate — no regression for local dev or iframe without auth.

Closes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)