### PR TITLE
feat(slack): deploy bot to VPS — saas compose block + identity wiring

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -305,6 +305,55 @@ services:
       retries: 3
       start_period: 15s
 
+  mira-bot-slack:
+    build:
+      context: ./mira-bots
+      dockerfile: slack/Dockerfile
+    container_name: mira-bot-slack
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
+      - SLACK_APP_TOKEN=${SLACK_APP_TOKEN}
+      - SLACK_SIGNING_SECRET=${SLACK_SIGNING_SECRET:-}
+      - SLACK_ALLOWED_CHANNELS=${SLACK_ALLOWED_CHANNELS:-}
+      - MIRA_DB_PATH=/mira-db/mira.db
+      - OPENWEBUI_BASE_URL=http://mira-core-saas:8080
+      - OPENWEBUI_API_KEY=${OPENWEBUI_API_KEY:-}
+      - KNOWLEDGE_COLLECTION_ID=${KNOWLEDGE_COLLECTION_ID:-}
+      - NEON_DATABASE_URL=${NEON_DATABASE_URL:-}
+      - MIRA_TENANT_ID=${MIRA_TENANT_ID:-}
+      - VISION_MODEL=qwen2.5vl:7b
+      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
+      - INFERENCE_BACKEND=cloud
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
+      - GROQ_MODEL=llama-3.3-70b-versatile
+      - GROQ_VISION_MODEL=meta-llama/llama-4-scout-17b-16e-instruct
+      - CEREBRAS_API_KEY=${CEREBRAS_API_KEY:-}
+      - CEREBRAS_MODEL=llama3.1-8b
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - GEMINI_MODEL=${GEMINI_MODEL:-gemini-2.5-flash}
+      - GEMINI_VISION_MODEL=${GEMINI_VISION_MODEL:-gemini-2.5-flash}
+      - MCP_REST_API_KEY=${MCP_REST_API_KEY:-}
+      - MCP_BASE_URL=http://mira-mcp-saas:8001
+      - SESSION_RECORDING_PATH=/data/sessions
+    volumes:
+      - /opt/mira/data:/mira-db
+      - /opt/mira/mira-bridge/data/sessions:/data/sessions
+    networks:
+      - mira-net
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    healthcheck:
+      test: ["CMD", "python", "-c", "import slack_bolt"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
   mira-docling:
     image: quay.io/docling-project/docling-serve:v1.16.1
     container_name: mira-docling-saas

--- a/mira-bots/slack/bot.py
+++ b/mira-bots/slack/bot.py
@@ -13,6 +13,7 @@ from PIL import Image
 from shared.chat.dispatcher import ChatDispatcher
 from shared.conversation_logger import log_turn, measure_ms
 from shared.engine import Supervisor
+from shared.identity.service import get_identity_service
 from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 from slack_bolt.async_app import AsyncApp
 
@@ -49,7 +50,13 @@ adapter = SlackChatAdapter(
     bot_token=SLACK_BOT_TOKEN,
     signing_secret=os.environ.get("SLACK_SIGNING_SECRET", ""),
 )
-dispatcher = ChatDispatcher(engine)
+_identity_service = get_identity_service()
+if _identity_service is None:
+    logger.warning(
+        "NEON_DATABASE_URL not set or sqlalchemy missing — Slack dispatcher will fail closed "
+        "until identity service is configured (multi-tenant gate)"
+    )
+dispatcher = ChatDispatcher(engine, identity_service=_identity_service)
 
 app = AsyncApp(token=SLACK_BOT_TOKEN)
 


### PR DESCRIPTION
## Summary

End-to-end fix to get `mira-bot-slack` running on the VPS and actually responding to messages:

1. **`docker-compose.saas.yml`** — adds `mira-bot-slack` service block (mirrors `mira-bot-telegram`). Build context `./mira-bots` so the existing `slack/Dockerfile` (which uses `slack/...` COPY paths) works without modification.

2. **`mira-bots/slack/bot.py`** — wires `identity_service` into `ChatDispatcher`. Without this the dispatcher fails closed (`if self._identity is None`) before reaching the engine, so every Slack message would get a "not configured for multi-tenant access" error. Telegram (`bot.py:102`) has this wiring; Slack's was missing.

## Why both changes in one PR

The compose block alone deploys a permanently-broken bot. The identity fix alone has no production effect (no compose target). Together they make Phase 2 verifiable end-to-end.

## Prerequisites verified

- All 3 Slack secrets present in Doppler `factorylm/prd`: `SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`, `SLACK_SIGNING_SECRET`
- `sqlalchemy` and `psycopg2-binary` already in `mira-bots/slack/requirements.txt`
- `NEON_DATABASE_URL` already in the saas.yml env block
- Compose validates (`docker compose -f docker-compose.saas.yml config --services` lists `mira-bot-slack`)

## Deploy steps post-merge

```bash
gh workflow run "Deploy to VPS" -f services=mira-bot-slack
```

## Verification plan

- [ ] Container reports `healthy` after deploy
- [ ] Slack Socket Mode connection established (logs show no token errors)
- [ ] `@mira hello` in a workspace channel produces a reply (proves engine round-trip)
- [ ] No `ModuleNotFoundError: chat_adapter`
- [ ] No `MIRA is not configured for multi-tenant access yet` response

## Known CI flake

`test_state_load_save_throughput` is a CI-runner-load-sensitive performance test (4.6s vs 2.0s budget). It passed on main at the same SHA family and can't be affected by compose/import changes. If it flakes here, treat as pre-existing — same handling as PR #1278.

Refs: #1270, #1271

🤖 Generated with [Claude Code](https://claude.com/claude-code)