### PR TITLE
feat(component-intelligence): three-layer schema + manifest-to-KG loader + template builder

### DIFF
--- a/docs/specs/mira-component-intelligence-architecture.md
+++ b/docs/specs/mira-component-intelligence-architecture.md
@@ -1,0 +1,172 @@
+# MIRA Component Intelligence Architecture
+
+**Status:** North Star — active build on `feat/component-intelligence`
+**Created:** 2026-05-13
+**Owner:** Mike Harper
+**Supersedes:** `docs/competitors/issue-bodies/03-component-templates.md` (closed catalog approach)
+
+---
+
+## Why this exists
+
+Diagnostic accuracy lives or dies on *how well the system knows the component*. A motor isn't a label — it's a power profile, a connector pinout, a signal envelope, a list of common failure modes, a wiring relationship to the panel terminal, and a chain of evidence connecting all of that to PLC tags, faults, and historical fixes.
+
+Factory AI ships a closed catalog of component templates. We ship an **open, evidence-tracked, multi-source** component intelligence layer that:
+
+1. **Templates** capture what a component *is* — extracted from manuals, datasheets, prints, technician notes.
+2. **Instances** capture what's actually *deployed* at a customer site, bound to a template plus location/wiring/PLC tag/MQTT topic.
+3. **Relationships** are *proposed* with evidence and *verified* by humans before they harden into the knowledge graph.
+
+The first proof-of-concept chain — and the heart of the product — is the **garage conveyor**:
+
+```
+Component (PE-B16-2) → Wire/Terminal (TB2-14) → PLC Tag (Line5.B16.PE2_Occupied)
+  → Logic Rung (Rung 42) → Fault (1.SOC B16.2) → Asset (Conveyor B16)
+  → Historical Fix → Recommendation
+```
+
+Every edge in that chain is a typed relationship with evidence pointing back to the source document (manual page, ladder rung, work order, technician note).
+
+---
+
+## Hard architectural constraints
+
+1. **PostgreSQL only.** No Neo4j. NeonDB is the system of record. JSONB for flexible specs.
+2. **ISA-95 / UNS-compliant paths** (`ltree`) on every new entity that lives in a plant hierarchy.
+3. **LLM extraction goes through the Groq cascade** (`mira-bots/shared/inference/router.py`). No Anthropic. No single-provider.
+4. **Tenant-scoped tables enforce RLS** with `current_setting('app.current_tenant_id')`.
+5. **Every relationship has provenance.** No bare edges — every `relationship_proposal` has ≥1 `relationship_evidence` row.
+
+---
+
+## The four core tables
+
+### 1. `component_templates` (catalog)
+
+Shared across tenants. Templates are the canonical description of a component family/model. Built once, used everywhere.
+
+| Field | Purpose |
+|---|---|
+| `component_category` | sensor, vfd, motor, contactor, plc, hmi, … |
+| `component_type` | proximity_sensor, variable_frequency_drive, … |
+| `manufacturer` + `model` | e.g. AutomationDirect / GS10 |
+| `power_specs` (JSONB) | input voltage, phase, amperage, frequency range |
+| `input_output_specs` (JSONB) | analog/digital I/O, signal types, ranges |
+| `signal_behavior` (JSONB) | expected envelope, normal/fault states, response time |
+| `connector_type` + `pinout` (JSONB) | physical interface |
+| `environmental_limits` (JSONB) | temp, humidity, IP rating, vibration |
+| `diagnostic_indicators` (JSONB[]) | what LEDs/displays mean |
+| `expected_signals` (JSONB[]) | what should be seen under normal operation |
+| `common_failure_modes` (JSONB[]) | each with cause, symptom, severity |
+| `troubleshooting_steps` (JSONB[]) | ordered procedure |
+| `pm_checks` (JSONB[]) | preventive maintenance items |
+| `safety_notes` (JSONB[]) | LOTO, arc-flash, hazards |
+| `recommended_uns_template` | e.g. `enterprise.kb.automationdirect.gs.gs10` |
+| `verification_status` | proposed / verified / rejected |
+| `version` | integer, bumped on edit |
+
+Companion table: `component_template_sources` — links each template to the manuals/datasheets it was extracted from, with page numbers and extraction confidence.
+
+### 2. `installed_component_instances` (deployment)
+
+Tenant-scoped. One row per physical component at a site. References a template (the "what is this") and adds location/wiring/PLC-binding (the "where is it and how is it wired").
+
+| Field | Purpose |
+|---|---|
+| `tenant_id` | RLS isolation |
+| `template_id` | FK to `component_templates` |
+| `asset_id` | FK to CMMS equipment (parent asset) |
+| `component_name` + `canonical_name` + `aliases[]` | name resolution |
+| `installed_location`, `panel`, `terminal`, `wire_number` | physical placement |
+| `plc_tag`, `mqtt_topic` | live data binding |
+| `uns_path` (ltree) | full hierarchy address |
+| `human_confirmed` (bool) + `confidence` | trust signal |
+
+### 3. `relationship_proposals` (the proposal layer)
+
+Every edge in the knowledge graph starts here, with confidence, status, and risk level. Safety-critical edges (LOTO, arc-flash, electrical interlock) require human review before promotion.
+
+Controlled vocabulary (relationship_type CHECK constraint):
+
+| Group | Types |
+|---|---|
+| Hierarchy | `HAS_COMPONENT`, `INSTANCE_OF`, `LOCATED_IN`, `HAS_PART` |
+| Documentation | `HAS_DOCUMENT`, `HAS_CHUNK`, `REFERENCES`, `HAS_PROCEDURE` |
+| Wiring & power | `WIRED_TO`, `POWERED_BY`, `MAPS_TO`, `PUBLISHED_AS` |
+| Logic & control | `USED_IN_LOGIC`, `TRIGGERS`, `CAUSES` |
+| Faults & resolution | `OCCURS_ON`, `RESOLVED_BY`, `HAS_FAILURE_MODE` |
+| Signals | `HAS_SIGNAL`, `HAS_ALIAS` |
+| Topology | `DEPENDS_ON`, `UPSTREAM_OF`, `DOWNSTREAM_OF`, `REPLACES` |
+| Evidence meta | `CONFIRMED_BY`, `CONTRADICTED_BY` |
+
+Status lifecycle: `proposed → reviewed → verified` (or `rejected`, `deprecated`, `contradicted`).
+
+`created_by`: `llm | human | import | rule`.
+`risk_level`: `low | medium | high | safety_critical` — drives `requires_human_review`.
+
+### 4. `relationship_evidence` (provenance)
+
+Each proposal has 1..N evidence rows pointing back to the source — document page, PLC rung, tag list, work order, technician note, or live data sample. Without evidence, a proposal stays at low confidence and is never auto-verified.
+
+---
+
+## Confidence scoring rules
+
+| Source of edge | Confidence |
+|---|---|
+| Multi-source confirmed (manual + tag list + technician note) | 0.95 |
+| Single primary source (manual or print) | 0.80 |
+| LLM-extracted from single chunk, no cross-check | 0.55 |
+| Inferred by rule (e.g. naming convention) | 0.40 |
+| LLM-proposed without any source | 0.25 (flagged for review) |
+
+Safety-critical edges below 0.80 require human review regardless of source count.
+
+---
+
+## Build sequence (this PR)
+
+| Step | Deliverable | File |
+|---|---|---|
+| 1 | Schema for templates + sources | `mira-hub/db/migrations/016_component_templates.sql` |
+| 2 | Schema for installed instances | `mira-hub/db/migrations/017_installed_component_instances.sql` |
+| 3 | Schema for proposals + evidence | `mira-hub/db/migrations/018_relationship_proposals.sql` |
+| 4 | Template Builder agent (LLM extraction → JSON → DB) | `tools/build_component_template.py` |
+| 5 | Manifest → KG entities + WIRED_TO/MAPS_TO proposals | `tools/load_manifest_to_kg.py` |
+
+Follow-ups (separate PRs, tracked as GitHub issues):
+
+- Relationship Proposer + Evidence Collector + Confidence Scorer pipeline.
+- Build the full garage-conveyor chain end-to-end (sensor → fix recommendation).
+- UI for human verification of proposals.
+- Promotion path from `relationship_proposals` (verified) → `kg_relationships`.
+
+---
+
+## Why proposals are separate from `kg_relationships`
+
+`kg_relationships` already exists in `mira-hub/db/migrations/001_knowledge_graph.sql`. The proposal layer is upstream: nothing lands in `kg_relationships` until a human (or a high-confidence rule) verifies it. This protects the diagnostic engine from LLM-hallucinated wiring claims while still letting us harvest the LLM's pattern-matching at scale.
+
+Once a proposal reaches `verified`, a downstream job mirrors it into `kg_relationships` (or, equivalently, we update the engine to query `relationship_proposals` directly with `status='verified'`). That cutover is a follow-up.
+
+---
+
+## First proof: garage conveyor
+
+Data already on disk: `research/variable-manifest.json` (78 PLC variables, 10 wiring notes, 16 gaps) describing a Micro820-driven conveyor with a GS10 VFD.
+
+`tools/load_manifest_to_kg.py` will:
+
+1. Create `kg_entities` for each I/O point, sensor, actuator, terminal, and modbus register.
+2. Create `relationship_proposals` for the chain:
+   - `_IO_EM_DI_05` `MAPS_TO` `Sensor 1` (alias) — evidence: manifest entry
+   - `Sensor 1` `WIRED_TO` `%IX0.5` — evidence: address field
+   - GS10 VFD `POWERED_BY` motor circuit — evidence: wiring notes
+   - VFD command word `USED_IN_LOGIC` of motor start rung — evidence: wiring note 7
+
+`tools/build_component_template.py` will:
+
+1. Find GS10 chunks in `knowledge_entries`.
+2. Send to Groq cascade with structured extraction prompt.
+3. Return a fully-populated `component_templates` row.
+4. Optionally insert (`--commit`) or print (`--dry-run`).

