### PR TITLE
fix(hub): resolve merge conflict markers in assets/page.tsx — unblock prod build

### DIFF
--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/app/(hub)/assets/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/page.tsx
@@ -7,13 +7,7 @@ import { useTranslations } from "next-intl";
 import {
   Search, QrCode, Wind, Zap, Cog, Thermometer, Droplets,
   Factory, Gauge, AlertCircle, CheckCircle2, AlertTriangle,
-<<<<<<< Updated upstream
-  Plus, X, Loader2, Wrench, Printer,
-||||||| Stash base
-  Plus, X, Loader2, Wrench,
-=======
-  Plus, X, Loader2, Wrench, Download,
->>>>>>> Stashed changes
+  Plus, X, Loader2, Wrench, Printer, Download,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
## Summary
- **P0 prod fix.** `mira-hub` container has been unbuildable since PR #1214 merged with unresolved `<<<<<<< / ||||||| / =======` markers in `mira-hub/src/app/(hub)/assets/page.tsx`. Result: every deploy fails Turbopack build → old hub container dies → `app.factorylm.com/api/health` returns 502.
- Resolved by keeping both icons (`Printer`, `Download`) — both are referenced downstream in the JSX (lines 478, 495).
- Bumps `mira-hub` 1.5.3 → 1.5.4 per `mira-hub/AGENTS.md` versioning rule (patch = hotfix).

## Diff
- `mira-hub/src/app/(hub)/assets/page.tsx`: 6-line conflict block → 1-line clean import
- `mira-hub/package.json`: version bump

## Test plan
- [x] `grep -rn "^<<<<<<< "` returns no other markers in `mira-hub/`
- [x] Both `Printer` and `Download` are used in JSX downstream (verified lines 478, 495)
- [ ] Merge → deploy-vps.yml auto-fires → hub builds → `curl https://app.factorylm.com/api/health` returns 200

## Rollback
Trivial — revert this commit. The conflict was committed in `fec84476` (PR #1214) so reverting takes us back to a state hub also couldn't build, but that's the current state anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)