### PR TITLE
security: strip RAG sentinel injection + add Stripe to hub CSP (#1007, #995)

### DIFF
--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -762,7 +762,9 @@ class RAGWorker:
                 label = format_source_label(chunk) or (chunk.get("equipment_type") or "unknown")
                 # Strip prompt-injection sentinel patterns before injection (#1007)
                 safe_content = _SENTINEL_RE.sub("[REF_DELIMITER]", chunk["content"])
-                system_content += f"--- [{i}] [Source: {label}] (score={score:.3f}) ---\n{safe_content}\n---\n"
+                system_content += (
+                    f"--- [{i}] [Source: {label}] (score={score:.3f}) ---\n{safe_content}\n---\n"
+                )
             system_content += "--- END NEONDB CONTEXT ---\n"
 
         messages = [{"role": "system", "content": system_content}]

--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -85,6 +85,16 @@ _FAULT_MENTION_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Strip prompt-injection delimiters from chunk text before LLM injection.
+# A crafted document containing these patterns could break the reference-block
+# boundary and inject instructions with system-role authority (#1007).
+_SENTINEL_RE = re.compile(
+    r"---\s*(?:END REFERENCES|END NEONDB CONTEXT|RETRIEVED REFERENCE DOCUMENTS"
+    r"|NEONDB KNOWLEDGE BASE|END GENERAL KNOWLEDGE MODE|END NO KB COVERAGE"
+    r"|CURRENT STATE)\s*---",
+    re.IGNORECASE,
+)
+
 
 def _build_clarification_request(message: str, asset_identified: str) -> str | None:
     """Return a targeted clarification question when the KB has no coverage.
@@ -618,6 +628,8 @@ class RAGWorker:
             else:
                 nc = _meta[i - 1] if i - 1 < len(_meta) else {}
                 text = chunk
+            # Strip prompt-injection sentinel patterns before injection (#1007)
+            text = _SENTINEL_RE.sub("[REF_DELIMITER]", text)
             label = format_source_label(nc)
             if label:
                 system_content += f"--- [{i}] [Source: {label}] ---\n{text}\n---\n"
@@ -748,7 +760,9 @@ class RAGWorker:
             for i, chunk in enumerate(neon_chunks, 1):
                 score = chunk.get("similarity") or 0.0
                 label = format_source_label(chunk) or (chunk.get("equipment_type") or "unknown")
-                system_content += f"--- [{i}] [Source: {label}] (score={score:.3f}) ---\n{chunk['content']}\n---\n"
+                # Strip prompt-injection sentinel patterns before injection (#1007)
+                safe_content = _SENTINEL_RE.sub("[REF_DELIMITER]", chunk["content"])
+                system_content += f"--- [{i}] [Source: {label}] (score={score:.3f}) ---\n{safe_content}\n---\n"
             system_content += "--- END NEONDB CONTEXT ---\n"
 
         messages = [{"role": "system", "content": system_content}]

--- a/mira-hub/src/middleware.ts
+++ b/mira-hub/src/middleware.ts
@@ -49,12 +49,12 @@ const authMiddleware = withAuth(
 function buildCsp(nonce: string): string {
   return [
     `default-src 'self'`,
-    `script-src 'self' 'nonce-${nonce}' https://accounts.google.com https://apis.google.com`,
-    `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com`,
+    `script-src 'self' 'nonce-${nonce}' https://accounts.google.com https://apis.google.com https://js.stripe.com`,
+    `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://js.stripe.com`,
     `font-src 'self' https://fonts.gstatic.com`,
     `img-src 'self' data: https:`,
-    `connect-src 'self' https://accounts.google.com https://api.hubapi.com`,
-    `frame-src https://accounts.google.com`,
+    `connect-src 'self' https://accounts.google.com https://api.hubapi.com https://api.stripe.com https://js.stripe.com`,
+    `frame-src https://accounts.google.com https://js.stripe.com https://hooks.stripe.com`,
   ].join("; ");
 }
 


### PR DESCRIPTION
## Summary

Two security/reliability fixes bundled:

### 1. RAG prompt injection via sentinel strings (closes #1007)

`rag_worker.py` injected raw chunk text into the system prompt without stripping prompt-boundary delimiters. A crafted OEM document containing `--- END REFERENCES ---` (or `--- END NEONDB CONTEXT ---`) could break the reference block and inject instructions with system-role authority into the LLM.

**Fix:** Added `_SENTINEL_RE` regex that strips known sentinel patterns from chunk text at both injection points (`_build_prompt_with_chunks` and `_build_prompt`) before concatenation into `system_content`. Matching text is replaced with `[REF_DELIMITER]` to preserve chunk structure without breaking formatting.

### 2. Stripe CSS/JS blocked by hub CSP (closes #995)

`middleware.ts` `buildCsp()` didn't include Stripe domains. Clicking "Start Free Trial" on `/pricing` hit `ERR_CONNECTION_RESET` on Stripe's fingerprinted CSS chunks from `js.stripe.com`.

**Fix:** Added Stripe origins to `script-src`, `style-src`, `connect-src`, and `frame-src` in `buildCsp()`. Previous PR #1241 fixed nginx-phase2-live.conf but was superseded by the CSP moving to Next.js middleware.

## Test plan
- [ ] CI passes (unit tests, lint, security scans)
- [ ] `bun test` in mira-hub passes  
- [ ] Visit `app.factorylm.com/pricing` → click "Start Free Trial" → Stripe Checkout loads without ERR_CONNECTION_RESET

🤖 Generated with [Claude Code](https://claude.com/claude-code)