--- a/mira-hub/db/migrations/016_component_templates.sql
+++ b/mira-hub/db/migrations/016_component_templates.sql
@@ -1,0 +1,97 @@
+BEGIN;
+
+-- Component Intelligence — Templates (Layer 1).
+-- Spec: docs/specs/mira-component-intelligence-architecture.md
+--
+-- Templates are the canonical, shared description of a component family/model
+-- (e.g. "AutomationDirect GS10 VFD"). They are NOT tenant-scoped — the catalog
+-- is shared across all customers. Tenant-specific deployment lives in
+-- installed_component_instances (migration 017).
+--
+-- JSONB is used for every field whose shape varies by component category
+-- (sensors vs. drives vs. PLCs have very different specs). The structured
+-- columns (manufacturer, model, category, type) are the queryable filter axis.
+
+CREATE EXTENSION IF NOT EXISTS ltree;
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+CREATE TABLE IF NOT EXISTS component_templates (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Identity
+    component_category TEXT NOT NULL,
+    component_type TEXT NOT NULL,
+    manufacturer TEXT,
+    model TEXT,
+    description TEXT,
+
+    -- Electrical / mechanical / I/O specs (shape varies by category)
+    power_specs JSONB NOT NULL DEFAULT '{}',
+    input_output_specs JSONB NOT NULL DEFAULT '{}',
+    signal_behavior JSONB NOT NULL DEFAULT '{}',
+    connector_type TEXT,
+    pinout JSONB NOT NULL DEFAULT '{}',
+    environmental_limits JSONB NOT NULL DEFAULT '{}',
+    mounting_notes TEXT,
+
+    -- Diagnostics & maintenance knowledge
+    diagnostic_indicators JSONB NOT NULL DEFAULT '[]',
+    expected_signals JSONB NOT NULL DEFAULT '[]',
+    common_failure_modes JSONB NOT NULL DEFAULT '[]',
+    troubleshooting_steps JSONB NOT NULL DEFAULT '[]',
+    pm_checks JSONB NOT NULL DEFAULT '[]',
+    safety_notes JSONB NOT NULL DEFAULT '[]',
+
+    -- ISA-95 / UNS placement
+    recommended_uns_template TEXT,
+    uns_path ltree,
+
+    -- Provenance
+    verification_status TEXT NOT NULL DEFAULT 'proposed'
+        CHECK (verification_status IN ('proposed', 'verified', 'rejected')),
+    version INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- One canonical row per manufacturer+model+version. NULLs are distinct in
+    -- PostgreSQL, so unbranded templates can coexist; the (mfr, model) index
+    -- handles the branded lookups.
+    UNIQUE (manufacturer, model, version)
+);
+
+-- Source provenance — every template should trace back to at least one document.
+CREATE TABLE IF NOT EXISTS component_template_sources (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    template_id UUID NOT NULL REFERENCES component_templates(id) ON DELETE CASCADE,
+
+    source_type TEXT NOT NULL
+        CHECK (source_type IN ('manual', 'datasheet', 'print', 'technician_note', 'oem_kb', 'other')),
+    source_document_id UUID,        -- FK into knowledge_entries / documents when available
+    source_url TEXT,
+    page_numbers TEXT,              -- free-form: "12", "12-15,22", "Appendix A"
+    excerpt TEXT,                   -- short quote that grounded the extraction
+
+    extraction_confidence FLOAT NOT NULL DEFAULT 0.5
+        CHECK (extraction_confidence >= 0.0 AND extraction_confidence <= 1.0),
+    extracted_by TEXT NOT NULL DEFAULT 'llm'
+        CHECK (extracted_by IN ('llm', 'human', 'import', 'rule')),
+    extracted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_component_templates_mfr_model
+    ON component_templates (manufacturer, model);
+CREATE INDEX IF NOT EXISTS idx_component_templates_category
+    ON component_templates (component_category);
+CREATE INDEX IF NOT EXISTS idx_component_templates_type
+    ON component_templates (component_type);
+CREATE INDEX IF NOT EXISTS idx_component_templates_status
+    ON component_templates (verification_status);
+CREATE INDEX IF NOT EXISTS idx_component_templates_uns
+    ON component_templates USING GIST (uns_path);
+
+CREATE INDEX IF NOT EXISTS idx_template_sources_template
+    ON component_template_sources (template_id);
+CREATE INDEX IF NOT EXISTS idx_template_sources_doc
+    ON component_template_sources (source_document_id);
+
+COMMIT;

--- a/mira-hub/db/migrations/017_installed_component_instances.sql
+++ b/mira-hub/db/migrations/017_installed_component_instances.sql
@@ -1,0 +1,81 @@
+BEGIN;
+
+-- Component Intelligence — Installed Instances (Layer 2).
+-- Spec: docs/specs/mira-component-intelligence-architecture.md
+--
+-- One row per physical component deployed at a tenant site. Binds a template
+-- (the "what is this") to a specific location, panel, wire, and PLC tag (the
+-- "where is it and how is it connected"). Tenant-scoped with RLS — every read
+-- requires app.current_tenant_id to match.
+
+CREATE EXTENSION IF NOT EXISTS ltree;
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+CREATE TABLE IF NOT EXISTS installed_component_instances (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+
+    -- Bind to a catalog template (the "what is this")
+    template_id UUID REFERENCES component_templates(id) ON DELETE SET NULL,
+
+    -- Bind to a CMMS asset (the parent equipment this component lives in).
+    -- NOT a hard FK because cmms_equipment may live in a different schema/db
+    -- in some deployments. Validated at the application layer.
+    asset_id UUID,
+
+    -- Name resolution — the same physical sensor is often called 3-4 different
+    -- things across drawings, PLC code, and operator chatter. canonical_name
+    -- is what we display; aliases is everything we'll match on.
+    component_name TEXT NOT NULL,
+    canonical_name TEXT,
+    aliases TEXT[] NOT NULL DEFAULT '{}',
+
+    -- Physical placement
+    installed_location TEXT,
+    panel TEXT,
+    terminal TEXT,
+    wire_number TEXT,
+
+    -- Live-data binding
+    plc_tag TEXT,
+    mqtt_topic TEXT,
+
+    -- ISA-95 / UNS address (full path including this component)
+    uns_path ltree,
+
+    -- Trust signal — distinguishes "we extracted this from an LLM and nobody
+    -- has confirmed it" from "the maintenance lead signed off in person".
+    human_confirmed BOOLEAN NOT NULL DEFAULT false,
+    confidence FLOAT NOT NULL DEFAULT 0.5
+        CHECK (confidence >= 0.0 AND confidence <= 1.0),
+
+    notes TEXT,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_installed_instances_tenant
+    ON installed_component_instances (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_installed_instances_asset
+    ON installed_component_instances (asset_id);
+CREATE INDEX IF NOT EXISTS idx_installed_instances_template
+    ON installed_component_instances (template_id);
+CREATE INDEX IF NOT EXISTS idx_installed_instances_uns
+    ON installed_component_instances USING GIST (uns_path);
+CREATE INDEX IF NOT EXISTS idx_installed_instances_tenant_uns
+    ON installed_component_instances USING GIST (tenant_id, uns_path);
+CREATE INDEX IF NOT EXISTS idx_installed_instances_plc_tag
+    ON installed_component_instances (tenant_id, plc_tag)
+    WHERE plc_tag IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_installed_instances_aliases
+    ON installed_component_instances USING GIN (aliases);
+
+-- Tenant isolation
+ALTER TABLE installed_component_instances ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY installed_instances_tenant
+    ON installed_component_instances
+    USING (tenant_id = current_setting('app.current_tenant_id')::UUID);
+
+COMMIT;

--- a/mira-hub/db/migrations/018_relationship_proposals.sql
+++ b/mira-hub/db/migrations/018_relationship_proposals.sql
@@ -1,0 +1,132 @@
+BEGIN;
+
+-- Component Intelligence — Relationship Proposals + Evidence (Layer 3).
+-- Spec: docs/specs/mira-component-intelligence-architecture.md
+--
+-- The proposal layer is upstream of kg_relationships. Every edge in the
+-- knowledge graph starts here with confidence, status, and evidence. Nothing
+-- lands in kg_relationships until verified (by a human or a high-confidence
+-- rule). This protects the diagnostic engine from LLM-hallucinated wiring
+-- claims while still letting us harvest the LLM's pattern-matching at scale.
+--
+-- Controlled vocabulary on relationship_type — keep this list in sync with
+-- docs/specs/mira-component-intelligence-architecture.md §"Controlled vocabulary".
+
+CREATE TABLE IF NOT EXISTS relationship_proposals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID,                 -- nullable: catalog-level proposals (template ↔ template) are tenant-agnostic
+
+    source_entity_id UUID NOT NULL,
+    source_entity_type TEXT NOT NULL,
+    target_entity_id UUID NOT NULL,
+    target_entity_type TEXT NOT NULL,
+
+    relationship_type TEXT NOT NULL CHECK (relationship_type IN (
+        -- Hierarchy
+        'HAS_COMPONENT', 'INSTANCE_OF', 'LOCATED_IN', 'HAS_PART',
+        -- Documentation
+        'HAS_DOCUMENT', 'HAS_CHUNK', 'REFERENCES', 'HAS_PROCEDURE',
+        -- Wiring & power
+        'WIRED_TO', 'POWERED_BY', 'MAPS_TO', 'PUBLISHED_AS',
+        -- Logic & control
+        'USED_IN_LOGIC', 'TRIGGERS', 'CAUSES',
+        -- Faults & resolution
+        'OCCURS_ON', 'RESOLVED_BY', 'HAS_FAILURE_MODE',
+        -- Signals
+        'HAS_SIGNAL', 'HAS_ALIAS',
+        -- Topology
+        'DEPENDS_ON', 'UPSTREAM_OF', 'DOWNSTREAM_OF', 'REPLACES',
+        -- Evidence meta
+        'CONFIRMED_BY', 'CONTRADICTED_BY'
+    )),
+
+    confidence FLOAT NOT NULL DEFAULT 0.5
+        CHECK (confidence >= 0.0 AND confidence <= 1.0),
+
+    status TEXT NOT NULL DEFAULT 'proposed'
+        CHECK (status IN ('proposed', 'reviewed', 'verified', 'rejected', 'deprecated', 'contradicted')),
+
+    created_by TEXT NOT NULL DEFAULT 'llm'
+        CHECK (created_by IN ('llm', 'human', 'import', 'rule')),
+
+    risk_level TEXT NOT NULL DEFAULT 'low'
+        CHECK (risk_level IN ('low', 'medium', 'high', 'safety_critical')),
+    requires_human_review BOOLEAN NOT NULL DEFAULT false,
+
+    reasoning TEXT,                 -- LLM rationale or human comment
+    version INTEGER NOT NULL DEFAULT 1,
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    reviewed_at TIMESTAMPTZ,
+    reviewed_by TEXT,
+
+    -- A self-edge would be a data bug. Catch it at the schema.
+    CONSTRAINT no_self_loop CHECK (source_entity_id <> target_entity_id)
+);
+
+-- 1..N evidence per proposal. Without at least one row here, a proposal cannot
+-- be promoted past 'proposed' (enforced at the application layer, not in the DB —
+-- a CHECK would prevent inserting the proposal first, evidence second).
+CREATE TABLE IF NOT EXISTS relationship_evidence (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    proposal_id UUID NOT NULL REFERENCES relationship_proposals(id) ON DELETE CASCADE,
+
+    evidence_type TEXT NOT NULL CHECK (evidence_type IN (
+        'document_page', 'plc_rung', 'tag_list', 'work_order',
+        'technician_note', 'live_data', 'manifest', 'oem_kb', 'human_observation'
+    )),
+    source_id UUID,                 -- FK depends on evidence_type — validated at app layer
+    source_description TEXT,
+    page_or_location TEXT,          -- "page 42", "Rung 12", "HR:104", etc.
+    excerpt TEXT,                   -- short quote that grounded the claim
+
+    confidence_contribution FLOAT NOT NULL DEFAULT 0.0
+        CHECK (confidence_contribution >= -1.0 AND confidence_contribution <= 1.0),
+    -- Negative contribution = this evidence contradicts the proposal.
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_rel_proposals_source
+    ON relationship_proposals (source_entity_id);
+CREATE INDEX IF NOT EXISTS idx_rel_proposals_target
+    ON relationship_proposals (target_entity_id);
+CREATE INDEX IF NOT EXISTS idx_rel_proposals_type
+    ON relationship_proposals (relationship_type);
+CREATE INDEX IF NOT EXISTS idx_rel_proposals_status
+    ON relationship_proposals (status);
+CREATE INDEX IF NOT EXISTS idx_rel_proposals_review_queue
+    ON relationship_proposals (status, requires_human_review, risk_level)
+    WHERE status = 'proposed';
+CREATE INDEX IF NOT EXISTS idx_rel_proposals_tenant
+    ON relationship_proposals (tenant_id)
+    WHERE tenant_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_rel_evidence_proposal
+    ON relationship_evidence (proposal_id);
+CREATE INDEX IF NOT EXISTS idx_rel_evidence_type
+    ON relationship_evidence (evidence_type);
+
+-- Tenant isolation — RLS on the proposal table. Evidence inherits via cascade.
+ALTER TABLE relationship_proposals ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY rel_proposals_tenant
+    ON relationship_proposals
+    USING (
+        tenant_id IS NULL
+        OR tenant_id = current_setting('app.current_tenant_id', true)::UUID
+    );
+
+ALTER TABLE relationship_evidence ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY rel_evidence_tenant
+    ON relationship_evidence
+    USING (
+        proposal_id IN (
+            SELECT id FROM relationship_proposals
+            WHERE tenant_id IS NULL
+               OR tenant_id = current_setting('app.current_tenant_id', true)::UUID
+        )
+    );
+
+COMMIT;

--- a/tools/build_component_template.py
+++ b/tools/build_component_template.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Component Template Builder — extract a component_templates row from KB chunks.
+
+Spec: docs/specs/mira-component-intelligence-architecture.md (Step 4)
+
+Pipeline:
+  1. Search knowledge_entries for chunks matching manufacturer + model.
+  2. Send the chunks to Groq (with Cerebras fallback) using a structured-
+     extraction prompt — mirrors the cascade order in
+     mira-bots/shared/inference/router.py.
+  3. Parse the JSON response into the component_templates schema.
+  4. Print (default) or insert into NeonDB with --commit.
+
+First proof:
+  doppler run --project factorylm --config prd -- \\
+    python3 tools/build_component_template.py \\
+      --manufacturer AutomationDirect --model GS10 \\
+      --category vfd --type variable_frequency_drive
+
+Run with --commit to actually insert into NeonDB.
+
+Why a local cascade instead of importing the bot router: the mira-bots package
+has subdirs that shadow stdlib names (email/, agents/), which breaks Python
+path insertion. The cascade is two providers in this tool; splitting it out is
+cheaper than restructuring mira-bots.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import uuid
+from typing import Any
+
+import httpx
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("build-component-template")
+
+
+# ---------- KB lookup --------------------------------------------------------
+
+def _engine():
+    """NeonDB engine — NullPool because Neon's PgBouncer handles pooling."""
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import NullPool
+
+    url = os.environ.get("NEON_DATABASE_URL")
+    if not url:
+        raise RuntimeError("NEON_DATABASE_URL not set — run under `doppler run`")
+    return create_engine(
+        url,
+        poolclass=NullPool,
+        connect_args={"sslmode": "require"},
+        pool_pre_ping=True,
+    )
+
+
+def fetch_chunks(manufacturer: str, model: str, limit: int = 40) -> list[dict[str, Any]]:
+    """Pull KB chunks that mention manufacturer + model.
+
+    Uses ILIKE against `content` — keyword match, not vector. For a focused
+    "give me everything about GS10 from AutomationDirect" lookup this is enough
+    and stays explainable. A future iteration can stack vector recall on top.
+    """
+    from sqlalchemy import text
+
+    sql = text(
+        """
+        SELECT id, content, source_type, metadata, created_at
+        FROM knowledge_entries
+        WHERE content ILIKE :mfr_pat AND content ILIKE :model_pat
+        ORDER BY length(content) DESC
+        LIMIT :limit
+        """
+    )
+    with _engine().connect() as conn:
+        rows = (
+            conn.execute(
+                sql,
+                {
+                    "mfr_pat": f"%{manufacturer}%",
+                    "model_pat": f"%{model}%",
+                    "limit": limit,
+                },
+            )
+            .mappings()
+            .fetchall()
+        )
+    return [dict(r) for r in rows]
+
+
+# ---------- LLM extraction ---------------------------------------------------
+
+_EXTRACTION_SYSTEM_PROMPT = """You are an industrial component-spec extractor.
+
+Read the provided manual/datasheet chunks and return a SINGLE JSON object that
+fits the MIRA component_templates schema. Be conservative — only populate fields
+you can ground in the chunks. Leave a field empty (null, [], or {}) when the
+chunks do not support it.
+
+Output ONLY valid JSON, no prose, no markdown fences."""
+
+
+_EXTRACTION_USER_TEMPLATE = """Manufacturer: {manufacturer}
+Model: {model}
+Category: {category}
+Type: {component_type}
+
+Source chunks (each is a manual/datasheet excerpt):
+---
+{chunks}
+---
+
+Return JSON with this exact shape:
+{{
+  "description": "<one-paragraph plain-English summary>",
+  "power_specs": {{ "input_voltage": "...", "phase": "...", "amperage": "...", "frequency_range": "..." }},
+  "input_output_specs": {{ "analog_inputs": [...], "digital_inputs": [...], "outputs": [...] }},
+  "signal_behavior": {{ "normal": "...", "fault_states": [...], "response_time": "..." }},
+  "connector_type": "<string or null>",
+  "pinout": {{ "<pin_name>": "<function>", ... }},
+  "environmental_limits": {{ "temp_c": "...", "humidity": "...", "ip_rating": "...", "vibration": "..." }},
+  "mounting_notes": "<string or null>",
+  "diagnostic_indicators": [
+    {{ "name": "RUN LED", "color": "green", "meaning_on": "...", "meaning_off": "...", "meaning_blink": "..." }}
+  ],
+  "expected_signals": [
+    {{ "signal": "...", "normal_range": "...", "units": "..." }}
+  ],
+  "common_failure_modes": [
+    {{ "name": "...", "symptom": "...", "root_cause": "...", "severity": "low|medium|high|safety_critical" }}
+  ],
+  "troubleshooting_steps": [
+    {{ "step": 1, "action": "...", "expected_result": "..." }}
+  ],
+  "pm_checks": [
+    {{ "interval": "monthly|quarterly|annually", "task": "...", "tools_required": [...] }}
+  ],
+  "safety_notes": [
+    {{ "hazard": "arc_flash|loto|electrical|stored_energy|...", "note": "..." }}
+  ],
+  "recommended_uns_template": "enterprise.kb.<mfr_lowercase>.<family>.<model_lowercase>"
+}}"""
+
+
+# Mirrors mira-bots/shared/inference/router.py provider config. Same order:
+# Groq → Cerebras. (Gemini omitted — the openai-compat shim diverges and adds
+# complexity this tool doesn't need. Add it back if both Groq and Cerebras fail
+# in practice.)
+_CASCADE_PROVIDERS = [
+    {
+        "name": "groq",
+        "key_env": "GROQ_API_KEY",
+        "base_url": "https://api.groq.com/openai/v1",
+        "model_env": "GROQ_MODEL",
+        "model_default": "llama-3.3-70b-versatile",
+    },
+    {
+        "name": "cerebras",
+        "key_env": "CEREBRAS_API_KEY",
+        "base_url": "https://api.cerebras.ai/v1",
+        "model_env": "CEREBRAS_MODEL",
+        "model_default": "llama3.1-8b",
+    },
+]
+
+
+async def _call_one_provider(
+    provider: dict[str, str],
+    messages: list[dict[str, Any]],
+    max_tokens: int,
+) -> str:
+    api_key = os.environ.get(provider["key_env"], "")
+    if not api_key:
+        raise RuntimeError(f"{provider['key_env']} not set")
+    model = os.environ.get(provider["model_env"], provider["model_default"])
+    async with httpx.AsyncClient(timeout=120.0) as client:
+        resp = await client.post(
+            f"{provider['base_url']}/chat/completions",
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            json={
+                "model": model,
+                "messages": messages,
+                "max_tokens": max_tokens,
+                "temperature": 0.1,
+                "response_format": {"type": "json_object"},
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    return data["choices"][0]["message"]["content"]
+
+
+async def extract_template(
+    manufacturer: str,
+    model: str,
+    category: str,
+    component_type: str,
+    chunks: list[dict[str, Any]],
+    max_tokens: int = 4096,
+) -> dict[str, Any]:
+    """Try Groq, fall through to Cerebras. Return parsed JSON."""
+    if not chunks:
+        raise RuntimeError(
+            f"No KB chunks found for {manufacturer} {model} — ingest the manual first"
+        )
+
+    # Trim chunk bodies so the whole prompt fits — keep the largest informative
+    # slice from each row. Manuals frequently have 8-12KB chunks; cap at 2KB so
+    # we can fit ~10 chunks under typical 32K context budgets.
+    chunk_text = "\n\n---\n\n".join(
+        f"[chunk {i + 1} | source={r.get('source_type', '?')}]\n{(r.get('content') or '')[:2000]}"
+        for i, r in enumerate(chunks[:10])
+    )
+
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": _EXTRACTION_SYSTEM_PROMPT},
+        {
+            "role": "user",
+            "content": _EXTRACTION_USER_TEMPLATE.format(
+                manufacturer=manufacturer,
+                model=model,
+                category=category,
+                component_type=component_type,
+                chunks=chunk_text,
+            ),
+        },
+    ]
+
+    content = ""
+    last_error: Exception | None = None
+    for provider in _CASCADE_PROVIDERS:
+        if not os.environ.get(provider["key_env"]):
+            continue
+        try:
+            content = await _call_one_provider(provider, messages, max_tokens)
+            log.info("Extraction ok via %s", provider["name"])
+            break
+        except Exception as e:
+            log.warning("Provider %s failed: %s — trying next", provider["name"], e)
+            last_error = e
+
+    if not content:
+        raise RuntimeError(f"All providers exhausted — last error: {last_error}")
+
+    # Strip code fences if a provider added them despite the "no markdown" instruction.
+    cleaned = content.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.split("```", 2)[1]
+        if cleaned.startswith("json"):
+            cleaned = cleaned[4:]
+        cleaned = cleaned.rsplit("```", 1)[0].strip()
+
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"LLM returned invalid JSON: {e}\n\n{cleaned[:500]}") from e
+
+
+# ---------- DB insert --------------------------------------------------------
+
+def insert_template(
+    extracted: dict[str, Any],
+    manufacturer: str,
+    model: str,
+    category: str,
+    component_type: str,
+    chunks: list[dict[str, Any]],
+) -> str:
+    """Insert into component_templates + component_template_sources. Returns template id."""
+    from sqlalchemy import text
+
+    template_id = str(uuid.uuid4())
+
+    with _engine().begin() as conn:
+        conn.execute(
+            text(
+                """
+                INSERT INTO component_templates (
+                    id, component_category, component_type, manufacturer, model, description,
+                    power_specs, input_output_specs, signal_behavior, connector_type, pinout,
+                    environmental_limits, mounting_notes, diagnostic_indicators, expected_signals,
+                    common_failure_modes, troubleshooting_steps, pm_checks, safety_notes,
+                    recommended_uns_template, verification_status, version
+                ) VALUES (
+                    :id, :cat, :type, :mfr, :model, :description,
+                    :power, :io, :signal, :connector, :pinout,
+                    :env, :mounting, :indicators, :signals,
+                    :failures, :troubleshooting, :pm, :safety,
+                    :uns, 'proposed', 1
+                )
+                """
+            ),
+            {
+                "id": template_id,
+                "cat": category,
+                "type": component_type,
+                "mfr": manufacturer,
+                "model": model,
+                "description": extracted.get("description"),
+                "power": json.dumps(extracted.get("power_specs", {})),
+                "io": json.dumps(extracted.get("input_output_specs", {})),
+                "signal": json.dumps(extracted.get("signal_behavior", {})),
+                "connector": extracted.get("connector_type"),
+                "pinout": json.dumps(extracted.get("pinout", {})),
+                "env": json.dumps(extracted.get("environmental_limits", {})),
+                "mounting": extracted.get("mounting_notes"),
+                "indicators": json.dumps(extracted.get("diagnostic_indicators", [])),
+                "signals": json.dumps(extracted.get("expected_signals", [])),
+                "failures": json.dumps(extracted.get("common_failure_modes", [])),
+                "troubleshooting": json.dumps(extracted.get("troubleshooting_steps", [])),
+                "pm": json.dumps(extracted.get("pm_checks", [])),
+                "safety": json.dumps(extracted.get("safety_notes", [])),
+                "uns": extracted.get("recommended_uns_template"),
+            },
+        )
+
+        for chunk in chunks[:10]:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO component_template_sources (
+                        template_id, source_type, source_document_id, excerpt,
+                        extraction_confidence, extracted_by
+                    ) VALUES (
+                        :tid, :stype, :sdoc, :excerpt, :conf, 'llm'
+                    )
+                    """
+                ),
+                {
+                    "tid": template_id,
+                    "stype": chunk.get("source_type") or "manual",
+                    "sdoc": chunk.get("id"),
+                    "excerpt": (chunk.get("content") or "")[:500],
+                    "conf": 0.55,  # single-chunk LLM extraction baseline
+                },
+            )
+
+    return template_id
+
+
+# ---------- CLI --------------------------------------------------------------
+
+async def amain(args: argparse.Namespace) -> int:
+    chunks = fetch_chunks(args.manufacturer, args.model, args.chunk_limit)
+    log.info("Found %d KB chunks for %s %s", len(chunks), args.manufacturer, args.model)
+    if not chunks:
+        log.error("No KB chunks — ingest the manual first, then retry.")
+        return 2
+
+    extracted = await extract_template(
+        args.manufacturer, args.model, args.category, args.type, chunks
+    )
+
+    print(json.dumps(extracted, indent=2))
+
+    if args.commit:
+        tid = insert_template(
+            extracted, args.manufacturer, args.model, args.category, args.type, chunks
+        )
+        log.info("Inserted template %s", tid)
+        print(f"\n→ Inserted as component_templates.id = {tid}")
+    else:
+        log.info("Dry run — pass --commit to insert into NeonDB.")
+
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--manufacturer", required=True)
+    p.add_argument("--model", required=True)
+    p.add_argument("--category", required=True, help="sensor, vfd, motor, contactor, plc, ...")
+    p.add_argument("--type", required=True, help="proximity_sensor, variable_frequency_drive, ...")
+    p.add_argument("--chunk-limit", type=int, default=40)
+    p.add_argument("--commit", action="store_true", help="Insert into NeonDB (default: dry run)")
+    args = p.parse_args()
+
+    return asyncio.run(amain(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/load_manifest_to_kg.py
+++ b/tools/load_manifest_to_kg.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Load research/variable-manifest.json into the knowledge graph.
+
+Spec: docs/specs/mira-component-intelligence-architecture.md (Step 5)
+
+For each PLC variable in the manifest, this tool creates:
+  * kg_entities rows for: the io_point, its sourceDevice, its PLC address,
+    its Modbus register (when present), and its alias.
+  * relationship_proposals (with evidence rows) for the edges:
+      io_point   HAS_ALIAS         alias
+      io_point   MAPS_TO           physical_device   (the sourceDevice)
+      io_point   WIRED_TO          plc_address       (the %IX/%QX address)
+      io_point   PUBLISHED_AS      modbus_register   (the HR/COIL address)
+
+Wiring notes that mention a variable are attached as additional
+`relationship_evidence` rows on the relevant proposals.
+
+This is the garage-conveyor proof-of-concept. The chain it stitches together —
+sensor → terminal → tag → rung → fault → asset → fix — is the heart of the
+diagnostic product.
+
+Usage (dry run prints to stdout, no DB writes):
+  doppler run --project factorylm --config prd -- \\
+    python3 tools/load_manifest_to_kg.py --tenant-id <uuid>
+
+Add --commit to actually write to NeonDB.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "research" / "variable-manifest.json"
+DEV_TENANT_ID = "00000000-0000-0000-0000-000000000000"  # seed/dev tenant
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("load-manifest-to-kg")
+
+
+# ---------- DB layer ---------------------------------------------------------
+
+def _engine():
+    from sqlalchemy import create_engine
+    from sqlalchemy.pool import NullPool
+
+    url = os.environ.get("NEON_DATABASE_URL")
+    if not url:
+        raise RuntimeError("NEON_DATABASE_URL not set — run under `doppler run`")
+    return create_engine(
+        url,
+        poolclass=NullPool,
+        connect_args={"sslmode": "require"},
+        pool_pre_ping=True,
+    )
+
+
+# ---------- Entity / relationship builders ----------------------------------
+
+def build_entities_and_proposals(
+    manifest: dict[str, Any],
+    tenant_id: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return (entities, proposals, evidence) lists ready for DB insert.
+
+    Entities use deterministic UUIDs (uuid5) so re-runs of this loader are
+    idempotent — the (tenant_id, entity_type, entity_id) unique key catches
+    duplicates, and the deterministic UUID makes cross-references stable.
+    """
+    ns = uuid.UUID("12345678-1234-5678-1234-567812345678")  # arbitrary fixed namespace
+    tenant_ns = uuid.uuid5(ns, tenant_id)
+
+    def ent_uuid(entity_type: str, entity_id: str) -> str:
+        return str(uuid.uuid5(tenant_ns, f"{entity_type}:{entity_id}"))
+
+    entities: dict[str, dict[str, Any]] = {}   # keyed by id to dedupe
+    proposals: list[dict[str, Any]] = []
+    evidence: list[dict[str, Any]] = []
+
+    def ensure_entity(entity_type: str, entity_id: str, name: str, props: dict[str, Any] | None = None) -> str:
+        eid = ent_uuid(entity_type, entity_id)
+        if eid not in entities:
+            entities[eid] = {
+                "id": eid,
+                "tenant_id": tenant_id,
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+                "name": name,
+                "properties": props or {},
+            }
+        return eid
+
+    def propose(
+        source_id: str,
+        source_type: str,
+        target_id: str,
+        target_type: str,
+        rel_type: str,
+        confidence: float,
+        reasoning: str,
+        risk_level: str = "low",
+        proposal_evidence: list[dict[str, Any]] | None = None,
+    ) -> str:
+        pid = str(uuid.uuid4())
+        proposals.append(
+            {
+                "id": pid,
+                "tenant_id": tenant_id,
+                "source_entity_id": source_id,
+                "source_entity_type": source_type,
+                "target_entity_id": target_id,
+                "target_entity_type": target_type,
+                "relationship_type": rel_type,
+                "confidence": confidence,
+                "created_by": "import",
+                "risk_level": risk_level,
+                "requires_human_review": risk_level in ("high", "safety_critical"),
+                "reasoning": reasoning,
+            }
+        )
+        for ev in proposal_evidence or []:
+            evidence.append({**ev, "proposal_id": pid})
+        return pid
+
+    manifest_source = ", ".join(manifest.get("sourceFiles") or []) or "variable-manifest.json"
+
+    # Pre-index wiring notes by variable name they mention — used as evidence.
+    wiring_notes: list[str] = manifest.get("wiringNotes") or []
+
+    def notes_for(var_name: str) -> list[str]:
+        return [n for n in wiring_notes if var_name in n]
+
+    for var in manifest.get("variables") or []:
+        name: str = var["name"]
+        alias: str | None = var.get("alias")
+        address: str | None = var.get("address")
+        modbus: str | None = var.get("modbusAddress")
+        source_device: str | None = var.get("sourceDevice")
+        direction: str = (var.get("direction") or "").upper() or "?"
+
+        io_point_id = ensure_entity(
+            "io_point",
+            name,
+            name,
+            {
+                "data_type": var.get("dataType"),
+                "scope": var.get("scope"),
+                "direction": direction,
+                "retain": var.get("retain", False),
+            },
+        )
+
+        per_var_evidence = [
+            {
+                "evidence_type": "manifest",
+                "source_description": manifest_source,
+                "page_or_location": f"variables[].name={name}",
+                "excerpt": json.dumps(var)[:500],
+                "confidence_contribution": 0.4,
+            }
+        ]
+        for note in notes_for(name):
+            per_var_evidence.append(
+                {
+                    "evidence_type": "technician_note",
+                    "source_description": "variable-manifest.json wiringNotes",
+                    "page_or_location": f"wiringNotes mentioning {name}",
+                    "excerpt": note,
+                    "confidence_contribution": 0.2,
+                }
+            )
+
+        if alias:
+            alias_id = ensure_entity("alias", alias, alias)
+            propose(
+                io_point_id, "io_point", alias_id, "alias",
+                "HAS_ALIAS",
+                confidence=0.85,
+                reasoning=f"Manifest alias field for {name}",
+                proposal_evidence=per_var_evidence,
+            )
+
+        if source_device:
+            dev_id = ensure_entity("physical_device", source_device, source_device)
+            propose(
+                io_point_id, "io_point", dev_id, "physical_device",
+                "MAPS_TO",
+                confidence=0.80,
+                reasoning=f"Manifest sourceDevice for {name} = {source_device}",
+                proposal_evidence=per_var_evidence,
+            )
+
+        if address:
+            addr_id = ensure_entity("plc_address", address, address, {"plc_type": "Micro820"})
+            propose(
+                io_point_id, "io_point", addr_id, "plc_address",
+                "WIRED_TO",
+                confidence=0.90,
+                reasoning=f"Manifest address for {name} = {address}",
+                proposal_evidence=per_var_evidence,
+            )
+
+        if modbus:
+            mb_id = ensure_entity("modbus_register", modbus, modbus)
+            # E-stop wiring is safety-critical when surfaced via Modbus.
+            is_safety = any(
+                kw in (alias or "").lower() for kw in ("e-stop", "estop", "safety", "interlock")
+            )
+            propose(
+                io_point_id, "io_point", mb_id, "modbus_register",
+                "PUBLISHED_AS",
+                confidence=0.90,
+                reasoning=f"Manifest modbusAddress for {name} = {modbus}",
+                risk_level="safety_critical" if is_safety else "low",
+                proposal_evidence=per_var_evidence,
+            )
+
+    return list(entities.values()), proposals, evidence
+
+
+# ---------- DB writes --------------------------------------------------------
+
+def write_to_db(
+    entities: list[dict[str, Any]],
+    proposals: list[dict[str, Any]],
+    evidence: list[dict[str, Any]],
+) -> dict[str, int]:
+    from sqlalchemy import text
+
+    inserted_ent = 0
+    inserted_prop = 0
+    inserted_ev = 0
+
+    with _engine().begin() as conn:
+        # Set the tenant context so RLS lets these inserts land.
+        if entities:
+            conn.execute(
+                text("SET LOCAL app.current_tenant_id = :tid"),
+                {"tid": entities[0]["tenant_id"]},
+            )
+
+        for e in entities:
+            res = conn.execute(
+                text(
+                    """
+                    INSERT INTO kg_entities (id, tenant_id, entity_type, entity_id, name, properties)
+                    VALUES (:id, :tenant_id, :entity_type, :entity_id, :name, :properties)
+                    ON CONFLICT (tenant_id, entity_type, entity_id) DO NOTHING
+                    """
+                ),
+                {**e, "properties": json.dumps(e["properties"])},
+            )
+            inserted_ent += res.rowcount or 0
+
+        for p in proposals:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO relationship_proposals (
+                        id, tenant_id, source_entity_id, source_entity_type,
+                        target_entity_id, target_entity_type, relationship_type,
+                        confidence, created_by, risk_level, requires_human_review,
+                        reasoning
+                    ) VALUES (
+                        :id, :tenant_id, :source_entity_id, :source_entity_type,
+                        :target_entity_id, :target_entity_type, :relationship_type,
+                        :confidence, :created_by, :risk_level, :requires_human_review,
+                        :reasoning
+                    )
+                    """
+                ),
+                p,
+            )
+            inserted_prop += 1
+
+        for ev in evidence:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO relationship_evidence (
+                        proposal_id, evidence_type, source_description,
+                        page_or_location, excerpt, confidence_contribution
+                    ) VALUES (
+                        :proposal_id, :evidence_type, :source_description,
+                        :page_or_location, :excerpt, :confidence_contribution
+                    )
+                    """
+                ),
+                ev,
+            )
+            inserted_ev += 1
+
+    return {
+        "entities_inserted": inserted_ent,
+        "proposals_inserted": inserted_prop,
+        "evidence_inserted": inserted_ev,
+    }
+
+
+# ---------- CLI --------------------------------------------------------------
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--manifest", default=str(DEFAULT_MANIFEST), help="Path to variable-manifest.json")
+    p.add_argument("--tenant-id", default=DEV_TENANT_ID, help="Tenant UUID for entity/proposal rows")
+    p.add_argument("--commit", action="store_true", help="Write to NeonDB (default: dry run)")
+    p.add_argument("--summary-only", action="store_true", help="Print counts only, not the full payload")
+    args = p.parse_args()
+
+    manifest_path = Path(args.manifest)
+    if not manifest_path.exists():
+        log.error("Manifest not found: %s", manifest_path)
+        return 2
+
+    manifest = json.loads(manifest_path.read_text())
+    entities, proposals, evidence = build_entities_and_proposals(manifest, args.tenant_id)
+
+    summary = {
+        "manifest": str(manifest_path),
+        "tenant_id": args.tenant_id,
+        "entities": len(entities),
+        "proposals": len(proposals),
+        "evidence_rows": len(evidence),
+        "by_entity_type": {},
+        "by_relationship_type": {},
+        "safety_critical_proposals": sum(1 for p in proposals if p["risk_level"] == "safety_critical"),
+    }
+    for e in entities:
+        summary["by_entity_type"][e["entity_type"]] = summary["by_entity_type"].get(e["entity_type"], 0) + 1
+    for p in proposals:
+        summary["by_relationship_type"][p["relationship_type"]] = (
+            summary["by_relationship_type"].get(p["relationship_type"], 0) + 1
+        )
+
+    if args.summary_only:
+        print(json.dumps(summary, indent=2))
+    else:
+        print(
+            json.dumps(
+                {"summary": summary, "entities": entities[:3], "proposals": proposals[:5]},
+                indent=2,
+            )
+        )
+
+    if args.commit:
+        result = write_to_db(entities, proposals, evidence)
+        log.info("DB write done: %s", result)
+        print(f"\n→ DB write: {json.dumps(result)}")
+    else:
+        log.info("Dry run — pass --commit to write to NeonDB.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements the **Component Intelligence** architecture — the new North Star for MIRA's diagnostic engine. Adds three database layers, a Groq-cascade template extractor, and a manifest-to-knowledge-graph loader. Lands the foundation for the garage-conveyor proof-of-concept chain (sensor → terminal → tag → rung → fault → asset → fix).

> **Note on the spec:** The original prompt referenced `docs/specs/mira-component-intelligence-architecture.md` as the North Star to "read first". That file did not exist in the repo. The prompt itself was a fully-specified architecture, so the doc was materialized from it (commit `b50a2371`) and used as the canonical reference for the rest of the work.

## What's in this PR

### Spec
- `docs/specs/mira-component-intelligence-architecture.md` — three-layer model, 25-type relationship vocabulary, confidence scoring rules, build sequence.

### Schema (PostgreSQL only — no Neo4j)
- `mira-hub/db/migrations/016_component_templates.sql` — shared catalog + provenance.
- `mira-hub/db/migrations/017_installed_component_instances.sql` — tenant-scoped deployments with RLS.
- `mira-hub/db/migrations/018_relationship_proposals.sql` — proposed edges + evidence, 25-type CHECK constraint, status lifecycle, risk-level review gating.

### Tools
- `tools/build_component_template.py` — KB chunks → Groq (with Cerebras fallback) → `component_templates` row. Dry-run by default; `--commit` inserts.
- `tools/load_manifest_to_kg.py` — `research/variable-manifest.json` → `kg_entities` + `relationship_proposals` + `relationship_evidence`. Dry-run by default; `--commit` writes.

## Smoke test

Dry-run of `tools/load_manifest_to_kg.py --summary-only` against `research/variable-manifest.json`:

```json
{
  "entities": 210,
  "proposals": 188,
  "evidence_rows": 209,
  "by_entity_type": {
    "io_point": 78, "alias": 65, "physical_device": 7,
    "plc_address": 24, "modbus_register": 36
  },
  "by_relationship_type": {
    "HAS_ALIAS": 65, "MAPS_TO": 63, "WIRED_TO": 24, "PUBLISHED_AS": 36
  },
  "safety_critical_proposals": 6
}
```

The 6 safety-critical proposals are the e-stop / interlock / safety Modbus mappings — they require human review before promotion to verified.

## Why this matters

Today, the diagnostic engine knows "there's an asset, here's a fault code, here's a snippet". After this PR lands and the next-step pipelines run, it will know:

```
PE-B16-2 (proximity sensor) ─WIRED_TO→ TB2-14 (terminal)
                            ─MAPS_TO→ Line5.B16.PE2_Occupied (PLC tag)
                            ─USED_IN_LOGIC→ Rung 42 (motor start interlock)
                            ─TRIGGERS→ Fault 1.SOC B16.2 (sensor open contact)
                            ─OCCURS_ON→ Conveyor B16 (asset)
                            ─RESOLVED_BY→ WO-2024-1138 (replaced sensor)
```

Every edge is evidence-tracked back to a manual page, ladder rung, work order, or technician note.

## Constraints honored

- PostgreSQL only — no Neo4j.
- ISA-95 / UNS-compliant `ltree` paths on every new entity.
- Groq cascade for LLM extraction — no Anthropic.
- RLS on every tenant-scoped table (`installed_component_instances`, `relationship_proposals`, `relationship_evidence`).
- Every relationship has provenance — `relationship_evidence` rows tie back to source documents.

## Test plan
- [ ] Apply migrations 016-018 against a NeonDB branch.
- [ ] Run `doppler run -- python3 tools/load_manifest_to_kg.py --commit --tenant-id <uuid>` and verify the 210 entities + 188 proposals land with the expected counts per entity_type / relationship_type.
- [ ] Run `doppler run -- python3 tools/build_component_template.py --manufacturer AutomationDirect --model GS10 --category vfd --type variable_frequency_drive` (dry run) and verify the extracted JSON has populated `power_specs`, `common_failure_modes`, and `troubleshooting_steps`.
- [ ] Verify the 6 safety-critical proposals appear in the review queue: `SELECT * FROM relationship_proposals WHERE risk_level = 'safety_critical' AND status = 'proposed';`
- [ ] Spot-check three random proposals — each should have ≥1 `relationship_evidence` row tracing back to the manifest.

## Follow-ups (separate PRs, tracked as GitHub issues)
1. Relationship Proposer + Evidence Collector + Confidence Scorer pipeline (LLM → proposals from documents).
2. Full garage-conveyor end-to-end chain (sensor → fix recommendation).
3. Component Template Builder agent integrated into ingest service (auto-extract templates on manual upload).
4. UI for human verification of proposals.
5. Promotion path from `relationship_proposals` (verified) → `kg_relationships`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)