### PR TITLE
perf(mira-web): defer posthog-init.js in head.ts — removes render-block on all dynamic pages (closes #1098)

### DIFF
--- a/mira-web/src/lib/head.ts
+++ b/mira-web/src/lib/head.ts
@@ -60,7 +60,7 @@ export function head(opts: HeadOpts, reqUrl?: string): string {
   <meta name="apple-mobile-web-app-title" content="FactoryLM">
   <link rel="apple-touch-icon" href="/public/icons/mira-192.png">
   <link rel="icon" type="image/svg+xml" href="/public/icons/favicon.svg">
-  <script src="/posthog-init.js"></script>
+  <script src="/posthog-init.js" defer></script>
   <script src="/pwa-install.js" defer></script>
   <script>(function(){try{if(localStorage.getItem('fl_sun_mode')==='1')document.documentElement.classList.add('sun-pre');}catch(e){}})()</script>
   <script>if('serviceWorker'in navigator)window.addEventListener('load',function(){navigator.serviceWorker.register('/sw.js').catch(function(){});});</script>


### PR DESCRIPTION
## Problem

All dynamic FactoryLM pages (home, cmms, limitations, security) use the shared `head.ts` helper. That helper emitted:

```html
<script src="/posthog-init.js"></script>
```

Without `defer` — blocking the parser until the script loads. Static HTML pages (pricing, privacy, etc.) already had `defer` on this tag. The inconsistency meant the marketing homepage paid an unnecessary parse-block penalty.

## Fix

Added `defer` to the posthog-init.js script tag in `head.ts`. The script initializes PostHog analytics — it has no dependency on the DOM being ready and is safe to defer.

Closes #1098

🤖 Generated with [Claude Code](https://claude.com/claude-code)