### PR TITLE
feat(uns): ISA-95 path backfill — migrations 014/015 + tools + MCP tools

### DIFF
--- a/mira-hub/db/migrations/014_uns_path_backfill.sql
+++ b/mira-hub/db/migrations/014_uns_path_backfill.sql
@@ -1,0 +1,123 @@
+BEGIN;
+
+-- Migration 014: Idempotent SQL-side backfill of kg_entities.uns_path.
+--
+-- Spec: docs/specs/uns-kg-unification-spec.md §3.1 (knowledge-base branch)
+-- Companion: mira-crawler/ingest/uns.py (path grammar, slug rules)
+-- Prior migration: 010_kg_uns_path.sql added the ltree column + GIST indexes.
+--
+-- What this fills:
+--   * kg_entities rows with NULL uns_path that have enough metadata in
+--     `properties` jsonb to compute the catalog-side path
+--     `enterprise.knowledge_base.{mfr}.{family?}.{model}`.
+--
+-- What it deliberately does NOT fill:
+--   * Site-side instance paths (those need ISA-95 hierarchy that lives
+--     on cmms_equipment — see migration 015 + tools/cmms_equipment_uns_backfill.py).
+--   * Rows with no manufacturer info — leave NULL so the Python
+--     orchestrator (tools/uns_backfill.py) can report orphans.
+--
+-- Idempotent: only updates rows where uns_path IS NULL. Re-running is a
+-- no-op for any row that already has a path. The Python orchestrator
+-- in tools/uns_backfill.py is responsible for the richer cases
+-- (creating entities from knowledge_entries pairs and linking chunks).
+
+-- ───────────────────────────────────────────────────────────────────────
+-- Slug helper — mirrors mira-crawler/ingest/uns.py:slug()
+-- ───────────────────────────────────────────────────────────────────────
+-- Lowercases, collapses runs of non-alphanumeric to `_`, strips
+-- leading/trailing `_`. Returns NULL if nothing usable remains so
+-- COALESCE chains can fall through to a default segment.
+
+CREATE OR REPLACE FUNCTION uns_slug(value text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+  SELECT NULLIF(
+    trim(BOTH '_' FROM regexp_replace(lower(coalesce(value, '')), '[^a-z0-9]+', '_', 'g')),
+    ''
+  )
+$$;
+
+-- ───────────────────────────────────────────────────────────────────────
+-- Build a knowledge-base UNS path from manufacturer / family / model.
+-- Returns NULL when manufacturer is missing — caller decides what to do
+-- with orphans.
+-- ───────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION uns_kb_path(manufacturer text, family text, model text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+  SELECT CASE
+    WHEN uns_slug(manufacturer) IS NULL THEN NULL
+    ELSE concat_ws(
+      '.',
+      'enterprise',
+      'knowledge_base',
+      uns_slug(manufacturer),
+      uns_slug(family),
+      uns_slug(model)
+    )
+  END
+$$;
+
+-- ───────────────────────────────────────────────────────────────────────
+-- Backfill pass: equipment / manual / fault_code / pm_schedule entities.
+-- Pulls manufacturer / family / model out of the properties jsonb the
+-- crawler stamps on every kg_entities row. Rows without enough info
+-- stay NULL.
+-- ───────────────────────────────────────────────────────────────────────
+
+UPDATE kg_entities
+   SET uns_path = uns_kb_path(
+         properties ->> 'manufacturer',
+         properties ->> 'family',
+         coalesce(properties ->> 'model', properties ->> 'model_number')
+       )::ltree
+ WHERE uns_path IS NULL
+   AND entity_type IN ('equipment', 'manual', 'fault_code', 'pm_schedule', 'parts_list')
+   AND uns_kb_path(
+         properties ->> 'manufacturer',
+         properties ->> 'family',
+         coalesce(properties ->> 'model', properties ->> 'model_number')
+       ) IS NOT NULL;
+
+-- Manuals/fault_codes/pm_schedules nest one level deeper than the
+-- equipment row. The orchestrator (tools/uns_backfill.py) writes the
+-- nested paths when it creates entities; this SQL pass only handles
+-- the equipment-level default. The richer logic stays in Python where
+-- the slug rules already live and can stay in sync with uns.py.
+
+-- ───────────────────────────────────────────────────────────────────────
+-- Audit view: surface what still needs attention.
+-- ───────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE VIEW kg_entities_uns_orphans AS
+SELECT id,
+       tenant_id,
+       entity_type,
+       name,
+       properties ->> 'manufacturer' AS manufacturer,
+       properties ->> 'model'        AS model,
+       created_at
+  FROM kg_entities
+ WHERE uns_path IS NULL;
+
+COMMENT ON VIEW kg_entities_uns_orphans IS
+'Entities without a uns_path — typically missing manufacturer/model. '
+'tools/uns_backfill.py reports these.';
+
+COMMIT;
+
+-- ─── Rollback ─────────────────────────────────────────────────────────
+-- DROP VIEW IF EXISTS kg_entities_uns_orphans;
+-- DROP FUNCTION IF EXISTS uns_kb_path(text, text, text);
+-- DROP FUNCTION IF EXISTS uns_slug(text);
+-- -- uns_path values backfilled by this migration can be reset with:
+-- --   UPDATE kg_entities SET uns_path = NULL
+-- --    WHERE entity_type IN ('equipment','manual','fault_code','pm_schedule','parts_list');

--- a/mira-hub/db/migrations/015_equipment_uns_path.sql
+++ b/mira-hub/db/migrations/015_equipment_uns_path.sql
@@ -1,0 +1,49 @@
+BEGIN;
+
+-- Migration 015: ISA-95 UNS path on cmms_equipment.
+--
+-- Spec: docs/specs/uns-kg-unification-spec.md §3.1 (per-company site
+-- hierarchy) — every cmms_equipment row gets a queryable ltree
+-- address so the Hub can answer "show me everything in site X, area Y"
+-- with a single index scan instead of multi-column WHERE chains.
+--
+-- Path grammar (per mira-crawler/ingest/uns.py:assigned_equipment_path):
+--   enterprise.{tenant}.site.{site}.area.{area}[.line.{line}[.work_cell.{cell}]].equipment.{eq_number}
+--
+-- The ISA-95 literal markers (`site`, `area`, `line`, `work_cell`,
+-- `equipment`) alternate with dynamic instance labels — that's what
+-- makes the tree explorable one level at a time.
+--
+-- This migration only adds the column + index. The backfill that
+-- populates it for existing rows lives in
+-- tools/cmms_equipment_uns_backfill.py — separate so the slug logic
+-- stays in one place (the Python helper module).
+
+CREATE EXTENSION IF NOT EXISTS ltree;
+-- btree_gist required for the compound (tenant_id, uns_path) GIST
+-- index — uuid has no default GIST opclass otherwise.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+ALTER TABLE cmms_equipment
+  ADD COLUMN IF NOT EXISTS uns_path ltree;
+
+CREATE INDEX IF NOT EXISTS idx_cmms_equipment_uns_path
+  ON cmms_equipment USING GIST (uns_path);
+
+-- Compound GIST so "tenant_id = X AND uns_path <@ Y" satisfies in one
+-- index scan. Mirrors the kg_entities pattern from migration 010.
+CREATE INDEX IF NOT EXISTS idx_cmms_equipment_tenant_uns_path
+  ON cmms_equipment USING GIST (tenant_id, uns_path);
+
+COMMENT ON COLUMN cmms_equipment.uns_path IS
+'ISA-95 Unified Namespace address: enterprise.{tenant}.site.{s}.area.{a}'
+'[.line.{l}[.work_cell.{c}]].equipment.{eq}. Populated by '
+'tools/cmms_equipment_uns_backfill.py for legacy rows; the Hub '
+'POST /api/assets path is responsible for stamping it on new rows.';
+
+COMMIT;
+
+-- ─── Rollback ─────────────────────────────────────────────────────────
+-- DROP INDEX IF EXISTS idx_cmms_equipment_tenant_uns_path;
+-- DROP INDEX IF EXISTS idx_cmms_equipment_uns_path;
+-- ALTER TABLE cmms_equipment DROP COLUMN IF EXISTS uns_path;

--- a/mira-mcp/kg_client.py
+++ b/mira-mcp/kg_client.py
@@ -57,21 +57,54 @@ def _post(op: str, tenant_id: str, args: dict[str, Any]) -> Any:
 
 def maintenance_context(
     tenant_id: str,
-    equipment_entity_id: str,
+    equipment_entity_id: str = "",
     *,
+    uns_path: Optional[str] = None,
     include_similar: bool = False,
     fault_window_days: Optional[int] = None,
     max_work_orders: Optional[int] = None,
 ) -> Any:
-    args: dict[str, Any] = {
-        "equipmentEntityId": equipment_entity_id,
-        "includeSimilar": include_similar,
-    }
+    """Aggregated maintenance context. Pass `equipment_entity_id` OR `uns_path`.
+
+    The hub-side `resolveEntityArg` accepts either an entity UUID or an
+    `unsPath` ltree address — see mira-hub/src/app/api/internal/kg/route.ts.
+    """
+    args: dict[str, Any] = {"includeSimilar": include_similar}
+    if equipment_entity_id:
+        args["equipmentEntityId"] = equipment_entity_id
+    if uns_path:
+        args["unsPath"] = uns_path
     if fault_window_days is not None:
         args["faultWindowDays"] = fault_window_days
     if max_work_orders is not None:
         args["maxWorkOrders"] = max_work_orders
     return _post("maintenance_context", tenant_id, args)
+
+
+def resolve_uns_path(tenant_id: str, uns_path: str) -> Any:
+    """Resolve an ltree UNS path to a kg_entities row.
+
+    Returns the entity record (id, entity_type, name, uns_path, properties)
+    or raises KgClientError if no match. Hub op: `resolve_uns_path`.
+    """
+    return _post("resolve_uns_path", tenant_id, {"unsPath": uns_path})
+
+
+def entities_under_uns_path(
+    tenant_id: str,
+    uns_path: str,
+    *,
+    limit: Optional[int] = None,
+) -> Any:
+    """List entities living under a UNS subtree (descendants of `uns_path`).
+
+    Uses Postgres ltree `<@` (is-descendant) on the hub side. Hub op:
+    `entities_under_uns_path`.
+    """
+    args: dict[str, Any] = {"unsPath": uns_path}
+    if limit is not None:
+        args["limit"] = limit
+    return _post("entities_under_uns_path", tenant_id, args)
 
 
 def impact_analysis(tenant_id: str, entity_id: str) -> Any:

--- a/mira-mcp/server.py
+++ b/mira-mcp/server.py
@@ -619,11 +619,17 @@ async def get_agent_status() -> dict:
 @mcp.tool
 def kg_maintenance_context(
     tenant_id: str,
-    equipment_entity_id: str,
+    equipment_entity_id: str = "",
+    uns_path: str = "",
     include_similar: bool = False,
     fault_window_days: int = 90,
 ) -> dict:
     """Aggregated maintenance context for one piece of equipment.
+
+    Pass `equipment_entity_id` (kg_entities.id UUID) OR `uns_path` (ltree
+    address, e.g. `enterprise.stardust_racers.site.garage_factory.area.
+    conveyor_lab.line.line1.work_cell.conveyor_cell.equipment.conveyor_b16`).
+    The hub resolves the path to a kg_entities row.
 
     Returns hierarchy (plant/area/line), components, recent faults (with
     counts in window), recent work orders, parts, manuals, PM schedule,
@@ -632,12 +638,16 @@ def kg_maintenance_context(
     """
     from kg_client import KgClientError, maintenance_context
 
+    if not equipment_entity_id and not uns_path:
+        return {"ok": False, "error": "pass equipment_entity_id or uns_path"}
+
     try:
         return {
             "ok": True,
             "result": maintenance_context(
                 tenant_id,
                 equipment_entity_id,
+                uns_path=uns_path or None,
                 include_similar=include_similar,
                 fault_window_days=fault_window_days,
             ),
@@ -723,6 +733,70 @@ def kg_flag_pm_mismatches(
                 tenant_id,
                 lookback_days=lookback_days,
                 equipment_entity_id=equipment_entity_id or None,
+            ),
+        }
+    except KgClientError as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+@mcp.tool
+def mira_browse_namespace(tenant_id: str, uns_path: str, limit: int = 100) -> dict:
+    """Browse the UNS tree under an ltree path. Returns the descendant
+    entities (`<@` ltree query) so the caller can render a tree view or
+    step one level deeper.
+
+    Path grammar lives in mira-crawler/ingest/uns.py — ISA-95 literal
+    markers (`site`, `area`, `line`, `work_cell`, `equipment`) alternate
+    with dynamic instance labels.
+
+    Examples:
+        mira_browse_namespace(tid, "enterprise.knowledge_base")
+            → every catalog manufacturer
+        mira_browse_namespace(tid, "enterprise.knowledge_base.rockwell_automation")
+            → families / models under Rockwell
+        mira_browse_namespace(tid, "enterprise.stardust_racers.site.garage_factory")
+            → areas, lines, equipment under that site
+    """
+    from kg_client import KgClientError, entities_under_uns_path
+
+    try:
+        return {
+            "ok": True,
+            "result": entities_under_uns_path(tenant_id, uns_path, limit=limit),
+        }
+    except KgClientError as exc:
+        return {"ok": False, "error": str(exc)}
+
+
+@mcp.tool
+def mira_get_equipment(
+    tenant_id: str,
+    uns_path: str = "",
+    equipment_entity_id: str = "",
+    fault_window_days: int = 90,
+) -> dict:
+    """Get equipment + components + linked docs by UNS path (or entity UUID).
+
+    Resolves the UNS path to a kg_entities row and returns the same
+    payload as `kg_maintenance_context`: hierarchy, components, recent
+    faults, work orders, parts, manuals, PM schedule, and plan-vs-actual
+    mismatches.
+
+    Pass exactly one of `uns_path` or `equipment_entity_id`.
+    """
+    from kg_client import KgClientError, maintenance_context
+
+    if not uns_path and not equipment_entity_id:
+        return {"ok": False, "error": "pass uns_path or equipment_entity_id"}
+
+    try:
+        return {
+            "ok": True,
+            "result": maintenance_context(
+                tenant_id,
+                equipment_entity_id,
+                uns_path=uns_path or None,
+                fault_window_days=fault_window_days,
             ),
         }
     except KgClientError as exc:

--- a/tools/cmms_equipment_uns_backfill.py
+++ b/tools/cmms_equipment_uns_backfill.py
@@ -1,0 +1,219 @@
+"""Backfill cmms_equipment.uns_path using the ISA-95 hierarchy.
+
+Spec: docs/specs/uns-kg-unification-spec.md §3.1 (per-company site
+hierarchy).
+Helper module: mira-crawler/ingest/uns.py (path grammar, slug rules).
+Schema: migration 015_equipment_uns_path.sql adds the column.
+
+Path grammar:
+    enterprise.{tenant}.site.{site}.area.{area}[.line.{line}
+        [.work_cell.{cell}]].equipment.{equipment_number}
+
+cmms_equipment doesn't carry first-class site/area/line/work_cell
+columns yet — that's a future schema change. For now we derive the
+hierarchy from the existing free-form fields:
+
+    site   ← location  (or "unassigned" if NULL)
+    area   ← department (or "unassigned" if NULL)
+    line   ← omitted (no source column)
+    cell   ← omitted (no source column)
+
+This produces a valid ltree path for every row and keeps the
+ISA-95 marker structure that the Hub UNS browser walks. When the
+schema grows real columns, this script's `_derive_path()` helper
+is the single spot to update.
+
+Idempotent: only writes rows where uns_path IS NULL, OR where
+`--force` is passed and the computed path differs from the current
+value.
+
+Usage:
+    python tools/cmms_equipment_uns_backfill.py                    # dry-run
+    python tools/cmms_equipment_uns_backfill.py --commit           # apply
+    python tools/cmms_equipment_uns_backfill.py --commit --force   # recompute all
+    python tools/cmms_equipment_uns_backfill.py --tenant T1 --commit
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
+# The crawler ships its ingest module both ways depending on context;
+# the dev workstation path uses the hyphenated directory.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "mira-crawler"))
+from ingest.uns import (  # noqa: E402
+    assigned_equipment_path,
+    is_valid_path,
+    slug,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("cmms-uns-backfill")
+
+
+@dataclass
+class Stats:
+    scanned: int = 0
+    updated: int = 0
+    unchanged: int = 0
+    skipped_invalid: int = 0
+
+
+def _engine():
+    url = os.getenv("NEON_DATABASE_URL")
+    if not url:
+        raise RuntimeError("NEON_DATABASE_URL not set")
+    return create_engine(
+        url,
+        poolclass=NullPool,
+        connect_args={"sslmode": "require"},
+        pool_pre_ping=True,
+    )
+
+
+def _derive_path(
+    tenant_id: str,
+    equipment_number: str | None,
+    location: str | None,
+    department: str | None,
+    asset_id: str,
+) -> str | None:
+    """Build the UNS path for a single cmms_equipment row.
+
+    Returns None when the row lacks enough structure to form a valid
+    ltree label (e.g. equipment_number is NULL and the UUID slug is
+    also blank — shouldn't happen but defensive against bad data).
+    """
+    tenant_slug = slug(tenant_id) or "unassigned"
+    site_slug = slug(location or "") or "unassigned"
+    area_slug = slug(department or "") or "unassigned"
+    eq_slug = slug(equipment_number or "") or slug(asset_id)
+    if not eq_slug:
+        return None
+
+    path = assigned_equipment_path(
+        company=tenant_slug,
+        site=site_slug,
+        area=area_slug,
+        equipment_id=eq_slug,
+    )
+    return path if is_valid_path(path) else None
+
+
+def run(tenant: str | None, batch_size: int, commit: bool, force: bool) -> Stats:
+    engine = _engine()
+    stats = Stats()
+
+    where: list[str] = []
+    params: dict = {}
+    if tenant:
+        where.append("tenant_id = :tenant")
+        params["tenant"] = tenant
+    if not force:
+        where.append("uns_path IS NULL")
+    where_sql = (" WHERE " + " AND ".join(where)) if where else ""
+
+    select_sql = f"""
+        SELECT id::text       AS id,
+               tenant_id,
+               equipment_number,
+               location,
+               department,
+               uns_path::text  AS current_path
+          FROM cmms_equipment
+          {where_sql}
+         ORDER BY tenant_id, id
+    """
+
+    with engine.connect() as c:
+        rows = list(c.execute(text(select_sql), params))
+
+    log.info("scanned %d cmms_equipment rows%s", len(rows), " (forcing recompute)" if force else "")
+
+    pending: list[tuple[str, str]] = []  # (id, new_path)
+
+    for r in rows:
+        stats.scanned += 1
+        new_path = _derive_path(
+            tenant_id=r.tenant_id,
+            equipment_number=r.equipment_number,
+            location=r.location,
+            department=r.department,
+            asset_id=r.id,
+        )
+        if not new_path:
+            stats.skipped_invalid += 1
+            log.debug("skipping %s — no valid path could be derived", r.id)
+            continue
+        if r.current_path == new_path:
+            stats.unchanged += 1
+            continue
+        pending.append((r.id, new_path))
+
+    if not commit:
+        log.warning("DRY-RUN — %d rows would be updated. Pass --commit to apply.", len(pending))
+        for asset_id, new_path in pending[:10]:
+            log.info("  would set %s → %s", asset_id, new_path)
+        if len(pending) > 10:
+            log.info("  … and %d more", len(pending) - 10)
+        return stats
+
+    for start in range(0, len(pending), batch_size):
+        chunk = pending[start : start + batch_size]
+        with engine.begin() as c:
+            for asset_id, new_path in chunk:
+                c.execute(
+                    text(
+                        "UPDATE cmms_equipment "
+                        "   SET uns_path = :p::ltree "
+                        " WHERE id = :id::uuid"
+                    ),
+                    {"p": new_path, "id": asset_id},
+                )
+        stats.updated += len(chunk)
+        log.info("committed %d / %d", stats.updated, len(pending))
+
+    return stats
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--tenant", help="Restrict backfill to one tenant_id")
+    p.add_argument("--batch-size", type=int, default=500)
+    p.add_argument(
+        "--commit",
+        action="store_true",
+        help="Apply writes (default = dry-run)",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="Recompute uns_path even for rows that already have one",
+    )
+    args = p.parse_args()
+
+    stats = run(args.tenant, args.batch_size, args.commit, args.force)
+
+    log.info("=== CMMS UNS BACKFILL %s ===", "COMMIT" if args.commit else "DRY-RUN")
+    log.info("  rows scanned:     %d", stats.scanned)
+    log.info("  rows updated:     %d", stats.updated)
+    log.info("  rows unchanged:   %d", stats.unchanged)
+    log.info("  rows skipped:     %d (no valid path could be derived)", stats.skipped_invalid)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/uns_backfill.py
+++ b/tools/uns_backfill.py
@@ -1,0 +1,190 @@
+"""kg_entities UNS-path backfill orchestrator.
+
+Spec: docs/specs/uns-kg-unification-spec.md §3.1 (knowledge-base branch).
+Companion: mira-crawler/ingest/uns.py (path grammar).
+
+Two backfill paths exist in the repo today; this script is the
+single entry point that runs them in the right order and reports
+the counts the spec's acceptance criteria call for:
+
+1. SQL pass — mira-hub/db/migrations/014_uns_path_backfill.sql
+   Fills uns_path on any pre-existing kg_entities row that has
+   manufacturer info in its properties jsonb but no path yet.
+
+2. Entity creation pass — tools/migrations/backfill_equipment_entities.py
+   Walks knowledge_entries to discover (manufacturer, model) pairs,
+   upserts equipment + manual entities at the right kb path, and
+   links chunks via knowledge_entries.equipment_entity_id.
+
+Output format:
+    entities_created   — new kg_entities rows written
+    entries_linked     — knowledge_entries rows that got equipment_entity_id
+    entries_orphaned   — knowledge_entries rows with no manufacturer/model
+    entities_unpathed  — kg_entities still missing uns_path after both passes
+
+Idempotent: re-running is safe. The SQL pass touches only rows where
+uns_path IS NULL; the entity-creation pass already uses ON CONFLICT
+DO NOTHING upserts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.pool import NullPool
+
+# Reuse the existing entity-creation pass — don't reimplement.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+from tools.migrations import backfill_equipment_entities  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%H:%M:%S",
+)
+log = logging.getLogger("uns-backfill")
+
+
+@dataclass
+class Counts:
+    entities_created: int = 0
+    entries_linked: int = 0
+    entries_orphaned: int = 0
+    entities_unpathed: int = 0
+
+
+def _engine():
+    url = os.getenv("NEON_DATABASE_URL")
+    if not url:
+        raise RuntimeError("NEON_DATABASE_URL not set")
+    return create_engine(
+        url,
+        poolclass=NullPool,
+        connect_args={"sslmode": "require"},
+        pool_pre_ping=True,
+    )
+
+
+def _count_orphans(engine, tenant: str | None) -> int:
+    sql = """
+        SELECT count(*) FROM knowledge_entries
+         WHERE equipment_entity_id IS NULL
+           AND (manufacturer IS NULL OR manufacturer = ''
+                OR model_number IS NULL OR model_number = '')
+    """
+    params: dict = {}
+    if tenant:
+        sql += " AND tenant_id = :tenant"
+        params["tenant"] = tenant
+    with engine.connect() as c:
+        return int(c.execute(text(sql), params).scalar() or 0)
+
+
+def _count_unpathed(engine, tenant: str | None) -> int:
+    sql = "SELECT count(*) FROM kg_entities WHERE uns_path IS NULL"
+    params: dict = {}
+    if tenant:
+        sql += " AND tenant_id = :tenant"
+        params["tenant"] = tenant
+    with engine.connect() as c:
+        return int(c.execute(text(sql), params).scalar() or 0)
+
+
+def _apply_sql_pass(engine) -> None:
+    """Run migration 014 against the active database.
+
+    This is intentionally separate from the canonical migration runner
+    so the orchestrator can be invoked ad-hoc without touching the
+    full migration pipeline. Idempotent.
+    """
+    migration = REPO_ROOT / "mira-hub" / "db" / "migrations" / "014_uns_path_backfill.sql"
+    if not migration.exists():
+        raise RuntimeError(f"migration not found: {migration}")
+    sql = migration.read_text()
+    with engine.begin() as c:
+        # The file already wraps itself in BEGIN/COMMIT — strip them so
+        # SQLAlchemy's transaction is the only one in play.
+        cleaned = sql.replace("BEGIN;", "").replace("COMMIT;", "")
+        for stmt in _split_statements(cleaned):
+            if stmt.strip():
+                c.execute(text(stmt))
+    log.info("SQL pass complete (migration 014)")
+
+
+def _split_statements(sql: str) -> list[str]:
+    """Split on `;` outside dollar-quoted blocks. PL/pgSQL bodies between
+    matching `$$ ... $$` are kept intact. Good enough for our migration
+    files — they don't nest dollar-tags."""
+    parts: list[str] = []
+    buf: list[str] = []
+    in_dollar = False
+    for line in sql.splitlines():
+        stripped = line.strip()
+        if "$$" in stripped:
+            # Toggle for each occurrence on the line.
+            occ = stripped.count("$$")
+            for _ in range(occ):
+                in_dollar = not in_dollar
+            buf.append(line)
+            continue
+        if not in_dollar and stripped.endswith(";"):
+            buf.append(line)
+            parts.append("\n".join(buf))
+            buf = []
+        else:
+            buf.append(line)
+    if buf:
+        parts.append("\n".join(buf))
+    return parts
+
+
+def run(tenant: str | None, batch_size: int, commit: bool) -> Counts:
+    engine = _engine()
+    counts = Counts()
+
+    if commit:
+        log.info("Applying SQL backfill (migration 014)…")
+        _apply_sql_pass(engine)
+    else:
+        log.warning("DRY-RUN — skipping SQL pass. Pass --commit to apply.")
+
+    log.info("Running entity-creation pass (backfill_equipment_entities)…")
+    stats = backfill_equipment_entities.run(tenant, batch_size, commit)
+    counts.entities_created = stats.equipment_upserted + stats.manuals_upserted
+    counts.entries_linked = stats.chunks_linked
+
+    counts.entries_orphaned = _count_orphans(engine, tenant)
+    counts.entities_unpathed = _count_unpathed(engine, tenant)
+    return counts
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--tenant", help="Restrict backfill to one tenant_id")
+    p.add_argument("--batch-size", type=int, default=1000)
+    p.add_argument(
+        "--commit",
+        action="store_true",
+        help="Apply writes (default = dry-run)",
+    )
+    args = p.parse_args()
+
+    counts = run(args.tenant, args.batch_size, args.commit)
+
+    log.info("=== UNS BACKFILL %s ===", "COMMIT" if args.commit else "DRY-RUN")
+    log.info("  entities created:    %d", counts.entities_created)
+    log.info("  entries linked:      %d", counts.entries_linked)
+    log.info("  entries orphaned:    %d", counts.entries_orphaned)
+    log.info("  entities unpathed:   %d", counts.entities_unpathed)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phase 2 of the UNS+KG unification — see [`docs/specs/uns-kg-unification-spec.md`](docs/specs/uns-kg-unification-spec.md) (§3.1 path grammar, §4.2 backfill, §6 readiness). Builds on migration 010 which already added `uns_path ltree` on `kg_entities`.

**Migrations** (SQL only — NOT applied to NeonDB):
- `mira-hub/db/migrations/014_uns_path_backfill.sql` — SQL helpers (`uns_slug`, `uns_kb_path`) + idempotent UPDATE that fills `uns_path` on existing `kg_entities` rows using manufacturer/family/model from `properties` jsonb. Creates `kg_entities_uns_orphans` view surfacing rows that still need attention.
- `mira-hub/db/migrations/015_equipment_uns_path.sql` — adds `uns_path ltree` + GIST indexes on `cmms_equipment`, mirroring the kg_entities pattern.

**Backfill scripts** (dry-run by default; `--commit` to apply):
- `tools/uns_backfill.py` — orchestrator. Applies migration 014, then delegates to existing `tools/migrations/backfill_equipment_entities.py` for entity creation + `knowledge_entries` linking. Reports `entities_created`, `entries_linked`, `entries_orphaned`, `entities_unpathed`.
- `tools/cmms_equipment_uns_backfill.py` — backfills `cmms_equipment.uns_path` using ISA-95 hierarchy via `mira-crawler/ingest/uns.assigned_equipment_path` (site←location, area←department, defaults to `unassigned`). Idempotent.

**MCP tools** (`mira-mcp/server.py` + `kg_client.py`):
- `mira_browse_namespace(tenant_id, uns_path, limit)` — wraps the existing hub `entities_under_uns_path` op for tree exploration.
- `mira_get_equipment(tenant_id, uns_path|equipment_entity_id)` — wraps `maintenance_context` with UNS path resolution.
- `kg_maintenance_context` — now also accepts `uns_path` alongside `equipment_entity_id`.

## Reconciliation notes for reviewer

- The spec named in the original task (\`isa95-protocol-agnostic-uns-spec.md\`) does **not** exist. This work follows the existing approved `docs/specs/uns-kg-unification-spec.md` and its companion `uns-kg-standards-compliance.md`. No new spec doc written.
- Migration numbers **013/014** in the task collide with the already-merged `013_external_ids.sql`. Used **014/015** instead, placed in `mira-hub/db/migrations/` to match existing layout.
- The Stardust example in the task (`...work_cell.conveyor_cell.conveyor_b16`) is missing the `.equipment.` literal marker that `mira-crawler/ingest/uns.py:assigned_equipment_path` mandates. Followed canonical grammar: `...work_cell.conveyor_cell.equipment.conveyor_b16`.
- `cmms_equipment` lacks first-class `site/area/line/work_cell` columns. Backfill derives them from existing `location`/`department` fields. When the schema grows real columns, `_derive_path()` in `tools/cmms_equipment_uns_backfill.py` is the one spot to update.
- The Hub `/api/uns/browse` route already uses ltree operators (`uns_path ~ \$::lquery`, `subpath`, `nlevel`) with depth-limited browsing and skeleton merge (`kind: literal|dynamic|both`). Left it unchanged. Adding an explicit `isa95_level` field per node is a small follow-up if needed.
- \"Existing tools accept uns_path\" applied to `kg_maintenance_context` only. `cmms_*` tools use external CMMS adapter IDs that don't have a natural UNS mapping.

## Test plan

- [ ] `python3 -m py_compile` already green for all 4 Python files (verified locally).
- [ ] Dry-run on synthetic data: `python tools/uns_backfill.py` (no `--commit`).
- [ ] Dry-run cmms: `python tools/cmms_equipment_uns_backfill.py --tenant <stardust_uuid>` — review first 10 paths.
- [ ] Inspect migration SQL for ltree validity (`uns_kb_path` returns valid ltree labels).
- [ ] After Mike approves, apply migrations via the standard runner (not by running the SQL pass through the orchestrator).
- [ ] Smoke MCP tools via `mira_browse_namespace(tenant, \"enterprise.knowledge_base\")` — expect non-empty descendants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)