### PR TITLE
security(hub): nonce-based CSP — removes unsafe-inline + unsafe-eval

### DIFF
--- a/mira-hub/src/app/layout.tsx
+++ b/mira-hub/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
+import { headers } from "next/headers";
 import Script from "next/script";
 import "./globals.css";
 import { RefineProviders } from "./refine-providers";
@@ -42,7 +43,8 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const nonce = (await headers()).get("x-nonce") ?? "";
   return (
     <html lang="en" className={`${inter.variable} h-full`}>
       <body className="h-full antialiased bg-background text-foreground">
@@ -51,6 +53,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Script
           id="sw-killer"
           strategy="beforeInteractive"
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `if('serviceWorker'in navigator){navigator.serviceWorker.getRegistrations().then(function(r){r.forEach(function(s){s.unregister()})});caches.keys().then(function(n){n.forEach(function(c){caches.delete(c)})})}`,
           }}

--- a/mira-hub/src/middleware.ts
+++ b/mira-hub/src/middleware.ts
@@ -1,5 +1,6 @@
 import { withAuth, type NextRequestWithAuth } from "next-auth/middleware";
 import { NextResponse, type NextFetchEvent, type NextRequest } from "next/server";
+import crypto from "node:crypto";
 
 // Gate pages: authenticated users with non-approved status land here;
 // skip the status check when already on these pages to avoid redirect loops.
@@ -45,6 +46,18 @@ const authMiddleware = withAuth(
   },
 );
 
+function buildCsp(nonce: string): string {
+  return [
+    `default-src 'self'`,
+    `script-src 'self' 'nonce-${nonce}' https://accounts.google.com https://apis.google.com`,
+    `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
+    `font-src 'self' https://fonts.gstatic.com`,
+    `img-src 'self' data: https:`,
+    `connect-src 'self' https://accounts.google.com https://api.hubapi.com`,
+    `frame-src https://accounts.google.com`,
+  ].join("; ");
+}
+
 export default async function middleware(req: NextRequest, ev: NextFetchEvent) {
   // Basepath root → redirect to /feed. `redirect()` from a Server Component
   // is silently swallowed in Next.js 16.2.4 standalone + basePath (response
@@ -56,7 +69,27 @@ export default async function middleware(req: NextRequest, ev: NextFetchEvent) {
     url.pathname = "/feed";
     return NextResponse.redirect(url);
   }
-  return authMiddleware(req as NextRequestWithAuth, ev);
+
+  // Per-request nonce for script-src CSP — removes unsafe-inline/unsafe-eval.
+  // Forwarded as x-nonce request header so RootLayout can attach it to <Script>.
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const csp = buildCsp(nonce);
+
+  // Auth check runs on the original request (auth reads cookies, not x-nonce).
+  const authResult = await authMiddleware(req as NextRequestWithAuth, ev);
+
+  // Auth issued a redirect (e.g. → /login) — stamp CSP and return as-is.
+  if (authResult && authResult.status >= 300 && authResult.status < 400) {
+    authResult.headers.set("Content-Security-Policy", csp);
+    return authResult;
+  }
+
+  // Pass through: forward nonce to server components + set CSP on response.
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set("x-nonce", nonce);
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set("Content-Security-Policy", csp);
+  return response;
 }
 
 export const config = {

--- a/nginx-phase2-live.conf
+++ b/nginx-phase2-live.conf
@@ -22,7 +22,9 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com https://apis.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://accounts.google.com https://api.hubapi.com; frame-src https://accounts.google.com;" always;
+    # CSP is set per-request by mira-hub middleware.ts with a per-request nonce,
+    # removing unsafe-inline + unsafe-eval. Do not add a static CSP here —
+    # it would override or conflict with the nonce-based header from Next.js.
     client_max_body_size 100M;
 
     # /hub/* bookmark redirects — 301 permanent, remove after 2026-07-28 (90 days)


### PR DESCRIPTION
## Summary
- Generates a per-request nonce in `middleware.ts` and sets a proper `Content-Security-Policy` header — removing `unsafe-inline` and `unsafe-eval` from `script-src`
- Forwards the nonce as `x-nonce` request header; `RootLayout` reads it and passes it to the `sw-killer` Script component
- Removes the static CSP `add_header` from `nginx-phase2-live.conf` — the middleware now owns CSP entirely

Closes #1118.

## Test plan
- [ ] Log in to app.factorylm.com — verify no CSP console errors in browser devtools
- [ ] Check that the service-worker killer script still executes (no legacy OWU SW remains after first load)
- [ ] Curl the response headers: `curl -I https://app.factorylm.com/login` should show `content-security-policy: default-src 'self'; script-src 'self' 'nonce-...` without `unsafe-inline` or `unsafe-eval`
- [ ] Auth redirect flow (unauthenticated → /login) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)