### PR TITLE
ci: paths-ignore for code-review.yml — prevent autolog CI starvation

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -3,6 +3,11 @@ name: Automated Code Review
 on:
   pull_request:
     branches: [main, develop, dev]
+    paths-ignore:
+      - 'docs/**'
+      - 'wiki/**'
+      - '**/*.md'
+      - '.claude/**'
   pull_request_target:
     types: [labeled]
 


### PR DESCRIPTION
## Summary
- Adds `paths-ignore` to the `pull_request` trigger in `.github/workflows/code-review.yml`, matching the same patterns already in `ci.yml` and `smoke-test.yml`
- Docs-only pushes (markdown, wiki, docs/, .claude/) will no longer trigger the Automated Code Review workflow

Closes #1090.

## Why
The 2026-05-08 incident: a runaway autolog session committed `chore: update PROGRESS.md` every 10-30s on an open draft PR, triggering 4 workflows per commit (code-review, ci, smoke, deepeval). ~95 concurrent runs starved the CI queue for 6+ hours, blocking other PRs. The `docs/context/PROGRESS.md` file is covered by `**/*.md` which ci.yml already ignores — but code-review.yml had no paths filter at all.

## Test plan
- [ ] After merge: push a docs-only commit to a PR branch — verify Automated Code Review does not trigger
- [ ] After merge: push a code change to a PR branch — verify Automated Code Review still triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)