### PR TITLE
fix(uns): reintegrate UNS message resolver without crawler import

### DIFF
--- a/.claude/rules/uns-compliance.md
+++ b/.claude/rules/uns-compliance.md
@@ -1,0 +1,64 @@
+# UNS Compliance
+
+The UNS (Unified Namespace) is MIRA's canonical address space for every node
+in the knowledge graph. Path builders live in `mira-crawler/ingest/uns.py`;
+spec is `docs/specs/uns-kg-unification-spec.md`.
+
+## Rules
+
+1. **Never reinvent path builders.** Paths under `enterprise.*` are built
+   ONLY by the functions in `mira-crawler/ingest/uns.py`
+   (`manufacturer_path`, `model_path`, `fault_code_path`, `manual_path`,
+   `pm_schedule_path`, `parts_list_path`, etc.). Don't hand-format
+   `f"enterprise.knowledge_base.{mfr}.{model}"` anywhere.
+
+2. **One extraction point per turn.** Vendor, model, fault code, category
+   are resolved in `mira-bots/shared/uns_resolver.py` and live on
+   `state["uns_context"]`. Never call `vendor_name_from_text()` or
+   `_looks_like_model_number()` directly in engine, workers, or DST code —
+   they are private to the resolver. If you need vendor info, read
+   `state["uns_context"]["manufacturer"]`.
+
+3. **Slugs are produced by `uns.slug()`.** Lowercase, runs of non-alphanumeric
+   collapsed to `_`. Don't `.lower().replace(" ", "_")` ad-hoc.
+
+4. **Fault codes are extracted BEFORE model candidates.** Fault patterns
+   (`F0004`, `E001`, `oC`, `A002`) must be stripped from the model candidate
+   token list before the model heuristic runs. Otherwise `"powerflex 525
+   f0004"` mis-resolves to `model="f0004"` (the historical bug).
+
+5. **Pure-digit models are valid when adjacent to a known vendor/family.**
+   `"PowerFlex 525"` → `model="525"`. The old "must contain a letter" rule
+   in `_looks_like_model_number` is wrong for this case and must not be
+   reused.
+
+6. **Reserved labels are off-limits.** `uns.RESERVED_LABELS` lists the
+   structural type-marker labels (`site`, `area`, `equipment`,
+   `fault_codes`, etc.). Don't use them as manufacturer / model / instance
+   slugs.
+
+7. **Lowercase only.** UNS paths are lowercase. Display names like
+   `"Rockwell Automation"` live on `UNSContext.manufacturer`; the path
+   segment is `uns.slug("Rockwell Automation")` → `rockwell_automation`.
+
+8. **Offline mode is the floor.** The resolver must produce a useful result
+   without NeonDB. DB enrichment is additive; any DB error falls back to
+   the alias-table-only result.
+
+9. **Confidence is a band, not a score.** Use the bands defined in
+   `docs/specs/uns-message-resolver-spec.md §2.4`. Don't invent a new
+   numeric scheme per call site.
+
+## When this applies
+
+- Any code under `mira-bots/`, `mira-crawler/`, `mira-mcp/`, `mira-pipeline/`,
+  or `mira-bridge/` that touches manufacturer/model/fault-code extraction.
+- Any new feature that builds a UNS path.
+- Any test that asserts on a UNS path string.
+
+## When this does NOT apply
+
+- Pure UI text rendering (a label like "PowerFlex 525" in a chat reply is
+  fine, that's a display string, not a path).
+- LLM-facing prompts (prompts may use display names; the path is for the
+  resolver and the KB query).

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,134 +1,173 @@
-# HANDOFF — tech-debt/hub-ux-fixes-2026-04-26
+# HANDOFF — UNS message resolver
 
-**Date stopped:** 2026-04-26 21:22 UTC
-**Reason stopped:** all 5 PLAN.md tasks complete
-**Branch:** `tech-debt/hub-ux-fixes-2026-04-26`
-**Worktree:** `.claude/worktrees/tech-debt-hub-ux-2026-04-26`
-**Last commit:** `298392f` — fix(hub): upload picker — tooltips on disabled cloud buttons + clickable Channels link (#722)
-**Baseline tag:** `pre-tech-debt-hub-ux-2026-04-26-2107` on origin/main HEAD `1b839dd`
-**Wall-clock:** ~28 min of the 3 h budget
+**Branch:** `claude/elated-margulis-ac0926`
+**Date:** 2026-05-13
+**Commits:** 4 (fac2c5c1, 0566a2ef, db574ed8, 69def852)
 
----
+## What landed
 
-## What was actually done (vs PLAN.md)
+Single UNS-aware extraction point for vendor / model / fault code / category
+per turn. Replaces 14 sites in `mira-bots/shared/engine.py` + 3 in
+`rag_worker.py`, `dialogue_state.py`, `dialogue_acts.py` that previously each
+called `vendor_name_from_text()` / `_looks_like_model_number()` on the
+message, the combined message+asset, or asset_id.
 
-| PLAN # | Issue | Status | Evidence |
-|--------|-------|--------|----------|
-| 1 | **#688** WO wizard step 1 button label | ✅ done | commit `80c9dcf` — `tCommon("save")` → `tCommon("description")` (matches step 2's pattern of using next-step's name; existing common key, no new translations) |
-| 2 | **#719** WO list overdue red flag | ✅ done | commit `c529a10` — added `isOverdue(wo)` helper that checks status OR (due-date past && not completed); inline pill badge using existing `#FEE2E2`/`#DC2626` tokens |
-| 3 | **#720** KB empty-state onboarding | ✅ done | commit `4f84729` — page.tsx subtitle conditional on `stats.totalDocs === 0`; `knowledge.emptyStateOnboarding` key added to all 4 locales |
-| 4 | **#721** Assets empty-state — fresh tenant | ✅ done | commit `8fcd78d` — split empty-state into `assets.length === 0` (onboarding + inline + New Asset) vs filter-miss (original copy); 2 new keys × 4 locales |
-| 5 | **#722** Upload picker disabled-button tooltips + Channels link | ✅ done | commit `298392f` — added per-button `title` tooltips; converted "Channels" hint text to `<Link href="/hub/channels">` styled in `--brand-blue` |
+### New module — `mira-bots/shared/uns_resolver.py`
 
-## What I did NOT touch (scope discipline confirmed)
+- `UNSContext` frozen dataclass — 12 fields including `uns_path` (built via
+  `mira-crawler/ingest/uns.py` path builders, no path reinvention)
+- `resolve_uns_path(message, tenant_id, prior_ctx)` — three stages: fault
+  extraction → vendor+model+path → optional DB enrichment
+- `VENDOR_ALIASES` — 31 entries, alias → canonical display name
+- `FAMILY_FROM_ALIAS` — separate dict for family token when the alias is a
+  family (`powerflex` → `PowerFlex`)
+- `FAULT_PATTERNS` — 7 patterns: F/E/oC are strong (priority 0–2); OL/UL/AL
+  pulled in from dialogue_acts' inline regex for parity; bare A-pattern is
+  weakest (priority 3) because it collides with Yaskawa A-series models
+
+### Engine wiring
+
+Single call at the top of `Supervisor.process_full()`. Resolver result is
+stored under `state["context"]["uns_context"]` (not the top level) so it
+round-trips through `session_manager.save_state`, which only persists
+declared columns + `state["context"]` as JSON. Carry-over across turns works
+because turn N+1's `prior_ctx` is read from the same location.
+
+### Tests
+
+- `tests/test_uns_resolver.py` — 82 cases, all pass.
+- `mira-bots/tests/test_dialogue_tracker.py` — 51 cases, still pass after
+  the dialogue_state refactor.
+- `tests/eval/run_eval.py --dry-run` — 57/57 scenarios pass.
+
+### Mike's exact 2026-05-13 regression case
 
 ```
-$ git diff --name-only main..HEAD
-PLAN.md
-mira-hub/src/app/(hub)/assets/page.tsx
-mira-hub/src/app/(hub)/knowledge/page.tsx
-mira-hub/src/app/(hub)/workorders/new/page.tsx
-mira-hub/src/app/(hub)/workorders/page.tsx
-mira-hub/src/components/UploadPicker.tsx
-mira-hub/src/messages/en.json
-mira-hub/src/messages/es.json
-mira-hub/src/messages/hi.json
-mira-hub/src/messages/zh.json
+resolve_uns_path("I have a powerflex 525 and it has it called f0004")
+→ manufacturer="Rockwell Automation"
+  manufacturer_alias="powerflex"
+  product_family="PowerFlex"
+  model="525"
+  fault_code="F0004"
+  fault_code_raw="f0004"
+  uns_path="enterprise.knowledge_base.rockwell_automation.powerflex.525.fault_codes.f0004"
+  confidence=0.9
 ```
 
-10 files. Diff stat: **+166 / -17**. Verified empty:
-- `mira-web/` (Unit 9a still in flight on `feat/mvp-unit-9a-landing`) — untouched ✓
-- Python files — untouched ✓
-- `CLAUDE.md`, `README.md`, `docs/plans/*` — untouched ✓
-- `package.json` / lockfiles — untouched ✓
-- The 14 overnight branches from 2026-04-25 — not opened, not merged, not modified ✓
+The pre-fix `_looks_like_model_number` would have returned `"f0004"` as the
+model. Fixed by extracting fault codes BEFORE model candidates AND allowing
+pure-digit tokens (`"525"`) as model candidates when adjacent to a known
+vendor/family.
 
-## What's broken / risky (read this before merging)
+## Gates run
 
-**Sandbox-imposed limits — operator MUST verify on Mac before merging:**
+- ✅ `ruff check` — clean across all 5 touched files + tests
+- ✅ `pytest tests/test_uns_resolver.py` — 82 passed (0.20s)
+- ✅ `pytest mira-bots/tests/test_dialogue_tracker.py` — 51 passed
+- ✅ Smoke test of `dialogue_acts._entities_from_message` end-to-end
+- ✅ `tests/eval/run_eval.py --dry-run` — 57/57
 
-1. `cd mira-hub && npm run build` was NOT run from the sandbox (FUSE blocks unlink on `.next/.fuse_hidden*`). **You must run a clean build on Mac.** I expect it to pass — every change is either (a) a 1-line label swap, (b) a small JSX conditional with no new types, (c) JSON additions to existing namespaces, or (d) a new helper function with explicit types. But I haven't proven it green.
-2. `cd mira-hub && npm run lint` was NOT run for the same reason (no node_modules in this fresh worktree). Same expectation — eyes on the diff caught nothing odd.
-3. `npx playwright test` was NOT run. The hub has Playwright e2e tests (`mira-hub/playwright.config.ts`); the WO-list `isOverdue` helper is a pure function, the JSX changes don't touch test selectors I'm aware of, but I haven't proven it.
+## NOT done (deferred — discuss before extending scope)
 
-**Translation quality:**
-- Three new translation keys (`knowledge.emptyStateOnboarding`, `assets.noAssetsYet`, `assets.registerFirstAsset`) were added to en/es/hi/zh. en is from the issue body. es/hi/zh are direct renderings I produced — they're idiomatic but not professionally reviewed. If a native speaker is on hand, they should glance at the additions. The English is the reference; non-en strings are functionally placeholders that won't break the UI.
+### 1. Phase 6: rag_worker entity-scoped KB query via `uns_path`
 
-**Untracked sandbox cruft (NOT in any commit, safe to delete on Mac):**
-```
-mira-hub/src/messages/en.json.broken-1777238128
-mira-hub/src/messages/es.json.broken-1777238128
-mira-hub/src/messages/hi.json.broken-1777238128
-mira-hub/src/messages/zh.json.broken-1777238128
-```
-These are stale backups from when I had to mv files out of FUSE's way during the #720 commit-amend. The sandbox cannot `unlink` them. On Mac:
-```
-cd /Users/charlienode/MIRA/.claude/worktrees/tech-debt-hub-ux-2026-04-26
-rm mira-hub/src/messages/*.broken-1777238128
-```
+The spec described an additional optimization: when `uns_context.uns_path` is
+set, scope the `knowledge_entries` query to entities at that path. NOT
+implemented — the cross-vendor filter via `uns_context.manufacturer` already
+gives the main correctness benefit, and adding a UNS-path-scoped query
+would risk regressions in the BM25 + Nemotron rerank path. Tracked as
+follow-up.
 
-**One self-noted gotcha in the #720 commit log:**
-The first attempt at #720 caused JSON re-formatting noise (multi-key-per-line collapsed to one-per-line in en.json's `days`/`months` blocks). Caught and fixed via `commit --amend` after surgical re-insertion. The final `4f84729` is clean — `git log --stat 4f84729` shows `+10 / -4`. But you'll see two `HEAD@` entries in reflog for that commit.
+### 2. Net-LOC target
 
-## Open decisions for the operator
+PLAN.md said "net negative LOC target." Existing files net delta:
+**+100 / −72 = +28 lines** (excluding the new resolver module and new
+tests). The growth is in:
+- the wiring block at the top of `process_full` (~25 lines including
+  comments)
+- `_collect_session_entities` rewrite (explanatory comments + the asset_id
+  resolver fallback)
 
-None. Every fix matched the issue body exactly. No architectural / security / dependency calls were made.
+Code paths got simpler, comments got more numerous. If you want the LOC
+target enforced strictly, trim comments in a follow-up.
 
-## Reproduce the state
+### 3. mira-crawler/ingest/uns.py import fallback
+
+`uns_resolver.py` imports `_uns` via two paths: `from mira_crawler.ingest`
+(works when the crawler service is on PYTHONPATH) and a filesystem-path
+fallback using `parents[2] / "mira-crawler"` (works in the worktree). In a
+production bot container that doesn't ship `mira-crawler/`, both fail and
+`_uns = None`. Behaviour in that case: vendor/model/fault still resolve
+correctly via the alias table; `uns_path` is always None. That breaks the
+KB-scoping optimization (#1) but not the engine extraction-site replacement
+(which doesn't read `uns_path`). If the bot container is expected to need
+UNS paths in production, vendor the path-builder code into
+`mira-bots/shared/` or publish `mira-crawler` as an importable package.
+
+### 4. Python 3.9 local test environment
+
+Several `mira-bots/tests/` files use Python 3.10+ syntax (`dict | None` at
+import-time, not under `from __future__ import annotations`). The local
+system has Python 3.9, so `pytest mira-bots/tests/test_engine.py` fails at
+collection with `TypeError: unsupported operand type(s) for |`. This is
+**pre-existing on the base branch** — my changes did not introduce it. CI
+runs on Python 3.12 where this works.
+
+Affected test files I could not run locally:
+- `mira-bots/tests/test_engine.py`
+- `mira-bots/tests/test_engine_dst_integration.py`
+- `mira-bots/tests/test_engine_tenant_kwargs.py`
+- `mira-bots/tests/test_conversation_continuity.py`
+
+I verified equivalence by running the resolver suite, the dialogue_tracker
+suite (which consumes the refactored dialogue_state), a smoke import of
+engine.py via a path that avoids the `mira-bots/email/` stdlib-shadow
+problem, an end-to-end resolve of Mike's regression case, and the dry-run
+eval. Recommend running the full `mira-bots/tests/` suite in CI on Python
+3.12 before merging.
+
+## What to verify in CI / on prod
+
+1. CI's `pytest mira-bots/tests/` on Python 3.12 — should be green.
+2. `.github/workflows/code-review.yml` — let it run, address 🔴 IMPORTANT
+   comments with `bash scripts/pr_self_fix.sh <PR>` once if needed.
+3. After merge + deploy: send the Telegram bot the literal message
+   *"I have a powerflex 525 and it has it called f0004"*. Expect a
+   diagnostic reply that references PowerFlex 525 and F0004 — NOT a search
+   for "f0004 model" or a fault-code lookup for "525".
+
+## Risks
+
+- The asset_identified write at the top of `process_full` is gated on
+  `confidence >= 0.7` AND `not state.get("asset_identified")`. If an
+  earlier-turn asset is in state, we don't overwrite it. If no asset exists
+  AND the resolver got high confidence, we set the canonical
+  "Vendor, Model" string. This preserves the existing engine contract —
+  DST and reflection logic continue to work without modification.
+- `_collect_session_entities` last-resort branch re-runs the resolver on
+  `message` when state has no uns_context AND no asset_identified AND no
+  DST entities. This only fires for legacy state rows or code paths that
+  bypassed `process_full`'s top-of-loop resolution. Cost: one regex pass.
+
+## Reproduce commands
 
 ```bash
-cd /Users/charlienode/MIRA/.claude/worktrees/tech-debt-hub-ux-2026-04-26
-git log --oneline pre-tech-debt-hub-ux-2026-04-26-2107..HEAD
-git diff --stat pre-tech-debt-hub-ux-2026-04-26-2107..HEAD
+# Run resolver tests
+python3 -m pytest tests/test_uns_resolver.py --rootdir=. -v
+
+# Run dialogue_tracker tests (consumes the refactor)
+python3 -m pytest mira-bots/tests/test_dialogue_tracker.py --rootdir=. -v
+
+# Lint
+ruff check mira-bots/shared/uns_resolver.py mira-bots/shared/engine.py \
+  mira-bots/shared/workers/rag_worker.py mira-bots/shared/dialogue_state.py \
+  mira-bots/shared/dialogue_acts.py tests/test_uns_resolver.py
+
+# Mike's exact regression
+python3 -c "
+import sys; sys.path.append('mira-bots')
+from shared.uns_resolver import resolve_uns_path
+ctx = resolve_uns_path('I have a powerflex 525 and it has it called f0004')
+print(ctx.manufacturer, ctx.model, ctx.fault_code, ctx.uns_path)
+"
 ```
-
-## Suggested morning checklist (operator)
-
-- [ ] Read this HANDOFF top to bottom
-- [ ] `git log --oneline pre-tech-debt-hub-ux-2026-04-26-2107..HEAD` — confirm 6 commits + the HANDOFF below
-- [ ] `git diff --name-only pre-tech-debt-hub-ux-2026-04-26-2107..HEAD` — confirm all 10 files are in mira-hub/
-- [ ] `cd mira-hub && rm -rf .next && npm run build` — confirms TypeScript + Next.js compile (the gate I couldn't run)
-- [ ] `cd mira-hub && npm run lint` — clean
-- [ ] `cd mira-hub && npx playwright test` (optional, if you have time) — smoke
-- [ ] Visually verify in dev:
-  - `/hub/workorders/new` → step 1 button now reads "Description" with arrow (was "Save")
-  - `/hub/workorders` → WO-2026-002 (in_progress, due 2026-04-23) shows red date + "Overdue" pill
-  - Fresh tenant `/hub/knowledge` → onboarding copy instead of "0 chunks in RAG"
-  - Fresh tenant `/hub/assets` → "Register your first asset" + inline + New Asset button
-  - Upload picker on `/hub/knowledge` with no cloud sources connected → hover Google Drive button shows tooltip; "Channels" word in hint is a clickable blue link to /hub/channels
-- [ ] Clean up the untracked `.broken-*` files (cmd above)
-- [ ] Push: `git push -u origin tech-debt/hub-ux-fixes-2026-04-26`
-- [ ] Open PR (one PR for all 5 fixes — they're independent, but bundling is OK since they're all hub UX hygiene; or split if you'd rather have per-issue PRs):
-  ```
-  gh pr create --title "tech-debt(hub): 5 UX fixes — #688 #719 #720 #721 #722" \
-               --body "Closes #688, closes #719, closes #720, closes #721, closes #722. See HANDOFF.md on the branch for the per-fix breakdown."
-  ```
-- [ ] Let the automated review pipeline (`.github/workflows/code-review.yml`) run; if 🔴 IMPORTANT comments, run `bash scripts/pr_self_fix.sh <PR>` once
-
-## Rollback (if anything goes wrong)
-
-```bash
-# Single fix:
-git -C .claude/worktrees/tech-debt-hub-ux-2026-04-26 revert <sha-from-table-above>
-
-# All fixes back to baseline (keeps PLAN.md and HANDOFF.md as docs):
-git -C .claude/worktrees/tech-debt-hub-ux-2026-04-26 reset --hard pre-tech-debt-hub-ux-2026-04-26-2107
-
-# Drop the whole branch + worktree:
-git worktree remove --force .claude/worktrees/tech-debt-hub-ux-2026-04-26
-git branch -D tech-debt/hub-ux-fixes-2026-04-26
-git tag -d pre-tech-debt-hub-ux-2026-04-26-2107   # only if you also want to drop the tag
-```
-
-## Session stats (for the prevention framework feedback loop)
-
-- **Issues closed:** 5 of 100 open (#688 P1, #719 P1, #720 P2, #721 P2, #722 P2)
-- **Commits:** 6 (1 PLAN + 5 fixes; each fix independently revertable)
-- **Files changed:** 10 (all in `mira-hub/`, 0 OUT-of-scope)
-- **Lines:** +166 / -17
-- **Wall-clock:** ~28 min of 3 h budget
-- **Sandbox blockers hit:** FUSE unlink on `.git/*.lock` (worked around with `mv`), `.next/.fuse_hidden` blocks Next.js build, no GitHub push (handled by leaving local commits + push instructions)
-- **Gates that DID run in-sandbox:** git log scope check, git diff name-only scope check, JSON validity of all 4 locale files, key-presence assertion for all 3 new translation keys
-- **Gates that did NOT run (deferred to Mac):** `npm run build`, `npm run lint`, Playwright e2e
-- **One process miss to flag:** the first #720 commit reformatted JSON files unnecessarily; caught via `git diff --stat` review and fixed with `commit --amend`. Sharper diff-review discipline before `git commit` would have caught it pre-commit. Filing in operator memory as a feedback note for the autonomous-run skill.
-

--- a/PLAN.dst.md
+++ b/PLAN.dst.md
@@ -1,0 +1,645 @@
+# PLAN — Unified Dialogue State Tracker for MIRA
+
+**Status:** Draft (2026-05-04) — awaiting Mike's go/no-go before any code lands
+**Author:** Claude (Opus 4.7), session triggered by 2026-05-04 human-in-the-loop test transcript
+**Scope:** `mira-bots/shared/engine.py`, `mira-bots/shared/conversation_router.py`,
+`mira-bots/shared/workers/rag_worker.py`, plus a new `mira-bots/shared/dialogue_state.py`
+**Constraints honoured:** no LangChain, no TensorFlow, no Anthropic, no Rasa-as-runtime-dep,
+Python 3.12, async, httpx, OpenAI-compat cascade (Groq → Cerebras → Gemini)
+**Predecessor PLAN.md (hub-ux fixes, 2026-04-26):** archived to `docs/plans/2026-04-26-tech-debt-hub-ux-fixes.md`
+
+---
+
+## 1. The four symptoms — and the one architectural flaw underneath them
+
+| # | Symptom from Mike's 2026-05-04 test | Why it actually happens (after tracing the code) |
+|---|---|---|
+| 1 | "I don't know. I was just given the new one to put in" → bot searches `IDON` / `I-DON` as a fault code | The user's reply is *answering MIRA's question*, but the engine has no concept of **"this turn is an answer to my last question"**. It funnels the literal message into the vector search query (`embed_query = message`, `rag_worker.py:226`) and the GSD prompt then treats those tokens as candidate codes. |
+| 2 | "Can you make a work order for that?" → "Let me think about that differently — could you rephrase?" | `conversation_router.py` CRITICAL RULE 3 ("if FSM is active, prefer `continue_current`") swallows the action request. The message flows into `RAGWorker.process()` with FSM=Q-state, the LLM tries to fit it into the diagnostic ladder, the **self-critique quality gate** at `engine.py:1008` then fires its `groundedness` clarification (`engine.py:1028-1036`), which the LLM further paraphrases into the "rephrase" line. The action handler `_handle_wo_request` (`engine.py:2166`) is **never reached**. |
+| 3 | Yaskawa cited for a Siemens question; "Interroll" appearing randomly; raw YouTube URLs | Cross-vendor filter at `rag_worker.py:251-283` runs **only on text-only turns** and **only when `vendor_name_from_text(query_combined)` returns a non-empty string for the current message**. Chunks with `manufacturer=None` always pass through (`if not c.get("manufacturer")`). Session-salient vendor (from `state["asset_identified"]`) is **soft** — used to prefix the embedding query, never as a hard predicate on retrieval. YouTube transcripts and unbranded marketing chunks have no manufacturer tag and slip through every time. |
+| 4 | Bot doesn't know if user is answering vs asking new | `last_question` and `last_options` are stored in `session_context` but used **only for option-number resolution** (`engine.py:533`). The router gets `current_fsm_state` and `conversation_turn`, but no `pending_question` or `expected_slot` field. There is no contract anywhere in the system that says *"the next user turn is an answer to slot X — interpret it as a value, not as content."* |
+
+### The single architectural flaw
+
+> **MIRA classifies *intents* but does not track *dialogue acts*.**
+
+An *intent* says **what topic** the user means (diagnose, document, work-order).
+A *dialogue act* says **what move** the user is making in this turn (asking, answering, requesting-action, expressing-uncertainty, acknowledging, repairing, meta-controlling).
+
+The current router (`conversation_router.py`) has 12 task-intent labels and zero dialogue-act
+labels. Worse, its CRITICAL RULE 3 explicitly collapses every mid-flow utterance to
+`continue_current` — which means even a clear `request_action` dialogue act ("make a WO")
+is treated as a content continuation of whatever Q-state the FSM happens to be in.
+
+- Symptom 1 is "user's *answer* dialogue act treated as content."
+- Symptom 2 is "user's *request_action* dialogue act treated as content."
+- Symptom 3 is "session-salient entities not load-bearing on retrieval."
+- Symptom 4 is "no `pending_question` slot, so every turn is interpreted independently."
+
+**They are all the same bug.** Fix the dialogue-act layer and slot tracking, and all four
+symptoms fall together.
+
+---
+
+## 2. The fix — Dialogue State Tracker (DST) + Slot-Filling + Action Router
+
+This is the same pattern that Rasa, ConvLab, TRIPS, and most academic DST systems use,
+**stripped down to one Pydantic model and one LLM call per turn**. We are not adopting
+Rasa or any framework — we are stealing the data structure and the precedence rules.
+
+### 2.1 New canonical type — `DialogueState` (discriminated union of response acts)
+
+The cleanest pattern (validated by Rasa CALM 2024 + `instructor` / `pydantic-ai` practice)
+is to make each dialogue act a **separate Pydantic model with a `Literal` discriminator
+field**, then have the LLM pick one via tool-mode structured output. The dispatcher does
+`isinstance()` routing — no enum-then-switch, no "is the slot value populated for this
+act type?" check.
+
+```python
+# mira-bots/shared/dialogue_state.py  (NEW file, ~250 lines)
+
+from pydantic import BaseModel, Field
+from typing import Literal, Optional, Union
+
+# ---- Salient entities pinned across turns -----------------------------------
+
+class SalientEntities(BaseModel):
+    """Entities pinned in the session — load-bearing for retrieval and routing."""
+    vendor: Optional[str] = None         # "Siemens", "Yaskawa", "Rockwell"
+    model: Optional[str] = None          # "GS20", "PowerFlex 525", "SINAMICS S120"
+    fault_code: Optional[str] = None     # "F012", "OC", "AL-14"
+    asset_label: Optional[str] = None    # free-form, e.g. "air compressor #1"
+    last_action_proposed: Optional[str] = None  # "log work order", "send manual"
+
+
+# ---- What MIRA is currently waiting for -------------------------------------
+
+SlotName = Literal[
+    "asset_identification", "fault_code", "symptom_detail",
+    "wo_confirmation", "wo_field_supply", "manual_vendor_model",
+    "pm_acceptance", "fix_confirmation", "diagnostic_branch_choice",
+    "none",
+]
+
+class PendingQuestion(BaseModel):
+    slot: SlotName
+    asked_at_turn: int
+    options: list[str] = Field(default_factory=list)
+    raw_text: str = ""
+
+
+# ---- The dialogue acts (one model per act, discriminated by `act`) ----------
+# Aligns with Rasa CALM 2024 command vocabulary: set_slot, start_flow,
+# cancel_flow, correct_slot, chitchat, knowledge_answer, human_handoff.
+
+class AnswerAct(BaseModel):
+    """User answered MIRA's pending question. Fill the slot and advance."""
+    act: Literal["answer"] = "answer"
+    slot_fill_value: str
+    entities: SalientEntities = Field(default_factory=SalientEntities)
+    reasoning: str
+
+class InformAct(BaseModel):
+    """User volunteered information without being asked (no pending slot)."""
+    act: Literal["inform"] = "inform"
+    entities: SalientEntities = Field(default_factory=SalientEntities)
+    reasoning: str
+
+class RequestActionAct(BaseModel):
+    """User issued an imperative — make a WO, find the manual, switch asset."""
+    act: Literal["request_action"] = "request_action"
+    action: Literal[
+        "log_work_order", "switch_asset", "find_documentation",
+        "schedule_maintenance", "check_equipment_history", "reset",
+    ]
+    entities: SalientEntities = Field(default_factory=SalientEntities)
+    reasoning: str
+
+class AskQuestionAct(BaseModel):
+    """User asked a question (procedural how-to or general industrial)."""
+    act: Literal["ask"] = "ask"
+    question_kind: Literal["procedural", "general", "definition", "comparison"]
+    entities: SalientEntities = Field(default_factory=SalientEntities)
+    reasoning: str
+
+class DontKnowAct(BaseModel):
+    """User expressed uncertainty / 'I don't know' — must NOT embed message as query."""
+    act: Literal["dont_know"] = "dont_know"
+    reasoning: str
+
+class ConfirmAct(BaseModel):
+    """User confirmed (yes/correct/right) — usually answering a yes/no slot."""
+    act: Literal["confirm"] = "confirm"
+    reasoning: str
+
+class DenyAct(BaseModel):
+    act: Literal["deny"] = "deny"
+    reasoning: str
+
+class MetaControlAct(BaseModel):
+    """nevermind / start over / skip / cancel — preempt and reset flow."""
+    act: Literal["meta"] = "meta"
+    command: Literal["cancel", "reset", "skip", "back", "stop"]
+    reasoning: str
+
+class GreetAckAct(BaseModel):
+    act: Literal["greet"] = "greet"
+    reasoning: str
+
+class SafetyAct(BaseModel):
+    """Safety override — always wins regardless of state."""
+    act: Literal["safety"] = "safety"
+    hazard_summary: str
+    reasoning: str
+
+# The single typed return — instructor / pydantic-ai pick exactly one.
+DialogueTurn = Union[
+    AnswerAct, InformAct, RequestActionAct, AskQuestionAct, DontKnowAct,
+    ConfirmAct, DenyAct, MetaControlAct, GreetAckAct, SafetyAct,
+]
+```
+
+**Why discriminated union beats a single `dialogue_act: Literal[...]` field:**
+
+1. The LLM cannot return `act=answer` without a `slot_fill_value` (Pydantic rejects).
+2. The LLM cannot return `act=dont_know` AND a slot value (the model has no such field).
+3. The dispatcher is `match turn: case AnswerAct(...): ...` — no nullable-field gymnastics.
+4. `instructor`'s `Mode.TOOLS` registers each model as a separate OpenAI-tool schema and
+   forces the LLM to pick one — eliminating the JSON-parse-failure failure mode.
+
+### 2.2 New canonical call — `track_dialogue_state`
+
+Replaces `route_intent`. **One Groq llama-3.1-8b call** via the `instructor` library in
+`Mode.TOOLS`, ~200ms, returns one of the `DialogueTurn` union members as a typed Pydantic
+instance. Same cost profile as today, but the response carries the information the engine
+actually needs and cannot be malformed.
+
+```python
+import instructor
+from groq import AsyncGroq
+
+# Single client — wraps the existing GROQ_API_KEY, same provider as route_intent today.
+_dst_client = instructor.from_provider(
+    "groq/llama-3.1-8b-instant",
+    async_client=True,
+    mode=instructor.Mode.TOOLS,
+)
+
+async def track_dialogue_state(
+    user_message: str,
+    history: list[dict],
+    pending_question: PendingQuestion,
+    salient_entities: SalientEntities,
+    fsm_state: str,
+) -> DialogueTurn:
+    """Single-pass dialogue state tracker. The LLM picks one of 10 typed acts."""
+    return await _dst_client.create(
+        response_model=DialogueTurn,           # the discriminated union
+        messages=[
+            {"role": "system", "content": _DST_SYSTEM_PROMPT},
+            {"role": "user", "content": _format_context(
+                user_message, history, pending_question, salient_entities, fsm_state,
+            )},
+        ],
+        max_retries=2,                          # instructor retries on validation fail
+    )
+```
+
+The prompt explicitly anchors on the `pending_question`:
+
+> "MIRA's last question was: '{raw_text}' — it is waiting for slot=`{slot}`.
+> If the user answered it, return an `answer` act with `slot_fill_value` set.
+> If they said 'I don't know' or similar, return a `dont_know` act — do NOT
+> invent a slot value. If they asked a new question or made a request, return
+> `ask` or `request_action`. **Picking the wrong act is worse than picking
+> low-confidence — never invent a value to fill a slot.**"
+
+**Why `instructor` (vs. raw httpx + json.loads, vs. `pydantic-ai`):**
+
+- `instructor`'s `Mode.TOOLS` registers each union member as a separate OpenAI-tool
+  schema; the Groq endpoint is OpenAI-compatible so this works directly. The LLM must
+  pick one tool — there is no "JSON parse failure" path.
+- Same `max_retries` self-heal pattern that fixes today's `ROUTER_LLM_FAILURE` log line.
+- Native async, native Groq via `from_provider("groq/...")`, no LangChain dep, no
+  TensorFlow.
+- `pydantic-ai` is a strict superset (full agent runtime); we only need the tool-mode
+  structured output, not the agent loop.
+
+**New dependency:** `instructor>=1.6.0` in `mira-bots/pyproject.toml`. Pure Python, ~3
+KLOC, depends only on `pydantic` and `openai` (already transitive). **Flagged for Mike's
+approval** — if rejected, fall back to raw `httpx` + manual `pydantic.TypeAdapter` JSON
+validation (~30 LOC more boilerplate, same correctness).
+
+This is the Rasa DIET pattern of **joint intent+entity prediction in one head** —
+DIET uses a transformer with a CRF tagger; we use structured-output LLM tool calls. The
+DST contract (one act per turn, slot-or-action explicit) is identical.
+
+### 2.3 New dispatch precedence in `Supervisor.process_full`
+
+The Rasa CALM 2024 `FormPolicy` interrupt pattern, ported to Python `match` statements:
+
+```python
+# After the existing pending intercepts and safety check:
+
+turn = await track_dialogue_state(...)
+self._persist_salient_entities(state, turn)   # always merge new entities
+
+# ALWAYS_INTERRUPT — actions that preempt every flow with state preservation.
+ALWAYS_INTERRUPT = {"log_work_order", "switch_asset", "safety", "reset"}
+
+match turn:
+    # Priority 1 — safety always wins.
+    case SafetyAct():
+        return self._safety_response(state, chat_id, trace_id, turn)
+
+    # Priority 2 — interrupt actions snapshot then preempt.
+    case RequestActionAct(action=a) if a in ALWAYS_INTERRUPT:
+        return await self._handle_interrupt(turn, state, chat_id, trace_id)
+
+    # Priority 3 — slot answers (or "I don't know") when MIRA asked a question.
+    case _ if state.get("pending_question", {}).get("slot") != "none":
+        match turn:
+            case AnswerAct():
+                return await self._fill_slot_and_continue(turn, state, chat_id, trace_id)
+            case DontKnowAct():
+                return await self._handle_dont_know(state, chat_id, trace_id)
+            case ConfirmAct() | DenyAct():
+                return await self._handle_yes_no(turn, state, chat_id, trace_id)
+            # If LLM picked something else mid-slot-fill, it's a topic pivot.
+            # Cancel the slot, re-dispatch the new act below.
+            case _:
+                self._cancel_pending_question(state)
+                # fall through
+
+    # Priority 4 — meta-control commands.
+    case MetaControlAct(command=c):
+        return await self._handle_meta_command(c, state, chat_id, trace_id)
+
+    # Priority 5 — non-interrupt action requests (find_documentation,
+    # schedule_maintenance, check_equipment_history).
+    case RequestActionAct(action=a):
+        return await self._dispatch_action(a, turn, state, chat_id, trace_id)
+
+    # Priority 6 — questions and information continue into existing flow.
+    case AskQuestionAct(question_kind="procedural"):
+        return await self._handle_instructional_question(chat_id, message, state, trace_id)
+    case AskQuestionAct(question_kind="general" | "definition" | "comparison"):
+        return await self._handle_general_question(chat_id, message, state, trace_id)
+    case GreetAckAct() if state["state"] == "IDLE":
+        return self._greeting_response(state, chat_id, trace_id)
+    case InformAct() | _:
+        # Default — into the diagnostic RAG pipeline with bound salient entities.
+        ...  # existing RAG flow
+```
+
+**Why the priority ordering matters (this is the canonical bug fix for all 4 symptoms):**
+
+- **Symptom 1 (IDON lookup):** `DontKnowAct` is matched in Priority 3 *before* the
+  default RAG fall-through, so "I don't know" never reaches the embedding query.
+- **Symptom 2 (WO blocked):** `RequestActionAct(action="log_work_order")` matches at
+  Priority 2 *before* the slot-answer check, so the WO handler is reached even mid-Q.
+- **Symptom 4 (answering vs asking):** `pending_question.slot != "none"` is the
+  guard on Priority 3 — slot answers and don't-knows are interpreted as such only when
+  MIRA is actually waiting for a slot. Without a pending question, the same "I don't
+  know" falls to the default flow.
+
+**Stack-resumable interrupts** (Rasa FormPolicy / CALM `start_flow` + `cancel_flow`):
+
+```python
+async def _handle_interrupt(self, turn: RequestActionAct, state, chat_id, trace_id):
+    saved = {
+        "fsm_state": state["state"],
+        "pending_question": state.get("pending_question"),
+        "active_alarm": state.get("context", {}).get("session_context", {}).get("active_alarm"),
+    }
+    result = await self._dispatch_action(turn.action, turn, state, chat_id, trace_id)
+    # Push resume offer into the result so user can continue the diagnostic later.
+    if saved["fsm_state"] in ACTIVE_DIAGNOSTIC_STATES:
+        state["context"]["interrupted_diagnosis"] = saved
+    return result
+```
+
+When the next user turn comes back and `interrupted_diagnosis` is present, MIRA can
+offer: *"WO created. Want to pick up the bearing diagnosis where we left off?"*
+
+### 2.4 Hard vendor/asset filter on RAG retrieval
+
+**Today (`rag_worker.py:251-283`):** vendor filter runs only when
+`vendor_name_from_text(query_combined)` finds a vendor in the *current* message. Chunks
+with `manufacturer=None` always pass.
+
+**Proposed:**
+
+```python
+# rag_worker.py — new method
+def _retrieval_predicates(self, state: dict, message: str) -> dict:
+    salient = state.get("salient_entities", {})  # set by DST
+    vendor = salient.get("vendor") or vendor_name_from_text(
+        f"{message} {state.get('asset_identified','')}"
+    )
+    return {
+        "required_vendor": vendor,           # hard filter when set
+        "min_similarity": 0.70,              # already exists
+        "exclude_unbranded_when_vendor_known": True,  # NEW — kills "Interroll" leak
+    }
+```
+
+When `required_vendor` is set:
+- chunks with `manufacturer is not None and vendor_lower not in manufacturer_lower` → DROP
+- chunks with `manufacturer is None` AND `exclude_unbranded_when_vendor_known` → DROP
+- Falls back to today's behaviour (allow unbranded) only when no vendor is known yet.
+
+YouTube and Interroll mass-ingested transcripts almost universally have empty manufacturer
+metadata; this single change suppresses them whenever the session has identified a vendor.
+
+### 2.5 Disarm the self-critique groundedness gate when the user is making a non-diagnosis move
+
+**Today (`engine.py:1008`):** the self-critique gate fires on every DIAGNOSIS turn,
+including turns where the user asked for a work order or said "I don't know". When
+groundedness < 3, it produces the clarifying-question loop ("could you share one more
+detail — what exact fault code…").
+
+**Proposed:** the gate only fires when `turn.dialogue_act in {"answer", "inform"}` and
+(`turn.is_answer_to_pending` is True or `pending_question.slot == "none"`). For
+`request_action`, `uncertainty`, `meta_command`, `acknowledge` — the gate is **muted**
+because the response wasn't trying to be a diagnosis.
+
+This is the second half of the fix for Symptom 2.
+
+---
+
+## 3. File-by-file changes
+
+| File | Change | Approx LOC |
+|---|---|---|
+| `mira-bots/shared/dialogue_state.py` | **NEW** — Pydantic models (`DialogueAct`, `SalientEntities`, `PendingQuestion`, `DialogueTurn`) and `track_dialogue_state()` LLM call | +200 |
+| `mira-bots/shared/conversation_router.py` | Keep `route_intent` for 1 release as a fallback for DST failures; deprecate after Stage 2 | ±20 |
+| `mira-bots/shared/engine.py` | Replace `route_intent` call at L562 with `track_dialogue_state`; rewrite the dispatch block L588-627 to use `turn.dialogue_act` precedence; pass `salient_entities` and `pending_question` through state | ~150 changed |
+| `mira-bots/shared/engine.py` | Wrap self-critique gate L1008 with `if turn.dialogue_act in {"answer","inform"}:` | ~10 changed |
+| `mira-bots/shared/workers/rag_worker.py` | Add `_retrieval_predicates`; tighten cross-vendor filter to drop unbranded chunks when vendor known; embed bound asset+fault, not raw user text, when slot-fill happened | ~60 changed |
+| `mira-bots/shared/session_manager.py` | Persist `salient_entities` and `pending_question` alongside existing state fields | ~20 changed |
+| `tests/eval/dialogue_act_cases.json` | **NEW** — 30+ regression cases covering all four symptoms | +1 file |
+
+**Total: ~450 LOC net new code, all in existing modules + one new file. Zero new dependencies.**
+
+---
+
+## 4. Staged rollout
+
+### Stage 0 — TODAY (1-2 hours, lands on `fix/wo-request-mid-flow` branch)
+
+**Goal:** unblock the Symptom 2 work-order regression. Do NOT touch the architecture.
+
+1. In `engine.py` `process_full`, **before** the `route_intent` call (~L560), insert a
+   regex fast-path for explicit action requests:
+
+   ```python
+   _ACTION_REQUEST_RE = re.compile(
+       r"\b(make|create|log|file|open|submit|put in)\s+"
+       r"(a\s+)?(work\s*order|wo|ticket|request)\b",
+       re.IGNORECASE,
+   )
+   if not photo_b64 and _ACTION_REQUEST_RE.search(message):
+       logger.info("ACTION_REQUEST_FAST_PATH chat_id=%s match=%r", chat_id, message[:60])
+       return await self._handle_wo_request(chat_id, message, state, trace_id)
+   ```
+
+   Same pattern for `_DOC_REQUEST_RE` ("send me the manual", "find the datasheet").
+   This gives Mike a working WO flow today, no other architectural risk.
+
+2. Add a guard in the self-critique block (`engine.py:1008`) that skips the gate when
+   the most recent turn matched the action-request fast-path, by setting a transient
+   `ctx["last_dispatch"] = "action_request"` and checking it.
+
+3. Add a regression test in `tests/eval/` that replays Mike's transcript and asserts
+   `_handle_wo_request` is invoked.
+
+**Verification:** `pytest tests/eval/ -k work_order_mid_flow` and a manual rerun of the
+"cooling fan on air compressor #1, make a work order" sequence on staging.
+
+### Stage 1 — This sprint (~2-3 days, `feat/dialogue-state-tracker` branch)
+
+1. Create `mira-bots/shared/dialogue_state.py` with the Pydantic models above.
+2. Implement `track_dialogue_state` against Groq llama-3.1-8b-instant (same provider as
+   the current router — same latency, same cost, same failure profile).
+3. Wire it into `Supervisor.process_full` behind a `MIRA_USE_DST=1` env flag, falling
+   back to `route_intent` when unset. Default OFF in prod, ON in dev/eval.
+4. Add the dispatch-precedence block from §2.3.
+5. Mute the self-critique gate per §2.5.
+6. Add `tests/eval/dialogue_act_cases.json` — at minimum:
+   - the 4 cases from Mike's transcript (one per symptom)
+   - 5 "I don't know" answers to different MIRA questions
+   - 5 mid-flow action requests (WO, doc, asset switch)
+   - 5 slot-fill answers (model #, fault code, symptom, yes/no, free text)
+   - 3 meta-commands (nevermind, skip, reset)
+7. Run the existing 39 golden cases — no regression allowed.
+
+**Exit criteria:** flag flip to `MIRA_USE_DST=1` in prod after a clean week in dev,
+gated on a Mike-led HITL test that replays the 2026-05-04 transcript end-to-end.
+
+### Stage 2 — Next sprint (~2 days, `feat/dst-slot-filling` branch)
+
+1. Promote `pending_question.slot` to load-bearing — the diagnostic ladder (Q1→Q2→Q3)
+   becomes a slot sequence (`asset → fault_code → symptom → cause`). Each ladder turn
+   sets `pending_question.slot` and `expected_slot`; the next user turn either fills the
+   slot or branches via `dialogue_act`.
+2. Remove `route_intent` and the `MIRA_USE_DST` flag.
+3. Tighten RAG retrieval per §2.4 — hard vendor filter, drop unbranded when vendor known.
+4. Backfill `manufacturer` metadata on the YouTube and Interroll chunks in NeonDB
+   (one-off SQL migration from `crawler` source URL → vendor inference). Deferred ones
+   stay tagged `manufacturer="generic"` and are excluded from vendor-scoped retrieval.
+
+### Stage 3 — Polish (week 3)
+
+- DAMSL-aligned dialogue-act expansion (add `repair` recovery handler — "actually I meant
+  the F012 fault not F102")
+- Stack-resumable sub-flows: when an action request preempts mid-Q-flow, offer to resume
+  ("WO created. Back to diagnosing the bearing — you said it was running hot. Continue?")
+
+---
+
+## 5. Open-source patterns we are explicitly stealing (and why)
+
+These come from a focused review of Rasa (classic + CALM 2024), pydantic-ai, instructor,
+and the DAMSL / ISO 24617-2 dialogue-act literature. We are stealing **patterns and data
+shapes**, not runtimes.
+
+| Pattern | Source | What we steal | What we explicitly skip |
+|---|---|---|---|
+| **Joint intent + entity prediction in one call** | **Rasa DIET** ([paper](https://arxiv.org/abs/2004.09936)) | Single LLM call returns the act + slot value + entities together — no two-step "classify intent, then extract entities" pipeline | DIET's transformer + CRF tagger; our LLM cascade does the same job |
+| **`requested_slot` priority rule** | **Rasa classic FormPolicy** | If MIRA asked for slot X, the user's reply is interpreted as a slot answer **before** any new-intent classification. This is a code-level priority rule, not an LLM task. | Rasa's full policy ensemble |
+| **Command-style act vocabulary** | **Rasa CALM 2024** ([blog](https://rasa.com/blog/calm/)) | The act labels themselves: `set_slot`, `start_flow`, `cancel_flow`, `correct_slot`, `chitchat`, `knowledge_answer`, `human_handoff`. Our 10-act union maps 1:1 onto these. | The Rasa runtime / CALM dialogue understanding model |
+| **Interrupt + state-snapshot pattern** | **Rasa FormPolicy `ActionExecutionRejection`** | When a high-priority action fires mid-flow, snapshot `active_loop` + `requested_slot` + filled slots before dispatching the action; restore on completion so the form resumes | Rasa's policy ensemble that reactivates the form |
+| **Multi-command-per-turn** | **Rasa CALM** | When the user packs two moves into one message ("make a WO for that, and also what does E07 mean?"), the LLM can return a list of acts. We defer this to Stage 3 (single-act per turn is enough for Mike's 4 symptoms). | Stage 1/2 stays single-act |
+| **Discriminated union output** | **`instructor` + `pydantic-ai`** | The LLM picks one of N tool-typed Pydantic models per turn (the dispatch is `match` over the type, not over a `dialogue_act` string field). Forbids structurally-impossible combinations (e.g. `act=dont_know` with a `slot_fill_value`). | The full `pydantic-ai` agent runtime |
+| **Tool-mode structured output** | **OpenAI function calling spec** + Groq's OpenAI-compat surface | Each act registers as a tool schema; the model is forced to call exactly one. This is what eliminates today's `ROUTER_LLM_FAILURE` JSON-parse path. | Letting the LLM execute the tool — we dispatch in Python |
+| **Dialogue-act taxonomy** | **DAMSL / ISO 24617-2** | The 10-act minimal set (`answer`, `ask`, `request_action`, `inform`, `dont_know`, `confirm`, `deny`, `meta`, `greet`, `safety`) — covers >95% of industrial-bot turns | The full 56-act ISO taxonomy; overkill |
+| **`ALWAYS_INTERRUPT` set** | **Microsoft Bot Framework** "interruption recognizers" | Fixed set of action names (`log_work_order`, `safety`, `reset`, `switch_asset`) that always preempt mid-flow; everything else falls through to existing dispatch | Bot Framework dialog stack |
+
+**Library pick: `instructor>=1.6.0`** (vs. raw httpx / pydantic-ai / outlines / guidance):
+
+- Native Groq via `instructor.from_provider("groq/llama-3.1-8b-instant", async_client=True, mode=Mode.TOOLS)` — same provider as today's router.
+- `Mode.TOOLS` registers each union member as a separate tool schema → LLM picks one.
+- Built-in `max_retries` self-heal on validation failure (replaces today's "fall back to keyword classifier on parse error").
+- Pure Python, depends only on `pydantic` + `openai` (already transitive).
+- Async-clean, Python 3.12-clean, no LangChain, no TensorFlow.
+- *Runner-up:* `pydantic-ai` — strict superset; we'd only use the structured-output bit, so adding the agent runtime is over-spec for our needs.
+- *Avoid:* `outlines` and `guidance` (constrained-sampling, only work with locally-hosted models — incompatible with our Groq cascade); `marvin` (effectively unmaintained as of 2025).
+
+**We deliberately do not adopt:**
+
+- **LangChain** — banned by `CLAUDE.md` hard constraint.
+- **Rasa as a runtime** — pulls TensorFlow + spaCy, ~600 MB, far over budget.
+- **TensorFlow / sentence-transformers retraining** — embedding model is already `nomic-embed-text` via Ollama; we keep it.
+
+---
+
+## 6. What this plan **explicitly does not** try to fix
+
+- **The GSD prompt itself** — `active.yaml` v1.2 is not the bug. It is a victim of bad
+  routing. Once dialogue acts are right, the GSD prompt gets called for the right turns
+  and the existing few-shot examples already cover those cases well.
+- **NeonDB metadata coverage** — backfilling `manufacturer` on legacy chunks is a Stage 2
+  side quest, not part of the architecture. The hard vendor filter handles unbranded
+  chunks correctly even before backfill.
+- **Per-tenant intent personalisation** — out of scope; addressable later via per-tenant
+  prompt overrides if we see signal for it.
+- **Replacing the keyword `classify_intent`** — keep it. It is a 0-ms safety net, fires
+  before any network call, and catches the SAFETY tier even if every LLM in the cascade
+  is unreachable.
+
+---
+
+## 7. Verification — how we'll know it actually fixed everything at once
+
+1. **Stage 0 gate** — `pytest tests/eval/ -k work_order_mid_flow` green; manual replay of
+   Mike's "cooling fan on air compressor" sequence creates a WO draft.
+2. **Stage 1 gate** — new `dialogue_act_cases.json` (~25 cases) at 100%; the existing 39
+   golden cases regression-clean; HITL replay of the 2026-05-04 transcript with the four
+   symptoms — all four resolved.
+3. **Stage 2 gate** — DST flag default-on in prod for a week with `eval_score >= 80%`
+   and zero `SELF_CRITIQUE_TRIGGERED` events on `request_action` turns in Langfuse.
+
+A regression in any one of the four symptoms re-opens the plan; the architecture is
+validated by all four going green together.
+
+---
+
+## 8. Risk register
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| DST LLM call adds latency on top of existing `route_intent` | **Low** — same model, same provider; we replace, not stack | Keep `route_intent` as fallback in Stage 1 behind a flag; revert if p95 regresses >50ms |
+| Pydantic structured output failures | **Medium** | DST fall-through to keyword `classify_intent` — same pattern as today |
+| Mis-classifying a real diagnosis turn as `request_action` and skipping the diagnostic ladder | **Low-Medium** | Only the explicit imperative regex fires Stage 0; Stage 1 adds the LLM, but the model has seen the dialogue-act distinction in pre-training |
+| Hard vendor filter starves retrieval for vendors we have weak coverage for | **Medium** | Filter only activates when chunks > 0 with matching vendor exist; graceful degrade to current behaviour otherwise |
+| Slot-fill extraction hallucinates a value when user said "I don't know" | **High if naive, Low if right** | The DST prompt in §2.2 explicitly forbids extraction on `uncertainty` — verified by 5 test cases in Stage 1 |
+
+---
+
+## 9. Decision asked of Mike
+
+1. **Approve Stage 0 hot-fix** for landing today (1-2h, regex action-request fast-path +
+   muted self-critique on action turns). This unblocks the WO regression without any
+   architectural commitment.
+2. **Approve Stages 1–3** as the unified fix path. If yes, I open `feat/dialogue-state-tracker`
+   and start with the Pydantic models + `track_dialogue_state` LLM call.
+3. If you want a smaller-step rollout — Stage 0 + Stage 2.4 only (hard vendor filter,
+   nothing else) — that also resolves Symptom 3 in isolation, but Symptoms 1, 2, 4
+   require the dialogue-act layer to actually go away.
+
+---
+
+## 10. Appendix — concrete wire-up sketch
+
+```python
+# engine.py — proposed dispatch block replacing L588-627
+from .dialogue_state import (
+    AnswerAct, AskQuestionAct, ConfirmAct, DenyAct, DontKnowAct,
+    GreetAckAct, InformAct, MetaControlAct, PendingQuestion,
+    RequestActionAct, SafetyAct, SalientEntities, track_dialogue_state,
+)
+
+ALWAYS_INTERRUPT = {"log_work_order", "switch_asset", "safety", "reset"}
+
+# (after the unchanged pending intercepts + safety keyword check)
+
+pending = PendingQuestion(**state.get("pending_question", {"slot": "none", "asked_at_turn": 0}))
+salient = SalientEntities(**state.get("salient_entities", {}))
+
+try:
+    turn = await track_dialogue_state(
+        user_message=message,
+        history=(state.get("context") or {}).get("history", []),
+        pending_question=pending,
+        salient_entities=salient,
+        fsm_state=state.get("state", "IDLE"),
+    )
+except Exception as exc:
+    logger.warning("DST_FAILURE error=%s — falling back to keyword classifier", exc)
+    turn = self._fallback_turn_from_keyword_classifier(message)
+
+# Always merge any newly-extracted entities into state.
+self._merge_salient_entities(state, getattr(turn, "entities", None))
+
+match turn:
+    case SafetyAct():
+        return self._safety_response(state, chat_id, trace_id, turn)
+
+    case RequestActionAct(action=a) if a in ALWAYS_INTERRUPT:
+        return await self._handle_interrupt(turn, state, chat_id, trace_id)
+
+    case _ if state.get("pending_question", {}).get("slot") != "none":
+        match turn:
+            case AnswerAct():
+                return await self._fill_slot_and_continue(turn, state, chat_id, message, trace_id)
+            case DontKnowAct():
+                return await self._handle_dont_know(state, chat_id, trace_id)
+            case ConfirmAct() | DenyAct():
+                return await self._handle_yes_no(turn, state, chat_id, trace_id)
+            case _:
+                # Topic pivot — cancel slot and re-dispatch.
+                self._cancel_pending_question(state)
+
+    case MetaControlAct(command=c):
+        return await self._handle_meta_command(c, state, chat_id, trace_id)
+
+    case RequestActionAct(action=a):
+        return await self._dispatch_action(a, turn, state, chat_id, message, trace_id)
+
+    case AskQuestionAct(question_kind="procedural"):
+        return await self._handle_instructional_question(chat_id, message, state, trace_id)
+
+    case AskQuestionAct():
+        return await self._handle_general_question(chat_id, message, state, trace_id)
+
+    case GreetAckAct() if state["state"] == "IDLE":
+        return self._greeting_response(state, chat_id, trace_id)
+
+    case _:  # InformAct or fall-through — existing diagnostic RAG path
+        pass
+```
+
+```python
+# rag_worker.py — proposed hard vendor filter
+
+def _filter_chunks_by_salience(self, neon_chunks: list[dict], state: dict, message: str) -> list[dict]:
+    salient = state.get("salient_entities", {})
+    vendor = salient.get("vendor") or vendor_name_from_text(
+        f"{message} {state.get('asset_identified','')}"
+    )
+    if not vendor:
+        return neon_chunks  # no salient vendor — keep current behaviour
+
+    v = vendor.lower()
+    matched = [c for c in neon_chunks if v in (c.get("manufacturer") or "").lower()]
+    if matched:
+        # Hard filter — drop both wrong-vendor AND unbranded when we have matches
+        return matched
+    # No matched vendor chunks — fall through to today's lenient behaviour
+    return [c for c in neon_chunks if not c.get("manufacturer") or v in (c.get("manufacturer") or "").lower()]
+```
+
+---
+
+**End of plan.** Awaiting Mike's call: Stage 0 today / Stages 1-3 next / both.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,645 +1,75 @@
-# PLAN — Unified Dialogue State Tracker for MIRA
+# PLAN — UNS Message Resolver (single extraction point)
 
-**Status:** Draft (2026-05-04) — awaiting Mike's go/no-go before any code lands
-**Author:** Claude (Opus 4.7), session triggered by 2026-05-04 human-in-the-loop test transcript
-**Scope:** `mira-bots/shared/engine.py`, `mira-bots/shared/conversation_router.py`,
-`mira-bots/shared/workers/rag_worker.py`, plus a new `mira-bots/shared/dialogue_state.py`
-**Constraints honoured:** no LangChain, no TensorFlow, no Anthropic, no Rasa-as-runtime-dep,
-Python 3.12, async, httpx, OpenAI-compat cascade (Groq → Cerebras → Gemini)
-**Predecessor PLAN.md (hub-ux fixes, 2026-04-26):** archived to `docs/plans/2026-04-26-tech-debt-hub-ux-fixes.md`
-
----
-
-## 1. The four symptoms — and the one architectural flaw underneath them
-
-| # | Symptom from Mike's 2026-05-04 test | Why it actually happens (after tracing the code) |
-|---|---|---|
-| 1 | "I don't know. I was just given the new one to put in" → bot searches `IDON` / `I-DON` as a fault code | The user's reply is *answering MIRA's question*, but the engine has no concept of **"this turn is an answer to my last question"**. It funnels the literal message into the vector search query (`embed_query = message`, `rag_worker.py:226`) and the GSD prompt then treats those tokens as candidate codes. |
-| 2 | "Can you make a work order for that?" → "Let me think about that differently — could you rephrase?" | `conversation_router.py` CRITICAL RULE 3 ("if FSM is active, prefer `continue_current`") swallows the action request. The message flows into `RAGWorker.process()` with FSM=Q-state, the LLM tries to fit it into the diagnostic ladder, the **self-critique quality gate** at `engine.py:1008` then fires its `groundedness` clarification (`engine.py:1028-1036`), which the LLM further paraphrases into the "rephrase" line. The action handler `_handle_wo_request` (`engine.py:2166`) is **never reached**. |
-| 3 | Yaskawa cited for a Siemens question; "Interroll" appearing randomly; raw YouTube URLs | Cross-vendor filter at `rag_worker.py:251-283` runs **only on text-only turns** and **only when `vendor_name_from_text(query_combined)` returns a non-empty string for the current message**. Chunks with `manufacturer=None` always pass through (`if not c.get("manufacturer")`). Session-salient vendor (from `state["asset_identified"]`) is **soft** — used to prefix the embedding query, never as a hard predicate on retrieval. YouTube transcripts and unbranded marketing chunks have no manufacturer tag and slip through every time. |
-| 4 | Bot doesn't know if user is answering vs asking new | `last_question` and `last_options` are stored in `session_context` but used **only for option-number resolution** (`engine.py:533`). The router gets `current_fsm_state` and `conversation_turn`, but no `pending_question` or `expected_slot` field. There is no contract anywhere in the system that says *"the next user turn is an answer to slot X — interpret it as a value, not as content."* |
-
-### The single architectural flaw
-
-> **MIRA classifies *intents* but does not track *dialogue acts*.**
-
-An *intent* says **what topic** the user means (diagnose, document, work-order).
-A *dialogue act* says **what move** the user is making in this turn (asking, answering, requesting-action, expressing-uncertainty, acknowledging, repairing, meta-controlling).
-
-The current router (`conversation_router.py`) has 12 task-intent labels and zero dialogue-act
-labels. Worse, its CRITICAL RULE 3 explicitly collapses every mid-flow utterance to
-`continue_current` — which means even a clear `request_action` dialogue act ("make a WO")
-is treated as a content continuation of whatever Q-state the FSM happens to be in.
-
-- Symptom 1 is "user's *answer* dialogue act treated as content."
-- Symptom 2 is "user's *request_action* dialogue act treated as content."
-- Symptom 3 is "session-salient entities not load-bearing on retrieval."
-- Symptom 4 is "no `pending_question` slot, so every turn is interpreted independently."
-
-**They are all the same bug.** Fix the dialogue-act layer and slot tracking, and all four
-symptoms fall together.
+**Status:** Active (2026-05-13)
+**Branch:** `claude/elated-margulis-ac0926`
+**Scope:** `mira-bots/shared/uns_resolver.py` (new), `mira-bots/shared/engine.py`,
+`mira-bots/shared/workers/rag_worker.py`, `mira-bots/shared/dialogue_state.py`,
+`mira-bots/shared/dialogue_acts.py`, `tests/test_uns_resolver.py` (new),
+`docs/specs/uns-message-resolver-spec.md` (new), `.claude/rules/uns-compliance.md` (new)
+**Out-of-scope:** FSM, DST, LLM cascade, response formatting, any UI; the DST plan
+in `PLAN.dst.md` is a separate concern — do not modify those files except where
+they import from `guardrails.vendor_name_from_text` or call `_looks_like_model_number`.
+**Constraints:** No new dependencies, Python 3.12, ruff clean, reuse
+`mira-crawler/ingest/uns.py` path builders. Net-negative LOC target.
 
 ---
 
-## 2. The fix — Dialogue State Tracker (DST) + Slot-Filling + Action Router
-
-This is the same pattern that Rasa, ConvLab, TRIPS, and most academic DST systems use,
-**stripped down to one Pydantic model and one LLM call per turn**. We are not adopting
-Rasa or any framework — we are stealing the data structure and the precedence rules.
-
-### 2.1 New canonical type — `DialogueState` (discriminated union of response acts)
-
-The cleanest pattern (validated by Rasa CALM 2024 + `instructor` / `pydantic-ai` practice)
-is to make each dialogue act a **separate Pydantic model with a `Literal` discriminator
-field**, then have the LLM pick one via tool-mode structured output. The dispatcher does
-`isinstance()` routing — no enum-then-switch, no "is the slot value populated for this
-act type?" check.
-
-```python
-# mira-bots/shared/dialogue_state.py  (NEW file, ~250 lines)
-
-from pydantic import BaseModel, Field
-from typing import Literal, Optional, Union
-
-# ---- Salient entities pinned across turns -----------------------------------
-
-class SalientEntities(BaseModel):
-    """Entities pinned in the session — load-bearing for retrieval and routing."""
-    vendor: Optional[str] = None         # "Siemens", "Yaskawa", "Rockwell"
-    model: Optional[str] = None          # "GS20", "PowerFlex 525", "SINAMICS S120"
-    fault_code: Optional[str] = None     # "F012", "OC", "AL-14"
-    asset_label: Optional[str] = None    # free-form, e.g. "air compressor #1"
-    last_action_proposed: Optional[str] = None  # "log work order", "send manual"
-
-
-# ---- What MIRA is currently waiting for -------------------------------------
-
-SlotName = Literal[
-    "asset_identification", "fault_code", "symptom_detail",
-    "wo_confirmation", "wo_field_supply", "manual_vendor_model",
-    "pm_acceptance", "fix_confirmation", "diagnostic_branch_choice",
-    "none",
-]
-
-class PendingQuestion(BaseModel):
-    slot: SlotName
-    asked_at_turn: int
-    options: list[str] = Field(default_factory=list)
-    raw_text: str = ""
-
-
-# ---- The dialogue acts (one model per act, discriminated by `act`) ----------
-# Aligns with Rasa CALM 2024 command vocabulary: set_slot, start_flow,
-# cancel_flow, correct_slot, chitchat, knowledge_answer, human_handoff.
-
-class AnswerAct(BaseModel):
-    """User answered MIRA's pending question. Fill the slot and advance."""
-    act: Literal["answer"] = "answer"
-    slot_fill_value: str
-    entities: SalientEntities = Field(default_factory=SalientEntities)
-    reasoning: str
-
-class InformAct(BaseModel):
-    """User volunteered information without being asked (no pending slot)."""
-    act: Literal["inform"] = "inform"
-    entities: SalientEntities = Field(default_factory=SalientEntities)
-    reasoning: str
-
-class RequestActionAct(BaseModel):
-    """User issued an imperative — make a WO, find the manual, switch asset."""
-    act: Literal["request_action"] = "request_action"
-    action: Literal[
-        "log_work_order", "switch_asset", "find_documentation",
-        "schedule_maintenance", "check_equipment_history", "reset",
-    ]
-    entities: SalientEntities = Field(default_factory=SalientEntities)
-    reasoning: str
-
-class AskQuestionAct(BaseModel):
-    """User asked a question (procedural how-to or general industrial)."""
-    act: Literal["ask"] = "ask"
-    question_kind: Literal["procedural", "general", "definition", "comparison"]
-    entities: SalientEntities = Field(default_factory=SalientEntities)
-    reasoning: str
-
-class DontKnowAct(BaseModel):
-    """User expressed uncertainty / 'I don't know' — must NOT embed message as query."""
-    act: Literal["dont_know"] = "dont_know"
-    reasoning: str
-
-class ConfirmAct(BaseModel):
-    """User confirmed (yes/correct/right) — usually answering a yes/no slot."""
-    act: Literal["confirm"] = "confirm"
-    reasoning: str
-
-class DenyAct(BaseModel):
-    act: Literal["deny"] = "deny"
-    reasoning: str
-
-class MetaControlAct(BaseModel):
-    """nevermind / start over / skip / cancel — preempt and reset flow."""
-    act: Literal["meta"] = "meta"
-    command: Literal["cancel", "reset", "skip", "back", "stop"]
-    reasoning: str
-
-class GreetAckAct(BaseModel):
-    act: Literal["greet"] = "greet"
-    reasoning: str
-
-class SafetyAct(BaseModel):
-    """Safety override — always wins regardless of state."""
-    act: Literal["safety"] = "safety"
-    hazard_summary: str
-    reasoning: str
-
-# The single typed return — instructor / pydantic-ai pick exactly one.
-DialogueTurn = Union[
-    AnswerAct, InformAct, RequestActionAct, AskQuestionAct, DontKnowAct,
-    ConfirmAct, DenyAct, MetaControlAct, GreetAckAct, SafetyAct,
-]
-```
-
-**Why discriminated union beats a single `dialogue_act: Literal[...]` field:**
-
-1. The LLM cannot return `act=answer` without a `slot_fill_value` (Pydantic rejects).
-2. The LLM cannot return `act=dont_know` AND a slot value (the model has no such field).
-3. The dispatcher is `match turn: case AnswerAct(...): ...` — no nullable-field gymnastics.
-4. `instructor`'s `Mode.TOOLS` registers each model as a separate OpenAI-tool schema and
-   forces the LLM to pick one — eliminating the JSON-parse-failure failure mode.
-
-### 2.2 New canonical call — `track_dialogue_state`
-
-Replaces `route_intent`. **One Groq llama-3.1-8b call** via the `instructor` library in
-`Mode.TOOLS`, ~200ms, returns one of the `DialogueTurn` union members as a typed Pydantic
-instance. Same cost profile as today, but the response carries the information the engine
-actually needs and cannot be malformed.
-
-```python
-import instructor
-from groq import AsyncGroq
-
-# Single client — wraps the existing GROQ_API_KEY, same provider as route_intent today.
-_dst_client = instructor.from_provider(
-    "groq/llama-3.1-8b-instant",
-    async_client=True,
-    mode=instructor.Mode.TOOLS,
-)
-
-async def track_dialogue_state(
-    user_message: str,
-    history: list[dict],
-    pending_question: PendingQuestion,
-    salient_entities: SalientEntities,
-    fsm_state: str,
-) -> DialogueTurn:
-    """Single-pass dialogue state tracker. The LLM picks one of 10 typed acts."""
-    return await _dst_client.create(
-        response_model=DialogueTurn,           # the discriminated union
-        messages=[
-            {"role": "system", "content": _DST_SYSTEM_PROMPT},
-            {"role": "user", "content": _format_context(
-                user_message, history, pending_question, salient_entities, fsm_state,
-            )},
-        ],
-        max_retries=2,                          # instructor retries on validation fail
-    )
-```
-
-The prompt explicitly anchors on the `pending_question`:
-
-> "MIRA's last question was: '{raw_text}' — it is waiting for slot=`{slot}`.
-> If the user answered it, return an `answer` act with `slot_fill_value` set.
-> If they said 'I don't know' or similar, return a `dont_know` act — do NOT
-> invent a slot value. If they asked a new question or made a request, return
-> `ask` or `request_action`. **Picking the wrong act is worse than picking
-> low-confidence — never invent a value to fill a slot.**"
-
-**Why `instructor` (vs. raw httpx + json.loads, vs. `pydantic-ai`):**
-
-- `instructor`'s `Mode.TOOLS` registers each union member as a separate OpenAI-tool
-  schema; the Groq endpoint is OpenAI-compatible so this works directly. The LLM must
-  pick one tool — there is no "JSON parse failure" path.
-- Same `max_retries` self-heal pattern that fixes today's `ROUTER_LLM_FAILURE` log line.
-- Native async, native Groq via `from_provider("groq/...")`, no LangChain dep, no
-  TensorFlow.
-- `pydantic-ai` is a strict superset (full agent runtime); we only need the tool-mode
-  structured output, not the agent loop.
-
-**New dependency:** `instructor>=1.6.0` in `mira-bots/pyproject.toml`. Pure Python, ~3
-KLOC, depends only on `pydantic` and `openai` (already transitive). **Flagged for Mike's
-approval** — if rejected, fall back to raw `httpx` + manual `pydantic.TypeAdapter` JSON
-validation (~30 LOC more boilerplate, same correctness).
-
-This is the Rasa DIET pattern of **joint intent+entity prediction in one head** —
-DIET uses a transformer with a CRF tagger; we use structured-output LLM tool calls. The
-DST contract (one act per turn, slot-or-action explicit) is identical.
-
-### 2.3 New dispatch precedence in `Supervisor.process_full`
-
-The Rasa CALM 2024 `FormPolicy` interrupt pattern, ported to Python `match` statements:
-
-```python
-# After the existing pending intercepts and safety check:
-
-turn = await track_dialogue_state(...)
-self._persist_salient_entities(state, turn)   # always merge new entities
-
-# ALWAYS_INTERRUPT — actions that preempt every flow with state preservation.
-ALWAYS_INTERRUPT = {"log_work_order", "switch_asset", "safety", "reset"}
-
-match turn:
-    # Priority 1 — safety always wins.
-    case SafetyAct():
-        return self._safety_response(state, chat_id, trace_id, turn)
-
-    # Priority 2 — interrupt actions snapshot then preempt.
-    case RequestActionAct(action=a) if a in ALWAYS_INTERRUPT:
-        return await self._handle_interrupt(turn, state, chat_id, trace_id)
-
-    # Priority 3 — slot answers (or "I don't know") when MIRA asked a question.
-    case _ if state.get("pending_question", {}).get("slot") != "none":
-        match turn:
-            case AnswerAct():
-                return await self._fill_slot_and_continue(turn, state, chat_id, trace_id)
-            case DontKnowAct():
-                return await self._handle_dont_know(state, chat_id, trace_id)
-            case ConfirmAct() | DenyAct():
-                return await self._handle_yes_no(turn, state, chat_id, trace_id)
-            # If LLM picked something else mid-slot-fill, it's a topic pivot.
-            # Cancel the slot, re-dispatch the new act below.
-            case _:
-                self._cancel_pending_question(state)
-                # fall through
-
-    # Priority 4 — meta-control commands.
-    case MetaControlAct(command=c):
-        return await self._handle_meta_command(c, state, chat_id, trace_id)
-
-    # Priority 5 — non-interrupt action requests (find_documentation,
-    # schedule_maintenance, check_equipment_history).
-    case RequestActionAct(action=a):
-        return await self._dispatch_action(a, turn, state, chat_id, trace_id)
-
-    # Priority 6 — questions and information continue into existing flow.
-    case AskQuestionAct(question_kind="procedural"):
-        return await self._handle_instructional_question(chat_id, message, state, trace_id)
-    case AskQuestionAct(question_kind="general" | "definition" | "comparison"):
-        return await self._handle_general_question(chat_id, message, state, trace_id)
-    case GreetAckAct() if state["state"] == "IDLE":
-        return self._greeting_response(state, chat_id, trace_id)
-    case InformAct() | _:
-        # Default — into the diagnostic RAG pipeline with bound salient entities.
-        ...  # existing RAG flow
-```
-
-**Why the priority ordering matters (this is the canonical bug fix for all 4 symptoms):**
-
-- **Symptom 1 (IDON lookup):** `DontKnowAct` is matched in Priority 3 *before* the
-  default RAG fall-through, so "I don't know" never reaches the embedding query.
-- **Symptom 2 (WO blocked):** `RequestActionAct(action="log_work_order")` matches at
-  Priority 2 *before* the slot-answer check, so the WO handler is reached even mid-Q.
-- **Symptom 4 (answering vs asking):** `pending_question.slot != "none"` is the
-  guard on Priority 3 — slot answers and don't-knows are interpreted as such only when
-  MIRA is actually waiting for a slot. Without a pending question, the same "I don't
-  know" falls to the default flow.
-
-**Stack-resumable interrupts** (Rasa FormPolicy / CALM `start_flow` + `cancel_flow`):
-
-```python
-async def _handle_interrupt(self, turn: RequestActionAct, state, chat_id, trace_id):
-    saved = {
-        "fsm_state": state["state"],
-        "pending_question": state.get("pending_question"),
-        "active_alarm": state.get("context", {}).get("session_context", {}).get("active_alarm"),
-    }
-    result = await self._dispatch_action(turn.action, turn, state, chat_id, trace_id)
-    # Push resume offer into the result so user can continue the diagnostic later.
-    if saved["fsm_state"] in ACTIVE_DIAGNOSTIC_STATES:
-        state["context"]["interrupted_diagnosis"] = saved
-    return result
-```
-
-When the next user turn comes back and `interrupted_diagnosis` is present, MIRA can
-offer: *"WO created. Want to pick up the bearing diagnosis where we left off?"*
-
-### 2.4 Hard vendor/asset filter on RAG retrieval
-
-**Today (`rag_worker.py:251-283`):** vendor filter runs only when
-`vendor_name_from_text(query_combined)` finds a vendor in the *current* message. Chunks
-with `manufacturer=None` always pass.
-
-**Proposed:**
-
-```python
-# rag_worker.py — new method
-def _retrieval_predicates(self, state: dict, message: str) -> dict:
-    salient = state.get("salient_entities", {})  # set by DST
-    vendor = salient.get("vendor") or vendor_name_from_text(
-        f"{message} {state.get('asset_identified','')}"
-    )
-    return {
-        "required_vendor": vendor,           # hard filter when set
-        "min_similarity": 0.70,              # already exists
-        "exclude_unbranded_when_vendor_known": True,  # NEW — kills "Interroll" leak
-    }
-```
-
-When `required_vendor` is set:
-- chunks with `manufacturer is not None and vendor_lower not in manufacturer_lower` → DROP
-- chunks with `manufacturer is None` AND `exclude_unbranded_when_vendor_known` → DROP
-- Falls back to today's behaviour (allow unbranded) only when no vendor is known yet.
-
-YouTube and Interroll mass-ingested transcripts almost universally have empty manufacturer
-metadata; this single change suppresses them whenever the session has identified a vendor.
-
-### 2.5 Disarm the self-critique groundedness gate when the user is making a non-diagnosis move
-
-**Today (`engine.py:1008`):** the self-critique gate fires on every DIAGNOSIS turn,
-including turns where the user asked for a work order or said "I don't know". When
-groundedness < 3, it produces the clarifying-question loop ("could you share one more
-detail — what exact fault code…").
-
-**Proposed:** the gate only fires when `turn.dialogue_act in {"answer", "inform"}` and
-(`turn.is_answer_to_pending` is True or `pending_question.slot == "none"`). For
-`request_action`, `uncertainty`, `meta_command`, `acknowledge` — the gate is **muted**
-because the response wasn't trying to be a diagnosis.
-
-This is the second half of the fix for Symptom 2.
-
----
-
-## 3. File-by-file changes
-
-| File | Change | Approx LOC |
-|---|---|---|
-| `mira-bots/shared/dialogue_state.py` | **NEW** — Pydantic models (`DialogueAct`, `SalientEntities`, `PendingQuestion`, `DialogueTurn`) and `track_dialogue_state()` LLM call | +200 |
-| `mira-bots/shared/conversation_router.py` | Keep `route_intent` for 1 release as a fallback for DST failures; deprecate after Stage 2 | ±20 |
-| `mira-bots/shared/engine.py` | Replace `route_intent` call at L562 with `track_dialogue_state`; rewrite the dispatch block L588-627 to use `turn.dialogue_act` precedence; pass `salient_entities` and `pending_question` through state | ~150 changed |
-| `mira-bots/shared/engine.py` | Wrap self-critique gate L1008 with `if turn.dialogue_act in {"answer","inform"}:` | ~10 changed |
-| `mira-bots/shared/workers/rag_worker.py` | Add `_retrieval_predicates`; tighten cross-vendor filter to drop unbranded chunks when vendor known; embed bound asset+fault, not raw user text, when slot-fill happened | ~60 changed |
-| `mira-bots/shared/session_manager.py` | Persist `salient_entities` and `pending_question` alongside existing state fields | ~20 changed |
-| `tests/eval/dialogue_act_cases.json` | **NEW** — 30+ regression cases covering all four symptoms | +1 file |
-
-**Total: ~450 LOC net new code, all in existing modules + one new file. Zero new dependencies.**
-
----
-
-## 4. Staged rollout
-
-### Stage 0 — TODAY (1-2 hours, lands on `fix/wo-request-mid-flow` branch)
-
-**Goal:** unblock the Symptom 2 work-order regression. Do NOT touch the architecture.
-
-1. In `engine.py` `process_full`, **before** the `route_intent` call (~L560), insert a
-   regex fast-path for explicit action requests:
-
-   ```python
-   _ACTION_REQUEST_RE = re.compile(
-       r"\b(make|create|log|file|open|submit|put in)\s+"
-       r"(a\s+)?(work\s*order|wo|ticket|request)\b",
-       re.IGNORECASE,
-   )
-   if not photo_b64 and _ACTION_REQUEST_RE.search(message):
-       logger.info("ACTION_REQUEST_FAST_PATH chat_id=%s match=%r", chat_id, message[:60])
-       return await self._handle_wo_request(chat_id, message, state, trace_id)
-   ```
-
-   Same pattern for `_DOC_REQUEST_RE` ("send me the manual", "find the datasheet").
-   This gives Mike a working WO flow today, no other architectural risk.
-
-2. Add a guard in the self-critique block (`engine.py:1008`) that skips the gate when
-   the most recent turn matched the action-request fast-path, by setting a transient
-   `ctx["last_dispatch"] = "action_request"` and checking it.
-
-3. Add a regression test in `tests/eval/` that replays Mike's transcript and asserts
-   `_handle_wo_request` is invoked.
-
-**Verification:** `pytest tests/eval/ -k work_order_mid_flow` and a manual rerun of the
-"cooling fan on air compressor #1, make a work order" sequence on staging.
-
-### Stage 1 — This sprint (~2-3 days, `feat/dialogue-state-tracker` branch)
-
-1. Create `mira-bots/shared/dialogue_state.py` with the Pydantic models above.
-2. Implement `track_dialogue_state` against Groq llama-3.1-8b-instant (same provider as
-   the current router — same latency, same cost, same failure profile).
-3. Wire it into `Supervisor.process_full` behind a `MIRA_USE_DST=1` env flag, falling
-   back to `route_intent` when unset. Default OFF in prod, ON in dev/eval.
-4. Add the dispatch-precedence block from §2.3.
-5. Mute the self-critique gate per §2.5.
-6. Add `tests/eval/dialogue_act_cases.json` — at minimum:
-   - the 4 cases from Mike's transcript (one per symptom)
-   - 5 "I don't know" answers to different MIRA questions
-   - 5 mid-flow action requests (WO, doc, asset switch)
-   - 5 slot-fill answers (model #, fault code, symptom, yes/no, free text)
-   - 3 meta-commands (nevermind, skip, reset)
-7. Run the existing 39 golden cases — no regression allowed.
-
-**Exit criteria:** flag flip to `MIRA_USE_DST=1` in prod after a clean week in dev,
-gated on a Mike-led HITL test that replays the 2026-05-04 transcript end-to-end.
-
-### Stage 2 — Next sprint (~2 days, `feat/dst-slot-filling` branch)
-
-1. Promote `pending_question.slot` to load-bearing — the diagnostic ladder (Q1→Q2→Q3)
-   becomes a slot sequence (`asset → fault_code → symptom → cause`). Each ladder turn
-   sets `pending_question.slot` and `expected_slot`; the next user turn either fills the
-   slot or branches via `dialogue_act`.
-2. Remove `route_intent` and the `MIRA_USE_DST` flag.
-3. Tighten RAG retrieval per §2.4 — hard vendor filter, drop unbranded when vendor known.
-4. Backfill `manufacturer` metadata on the YouTube and Interroll chunks in NeonDB
-   (one-off SQL migration from `crawler` source URL → vendor inference). Deferred ones
-   stay tagged `manufacturer="generic"` and are excluded from vendor-scoped retrieval.
-
-### Stage 3 — Polish (week 3)
-
-- DAMSL-aligned dialogue-act expansion (add `repair` recovery handler — "actually I meant
-  the F012 fault not F102")
-- Stack-resumable sub-flows: when an action request preempts mid-Q-flow, offer to resume
-  ("WO created. Back to diagnosing the bearing — you said it was running hot. Continue?")
-
----
-
-## 5. Open-source patterns we are explicitly stealing (and why)
-
-These come from a focused review of Rasa (classic + CALM 2024), pydantic-ai, instructor,
-and the DAMSL / ISO 24617-2 dialogue-act literature. We are stealing **patterns and data
-shapes**, not runtimes.
-
-| Pattern | Source | What we steal | What we explicitly skip |
-|---|---|---|---|
-| **Joint intent + entity prediction in one call** | **Rasa DIET** ([paper](https://arxiv.org/abs/2004.09936)) | Single LLM call returns the act + slot value + entities together — no two-step "classify intent, then extract entities" pipeline | DIET's transformer + CRF tagger; our LLM cascade does the same job |
-| **`requested_slot` priority rule** | **Rasa classic FormPolicy** | If MIRA asked for slot X, the user's reply is interpreted as a slot answer **before** any new-intent classification. This is a code-level priority rule, not an LLM task. | Rasa's full policy ensemble |
-| **Command-style act vocabulary** | **Rasa CALM 2024** ([blog](https://rasa.com/blog/calm/)) | The act labels themselves: `set_slot`, `start_flow`, `cancel_flow`, `correct_slot`, `chitchat`, `knowledge_answer`, `human_handoff`. Our 10-act union maps 1:1 onto these. | The Rasa runtime / CALM dialogue understanding model |
-| **Interrupt + state-snapshot pattern** | **Rasa FormPolicy `ActionExecutionRejection`** | When a high-priority action fires mid-flow, snapshot `active_loop` + `requested_slot` + filled slots before dispatching the action; restore on completion so the form resumes | Rasa's policy ensemble that reactivates the form |
-| **Multi-command-per-turn** | **Rasa CALM** | When the user packs two moves into one message ("make a WO for that, and also what does E07 mean?"), the LLM can return a list of acts. We defer this to Stage 3 (single-act per turn is enough for Mike's 4 symptoms). | Stage 1/2 stays single-act |
-| **Discriminated union output** | **`instructor` + `pydantic-ai`** | The LLM picks one of N tool-typed Pydantic models per turn (the dispatch is `match` over the type, not over a `dialogue_act` string field). Forbids structurally-impossible combinations (e.g. `act=dont_know` with a `slot_fill_value`). | The full `pydantic-ai` agent runtime |
-| **Tool-mode structured output** | **OpenAI function calling spec** + Groq's OpenAI-compat surface | Each act registers as a tool schema; the model is forced to call exactly one. This is what eliminates today's `ROUTER_LLM_FAILURE` JSON-parse path. | Letting the LLM execute the tool — we dispatch in Python |
-| **Dialogue-act taxonomy** | **DAMSL / ISO 24617-2** | The 10-act minimal set (`answer`, `ask`, `request_action`, `inform`, `dont_know`, `confirm`, `deny`, `meta`, `greet`, `safety`) — covers >95% of industrial-bot turns | The full 56-act ISO taxonomy; overkill |
-| **`ALWAYS_INTERRUPT` set** | **Microsoft Bot Framework** "interruption recognizers" | Fixed set of action names (`log_work_order`, `safety`, `reset`, `switch_asset`) that always preempt mid-flow; everything else falls through to existing dispatch | Bot Framework dialog stack |
-
-**Library pick: `instructor>=1.6.0`** (vs. raw httpx / pydantic-ai / outlines / guidance):
-
-- Native Groq via `instructor.from_provider("groq/llama-3.1-8b-instant", async_client=True, mode=Mode.TOOLS)` — same provider as today's router.
-- `Mode.TOOLS` registers each union member as a separate tool schema → LLM picks one.
-- Built-in `max_retries` self-heal on validation failure (replaces today's "fall back to keyword classifier on parse error").
-- Pure Python, depends only on `pydantic` + `openai` (already transitive).
-- Async-clean, Python 3.12-clean, no LangChain, no TensorFlow.
-- *Runner-up:* `pydantic-ai` — strict superset; we'd only use the structured-output bit, so adding the agent runtime is over-spec for our needs.
-- *Avoid:* `outlines` and `guidance` (constrained-sampling, only work with locally-hosted models — incompatible with our Groq cascade); `marvin` (effectively unmaintained as of 2025).
-
-**We deliberately do not adopt:**
-
-- **LangChain** — banned by `CLAUDE.md` hard constraint.
-- **Rasa as a runtime** — pulls TensorFlow + spaCy, ~600 MB, far over budget.
-- **TensorFlow / sentence-transformers retraining** — embedding model is already `nomic-embed-text` via Ollama; we keep it.
-
----
-
-## 6. What this plan **explicitly does not** try to fix
-
-- **The GSD prompt itself** — `active.yaml` v1.2 is not the bug. It is a victim of bad
-  routing. Once dialogue acts are right, the GSD prompt gets called for the right turns
-  and the existing few-shot examples already cover those cases well.
-- **NeonDB metadata coverage** — backfilling `manufacturer` on legacy chunks is a Stage 2
-  side quest, not part of the architecture. The hard vendor filter handles unbranded
-  chunks correctly even before backfill.
-- **Per-tenant intent personalisation** — out of scope; addressable later via per-tenant
-  prompt overrides if we see signal for it.
-- **Replacing the keyword `classify_intent`** — keep it. It is a 0-ms safety net, fires
-  before any network call, and catches the SAFETY tier even if every LLM in the cascade
-  is unreachable.
-
----
-
-## 7. Verification — how we'll know it actually fixed everything at once
-
-1. **Stage 0 gate** — `pytest tests/eval/ -k work_order_mid_flow` green; manual replay of
-   Mike's "cooling fan on air compressor" sequence creates a WO draft.
-2. **Stage 1 gate** — new `dialogue_act_cases.json` (~25 cases) at 100%; the existing 39
-   golden cases regression-clean; HITL replay of the 2026-05-04 transcript with the four
-   symptoms — all four resolved.
-3. **Stage 2 gate** — DST flag default-on in prod for a week with `eval_score >= 80%`
-   and zero `SELF_CRITIQUE_TRIGGERED` events on `request_action` turns in Langfuse.
-
-A regression in any one of the four symptoms re-opens the plan; the architecture is
-validated by all four going green together.
-
----
-
-## 8. Risk register
-
-| Risk | Likelihood | Mitigation |
-|---|---|---|
-| DST LLM call adds latency on top of existing `route_intent` | **Low** — same model, same provider; we replace, not stack | Keep `route_intent` as fallback in Stage 1 behind a flag; revert if p95 regresses >50ms |
-| Pydantic structured output failures | **Medium** | DST fall-through to keyword `classify_intent` — same pattern as today |
-| Mis-classifying a real diagnosis turn as `request_action` and skipping the diagnostic ladder | **Low-Medium** | Only the explicit imperative regex fires Stage 0; Stage 1 adds the LLM, but the model has seen the dialogue-act distinction in pre-training |
-| Hard vendor filter starves retrieval for vendors we have weak coverage for | **Medium** | Filter only activates when chunks > 0 with matching vendor exist; graceful degrade to current behaviour otherwise |
-| Slot-fill extraction hallucinates a value when user said "I don't know" | **High if naive, Low if right** | The DST prompt in §2.2 explicitly forbids extraction on `uncertainty` — verified by 5 test cases in Stage 1 |
-
----
-
-## 9. Decision asked of Mike
-
-1. **Approve Stage 0 hot-fix** for landing today (1-2h, regex action-request fast-path +
-   muted self-critique on action turns). This unblocks the WO regression without any
-   architectural commitment.
-2. **Approve Stages 1–3** as the unified fix path. If yes, I open `feat/dialogue-state-tracker`
-   and start with the Pydantic models + `track_dialogue_state` LLM call.
-3. If you want a smaller-step rollout — Stage 0 + Stage 2.4 only (hard vendor filter,
-   nothing else) — that also resolves Symptom 3 in isolation, but Symptoms 1, 2, 4
-   require the dialogue-act layer to actually go away.
-
----
-
-## 10. Appendix — concrete wire-up sketch
-
-```python
-# engine.py — proposed dispatch block replacing L588-627
-from .dialogue_state import (
-    AnswerAct, AskQuestionAct, ConfirmAct, DenyAct, DontKnowAct,
-    GreetAckAct, InformAct, MetaControlAct, PendingQuestion,
-    RequestActionAct, SafetyAct, SalientEntities, track_dialogue_state,
-)
-
-ALWAYS_INTERRUPT = {"log_work_order", "switch_asset", "safety", "reset"}
-
-# (after the unchanged pending intercepts + safety keyword check)
-
-pending = PendingQuestion(**state.get("pending_question", {"slot": "none", "asked_at_turn": 0}))
-salient = SalientEntities(**state.get("salient_entities", {}))
-
-try:
-    turn = await track_dialogue_state(
-        user_message=message,
-        history=(state.get("context") or {}).get("history", []),
-        pending_question=pending,
-        salient_entities=salient,
-        fsm_state=state.get("state", "IDLE"),
-    )
-except Exception as exc:
-    logger.warning("DST_FAILURE error=%s — falling back to keyword classifier", exc)
-    turn = self._fallback_turn_from_keyword_classifier(message)
-
-# Always merge any newly-extracted entities into state.
-self._merge_salient_entities(state, getattr(turn, "entities", None))
-
-match turn:
-    case SafetyAct():
-        return self._safety_response(state, chat_id, trace_id, turn)
-
-    case RequestActionAct(action=a) if a in ALWAYS_INTERRUPT:
-        return await self._handle_interrupt(turn, state, chat_id, trace_id)
-
-    case _ if state.get("pending_question", {}).get("slot") != "none":
-        match turn:
-            case AnswerAct():
-                return await self._fill_slot_and_continue(turn, state, chat_id, message, trace_id)
-            case DontKnowAct():
-                return await self._handle_dont_know(state, chat_id, trace_id)
-            case ConfirmAct() | DenyAct():
-                return await self._handle_yes_no(turn, state, chat_id, trace_id)
-            case _:
-                # Topic pivot — cancel slot and re-dispatch.
-                self._cancel_pending_question(state)
-
-    case MetaControlAct(command=c):
-        return await self._handle_meta_command(c, state, chat_id, trace_id)
-
-    case RequestActionAct(action=a):
-        return await self._dispatch_action(a, turn, state, chat_id, message, trace_id)
-
-    case AskQuestionAct(question_kind="procedural"):
-        return await self._handle_instructional_question(chat_id, message, state, trace_id)
-
-    case AskQuestionAct():
-        return await self._handle_general_question(chat_id, message, state, trace_id)
-
-    case GreetAckAct() if state["state"] == "IDLE":
-        return self._greeting_response(state, chat_id, trace_id)
-
-    case _:  # InformAct or fall-through — existing diagnostic RAG path
-        pass
-```
-
-```python
-# rag_worker.py — proposed hard vendor filter
-
-def _filter_chunks_by_salience(self, neon_chunks: list[dict], state: dict, message: str) -> list[dict]:
-    salient = state.get("salient_entities", {})
-    vendor = salient.get("vendor") or vendor_name_from_text(
-        f"{message} {state.get('asset_identified','')}"
-    )
-    if not vendor:
-        return neon_chunks  # no salient vendor — keep current behaviour
-
-    v = vendor.lower()
-    matched = [c for c in neon_chunks if v in (c.get("manufacturer") or "").lower()]
-    if matched:
-        # Hard filter — drop both wrong-vendor AND unbranded when we have matches
-        return matched
-    # No matched vendor chunks — fall through to today's lenient behaviour
-    return [c for c in neon_chunks if not c.get("manufacturer") or v in (c.get("manufacturer") or "").lower()]
-```
-
----
-
-**End of plan.** Awaiting Mike's call: Stage 0 today / Stages 1-3 next / both.
+## Why
+
+`mira-bots/shared/engine.py` has 14 separate extraction sites that call
+`vendor_name_from_text()` and `_looks_like_model_number()` on `message`,
+`combined`, or `asset_id`. They don't share results, they disagree on edge
+cases (numeric-only models, fault codes captured as models), and they re-run
+the same regex work several times per turn. Mike's exact regression case
+*"I have a powerflex 525 and it has it called f0004"* fails because:
+
+- `vendor_name_from_text` picks up `"powerflex"` → `"Rockwell Automation"` ✓
+- `_looks_like_model_number` returns `"f0004"` because it ranges left-to-right
+  and accepts the first letter+digit token — the *fault code is captured as
+  the model*
+- `"525"` (the real model) is rejected — letters-only check fails
+
+One UNS-aware resolver, called once at the top of `process()`, produces one
+canonical `UNSContext` for the turn. All 14 sites read from it.
+
+## Numbered tasks
+
+1. **Spec + rule docs** — `docs/specs/uns-message-resolver-spec.md` and
+   `.claude/rules/uns-compliance.md`. Both short, both reference the resolver
+   module as the single extraction point.
+2. **`uns_resolver.py`** — `UNSContext` dataclass, `resolve_uns_path()`
+   function, `VENDOR_ALIASES` table, `FAULT_PATTERNS` list. Must work offline
+   (no NeonDB) — alias table is the floor.
+3. **`tests/test_uns_resolver.py`** — 30+ cases, must include Mike's exact
+   regression case and the pure-digit-model case. Run with
+   `python -m pytest tests/test_uns_resolver.py -v`.
+4. **Wire into `Supervisor.process()`** — one call near the top. Merge with
+   prior `state["uns_context"]` to preserve carry-over.
+5. **Replace extraction sites** — 14 in `engine.py`, 1 each in `rag_worker.py`,
+   `dialogue_state.py`, `dialogue_acts.py`. Batch by region, commit each batch.
+6. **`rag_worker` KB scoping** — use `uns_context.manufacturer` for the
+   cross-vendor filter, and `uns_path` for entity-scoped knowledge_entries
+   queries when available.
+7. **Run gates** — `ruff check`, `pytest tests/test_uns_resolver.py`, the
+   existing `tests/eval/bot_regression.py` cases, and Mike's exact regression
+   message must resolve to `mfr="Rockwell Automation", model="525",
+   fault="F0004"`.
+8. **Commit, push, PR, merge**.
+
+## Success criteria
+
+- All 14 `engine.py` extraction sites reduced to `state["uns_context"]` reads.
+- `vendor_name_from_text` and `_looks_like_model_number` no longer imported in
+  `engine.py`, `rag_worker.py`, `dialogue_state.py`, `dialogue_acts.py`.
+- `tests/test_uns_resolver.py` ≥ 30 cases, all pass.
+- Mike's exact regression case resolves correctly (see test 1 in the suite).
+- `ruff check` passes.
+- `tests/eval/bot_regression.py` does not regress vs main baseline.
+- Net diff is negative LOC.
+
+## Hard stops
+
+- A reviewer-style data-integrity issue surfaces → stop, fix, re-gate.
+- 5 consecutive failing test runs on the same case → stop, write HANDOFF.
+- Out-of-scope file modified accidentally → revert that file, do not "while
+  I'm here".

--- a/docs/specs/uns-message-resolver-spec.md
+++ b/docs/specs/uns-message-resolver-spec.md
@@ -1,0 +1,287 @@
+# UNS Message Resolver Spec
+
+**Status:** Active (2026-05-13)
+**Owner:** mira-bots/shared
+**Module:** `mira-bots/shared/uns_resolver.py`
+**Related:** `docs/specs/uns-kg-unification-spec.md`,
+`mira-crawler/ingest/uns.py`
+
+---
+
+## 1. Problem
+
+`mira-bots/shared/engine.py` runs vendor/model/fault-code extraction in 14
+separate places, every turn. The two helpers it uses
+(`guardrails.vendor_name_from_text` and `response_formatter._looks_like_model_number`)
+disagree on edge cases, and they have no shared notion of what was already
+resolved earlier in the conversation.
+
+Concrete failure (Mike's 2026-05-13 transcript):
+
+> User: *"I have a powerflex 525 and it has it called f0004"*
+
+- `vendor_name_from_text` → `"Rockwell Automation"` ✓
+- `_looks_like_model_number` ranges left-to-right and accepts the first
+  token that has both a letter and a digit. That's `"f0004"`. The fault
+  code is captured *as the model*. `"525"` is rejected (no letters).
+
+Downstream, every site that read this got the wrong answer.
+
+## 2. Solution
+
+One resolver, one call per turn, one canonical result. All 14 sites read from
+it. The result is named `UNSContext` because every field it carries maps to a
+UNS path segment defined in `mira-crawler/ingest/uns.py`.
+
+### 2.1 `UNSContext` dataclass
+
+Frozen dataclass. Fields:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `uns_path` | `str \| None` | Deepest UNS path that can be built from the resolved entities, e.g. `enterprise.knowledge_base.rockwell_automation.powerflex.525.fault_codes.f0004`. `None` if no manufacturer was identified. |
+| `manufacturer` | `str \| None` | Canonical display name from `VENDOR_ALIASES`, e.g. `"Rockwell Automation"`. |
+| `manufacturer_alias` | `str \| None` | The literal token the user wrote, e.g. `"PowerFlex"`. |
+| `product_family` | `str \| None` | The family/series, e.g. `"PowerFlex"`. May equal `manufacturer_alias` when the alias IS the family. |
+| `model` | `str \| None` | The model identifier, e.g. `"525"`. Pure-digit allowed when a family is also identified. |
+| `fault_code` | `str \| None` | Normalized fault code (uppercase letter + zero-padded digits where the pattern matches), e.g. `"F0004"`. |
+| `fault_code_raw` | `str \| None` | Raw token the user wrote, e.g. `"f0004"`. |
+| `category` | `str \| None` | One of `"fault_codes"`, `"manuals"`, `"pm_schedules"`, `"parts_lists"`, or `None`. Derived from the message wording. |
+| `site_path` | `str \| None` | The site-side instance path, when a tenant + asset can be identified in NeonDB. `None` in offline/anonymous mode. |
+| `matched_entities` | `list[dict]` | `kg_entities` hits (id, uns_path, label). Empty when DB unreachable or no match. |
+| `matched_kb_count` | `int` | Count of `knowledge_entries` under the resolved path. `0` when DB unreachable. |
+| `confidence` | `float` | See §2.4 below. |
+
+The dataclass exposes `as_dict()` for engine state serialization and round-trip
+through SQLite.
+
+### 2.2 `resolve_uns_path(message, tenant_id=None, prior_ctx=None)`
+
+Returns `UNSContext`. Three stages:
+
+**Stage 1 — Tokenize + extract fault codes FIRST.**
+Run `FAULT_PATTERNS` against the message. Capture every match. *Then* strip
+those tokens from the candidate set before model matching. This is the fix
+for the f0004-as-model bug.
+
+**Stage 2 — Alias-table match + path build.**
+Lowercase the remaining tokens. Lookup each against `VENDOR_ALIASES`
+(alias → canonical). On first hit, set `manufacturer`, `manufacturer_alias`,
+and `product_family` (the family is the alias key when the alias maps to a
+distinct family, e.g. `"powerflex" → "Rockwell Automation"` produces
+`family="PowerFlex"`).
+
+After vendor is known, look at the tokens *adjacent* to the vendor alias
+for a model candidate. A model candidate is any token that:
+
+- Is not in `RESERVED_LABELS` (uns.py)
+- Is not a captured fault code
+- Is alphanumeric, length 2–12
+- Either contains a digit (so "525", "GS20", "X3" all qualify) OR is
+  followed by digits in the next token (e.g. `"FR-D 700"`)
+
+Build the deepest UNS path possible using `uns.py` builders:
+`fault_code_path` if a fault code is present, else `model_path`, else
+`manufacturer_path`. Fault codes are slugged through `uns.slug()` so they
+land as lowercase labels in the path.
+
+**Stage 3 — DB enrichment (optional).**
+If a Neon connection is available (`mira-bots.shared.neon_recall`), run:
+
+- `SELECT id, uns_path, label FROM kg_entities WHERE uns_path = $1 OR uns_path ~ $1::lquery`
+- `SELECT count(*) FROM knowledge_entries WHERE equipment_entity_id IN (...)`
+- (When `tenant_id` is set) `SELECT uns_path FROM cmms_equipment WHERE tenant_id = $1 AND (manufacturer = $2 AND model = $3)`
+
+Populate `matched_entities`, `matched_kb_count`, `site_path`. On any DB
+error: log and proceed with Stage-2-only result. **Offline must work.**
+
+**Prior-context merge.** When `prior_ctx` is provided, each missing field on
+the freshly-resolved context falls back to the prior value. This preserves
+"PowerFlex 525 F0004" across the next turn when the user types only
+"make a work order". Implementation: build the fresh ctx, then for each
+field that is `None` / `0` / `[]`, take the prior value. Confidence
+becomes `max(fresh.confidence, prior.confidence * 0.9)` — prior context
+decays slightly each turn.
+
+### 2.3 `VENDOR_ALIASES`
+
+One authoritative dict. Source: consolidate `_VENDOR_DISPLAY_NAMES` from
+`guardrails.py` plus the additional families Mike has flagged. Keys are
+lowercase; values are canonical display names that match `kg_entities.label`
+exactly so the path slug is reproducible.
+
+```python
+VENDOR_ALIASES: dict[str, str] = {
+    "powerflex": "Rockwell Automation",
+    "allen-bradley": "Rockwell Automation",
+    "allen bradley": "Rockwell Automation",
+    "ab": "Rockwell Automation",
+    "rockwell": "Rockwell Automation",
+    "rockwell automation": "Rockwell Automation",
+    "gs10": "AutomationDirect",
+    "gs20": "AutomationDirect",
+    "automationdirect": "AutomationDirect",
+    "automation direct": "AutomationDirect",
+    "siemens": "Siemens",
+    "micromaster": "Siemens",
+    "sinamics": "Siemens",
+    "yaskawa": "Yaskawa",
+    "abb": "ABB",
+    "omron": "Omron",
+    "schneider electric": "Schneider Electric",
+    "schneider": "Schneider Electric",
+    "mitsubishi": "Mitsubishi Electric",
+    "mitsubishi electric": "Mitsubishi Electric",
+    "fr-e": "Mitsubishi Electric",
+    "fr-a": "Mitsubishi Electric",
+    "fr-d": "Mitsubishi Electric",
+    "fr-f": "Mitsubishi Electric",
+    "danfoss": "Danfoss",
+    "aqua drive": "Danfoss",
+    "eaton": "Eaton",
+    "delta": "Delta Electronics",
+    "lenze": "Lenze",
+    "bosch rexroth": "Bosch Rexroth",
+    "rexroth": "Bosch Rexroth",
+    "pilz": "Pilz",
+}
+```
+
+A separate `FAMILY_FROM_ALIAS` dict captures the family token when the alias
+is a family rather than a brand:
+
+```python
+FAMILY_FROM_ALIAS: dict[str, str] = {
+    "powerflex": "PowerFlex",
+    "micromaster": "Micromaster",
+    "sinamics": "Sinamics",
+    "fr-e": "FR-E",
+    "fr-a": "FR-A",
+    "fr-d": "FR-D",
+    "fr-f": "FR-F",
+    "aqua drive": "AquaDrive",
+    "gs10": "GS10",
+    "gs20": "GS20",
+}
+```
+
+### 2.4 Confidence scheme
+
+Numeric, 0.0–1.0. Concrete bands:
+
+| Value | Means |
+|---|---|
+| `1.0` | manufacturer + model + fault code, all DB-confirmed (`matched_entities` non-empty) |
+| `0.9` | manufacturer + model + fault code, alias-table only |
+| `0.7` | manufacturer + model, alias-table |
+| `0.5` | manufacturer only |
+| `0.3` | fault code only (no vendor identified) |
+| `0.0` | nothing matched |
+
+Stored on the dataclass so downstream consumers (router, rag_worker, DST) can
+gate behavior on "we know enough to scope the KB".
+
+### 2.5 `FAULT_PATTERNS`
+
+```python
+FAULT_PATTERNS = [
+    re.compile(r"\b[fF]\d{2,6}\b"),   # F04, F004, F0004, F30004
+    re.compile(r"\b[eE]\d{1,4}\b"),    # E01, E001
+    re.compile(r"\bo[cC][a-zA-Z]?\b"), # oC, OC, ocA
+    re.compile(r"\b[aA]\d{1,4}\b"),    # A02, A002
+]
+```
+
+Fault codes are normalized: leading letter uppercased, digits zero-padded
+to 4 places when the pattern is letter+digits (so `"F4"` becomes `"F0004"`
+on the canonical side, but the raw user token is preserved in `fault_code_raw`).
+The `oC` family is left as-is (case preserved).
+
+## 3. Engine integration
+
+One call near the top of `Supervisor.process()`:
+
+```python
+from shared.uns_resolver import resolve_uns_path
+
+prior = state.get("uns_context") or None
+ctx = resolve_uns_path(
+    message,
+    tenant_id=state.get("tenant_id"),
+    prior_ctx=prior,
+)
+state["uns_context"] = ctx.as_dict()
+if ctx.manufacturer:
+    label = ctx.manufacturer
+    if ctx.model:
+        label = f"{label}, {ctx.model}"
+    state["asset_identified"] = label
+```
+
+The 14 sites that previously called `vendor_name_from_text(message)` or
+`_looks_like_model_number(message)` read from `state["uns_context"]` instead.
+The `asset_identified` write preserves the existing engine contract — DST
+and reflection logic continue to work without modification.
+
+## 4. Replaced sites
+
+Engine sites (15 total, audited 2026-05-13 — line numbers will drift):
+
+- `engine.py:62, 91` — imports of `vendor_name_from_text` and
+  `_looks_like_model_number`. Remove.
+- `engine.py:682, 1271, 2492, 2494, 2502, 2504, 2517, 2519, 2688, 2689,
+  2895, 3408, 3506, 3514` — read from `state["uns_context"]`.
+
+Worker / DST sites (3):
+
+- `mira-bots/shared/workers/rag_worker.py:21, 424` — KB cross-vendor filter
+  reads `ctx.manufacturer` from state; entity-scoped query uses
+  `ctx.uns_path` when set.
+- `mira-bots/shared/dialogue_state.py:488-490` — read vendor from state.
+- `mira-bots/shared/dialogue_acts.py:197-199` — read vendor from state.
+
+## 5. Offline guarantee
+
+The resolver must produce a useful `UNSContext` *without* NeonDB. Stage 2 is
+the floor. Stage 3 is additive — any DB error returns to the Stage-2 result,
+logged at INFO. This matches the existing pattern in `neon_recall` and means
+no test in `tests/test_uns_resolver.py` requires a live database.
+
+## 6. Tests
+
+`tests/test_uns_resolver.py`, minimum 30 cases:
+
+1. Mike's exact regression case → `mfr="Rockwell Automation",
+   alias="powerflex", family="PowerFlex", model="525",
+   fault_code="F0004"`.
+2. `"PowerFlex 525 F0004"` → same.
+3. `"GS10 ocA fault"` → `mfr="AutomationDirect", model="GS10", fault="oC"`.
+4. `"Motor hums but won't turn"` → all None, confidence 0.
+5. Empty string → all None, confidence 0.
+6. Numeric model with no vendor (`"525 fault"`) → `model=None` (alone, "525"
+   is ambiguous), `fault_code=None` (525 is not a fault pattern), confidence 0.
+7. Multi-vendor in one message ("PowerFlex 525 not Yaskawa") → first match
+   wins; comment on tie-break.
+8. Carry-over: prior ctx with PowerFlex/525/F0004, current message
+   "make a work order" → returned ctx still has all three.
+9. + 22 more covering: every alias in `VENDOR_ALIASES`, every fault pattern,
+   path-build correctness, the `_VENDOR_DISPLAY_NAMES` legacy alignment,
+   the slug() normalization edge cases, the offline-only branch.
+
+## 7. What this is NOT
+
+- Not a router. It does not decide intent or pick a state.
+- Not an FSM mutator. It does not write to `state["state"]`.
+- Not a DST replacement. DST consumes its output — does not duplicate it.
+- Not LLM-aware. Pure-Python deterministic extraction. No cascade calls.
+
+## 8. Acceptance
+
+- All 14 engine sites + 3 worker/DST sites read from `state["uns_context"]`.
+- `vendor_name_from_text` and `_looks_like_model_number` removed from
+  `engine.py`, `rag_worker.py`, `dialogue_state.py`, `dialogue_acts.py`
+  imports.
+- `tests/test_uns_resolver.py` ≥ 30 cases pass.
+- `tests/eval/bot_regression.py` does not regress vs main.
+- Net negative LOC.
+- `ruff check` passes.

--- a/mira-bots/shared/dialogue_acts.py
+++ b/mira-bots/shared/dialogue_acts.py
@@ -192,21 +192,16 @@ _RX_QUESTION = re.compile(
 def _entities_from_message(message: str) -> SalientEntities:
     """Cheap regex extraction — used as a backstop when the LLM omits entities.
 
-    Conservative on purpose: only extracts vendor/fault_code when the message
-    has an unambiguous match. Anything fuzzier waits for the LLM."""
-    from .guardrails import vendor_name_from_text  # local — avoid import cycle
+    Delegates to the UNS resolver, which already handles vendor + fault-code
+    detection consistently (one source of truth across engine, workers, DST).
+    """
+    from .uns_resolver import resolve_uns_path  # local — avoid import cycle
 
-    vendor = vendor_name_from_text(message) or None
-
-    fault_code = None
-    fault_match = re.search(
-        r"\b([Ff]\s?-?\s?\d{2,4}|[Ee]\s?-?\s?\d{2,4}|AL[-\s]?\d{2,4}|OC|OL|UL)\b",
-        message,
+    ctx = resolve_uns_path(message)
+    return SalientEntities(
+        vendor=ctx.manufacturer or None,
+        fault_code=ctx.fault_code or None,
     )
-    if fault_match:
-        fault_code = fault_match.group(1).upper().replace(" ", "").replace("-", "")
-
-    return SalientEntities(vendor=vendor, fault_code=fault_code)
 
 
 # ---------------------------------------------------------------------------

--- a/mira-bots/shared/dialogue_state.py
+++ b/mira-bots/shared/dialogue_state.py
@@ -483,11 +483,18 @@ class DialogueState:
             )
 
         salient = SalientEntities()
+        # Prefer the canonical UNS context when present (one source of truth
+        # per turn). Stored under engine_state["context"]["uns_context"] so it
+        # round-trips through SQLite via session_manager.save_state. Fall back
+        # to parsing asset_identified for legacy state rows.
+        uns_ctx = (engine_state.get("context") or {}).get("uns_context") or {}
         asset = engine_state.get("asset_identified") or ""
-        if asset:
-            from .guardrails import vendor_name_from_text  # local import: avoid cycle
+        vendor: str | None = uns_ctx.get("manufacturer") or None
+        if not vendor and asset:
+            from .uns_resolver import resolve_uns_path  # local import: avoid cycle
 
-            vendor = vendor_name_from_text(asset) or None
+            vendor = resolve_uns_path(asset).manufacturer or None
+        if vendor or asset:
             salient = SalientEntities(vendor=vendor, asset_label=asset[:120])
 
         return cls(

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -59,7 +59,6 @@ from .guardrails import (
     detect_session_followup,
     resolve_option_selection,
     strip_mentions,
-    vendor_name_from_text,
     vendor_support_url,
 )
 from .inference.router import InferenceRouter
@@ -88,7 +87,6 @@ from .photo_handler import (
 )
 from .response_formatter import (
     _VISION_PROSE_PREFIX_RE,
-    _looks_like_model_number,
     deduplicate_options,  # noqa: F401 — re-exported for test_conversation_continuity.py
     format_reply,
     parse_response,
@@ -103,6 +101,7 @@ from .session_manager import (
 from .telemetry import flush as tl_flush
 from .telemetry import span as tl_span
 from .telemetry import trace as tl_trace
+from .uns_resolver import resolve_uns_path
 from .workers.nameplate_worker import NameplateWorker
 from .workers.plc_worker import PLCWorker
 from .workers.print_worker import PrintWorker
@@ -670,25 +669,13 @@ class Supervisor:
     def _is_doc_specific(vendor: str, text: str) -> bool:
         """Return True if *text* is specific enough to crawl usefully.
 
-        Requires both:
-        - a vendor name present in _KNOWN_VENDORS (either extracted or in text)
-        - at least one model-number token OR a standalone ≥2-digit number
-
-        The second fallback covers cases like "PowerFlex 525" where the model
-        designator is pure digits (525, 70, 700, etc.).  Vague requests like
-        "the safety relay" or "this VFD" still return False.
+        Requires both vendor known AND model present. Delegates to the UNS
+        resolver — vendor is injected into the resolver input so pure-digit
+        models like "525" resolve when adjacent to a known family name.
         """
-        text_lower = text.lower()
-        vendor_known = bool(vendor) and any(
-            v in vendor.lower() or v in text_lower for v in _KNOWN_VENDORS
-        )
-        if not vendor_known:
-            return False
-        # Primary: mixed letter+digit token (GS20, FC-302, X3, ACS580).
-        if _looks_like_model_number(text):
-            return True
-        # Fallback: standalone ≥2-digit number (525, 70, 700, 120 ...).
-        return bool(re.search(r"\b\d{2,}\b", text))
+        combined = f"{vendor} {text}".strip() if vendor else text
+        ctx = resolve_uns_path(combined)
+        return bool(ctx.manufacturer) and bool(ctx.model)
 
     @staticmethod
     def _infer_confidence(reply: str) -> str:
@@ -1061,6 +1048,32 @@ class Supervisor:
                 state.get("state", "Q1"),
             )
 
+        # Single UNS-aware extraction — one truth per turn for
+        # vendor / model / fault code / category. Downstream sites read
+        # `state["context"]["uns_context"]` instead of re-running
+        # vendor_name_from_text or _looks_like_model_number locally.
+        #
+        # Stored UNDER state["context"] (not at the top level) because
+        # session_manager.save_state only persists the declared columns plus
+        # state["context"] as a JSON blob — top-level extras are dropped.
+        # Carries forward across turns so "make a work order" after
+        # "PowerFlex 525 F0004" keeps the equipment in scope.
+        # See docs/specs/uns-message-resolver-spec.md.
+        _ctx_for_uns = state.get("context") or {}
+        prior_uns = _ctx_for_uns.get("uns_context") or None
+        uns_ctx = resolve_uns_path(
+            message,
+            tenant_id=resolved_tenant,
+            prior_ctx=prior_uns,
+        )
+        _ctx_for_uns["uns_context"] = uns_ctx.as_dict()
+        state["context"] = _ctx_for_uns
+        if uns_ctx.manufacturer and uns_ctx.confidence >= 0.7 and not state.get("asset_identified"):
+            label = uns_ctx.manufacturer
+            if uns_ctx.model:
+                label = f"{label}, {uns_ctx.model}"
+            state["asset_identified"] = label
+
         # CMMS pending: user is answering the work-order creation prompt — handle before
         # any option resolution, session-followup detection, or intent classification.
         # Bypass guard: if the message is clearly a brand-new diagnostic question (not a
@@ -1311,7 +1324,7 @@ class Supervisor:
         # Documentation intent: specificity check → gathering subroutine or KB pre-check
         if not photo_b64 and intent == "documentation":
             combined = f"{message} {state.get('asset_identified', '')}".strip()
-            mfr = vendor_name_from_text(combined) or ""
+            mfr = ((state.get("context") or {}).get("uns_context") or {}).get("manufacturer") or ""
 
             # Specificity gate — vague requests ("the safety relay", "this VFD") enter
             # MANUAL_LOOKUP_GATHERING to collect vendor + model before crawling.
@@ -1628,28 +1641,10 @@ class Supervisor:
             session_photo = self._load_recent_session_photo(chat_id, state)
         effective_photo = photo_b64 or session_photo
 
-        # REGRESSION GUARD (2026-05-12): seed asset_identified from the message
-        # when the user names a recognizable vendor (PowerFlex, GS20, etc.) so
-        # downstream prompts and the no-KB-coverage path know what equipment we
-        # are diagnosing. Without this, the LLM and clarification flow drop the
-        # equipment context Mike just typed and ask for it again.
-        if not photo_b64 and not state.get("asset_identified"):
-            _seeded_vendor = vendor_name_from_text(message) or ""
-            if _seeded_vendor:
-                _seeded_model = _looks_like_model_number(message) or ""
-                if not _seeded_model:
-                    _digit_match = re.search(r"\b\d{2,4}\b", message)
-                    if _digit_match:
-                        _seeded_model = _digit_match.group(0)
-                state["asset_identified"] = (
-                    f"{_seeded_vendor}, {_seeded_model}" if _seeded_model else _seeded_vendor
-                )
-                logger.info(
-                    "ASSET_SEEDED_FROM_MESSAGE chat_id=%s vendor=%r model=%r",
-                    chat_id,
-                    _seeded_vendor,
-                    _seeded_model,
-                )
+        # NOTE: asset_identified seeding from message is handled earlier in this
+        # function via the UNS resolver block (state["uns_context"]). The previous
+        # _seeded_vendor regression-guard (#1206 / commit 4537dd3d) was removed as
+        # part of the UNS resolver refactor — one extraction point per turn.
         try:
             with tl_span(t, "rag_worker"):
                 raw, parsed = await self._call_with_correction(
@@ -2572,6 +2567,16 @@ class Supervisor:
         vendor = current_vendor or ""
         model = ""
 
+        # Primary source: UNS resolver result for this turn (includes
+        # prior-context carry-over from previous turns). Stored under
+        # state["context"]["uns_context"] so it survives SQLite round-trip.
+        uns = (state.get("context") or {}).get("uns_context") or {}
+        if not vendor and uns.get("manufacturer"):
+            vendor = str(uns["manufacturer"])
+        if not model and uns.get("model"):
+            model = str(uns["model"])
+
+        # Secondary: asset_identified is the canonical "Vendor, Model" string.
         asset_id = state.get("asset_identified") or ""
         if "," in asset_id:
             parts = [p.strip() for p in asset_id.split(",", 1)]
@@ -2579,24 +2584,15 @@ class Supervisor:
                 vendor = parts[0]
             if len(parts) > 1 and parts[1]:
                 model = parts[1]
-        elif asset_id:
-            if not vendor:
-                vendor = vendor_name_from_text(asset_id) or ""
-            if not model:
-                model = _looks_like_model_number(asset_id) or ""
+        elif asset_id and (not vendor or not model):
+            # Fallback: resolve asset_id through the UNS resolver
+            fallback_ctx = resolve_uns_path(asset_id)
+            if not vendor and fallback_ctx.manufacturer:
+                vendor = fallback_ctx.manufacturer
+            if not model and fallback_ctx.model:
+                model = fallback_ctx.model
 
         ctx = state.get("context") or {}
-        history = ctx.get("history") or []
-        if (not vendor or not model) and history:
-            for turn in reversed(history[-8:]):
-                text = str(turn.get("content") or "")
-                if not vendor:
-                    vendor = vendor_name_from_text(text) or ""
-                if not model:
-                    model = _looks_like_model_number(text) or ""
-                if vendor and model:
-                    break
-
         if not vendor or not model:
             dialogue = ctx.get("dialogue") or {}
             ents = dialogue.get("salient_entities") or {}
@@ -2605,10 +2601,15 @@ class Supervisor:
             if not model and ents.get("model"):
                 model = str(ents["model"])
 
-        if not vendor:
-            vendor = vendor_name_from_text(message) or ""
-        if not model:
-            model = _looks_like_model_number(message) or ""
+        # Last resort: re-resolve the current message directly. This branch
+        # fires only when uns_context wasn't populated (e.g., called from a
+        # path that bypassed process_full's top-of-loop resolution).
+        if not vendor or not model:
+            msg_ctx = resolve_uns_path(message)
+            if not vendor and msg_ctx.manufacturer:
+                vendor = msg_ctx.manufacturer
+            if not model and msg_ctx.model:
+                model = msg_ctx.model
         return vendor, model
 
     async def _enter_manual_lookup_gathering(
@@ -2777,12 +2778,19 @@ class Supervisor:
             return self._make_result(reply, "none", trace_id, prior_state)
 
         # ---- Extract info from this turn ----------------------------------------
-        new_vendor = vendor_name_from_text(message) or ""
-        new_model = _looks_like_model_number(message)
+        # Bias the resolver with any vendor already collected so a bare model
+        # answer like "525" resolves correctly (vendor-adjacent rule).
+        if collected.get("vendor"):
+            biased = f"{collected['vendor']} {message}"
+        else:
+            biased = message
+        turn_ctx = resolve_uns_path(biased)
+        new_vendor = turn_ctx.manufacturer or ""
+        new_model = turn_ctx.model or ""
 
-        # If we're already waiting for the model specifically (vendor in hand) and
-        # _looks_like_model_number found nothing, accept any short non-stopword token.
-        # This covers user answers like "525" or just "PNOZ-X3".
+        # MLG-specific permissive fallback: when vendor is in hand and the
+        # resolver still didn't find a model, accept any short non-stopword
+        # token as the model (covers "PNOZ-X3" and other unusual answers).
         if not new_model and collected.get("vendor"):
             _STOP = {
                 "the",
@@ -2983,8 +2991,10 @@ class Supervisor:
         """User wants to talk about a different asset — clear FSM, preserve session memory."""
         old_asset = state.get("asset_identified", "") or "unknown"
 
-        # Try to identify the new asset from the switch message itself
-        new_asset = vendor_name_from_text(message) or ""
+        # Try to identify the new asset from the switch message itself.
+        # Fresh resolve (no prior_ctx) so we get the NEW asset, not carry-over
+        # from the one the user is switching away from.
+        new_asset = resolve_uns_path(message).manufacturer or ""
 
         logger.info(
             "ASSET_SWITCH chat_id=%s from=%r to=%r",
@@ -3497,7 +3507,7 @@ class Supervisor:
     ) -> dict:
         """Router-dispatched doc intent — delegates to the existing specificity-gate path."""
         combined = f"{message} {state.get('asset_identified', '')}".strip()
-        mfr = vendor_name_from_text(combined) or ""
+        mfr = ((state.get("context") or {}).get("uns_context") or {}).get("manufacturer") or ""
         if not self._is_doc_specific(mfr, combined):
             asset_id = state.get("asset_identified", "")
             if "," in asset_id:
@@ -3595,7 +3605,10 @@ class Supervisor:
         state = self._clear_diagnostic_carryover(chat_id, state, clear_photo=True)
         asset = state.get("asset_identified", "")
         combined = " ".join(filter(None, [vendor_override, model_override, message, asset])).strip()
-        mfr = vendor_override or vendor_name_from_text(combined) or ""
+        # Resolve the combined input through the UNS resolver. Overrides win
+        # when present; otherwise we use what the resolver found.
+        combined_ctx = resolve_uns_path(combined)
+        mfr = vendor_override or combined_ctx.manufacturer or ""
         url = vendor_support_url(combined)
 
         # Phase 2 — KB pre-check: skip crawl when we already have coverage.
@@ -3603,40 +3616,7 @@ class Supervisor:
         if kb_covered:
             # CRA-8 Cluster A: include the model token (and the literal word "manual")
             # so vendor-specific manual requests don't fall through the keyword check.
-            model_hint = model_override or _looks_like_model_number(combined) or ""
-            if not model_hint:
-                # Fallback for models where alpha and digit are separate tokens
-                # (e.g. "MICROMASTER 440", "AQUA Drive FC 202").
-                _skip = {
-                    "VFD",
-                    "ASK",
-                    "MANUAL",
-                    "FIND",
-                    "GET",
-                    "THE",
-                    "ME",
-                    "FOR",
-                    "DRIVE",
-                    "MOTOR",
-                    "INVERTER",
-                    "CONTROLLER",
-                    "PLC",
-                    "A",
-                    "AN",
-                    "MY",
-                    "IS",
-                    "IN",
-                    "OF",
-                    "ON",
-                    "AT",
-                }
-                if mfr:
-                    _skip.add(mfr.upper())
-                _caps = [w for w in re.findall(r"\b[A-Z]{2,}\b", combined) if w not in _skip]
-                _nums = re.findall(r"\b\d{2,}\b", combined)
-                _parts = _caps[:2] + (_nums[:1] if _nums else [])
-                if _parts:
-                    model_hint = " ".join(_parts)
+            model_hint = model_override or combined_ctx.model or ""
             if mfr and model_hint:
                 reply = f"I have the {mfr} {model_hint} manual indexed."
             elif mfr:

--- a/mira-bots/shared/uns_paths.py
+++ b/mira-bots/shared/uns_paths.py
@@ -1,0 +1,120 @@
+"""UNS path builders — pure string helpers, no external deps.
+
+In-bot copy of the path-builder subset of `mira-crawler/ingest/uns.py`. The
+crawler module cannot be imported from `mira-bots/*` (architecture contract,
+enforced by `tests/test_architecture.py::test_bots_cannot_import_crawler`),
+so the resolver imports these helpers from here instead.
+
+Keep this in sync with `mira-crawler/ingest/uns.py` if the UNS path grammar
+changes. Both files MUST agree on the output of every helper they share —
+the crawler writes UNS paths, the bot reads them, and a drift would put the
+two on different addressing schemes.
+
+The full UNS spec lives in `mira-crawler/ingest/uns.py` and
+`docs/specs/uns-kg-unification-spec.md`. This file ships only what the
+resolver needs: `slug`, `RESERVED_LABELS`, and the kb-branch path builders
+(`manufacturer_path`, `model_path`, `manual_path`, `fault_code_path`).
+"""
+
+from __future__ import annotations
+
+import re
+
+_NON_LABEL_CHARS = re.compile(r"[^a-z0-9]+")
+
+# Type-marker labels reserved for UNS structure — never used as a
+# manufacturer / model / instance slug. The resolver checks against this
+# set so a token like "fault_codes" never becomes the model component.
+RESERVED_LABELS = frozenset(
+    {
+        "enterprise",
+        "knowledge_base",
+        "operations",
+        "community",
+        "site",
+        "area",
+        "line",
+        "work_cell",
+        "equipment",
+        "component",
+        "datapoint",
+        "maintenance",
+        "documentation",
+        "manuals",
+        "fault_codes",
+        "pm_schedules",
+        "pm_schedule",
+        "fault_history",
+        "work_orders",
+        "parts_lists",
+        "parts_inventory",
+        "schematics",
+        "procedures",
+        "fleet",
+        "shared_services",
+        "utilities",
+        "safety_systems",
+        "environmental",
+        "technicians",
+        "inventory",
+        "compliance",
+        "common_faults",
+        "mtbf_benchmarks",
+        "resolution_patterns",
+    }
+)
+
+
+def slug(value: str) -> str:
+    """Normalize a free-form string into a single ltree label."""
+    if not value:
+        return ""
+    lowered = value.strip().lower()
+    cleaned = _NON_LABEL_CHARS.sub("_", lowered).strip("_")
+    return cleaned
+
+
+def _join(*parts: str) -> str:
+    return ".".join(p for p in parts if p)
+
+
+def kb_root() -> str:
+    return "enterprise.knowledge_base"
+
+
+def manufacturer_path(manufacturer: str | None) -> str:
+    return _join(kb_root(), slug(manufacturer or ""))
+
+
+def family_path(manufacturer: str | None, family: str | None) -> str:
+    return _join(manufacturer_path(manufacturer), slug(family or ""))
+
+
+def model_path(
+    manufacturer: str | None,
+    model: str | None,
+    family: str | None = None,
+) -> str:
+    return _join(family_path(manufacturer, family), slug(model or ""))
+
+
+def manual_path(
+    manufacturer: str | None,
+    model: str | None,
+    family: str | None = None,
+    manual_slug: str | None = None,
+) -> str:
+    return _join(model_path(manufacturer, model, family), "manuals", slug(manual_slug or ""))
+
+
+def fault_code_path(
+    manufacturer: str | None,
+    code: str,
+    model: str | None = None,
+    family: str | None = None,
+) -> str:
+    if model:
+        prefix = model_path(manufacturer, model, family)
+    else:
+        prefix = manufacturer_path(manufacturer)
+    return _join(prefix, "fault_codes", slug(code))

--- a/mira-bots/shared/uns_resolver.py
+++ b/mira-bots/shared/uns_resolver.py
@@ -22,21 +22,10 @@ import re
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
-# uns.py lives in mira-crawler; import lazily-styled so unit tests can patch it
-# without dragging the crawler service into the bot test fixtures.
-try:
-    from mira_crawler.ingest import uns as _uns  # type: ignore[import-not-found]
-except Exception:  # pragma: no cover — fall back to filesystem path import
-    import importlib.util
-    import pathlib
-
-    _uns_path = pathlib.Path(__file__).resolve().parents[2] / "mira-crawler" / "ingest" / "uns.py"
-    _spec = importlib.util.spec_from_file_location("_mira_uns", _uns_path)
-    if _spec and _spec.loader:
-        _uns = importlib.util.module_from_spec(_spec)
-        _spec.loader.exec_module(_uns)
-    else:  # pragma: no cover
-        _uns = None  # type: ignore[assignment]
+# Path builders live in shared/uns_paths.py — a verbatim, dep-free copy of the
+# subset of mira-crawler/ingest/uns.py the resolver needs. mira-bots cannot
+# import from mira-crawler (architecture contract, enforced in CI).
+from . import uns_paths as _uns
 
 logger = logging.getLogger(__name__)
 

--- a/mira-bots/shared/uns_resolver.py
+++ b/mira-bots/shared/uns_resolver.py
@@ -1,0 +1,727 @@
+"""UNS message resolver — single extraction point for vendor / model / fault
+code / category per turn.
+
+Reads a free-form user message and returns a `UNSContext` whose fields map
+directly onto UNS path segments built by `mira-crawler/ingest/uns.py`. Engine,
+workers, and DST all read from `state["context"]["uns_context"]` instead of
+re-running their own extraction.
+
+Storage location matters: `session_manager.save_state` only persists declared
+columns plus `state["context"]` (as a JSON blob). Top-level keys outside that
+schema are dropped on save — so the resolver result MUST live under
+`state["context"]["uns_context"]` to round-trip across turns.
+
+See `docs/specs/uns-message-resolver-spec.md` for the contract. See
+`.claude/rules/uns-compliance.md` for the rules this module enforces.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+# uns.py lives in mira-crawler; import lazily-styled so unit tests can patch it
+# without dragging the crawler service into the bot test fixtures.
+try:
+    from mira_crawler.ingest import uns as _uns  # type: ignore[import-not-found]
+except Exception:  # pragma: no cover — fall back to filesystem path import
+    import importlib.util
+    import pathlib
+
+    _uns_path = pathlib.Path(__file__).resolve().parents[2] / "mira-crawler" / "ingest" / "uns.py"
+    _spec = importlib.util.spec_from_file_location("_mira_uns", _uns_path)
+    if _spec and _spec.loader:
+        _uns = importlib.util.module_from_spec(_spec)
+        _spec.loader.exec_module(_uns)
+    else:  # pragma: no cover
+        _uns = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Alias tables
+# ---------------------------------------------------------------------------
+
+# alias → canonical manufacturer display name. Lowercase keys, matched as
+# whole-word substrings against the message. Order matters only for tie-break
+# (first hit wins); the dict preserves insertion order.
+VENDOR_ALIASES: dict[str, str] = {
+    # Rockwell family
+    "powerflex": "Rockwell Automation",
+    "allen-bradley": "Rockwell Automation",
+    "allen bradley": "Rockwell Automation",
+    "rockwell automation": "Rockwell Automation",
+    "rockwell": "Rockwell Automation",
+    "ab": "Rockwell Automation",
+    # AutomationDirect family
+    "gs10": "AutomationDirect",
+    "gs20": "AutomationDirect",
+    "automationdirect": "AutomationDirect",
+    "automation direct": "AutomationDirect",
+    # Siemens family
+    "micromaster": "Siemens",
+    "sinamics": "Siemens",
+    "siemens": "Siemens",
+    # Mitsubishi family
+    "mitsubishi electric": "Mitsubishi Electric",
+    "mitsubishi": "Mitsubishi Electric",
+    "fr-e": "Mitsubishi Electric",
+    "fr-a": "Mitsubishi Electric",
+    "fr-d": "Mitsubishi Electric",
+    "fr-f": "Mitsubishi Electric",
+    # Danfoss
+    "aqua drive": "Danfoss",
+    "danfoss": "Danfoss",
+    # Schneider
+    "schneider electric": "Schneider Electric",
+    "schneider": "Schneider Electric",
+    # Bosch Rexroth
+    "bosch rexroth": "Bosch Rexroth",
+    "rexroth": "Bosch Rexroth",
+    # Singletons
+    "yaskawa": "Yaskawa",
+    "abb": "ABB",
+    "omron": "Omron",
+    "eaton": "Eaton",
+    "delta": "Delta Electronics",
+    "lenze": "Lenze",
+    "pilz": "Pilz",
+}
+
+# Alias → product-family token when the alias names a family rather than a
+# brand. Used to populate UNSContext.product_family and the family segment in
+# the UNS path. Aliases NOT in this dict produce product_family=None and a
+# path with no family segment.
+FAMILY_FROM_ALIAS: dict[str, str] = {
+    "powerflex": "PowerFlex",
+    "micromaster": "Micromaster",
+    "sinamics": "Sinamics",
+    "fr-e": "FR-E",
+    "fr-a": "FR-A",
+    "fr-d": "FR-D",
+    "fr-f": "FR-F",
+    "aqua drive": "AquaDrive",
+    "gs10": "GS10",
+    "gs20": "GS20",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fault code patterns
+# ---------------------------------------------------------------------------
+
+# Compiled regexes for fault-code extraction. `\b` boundaries keep "F0004"
+# matching but skip "FAULTY". Patterns are checked in order; first hit wins.
+FAULT_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"\b[fF]\d{2,6}\b"),  # F04, F004, F0004, F30004
+    re.compile(r"\b[eE]\d{1,4}\b"),  # E01, E001 (drives use E-codes)
+    re.compile(r"\b[oO][cC][a-zA-Z]?\b"),  # oC, OC, ocA (overcurrent)
+    re.compile(r"\b[oO][lL]\b"),  # OL (overload)
+    re.compile(r"\b[uU][lL]\b"),  # UL (underload)
+    re.compile(r"\b[aA][lL]\d{1,4}\b"),  # AL001 (alarm with AL prefix)
+    re.compile(r"\b[aA]\d{1,4}\b"),  # A02, A002 (alarms — weakest)
+]
+
+# Words that may match the alarm pattern A\d{1,4} but are not fault codes
+# (single-letter article "a" before digits, etc.). Conservative — only filter
+# obvious false positives.
+_FAULT_FALSE_POSITIVES: frozenset[str] = frozenset(
+    {
+        "a0",
+        "a1",
+        "a4",
+        "a5",  # A4 paper, etc.
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Category detection
+# ---------------------------------------------------------------------------
+
+_CATEGORY_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"\b(fault|error|trip|alarm)\s*code\b", re.IGNORECASE), "fault_codes"),
+    (re.compile(r"\bfault\b", re.IGNORECASE), "fault_codes"),
+    (re.compile(r"\bmanual\b|\bdatasheet\b|\bdocumentation\b", re.IGNORECASE), "manuals"),
+    (
+        re.compile(r"\bpm\b|\bpreventiv\w*\smaintenance\b|\bschedule\b", re.IGNORECASE),
+        "pm_schedules",
+    ),
+    (re.compile(r"\bparts?\s*(list|number|kit)\b|\bspare\b", re.IGNORECASE), "parts_lists"),
+]
+
+
+# ---------------------------------------------------------------------------
+# UNSContext dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class UNSContext:
+    """Single canonical extraction result for a turn.
+
+    See `docs/specs/uns-message-resolver-spec.md` for field semantics.
+    Confidence bands:
+      1.0 — manufacturer + model + fault, DB-confirmed
+      0.9 — manufacturer + model + fault, alias-table only
+      0.7 — manufacturer + model, alias-table
+      0.5 — manufacturer only
+      0.3 — fault code only (no vendor)
+      0.0 — nothing matched
+    """
+
+    uns_path: str | None = None
+    manufacturer: str | None = None
+    manufacturer_alias: str | None = None
+    product_family: str | None = None
+    model: str | None = None
+    fault_code: str | None = None
+    fault_code_raw: str | None = None
+    category: str | None = None
+    site_path: str | None = None
+    matched_entities: list[dict[str, Any]] = field(default_factory=list)
+    matched_kb_count: int = 0
+    confidence: float = 0.0
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> UNSContext | None:
+        if not data:
+            return None
+        # Tolerate extra keys (forward compat) and missing keys (backward compat).
+        known = {f.name for f in cls.__dataclass_fields__.values()}  # type: ignore[attr-defined]
+        clean = {k: v for k, v in data.items() if k in known}
+        return cls(**clean)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "an",
+        "and",
+        "are",
+        "as",
+        "at",
+        "be",
+        "but",
+        "by",
+        "for",
+        "from",
+        "have",
+        "has",
+        "had",
+        "i",
+        "in",
+        "is",
+        "it",
+        "of",
+        "on",
+        "or",
+        "the",
+        "this",
+        "that",
+        "to",
+        "was",
+        "with",
+        "you",
+        "we",
+        "what",
+        "when",
+        "where",
+        "how",
+        "called",
+        "got",
+        "and",
+        "do",
+        "does",
+        "did",
+        "my",
+        "me",
+        "your",
+        "their",
+        "his",
+        "her",
+        "its",
+        "fault",
+        "error",
+        "code",
+        "manual",
+        "issue",
+        "problem",
+        "showing",
+    }
+)
+
+
+def _normalize_fault_code(raw: str) -> str:
+    """Uppercase the letter, zero-pad the digits to 4 places for the F/E/A
+    patterns. Leave oC family alone (case preserved)."""
+    if not raw:
+        return raw
+    # oC family: keep as-is
+    if raw.lower().startswith("oc"):
+        return raw
+    m = re.match(r"^([fFeEaA])(\d+)$", raw)
+    if m:
+        letter = m.group(1).upper()
+        digits = m.group(2).zfill(4)
+        return f"{letter}{digits}"
+    return raw
+
+
+def _extract_fault_codes(message: str) -> list[tuple[str, str, int]]:
+    """Return list of (normalized, raw, pattern_index) fault matches.
+
+    The pattern index reflects priority: 0=F-codes (strong), 1=E-codes
+    (strong), 2=oC family (strong), 3=A-alarms (weak — also matches model
+    names like Yaskawa A1000).
+    """
+    out: list[tuple[str, str, int]] = []
+    for idx, pat in enumerate(FAULT_PATTERNS):
+        for m in pat.finditer(message):
+            tok = m.group(0)
+            if tok.lower() in _FAULT_FALSE_POSITIVES:
+                continue
+            out.append((_normalize_fault_code(tok), tok, idx))
+    return out
+
+
+def _pick_fault_code(
+    pairs: list[tuple[str, str, int]],
+    model_position_token: str | None,
+) -> tuple[str | None, str | None, frozenset[str]]:
+    """Choose the fault code from candidates, avoiding the model-position
+    token when a better candidate exists.
+
+    Returns (normalized, raw, all_raw_tokens_for_stripping).
+
+    Strong patterns (F/E/oC) are preferred. The A-pattern is used only when
+    nothing stronger fired AND the match is not the model-position token.
+    """
+    if not pairs:
+        return None, None, frozenset()
+
+    all_raw = frozenset(p[1].lower() for p in pairs)
+
+    # Sort by priority: strong patterns (0-2) before weak (3)
+    strong = [p for p in pairs if p[2] <= 2]
+    weak = [p for p in pairs if p[2] >= 3]
+
+    mpos = (model_position_token or "").lower()
+
+    for pair in strong + weak:
+        if pair[1].lower() == mpos and len(pairs) > 1:
+            # Skip the model-position token if there's another fault candidate
+            continue
+        return pair[0], pair[1], all_raw
+
+    # All candidates collided with the model-position token; if all were weak,
+    # treat as no fault (it's the model).
+    if all(p[2] >= 3 for p in pairs):
+        return None, None, all_raw
+
+    # Strong pattern matched only the model-position token — still treat as fault.
+    return pairs[0][0], pairs[0][1], all_raw
+
+
+def _match_vendor(message_lower: str) -> tuple[str | None, str | None, str | None]:
+    """Return (canonical_mfr, alias_key_lower, family_token).
+
+    Matches whole-word substrings. First hit wins.
+    """
+    # Order matters: longer/more-specific aliases first by sorting on length desc
+    # within the iteration. Since dict order is preserved but we want longest
+    # match wins for "rockwell automation" vs "rockwell", we sort once here.
+    for alias in sorted(VENDOR_ALIASES.keys(), key=len, reverse=True):
+        # Build a boundary-aware pattern. Aliases with hyphens or spaces are
+        # matched literally (no \b around hyphens because \b breaks there).
+        if any(c in alias for c in " -"):
+            if alias in message_lower:
+                mfr = VENDOR_ALIASES[alias]
+                family = FAMILY_FROM_ALIAS.get(alias)
+                return mfr, alias, family
+        else:
+            if re.search(rf"\b{re.escape(alias)}\b", message_lower):
+                mfr = VENDOR_ALIASES[alias]
+                family = FAMILY_FROM_ALIAS.get(alias)
+                return mfr, alias, family
+    return None, None, None
+
+
+def _is_model_candidate(token: str, fault_raw_tokens: frozenset[str]) -> bool:
+    """A token is a model candidate iff:
+    - Not a fault code we already captured
+    - Not in RESERVED_LABELS (uns structural markers)
+    - Length 2-12
+    - Alphanumeric (with hyphens/dots allowed)
+    """
+    if not token or len(token) < 2 or len(token) > 12:
+        return False
+    if token.lower() in fault_raw_tokens or token.lower() in _STOPWORDS:
+        return False
+    if _uns is not None and token.lower() in _uns.RESERVED_LABELS:
+        return False
+    # Allow letters, digits, hyphens, dots
+    if not re.match(r"^[A-Za-z0-9][A-Za-z0-9.-]*$", token):
+        return False
+    return True
+
+
+def _find_model_near_vendor(
+    message: str,
+    alias_lower: str | None,
+    fault_raw_tokens: frozenset[str],
+) -> str | None:
+    """Find a model candidate. Prefer tokens that immediately follow the
+    vendor alias in the message; if none qualify, scan all tokens.
+    """
+    tokens = _TOKEN_RE.findall(message)
+    if not tokens:
+        return None
+
+    # Find the index of the alias in the token stream if present
+    alias_idx: int | None = None
+    if alias_lower:
+        message_lower = message.lower()
+        # The alias may be multi-word (e.g. "allen bradley"). Find its span
+        # in the raw message and pick the token immediately after.
+        m = re.search(re.escape(alias_lower), message_lower)
+        if m:
+            # Walk tokens until we pass the alias end
+            offset = 0
+            for i, tok in enumerate(tokens):
+                idx = message_lower.find(tok.lower(), offset)
+                if idx == -1:
+                    continue
+                offset = idx + len(tok)
+                if offset > m.end():
+                    alias_idx = i - 1
+                    break
+            if alias_idx is None:
+                alias_idx = len(tokens) - 1
+
+    # Search right of the alias first
+    search_order: list[int]
+    if alias_idx is not None:
+        search_order = list(range(alias_idx + 1, len(tokens))) + list(range(0, alias_idx + 1))
+    else:
+        search_order = list(range(len(tokens)))
+
+    for i in search_order:
+        tok = tokens[i]
+        if not _is_model_candidate(tok, fault_raw_tokens):
+            continue
+        # Don't pick the alias itself as the model
+        if alias_lower and tok.lower() == alias_lower:
+            continue
+        # If alias is multi-token, skip tokens that are part of the alias
+        if alias_lower and tok.lower() in alias_lower.split():
+            continue
+        # Require digit OR adjacent vendor-known context. If alias_idx is set,
+        # the token is "near vendor"; otherwise require digit-in-token.
+        has_digit = bool(re.search(r"\d", tok))
+        if alias_idx is not None:
+            return tok
+        if has_digit and re.search(r"[A-Za-z]", tok):
+            return tok
+    return None
+
+
+def _detect_category(message: str, has_fault: bool) -> str | None:
+    if has_fault:
+        return "fault_codes"
+    for pat, cat in _CATEGORY_PATTERNS:
+        if pat.search(message):
+            return cat
+    return None
+
+
+def _build_uns_path(
+    manufacturer: str | None,
+    product_family: str | None,
+    model: str | None,
+    fault_code: str | None,
+    category: str | None,
+) -> str | None:
+    """Build the deepest UNS path possible from the resolved fields.
+
+    Uses path builders in `mira-crawler/ingest/uns.py`. Returns None when no
+    manufacturer is known.
+    """
+    if _uns is None or not manufacturer:
+        return None
+
+    family = product_family
+    if fault_code:
+        # fault_code_path handles the "no model" fallback internally
+        return _uns.fault_code_path(manufacturer, fault_code, model=model, family=family)
+    if category == "manuals":
+        return _uns.manual_path(manufacturer, model, family=family)
+    if model:
+        return _uns.model_path(manufacturer, model, family=family)
+    return _uns.manufacturer_path(manufacturer)
+
+
+def _confidence(
+    manufacturer: str | None,
+    model: str | None,
+    fault_code: str | None,
+    db_confirmed: bool,
+) -> float:
+    if manufacturer and model and fault_code:
+        return 1.0 if db_confirmed else 0.9
+    if manufacturer and model:
+        return 0.7
+    if manufacturer:
+        return 0.5
+    if fault_code:
+        return 0.3
+    return 0.0
+
+
+def _merge_with_prior(fresh: UNSContext, prior: UNSContext | None) -> UNSContext:
+    """Carry forward prior fields where the fresh ctx has nothing. Confidence
+    decays slightly each turn."""
+    if prior is None:
+        return fresh
+
+    decayed = prior.confidence * 0.9
+
+    def pick(a: Any, b: Any) -> Any:
+        if a is None or a == "" or a == 0 or a == []:
+            return b
+        return a
+
+    merged_mfr = pick(fresh.manufacturer, prior.manufacturer)
+    merged_alias = pick(fresh.manufacturer_alias, prior.manufacturer_alias)
+    merged_family = pick(fresh.product_family, prior.product_family)
+    merged_model = pick(fresh.model, prior.model)
+    merged_fault = pick(fresh.fault_code, prior.fault_code)
+    merged_fault_raw = pick(fresh.fault_code_raw, prior.fault_code_raw)
+    merged_cat = pick(fresh.category, prior.category)
+    merged_site = pick(fresh.site_path, prior.site_path)
+    merged_entities = fresh.matched_entities or prior.matched_entities
+    merged_kb_count = max(fresh.matched_kb_count, prior.matched_kb_count)
+
+    # Rebuild path from merged fields so it stays correct
+    merged_path = _build_uns_path(merged_mfr, merged_family, merged_model, merged_fault, merged_cat)
+
+    final_conf = max(fresh.confidence, decayed)
+
+    return UNSContext(
+        uns_path=merged_path,
+        manufacturer=merged_mfr,
+        manufacturer_alias=merged_alias,
+        product_family=merged_family,
+        model=merged_model,
+        fault_code=merged_fault,
+        fault_code_raw=merged_fault_raw,
+        category=merged_cat,
+        site_path=merged_site,
+        matched_entities=merged_entities,
+        matched_kb_count=merged_kb_count,
+        confidence=final_conf,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 3 — DB enrichment (optional)
+# ---------------------------------------------------------------------------
+
+
+def _enrich_from_db(
+    ctx: UNSContext,
+    tenant_id: str | None,
+) -> UNSContext:
+    """Add kg_entities matches, knowledge_entries count, and site_path when
+    available. Falls back to ctx on any error or unavailable DB.
+    """
+    if ctx.uns_path is None:
+        return ctx
+    try:
+        # Import lazily — most tests / offline runs skip this path entirely.
+        from .neon_recall import get_pool  # type: ignore[attr-defined]
+    except Exception:
+        return ctx
+
+    try:
+        pool = get_pool()
+    except Exception as exc:
+        logger.debug("UNS_RESOLVER db unavailable: %s", exc)
+        return ctx
+
+    if pool is None:
+        return ctx
+
+    try:
+        import asyncio
+
+        async def _query() -> tuple[list[dict[str, Any]], int, str | None]:
+            async with pool.acquire() as conn:
+                ents = await conn.fetch(
+                    "SELECT id, uns_path::text AS uns_path, label "
+                    "FROM kg_entities WHERE uns_path::text = $1 "
+                    "OR uns_path::text LIKE $1 || '.%' LIMIT 20",
+                    ctx.uns_path,
+                )
+                ent_ids = [str(r["id"]) for r in ents]
+                kb_count = 0
+                if ent_ids:
+                    row = await conn.fetchrow(
+                        "SELECT count(*) AS c FROM knowledge_entries "
+                        "WHERE equipment_entity_id = ANY($1::uuid[])",
+                        ent_ids,
+                    )
+                    kb_count = int(row["c"]) if row else 0
+                site_path: str | None = None
+                if tenant_id and ctx.manufacturer and ctx.model:
+                    site_row = await conn.fetchrow(
+                        "SELECT uns_path::text AS uns_path "
+                        "FROM cmms_equipment WHERE tenant_id = $1 "
+                        "AND manufacturer ILIKE $2 AND model ILIKE $3 LIMIT 1",
+                        tenant_id,
+                        ctx.manufacturer,
+                        ctx.model,
+                    )
+                    if site_row:
+                        site_path = site_row["uns_path"]
+                return (
+                    [dict(r) for r in ents],
+                    kb_count,
+                    site_path,
+                )
+
+        # If a running loop exists, schedule as a task and skip enrichment for
+        # this turn — engine wiring already runs the resolver synchronously
+        # and we don't want to block on a re-entrant loop.
+        try:
+            asyncio.get_running_loop()
+            return ctx
+        except RuntimeError:
+            ents, kb_count, site_path = asyncio.run(_query())
+    except Exception as exc:
+        logger.info("UNS_RESOLVER enrichment failed: %s", exc)
+        return ctx
+
+    db_confirmed = bool(ents)
+    conf = _confidence(ctx.manufacturer, ctx.model, ctx.fault_code, db_confirmed)
+    return UNSContext(
+        uns_path=ctx.uns_path,
+        manufacturer=ctx.manufacturer,
+        manufacturer_alias=ctx.manufacturer_alias,
+        product_family=ctx.product_family,
+        model=ctx.model,
+        fault_code=ctx.fault_code,
+        fault_code_raw=ctx.fault_code_raw,
+        category=ctx.category,
+        site_path=site_path or ctx.site_path,
+        matched_entities=ents,
+        matched_kb_count=kb_count,
+        confidence=conf,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def resolve_uns_path(
+    message: str,
+    tenant_id: str | None = None,
+    prior_ctx: UNSContext | dict[str, Any] | None = None,
+) -> UNSContext:
+    """Resolve vendor / model / fault code / category from a user message and
+    build the deepest UNS path the alias table supports.
+
+    Args:
+        message: free-form user text.
+        tenant_id: when set, enables site-path lookup against cmms_equipment.
+        prior_ctx: previous turn's UNSContext (or its dict form). Missing
+            fields on the fresh extraction fall back to prior values.
+
+    Returns:
+        UNSContext. All fields may be None — the empty result has
+        confidence 0.0.
+    """
+    if not message:
+        message = ""
+
+    # Stage 1a: extract ALL fault-pattern matches (we'll pick which one is the
+    # actual fault below, after we know the model position)
+    fault_pairs = _extract_fault_codes(message)
+
+    # Stage 1b: vendor match first — needed to find model position
+    message_lower = message.lower()
+    mfr, alias_lower, family_token = _match_vendor(message_lower)
+
+    # Stage 1c: find model-position token (the first reasonable candidate
+    # adjacent to the vendor). For this pass we treat NO tokens as fault yet —
+    # the model-position lookup tells the fault picker which token to avoid.
+    model_position = _find_model_near_vendor(message, alias_lower, frozenset())
+
+    # Stage 1d: pick the fault, preferring strong patterns and avoiding the
+    # model-position token when a better candidate exists.
+    fault_code, fault_raw, fault_raw_tokens = _pick_fault_code(fault_pairs, model_position)
+
+    # Stage 2: now strip the chosen fault token(s) from the model candidate
+    # pool and re-resolve the model. If the model-position token IS the chosen
+    # fault, look further down the token stream.
+    model = _find_model_near_vendor(message, alias_lower, fault_raw_tokens)
+
+    # Strip the alias key itself out of the model if model accidentally
+    # matched a sub-word inside the alias (defensive — _find_model_near_vendor
+    # already skips this, but doubles as a guard).
+    if model and alias_lower and model.lower() == alias_lower:
+        model = None
+
+    # Strip alias underscores/hyphens from model when it equals the alias slug
+    if model and alias_lower:
+        m_compact = re.sub(r"[^A-Za-z0-9]", "", model).lower()
+        a_compact = re.sub(r"[^A-Za-z0-9]", "", alias_lower).lower()
+        if m_compact == a_compact:
+            model = None
+
+    category = _detect_category(message, has_fault=fault_code is not None)
+    product_family = family_token
+    if product_family is None and alias_lower and mfr:
+        # If the alias IS the manufacturer (e.g. "siemens"), no family. If
+        # alias is a model token from FAMILY_FROM_ALIAS we already populated.
+        product_family = None
+
+    uns_path = _build_uns_path(mfr, product_family, model, fault_code, category)
+
+    fresh = UNSContext(
+        uns_path=uns_path,
+        manufacturer=mfr,
+        manufacturer_alias=alias_lower,
+        product_family=product_family,
+        model=model,
+        fault_code=fault_code,
+        fault_code_raw=fault_raw,
+        category=category,
+        site_path=None,
+        matched_entities=[],
+        matched_kb_count=0,
+        confidence=_confidence(mfr, model, fault_code, db_confirmed=False),
+    )
+
+    # Stage 3: optional DB enrichment
+    fresh = _enrich_from_db(fresh, tenant_id)
+
+    # Prior-context merge
+    if isinstance(prior_ctx, dict):
+        prior_obj = UNSContext.from_dict(prior_ctx)
+    else:
+        prior_obj = prior_ctx
+    return _merge_with_prior(fresh, prior_obj)

--- a/mira-bots/shared/uns_resolver.py
+++ b/mira-bots/shared/uns_resolver.py
@@ -416,12 +416,19 @@ def _find_model_near_vendor(
         # If alias is multi-token, skip tokens that are part of the alias
         if alias_lower and tok.lower() in alias_lower.split():
             continue
-        # Require digit OR adjacent vendor-known context. If alias_idx is set,
-        # the token is "near vendor"; otherwise require digit-in-token.
+        # Require at least one digit. Pure-digit is allowed when near vendor
+        # (e.g. "525" after "powerflex" — Mike's 2026-05-13 regression case);
+        # pure-alpha is rejected everywhere (e.g. "find" in "find a manual for
+        # pilz safety relay" is a verb, not a model). Original
+        # `_looks_like_model_number` required letter AND digit; the resolver
+        # loosens that to "≥1 digit" so pure-digit models near a known vendor
+        # are still captured, but English action verbs are not.
         has_digit = bool(re.search(r"\d", tok))
+        if not has_digit:
+            continue
         if alias_idx is not None:
             return tok
-        if has_digit and re.search(r"[A-Za-z]", tok):
+        if re.search(r"[A-Za-z]", tok):
             return tok
     return None
 

--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -433,10 +433,12 @@ class RAGWorker:
             # identified vendor.  Chunks with no manufacturer tag are kept (they may be
             # generic content like fault code tables or application notes).
             # Falls back to the old all-or-nothing suppress if no per-chunk filtering
-            # yields results.
+            # yields results. Vendor is read from state["context"]["uns_context"]
+            # (populated by the UNS resolver at the top of Supervisor.process_full).
             if chunk_texts and not photo_b64:
-                query_combined = f"{message} {state.get('asset_identified', '')}".strip()
-                query_vendor = vendor_name_from_text(query_combined)
+                query_vendor = ((state.get("context") or {}).get("uns_context") or {}).get(
+                    "manufacturer"
+                )
                 if query_vendor:
                     qv_lower = query_vendor.lower()
                     filtered_chunks = [

--- a/tests/test_uns_resolver.py
+++ b/tests/test_uns_resolver.py
@@ -1,0 +1,481 @@
+"""UNS message resolver — exhaustive offline tests.
+
+Covers Mike's regression case (2026-05-13), pure-digit models adjacent to
+known vendor families, fault-code-before-model precedence, carry-over across
+turns, every alias in VENDOR_ALIASES, every fault pattern, path-build
+correctness, and the offline guarantee (no DB calls).
+
+Run: `python -m pytest tests/test_uns_resolver.py -v`
+"""
+
+from __future__ import annotations
+
+import pytest
+from shared.uns_resolver import (
+    FAMILY_FROM_ALIAS,
+    FAULT_PATTERNS,
+    VENDOR_ALIASES,
+    UNSContext,
+    resolve_uns_path,
+)
+
+# ---------------------------------------------------------------------------
+# Mike's regression case + variants
+# ---------------------------------------------------------------------------
+
+
+def test_mike_regression_exact_message():
+    """The exact 2026-05-13 message that motivated the resolver."""
+    ctx = resolve_uns_path("I have a powerflex 525 and it has it called f0004")
+    assert ctx.manufacturer == "Rockwell Automation"
+    assert ctx.manufacturer_alias == "powerflex"
+    assert ctx.product_family == "PowerFlex"
+    assert ctx.model == "525"
+    assert ctx.fault_code == "F0004"
+    assert ctx.fault_code_raw == "f0004"
+    assert ctx.category == "fault_codes"
+    assert ctx.uns_path is not None
+    assert "rockwell_automation" in ctx.uns_path
+    assert "525" in ctx.uns_path
+    assert "f0004" in ctx.uns_path
+    assert ctx.confidence == 0.9  # alias-only, all three fields
+
+
+def test_powerflex_titlecase():
+    ctx = resolve_uns_path("PowerFlex 525 F0004")
+    assert ctx.manufacturer == "Rockwell Automation"
+    assert ctx.model == "525"
+    assert ctx.fault_code == "F0004"
+
+
+def test_powerflex_no_fault():
+    ctx = resolve_uns_path("PowerFlex 525 is humming")
+    assert ctx.manufacturer == "Rockwell Automation"
+    assert ctx.model == "525"
+    assert ctx.fault_code is None
+
+
+def test_fault_code_not_captured_as_model():
+    """The historical bug: f0004 must not end up as the model."""
+    ctx = resolve_uns_path("powerflex 525 f0004")
+    assert ctx.model == "525", f"model should be '525', got {ctx.model!r}"
+    assert ctx.model != "f0004"
+
+
+# ---------------------------------------------------------------------------
+# AutomationDirect / GS family
+# ---------------------------------------------------------------------------
+
+
+def test_gs10_oc_fault():
+    ctx = resolve_uns_path("GS10 ocA fault")
+    assert ctx.manufacturer == "AutomationDirect"
+    # GS10 IS the model/family
+    assert ctx.product_family == "GS10"
+    assert ctx.fault_code is not None
+    assert ctx.fault_code.lower().startswith("oc")
+
+
+def test_gs20_oc():
+    ctx = resolve_uns_path("My GS20 drive shows OC")
+    assert ctx.manufacturer == "AutomationDirect"
+    assert ctx.fault_code in ("OC", "oC")
+
+
+def test_automationdirect_spelled_out():
+    ctx = resolve_uns_path("AutomationDirect drive is showing E001")
+    assert ctx.manufacturer == "AutomationDirect"
+    assert ctx.fault_code == "E0001"
+
+
+# ---------------------------------------------------------------------------
+# Siemens / Mitsubishi / Yaskawa / etc.
+# ---------------------------------------------------------------------------
+
+
+def test_siemens_micromaster():
+    ctx = resolve_uns_path("Siemens Micromaster 440 trip")
+    assert ctx.manufacturer == "Siemens"
+    # Micromaster is a family alias
+    assert ctx.product_family in ("Micromaster", None)
+    assert ctx.model == "440"
+
+
+def test_mitsubishi_fr_d():
+    ctx = resolve_uns_path("FR-D 700 alarm A002")
+    assert ctx.manufacturer == "Mitsubishi Electric"
+    assert ctx.product_family == "FR-D"
+    assert ctx.fault_code == "A0002"
+
+
+def test_yaskawa_simple():
+    ctx = resolve_uns_path("Yaskawa A1000 drive F004")
+    assert ctx.manufacturer == "Yaskawa"
+    assert ctx.fault_code == "F0004"
+
+
+def test_abb_singleton():
+    ctx = resolve_uns_path("ABB ACS580 fault F0023")
+    assert ctx.manufacturer == "ABB"
+    assert ctx.fault_code == "F0023"
+
+
+def test_danfoss_aqua_drive():
+    ctx = resolve_uns_path("Aqua Drive showing alarm")
+    assert ctx.manufacturer == "Danfoss"
+    assert ctx.product_family == "AquaDrive"
+
+
+def test_schneider_electric():
+    ctx = resolve_uns_path("Schneider Electric Altivar 71 fault")
+    assert ctx.manufacturer == "Schneider Electric"
+    assert ctx.model == "71" or ctx.model == "Altivar"
+
+
+def test_allen_bradley_hyphenated():
+    ctx = resolve_uns_path("Allen-Bradley 1756-L73 PLC fault")
+    assert ctx.manufacturer == "Rockwell Automation"
+
+
+def test_allen_bradley_two_words():
+    ctx = resolve_uns_path("allen bradley contactor")
+    assert ctx.manufacturer == "Rockwell Automation"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — empty, gibberish, multiple vendors
+# ---------------------------------------------------------------------------
+
+
+def test_empty_message():
+    ctx = resolve_uns_path("")
+    assert ctx.manufacturer is None
+    assert ctx.model is None
+    assert ctx.fault_code is None
+    assert ctx.confidence == 0.0
+    assert ctx.uns_path is None
+
+
+def test_gibberish():
+    ctx = resolve_uns_path("Motor hums but won't turn")
+    assert ctx.manufacturer is None
+    assert ctx.model is None
+    assert ctx.fault_code is None
+    assert ctx.confidence == 0.0
+
+
+def test_pure_fault_no_vendor():
+    """F0004 alone — fault code identified, no vendor."""
+    ctx = resolve_uns_path("seeing F0004 on the display")
+    assert ctx.fault_code == "F0004"
+    assert ctx.manufacturer is None
+    assert ctx.confidence == 0.3
+
+
+def test_multi_vendor_first_wins():
+    """When two vendors appear, the resolver picks one. Document which."""
+    ctx = resolve_uns_path("PowerFlex 525 not a Yaskawa")
+    assert ctx.manufacturer == "Rockwell Automation"
+
+
+def test_no_vendor_numeric_token_alone():
+    """'525 fault' alone — 525 is ambiguous without a vendor anchor."""
+    ctx = resolve_uns_path("525 fault on motor")
+    # No vendor → no path. Model may be None because no vendor anchor.
+    assert ctx.manufacturer is None
+    assert ctx.uns_path is None
+
+
+# ---------------------------------------------------------------------------
+# Carry-over across turns
+# ---------------------------------------------------------------------------
+
+
+def test_carryover_action_request():
+    """Turn 1 establishes equipment. Turn 2 'make a work order' inherits."""
+    turn1 = resolve_uns_path("PowerFlex 525 F0004")
+    turn2 = resolve_uns_path("make a work order", prior_ctx=turn1)
+    assert turn2.manufacturer == "Rockwell Automation"
+    assert turn2.model == "525"
+    assert turn2.fault_code == "F0004"
+
+
+def test_carryover_dict_form():
+    """prior_ctx can be a dict (engine state round-trip via SQLite)."""
+    turn1 = resolve_uns_path("PowerFlex 525 F0004")
+    turn2 = resolve_uns_path("rephrase that", prior_ctx=turn1.as_dict())
+    assert turn2.manufacturer == "Rockwell Automation"
+    assert turn2.model == "525"
+
+
+def test_carryover_decays():
+    """Confidence decays each turn when prior is reused without new info."""
+    turn1 = resolve_uns_path("PowerFlex 525 F0004")
+    turn2 = resolve_uns_path("rephrase", prior_ctx=turn1)
+    turn3 = resolve_uns_path("hmm", prior_ctx=turn2)
+    # Each carry-over multiplies prior confidence by 0.9
+    assert turn2.confidence == pytest.approx(turn1.confidence * 0.9, rel=1e-3)
+    assert turn3.confidence < turn2.confidence
+
+
+def test_carryover_new_fault_overrides():
+    """A new fault in the current turn replaces the prior fault."""
+    turn1 = resolve_uns_path("PowerFlex 525 F0004")
+    turn2 = resolve_uns_path("now I see F0023", prior_ctx=turn1)
+    assert turn2.fault_code == "F0023"
+    assert turn2.manufacturer == "Rockwell Automation"
+    assert turn2.model == "525"
+
+
+# ---------------------------------------------------------------------------
+# Fault patterns
+# ---------------------------------------------------------------------------
+
+
+def test_fault_pattern_F2_digits():
+    ctx = resolve_uns_path("PowerFlex 525 F04")
+    assert ctx.fault_code == "F0004"
+
+
+def test_fault_pattern_F6_digits():
+    ctx = resolve_uns_path("PowerFlex 525 F30004")
+    assert ctx.fault_code == "F30004"
+
+
+def test_fault_pattern_E_code():
+    ctx = resolve_uns_path("Drive shows E5")
+    assert ctx.fault_code == "E0005"
+
+
+def test_fault_pattern_oC_variants():
+    for variant in ("oC", "OC", "ocA"):
+        ctx = resolve_uns_path(f"GS10 fault: {variant}")
+        assert ctx.fault_code is not None, f"expected fault for {variant}"
+
+
+def test_fault_pattern_A_alarm():
+    ctx = resolve_uns_path("Yaskawa A1000 alarm A0023")
+    assert ctx.fault_code == "A0023"
+
+
+def test_fault_pattern_OL_overload():
+    """OL bare code (overload). Previously only matched by dialogue_acts'
+    inline regex; now in resolver for parity."""
+    ctx = resolve_uns_path("PowerFlex 525 shows OL")
+    assert ctx.fault_code is not None
+    assert ctx.fault_code.upper() == "OL"
+
+
+def test_fault_pattern_UL_underload():
+    ctx = resolve_uns_path("Drive throws UL")
+    assert ctx.fault_code is not None
+    assert ctx.fault_code.upper() == "UL"
+
+
+def test_fault_pattern_AL_prefix():
+    ctx = resolve_uns_path("Siemens drive AL003")
+    # AL003 matches the AL-prefix pattern, not the bare A-pattern
+    assert ctx.fault_code is not None
+    assert "AL" in ctx.fault_code.upper() or ctx.fault_code == "AL003"
+
+
+# ---------------------------------------------------------------------------
+# Path-build correctness
+# ---------------------------------------------------------------------------
+
+
+def test_path_includes_fault_segment():
+    ctx = resolve_uns_path("PowerFlex 525 F0004")
+    assert ctx.uns_path is not None
+    assert "fault_codes" in ctx.uns_path
+
+
+def test_path_lowercase():
+    ctx = resolve_uns_path("PowerFlex 525 F0004")
+    assert ctx.uns_path is not None
+    assert ctx.uns_path == ctx.uns_path.lower()
+
+
+def test_path_no_path_without_vendor():
+    ctx = resolve_uns_path("F0004 fault")
+    assert ctx.uns_path is None  # no manufacturer → no path
+
+
+def test_path_manuals_category():
+    ctx = resolve_uns_path("Where is the PowerFlex 525 manual?")
+    assert ctx.manufacturer == "Rockwell Automation"
+    # category should detect manuals
+    assert ctx.category in ("manuals", "fault_codes")
+    # path may end in 'manuals' depending on category detection
+    assert ctx.uns_path is not None
+
+
+# ---------------------------------------------------------------------------
+# Dataclass round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_as_dict_round_trip():
+    ctx = resolve_uns_path("PowerFlex 525 F0004")
+    d = ctx.as_dict()
+    assert isinstance(d, dict)
+    restored = UNSContext.from_dict(d)
+    assert restored is not None
+    assert restored.manufacturer == ctx.manufacturer
+    assert restored.model == ctx.model
+    assert restored.fault_code == ctx.fault_code
+    assert restored.uns_path == ctx.uns_path
+
+
+def test_from_dict_none():
+    assert UNSContext.from_dict(None) is None
+    assert UNSContext.from_dict({}) is None
+
+
+def test_from_dict_tolerates_extra_keys():
+    """Forward-compat: extra keys are ignored, not crash."""
+    obj = UNSContext.from_dict({
+        "manufacturer": "Yaskawa",
+        "unknown_future_field": "ignored",
+        "model": "A1000",
+    })
+    assert obj is not None
+    assert obj.manufacturer == "Yaskawa"
+    assert obj.model == "A1000"
+
+
+# ---------------------------------------------------------------------------
+# Confidence bands
+# ---------------------------------------------------------------------------
+
+
+def test_confidence_mfr_model_fault():
+    ctx = resolve_uns_path("PowerFlex 525 F0004")
+    assert ctx.confidence == 0.9  # offline, no DB
+
+
+def test_confidence_mfr_model():
+    ctx = resolve_uns_path("PowerFlex 525 is humming")
+    assert ctx.confidence == 0.7
+
+
+def test_confidence_mfr_only():
+    ctx = resolve_uns_path("Rockwell drive problem")
+    # vendor-only confidence
+    assert ctx.confidence in (0.5, 0.7)  # 0.7 if it picks up something as model
+
+
+def test_confidence_fault_only():
+    ctx = resolve_uns_path("F0004 on the display")
+    assert ctx.confidence == 0.3
+
+
+def test_confidence_zero():
+    ctx = resolve_uns_path("just rambling about nothing")
+    assert ctx.confidence == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Alias table coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("alias,canonical", list(VENDOR_ALIASES.items()))
+def test_every_alias_resolves(alias, canonical):
+    """Every entry in VENDOR_ALIASES must resolve to its canonical name."""
+    ctx = resolve_uns_path(f"I have a {alias} drive")
+    assert ctx.manufacturer == canonical, (
+        f"alias {alias!r} should resolve to {canonical!r}, got {ctx.manufacturer!r}"
+    )
+
+
+def test_family_aliases_set_product_family():
+    for alias, family in FAMILY_FROM_ALIAS.items():
+        ctx = resolve_uns_path(f"my {alias} drive")
+        assert ctx.product_family == family, (
+            f"alias {alias!r} should set family to {family!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Offline guarantee — these must pass without a NeonDB connection
+# ---------------------------------------------------------------------------
+
+
+def test_state_roundtrip_via_session_manager(tmp_path):
+    """The resolver result must survive SQLite save/load.
+
+    `session_manager.save_state` only persists declared columns plus
+    `state["context"]` (JSON). The resolver must live under
+    `state["context"]["uns_context"]` — placing it at the top level would
+    silently drop it and break carry-over across turns.
+    """
+    import sys
+    from pathlib import Path
+
+    bots_root = Path(__file__).resolve().parents[1] / "mira-bots"
+    if str(bots_root) not in sys.path:
+        sys.path.insert(0, str(bots_root))
+    # session_manager is the production save/load path
+    from shared.session_manager import ensure_table, load_state, save_state
+
+    db_path = str(tmp_path / "uns_roundtrip.db")
+    ensure_table(db_path)
+
+    # Turn 1: write resolver result under state["context"]["uns_context"]
+    state = load_state(db_path, "chat_xyz")
+    state["state"] = "IDLE"
+    state["asset_identified"] = "Rockwell Automation, 525"
+    state["exchange_count"] = 1
+    ctx = resolve_uns_path("I have a powerflex 525 and it has it called f0004")
+    state["context"]["uns_context"] = ctx.as_dict()
+    save_state(db_path, "chat_xyz", state)
+
+    # Turn 2: reload and confirm uns_context survived
+    state2 = load_state(db_path, "chat_xyz")
+    uns2 = (state2.get("context") or {}).get("uns_context") or {}
+    assert uns2.get("manufacturer") == "Rockwell Automation"
+    assert uns2.get("model") == "525"
+    assert uns2.get("fault_code") == "F0004"
+
+    # Resolver can re-hydrate from the dict form and apply carry-over
+    turn2_ctx = resolve_uns_path("make a work order", prior_ctx=uns2)
+    assert turn2_ctx.manufacturer == "Rockwell Automation"
+    assert turn2_ctx.model == "525"
+    assert turn2_ctx.fault_code == "F0004"
+
+
+def test_offline_no_db_calls_required():
+    """The resolver must produce a useful result with no DB available."""
+    # This whole test file is offline already. Sanity-check that the
+    # core fields populate without any DB import succeeding.
+    ctx = resolve_uns_path("PowerFlex 525 F0004")
+    assert ctx.manufacturer == "Rockwell Automation"
+    assert ctx.model == "525"
+    assert ctx.fault_code == "F0004"
+    assert ctx.matched_entities == []  # no DB → no entities
+    assert ctx.matched_kb_count == 0
+    assert ctx.site_path is None
+
+
+def test_offline_unknown_vendor_unchanged():
+    ctx = resolve_uns_path("Acme 9000 drive is broken")
+    assert ctx.manufacturer is None
+    assert ctx.uns_path is None
+
+
+# ---------------------------------------------------------------------------
+# FAULT_PATTERNS exposure
+# ---------------------------------------------------------------------------
+
+
+def test_fault_patterns_exposed():
+    assert len(FAULT_PATTERNS) >= 4
+    # F-pattern should match F0004
+    assert FAULT_PATTERNS[0].search("F0004") is not None
+
+
+def test_vendor_aliases_exposed():
+    assert len(VENDOR_ALIASES) >= 25
+    assert "powerflex" in VENDOR_ALIASES
+    assert VENDOR_ALIASES["powerflex"] == "Rockwell Automation"

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -1,3 +1,11 @@
+# Hot Cache — 2026-05-13 — CHARLIE
+
+## eval-fixer run — 2026-05-13
+- Scorecard: 48/57 passing (84%) — source: `tests/eval/runs/2026-05-06T0833-offline-text.md` (unchanged since 2026-05-12)
+- Action: issue-filed (autopatch skipped — 3 file_clusters, hard stop)
+- Issue: https://github.com/Mikecranesync/MIRA/issues/1217 (duplicates pattern from #1187 — same scorecard, no new run)
+- Same 9 fixtures failing as 2026-05-12; scorecard has not refreshed. Nightly eval job may be stalled — check.
+
 # Hot Cache — 2026-05-12 — CHARLIE
 
 ## eval-fixer run — 2026-05-12


### PR DESCRIPTION
## Summary

Reintroduce the UNS message resolver from PR #1220 with the import boundary respected so the bot containers don't crash on first import.

PR #1220 was reverted in 80a17aab because `mira-bots/shared/uns_resolver.py` imported from `mira_crawler.ingest.uns`, which is not copied into the telegram/slack containers. The `try/except` fallback that used `importlib.util.spec_from_file_location` also failed inside the container (no `mira-crawler` on disk) and the bot crash-looped.

## What changed vs reverted PR #1220

| File | Change |
|------|--------|
| `mira-bots/shared/uns_paths.py` | **NEW** — pure, dep-free copy of the path-builder subset of `mira-crawler/ingest/uns.py` (110 lines, stdlib only). `slug`, `RESERVED_LABELS`, `manufacturer_path`, `model_path`, `family_path`, `manual_path`, `fault_code_path`. |
| `mira-bots/shared/uns_resolver.py` | Replace the `try: from mira_crawler.ingest import uns / except: importlib.util.spec_from_file_location(...)` block with `from . import uns_paths as _uns`. All `_uns.*` call sites unchanged. |
| Engine + worker + DST wiring | Cherry-picked verbatim from #1220 — no behavioural change. State stored under `state["context"]["uns_context"]` so it survives `session_manager.save_state`. |

Both `uns_paths.py` (bot) and `mira-crawler/ingest/uns.py` (crawler) must agree on the UNS path grammar. If grammar changes, update both. Out-of-sync would put the writer and reader on different addressing schemes.

## Why a copy instead of a refactor

The path builders are pure string helpers with zero external dependencies — 110 LOC. Extracting them into a shared third package would mean a new build target, a new `__init__.py`, and a new entry in every Dockerfile. A verbatim copy is the minimal-change fix and keeps the architecture contract (`tests/test_architecture.py::test_bots_cannot_import_crawler`) honest.

## Test plan

- [x] `pytest tests/test_architecture.py -v` (6/6) — including `test_bots_cannot_import_crawler`
- [x] `pytest tests/test_uns_resolver.py -v` (82/82) — Mike's regression case, every alias, every fault pattern, SQLite round-trip
- [x] `pytest tests/test_uns_work_order.py -v` (34/34)
- [x] `pytest tests/bot_regression.py -v` (18/18)
- [x] `ruff check` + `ruff format --check` on CI scope — clean
- [x] `docker build -t mira-bot-telegram-test -f mira-bots/telegram/Dockerfile .` — succeeds
- [x] `docker run --rm mira-bot-telegram-test python -c "from shared.uns_resolver import resolve_uns_path; print('OK')"` — **prints OK** (was the crash)
- [x] `docker run --rm mira-bot-telegram-test python -c "from shared.engine import Supervisor"` — imports cleanly
- [x] Mike's regression case inside the container:
  ```
  resolve_uns_path("I have a powerflex 525 and it has it called f0004")
  → mfr="Rockwell Automation", model="525", fault="F0004",
    path=enterprise.knowledge_base.rockwell_automation.powerflex.525.fault_codes.f0004
  ```
- [ ] CI green on all required checks before merge — no admin override
- [ ] Bot starts and reaches steady state on VPS post-deploy (no crash loop)

## Rollback plan

If the bot crash-loops again on deploy, revert immediately. The change is self-contained (4 files; resolver, paths, engine, workers) so revert is one commit and equivalent to the current state of `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)