### PR TITLE
fix(nginx): add Stripe to hub CSP — fixes Checkout ERR_CONNECTION_RESET (#995)

### DIFF
--- a/nginx-phase2-live.conf
+++ b/nginx-phase2-live.conf
@@ -22,7 +22,7 @@ server {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com https://apis.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://accounts.google.com https://api.hubapi.com; frame-src https://accounts.google.com;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com https://apis.google.com https://js.stripe.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://js.stripe.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://accounts.google.com https://api.hubapi.com https://api.stripe.com https://js.stripe.com; frame-src https://accounts.google.com https://js.stripe.com https://hooks.stripe.com;" always;
     client_max_body_size 100M;
 
     # /hub/* bookmark redirects — 301 permanent, remove after 2026-07-28 (90 days)


### PR DESCRIPTION
## Summary
- Hub CSP (`nginx-phase2-live.conf`) blocked Stripe's fingerprinted CSS chunks and JS when opening Checkout from `app.factorylm.com/pricing`
- Every "Start Free Trial" click hit `ERR_CONNECTION_RESET` on `js.stripe.com` CSS/frame assets
- Added Stripe origins to `script-src`, `style-src`, `connect-src`, and `frame-src` — matching the apex config that already whitelists these

## Fixes
Closes #995

## Changes
```diff
-script-src ... https://apis.google.com;
+script-src ... https://apis.google.com https://js.stripe.com;
-style-src ... https://fonts.googleapis.com;
+style-src ... https://fonts.googleapis.com https://js.stripe.com;
-connect-src 'self' https://accounts.google.com https://api.hubapi.com;
+connect-src 'self' https://accounts.google.com https://api.hubapi.com https://api.stripe.com https://js.stripe.com;
-frame-src https://accounts.google.com;
+frame-src https://accounts.google.com https://js.stripe.com https://hooks.stripe.com;
```

## Test plan
- [ ] Apply conf to VPS: `nginx -t && systemctl reload nginx`
- [ ] Visit `app.factorylm.com/pricing` → click "Start Free Trial" → Stripe Checkout opens without ERR_CONNECTION_RESET

🤖 Generated with [Claude Code](https://claude.com/claude-code)