### PR TITLE
feat(ingest): wire Component Template Builder into Celery chain (#1257)

### DIFF
--- a/mira-crawler/celery_app.py
+++ b/mira-crawler/celery_app.py
@@ -43,6 +43,7 @@ app.config_from_object(_config_module)
 # Explicit imports ensure task registration in both Docker (mira_crawler.*) and local dev
 try:
     import mira_crawler.tasks.blog  # noqa: F401
+    import mira_crawler.tasks.component_template  # noqa: F401
     import mira_crawler.tasks.content  # noqa: F401
     import mira_crawler.tasks.discover  # noqa: F401
     import mira_crawler.tasks.foundational  # noqa: F401
@@ -63,6 +64,7 @@ try:
     import mira_crawler.tasks.youtube_intent  # noqa: F401
 except ImportError:
     import tasks.blog  # noqa: F401
+    import tasks.component_template  # noqa: F401
     import tasks.content  # noqa: F401
     import tasks.discover  # noqa: F401
     import tasks.foundational  # noqa: F401

--- a/mira-crawler/celeryconfig.py
+++ b/mira-crawler/celeryconfig.py
@@ -58,6 +58,7 @@ task_routes = {
     "mira_crawler.tasks.intent_digest.*": {"queue": "default"},
     "mira_crawler.tasks.gdrive.*": {"queue": "ingest"},
     "mira_crawler.tasks.freshness.*": {"queue": "freshness"},
+    "mira_crawler.tasks.component_template.*": {"queue": "ingest"},
     # --- LinkedIn draft generation ---
     "linkedin.*": {"queue": "celery"},
 }
@@ -88,6 +89,11 @@ task_annotations = {
     "tasks.reddit_intent.scan_reddit_intent": {"rate_limit": "1/h"},
     "tasks.youtube_intent.scan_youtube_intent": {"rate_limit": "1/h"},
     "tasks.intent_digest.send_daily_digest": {"rate_limit": "1/h"},
+    # Component template builder — rate-limited so an ingest burst doesn't
+    # blow through the Groq cascade's free-tier hourly cap.
+    "mira_crawler.tasks.component_template.extract_component_template": {
+        "rate_limit": "10/m",
+    },
 }
 
 # ---------------------------------------------------------------------------

--- a/mira-crawler/tasks/component_template.py
+++ b/mira-crawler/tasks/component_template.py
@@ -1,0 +1,467 @@
+"""Component template extraction — automated post-ingest pipeline.
+
+After a manual lands in `knowledge_entries`, this task pulls the chunks for
+(manufacturer, model), runs the existing Groq → Cerebras cascade in
+`tools/build_component_template.py`, and upserts one row into
+`component_templates` (+ provenance rows in `component_template_sources`).
+
+Constraints
+-----------
+- LLM cascade is the Groq → Cerebras path defined in tools/build_component_template.py.
+  No Anthropic — CLAUDE.md hard constraint #2.
+- Idempotent. `verified` rows are never overwritten by the LLM; `rejected` rows
+  are left as-is until a human re-opens them; `proposed` rows are updated in
+  place so the latest extraction wins.
+- Never blocks ingest — failures are logged with structured fields, not raised.
+
+Issue: #1257.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Path bootstrap — make tools/build_component_template.py importable from
+# both Docker (PYTHONPATH includes /app/tools) and local dev (sibling dir).
+# ---------------------------------------------------------------------------
+
+_TASK_DIR = Path(__file__).resolve().parent
+_CRAWLER_DIR = _TASK_DIR.parent
+_REPO_ROOT = _CRAWLER_DIR.parent
+
+for _candidate in (_REPO_ROOT / "tools", Path("/app/tools")):
+    if _candidate.exists() and str(_candidate) not in sys.path:
+        sys.path.insert(0, str(_candidate))
+
+# ---------------------------------------------------------------------------
+# Celery app — supports both mira_crawler.* (Docker) and tasks.* (local) layouts.
+# ---------------------------------------------------------------------------
+
+try:
+    from mira_crawler.celery_app import app
+except ImportError:
+    from celery_app import app  # type: ignore[no-redef]
+
+from build_component_template import (  # type: ignore[import-not-found]  # noqa: E402
+    _engine,
+    extract_template,
+    fetch_chunks,
+)
+
+try:
+    from mira_crawler.ingest.uns import model_path  # type: ignore[import-not-found]
+except ImportError:
+    from ingest.uns import model_path  # type: ignore[import-not-found]
+
+logger = logging.getLogger("mira-crawler.tasks.component_template")
+
+
+# ---------------------------------------------------------------------------
+# Idempotent upsert helpers.
+# ---------------------------------------------------------------------------
+
+
+def _existing_template(manufacturer: str, model: str) -> dict[str, Any] | None:
+    """Return the latest-version row for (manufacturer, model), or None."""
+    from sqlalchemy import text
+
+    sql = text(
+        """
+        SELECT id, version, verification_status
+        FROM component_templates
+        WHERE manufacturer ILIKE :mfr AND model ILIKE :model
+        ORDER BY version DESC
+        LIMIT 1
+        """
+    )
+    with _engine().connect() as conn:
+        row = conn.execute(sql, {"mfr": manufacturer, "model": model}).mappings().fetchone()
+    return dict(row) if row else None
+
+
+def _upsert_template(
+    extracted: dict[str, Any],
+    manufacturer: str,
+    model: str,
+    category: str,
+    component_type: str,
+    chunks: list[dict[str, Any]],
+    existing: dict[str, Any] | None,
+    knowledge_entry_id: str | None,
+    source_type: str,
+) -> tuple[str, str]:
+    """INSERT a new row or UPDATE an existing `proposed` one in place.
+
+    Returns (template_id, action). action ∈
+        {"inserted", "updated", "updated_after_race", "skipped_verified"}.
+    """
+    from sqlalchemy import text
+    from sqlalchemy.exc import IntegrityError
+
+    if existing and existing.get("verification_status") == "verified":
+        logger.info(
+            "Template %s for %s %s is verified — skipping LLM overwrite",
+            existing["id"],
+            manufacturer,
+            model,
+        )
+        return str(existing["id"]), "skipped_verified"
+
+    uns_path = model_path(manufacturer, model)
+
+    params: dict[str, Any] = {
+        "cat": category,
+        "type": component_type,
+        "mfr": manufacturer,
+        "model": model,
+        "description": extracted.get("description"),
+        "power": json.dumps(extracted.get("power_specs", {})),
+        "io": json.dumps(extracted.get("input_output_specs", {})),
+        "signal": json.dumps(extracted.get("signal_behavior", {})),
+        "connector": extracted.get("connector_type"),
+        "pinout": json.dumps(extracted.get("pinout", {})),
+        "env": json.dumps(extracted.get("environmental_limits", {})),
+        "mounting": extracted.get("mounting_notes"),
+        "indicators": json.dumps(extracted.get("diagnostic_indicators", [])),
+        "signals": json.dumps(extracted.get("expected_signals", [])),
+        "failures": json.dumps(extracted.get("common_failure_modes", [])),
+        "troubleshooting": json.dumps(extracted.get("troubleshooting_steps", [])),
+        "pm": json.dumps(extracted.get("pm_checks", [])),
+        "safety": json.dumps(extracted.get("safety_notes", [])),
+        "uns_rec": extracted.get("recommended_uns_template") or uns_path,
+        "uns_path": uns_path,
+    }
+
+    update_sql = text(
+        """
+        UPDATE component_templates SET
+            component_category = :cat,
+            component_type = :type,
+            description = :description,
+            power_specs = :power,
+            input_output_specs = :io,
+            signal_behavior = :signal,
+            connector_type = :connector,
+            pinout = :pinout,
+            environmental_limits = :env,
+            mounting_notes = :mounting,
+            diagnostic_indicators = :indicators,
+            expected_signals = :signals,
+            common_failure_modes = :failures,
+            troubleshooting_steps = :troubleshooting,
+            pm_checks = :pm,
+            safety_notes = :safety,
+            recommended_uns_template = :uns_rec,
+            uns_path = :uns_path::ltree,
+            updated_at = now()
+        WHERE id = :id AND verification_status <> 'verified'
+        """
+    )
+
+    with _engine().begin() as conn:
+        if existing:
+            template_id = str(existing["id"])
+            params["id"] = template_id
+            conn.execute(update_sql, params)
+            conn.execute(
+                text(
+                    "DELETE FROM component_template_sources "
+                    "WHERE template_id = :id AND extracted_by = 'llm'"
+                ),
+                {"id": template_id},
+            )
+            action = "updated"
+        else:
+            template_id = str(uuid.uuid4())
+            params["id"] = template_id
+            try:
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO component_templates (
+                            id, component_category, component_type,
+                            manufacturer, model, description,
+                            power_specs, input_output_specs, signal_behavior,
+                            connector_type, pinout, environmental_limits,
+                            mounting_notes, diagnostic_indicators, expected_signals,
+                            common_failure_modes, troubleshooting_steps, pm_checks,
+                            safety_notes, recommended_uns_template, uns_path,
+                            verification_status, version
+                        ) VALUES (
+                            :id, :cat, :type,
+                            :mfr, :model, :description,
+                            :power, :io, :signal,
+                            :connector, :pinout, :env,
+                            :mounting, :indicators, :signals,
+                            :failures, :troubleshooting, :pm,
+                            :safety, :uns_rec, :uns_path::ltree,
+                            'proposed', 1
+                        )
+                        ON CONFLICT (manufacturer, model, version) DO NOTHING
+                        """
+                    ),
+                    params,
+                )
+                action = "inserted"
+            except IntegrityError:
+                # Belt-and-suspenders: ON CONFLICT should swallow dupes, but a
+                # parallel worker could have raced on a different constraint.
+                action = "updated_after_race"
+
+            winner = _existing_template(manufacturer, model)
+            if winner and str(winner["id"]) != template_id:
+                template_id = str(winner["id"])
+                params["id"] = template_id
+                conn.execute(update_sql, params)
+                conn.execute(
+                    text(
+                        "DELETE FROM component_template_sources "
+                        "WHERE template_id = :id AND extracted_by = 'llm'"
+                    ),
+                    {"id": template_id},
+                )
+                action = "updated_after_race"
+
+        for chunk in chunks[:10]:
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO component_template_sources (
+                        template_id, source_type, source_document_id, excerpt,
+                        extraction_confidence, extracted_by
+                    ) VALUES (:tid, :stype, :sdoc, :excerpt, :conf, 'llm')
+                    """
+                ),
+                {
+                    "tid": template_id,
+                    "stype": _normalize_source_type(chunk.get("source_type") or source_type),
+                    "sdoc": chunk.get("id"),
+                    "excerpt": (chunk.get("content") or "")[:500],
+                    "conf": 0.55,
+                },
+            )
+
+        if knowledge_entry_id:
+            try:
+                sdoc_uuid: str | None = str(uuid.UUID(knowledge_entry_id))
+            except (ValueError, AttributeError):
+                sdoc_uuid = None
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO component_template_sources (
+                        template_id, source_type, source_document_id, excerpt,
+                        extraction_confidence, extracted_by
+                    ) VALUES (:tid, :stype, :sdoc, :excerpt, :conf, 'llm')
+                    """
+                ),
+                {
+                    "tid": template_id,
+                    "stype": _normalize_source_type(source_type),
+                    "sdoc": sdoc_uuid,
+                    "excerpt": f"trigger:knowledge_entry_id={knowledge_entry_id}",
+                    "conf": 0.55,
+                },
+            )
+
+    return template_id, action
+
+
+_ALLOWED_SOURCE_TYPES = {
+    "manual",
+    "datasheet",
+    "print",
+    "technician_note",
+    "oem_kb",
+    "other",
+}
+
+
+def _normalize_source_type(raw: str | None) -> str:
+    """Map ingest-side source_type values onto the CHECK-constrained enum."""
+    if not raw:
+        return "manual"
+    lower = raw.lower()
+    if lower in _ALLOWED_SOURCE_TYPES:
+        return lower
+    if "manual" in lower:
+        return "manual"
+    if "datasheet" in lower or "data_sheet" in lower:
+        return "datasheet"
+    return "other"
+
+
+def _log_extraction(
+    manufacturer: str,
+    model: str,
+    status: str,
+    chunks_used: int,
+    template_id: str | None = None,
+    error: str | None = None,
+) -> None:
+    logger.info(
+        "component_template_extraction status=%s mfr=%r model=%r chunks=%d template=%s err=%s",
+        status,
+        manufacturer,
+        model,
+        chunks_used,
+        template_id or "-",
+        (error or "")[:200],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Celery task.
+# ---------------------------------------------------------------------------
+
+
+@app.task(
+    bind=True,
+    name="mira_crawler.tasks.component_template.extract_component_template",
+    max_retries=2,
+    soft_time_limit=300,
+    time_limit=420,
+    acks_late=True,
+    autoretry_for=(),
+    default_retry_delay=60,
+)
+def extract_component_template(
+    self,
+    manufacturer: str = "",
+    model: str = "",
+    category: str = "unknown",
+    component_type: str = "unknown",
+    knowledge_entry_id: str | None = None,
+    source_type: str = "manual",
+    chunk_limit: int = 40,
+) -> dict[str, Any]:
+    """Pull chunks for (manufacturer, model), run extraction, upsert template.
+
+    Idempotent — safe to call repeatedly. `verified` rows stay untouched;
+    `rejected` rows stay rejected; `proposed` rows are refreshed in place.
+    """
+    if not manufacturer or not model:
+        _log_extraction(manufacturer, model, "skipped_no_identifiers", 0)
+        return {"status": "skipped", "reason": "missing_identifiers"}
+
+    try:
+        chunks = fetch_chunks(manufacturer, model, limit=chunk_limit)
+    except Exception as exc:
+        logger.warning("fetch_chunks failed for %s %s: %s", manufacturer, model, exc)
+        raise self.retry(exc=exc, countdown=60)
+
+    if not chunks:
+        _log_extraction(manufacturer, model, "skipped_no_chunks", 0)
+        return {
+            "status": "skipped",
+            "reason": "no_chunks",
+            "manufacturer": manufacturer,
+            "model": model,
+        }
+
+    existing = _existing_template(manufacturer, model)
+    if existing and existing.get("verification_status") == "verified":
+        _log_extraction(
+            manufacturer,
+            model,
+            "skipped_verified",
+            len(chunks),
+            template_id=str(existing["id"]),
+        )
+        return {
+            "status": "skipped",
+            "reason": "already_verified",
+            "template_id": str(existing["id"]),
+            "manufacturer": manufacturer,
+            "model": model,
+        }
+    if existing and existing.get("verification_status") == "rejected":
+        _log_extraction(
+            manufacturer,
+            model,
+            "skipped_rejected",
+            len(chunks),
+            template_id=str(existing["id"]),
+        )
+        return {
+            "status": "skipped",
+            "reason": "previous_rejected",
+            "template_id": str(existing["id"]),
+            "manufacturer": manufacturer,
+            "model": model,
+        }
+
+    try:
+        extracted = asyncio.run(
+            extract_template(manufacturer, model, category, component_type, chunks)
+        )
+    except Exception as exc:
+        logger.warning(
+            "Cascade extraction failed for %s %s: %s",
+            manufacturer,
+            model,
+            exc,
+        )
+        try:
+            raise self.retry(exc=exc, countdown=120)
+        except self.MaxRetriesExceededError:
+            _log_extraction(
+                manufacturer,
+                model,
+                "failed_extraction",
+                len(chunks),
+                error=str(exc),
+            )
+            return {
+                "status": "failed",
+                "stage": "extraction",
+                "error": str(exc),
+                "manufacturer": manufacturer,
+                "model": model,
+            }
+
+    try:
+        template_id, action = _upsert_template(
+            extracted,
+            manufacturer,
+            model,
+            category,
+            component_type,
+            chunks,
+            existing,
+            knowledge_entry_id,
+            source_type,
+        )
+    except Exception as exc:
+        logger.exception("Upsert failed for %s %s", manufacturer, model)
+        _log_extraction(
+            manufacturer,
+            model,
+            "failed_db",
+            len(chunks),
+            error=str(exc),
+        )
+        return {
+            "status": "failed",
+            "stage": "db",
+            "error": str(exc),
+            "manufacturer": manufacturer,
+            "model": model,
+        }
+
+    _log_extraction(manufacturer, model, action, len(chunks), template_id=template_id)
+    return {
+        "status": "ok",
+        "action": action,
+        "template_id": template_id,
+        "manufacturer": manufacturer,
+        "model": model,
+        "chunks_used": len(chunks),
+    }

--- a/mira-crawler/tasks/ingest.py
+++ b/mira-crawler/tasks/ingest.py
@@ -78,7 +78,6 @@ def ingest_url(self, url: str, manufacturer: str = "",
     is_pdf_url = url.lower().endswith(".pdf")
 
     if url.startswith("file://"):
-        from pathlib import Path
         from urllib.parse import urlparse as _urlparse
         from urllib.request import url2pathname
 

--- a/mira-crawler/tasks/ingest.py
+++ b/mira-crawler/tasks/ingest.py
@@ -252,6 +252,35 @@ def ingest_url(self, url: str, manufacturer: str = "",
         "Completed %s: %d inserted, %d skipped, %d total chunks",
         url[:60], inserted, skipped, total,
     )
+
+    # Auto-extract a component_templates row when fresh chunks landed for a
+    # branded source. Dispatched async on the same queue — the ingest task
+    # never blocks on the LLM cascade. Issue #1257.
+    if inserted > 0 and manufacturer and model:
+        try:
+            try:
+                from mira_crawler.tasks.component_template import (
+                    extract_component_template,
+                )
+            except ImportError:
+                from tasks.component_template import (  # type: ignore[no-redef]
+                    extract_component_template,
+                )
+            extract_component_template.delay(
+                manufacturer=manufacturer,
+                model=model,
+                source_type=source_type,
+            )
+            logger.info(
+                "Queued component_template extraction for %s %s (%d new chunks)",
+                manufacturer, model, inserted,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to queue component_template extraction for %s %s: %s",
+                manufacturer, model, exc,
+            )
+
     return {"url": url, "inserted": inserted, "skipped": skipped, "total": total}
 
 

--- a/tools/build_component_template.py
+++ b/tools/build_component_template.py
@@ -177,10 +177,12 @@ Return JSON with this exact shape:
 }}"""
 
 
-# Mirrors mira-bots/shared/inference/router.py provider config. Same order:
-# Groq → Cerebras. (Gemini omitted — the openai-compat shim diverges and adds
-# complexity this tool doesn't need. Add it back if both Groq and Cerebras fail
-# in practice.)
+# Mirrors mira-bots/shared/inference/router.py cascade order:
+# Groq → Cerebras → Gemini. Each provider is OpenAI-compatible, so the same
+# httpx call shape works for all three. Gemini is in the documented cascade
+# (CLAUDE.md + InferenceRouter) — if its openai-compat shim rejects
+# `response_format`, the per-provider exception handler drops to the next one,
+# which is the same behavior we want for any provider failure.
 _CASCADE_PROVIDERS = [
     {
         "name": "groq",
@@ -195,6 +197,13 @@ _CASCADE_PROVIDERS = [
         "base_url": "https://api.cerebras.ai/v1",
         "model_env": "CEREBRAS_MODEL",
         "model_default": "llama3.1-8b",
+    },
+    {
+        "name": "gemini",
+        "key_env": "GEMINI_API_KEY",
+        "base_url": "https://generativelanguage.googleapis.com/v1beta/openai",
+        "model_env": "GEMINI_MODEL",
+        "model_default": "gemini-2.5-flash",
     },
 ]
 


### PR DESCRIPTION
## Summary

Wires the existing `tools/build_component_template.py` CLI into the Celery chain so every manual upload auto-extracts a `component_templates` row in the background. Closes prerequisite of #1257.

- After `tasks/ingest.ingest_url` finishes persisting chunks for a branded source, it dispatches `extract_component_template.delay(manufacturer, model, source_type)` on the `ingest` queue.
- The new task runs the existing Groq → Cerebras → Gemini cascade in `tools/build_component_template.py`, parses the structured JSON, and upserts into `component_templates` (+ provenance rows in `component_template_sources`).
- Idempotent: `verified` rows are never overwritten by the LLM; `rejected` rows are skipped until a human re-opens them; `proposed` rows are refreshed in place.

## No-Anthropic guardrail

Per CLAUDE.md hard constraint #2 (and the PR-template "Inference path is Groq → Cerebras → Gemini — no Anthropic" checkbox), the cascade goes through the existing OpenAI-compat path in `tools/build_component_template.py`. **PR #1263** attempted the same wiring with the Anthropic Messages API — this PR supersedes it. Grep for `anthropic` in the diff returns zero matches.

Per advisor review, Gemini was missing from the CLI tool's cascade (it had only Groq + Cerebras). This PR adds it so the order matches `mira-bots/shared/inference/router.py InferenceRouter` and the documented cascade in CLAUDE.md.

## Files changed

| File | Change |
|---|---|
| `mira-crawler/tasks/component_template.py` | **new** — Celery task `extract_component_template` with idempotent upsert + race-safe ON CONFLICT |
| `mira-crawler/tasks/ingest.py` | dispatch `extract_component_template.delay(...)` after chunks land (manufacturer+model required, ≥1 chunk inserted) |
| `mira-crawler/celery_app.py` | register `tasks.component_template` for both Docker and local-dev import branches |
| `mira-crawler/celeryconfig.py` | route `component_template.*` → `ingest` queue + `10/m` rate limit (free-tier guard) |
| `tools/build_component_template.py` | add Gemini as 3rd provider in `_CASCADE_PROVIDERS` |

## Design notes

- **Trigger placement**: after the chunk-insert loop in `ingest_url` so the LLM only runs against data that actually landed. `inserted > 0 and manufacturer and model` gate avoids burning provider budget on pure-dedup re-runs and on URLs with no model identifier.
- **Idempotency**: `_existing_template(manufacturer, model)` resolves the latest row before INSERT. On `verification_status='verified'` we skip; on `'rejected'` we skip; on `'proposed'` we UPDATE in place and rebuild the `extracted_by='llm'` source rows. Human-entered source rows are preserved across re-extractions.
- **Race handling**: ON CONFLICT (manufacturer, model, version) DO NOTHING + a winner-lookup that switches the worker to UPDATE if a parallel ingest beat us to the row.
- **Source-type normalization**: ingest emits `source_type='equipment_manual'`; the migration's CHECK constraint only accepts `('manual', 'datasheet', 'print', 'technician_note', 'oem_kb', 'other')`. `_normalize_source_type` maps `equipment_manual → manual`, passes through `datasheet`, falls back to `other` for unknowns.
- **Failure semantics**: extraction failures are caught, retried twice (60s/120s), then logged with `status=failed_*` and returned as a result dict — the calling `ingest_url` task never sees an exception so the chunk store stays consistent.

## Prior-work note

Local branch `claude/adoring-yalow-c8bfc7` (commit `703e6728`) drafted a similar task but was never opened as a PR. This PR is an independent implementation that lands directly on top of the merged #1268 fix.

## Test plan

- [x] `python3 -m py_compile` on all 5 touched files — passes
- [x] `ruff check` on new file and edited files — clean
- [x] Import smoke test under mocked `celery_app` — task module loads, `extract_component_template` registered, `_normalize_source_type` returns correct enum values for `equipment_manual`/`manual`/`None`/`datasheet`/`weird`
- [ ] Live smoke (post-merge, separate ops work): ingest one AB PowerFlex 525 manual through `mira-crawler` and confirm a `component_templates` row appears within ~60s with `verification_status='proposed'` and `>=1` row in `component_template_sources`
- [ ] Re-ingest the same manual and confirm the task returns `status='ok' action='updated'` (no duplicate template row)
- [ ] Manually flip `verification_status='verified'` on the row and re-ingest; confirm `action='skipped_verified'` and no `component_template_sources` rows replaced

Closes-toward: #1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)