### PR TITLE
fix(slack): resolve chat_adapter import + Phase 1 discovery audit

### DIFF
--- a/docs/audits/slack-phase1-discovery-2026-05-14.md
+++ b/docs/audits/slack-phase1-discovery-2026-05-14.md
@@ -1,0 +1,289 @@
+# Slack Phase 1 — Discovery & Existing Code Audit
+
+**Date:** 2026-05-14
+**Node:** CHARLIE
+**Branch:** `claude/happy-chatterjee-7ce28f`
+**Issue:** [#1270](https://github.com/Mikecranesync/MIRA/issues/1270)
+**Status:** Discovery complete. Crash root cause identified and patched.
+
+---
+
+## TL;DR
+
+- **Crash root cause:** `mira-bots/slack/Dockerfile` did not COPY `chat_adapter.py` into the image. `bot.py` imports `from chat_adapter import SlackChatAdapter` → `ModuleNotFoundError: chat_adapter`. The file exists in the repo; it was simply never copied. **Fixed in this PR** (one-line Dockerfile change).
+- **Architecture:** the Slack adapter already implements the platform-agnostic `ChatAdapter` protocol (same pattern as Telegram). It wires `SlackChatAdapter` → `ChatDispatcher` → `Supervisor` (shared engine). No re-architecture required.
+- **Secrets:** all 3 required Slack secrets exist in Doppler `factorylm/prd`. Nothing to ask Mike for on credentials.
+- **Specs:** the two spec docs referenced by issue #1270 (`docs/specs/slack-technician-workflow-spec.md` and `docs/specs/mira-component-intelligence-architecture.md`) **do not exist yet**. So is the cited rule `.claude/rules/uns-confirmation-gate.md`. These are prerequisites for Phase 2 and must be written before further Slack work.
+- **Tests:** `test_slack_adapter.py` and `test_slack_relay.py` exist in `mira-bots/tests/`. Coverage status not measured in Phase 1.
+
+---
+
+## 1. Every Slack-related file in the repo
+
+### 1a. Slack bot adapter (`mira-bots/slack/`)
+
+| File | Size | Role |
+|---|---|---|
+| `mira-bots/slack/bot.py` | 14 KB | Entry point. Socket Mode app, `app_mention` + `message.im` handlers, `/mira-equipment`, `/mira-faults`, `/mira-reset`, `/mira` slash commands. Wires `Supervisor` + `SlackChatAdapter` + `ChatDispatcher`. |
+| `mira-bots/slack/chat_adapter.py` | 3.9 KB | `SlackChatAdapter` class implementing the platform-agnostic `ChatAdapter` protocol. `normalize_incoming` / `render_outgoing` / `download_attachment`. Renders via `shared/chat/renderers/slack_blocks.py`. |
+| `mira-bots/slack/pdf_handler.py` | 4.4 KB | Uploads PDFs from Slack DMs into Open WebUI KB. |
+| `mira-bots/slack/requirements.txt` | 131 B | `slack-bolt`, `httpx`, `Pillow`, etc. |
+| `mira-bots/slack/Dockerfile` | 392 B | Build recipe. **Bug:** chat_adapter.py was missing from COPY (fixed in this PR). |
+| `mira-bots/slack/.doppler.yaml` | 42 B | Pins Doppler project=factorylm, config=prd. |
+| `mira-bots/slack/.env.example` | 962 B | Local-dev example of required env vars. |
+
+### 1b. Shared abstractions used by Slack
+
+| File | Role |
+|---|---|
+| `mira-bots/shared/chat/dispatcher.py` | `ChatDispatcher` — feeds `NormalizedChatEvent`s into `Supervisor` (the engine). |
+| `mira-bots/shared/chat/types.py` | `NormalizedChatEvent`, `NormalizedChatResponse`, `NormalizedAttachment`. Platform-agnostic. |
+| `mira-bots/shared/chat/renderers/slack_blocks.py` | `render_slack()` — converts a `NormalizedChatResponse` into Slack Block Kit JSON. |
+| `mira-bots/shared/engine.py` | `Supervisor` — the GSD/diagnostic engine all adapters share. |
+
+### 1c. Tests
+
+| File | Notes |
+|---|---|
+| `mira-bots/tests/test_slack_adapter.py` | Stubs `slack_bolt` (MIT) before import. Fixtures use placeholder tokens. |
+| `mira-bots/tests/test_slack_relay.py` | Slack relay/webhook tests. |
+
+### 1d. OAuth / install (mira-hub)
+
+| File | Role |
+|---|---|
+| `mira-hub/src/app/api/auth/slack/route.ts` | Initiates Slack workspace install / OAuth flow. |
+| `mira-hub/src/app/api/auth/slack/callback/route.ts` | OAuth callback — exchanges code for workspace tokens. |
+
+### 1e. Compose
+
+| File | Defines `slack-bot`? |
+|---|---|
+| `mira-bots/docker-compose.yml` | YES — service `slack-bot` (`container_name: mira-bot-slack`, `bot-net` + `core-net`). |
+| `docker-compose.hub.yml` (repo root) | No `slack-bot` block. |
+| `docker-compose.saas.yml` (repo root) | No `slack-bot` block. |
+
+### 1f. Docs
+
+| File | Notes |
+|---|---|
+| `docs/integrations/slack_api_reference.md` | Reference of Slack OAuth + Bolt + webhook capabilities we use. |
+
+---
+
+## 2. Slack environment variables
+
+### 2a. Required by `mira-bots/slack/bot.py`
+
+| Var | Required? | Source |
+|---|---|---|
+| `SLACK_BOT_TOKEN` | required (`os.environ[...]`) | Doppler `factorylm/prd` — present (`xoxb-10648436040919-...`). |
+| `SLACK_APP_TOKEN` | required (`os.environ[...]`) | Doppler `factorylm/prd` — present (`xapp-1-A0AK2DL94EB-...`). |
+| `OPENWEBUI_BASE_URL` | optional (default `http://mira-core:8080`) | core compose env. |
+| `OPENWEBUI_API_KEY` | optional | Doppler. |
+| `MCP_BASE_URL` | optional | Doppler. |
+| `MCP_REST_API_KEY` | optional | Doppler. |
+| `KNOWLEDGE_COLLECTION_ID` | optional | Doppler. |
+| `SLACK_ALLOWED_CHANNELS` | optional (CSV channel IDs) | — |
+| `MIRA_DB_PATH` | optional (default `/data/mira.db`) | mira-bridge mounted volume. |
+| `VISION_MODEL` | optional (default `qwen2.5vl:7b`) | Doppler. |
+| `MIRA_TENANT_ID` | optional | Doppler. |
+
+### 2b. Used by `chat_adapter.py`
+
+| Var | Required? |
+|---|---|
+| `SLACK_SIGNING_SECRET` | passed in (optional, used for signature verification in non-Socket-Mode deployments). |
+
+### 2c. Doppler status (`factorylm/prd`)
+
+| Var | In Doppler? |
+|---|---|
+| `SLACK_APP_TOKEN` | ✅ present |
+| `SLACK_BOT_TOKEN` | ✅ present |
+| `SLACK_SIGNING_SECRET` | ✅ present |
+
+**Conclusion: no missing credentials. Mike does not need to provision new Slack secrets.**
+
+---
+
+## 3. The `chat_adapter` crash — root cause
+
+### 3a. The error
+
+`mira-bot-slack` container crash-looping with:
+
+```
+ModuleNotFoundError: No module named 'chat_adapter'
+```
+
+### 3b. The cause
+
+`mira-bots/slack/Dockerfile` (line 10, pre-fix):
+
+```dockerfile
+COPY slack/bot.py slack/pdf_handler.py ./
+```
+
+But `bot.py` does:
+
+```python
+from chat_adapter import SlackChatAdapter
+from pdf_handler import ingest_pdf
+```
+
+`chat_adapter.py` exists in the repo at `mira-bots/slack/chat_adapter.py`, but the Dockerfile never copied it into the image. When the container started, the Python sibling-import failed at module load time → crash loop.
+
+### 3c. Why Telegram works and Slack didn't
+
+Telegram's Dockerfile (line 8) copies its full module set:
+
+```dockerfile
+COPY mira-bots/telegram/bot.py mira-bots/telegram/chat_adapter.py mira-bots/telegram/renderers.py mira-bots/telegram/voice_transcription.py mira-bots/telegram/admin_commands.py mira-bots/telegram/start_command.py ./
+```
+
+`chat_adapter.py` is explicitly listed. Slack's was a `git mv` / refactor leftover — the file was added to the source tree but never to the Dockerfile manifest.
+
+### 3d. The fix (in this PR)
+
+`mira-bots/slack/Dockerfile`:
+
+```diff
+- COPY slack/bot.py slack/pdf_handler.py ./
++ COPY slack/bot.py slack/chat_adapter.py slack/pdf_handler.py ./
+```
+
+One-line change. No code change, no architectural change.
+
+### 3e. Path convention difference (cosmetic, not bug)
+
+- Slack compose uses `context: .` from inside `mira-bots/` → COPY paths are `slack/...`.
+- Telegram compose uses `context: ../` (one level up) → COPY paths are `mira-bots/telegram/...`.
+
+This is an inconsistency worth normalizing eventually, but it does **not** affect functionality. Leaving as-is for Phase 1 (out of scope per "surgical changes" rule in `karpathy-principles.md`).
+
+---
+
+## 4. Slack adapter ↔ Telegram adapter — pattern map
+
+Both adapters implement the same `ChatAdapter` protocol. The shared engine never sees a Slack-specific or Telegram-specific object.
+
+| Concern | Telegram | Slack |
+|---|---|---|
+| Entry-point lib | `python-telegram-bot` (`Application` + `MessageHandler`) | `slack-bolt` (`AsyncApp` + Socket Mode handler) |
+| Event handler | `MessageHandler(filters.PHOTO, on_photo)`, etc. | `@app.event("app_mention")`, `@app.event("message")` |
+| Normalize step | `TelegramChatAdapter.normalize_incoming(update)` → `NormalizedChatEvent` | `SlackChatAdapter.normalize_incoming(event)` → `NormalizedChatEvent` |
+| Dispatch | `ChatDispatcher.dispatch(normalized)` (shared) | `ChatDispatcher.dispatch(normalized)` (shared) |
+| Engine | `Supervisor` (shared) | `Supervisor` (shared) |
+| Render | `shared/chat/renderers/telegram_md.py` (or similar) | `shared/chat/renderers/slack_blocks.py` |
+| Attachment download | bearer-token-authenticated GET on file URL | bearer-token-authenticated GET on `url_private_download` |
+| Session key | `f"telegram:{chat_id}"` | `f"slack:{channel}:{thread_ts or 'main'}"` |
+
+**Slack-specific features beyond Telegram parity:**
+
+- Thread awareness (`thread_ts` in session key + `say(thread_ts=...)`) — Slack conversations are tree-shaped, not linear.
+- Slash commands: `/mira`, `/mira-equipment`, `/mira-faults`, `/mira-reset`.
+- Block Kit responses (richer formatting via `slack_blocks.py`).
+
+**Telegram features absent from Slack:**
+
+- Voice transcription (`voice_transcription.py`)
+- Admin commands (`admin_commands.py` — `/invite`, `/revoke`, `/team`)
+- Identity service wiring (`shared.identity.service`)
+- Photo batch queue (`shared.photo_batch_queue`)
+- Atlas CMMS outbox drain (`shared.integrations.wo_outbox.run_drain_forever`)
+- Push notification handoff
+- Tenant authorizer
+- Start command UX
+
+These gaps are not in scope for Phase 1 (just discovery + crash fix). They are the candidates for Phase 2+ when we port the technician workflow to Slack.
+
+---
+
+## 5. What's implemented vs. broken vs. missing
+
+### Implemented ✅
+
+- Socket Mode connection to Slack workspace
+- `app_mention` + `message.im` handlers
+- Photo attachment normalization + vision pipeline pre-resize
+- PDF ingestion into Open WebUI KB (`pdf_handler.py`)
+- 4 slash commands (`/mira`, `/mira-equipment`, `/mira-faults`, `/mira-reset`)
+- Block Kit response renderer
+- Thread-aware session keying
+- Channel allowlist gate (`SLACK_ALLOWED_CHANNELS`)
+- ChatAdapter protocol conformance — drops cleanly into the shared dispatcher
+- Doppler integration (`.doppler.yaml` pinned to `factorylm/prd`)
+- OAuth install routes in mira-hub (TS) — for self-serve workspace install
+- Unit tests stubbing `slack_bolt`
+
+### Broken 🔧 (fixed in this PR)
+
+- Dockerfile missing `chat_adapter.py` in COPY → `ModuleNotFoundError` crash loop
+
+### Missing / not yet built ⏳
+
+| Item | Notes |
+|---|---|
+| `docs/specs/slack-technician-workflow-spec.md` | Referenced by issue #1270; does not exist yet. Must be written before Phase 2. |
+| `docs/specs/mira-component-intelligence-architecture.md` | Referenced; does not exist. |
+| `.claude/rules/uns-confirmation-gate.md` | Referenced; does not exist. Only `karpathy-principles.md`, `python-standards.md`, `security-boundaries.md` present in `.claude/rules/`. |
+| Identity service wiring on Slack | Telegram has `shared.identity.service.get_identity_service()` — Slack does not. Required before per-tech feature gating. |
+| Tenant authorizer on Slack | Telegram has `Authorizer` — Slack does not. |
+| WO outbox drain on Slack worker | Telegram runs `run_drain_forever` in-process. Slack would need either the same wiring or a shared worker. |
+| Slack app manifest JSON | No `manifest.json` / `app_manifest.yaml` checked into repo. Workspace install today appears to be hand-configured. Should be codified before onboarding any new workspace. |
+| Health endpoint | Compose healthcheck is `python -c "import slack_bolt"` — fine for build verification, but does not confirm Socket Mode is connected. Telegram bot also lacks a true liveness probe; not a regression. |
+| Smoke test for Slack path | `install/smoke_test.sh` does not appear to exercise the Slack adapter. Worth adding once container is verified healthy on the VPS. |
+| Coverage measurement | Tests exist; no coverage report on file. Not in scope for Phase 1. |
+
+---
+
+## 6. Slack API credentials Mike needs to set up
+
+**None for Phase 1.** All three required secrets are already in Doppler `factorylm/prd`:
+
+- `SLACK_APP_TOKEN`
+- `SLACK_BOT_TOKEN`
+- `SLACK_SIGNING_SECRET`
+
+For Phase 2+ (multi-workspace / SaaS install), we will additionally need:
+
+- `SLACK_CLIENT_ID` (for OAuth install flow in mira-hub)
+- `SLACK_CLIENT_SECRET` (for the callback exchange)
+- `SLACK_REDIRECT_URI` (set on app config: `https://factorylm.com/api/auth/slack/callback`)
+
+These are NOT yet in Doppler. They are needed only when we open the Slack app to workspaces beyond Mike's dev workspace.
+
+---
+
+## 7. Recommended next steps for Phase 2
+
+1. **Write the missing specs** (blocker for any further Slack work):
+   - `docs/specs/slack-technician-workflow-spec.md` — what the technician journey on Slack looks like end-to-end (intake → diagnosis → confirmation → WO creation → recall).
+   - `docs/specs/mira-component-intelligence-architecture.md` — the cross-bot component intelligence layer.
+   - `.claude/rules/uns-confirmation-gate.md` — the UNS confirmation gate behavior rule.
+2. **Verify the Dockerfile fix on the VPS** — rebuild `mira-bot-slack`, confirm Socket Mode connects, `app_mention` echoes through, no crash loop. Capture container logs as evidence (Law 1).
+3. **Wire identity service + tenant authorizer** into Slack `bot.py`, matching the Telegram pattern. Mandatory before exposing the adapter to any real tech beyond Mike.
+4. **Codify the Slack app manifest** as a checked-in `mira-bots/slack/app_manifest.yaml`. Source of truth for scopes, events, slash commands, OAuth URLs.
+5. **Normalize the compose build-context convention** between Telegram (root context) and Slack (mira-bots context). Tiny refactor; pick one and align.
+6. **Port the WO outbox drain** to a shared worker so every adapter benefits without duplicating `run_drain_forever`.
+7. **Add a Slack-path smoke test** to `install/smoke_test.sh`.
+
+---
+
+## 8. Out-of-scope deferrals (intentionally not done in Phase 1)
+
+- Migrating `slack-bot` service into `docker-compose.hub.yml` / `docker-compose.saas.yml` (currently only in `mira-bots/docker-compose.yml`).
+- Standardizing COPY-path convention across all bot Dockerfiles.
+- Adding Slack-specific photo batch queue.
+- Writing the three missing prereq docs (specs + rule) — these need product-level input from Mike, not a discovery audit.
+- Slack `manifest.yaml` — needs the spec doc first to know what scopes/events the technician workflow requires.
+
+---
+
+## Evidence
+
+- Doppler secrets listed: `doppler secrets --project factorylm --config prd | grep -i slack` → 3 keys present.
+- Dockerfile diff: see `mira-bots/slack/Dockerfile` in this PR.
+- Telegram pattern reference: `mira-bots/telegram/Dockerfile` line 8 — `chat_adapter.py` explicitly copied.
+- Files listed: `find . -path '*/slack*' -o -name '*slack*'` (filtered, see Section 1).

--- a/docs/superpowers/plans/2026-05-13-cowork-continuation-prompt.md
+++ b/docs/superpowers/plans/2026-05-13-cowork-continuation-prompt.md
@@ -1,0 +1,189 @@
+# Cowork Continuation Prompt — Conveyor Demo MVP
+
+> **Paste this whole document into a fresh Claude Code session on CHARLIE (or drop into `/cluster/betterclaw/task_queue/` as a Task.md for midnight cowork).** It is self-contained — fresh agent has zero prior context.
+
+---
+
+## Identity & Scope
+
+You are continuing the MIRA garage-conveyor demo build for the **Florida Automation Expo on 2026-05-21**. Change freeze starts **2026-05-18**. Today is 2026-05-13 (or later — check `date`). You are on the CHARLIE node of the FactoryLM cluster, working in `~/MIRA`.
+
+Mike's vision: he ingests his physical demo conveyor by sending nameplate photos to the Telegram bot. MIRA OCRs nameplates → finds manuals → builds UNS-compliant component templates → fleshes out the asset in the FactoryLM Hub UI. At the booth, he asks "Why is Conveyor 1 stopped?" and gets a graph-walked, evidence-cited answer.
+
+**Authoritative spec:** `docs/specs/mira-component-intelligence-architecture.md`
+**Plan (read before doing anything):** `docs/superpowers/plans/2026-05-13-mira-conveyor-demo-mvp.md`
+**Cluster laws (non-negotiable):** `~/factorylm/CLUSTER.md` — Evidence-Only Completion (Law 1), 300-line orchestrator limit (Law 3), Task.md protocol (Law 4), Lesson Log every session (Law 5).
+
+## Decisions Already Locked (do NOT re-litigate)
+
+- **Tenant:** new "Demo Plant" tenant (slug `demo_plant`). UUID needs to be generated + stored in Doppler `factorylm/prd` as `DEMO_PLANT_TENANT_ID` if not present.
+- **Asset name:** Conveyor 1.
+- **Review UI:** screenshot in pitch — bot Q&A is the live moment.
+- **No Anthropic, no LangChain, Groq → Cerebras → Gemini cascade only** (per CLAUDE.md Hard Constraint #2).
+- **UNS-compliant ltree everywhere** (per `.claude/rules/uns-compliance.md`).
+
+## Audits Already Done (don't re-run; trust the file:line references)
+
+Four parallel `feature-dev:code-explorer` agents traced the workflow on 2026-05-13. Findings:
+
+### Photo → nameplate → asset
+- `mira-bots/telegram/bot.py:582–619` — photo handler, 4s burst window, multi-photo path works
+- `mira-bots/shared/workers/vision_worker.py:133–411` — classifies NAMEPLATE / ELECTRICAL_PRINT / EQUIPMENT_PHOTO
+- `mira-bots/shared/workers/nameplate_worker.py:81–197` — extracts `{manufacturer, model, serial, voltage, fla, hp, frequency, rpm}` via cascade
+- `mira-bots/shared/engine.py:2146–2306` — `_handle_nameplate()` runs the full flow
+- **CRITICAL BUG:** `engine.py:2191` POSTs to `/api/cmms/nameplate` but **the REST endpoint does not exist** in `mira-mcp/server.py`. Only the MCP tool `create_asset_from_nameplate` at line 388 is wired. **Every nameplate photo silently fails to create the asset in Atlas CMMS today.** Fix is to add `_rest_cmms_nameplate(request)` handler.
+
+### OEM manual discovery
+- `mira-crawler/tasks/discover.py:86` — `discover_manufacturer` Celery task, Apify-powered. Hardcoded for Rockwell, Siemens, ABB, Schneider, Mitsubishi, Yaskawa, Danfoss, Lenze.
+- `mira-crawler/tasks/ingest.py:58` — `ingest_url` task: Docling PDF → 2000-char chunks → Ollama `nomic-embed-text` → NeonDB `knowledge_entries`
+- **Gap:** AutomationDirect (GS10 VFD) is in `scripts/discover_manuals.py` but NOT in the main task hardcode. For the GS10 demo, either add it or pre-stage the PDF.
+- **Gap:** UNS path not stamped at ingest (violates `uns-compliance.md` rule 2).
+
+### Component template builder
+- `tools/build_component_template.py` (in PR #1253) — CLI tool, but `extract_template()` and `insert_template()` are importable as Python functions.
+- **No MCP tool exposes the template builder.** Engine has no tool-calling loop; it only dispatches to workers (vision/nameplate/RAG/print/PLC).
+- Correct integration plane is a **Celery task chain**: `discover → ingest → build_template_for(manufacturer, model)` — not an MCP tool.
+
+### Hub UI (this is in `mira-hub`, NOT `mira-web`)
+- `mira-web` is the PLG funnel + QR handler. **The Hub UI is `mira-hub/` (Next.js 16).**
+- `mira-hub/src/app/api/uns/browse/route.ts:36–168` — UNS ltree browser endpoint (kind: literal/dynamic/both) **exists; no UI consumer yet.**
+- `mira-hub/src/app/(hub)/assets/[id]/page.tsx:19–101` — asset detail page **renders mock data; needs real wiring.**
+
+## Open PRs Blocking Day 1
+
+| PR | Title | CI state | Blocker |
+|---|---|---|---|
+| #1245 | UNS ISA-95 path backfill | 17/18 pass; E2E smoke red **but same red on main** | Mike must confirm-and-merge per CI policy |
+| #1253 | Component intelligence schema + tools | 17/18 pass; same E2E smoke red | Same — Mike confirm |
+
+**Do NOT auto-merge these PRs.** Repo CI & Merge Policy in `~/.claude/CLAUDE.md` requires user confirmation when pre-existing red on main is the only failure.
+
+## Decisions Mike Still Owes (4)
+
+These were posed in the last conversation; he hasn't answered. Make the reasonable call only if it doesn't paint into a corner:
+
+1. **Live-or-canned at booth:** all-in on live ingestion vs. live-primary + canned fallback toggle. *Recommended default: build both; canned is the fallback `tools/seed_demo_conveyor.py`.*
+2. **Multi-photo UX:** bot prompts for asset overview first vs. Mike sends a "starter" message and bot collects in burst mode. *Recommended default: starter message + burst — fewer states.*
+3. **AutomationDirect GS10 manual fetch:** add to `discover.py` hardcode vs. pre-stage PDF in `knowledge_entries`. *Recommended default: pre-stage the GS10 PDF; one less moving piece for the demo.*
+4. **Where live demo runs:** prod NeonDB Demo Plant tenant vs. staging branch. *Recommended default: staging branch you can wipe between rehearsals; promote to prod only after dress rehearsal succeeds.*
+
+If Mike pings during the session, surface these. Otherwise default-and-flag.
+
+---
+
+## Authorized Work for This Session (autonomous, no human approval needed)
+
+Execute in this order. Each item lists what proves it's done.
+
+### 1. Sanity checks (read-only) — 15 min
+- [ ] `cd ~/MIRA && git pull --rebase origin main` (must succeed cleanly)
+- [ ] `gh pr checks 1245 && gh pr checks 1253` — confirm CI state matches handoff
+- [ ] Run Day 0 Step 4 CHECK-constraint audit (read-only SQL):
+      ```bash
+      doppler run -p factorylm -c prd -- python -c "
+      import os, psycopg2
+      conn = psycopg2.connect(os.environ['NEONDB_URL'])
+      cur = conn.cursor()
+      cur.execute(\"\"\"
+        SELECT relationship_type, COUNT(*) FROM kg_relationships GROUP BY relationship_type
+        EXCEPT
+        SELECT unnest(ARRAY['HAS_COMPONENT','INSTANCE_OF','HAS_DOCUMENT','HAS_CHUNK','HAS_PART','HAS_PROCEDURE',
+          'WIRED_TO','LOCATED_IN','POWERED_BY','MAPS_TO','PUBLISHED_AS','USED_IN_LOGIC',
+          'TRIGGERS','CAUSES','OCCURS_ON','RESOLVED_BY','REFERENCES','REPLACES',
+          'HAS_FAILURE_MODE','HAS_SIGNAL','HAS_ALIAS','DEPENDS_ON','UPSTREAM_OF',
+          'DOWNSTREAM_OF','CONFIRMED_BY','CONTRADICTED_BY']), NULL;
+      \"\"\")
+      rows = cur.fetchall()
+      print('Rows violating migration 018 CHECK:', rows or 'NONE — safe to merge')
+      "
+      ```
+      **Proof:** paste output into the handoff doc. If non-empty: STOP and surface — migration 018 will fail.
+- [ ] Eval baseline: `cd ~/MIRA && pytest tests/eval/ -v --tb=short 2>&1 | tail -50 > /tmp/eval-baseline-$(date +%Y%m%d).txt`
+      **Proof:** pass rate copied to `wiki/hot.md` under today's date.
+
+### 2. Fix the broken `/api/cmms/nameplate` REST endpoint — ½ day
+
+- [ ] Create worktree: `git worktree add ../mira-fix-nameplate-rest fix/cmms-nameplate-rest-endpoint`
+- [ ] Read `mira-mcp/server.py` near the existing `create_asset_from_nameplate` MCP tool (line 388) — understand its signature.
+- [ ] Find the existing REST handler pattern in `mira-mcp/server.py` (search for `async def _rest_` or `aiohttp.web.RouteTableDef`).
+- [ ] Add a new REST handler `_rest_cmms_nameplate(request)` that wraps the same logic. Body shape per `engine.py:2173–2195` — `{tenant_id, manufacturer, model, serial, voltage, hp, fla, ...}`.
+- [ ] Wire it to the route table (`/api/cmms/nameplate`).
+- [ ] Write a pytest test in `tests/test_mcp_rest_nameplate.py` that POSTs synthetic nameplate data and asserts an `cmms_equipment` row + `kg_entity` row are created with a proper UNS path.
+- [ ] Run the test. **Proof:** paste pytest output.
+- [ ] Run the full eval suite — pass rate must match baseline. **Proof:** paste tail output.
+- [ ] Commit: `fix(mcp): add REST endpoint for /api/cmms/nameplate (was 404 from engine)`
+- [ ] Push + open PR as **draft** with body referencing the audit finding from this plan.
+
+### 3. Draft `mira-bots/shared/graph_traversal.py` (feature-flag default OFF) — ½ day
+
+- [ ] Worktree: `git worktree add ../mira-graph-traversal feat/engine-graph-walk-augmentation`
+- [ ] TDD-first: write `tests/test_graph_traversal.py` with the failing tests in plan Day 4 Step 1.
+- [ ] Implement `augment_context(entities, tenant_id, max_hops=2) -> str` per plan Day 4 Step 3.
+- [ ] Wire into `engine.py` as **additive only**, gated by `MIRA_ENGINE_GRAPH_WALK` env var. **Default OFF in this PR**; we'll flip it on after eval+dress-rehearsal validation.
+- [ ] Run eval — must not regress. **Proof:** baseline vs. with-flag-off (identical pass rate expected).
+- [ ] Commit on the feat branch. Push + open PR as **draft**.
+
+### 4. Write `tools/seed_demo_conveyor.py` (canned fallback) — ½ day
+
+- [ ] Follow plan §10 Day 1 Steps 1–3 exactly.
+- [ ] Idempotent (rerun-safe). Dry-run by default; `--commit` writes.
+- [ ] Validate dry-run output matches plan Day 1 Step 3 expected counts.
+- [ ] Demo data YAMLs in `demo-data/garage-conveyor/`.
+- [ ] Commit on its own branch `feat/demo-plant-seeder`. Push + open PR as **draft**.
+
+### 5. Unified plan rewrite (if time permits) — 1 hr
+
+- [ ] Read the original plan + last 4 audit findings (in this prompt).
+- [ ] Rewrite `docs/superpowers/plans/2026-05-13-mira-conveyor-demo-mvp.md` to integrate the live-ingestion pieces (broken endpoint fix, parent-asset multi-photo flow, on-demand manual fetch, auto template build, Hub asset detail page) on top of the existing Day 0–7 structure.
+- [ ] Commit on a `docs/` branch. PR as draft.
+
+---
+
+## HARD STOPS (do not cross without Mike's explicit go)
+
+1. **Do NOT merge any PR.** Pre-existing red on main; CI & Merge Policy demands user confirm.
+2. **Do NOT apply migrations to prod NeonDB.** NeonDB branches only; the prod apply is Mike's call.
+3. **Do NOT flip `MIRA_ENGINE_GRAPH_WALK` to true in any deployment.** Default OFF until dress rehearsal.
+4. **Do NOT push directly to main.** Per repo branching policy.
+5. **Do NOT commit `.env` or anything in `marketing/prospects/hardening-alerts.jsonl` or other unrelated `??` files** that may be sensitive/in-flight.
+6. **Do NOT add tracked files outside this work** (`git add -A` is forbidden; add by explicit path only).
+7. **No `--no-verify`, no `--amend`, no `--force` on shared branches.**
+8. **If anything crashes the bot or breaks an existing eval case: stop, write LESSON to `/cluster/betterclaw/logs/`, hand off.**
+
+---
+
+## End-of-Session Deliverables (write before stopping)
+
+1. **`HANDOFF_$(date +%Y-%m-%d).md` at repo root** with:
+   - What got done with proof (file paths, line counts, pytest output, PR URLs)
+   - What failed and why (root cause, not "I'll fix it")
+   - Eval pass rate: baseline vs. now
+   - Open PRs awaiting Mike's nod (list + 1-line context each)
+   - Decisions still pending (Mike's 4 from the last conversation)
+   - Recommended next-cowork actions
+
+2. **`LESSON-$(date +%Y-%m-%d).md` to `/cluster/betterclaw/logs/`** with:
+   - Human mistakes observed (likely: none this session — Mike isn't pairing)
+   - AI mistakes observed (rules you re-discovered the hard way, bad detours, dead-ends)
+   - Fine-tuning candidates (patterns that should be a `.claude/rules/` entry)
+
+3. **Update `wiki/hot.md`** under today's date with one paragraph of what changed.
+
+4. **Post to Discord `#alpha-status`** via the cluster pattern (only if you're invoked through Alpha cowork; on a manual run, skip).
+
+---
+
+## Evidence-Only Completion Reminder
+
+> "Done = deterministic proof only. File exists. Test returned real numbers. Code actually ran. 'I think it's done' = NOT DONE." — Cluster Law 1
+
+Every checkbox above requires proof in the handoff doc. If you can't paste output, you didn't finish it.
+
+---
+
+## If You Get Stuck
+
+- Hit an architecture decision not covered here → write down both options in the handoff, default-and-flag, move on.
+- Hit a tool/service that's misbehaving → don't fight it for more than 30 min. Log it as a blocker and skip to the next authorized item.
+- Hit a "should I" question that isn't in the decisions list → default to the safer option, write a `## Open Question for Mike` block in the handoff.
+- Eval drops → halt all engine work, root-cause, do not push.

--- a/docs/superpowers/plans/2026-05-13-mira-conveyor-demo-mvp.md
+++ b/docs/superpowers/plans/2026-05-13-mira-conveyor-demo-mvp.md
@@ -1,0 +1,583 @@
+# MIRA Garage-Conveyor Demo MVP — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a Florida-Automation-Expo-ready (May 21) demo where MIRA answers "Why is Conveyor B16 stopped? What should I check?" by walking the Component → Wire/Terminal → PLC Tag → Logic → Fault → Asset → Historical Fix chain — using evidence from documents, the graph, and resolution history.
+
+**Architecture:** Three-layer Postgres model (`kg_entities`/`kg_relationships` exist; `component_templates`/`installed_component_instances`/`relationship_proposals`/`relationship_evidence` arriving via PR #1253). LLM proposes via Groq cascade. Human verifies via a minimal review UI. Engine retrieval **augments** existing RAG with a 1–2-hop graph walk — does NOT reorder retrieval (eval-safety).
+
+**Tech Stack:** Postgres (NeonDB) + pgvector + ltree, Groq → Cerebras → Gemini cascade, Python 3.12 + uv + ruff + httpx, Hono/Bun (mira-web), FastAPI (mira-mcp/mira-hub), pytest, Doppler `factorylm/prd`, existing `kg_entities` + `cmms_equipment` + `knowledge_entries`.
+
+---
+
+## Calendar Constraints
+
+- **2026-05-13** (today): T-8 days. PR #1253, #1245 open; CI pending.
+- **2026-05-18**: Change freeze begins. **5 code-days available.**
+- **2026-05-21**: Florida Automation Expo. Demo must work.
+
+---
+
+## Decisions (locked 2026-05-13)
+
+1. **Tenant identity: new "Demo Plant" tenant.** Clean slate. Mike confirmed.
+   - Tenant slug: `demo_plant`
+   - Tenant UUID: TBD on Day 0 — generate fresh, store in Doppler `factorylm/prd` as `DEMO_PLANT_TENANT_ID`.
+   - Asset name: **Conveyor 1** (not Conveyor B16 — Mike's call; cleaner for booth).
+
+2. **Review UI posture: screenshot in pitch, bot Q&A is the live moment.** UI ships + tested, doesn't carry the demo. Default per advisor recommendation; flip to live approval only if Mike redirects before Day 3.
+
+---
+
+## Booth Script (this is the spec that drives the plan)
+
+Mike at the FactoryLM booth, ~3–5 minutes, phone or kiosk:
+
+```
+1. SCAN QR → opens Telegram bot → "Demo Plant — Conveyor 1"
+2. ASK: "Why is Conveyor 1 stopped?"
+   → MIRA answers: fault OCCUPIED_TOO_LONG is active.
+     PE-001 (photoeye, Banner Q4X) is reporting blocked.
+     Wired to Panel 001 terminal TB2-14.
+     Maps to PLC tag Conveyor1.PE001_Occupied (Modbus coil 12 on Micro820).
+     Used in rung 42 of Prog2_ladder (motor-start interlock).
+     Cites manual page, ladder rung, prior work order.
+3. ASK: "How do I reset?"
+   → MIRA replies with troubleshooting steps from the Banner Q4X template,
+     last-3-resolutions from the resolution KB, AND a safety advisory
+     (this is a conveyor — qualified-human approval required).
+4. SCREENSHOT MOMENT: pitch slide shows the /review UI with a proposal
+   (e.g. "PE-001 WIRED_TO TB2-14, evidence: panel-001-print.pdf p.3, confidence 0.85")
+   moved from "proposed" → "verified" by Mike earlier in the day.
+5. CLOSING: "MIRA doesn't run Conveyor 1. Ignition runs the conveyor.
+            HiveMQ moves the data. MIRA explains what the data means."
+```
+
+Every plan task below is justified by what it puts on that script. Tasks that don't show up there → post-Expo GitHub issue.
+
+---
+
+## 1. What We Already Have That Matches the Plan
+
+| Spec layer | Status | Where it lives |
+|---|---|---|
+| Document/vector KB | ✅ shipped | `mira-crawler/ingest/{chunker,embedder,store}.py` → `knowledge_entries` + pgvector |
+| Component template library | 🟡 in PR #1253 | `mira-hub/db/migrations/016_component_templates.sql`, `tools/build_component_template.py` |
+| Installed component instances | 🟡 in PR #1253 | `mira-hub/db/migrations/017_installed_component_instances.sql` |
+| Relationship proposals + evidence | 🟡 in PR #1253 | `mira-hub/db/migrations/018_relationship_proposals.sql` (25-type CHECK, status lifecycle, risk-level gating) |
+| Graph nodes + edges | ✅ shipped | `mira-hub/db/migrations/001_knowledge_graph.sql` — `kg_entities`, `kg_relationships`, RLS-on |
+| UNS / ISA-95 ltree paths | ✅ shipped, 🟡 backfill in PR #1245 | `mira-crawler/ingest/uns.py` + migrations 010/014/015 |
+| Garage conveyor data (PLC manifest) | ✅ shipped | `research/variable-manifest.json` — 210 entities, 188 proposals queued (78 io_point, 65 alias, 7 physical_device, 24 plc_address, 36 modbus_register) |
+| PLC ladder + IECST + Connected Components Workbench exports | ✅ shipped | `plc/specs/Prog2_ladder.md`, `plc/ccw/` |
+| Ignition tag export (data) | ✅ shipped (data only) | `plc/ccw/ignition/step1_io_check/tags.json` |
+| Diagnostic engine + cascade | ✅ shipped | `mira-bots/shared/engine.py`, `shared/inference/router.py` (Groq → Cerebras → Gemini, no Anthropic) |
+| MCP server with NeonDB recall + equipment tools | ✅ shipped | `mira-mcp/server.py` |
+| UNS browse API | ✅ shipped | `mira-hub` `/api/uns/browse` (ltree queries) |
+| Atlas CMMS equipment table | ✅ shipped | `cmms_equipment` with `uns_path` column |
+| Telegram + Slack bots | ✅ shipped | `mira-bots/` |
+| Manifest → KG loader | 🟡 in PR #1253 | `tools/load_manifest_to_kg.py` (dry-run today; `--commit` writes 210 entities + 188 proposals + 209 evidence rows) |
+| Component template extractor (Groq cascade) | 🟡 in PR #1253 | `tools/build_component_template.py` |
+| Asset CSV import | ✅ shipped | `mira-web/src/lib/asset-csv-import.ts` (PR #1190) |
+
+---
+
+## 2. What Is Missing
+
+| Capability | Why it matters for the booth | MVP-critical? |
+|---|---|---|
+| Demo Conveyor B16 seeded as a real asset (cmms_equipment row + kg_entity + UNS path) | Without this, the bot has no anchor for "the conveyor" | **YES** |
+| `relationship_proposals` populated from manifest (`tools/load_manifest_to_kg.py --commit`) | This is the Component→Wire→Tag chain | **YES** |
+| Component templates for GS10 VFD, Micro820, Banner photoeye, motor | Powers "manual says check…" answers | **YES** |
+| Promotion path: verified proposals → `kg_relationships` | Engine reads `kg_relationships`, not proposals | **YES** |
+| Minimal human-review UI (list / approve / reject) | Needed at least as screenshot; live demo if Decision 2(a) | **YES (screenshot or live)** |
+| Engine graph-walk **augmentation** (1–2 hop) + prompt-context injection | This is what produces the cited answer | **YES** |
+| Resolution history seeding (3–5 fake work-order fixes for fault 1.SOC B16.2) | "Last time this was fixed by…" line | **YES** |
+| MQTT subscriber (paho-mqtt → topic state) | Live tag values in answers | **NO — defer** (advisor confirmed) |
+| Ignition tag-export importer (CSV/JSON → kg_entities) | Customer-installable feature, not needed for booth | **NO — defer (issue exists)** |
+| Relationship Proposer agent (LLM extracts proposals from new docs) | Issue #1259; replaces the manifest scaffold long-term | **NO — defer** |
+| Native Ignition Module (Java SDK) | Customer install path | **NO — defer (user explicit)** |
+| Component Template Builder integrated into ingest service (auto-extract on manual upload) | Issue #1257; nice-to-have | **NO — defer** |
+| OPC UA / Sparkplug B subscriber | Issues #1247/#1248 | **NO — defer** |
+| Resolution-pattern learning loop | Spec calls for `resolution_patterns` table; not needed for first demo | **NO — defer** |
+| `live_signal_snapshots` table + populate | Demo can show "topic X is true right now" — but only if MQTT lands | **NO — defer** |
+
+---
+
+## 3. Recommended Scope Cut (Smallest Useful Demo)
+
+```
+IN:  seed → templates → graph-walk → review UI → booth Q&A
+OUT: live MQTT, Ignition importer, native module, LLM-from-docs proposer
+```
+
+Justification: the manifest already proves the chain. The booth answer is the demo. The review UI is the story. Everything else is post-Expo.
+
+---
+
+## 4. What's Deferred and Why
+
+Each goes to a follow-up issue with a 1-line "why deferred". Already filed; don't re-file:
+
+- **#1257** Component Template Builder integrated into ingest — manual CLI extraction is enough for 4 components
+- **#1259** Relationship Proposer agent — manifest scaffolding covers garage conveyor
+- **#1247** Sparkplug B subscriber — no live data on booth
+- **#1248** OPC UA — same
+- **#1249** Path-addressable REST API — UNS browse is enough for demo
+- **New issue to file:** MQTT subscriber (paho-mqtt) + `live_signal_snapshots` — deferred to post-Expo
+- **New issue to file:** Ignition tag-export importer — defer; data file already covers the demo
+- **New issue to file:** Native Ignition Module — defer to "after external workflow proves value"
+
+---
+
+## 5. Recommended File / Module Structure
+
+### Existing files we touch (minimal surface — no new modules)
+
+| File | Change |
+|---|---|
+| `mira-bots/shared/engine.py` | Add hook to call `graph_traversal.augment_context(entities, tenant_id)` and append result to the prompt context. **No re-ordering.** |
+| `mira-mcp/server.py` | Add 2 new MCP tools: `propose_review_list(status='proposed')`, `propose_review_decide(proposal_id, verdict)` |
+| `mira-web/src/server.ts` | Add 2 routes: `GET /api/review/proposals`, `POST /api/review/proposals/:id/decide` |
+| `mira-web/src/pages/review.tsx` *(new)* | Minimal table UI: proposal list, source/target/confidence/evidence/risk, Approve/Reject buttons |
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| `mira-bots/shared/graph_traversal.py` | One function: `augment_context(entities: list[str], tenant_id: UUID) -> str` — walks 1–2 hops of verified `kg_relationships`, returns a formatted text block for prompt injection |
+| `tools/seed_demo_conveyor.py` | Idempotent seeder: creates Demo Plant tenant (if Decision 1(b)), inserts Conveyor B16 + components + UNS paths + fake work orders + fake resolutions |
+| `tools/promote_proposal.py` | Promotes `relationship_proposals` (status='verified') → `kg_relationships`. Wired to review UI. |
+| `mira-hub/db/migrations/019_proposal_promotion_trigger.sql` | Optional: trigger that auto-inserts into `kg_relationships` when a proposal status flips to `verified` (alternative to Python promoter — pick one in Day 3) |
+| `tests/eval/golden_garage_conveyor.yaml` | 5 golden Q&A pairs for the booth script: "Why is conveyor stopped?", "What sensor?", "Where is it wired?", "How do I reset?", "What fixed this last time?" |
+
+---
+
+## 6. Recommended Database / Schema Changes
+
+### Migrations to merge (already written in open PRs)
+
+- `014_uns_path_backfill.sql` (PR #1245)
+- `015_equipment_uns_path.sql` (PR #1245)
+- `016_component_templates.sql` (PR #1253)
+- `017_installed_component_instances.sql` (PR #1253)
+- `018_relationship_proposals.sql` (PR #1253)
+
+### Migrations to add this week
+
+- `019_proposal_promotion_trigger.sql` — optional. See Day 3 task.
+
+### Pre-merge verification (mandatory, advisor flagged)
+
+Apply 014→018 to a **NeonDB branch first**, run:
+```sql
+SELECT COUNT(*) FROM kg_relationships;  -- baseline before
+-- apply migrations
+SELECT COUNT(*) FROM kg_relationships;  -- should match
+SELECT DISTINCT relationship_type FROM kg_relationships;  -- verify none violate 018's 25-type CHECK
+```
+Migration 018 introduces a CHECK constraint on `relationship_type`. If any existing row has a type outside the 25-type vocabulary, the migration fails. **Audit before applying.**
+
+---
+
+## 7. Recommended APIs / Services
+
+| Endpoint | Service | Purpose |
+|---|---|---|
+| `GET /api/review/proposals?status=proposed&limit=50` | mira-web/Hono | List proposals + evidence + risk_level for review UI |
+| `POST /api/review/proposals/:id/decide` | mira-web/Hono | Body: `{verdict: "approve"|"reject", notes?: string}`. On approve: status='verified' + call `promote_proposal.py` |
+| `MCP tool: propose_review_list` | mira-mcp | Same as GET above but available to engine/bots |
+| `MCP tool: propose_review_decide` | mira-mcp | Same as POST above; used by future "ask Mike to verify" flow |
+| **No new external services this week** | — | MQTT subscriber, Ignition importer = post-Expo |
+
+---
+
+## 8. Recommended UI Screens
+
+**One screen total for this week.** Defer everything else.
+
+### `/review` (mira-web)
+
+- Table of proposals: source name → relationship_type → target name → confidence → risk_level → evidence-count
+- Click row → side panel with full evidence list (source documents, page numbers, snippets)
+- Two buttons: **Approve** / **Reject**
+- Approval triggers backend promotion → `kg_relationships`
+- Filter dropdown: status, risk_level, relationship_type
+- Sort: confidence ascending (review weakest first)
+
+**NOT building this week:** asset detail page, component template viewer, graph visualization, MQTT topic dashboard. Booth doesn't need them.
+
+---
+
+## 9. Recommended Demo Data Package Structure
+
+```
+demo-data/garage-conveyor/                  (new dir, gitignored except README + manifest)
+├── README.md                               # what's in the package, how to seed
+├── manifest.yaml                           # version, source files, tenant target
+├── asset.yaml                              # Conveyor B16 + UNS path + components
+├── work-orders.yaml                        # 5 fake historical WOs for fault 1.SOC B16.2
+├── resolutions.yaml                        # what fixed what + counts (3 reset, 1 cleaned, 1 replaced)
+├── documents/                              # PDFs already in KB, no copies — just references
+│   ├── gs10-user-manual.ref.json
+│   ├── micro820-datasheet.ref.json
+│   ├── banner-q4x-photoeye.ref.json
+│   └── motor-spec.ref.json
+└── tags-and-topics.yaml                    # PLC tag ↔ MQTT topic (labels only, no live broker)
+```
+
+Seeded by `tools/seed_demo_conveyor.py` — single command, idempotent, rerunnable.
+
+---
+
+## 10. Step-by-Step MVP Execution Plan
+
+Each day has 2–5 tasks. Verification command listed for each. Commit cadence: after each task.
+
+---
+
+### Day 0 — 2026-05-13/14: Foundation merge + tenant decision + baseline
+
+**Files:** none modified directly. Verification + decisions.
+
+- [ ] **Step 1: Get Mike's answer on Decision 1 (tenant) and Decision 2 (review UI posture).**
+  - These two answers change the plan. Don't seed data until pinned.
+
+- [ ] **Step 2: Verify PR #1253 + #1245 CI green; resolve any pre-existing red checks per repo policy.**
+  - Run: `gh pr checks 1253 && gh pr checks 1245`
+  - If red: compare against `main` HEAD before claiming failure is from the PR.
+
+- [ ] **Step 3: Apply migrations 014→018 to a NeonDB branch (not prod).**
+  - Run: `doppler run -- python tools/migrations/apply_to_branch.py --branch demo-may21 --from 014 --to 018`
+  - Verify: `SELECT version FROM schema_migrations ORDER BY version DESC LIMIT 5;` shows 014–018.
+
+- [ ] **Step 4: Audit existing `kg_relationships.relationship_type` against migration 018's 25-type CHECK.**
+  - Run:
+    ```sql
+    SELECT relationship_type, COUNT(*) FROM kg_relationships
+    GROUP BY relationship_type
+    EXCEPT
+    SELECT unnest(ARRAY['HAS_COMPONENT','INSTANCE_OF','HAS_DOCUMENT','HAS_CHUNK','HAS_PART','HAS_PROCEDURE',
+                       'WIRED_TO','LOCATED_IN','POWERED_BY','MAPS_TO','PUBLISHED_AS','USED_IN_LOGIC',
+                       'TRIGGERS','CAUSES','OCCURS_ON','RESOLVED_BY','REFERENCES','REPLACES',
+                       'HAS_FAILURE_MODE','HAS_SIGNAL','HAS_ALIAS','DEPENDS_ON','UPSTREAM_OF',
+                       'DOWNSTREAM_OF','CONFIRMED_BY','CONTRADICTED_BY']), NULL;
+    ```
+  - If anything returns: either update migration 018 to include those types OR remap legacy rows before merge.
+
+- [ ] **Step 5: Run the eval baseline.**
+  - Run: `cd ~/MIRA && pytest tests/eval/ -v --tb=short > /tmp/eval-baseline-$(date +%s).txt`
+  - Record pass-rate to `wiki/hot.md` under today's section. **This is the floor — Day 4 engine change cannot drop below it.**
+
+- [ ] **Step 6: Merge PRs (after CI + checks green + Mike approval).**
+  - Run: `gh pr merge 1245 --squash --delete-branch && gh pr merge 1253 --squash --delete-branch`
+
+- [ ] **Step 7: Apply migrations 014→018 to **prod NeonDB** during a quiet window.**
+  - Run: `doppler run -p factorylm -c prd -- python tools/migrations/apply.py --from 014 --to 018`
+  - Re-run baseline eval against prod to confirm no regression.
+
+- [ ] **Step 8: Commit `wiki/hot.md` update.**
+  - `git add wiki/hot.md && git commit -m "ops(hot): Day 0 baseline + migrations 014-018 applied"`
+
+---
+
+### Day 1 — 2026-05-15: Demo data foundation
+
+**Files:**
+- Create: `tools/seed_demo_conveyor.py`
+- Create: `demo-data/garage-conveyor/{README.md,manifest.yaml,asset.yaml,work-orders.yaml,resolutions.yaml,tags-and-topics.yaml}`
+
+- [ ] **Step 1: Write `demo-data/garage-conveyor/manifest.yaml` + asset.yaml.**
+  - Asset: **Conveyor 1**, UNS path `enterprise.demo_plant.site.training.area.conveyor_lab.line.line1.work_cell.conveyor_cell.equipment.conveyor_1`.
+  - Components: motor M-001, VFD GS10-001, PLC Micro820-001, photoeye PE-001 (Banner Q4X), start button, stop button, fault reset, panel 001, terminals TB2-13 through TB2-20.
+
+- [ ] **Step 2: Write `work-orders.yaml` + `resolutions.yaml`.**
+  - 5 historical WOs for fault `OCCUPIED_TOO_LONG` on Conveyor 1: 3 resolved by "cleared product from sensor path + reset", 1 by "realigned photoeye", 1 by "replaced PE-001".
+  - Each WO has: id, asset_uns_path, fault_code, symptoms, action_taken, time_to_resolve_min, technician_id (fake).
+
+- [ ] **Step 3: Write `tools/seed_demo_conveyor.py` — idempotent seeder.**
+  - Inputs: `--tenant-id <uuid>`, `--commit` (default dry-run).
+  - Creates:
+    - 1 cmms_equipment row (Conveyor B16) with `uns_path`
+    - ~12 kg_entities (asset + components + panel + terminals)
+    - ~12 kg_relationships (HAS_COMPONENT, LOCATED_IN, WIRED_TO) — status='verified' since these are seeded ground-truth
+    - 5 work_orders rows
+    - 5 resolution_patterns rows (or equivalent — TBD when table lands; for week 1, write to `kg_triples_log` as `(asset, RESOLVED_BY, action)` triples)
+  - Run dry-run: `doppler run -- python tools/seed_demo_conveyor.py --tenant-id $DEMO_PLANT_TENANT_ID`
+  - Expected: summary like `{equipment: 1, entities: 12, relationships: 12, work_orders: 5, resolutions: 5}`.
+
+- [ ] **Step 4: Run `--commit` against prod NeonDB.**
+  - Run: `doppler run -p factorylm -c prd -- python tools/seed_demo_conveyor.py --tenant-id $DEMO_PLANT_TENANT_ID --commit`
+  - Verify: `SELECT name FROM kg_entities WHERE tenant_id = '<demo_plant_uuid>' AND (name ILIKE '%conveyor 1%' OR name ILIKE '%PE-001%');` returns the seeded names.
+
+- [ ] **Step 5: Run `tools/load_manifest_to_kg.py --commit` against the manifest.**
+  - Run: `doppler run -p factorylm -c prd -- python tools/load_manifest_to_kg.py --commit --tenant-id $DEMO_PLANT_TENANT_ID`
+  - Expected: 210 entities + 188 proposals + 209 evidence rows land.
+  - Verify counts match dry-run output.
+
+- [ ] **Step 6: Sanity-check the 6 safety-critical proposals.**
+  - Run:
+    ```sql
+    SELECT id, source_id, target_id, relationship_type, risk_level
+      FROM relationship_proposals
+     WHERE risk_level = 'safety_critical' AND status = 'proposed';
+    ```
+  - Expected: 6 rows, e-stop / interlock / safety Modbus mappings.
+
+- [ ] **Step 7: Commit.**
+  - `git add tools/seed_demo_conveyor.py demo-data/ && git commit -m "feat(demo): seed garage conveyor demo asset + history (#1258)"`
+
+---
+
+### Day 2 — 2026-05-16: Component templates + promotion path
+
+**Files:**
+- Modify: none new — uses `tools/build_component_template.py` (already in PR #1253)
+- Create: `tools/promote_proposal.py`
+
+- [ ] **Step 1: Extract component template for GS10 VFD.**
+  - Run: `doppler run -- python tools/build_component_template.py --manufacturer AutomationDirect --model GS10 --category vfd --type variable_frequency_drive --commit`
+  - Verify: `SELECT template_id, jsonb_array_length(common_failure_modes), jsonb_array_length(troubleshooting_steps) FROM component_templates WHERE model = 'GS10';`
+  - Expected: at least 3 failure modes, at least 5 troubleshooting steps.
+
+- [ ] **Step 2: Extract templates for Micro820, Banner Q4X photoeye, conveyor motor.**
+  - Same command, four runs total. Capture template_ids.
+
+- [ ] **Step 3: Create INSTANCE_OF relationships from seeded installed components → templates.**
+  - Add to `tools/seed_demo_conveyor.py` (or a short SQL script `demo-data/garage-conveyor/instance_of.sql`):
+    ```sql
+    INSERT INTO kg_relationships (tenant_id, source_id, target_id, relationship_type, confidence)
+    SELECT '<uuid>', ic.id, ct.id, 'INSTANCE_OF', 0.95
+      FROM kg_entities ic
+      JOIN component_templates ct ON ct.model = ic.properties->>'model'
+     WHERE ic.tenant_id = '<uuid>' AND ic.entity_type = 'installed_component';
+    ```
+
+- [ ] **Step 4: Write `tools/promote_proposal.py`.**
+  - Reads `relationship_proposals` rows by id, validates status='verified', inserts into `kg_relationships`, sets `properties->>'promoted_from_proposal_id' = <id>`.
+  - Idempotent — won't double-insert.
+  - Run dry-run: `python tools/promote_proposal.py --proposal-id <id>`.
+
+- [ ] **Step 5: Test: manually mark 3 garage-conveyor proposals as `verified`, run promoter, confirm they land in `kg_relationships`.**
+  - SQL: `UPDATE relationship_proposals SET status = 'verified' WHERE id IN (...) RETURNING id;`
+  - Run: `python tools/promote_proposal.py --proposal-ids <ids>` (multi-id flag).
+  - Verify: `SELECT COUNT(*) FROM kg_relationships WHERE properties ? 'promoted_from_proposal_id';` returns 3.
+
+- [ ] **Step 6: Commit.**
+  - `git add tools/promote_proposal.py demo-data/garage-conveyor/instance_of.sql && git commit -m "feat(graph): component template instances + proposal promoter"`
+
+---
+
+### Day 3 — 2026-05-17: Review UI + promotion wiring
+
+**Files:**
+- Create: `mira-web/src/pages/review.tsx`
+- Modify: `mira-web/src/server.ts` (add 2 routes)
+- Create: `mira-web/src/lib/review-api.ts`
+- Modify: `mira-mcp/server.py` (add 2 MCP tools)
+
+- [ ] **Step 1: Add backend routes to `mira-web/src/server.ts`.**
+  - `GET /api/review/proposals?status=proposed&limit=50&risk_level=...` — RLS-scoped via tenant from JWT.
+  - `POST /api/review/proposals/:id/decide` — body `{verdict, notes}`; on approve, set status='verified' AND shell out to `tools/promote_proposal.py --proposal-id :id` (or call the same logic via shared lib).
+
+- [ ] **Step 2: Write `mira-web/src/lib/review-api.ts` — typed client for the two routes above.**
+
+- [ ] **Step 3: Write `mira-web/src/pages/review.tsx`.**
+  - Table: source name → relationship_type → target name → confidence → risk badge → evidence count.
+  - Row click → side panel with evidence list (source_id, page, snippet).
+  - Approve / Reject buttons → call `review-api.ts` → optimistic update + toast.
+  - Filters: status (default proposed), risk_level, relationship_type.
+  - Sort: confidence ASC (review weakest first).
+  - No fancy state lib — plain React + fetch.
+
+- [ ] **Step 4: Manually walk through 3 proposals via the UI.**
+  - Approve 2, reject 1, verify DB state matches.
+  - Capture screenshot 1440x900 + 412x915 → `docs/promo-screenshots/2026-05-17_review-ui_{desktop,mobile}.png` (mandatory rule).
+
+- [ ] **Step 5: Add `propose_review_list` + `propose_review_decide` MCP tools to `mira-mcp/server.py`.**
+  - Same surface as REST routes. Used by engine + future Mike-on-Telegram review flow.
+
+- [ ] **Step 6: Commit.**
+  - `git add mira-web/ mira-mcp/server.py docs/promo-screenshots/2026-05-17_* && git commit -m "feat(review): minimal proposal review UI + MCP tools (#1259)"`
+
+---
+
+### Day 4 — 2026-05-18 (last day before freeze): Engine graph-walk augmentation + eval gate
+
+**Files:**
+- Create: `mira-bots/shared/graph_traversal.py`
+- Modify: `mira-bots/shared/engine.py` (additive only — no retrieval reorder)
+- Create: `tests/eval/golden_garage_conveyor.yaml`
+- Create: `tests/test_graph_traversal.py`
+
+- [ ] **Step 1: Write failing test for `graph_traversal.augment_context`.**
+  - File: `tests/test_graph_traversal.py`
+  - Test: given entities `["PE-001"]` and the seeded Demo Plant tenant, returns a string containing "Conveyor 1", "TB2-14", "Conveyor1.PE001_Occupied", and at least one citation.
+  ```python
+  def test_augment_context_returns_chain():
+      ctx = augment_context(entities=["PE-001"], tenant_id=DEMO_PLANT_UUID, max_hops=2)
+      assert "Conveyor 1" in ctx
+      assert "TB2-14" in ctx
+      assert "Conveyor1.PE001_Occupied" in ctx
+      assert "[evidence:" in ctx  # citation marker
+  ```
+
+- [ ] **Step 2: Run test — expect ImportError.**
+  - `pytest tests/test_graph_traversal.py -v` → fail.
+
+- [ ] **Step 3: Implement `mira-bots/shared/graph_traversal.py`.**
+  - One function: `augment_context(entities: list[str], tenant_id: UUID, max_hops: int = 2) -> str`
+  - Resolves names → kg_entity ids via `name ILIKE` + alias relationships.
+  - Walks `kg_relationships` BFS up to max_hops. Filter: only verified (treat `kg_relationships` rows as verified by definition since promotion is gated).
+  - Returns formatted text block:
+    ```
+    Graph context for [PE-B16-2]:
+    - PE-B16-2 (proximity sensor) WIRED_TO TB2-14 [evidence: panel-b16-print.pdf p.3]
+    - PE-B16-2 MAPS_TO Line5.B16.PE2_Occupied [evidence: ignition-export#tag-12]
+    - PE-B16-2 TRIGGERS Fault 1.SOC B16.2 OCCURS_ON Conveyor B16 [evidence: prog2_ladder.md rung 42]
+    - Fault 1.SOC B16.2 RESOLVED_BY {3× cleared product, 1× realigned, 1× replaced} [evidence: WO-2024-{1138,1142,1156,...}]
+    ```
+  - Token-budget cap (default 800 tokens) to avoid prompt blowout.
+  - Example output format:
+    ```
+    Graph context for [PE-001]:
+    - PE-001 (proximity sensor, Banner Q4X) WIRED_TO TB2-14 [evidence: panel-001-print.pdf p.3]
+    - PE-001 MAPS_TO Conveyor1.PE001_Occupied [evidence: prog2_ladder.md rung 42]
+    - PE-001 TRIGGERS Fault OCCUPIED_TOO_LONG OCCURS_ON Conveyor 1
+    - Fault OCCUPIED_TOO_LONG RESOLVED_BY {3× cleared product, 1× realigned, 1× replaced} [evidence: WO-2024-{...}]
+    ```
+
+- [ ] **Step 4: Run test — expect pass.**
+
+- [ ] **Step 5: Wire augmentation into `engine.py` — additive only.**
+  - After existing entity extraction, before existing prompt build:
+    ```python
+    graph_context = ""
+    if entities and graph_walk_enabled():  # feature flag
+        try:
+            graph_context = augment_context(entities, tenant_id, max_hops=2)
+        except Exception as e:
+            logger.warning("graph_traversal failed, falling back to RAG only: %s", e)
+            graph_context = ""
+    # ... existing RAG retrieval continues unchanged ...
+    final_prompt = build_prompt(rag_chunks, graph_context, user_q)  # graph_context inserted at top of context
+    ```
+  - Feature flag env: `MIRA_ENGINE_GRAPH_WALK=true` (default true in prod, false in tests until rolled out).
+
+- [ ] **Step 6: Write `tests/eval/golden_garage_conveyor.yaml`.**
+  - 5 cases (tenant pre-set to Demo Plant):
+    1. "Why is Conveyor 1 stopped?" → expect mention of fault `OCCUPIED_TOO_LONG`, `PE-001`
+    2. "Where is PE-001 wired?" → expect `TB2-14`, `Panel 001`
+    3. "What PLC tag is PE-001?" → expect `Conveyor1.PE001_Occupied`, Micro820
+    4. "How was OCCUPIED_TOO_LONG fixed last time?" → expect "cleared product" or "reset"
+    5. "How do I reset the fault on Conveyor 1?" → expect safety advisory + qualified-human language
+
+- [ ] **Step 7: Run full eval suite — pass-rate must be ≥ Day 0 baseline.**
+  - Run: `pytest tests/eval/ -v`
+  - Compare to baseline in `wiki/hot.md` Day 0 entry.
+  - **HARD GATE:** if eval drops, set `MIRA_ENGINE_GRAPH_WALK=false` in Doppler and root-cause before re-enabling.
+
+- [ ] **Step 8: Run new golden_garage_conveyor cases — all 5 must pass.**
+  - Run: `pytest tests/eval/ -k garage_conveyor -v`
+
+- [ ] **Step 9: Commit + push.**
+  - `git add mira-bots/shared/graph_traversal.py mira-bots/shared/engine.py tests/ && git commit -m "feat(engine): graph-walk context augmentation (additive, eval-gated)"`
+
+---
+
+### Day 5 — 2026-05-19: Dress rehearsal + promo screenshots + freeze prep
+
+**Files:**
+- Create: `docs/promo-screenshots/2026-05-19_garage-conveyor-demo_{desktop,mobile}.png` (multiple)
+- Update: `wiki/hot.md`
+- Create: `docs/demo/garage-conveyor-booth-script.md`
+
+- [ ] **Step 1: Run the booth script end-to-end via Telegram bot pointed at prod.**
+  - Open Telegram → @MiraDiagnosticBot
+  - Send each of the 5 booth-script questions.
+  - Save chat screenshots to `docs/promo-screenshots/2026-05-19_demo-q{1-5}_mobile.png`.
+  - If any answer misses cited evidence or sounds generic: triage, decide fix-or-defer based on freeze rule.
+
+- [ ] **Step 2: Run the same flow against a kiosk-style web chat (if mira-web has chat surface).**
+  - Save desktop screenshots.
+
+- [ ] **Step 3: Write `docs/demo/garage-conveyor-booth-script.md`.**
+  - The exact 5 Q&A + an "if MIRA says X, redirect to Y" cheat sheet for Mike.
+
+- [ ] **Step 4: Update `wiki/hot.md` with demo-ready status + known issues.**
+
+- [ ] **Step 5: Commit. Tag the freeze.**
+  - `git add docs/ wiki/hot.md && git commit -m "docs(demo): garage conveyor booth script + dress rehearsal screenshots"`
+  - `git tag -a freeze-2026-05-19-expo -m "Florida Automation Expo freeze"`
+
+---
+
+### Days 6–7 — 2026-05-20/21: Freeze buffer + travel + booth
+
+**No code changes unless P0.** Use buffer for:
+- Migration / Doppler / VPS hiccups
+- Booth-day Telegram bot health monitoring
+- Mike's Stripe live-key rotation and Calendly setup (separate from this plan but already on his list)
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Migration 018 CHECK rejects existing kg_relationships rows | M | H | Day 0 Step 4 audit before merge |
+| Day 4 engine change drops eval pass-rate | M | H | Hard eval gate; feature flag rollback path |
+| 014/015 vs 016–018 merge out of order | L | M | Both PRs depend on shared base; resolve sequencing at merge time |
+| Tenant_id decision delayed | M | M | Block Day 1 on Mike's answer; pre-Day-1 nudge required |
+| Bot answer cites wrong work order in front of customers | L | H | Day 5 dress rehearsal is the gate; if it fires, fall back to scripted answers + "see slide" |
+| Macros/keychain SSH issue on Bravo during migration | L | M | Apply migrations from CHARLIE only |
+| Demo bot rate-limited at booth (multiple visitors) | M | M | Pre-warm Groq cascade; have Cerebras fallback verified Day 5 |
+
+---
+
+## Success Criteria (booth-day acceptance)
+
+1. ✅ Telegram bot answers all 5 golden-conveyor questions with cited evidence in <8s p95.
+2. ✅ Bot's answer to "How do I reset?" includes the safety advisory language.
+3. ✅ Eval pass-rate ≥ Day 0 baseline (no regression).
+4. ✅ Review UI loads, lists proposals, can approve/reject (live demo OR screenshot per Decision 2).
+5. ✅ Garage-conveyor demo data is reproducible: anyone with Doppler access can re-seed in one command.
+6. ✅ At least 6 safety-critical proposals are in the review queue (proves the risk gate works).
+7. ✅ At least 4 component templates have ≥3 failure modes + ≥5 troubleshooting steps populated.
+
+---
+
+## Self-Review
+
+**Spec coverage check (user's 10 deliverables):**
+1. What we already have → §1 ✓
+2. What is missing → §2 ✓
+3. What to build first → §3 + §10 Day 0–4 ✓
+4. What to defer → §4 ✓
+5. Recommended file/module structure → §5 ✓
+6. Recommended database/schema changes → §6 ✓
+7. Recommended APIs/services → §7 ✓
+8. Recommended UI screens → §8 ✓
+9. Recommended demo data package structure → §9 ✓
+10. Step-by-step MVP plan → §10 ✓
+
+**Placeholder scan:** No "TBD", "implement later", or "add appropriate error handling" survives. The one TBD-like item is `resolution_patterns` table — explicitly noted as "write to kg_triples_log this week" in Day 1 Step 3.
+
+**Type consistency:** `tenant_id` is UUID throughout. `entity_id` is TEXT (per existing 001 schema). `proposal_id` is UUID. `kg_relationships` has no status column (verified by definition) — promotion writes via `tools/promote_proposal.py`.
+
+**Native Ignition Module:** Not started, deferred to post-Expo issue (per user explicit instruction).
+
+---
+
+## Execution Handoff
+
+**Two execution options:**
+
+**1. Subagent-Driven (recommended)** — dispatch fresh subagent per day; review between days; checkpoint after Day 0 (migrations safe?) and Day 4 (eval safe?). Best for an unattended-overnight scenario.
+
+**2. Inline Execution** — execute Day 0 → Day 5 in this session with checkpoints. Best when Mike is actively pairing.
+
+**Pre-flight before either:**
+- ~~Mike answers Decisions 1 + 2~~ ✅ Locked 2026-05-13: Demo Plant tenant, Conveyor 1 asset, review UI = screenshot in pitch.
+- PR #1253 + #1245 CI green.
+- Day 0 Step 4 (CHECK-constraint audit) returns empty.
+- `DEMO_PLANT_TENANT_ID` generated + stored in Doppler `factorylm/prd`.

--- a/mira-bots/slack/Dockerfile
+++ b/mira-bots/slack/Dockerfile
@@ -7,7 +7,7 @@ COPY slack/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY shared/ ./shared/
 COPY prompts/ ./prompts/
-COPY slack/bot.py slack/pdf_handler.py ./
+COPY slack/bot.py slack/chat_adapter.py slack/pdf_handler.py ./
 
 ENV PYTHONUNBUFFERED=1
 CMD ["python", "bot.py"]

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -1,3 +1,11 @@
+# Hot Cache — 2026-05-14 — CHARLIE
+
+## eval-fixer run — 2026-05-14
+- Scorecard: 48/57 passing (84%) — source: `tests/eval/runs/2026-05-06T0833-offline-text.md` (unchanged since 2026-05-12, now 8 days stale)
+- Action: issue-filed (autopatch skipped — 3 file_clusters, hard stop)
+- Issue: https://github.com/Mikecranesync/MIRA/issues/1269 (third repeat — see #1217, #1187 — same scorecard, no fresh eval run)
+- Same 9 fixtures still failing across `engine.py`, `guardrails.py`, `prompts/diagnose/active.yaml`. Nightly eval job is almost certainly dead — needs human investigation, not another auto-issue.
+
 # Hot Cache — 2026-05-13 — CHARLIE
 
 ## eval-fixer run — 2026-05-13


### PR DESCRIPTION
## Summary

- **Fixes the `ModuleNotFoundError: chat_adapter` crash** in `mira-bot-slack`. Root cause: `mira-bots/slack/Dockerfile` did not COPY `chat_adapter.py` into the image. One-line manifest fix, matching the Telegram pattern.
- **Delivers the Phase 1 discovery audit** for issue #1270 at `docs/audits/slack-phase1-discovery-2026-05-14.md` — every file, every env var, every implemented/broken/missing item, adapter parity table, Phase 2 next steps.
- **Discovery surfaced 3 missing prereq docs** referenced by #1270 but not yet written: `docs/specs/slack-technician-workflow-spec.md`, `docs/specs/mira-component-intelligence-architecture.md`, `.claude/rules/uns-confirmation-gate.md`. Audit flags them as Phase 2 blockers.

## What changed

| File | Change |
|---|---|
| `mira-bots/slack/Dockerfile` | Added `slack/chat_adapter.py` to COPY line. |
| `docs/audits/slack-phase1-discovery-2026-05-14.md` | New — 290-line Phase 1 audit. |

No code/runtime behavior change other than the container now actually starting.

## Key findings

- All 3 required Slack secrets (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET`) are already in Doppler `factorylm/prd`. Mike does not need to provision new credentials for Phase 1.
- Slack adapter already conforms to the platform-agnostic `ChatAdapter` protocol (same dispatcher + engine as Telegram). No re-architecture needed.
- Slack lags Telegram on: identity service wiring, tenant authorizer, WO outbox drain, photo batch queue. None are Phase 1 scope.
- Compose convention drift: Telegram builds from repo root, Slack builds from `mira-bots/`. Cosmetic — not the bug.

## Test plan

- [ ] Rebuild `mira-bot-slack` against this branch on the VPS: `doppler run --project factorylm --config prd -- docker compose -f mira-bots/docker-compose.yml up -d --build slack-bot`
- [ ] Confirm container no longer crash-loops: `docker logs mira-bot-slack | head -30` (no `ModuleNotFoundError`)
- [ ] Confirm Socket Mode connects: look for `slack_bolt.adapter.socket_mode` connection log line
- [ ] Send `@MIRA` mention in a test channel and confirm a response renders via Block Kit
- [ ] If broken, rollback before reporting (per CLAUDE.md verification workflow)

## Out of scope (deferred)

Per Karpathy "surgical changes" rule:
- Migrating `slack-bot` into root compose files
- Normalizing the compose build-context convention
- Wiring identity/tenant/outbox into Slack
- Writing the 3 missing prereq docs (need product input)

Refs: #1270

🤖 Generated with [Claude Code](https://claude.com/claude-code)