### PR TITLE
fix(nginx): route mira-web static assets to avoid 404s on /pricing (#1116)

### DIFF
--- a/nginx-phase2-live.conf
+++ b/nginx-phase2-live.conf
@@ -276,6 +276,22 @@ Sitemap: https://app.factorylm.com/sitemap.xml
 ";
     }
 
+    # mira-web static assets needed by /pricing page (CRA-121/#1116)
+    # Without these, root-relative asset paths (/posthog-init.js, /public/*)
+    # in pricing.html fall through to mira-hub and get 404s → console errors.
+    location = /posthog-init.js {
+        proxy_pass http://127.0.0.1:3200/posthog-init.js;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Cache-Control "public, max-age=3600" always;
+    }
+    location /public/ {
+        proxy_pass http://127.0.0.1:3200/public/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        add_header Cache-Control "public, max-age=86400" always;
+    }
+
     # mira-hub — Phase 2: hub serves at root (rebuilt with basePath='')
     location / {
         proxy_pass http://127.0.0.1:3101;


### PR DESCRIPTION
## Summary

When `pricing.html` loads at `app.factorylm.com/pricing`, its root-relative asset requests (`/posthog-init.js`, `/public/icons/...`) fall through to the mira-hub catch-all location and get 404s. These 404s trigger Lighthouse's `errors-in-console` audit failure (score 0).

- Added `location = /posthog-init.js` → proxies to mira-web:3200 with 1-hour cache
- Added `location /public/` → proxies to mira-web:3200 with 1-day cache

Both location blocks are placed before the `location /` catch-all so they take precedence.

## Deploy

```bash
scp nginx-phase2-live.conf factorylm-prod:/etc/nginx/sites-enabled/mira
ssh factorylm-prod "nginx -t && nginx -s reload"
```

## Test plan
- [ ] `curl -sI https://app.factorylm.com/posthog-init.js` returns 200
- [ ] `curl -sI https://app.factorylm.com/public/icons/favicon.svg` returns 200
- [ ] Browser devtools on `/pricing` shows no 404 console errors
- [ ] Lighthouse `errors-in-console` score improves on `/pricing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)