### PR TITLE
feat(component-profiles): manual-to-profile extraction pipeline (v1 MVP)

### DIFF
--- a/mira-core/component_profiles/__init__.py
+++ b/mira-core/component_profiles/__init__.py
@@ -1,0 +1,39 @@
+"""Component profile schema + LLM extractor.
+
+A ComponentProfile is a structured representation of a single industrial
+component (VFD, sensor, contactor, etc.) extracted from one or more vendor
+manuals. Stored in NeonDB table `component_profiles`. Distinct from
+sm_profiles.SmProfile, which models equipment state, not maintenance docs.
+"""
+
+from .schema import (
+    ComponentProfile,
+    Confidence,
+    CopyrightHandling,
+    ElectricalSpecs,
+    FaultCode,
+    Parameter,
+    PreventiveMaintenance,
+    SafetyWarning,
+    SourceDocument,
+    SparePart,
+    Terminal,
+    Troubleshooting,
+    UnsSuggestions,
+)
+
+__all__ = [
+    "ComponentProfile",
+    "Confidence",
+    "CopyrightHandling",
+    "ElectricalSpecs",
+    "FaultCode",
+    "Parameter",
+    "PreventiveMaintenance",
+    "SafetyWarning",
+    "SourceDocument",
+    "SparePart",
+    "Terminal",
+    "Troubleshooting",
+    "UnsSuggestions",
+]

