### PR TITLE
fix(web): aria-hidden icon text + 1-day cache headers for static assets (#1100, #1096)

### DIFF
--- a/mira-web/public/mira-chat.js
+++ b/mira-web/public/mira-chat.js
@@ -63,8 +63,8 @@
     camera: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" width="18" height="18"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><circle cx="12" cy="13" r="4" stroke="currentColor" stroke-width="1.6"/></svg>',
     speaker: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" width="14" height="14"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>',
     speakeroff: '<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" width="14" height="14"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><line x1="23" y1="9" x2="17" y2="15" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/><line x1="17" y1="9" x2="23" y2="15" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>',
-    minimize: '—',
-    close: '×',
+    minimize: '<span aria-hidden="true">—</span>',
+    close: '<span aria-hidden="true">×</span>',
   };
 
   // ── Build DOM ─────────────────────────────────────────────

--- a/mira-web/src/server.ts
+++ b/mira-web/src/server.ts
@@ -287,6 +287,18 @@ if (process.env.NODE_ENV !== "test" && process.env.MIRA_DISABLE_PURGE_WORKER !==
 // Static files
 // ---------------------------------------------------------------------------
 
+// Cache static assets for 1 day. These files are not content-hash fingerprinted,
+// so we stay conservative rather than using immutable/max-age=31536000.
+app.use(async (c, next) => {
+  await next();
+  const path = c.req.path;
+  if (/\.(js|css|png|jpg|jpeg|svg|webp|woff2?|ttf|ico)$/i.test(path)) {
+    if (!c.res.headers.get("Cache-Control")) {
+      c.header("Cache-Control", "public, max-age=86400");
+    }
+  }
+});
+
 app.use("/public/*", serveStatic({ root: "./" }));
 // Marketing/site imagery served at the conventional /images/* path so the
 // landing page can reference assets the way every other web app does


### PR DESCRIPTION
## Summary

- **#1100 (a11y WCAG 2.5.3):** The chat widget's minimize (`—`) and close (`×`) buttons had `aria-label` values that didn't contain their visible text characters, triggering Lighthouse's label-content-name-mismatch audit. Fixed by wrapping the icon characters in `<span aria-hidden="true">` so the `aria-label` is the sole accessible name.
- **#1096 (cache headers):** Static assets (JS, CSS, images, fonts) were served with no `Cache-Control` header. Added a Hono middleware that sets `Cache-Control: public, max-age=86400` on any response for a static file extension that hasn't already set a cache header. Repeat visitors now get a 1-day cache benefit (~3,335 KiB savings per Lighthouse estimate).

## Test plan
- [ ] Existing test suite passes (pre-existing 14 failures in view tests are unrelated)
- [ ] `curl -sI https://factorylm.com/mira-chat.js` shows `Cache-Control: public, max-age=86400` after deploy
- [ ] Lighthouse label-content-name-mismatch audit passes on factorylm.com /

🤖 Generated with [Claude Code](https://claude.com/claude-code)