--- a/mira-core/component_profiles/extractor.py
+++ b/mira-core/component_profiles/extractor.py
@@ -1,0 +1,342 @@
+"""Anthropic Messages API wrapper for ComponentProfile extraction.
+
+Calls Claude with the cached system prompt + tool definition from prompts.py,
+forces the model to invoke `save_component_profile` via tool_choice, validates
+the returned JSON against the Pydantic schema, and retries once on parse
+failure with the validation error fed back to the model.
+
+Returns a validated ComponentProfile plus per-call metadata (latency, tokens,
+cache hit stats) so the Celery wrapper can persist cost telemetry.
+
+Model selection:
+  - Default model: claude-sonnet-4-6 (best speed/intelligence balance for
+    high-volume document extraction). The plan's $0.20-0.60/manual cost
+    estimate assumes Sonnet 4.6 pricing.
+  - Override via CLAUDE_MODEL env var or `model=` argument.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+
+import anthropic
+from pydantic import ValidationError
+
+from .prompts import SYSTEM_PROMPT, TOOL_DEFINITION, TOOL_NAME, build_user_message
+from .schema import ComponentProfile, CopyrightHandling
+
+logger = logging.getLogger("mira-component-profiles")
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_MAX_TOKENS = 16000
+DEFAULT_TIMEOUT_SECONDS = 120.0
+
+
+class ExtractionError(Exception):
+    """Raised when extraction fails after retries (validation or API error)."""
+
+
+@dataclass
+class ExtractionMetadata:
+    model: str
+    latency_ms: int
+    input_tokens: int
+    output_tokens: int
+    cache_read_input_tokens: int
+    cache_creation_input_tokens: int
+    retry_attempted: bool
+
+    def to_dict(self) -> dict:
+        return {
+            "model": self.model,
+            "latency_ms": self.latency_ms,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_input_tokens": self.cache_read_input_tokens,
+            "cache_creation_input_tokens": self.cache_creation_input_tokens,
+            "retry_attempted": self.retry_attempted,
+        }
+
+
+def _extract_tool_use_input(message: anthropic.types.Message) -> dict | None:
+    """Pull the save_component_profile tool input out of a response message."""
+    for block in message.content:
+        if block.type == "tool_use" and block.name == TOOL_NAME:
+            return block.input  # type: ignore[return-value]
+    return None
+
+
+def _build_messages(
+    user_msg: str,
+    *,
+    prior_assistant_content: list | None = None,
+    retry_feedback: str | None = None,
+) -> list[dict]:
+    """Build the messages array.
+
+    For the initial call: just the user message.
+    For the retry: original user message → assistant's bad tool_use → user
+    message that includes the tool_result with the validation error so Claude
+    can correct itself.
+    """
+    messages: list[dict] = [{"role": "user", "content": user_msg}]
+    if prior_assistant_content is not None and retry_feedback is not None:
+        messages.append({"role": "assistant", "content": prior_assistant_content})
+        # Include a tool_result tied to the failed tool_use so Claude sees its
+        # own attempt and the error in one coherent turn.
+        tool_use_id = next(
+            (b.id for b in prior_assistant_content if getattr(b, "type", "") == "tool_use"),
+            None,
+        )
+        if tool_use_id is not None:
+            messages.append(
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_use_id,
+                            "content": retry_feedback,
+                            "is_error": True,
+                        }
+                    ],
+                }
+            )
+        else:
+            # Fallback if no tool_use id was found — plain text follow-up.
+            messages.append({"role": "user", "content": retry_feedback})
+    return messages
+
+
+def _call_claude(
+    client: anthropic.Anthropic,
+    *,
+    model: str,
+    messages: list[dict],
+    max_tokens: int,
+) -> anthropic.types.Message:
+    """Single Messages API call with prompt caching on system + tool definition.
+
+    cache_control on the last system block caches BOTH the tool definition
+    and the system prompt (render order is tools → system → messages). System
+    + tool together is ~7-8k tokens, well over the 2048-token cache minimum
+    for Sonnet 4.6, so the cache will actually populate.
+    """
+    return client.messages.create(
+        model=model,
+        max_tokens=max_tokens,
+        system=[
+            {
+                "type": "text",
+                "text": SYSTEM_PROMPT,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
+        tools=[TOOL_DEFINITION],
+        tool_choice={"type": "tool", "name": TOOL_NAME},
+        thinking={"type": "adaptive"},
+        output_config={"effort": "medium"},
+        messages=messages,
+    )
+
+
+def extract_component_profile(
+    manual_text: str,
+    *,
+    manufacturer_hint: str | None = None,
+    model_hint: str | None = None,
+    known_fault_codes: list[tuple[str, str, str]] | None = None,
+    source_title: str | None = None,
+    source_url: str | None = None,
+    copyright_handling: CopyrightHandling | str = CopyrightHandling.LINK_ONLY,
+    model: str | None = None,
+    api_key: str | None = None,
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    client: anthropic.Anthropic | None = None,
+) -> tuple[ComponentProfile, ExtractionMetadata]:
+    """Extract a structured ComponentProfile from manual text.
+
+    Args:
+        manual_text: docling-extracted manual text with page markers preserved.
+        manufacturer_hint / model_hint: EquipmentMatch outputs (deterministic
+            regex). Help Claude anchor identification.
+        known_fault_codes: FaultCodeMatch priors for this manufacturer — list
+            of (code, manufacturer, description) tuples.
+        source_title / source_url: provenance for source_documents.
+        copyright_handling: enum value for source_documents[].copyright_handling.
+        model: override the default model (or set CLAUDE_MODEL env var).
+        api_key: override the default API key (or set ANTHROPIC_API_KEY env var).
+        max_tokens: response budget; default 16000 (allows for thinking + ~4k
+            JSON output).
+        timeout: per-call HTTP timeout in seconds.
+        client: optional pre-built anthropic.Anthropic for testing.
+
+    Returns:
+        (profile, metadata) on success.
+
+    Raises:
+        ExtractionError: validation failed after one retry, the model did not
+            call the tool, or the Anthropic API errored irrecoverably.
+    """
+    model = model or os.getenv("CLAUDE_MODEL", DEFAULT_MODEL)
+    handling_str = (
+        copyright_handling.value
+        if isinstance(copyright_handling, CopyrightHandling)
+        else str(copyright_handling)
+    )
+
+    user_msg = build_user_message(
+        manual_text,
+        manufacturer_hint=manufacturer_hint,
+        model_hint=model_hint,
+        known_fault_codes=known_fault_codes,
+        source_title=source_title,
+        source_url=source_url,
+        copyright_handling=handling_str,
+    )
+
+    if client is None:
+        client = anthropic.Anthropic(
+            api_key=api_key or os.environ.get("ANTHROPIC_API_KEY"),
+            timeout=timeout,
+            # SDK defaults max_retries=2 — good for 429/5xx, no override needed.
+        )
+
+    # --- First attempt -------------------------------------------------------
+    t0 = time.monotonic()
+    try:
+        response = _call_claude(
+            client,
+            model=model,
+            messages=_build_messages(user_msg),
+            max_tokens=max_tokens,
+        )
+    except anthropic.APIError as e:
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        logger.error(
+            "Anthropic API error on first attempt model=%s latency_ms=%d: %s",
+            model,
+            elapsed_ms,
+            e,
+        )
+        raise ExtractionError(f"Anthropic API error: {e}") from e
+
+    tool_input = _extract_tool_use_input(response)
+    if tool_input is None:
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        logger.warning(
+            "Model returned no tool_use block model=%s stop_reason=%s — refusing extraction",
+            model,
+            response.stop_reason,
+        )
+        raise ExtractionError(
+            f"Model did not call {TOOL_NAME} (stop_reason={response.stop_reason})"
+        )
+
+    try:
+        profile = ComponentProfile.model_validate(tool_input)
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        meta = ExtractionMetadata(
+            model=model,
+            latency_ms=elapsed_ms,
+            input_tokens=response.usage.input_tokens,
+            output_tokens=response.usage.output_tokens,
+            cache_read_input_tokens=getattr(response.usage, "cache_read_input_tokens", 0) or 0,
+            cache_creation_input_tokens=getattr(response.usage, "cache_creation_input_tokens", 0)
+            or 0,
+            retry_attempted=False,
+        )
+        logger.info(
+            "EXTRACTION_OK model=%s latency_ms=%d input=%d output=%d cache_read=%d "
+            "confidence=%.2f review=%s",
+            meta.model,
+            meta.latency_ms,
+            meta.input_tokens,
+            meta.output_tokens,
+            meta.cache_read_input_tokens,
+            profile.confidence.overall,
+            profile.confidence.needs_human_review,
+        )
+        return profile, meta
+    except ValidationError as ve:
+        logger.warning("First-attempt validation failed: %s", ve)
+        first_attempt_content = response.content
+        first_attempt_error = str(ve)
+
+    # --- Retry once with the validation error in a tool_result --------------
+    retry_feedback = (
+        "Your previous save_component_profile call failed Pydantic validation "
+        "with this error:\n\n"
+        f"{first_attempt_error}\n\n"
+        "Call save_component_profile again with a corrected payload. Do not "
+        "change facts — only fix the schema violations (missing required fields, "
+        "wrong types, invalid enum values, etc.)."
+    )
+    try:
+        retry_response = _call_claude(
+            client,
+            model=model,
+            messages=_build_messages(
+                user_msg,
+                prior_assistant_content=first_attempt_content,
+                retry_feedback=retry_feedback,
+            ),
+            max_tokens=max_tokens,
+        )
+    except anthropic.APIError as e:
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        logger.error(
+            "Anthropic API error on retry model=%s latency_ms=%d: %s",
+            model,
+            elapsed_ms,
+            e,
+        )
+        raise ExtractionError(f"Anthropic API error on retry: {e}") from e
+
+    retry_tool_input = _extract_tool_use_input(retry_response)
+    if retry_tool_input is None:
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        raise ExtractionError(
+            f"Retry: model did not call {TOOL_NAME} "
+            f"(stop_reason={retry_response.stop_reason})"
+        )
+
+    try:
+        profile = ComponentProfile.model_validate(retry_tool_input)
+    except ValidationError as ve2:
+        logger.error("Retry validation also failed: %s", ve2)
+        raise ExtractionError(
+            f"Validation failed twice — first: {first_attempt_error}\nretry: {ve2}"
+        ) from ve2
+
+    elapsed_ms = int((time.monotonic() - t0) * 1000)
+    meta = ExtractionMetadata(
+        model=model,
+        latency_ms=elapsed_ms,
+        input_tokens=response.usage.input_tokens + retry_response.usage.input_tokens,
+        output_tokens=response.usage.output_tokens + retry_response.usage.output_tokens,
+        cache_read_input_tokens=(
+            (getattr(response.usage, "cache_read_input_tokens", 0) or 0)
+            + (getattr(retry_response.usage, "cache_read_input_tokens", 0) or 0)
+        ),
+        cache_creation_input_tokens=(
+            (getattr(response.usage, "cache_creation_input_tokens", 0) or 0)
+            + (getattr(retry_response.usage, "cache_creation_input_tokens", 0) or 0)
+        ),
+        retry_attempted=True,
+    )
+    logger.info(
+        "EXTRACTION_OK_AFTER_RETRY model=%s latency_ms=%d input=%d output=%d "
+        "confidence=%.2f review=%s",
+        meta.model,
+        meta.latency_ms,
+        meta.input_tokens,
+        meta.output_tokens,
+        profile.confidence.overall,
+        profile.confidence.needs_human_review,
+    )
+    return profile, meta

--- a/mira-core/component_profiles/prompts.py
+++ b/mira-core/component_profiles/prompts.py
@@ -1,0 +1,167 @@
+"""Extraction prompt + tool definition for ComponentProfile extraction.
+
+Design:
+  - SYSTEM_PROMPT is large + stable → cached via Anthropic prompt caching.
+  - TOOL_DEFINITION is also stable → cached on the same cache_control marker.
+  - build_user_message(...) returns the variable per-call user content
+    (manual text + hints). NOT cached.
+
+The schema embedded in TOOL_DEFINITION is generated from ComponentProfile
+to stay in lock-step with the Pydantic source of truth. Anthropic's
+tool_use forces the model to fill in this shape, giving us much higher
+JSON-validity rates than prose-mode JSON.
+"""
+
+from __future__ import annotations
+
+from .schema import ComponentProfile
+
+TOOL_NAME = "save_component_profile"
+
+
+# Built once at import time. Pydantic's $defs-based schema is what Anthropic
+# expects for nested objects. We strip Pydantic-specific keys that the
+# tool-use validator does not understand.
+def _build_tool_schema() -> dict:
+    raw = ComponentProfile.model_json_schema()
+    raw.setdefault("description", "Structured maintenance profile for one industrial component.")
+    return raw
+
+
+TOOL_DEFINITION = {
+    "name": TOOL_NAME,
+    "description": (
+        "Save a structured maintenance profile for one industrial component, "
+        "extracted from a vendor manual. Fill in only what the manual supports; "
+        "use null / empty arrays for missing fields and surface gaps in "
+        "confidence.missing_information."
+    ),
+    "input_schema": _build_tool_schema(),
+}
+
+
+SYSTEM_PROMPT = """You are MIRA's Component Profiler. You convert industrial equipment manuals into structured component profiles. Each profile becomes a row in MIRA's maintenance-intelligence library — read later by technicians who need fast, accurate, sourced answers about real equipment on a factory floor.
+
+## How you work
+
+Read the manual text the user provides. Identify the single component the manual describes (a specific VFD model, a specific contactor family, a specific photoelectric sensor, etc.). Extract structured facts useful to a maintenance technician. Return your output by calling the `save_component_profile` tool with a JSON payload that matches the schema. Do not return prose. Do not return markdown. Call the tool exactly once.
+
+## Hard rules — do not violate these
+
+1. EXTRACT, DO NOT INVENT. Every fault code, parameter, terminal, part number, rating, procedure, and warning you record must be supported by text in the provided manual. If the manual does not contain a piece of information, set the field to null (for scalars) or [] (for lists). Never fabricate codes, ratings, or steps from background knowledge.
+
+2. CITE PAGES. Whenever the source text includes a page marker, fill page_reference. A profile a technician can trace back to a page is worth ten profiles they cannot.
+
+3. SUMMARIZE — DO NOT COPY. Convert procedures into short technician-friendly steps. Do not transcribe long verbatim passages from the manual. Copyright matters: store facts, not photocopies.
+
+4. PREFER FIELD VOCABULARY. "Megger the motor" not "perform an insulation resistance test." "Trips on run" not "experiences a fault during the run command." Imagine a senior tech reading this at 2am.
+
+5. POPULATE CONFIDENCE HONESTLY. confidence.overall is 0.0..1.0. Use these anchors:
+   - 0.90+ — manual cleanly identifies the component, fault tables and PM tables are complete and well-structured, you found page references throughout.
+   - 0.70 — solid coverage with a few gaps. Most fault codes present, some parameters missing.
+   - 0.50 — partial: you got the component identity but the manual is ambiguous or shallow on procedures.
+   - 0.30 or lower — you suspect this manual is for a different/adjacent component or you cannot identify the component cleanly.
+   List every meaningful gap in confidence.missing_information.
+
+6. SAFETY-CRITICAL = HUMAN REVIEW. If any safety_warnings entries exist, or any fault has severity=="critical", set confidence.needs_human_review=true regardless of overall confidence. A technician's safety must not depend on an unreviewed LLM extraction.
+
+7. NEVER USE PROSE. Only call save_component_profile. No greetings, no explanations, no apologies. If the manual is unreadable, call the tool with a near-empty profile, overall=0.0, and an explanation in confidence.missing_information.
+
+## Schema conventions
+
+- component_type uses snake_case nouns: variable_frequency_drive, contactor, photoelectric_sensor, motor_overload_relay, plc_input_module, proximity_sensor, soft_starter, motor_starter, hmi_panel, safety_relay. Pick the most specific match. If none fits, invent a snake_case noun phrase.
+- manufacturer uses the canonical brand: "Allen-Bradley" (not "AB"), "Schneider" (not "Square D"), "ABB", "Siemens", "Yaskawa", "Mitsubishi", "Danfoss", "SEW-Eurodrive", "Banner", "SICK", "IFM", "Keyence", "Omron", "Phoenix Contact", "Eaton".
+- series is the product family ("PowerFlex 525", "GS20", "Sinamics V20"). model_numbers is the specific catalog numbers (["25B-D2P3N104", "25B-D4P0N104"]) — these often come from a model-number breakdown table.
+- fault_codes[].severity is one of: low, medium, high, critical. Use critical only for safety-impacting faults (ground fault to chassis, gate-driver short, etc.). Default to medium if the manual does not classify.
+- preventive_maintenance[].interval uses field vocabulary: "monthly", "quarterly", "annually", "every 6 months", "every 1000 operating hours". Do not invent intervals if the manual is silent.
+- source_documents[].copyright_handling defaults to "link_only" unless you are told otherwise in the user message.
+
+## Worked micro-example
+
+A manual fragment like:
+
+  "F004 — Undervoltage. Cause: input voltage below the minimum specified
+  in Table 5. Action: confirm L1, L2, L3 input within nameplate range,
+  measure bus voltage at TB+/TB- terminals, replace input fuses if open.
+  See page 47."
+
+Should produce one fault_codes entry (among many):
+
+  {
+    "code": "F004",
+    "meaning": "Undervoltage",
+    "likely_causes": ["Input voltage below specified minimum", "Open input fuse", "Brownout on plant feeder"],
+    "technician_steps": ["Verify L1/L2/L3 input within nameplate range", "Measure DC bus voltage at TB+/TB-", "Inspect input fuses"],
+    "reset_method": null,
+    "severity": "medium",
+    "page_reference": "p.47"
+  }
+
+That is the level of detail and field-language we want — derived from the source, summarized, traceable.
+
+## Final reminder
+
+You are not chatting. You are not writing prose. You call save_component_profile once with a JSON payload that matches the schema, and that is the whole response."""
+
+
+def build_user_message(
+    manual_text: str,
+    *,
+    manufacturer_hint: str | None = None,
+    model_hint: str | None = None,
+    known_fault_codes: list[tuple[str, str, str]] | None = None,
+    source_title: str | None = None,
+    source_url: str | None = None,
+    copyright_handling: str = "link_only",
+) -> str:
+    """Assemble the per-call user message.
+
+    Args:
+        manual_text: extracted manual text (post-docling). Should already be
+            chunked to fit the model context window.
+        manufacturer_hint / model_hint: outputs from EquipmentMatch — tell the
+            model what the deterministic regex already inferred so it doesn't
+            re-derive incorrectly.
+        known_fault_codes: list of (code, manufacturer, description) tuples
+            from FaultCodeMatch._KNOWN_CODES for the inferred manufacturer.
+            Helps Claude verify codes it sees in the manual against priors.
+        source_title / source_url: provenance for the source_documents block.
+        copyright_handling: one of link_only | customer_uploaded | licensed | unknown.
+    """
+    parts: list[str] = []
+
+    # Hints block — small, deterministic, helps the model anchor.
+    hint_lines: list[str] = []
+    if manufacturer_hint:
+        hint_lines.append(f"  - manufacturer (regex hint): {manufacturer_hint}")
+    if model_hint:
+        hint_lines.append(f"  - model (regex hint): {model_hint}")
+    if source_title:
+        hint_lines.append(f"  - source title: {source_title}")
+    if source_url:
+        hint_lines.append(f"  - source URL: {source_url}")
+    hint_lines.append(f"  - copyright_handling: {copyright_handling}")
+
+    parts.append("Hints from deterministic extractors (verify against the manual; override if the manual disagrees):")
+    parts.extend(hint_lines)
+    parts.append("")
+
+    if known_fault_codes:
+        parts.append(
+            "Fault-code priors for this manufacturer (only record codes that ALSO appear in the manual text; do not introduce codes from this list alone):"
+        )
+        for code, mfr, desc in known_fault_codes[:50]:
+            parts.append(f"  - {code} ({mfr}): {desc}")
+        parts.append("")
+
+    parts.append("Manual text (extracted by docling — page markers preserved as 'p.NN'):")
+    parts.append("---BEGIN MANUAL---")
+    parts.append(manual_text)
+    parts.append("---END MANUAL---")
+    parts.append("")
+    parts.append(
+        "Call save_component_profile once with the structured profile. "
+        "Remember: every fact must be supported by the manual above."
+    )
+
+    return "\n".join(parts)

--- a/mira-core/component_profiles/schema.py
+++ b/mira-core/component_profiles/schema.py
@@ -1,0 +1,192 @@
+"""ComponentProfile Pydantic schema — manual → structured maintenance brain.
+
+Extraction target for `component_profiles.extractor.extract()`. Validates
+LLM-produced JSON before it lands in the `component_profiles` NeonDB table.
+
+Design rules baked into the schema:
+  - Every optional fact is Optional[T] = None. Missing data must not crash.
+  - Every list defaults to []. Missing data must not crash.
+  - Confidence.needs_human_review auto-flips True when:
+      overall < 0.7, OR any fault has severity == "critical",
+      OR any safety_warnings were extracted.
+  - source_documents[].copyright_handling restricted to a closed enum.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class CopyrightHandling(str, Enum):
+    LINK_ONLY = "link_only"
+    CUSTOMER_UPLOADED = "customer_uploaded"
+    LICENSED = "licensed"
+    UNKNOWN = "unknown"
+
+
+class Severity(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    CRITICAL = "critical"
+
+
+class Criticality(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class DocumentType(str, Enum):
+    MANUAL = "manual"
+    DATASHEET = "datasheet"
+    WORK_ORDER = "work_order"
+    PLC_EXPORT = "plc_export"
+    OTHER = "other"
+
+
+class ElectricalSpecs(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    input_voltage: Optional[str] = None
+    output_voltage: Optional[str] = None
+    phase: Optional[str] = None
+    horsepower_range: Optional[str] = None
+    current_range: Optional[str] = None
+    frequency_range: Optional[str] = None
+
+
+class Terminal(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    terminal: str = Field(min_length=1)
+    purpose: Optional[str] = None
+    notes: Optional[str] = None
+    page_reference: Optional[str] = None
+
+
+class Parameter(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    parameter: str = Field(min_length=1)
+    name: Optional[str] = None
+    description: Optional[str] = None
+    default: Optional[str] = None
+    maintenance_relevance: Optional[str] = None
+    page_reference: Optional[str] = None
+
+
+class FaultCode(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: str = Field(min_length=1)
+    meaning: Optional[str] = None
+    likely_causes: list[str] = []
+    technician_steps: list[str] = []
+    reset_method: Optional[str] = None
+    severity: Optional[Severity] = None
+    page_reference: Optional[str] = None
+
+
+class PreventiveMaintenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    task: str = Field(min_length=1)
+    interval: Optional[str] = None
+    tools_required: list[str] = []
+    safety_notes: list[str] = []
+    page_reference: Optional[str] = None
+
+
+class SparePart(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    part_number: Optional[str] = None
+    description: Optional[str] = None
+    criticality: Optional[Criticality] = None
+    page_reference: Optional[str] = None
+
+
+class SafetyWarning(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    warning: str = Field(min_length=1)
+    page_reference: Optional[str] = None
+
+
+class Troubleshooting(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    symptom: str = Field(min_length=1)
+    possible_causes: list[str] = []
+    recommended_actions: list[str] = []
+    page_reference: Optional[str] = None
+
+
+class UnsSuggestions(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    asset_type: Optional[str] = None
+    suggested_topics: list[str] = []
+    suggested_tags: list[str] = []
+
+
+class SourceDocument(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    title: Optional[str] = None
+    url: Optional[str] = None
+    storage_path: Optional[str] = None
+    document_type: DocumentType = DocumentType.MANUAL
+    copyright_handling: CopyrightHandling = CopyrightHandling.LINK_ONLY
+    page_references_used: list[str] = []
+
+
+class Confidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    overall: float = Field(ge=0.0, le=1.0)
+    missing_information: list[str] = []
+    assumptions: list[str] = []
+    needs_human_review: bool = False
+
+
+class ComponentProfile(BaseModel):
+    """Structured maintenance intelligence for one industrial component."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    component_type: str = Field(min_length=1)
+    manufacturer: Optional[str] = None
+    series: Optional[str] = None
+    model_numbers: list[str] = []
+    description: Optional[str] = None
+    common_applications: list[str] = []
+
+    electrical_specs: ElectricalSpecs = Field(default_factory=ElectricalSpecs)
+    terminals: list[Terminal] = []
+    parameters: list[Parameter] = []
+    fault_codes: list[FaultCode] = []
+    preventive_maintenance: list[PreventiveMaintenance] = []
+    spare_parts: list[SparePart] = []
+    safety_warnings: list[SafetyWarning] = []
+    troubleshooting: list[Troubleshooting] = []
+    uns_suggestions: UnsSuggestions = Field(default_factory=UnsSuggestions)
+    source_documents: list[SourceDocument] = []
+
+    confidence: Confidence
+
+    @model_validator(mode="after")
+    def _set_review_flag(self) -> "ComponentProfile":
+        """Auto-flip needs_human_review when safety-critical content is present."""
+        has_critical_fault = any(
+            f.severity == Severity.CRITICAL for f in self.fault_codes
+        )
+        has_safety_warning = len(self.safety_warnings) > 0
+        low_confidence = self.confidence.overall < 0.7
+        if has_critical_fault or has_safety_warning or low_confidence:
+            self.confidence.needs_human_review = True
+        return self

--- a/mira-core/component_profiles/tests/test_schema.py
+++ b/mira-core/component_profiles/tests/test_schema.py
@@ -1,0 +1,127 @@
+"""Tests for ComponentProfile schema — validation + auto-review-flag logic."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from component_profiles.schema import (
+    ComponentProfile,
+    Confidence,
+    CopyrightHandling,
+    DocumentType,
+    FaultCode,
+    SafetyWarning,
+    Severity,
+    SourceDocument,
+)
+
+
+def _minimal_payload(overall: float = 0.9) -> dict:
+    return {
+        "component_type": "variable_frequency_drive",
+        "confidence": {"overall": overall},
+    }
+
+
+def test_minimal_profile_validates():
+    p = ComponentProfile(**_minimal_payload())
+    assert p.component_type == "variable_frequency_drive"
+    assert p.fault_codes == []
+    assert p.confidence.overall == 0.9
+    assert p.confidence.needs_human_review is False
+
+
+def test_low_confidence_flips_review_flag():
+    p = ComponentProfile(**_minimal_payload(overall=0.5))
+    assert p.confidence.needs_human_review is True
+
+
+def test_critical_fault_flips_review_flag():
+    payload = _minimal_payload()
+    payload["fault_codes"] = [
+        {"code": "F012", "severity": "critical"},
+        {"code": "F002", "severity": "low"},
+    ]
+    p = ComponentProfile(**payload)
+    assert p.confidence.needs_human_review is True
+
+
+def test_safety_warning_flips_review_flag():
+    payload = _minimal_payload()
+    payload["safety_warnings"] = [{"warning": "De-energize before opening cover"}]
+    p = ComponentProfile(**payload)
+    assert p.confidence.needs_human_review is True
+
+
+def test_no_triggers_keeps_review_flag_false():
+    payload = _minimal_payload()
+    payload["fault_codes"] = [{"code": "F012", "severity": "low"}]
+    p = ComponentProfile(**payload)
+    assert p.confidence.needs_human_review is False
+
+
+def test_overall_out_of_range_rejected():
+    with pytest.raises(ValidationError):
+        ComponentProfile(**_minimal_payload(overall=1.5))
+
+
+def test_extra_fields_rejected():
+    payload = _minimal_payload()
+    payload["bogus_field"] = "nope"
+    with pytest.raises(ValidationError):
+        ComponentProfile(**payload)
+
+
+def test_fault_code_severity_enum_strict():
+    payload = _minimal_payload()
+    payload["fault_codes"] = [{"code": "F012", "severity": "kinda-bad"}]
+    with pytest.raises(ValidationError):
+        ComponentProfile(**payload)
+
+
+def test_source_document_defaults():
+    payload = _minimal_payload()
+    payload["source_documents"] = [{"title": "PowerFlex 525 UM001"}]
+    p = ComponentProfile(**payload)
+    sd = p.source_documents[0]
+    assert sd.document_type == DocumentType.MANUAL
+    assert sd.copyright_handling == CopyrightHandling.LINK_ONLY
+
+
+def test_round_trip_json():
+    payload = _minimal_payload(overall=0.85)
+    payload["manufacturer"] = "Allen-Bradley"
+    payload["series"] = "PowerFlex 525"
+    payload["model_numbers"] = ["25B-D2P3N104", "25B-D4P0N104"]
+    payload["fault_codes"] = [
+        {
+            "code": "F004",
+            "meaning": "Undervoltage",
+            "likely_causes": ["Input power loss", "Brownout"],
+            "technician_steps": ["Check input voltage at L1/L2/L3"],
+            "reset_method": "Cycle power",
+            "severity": "medium",
+            "page_reference": "p.47",
+        }
+    ]
+    p = ComponentProfile(**payload)
+    blob = p.model_dump_json()
+    p2 = ComponentProfile.model_validate_json(blob)
+    assert p2 == p
+
+
+def test_confidence_missing_information_flows_through():
+    payload = _minimal_payload(overall=0.65)
+    payload["confidence"]["missing_information"] = ["No PM table found"]
+    p = ComponentProfile(**payload)
+    assert p.confidence.missing_information == ["No PM table found"]
+    assert p.confidence.needs_human_review is True
+
+
+def test_load_from_external_json():
+    raw = json.dumps(_minimal_payload(overall=0.9))
+    p = ComponentProfile.model_validate_json(raw)
+    assert p.component_type == "variable_frequency_drive"

--- a/mira-core/mira-ingest/db/migrations/011_component_profiles.sql
+++ b/mira-core/mira-ingest/db/migrations/011_component_profiles.sql
@@ -1,0 +1,86 @@
+-- mira-core/mira-ingest/db/migrations/011_component_profiles.sql
+--
+-- ComponentProfile storage — structured maintenance intelligence extracted
+-- by mira-core.component_profiles.extractor from one or more vendor manuals.
+--
+-- Scope: one row per (tenant_id, manufacturer, series, model_number). The
+-- profile JSONB blob matches the ComponentProfile pydantic schema in
+-- mira-core/component_profiles/schema.py. Source PDFs continue to live in
+-- the existing manuals / manual_cache tables; this table holds the LLM
+-- extraction output, not the source documents themselves.
+--
+-- source_manual_id is intentionally NOT a hard foreign key: a profile can
+-- aggregate facts from multiple manuals over time, and we don't want a
+-- DELETE on manuals to cascade-delete profiles built from that manual.
+-- The column records the primary source for provenance.
+--
+-- New table, no existing readers — single-block transactional, no
+-- CREATE INDEX CONCURRENTLY needed.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS component_profiles (
+    id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id           TEXT        NOT NULL,
+    manufacturer        TEXT        NOT NULL,
+    series              TEXT,
+    model_number        TEXT,
+    component_type      TEXT        NOT NULL,                  -- e.g. 'variable_frequency_drive', 'photoelectric_sensor'
+    profile             JSONB       NOT NULL,                  -- full ComponentProfile JSON (matches pydantic schema)
+    source_manual_id    UUID,                                  -- pointer into manuals(id) — soft reference, no FK
+    confidence_overall  NUMERIC(3,2),                          -- 0.00 .. 1.00 (mirrors profile->'confidence'->>'overall')
+    needs_human_review  BOOLEAN     NOT NULL DEFAULT FALSE,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (tenant_id, manufacturer, series, model_number)
+);
+
+-- Primary lookup: technician asks about "Allen-Bradley PowerFlex 525 model X".
+CREATE INDEX IF NOT EXISTS idx_cp_lookup
+    ON component_profiles (tenant_id, manufacturer, model_number);
+
+-- Review queue: surface anything flagged for human eval.
+CREATE INDEX IF NOT EXISTS idx_cp_review
+    ON component_profiles (created_at DESC)
+    WHERE needs_human_review;
+
+-- Fault-code search: "what does F004 mean" — JSONB containment over the array.
+CREATE INDEX IF NOT EXISTS idx_cp_fault_codes
+    ON component_profiles
+    USING gin ((profile -> 'fault_codes'));
+
+-- Component-type browse: "show me all VFD profiles".
+CREATE INDEX IF NOT EXISTS idx_cp_component_type
+    ON component_profiles (tenant_id, component_type);
+
+-- updated_at auto-bump on any row update.
+CREATE OR REPLACE FUNCTION component_profiles_touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_component_profiles_updated_at ON component_profiles;
+CREATE TRIGGER trg_component_profiles_updated_at
+    BEFORE UPDATE ON component_profiles
+    FOR EACH ROW
+    EXECUTE FUNCTION component_profiles_touch_updated_at();
+
+COMMIT;
+
+-- Verification:
+--   \d component_profiles
+--   \di idx_cp_lookup idx_cp_review idx_cp_fault_codes idx_cp_component_type
+--   INSERT INTO component_profiles (tenant_id, manufacturer, component_type, profile, confidence_overall)
+--     VALUES ('00000000-test', 'Allen-Bradley', 'variable_frequency_drive',
+--             '{"component_type":"variable_frequency_drive","confidence":{"overall":0.9}}'::jsonb, 0.90);
+--   SELECT id, manufacturer, component_type, confidence_overall, needs_human_review
+--     FROM component_profiles WHERE tenant_id = '00000000-test';
+--   DELETE FROM component_profiles WHERE tenant_id = '00000000-test';
+--
+-- Rollback:
+--   DROP TRIGGER IF EXISTS trg_component_profiles_updated_at ON component_profiles;
+--   DROP FUNCTION IF EXISTS component_profiles_touch_updated_at();
+--   DROP TABLE IF EXISTS component_profiles;

--- a/mira-core/mira-ingest/db/neon.py
+++ b/mira-core/mira-ingest/db/neon.py
@@ -671,3 +671,105 @@ def tenant_ingested_files_record(
             )
     except Exception:
         pass
+
+
+# ---------------------------------------------------------------------------
+# Component profile writes — see migrations/011_component_profiles.sql.
+# Profile JSON shape matches mira-core/component_profiles/schema.py.
+# ---------------------------------------------------------------------------
+
+
+def upsert_component_profile(
+    tenant_id: str,
+    manufacturer: str,
+    component_type: str,
+    profile: dict,
+    *,
+    series: str | None = None,
+    model_number: str | None = None,
+    source_manual_id: str | None = None,
+) -> str:
+    """Insert or update one component_profiles row. Returns the row id.
+
+    Uniqueness is (tenant_id, manufacturer, series, model_number). On
+    conflict, refresh the profile blob, confidence_overall, review flag,
+    and source_manual_id. updated_at bumps automatically via trigger.
+
+    `profile` is the JSON-serializable dict produced by
+    ComponentProfile.model_dump(mode='json'). confidence_overall and
+    needs_human_review are pulled out for indexed access.
+    """
+    confidence = profile.get("confidence", {}) or {}
+    overall = confidence.get("overall")
+    needs_review = bool(confidence.get("needs_human_review", False))
+
+    with _engine().begin() as conn:
+        row = conn.execute(
+            text("""
+                INSERT INTO component_profiles
+                    (tenant_id, manufacturer, series, model_number,
+                     component_type, profile,
+                     source_manual_id, confidence_overall, needs_human_review)
+                VALUES
+                    (:tid, :mfr, :series, :model,
+                     :ctype, cast(:profile AS jsonb),
+                     :src_manual, :conf, :review)
+                ON CONFLICT (tenant_id, manufacturer, series, model_number)
+                DO UPDATE SET
+                    component_type      = EXCLUDED.component_type,
+                    profile             = EXCLUDED.profile,
+                    source_manual_id    = EXCLUDED.source_manual_id,
+                    confidence_overall  = EXCLUDED.confidence_overall,
+                    needs_human_review  = EXCLUDED.needs_human_review
+                RETURNING id
+            """),
+            {
+                "tid": tenant_id,
+                "mfr": manufacturer,
+                "series": series,
+                "model": model_number,
+                "ctype": component_type,
+                "profile": json.dumps(profile),
+                "src_manual": source_manual_id,
+                "conf": overall,
+                "review": needs_review,
+            },
+        ).fetchone()
+    return str(row[0])
+
+
+def get_component_profile(
+    tenant_id: str,
+    manufacturer: str,
+    *,
+    series: str | None = None,
+    model_number: str | None = None,
+) -> dict[str, Any] | None:
+    """Look up one component_profiles row by unique key. Returns None if absent."""
+    sql = """
+        SELECT id, tenant_id, manufacturer, series, model_number,
+               component_type, profile, source_manual_id,
+               confidence_overall, needs_human_review,
+               created_at, updated_at
+        FROM component_profiles
+        WHERE tenant_id = :tid
+          AND manufacturer = :mfr
+          AND series IS NOT DISTINCT FROM :series
+          AND model_number IS NOT DISTINCT FROM :model
+        LIMIT 1
+    """
+    with _engine().connect() as conn:
+        row = (
+            conn.execute(
+                text(sql),
+                {
+                    "tid": tenant_id,
+                    "mfr": manufacturer,
+                    "series": series,
+                    "model": model_number,
+                },
+            )
+            .mappings()
+            .fetchone()
+        )
+    return dict(row) if row else None

--- a/mira-crawler/celery_app.py
+++ b/mira-crawler/celery_app.py
@@ -43,6 +43,7 @@ app.config_from_object(_config_module)
 # Explicit imports ensure task registration in both Docker (mira_crawler.*) and local dev
 try:
     import mira_crawler.tasks.blog  # noqa: F401
+    import mira_crawler.tasks.component_profile  # noqa: F401
     import mira_crawler.tasks.content  # noqa: F401
     import mira_crawler.tasks.discover  # noqa: F401
     import mira_crawler.tasks.foundational  # noqa: F401
@@ -63,6 +64,7 @@ try:
     import mira_crawler.tasks.youtube_intent  # noqa: F401
 except ImportError:
     import tasks.blog  # noqa: F401
+    import tasks.component_profile  # noqa: F401
     import tasks.content  # noqa: F401
     import tasks.discover  # noqa: F401
     import tasks.foundational  # noqa: F401

--- a/mira-crawler/celeryconfig.py
+++ b/mira-crawler/celeryconfig.py
@@ -60,6 +60,8 @@ task_routes = {
     "mira_crawler.tasks.freshness.*": {"queue": "freshness"},
     # --- LinkedIn draft generation ---
     "linkedin.*": {"queue": "celery"},
+    # --- Component profile extraction (Anthropic Messages API) ---
+    "component_profile.*": {"queue": "ingest"},
 }
 
 # ---------------------------------------------------------------------------

--- a/mira-crawler/requirements-celery.txt
+++ b/mira-crawler/requirements-celery.txt
@@ -21,3 +21,11 @@ PyYAML>=6.0.0
 # 24/7 ingest pipeline deps
 feedparser>=6.0.12
 yt-dlp>=2024.0.0
+
+# Component profile extraction (LLM)
+anthropic>=0.50.0
+pydantic>=2.5
+
+# Pydantic schema for ComponentProfile lives in mira-core/component_profiles/.
+# Containerization step: mira-crawler image must mount or copy
+# mira-core/component_profiles/ onto PYTHONPATH so the Celery task can import it.

--- a/mira-crawler/tasks/component_profile.py
+++ b/mira-crawler/tasks/component_profile.py
@@ -1,0 +1,391 @@
+"""Celery task: extract a structured ComponentProfile from a manual.
+
+Pipeline:
+    manual_cache row → download PDF → docling extract → run deterministic
+    EquipmentMatch + FaultCodeMatch for hints → Anthropic Messages API call
+    via mira-core.component_profiles.extractor → validate → upsert into
+    component_profiles table.
+
+Depends on mira-core/component_profiles/ being on PYTHONPATH inside the
+worker container. See requirements-celery.txt for the mount/copy note.
+
+Daily Anthropic spend is gated by a Redis counter
+`mira:component_profile:spend_today:YYYY-MM-DD` with a $50/day default cap.
+Cheap insurance against runaway retry storms.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+import redis
+
+try:
+    from mira_crawler.celery_app import app
+except ImportError:
+    from celery_app import app
+
+logger = logging.getLogger("mira-crawler.tasks.component_profile")
+
+DOWNLOAD_TIMEOUT = int(os.getenv("CP_DOWNLOAD_TIMEOUT", "60"))
+MAX_PDF_BYTES = int(os.getenv("CP_MAX_PDF_BYTES", str(50 * 1024 * 1024)))
+MAX_MANUAL_CHARS = int(os.getenv("CP_MAX_MANUAL_CHARS", str(600_000)))  # ~200K tokens
+
+# Daily spend ceiling — abort the task if today's cumulative estimated spend
+# has crossed this. Defaults to $50/day. Set CP_DAILY_SPEND_USD_CAP=0 to disable.
+DAILY_SPEND_USD_CAP = float(os.getenv("CP_DAILY_SPEND_USD_CAP", "50.0"))
+
+# Sonnet 4.6 pricing per 1M tokens. Used only for the daily-budget estimate —
+# real cost is reported by Anthropic in the usage block and tracked separately
+# by the org-level dashboard. Override via env if migrating to Opus 4.7 etc.
+PRICE_INPUT_PER_M = float(os.getenv("CP_PRICE_INPUT_PER_M", "3.0"))
+PRICE_OUTPUT_PER_M = float(os.getenv("CP_PRICE_OUTPUT_PER_M", "15.0"))
+PRICE_CACHE_READ_PER_M = float(os.getenv("CP_PRICE_CACHE_READ_PER_M", "0.30"))
+PRICE_CACHE_WRITE_PER_M = float(os.getenv("CP_PRICE_CACHE_WRITE_PER_M", "3.75"))
+
+
+def _estimate_spend_usd(meta_dict: dict) -> float:
+    """Rough cost estimate from Anthropic usage tokens."""
+    return (
+        meta_dict["input_tokens"] * PRICE_INPUT_PER_M
+        + meta_dict["output_tokens"] * PRICE_OUTPUT_PER_M
+        + meta_dict["cache_read_input_tokens"] * PRICE_CACHE_READ_PER_M
+        + meta_dict["cache_creation_input_tokens"] * PRICE_CACHE_WRITE_PER_M
+    ) / 1_000_000.0
+
+
+def _spend_key() -> str:
+    return f"mira:component_profile:spend_today:{datetime.now(timezone.utc):%Y-%m-%d}"
+
+
+def _redis_client() -> redis.Redis:
+    return redis.Redis.from_url(
+        os.environ.get("CELERY_BROKER_URL", "redis://localhost:6379/0"),
+        decode_responses=True,
+    )
+
+
+def _check_budget(r: redis.Redis) -> tuple[bool, float]:
+    """(allowed, spend_today_usd). Fails open on Redis errors."""
+    if DAILY_SPEND_USD_CAP <= 0:
+        return True, 0.0
+    try:
+        raw = r.get(_spend_key())
+        spent = float(raw) if raw else 0.0
+        return spent < DAILY_SPEND_USD_CAP, spent
+    except Exception as exc:
+        logger.warning("Budget check failed (fail-open): %s", exc)
+        return True, 0.0
+
+
+def _record_spend(r: redis.Redis, usd: float) -> None:
+    """Best-effort increment; auto-expire after 36h so the key tidies itself."""
+    try:
+        key = _spend_key()
+        pipe = r.pipeline()
+        pipe.incrbyfloat(key, usd)
+        pipe.expire(key, 36 * 3600)
+        pipe.execute()
+    except Exception as exc:
+        logger.warning("Spend record failed (non-fatal): %s", exc)
+
+
+def _load_manual_cache_row(manual_cache_id: int) -> dict | None:
+    """Look up one manual_cache row by id. Returns dict or None."""
+    from sqlalchemy import text  # type: ignore
+
+    from db.neon import _engine  # type: ignore
+
+    with _engine().connect() as conn:
+        row = (
+            conn.execute(
+                text(
+                    "SELECT id, manufacturer, model, manual_url, manual_title, "
+                    "source, confidence "
+                    "FROM manual_cache WHERE id = :id"
+                ),
+                {"id": manual_cache_id},
+            )
+            .mappings()
+            .fetchone()
+        )
+    return dict(row) if row else None
+
+
+def _download_pdf(url: str) -> bytes:
+    """Streamed PDF download with the same size guards as ingest_url."""
+    if url.startswith("file://"):
+        from urllib.parse import urlparse as _urlparse
+        from urllib.request import url2pathname
+
+        local_path = Path(url2pathname(_urlparse(url).path))
+        data = local_path.read_bytes()
+        if len(data) > MAX_PDF_BYTES:
+            raise ValueError(f"file_too_large: {len(data)} bytes")
+        return data
+
+    tmp = tempfile.NamedTemporaryFile(prefix="mira-cp-", suffix=".pdf", delete=False)
+    tmp_path = Path(tmp.name)
+    downloaded = 0
+    try:
+        with httpx.Client(
+            timeout=DOWNLOAD_TIMEOUT,
+            follow_redirects=True,
+            headers={"User-Agent": "MIRA-ComponentProfileBot/1.0"},
+        ) as client:
+            with client.stream("GET", url) as resp:
+                resp.raise_for_status()
+                for chunk in resp.iter_bytes(chunk_size=64 * 1024):
+                    downloaded += len(chunk)
+                    if downloaded > MAX_PDF_BYTES:
+                        tmp.close()
+                        tmp_path.unlink(missing_ok=True)
+                        raise ValueError(
+                            f"file_too_large: exceeded {MAX_PDF_BYTES} bytes mid-stream"
+                        )
+                    tmp.write(chunk)
+        tmp.close()
+        return tmp_path.read_bytes()
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _blocks_to_text(blocks: list[dict]) -> str:
+    """Flatten docling/converter blocks into one string with page markers.
+
+    Preserves page_num markers as `[p.{n}]` so the model can produce
+    page_reference fields in the profile.
+    """
+    parts: list[str] = []
+    for b in blocks:
+        text = b.get("text", "").strip()
+        if not text:
+            continue
+        page = b.get("page_num")
+        section = (b.get("section") or "").strip()
+        prefix_bits: list[str] = []
+        if page is not None:
+            prefix_bits.append(f"[p.{page}]")
+        if section:
+            prefix_bits.append(f"§ {section}")
+        prefix = " ".join(prefix_bits)
+        parts.append(f"{prefix}\n{text}" if prefix else text)
+    return "\n\n".join(parts)
+
+
+def _truncate_manual(manual_text: str) -> str:
+    """Soft truncation to keep context spend bounded.
+
+    Sonnet 4.6 has a 1M context window but per-call cost scales with input
+    tokens. Default 600K chars (~200K tokens) keeps spend predictable.
+    Note: docling preserves manual structure so the head of the doc carries
+    nameplate, fault tables, parameters — the part we actually need.
+    """
+    if len(manual_text) <= MAX_MANUAL_CHARS:
+        return manual_text
+    truncated = manual_text[:MAX_MANUAL_CHARS]
+    logger.warning(
+        "Manual truncated %d → %d chars (cap=%d)",
+        len(manual_text),
+        len(truncated),
+        MAX_MANUAL_CHARS,
+    )
+    return truncated + "\n\n[...manual truncated for extraction budget...]"
+
+
+def _build_hints(manual_text: str, manual_row: dict) -> dict:
+    """Run EquipmentMatch + FaultCodeMatch and assemble extractor hints.
+
+    Falls back to manual_cache fields if the regex extractors find nothing —
+    the hints are guidance for Claude, not ground truth.
+    """
+    head = manual_text[:8000]  # nameplate / cover page should be here
+
+    manufacturer_hint = manual_row.get("manufacturer") or None
+    model_hint = manual_row.get("model") or None
+    known_codes: list[tuple[str, str, str]] = []
+
+    try:
+        from corpus.extractors.equipment import _MFR_PATTERNS  # type: ignore
+        # _MFR_PATTERNS is the canonical regex table.
+        for pattern, canonical in _MFR_PATTERNS:
+            if pattern.search(head):
+                manufacturer_hint = manufacturer_hint or canonical
+                break
+    except ImportError:
+        logger.debug("EquipmentMatch regex unavailable in this worker — skipping")
+
+    try:
+        from corpus.extractors.fault_codes import _KNOWN_CODES  # type: ignore
+        if manufacturer_hint:
+            mfr_lower = manufacturer_hint.lower()
+            known_codes = [
+                (code, mfr, desc)
+                for code, (mfr, desc) in _KNOWN_CODES.items()
+                if mfr.lower() == mfr_lower
+            ]
+    except ImportError:
+        logger.debug("FaultCodeMatch registry unavailable in this worker — skipping")
+
+    return {
+        "manufacturer_hint": manufacturer_hint,
+        "model_hint": model_hint,
+        "known_fault_codes": known_codes,
+    }
+
+
+@app.task(
+    name="component_profile.extract",
+    bind=True,
+    max_retries=3,
+    default_retry_delay=60,
+    soft_time_limit=300,
+    time_limit=600,
+    acks_late=False,
+    rate_limit="20/m",
+    autoretry_for=(httpx.HTTPError, httpx.TimeoutException),
+    retry_backoff=True,
+    retry_backoff_max=300,
+    retry_jitter=True,
+)
+def extract_component_profile_task(self, manual_cache_id: int) -> dict:
+    """Extract one component profile from a manual_cache row.
+
+    Returns:
+        {profile_id, confidence, needs_review, model, latency_ms,
+         input_tokens, output_tokens, spend_usd}
+        — or {error: str} on failure.
+    """
+    # Imports inside the task body so import errors don't crash the worker
+    # at startup if mira-core/component_profiles isn't mounted yet.
+    from component_profiles.extractor import (  # type: ignore
+        ExtractionError,
+        extract_component_profile,
+    )
+    from component_profiles.schema import CopyrightHandling  # type: ignore
+    from db.neon import upsert_component_profile  # type: ignore
+    from ingest.converter import extract_from_pdf_with_fallback  # type: ignore
+
+    tenant_id = os.getenv("MIRA_TENANT_ID", "")
+    if not tenant_id:
+        logger.error("MIRA_TENANT_ID not set — cannot extract")
+        return {"error": "no_tenant_id"}
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        logger.error("ANTHROPIC_API_KEY not set — cannot extract")
+        return {"error": "no_anthropic_key"}
+
+    r = _redis_client()
+    allowed, spend_today = _check_budget(r)
+    if not allowed:
+        logger.warning(
+            "BUDGET_CAP_REACHED today=%.2f cap=%.2f — skipping manual_cache_id=%s",
+            spend_today,
+            DAILY_SPEND_USD_CAP,
+            manual_cache_id,
+        )
+        return {
+            "error": "daily_spend_cap_reached",
+            "spend_today_usd": round(spend_today, 4),
+        }
+
+    manual_row = _load_manual_cache_row(manual_cache_id)
+    if not manual_row:
+        return {"error": "manual_cache_row_not_found", "manual_cache_id": manual_cache_id}
+
+    url = manual_row["manual_url"]
+    if not url:
+        return {"error": "manual_url_missing", "manual_cache_id": manual_cache_id}
+
+    # 1. Download
+    try:
+        pdf_bytes = _download_pdf(url)
+    except ValueError as ve:
+        return {"error": str(ve), "url": url[:120]}
+
+    # 2. Extract text + tables (docling under the hood, with fallbacks)
+    blocks = extract_from_pdf_with_fallback(pdf_bytes)
+    if not blocks:
+        return {"error": "no_extractable_text", "url": url[:120]}
+
+    manual_text = _truncate_manual(_blocks_to_text(blocks))
+
+    # 3. Build hints from deterministic extractors
+    hints = _build_hints(manual_text, manual_row)
+
+    # 4. Anthropic call
+    try:
+        profile, meta = extract_component_profile(
+            manual_text,
+            manufacturer_hint=hints["manufacturer_hint"],
+            model_hint=hints["model_hint"],
+            known_fault_codes=hints["known_fault_codes"],
+            source_title=manual_row.get("manual_title"),
+            source_url=url,
+            copyright_handling=CopyrightHandling.LINK_ONLY,
+        )
+    except ExtractionError as ee:
+        logger.error("Extraction failed for manual_cache_id=%s: %s", manual_cache_id, ee)
+        return {"error": f"extraction_failed: {ee}", "manual_cache_id": manual_cache_id}
+
+    # 5. Record spend
+    meta_dict = meta.to_dict()
+    spend_usd = _estimate_spend_usd(meta_dict)
+    _record_spend(r, spend_usd)
+
+    # 6. Persist
+    profile_dict = profile.model_dump(mode="json")
+    # If the LLM left the manufacturer empty but the hint had one, fall back to it
+    # so the unique-key write doesn't violate NOT NULL.
+    manufacturer = profile.manufacturer or hints["manufacturer_hint"]
+    if not manufacturer:
+        return {
+            "error": "manufacturer_undetermined",
+            "manual_cache_id": manual_cache_id,
+            "spend_usd": round(spend_usd, 4),
+        }
+
+    profile_id = upsert_component_profile(
+        tenant_id=tenant_id,
+        manufacturer=manufacturer,
+        component_type=profile.component_type,
+        profile=profile_dict,
+        series=profile.series,
+        model_number=(profile.model_numbers[0] if profile.model_numbers else hints["model_hint"]),
+        source_manual_id=None,  # manual_cache has integer ids; manuals table FK is UUID-only
+    )
+
+    logger.info(
+        "COMPONENT_PROFILE_UPSERTED id=%s manufacturer=%s component_type=%s "
+        "confidence=%.2f review=%s spend=$%.4f tokens_in=%d tokens_out=%d cache_read=%d",
+        profile_id,
+        manufacturer,
+        profile.component_type,
+        profile.confidence.overall,
+        profile.confidence.needs_human_review,
+        spend_usd,
+        meta_dict["input_tokens"],
+        meta_dict["output_tokens"],
+        meta_dict["cache_read_input_tokens"],
+    )
+
+    return {
+        "profile_id": profile_id,
+        "manufacturer": manufacturer,
+        "component_type": profile.component_type,
+        "confidence": profile.confidence.overall,
+        "needs_review": profile.confidence.needs_human_review,
+        "model": meta_dict["model"],
+        "latency_ms": meta_dict["latency_ms"],
+        "input_tokens": meta_dict["input_tokens"],
+        "output_tokens": meta_dict["output_tokens"],
+        "cache_read_input_tokens": meta_dict["cache_read_input_tokens"],
+        "cache_creation_input_tokens": meta_dict["cache_creation_input_tokens"],
+        "spend_usd": round(spend_usd, 4),
+        "retry_attempted": meta_dict["retry_attempted"],
+    }


### PR DESCRIPTION
## Summary

- New Celery pipeline that turns vendor manuals into structured maintenance intelligence (fault codes, parameters, terminals, PM schedules, spare parts, safety warnings) — each with page references and a confidence score
- Architecture: Anthropic Messages API + `tool_use` + prompt caching (**NOT** the Agent SDK — single-shot doc → JSON is a pure function; agent loop reserved for v2)
- Code-only — nothing in this PR touches an existing prod path. Migration is included but not yet run

## What landed

- `mira-core/component_profiles/` — Pydantic `ComponentProfile` schema, system prompt + tool definition, Anthropic SDK wrapper with one validation-retry. **12/12 schema tests passing**
- `mira-core/mira-ingest/db/migrations/011_component_profiles.sql` — new table with `(tenant_id, manufacturer, series, model_number)` unique key, GIN index on `profile->'fault_codes'`, `updated_at` trigger
- `mira-core/mira-ingest/db/neon.py` — `upsert_component_profile()` + `get_component_profile()` helpers
- `mira-crawler/tasks/component_profile.py` — `component_profile.extract(manual_cache_id)` Celery task: load row → stream PDF (50MB cap) → docling extract → `EquipmentMatch` + `FaultCodeMatch` hints → Anthropic call → upsert. Includes a $50/day Redis spend cap as insurance against retry storms
- `mira-crawler/{celery_app,celeryconfig}.py` — registers task on the `ingest` queue with 20/min rate limit
- `mira-crawler/requirements-celery.txt` — `anthropic>=0.50.0`, `pydantic>=2.5`

Default model `claude-sonnet-4-6` (cost-optimized for bulk extraction). Plan estimates **$0.20–0.60 per manual** with prompt-cache hits — the $200 credit translates to ~400–1000 manuals end-to-end.

## Why Messages API and not Agent SDK

The extraction is a pure function: `(manual_chunks, schema) → JSON`. No tool calls needed during extraction — docling already extracted the text and tables before the model sees it. Single-shot with `tool_choice` for forced JSON output is deterministic, cheap, trivial to retry on validation failure, and easy to swap models on. Agent SDK becomes worth it in v2 when the extractor wants to query existing `component_profiles` for "have I seen this model already?" or fetch a specific page on demand.

## Test plan

Pre-merge:
- [ ] `cd mira-core && python -m pytest component_profiles/tests/ -v` — expect 12/12 green
- [ ] Confirm `anthropic` + `pydantic` resolve in the CI `requirements-celery.txt` install step

Deployment (post-merge, separate ops work):
- [ ] Run migration 011 against NeonDB (preview env first)
- [ ] Update `mira-crawler` Dockerfile to mount `mira-core/component_profiles/` onto worker PYTHONPATH (and optionally `mira-bots/benchmarks/corpus/extractors/` for hint enrichment — task degrades gracefully if absent)
- [ ] Set `ANTHROPIC_API_KEY` in worker env (Doppler); confirm `MIRA_TENANT_ID`
- [ ] Rebuild + redeploy `mira-celery-worker`
- [ ] Smoke-test one AB PowerFlex 525 `manual_cache` row: `celery -A mira_crawler.celery_app call component_profile.extract --args='[<id>]'`
- [ ] Hand-eval 10 profiles across 3 manufacturers (AB / Siemens / ABB). Gate: ≥7/10 accurate before opening the full queue

## Plan + design context

Full design, phasing, and the "honest take on the proposal" lives in Mike's local plan file: `~/.claude/plans/https-youtu-be-ov56rddyfuu-si-1hlygnni1n-transient-forest.md`

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>