### PR TITLE
ops: workflow to apply prod migrations 014-018

### DIFF
--- a/.github/workflows/apply-migrations.yml
+++ b/.github/workflows/apply-migrations.yml
@@ -1,0 +1,312 @@
+name: Apply Prod Migrations
+
+# Manually-triggered workflow to apply mira-hub/db/migrations/*.sql against
+# prod NeonDB. All target migrations use IF NOT EXISTS / OR REPLACE and are
+# idempotent — re-running is safe.
+#
+# Pre-reqs:
+#   - GitHub secret `DOPPLER_TOKEN` set to a Doppler service token scoped to
+#     `factorylm/prd` (read-only is enough; it just needs DATABASE_URL).
+#     Create at https://dashboard.doppler.com → Access → Service Tokens.
+#     CLI:  doppler configs tokens create ci-apply-migrations --plain
+#     Then: gh secret set DOPPLER_TOKEN
+#   - Repo admin runs the workflow. workflow_dispatch already restricts to
+#     users with write access; the `production` environment gate adds an
+#     audit-log entry in the deployments tab. Add required reviewers to
+#     that environment (Settings → Environments → production) for an
+#     interactive approval gate.
+
+on:
+  workflow_dispatch:
+    inputs:
+      migrations:
+        description: 'Migrations to apply (e.g. "014,015,016,017,018" or "all" for everything in mira-hub/db/migrations not yet recorded).'
+        required: true
+        default: '014,015,016,017,018'
+        type: string
+      mode:
+        description: 'dry-run = print plan + show statements only. apply = actually run.'
+        required: true
+        default: 'dry-run'
+        type: choice
+        options:
+          - dry-run
+          - apply
+      run_backfill:
+        description: 'After migrations, also run tools/uns_backfill.py + tools/cmms_equipment_uns_backfill.py'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+# workflow_dispatch already requires repo write access. The environment
+# scope below adds a deployment record + lets repo admins add required
+# reviewers in Settings → Environments → production.
+permissions:
+  contents: read
+
+concurrency:
+  group: prod-migrations
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: Apply migrations (${{ inputs.mode }})
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Install psql (postgresql-client-16 for ltree/jsonb parity with Neon)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends postgresql-client-16
+          psql --version
+
+      - name: Authenticate Doppler + resolve DATABASE_URL
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DOPPLER_TOKEN:-}" ]; then
+            echo "::error::DOPPLER_TOKEN secret not set. Create a service token at https://dashboard.doppler.com (factorylm/prd) and run: gh secret set DOPPLER_TOKEN"
+            exit 1
+          fi
+          DATABASE_URL="$(doppler secrets get DATABASE_URL --project factorylm --config prd --plain)"
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::DATABASE_URL empty after Doppler fetch — token scope wrong?"
+            exit 1
+          fi
+          # Mask it so it never leaks to the log if a later step echoes env.
+          echo "::add-mask::$DATABASE_URL"
+          echo "DATABASE_URL=$DATABASE_URL" >> "$GITHUB_ENV"
+          # Sanity-print only the host (Neon endpoint identifier), nothing else.
+          HOST=$(printf '%s' "$DATABASE_URL" | sed -E 's|.*@([^/:]+).*|\1|')
+          echo "DB host: $HOST"
+          echo "DB_HOST=$HOST" >> "$GITHUB_ENV"
+
+      - name: Resolve migration file list
+        id: resolve
+        run: |
+          set -euo pipefail
+          MIG_DIR="mira-hub/db/migrations"
+          if [ ! -d "$MIG_DIR" ]; then
+            echo "::error::$MIG_DIR not found in checkout"
+            exit 1
+          fi
+          REQUESTED="${{ inputs.migrations }}"
+          FILES=()
+          if [ "$REQUESTED" = "all" ]; then
+            while IFS= read -r f; do FILES+=("$f"); done < <(ls "$MIG_DIR"/*.sql | sort)
+          else
+            IFS=',' read -ra PREFIXES <<< "$REQUESTED"
+            for p in "${PREFIXES[@]}"; do
+              p_trimmed="$(echo "$p" | xargs)"
+              MATCHES=( "$MIG_DIR"/"${p_trimmed}"_*.sql )
+              if [ ! -e "${MATCHES[0]}" ]; then
+                echo "::error::No migration file matched prefix '${p_trimmed}' in $MIG_DIR"
+                exit 1
+              fi
+              for m in "${MATCHES[@]}"; do FILES+=("$m"); done
+            done
+          fi
+          # Sort numerically for safety
+          IFS=$'\n' SORTED=($(printf '%s\n' "${FILES[@]}" | sort))
+          unset IFS
+          printf '%s\n' "${SORTED[@]}" > .migration_plan
+          echo "Plan:"
+          cat .migration_plan
+          echo "count=${#SORTED[@]}" >> "$GITHUB_OUTPUT"
+
+      - name: Summarise plan
+        run: |
+          {
+            echo "## Migration plan"
+            echo ""
+            echo "Mode: \`${{ inputs.mode }}\`"
+            echo ""
+            echo "DB host: \`${DB_HOST}\`"
+            echo ""
+            echo "Files (in apply order):"
+            echo ""
+            while IFS= read -r f; do
+              SIZE=$(wc -c < "$f" | tr -d ' ')
+              echo "- \`$f\` (${SIZE} bytes)"
+            done < .migration_plan
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dry-run — show statements only (no execution)
+        if: inputs.mode == 'dry-run'
+        run: |
+          set -euo pipefail
+          echo "### Dry-run: SQL preview" >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r f; do
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "#### $f" >> "$GITHUB_STEP_SUMMARY"
+            echo '```sql' >> "$GITHUB_STEP_SUMMARY"
+            head -60 "$f" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          done < .migration_plan
+          echo ""
+          echo "Dry-run complete. Re-run with mode=apply to execute against $DB_HOST."
+
+      - name: Apply migrations (ON_ERROR_STOP=1, single transaction per file)
+        if: inputs.mode == 'apply'
+        run: |
+          set -euo pipefail
+          echo "### Apply results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| File | Status | Duration |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|--------|----------|" >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r f; do
+            echo "::group::Applying $f"
+            START=$(date +%s)
+            if psql "$DATABASE_URL" \
+                 --single-transaction \
+                 --set ON_ERROR_STOP=1 \
+                 --no-psqlrc \
+                 -v ECHO=errors \
+                 -f "$f"; then
+              END=$(date +%s)
+              DUR=$((END-START))
+              echo "| \`$f\` | OK | ${DUR}s |" >> "$GITHUB_STEP_SUMMARY"
+              echo "::endgroup::"
+            else
+              END=$(date +%s)
+              DUR=$((END-START))
+              echo "| \`$f\` | FAILED | ${DUR}s |" >> "$GITHUB_STEP_SUMMARY"
+              echo "::endgroup::"
+              echo "::error file=$f::psql failed on $f after ${DUR}s"
+              exit 1
+            fi
+          done < .migration_plan
+
+      - name: Verify schema (post-apply only)
+        if: inputs.mode == 'apply'
+        run: |
+          set -euo pipefail
+          # Build verification SQL from the actual declarations we extracted
+          # from mira-hub/db/migrations/01[4-8]*.sql at workflow-write time.
+          # Each row asserts an object exists; CASE labels what's missing so
+          # the step summary is greppable.
+          cat > /tmp/verify.sql <<'SQL'
+          \echo === extensions ===
+          SELECT extname FROM pg_extension WHERE extname IN ('ltree','btree_gist') ORDER BY extname;
+
+          \echo === 014 — uns_slug function ===
+          SELECT
+            CASE WHEN to_regprocedure('public.uns_slug(text)') IS NOT NULL
+                 THEN 'OK: uns_slug(text)'
+                 ELSE 'MISSING: uns_slug(text)' END AS check_014;
+
+          \echo === 015 — cmms_equipment.uns_path + indexes ===
+          SELECT
+            CASE WHEN EXISTS (
+              SELECT 1 FROM information_schema.columns
+              WHERE table_name='cmms_equipment' AND column_name='uns_path'
+            ) THEN 'OK: cmms_equipment.uns_path'
+              ELSE 'MISSING: cmms_equipment.uns_path' END AS col_015,
+            CASE WHEN to_regclass('public.idx_cmms_equipment_uns_path') IS NOT NULL
+                 THEN 'OK: idx_cmms_equipment_uns_path'
+                 ELSE 'MISSING: idx_cmms_equipment_uns_path' END AS idx_015a,
+            CASE WHEN to_regclass('public.idx_cmms_equipment_tenant_uns_path') IS NOT NULL
+                 THEN 'OK: idx_cmms_equipment_tenant_uns_path'
+                 ELSE 'MISSING: idx_cmms_equipment_tenant_uns_path' END AS idx_015b;
+
+          \echo === 016 — component_templates + sources ===
+          SELECT
+            CASE WHEN to_regclass('public.component_templates') IS NOT NULL
+                 THEN 'OK: component_templates'
+                 ELSE 'MISSING: component_templates' END AS tbl_016a,
+            CASE WHEN to_regclass('public.component_template_sources') IS NOT NULL
+                 THEN 'OK: component_template_sources'
+                 ELSE 'MISSING: component_template_sources' END AS tbl_016b;
+
+          \echo === 017 — installed_component_instances ===
+          SELECT
+            CASE WHEN to_regclass('public.installed_component_instances') IS NOT NULL
+                 THEN 'OK: installed_component_instances'
+                 ELSE 'MISSING: installed_component_instances' END AS tbl_017;
+
+          \echo === 018 — relationship_proposals + evidence ===
+          SELECT
+            CASE WHEN to_regclass('public.relationship_proposals') IS NOT NULL
+                 THEN 'OK: relationship_proposals'
+                 ELSE 'MISSING: relationship_proposals' END AS tbl_018a,
+            CASE WHEN to_regclass('public.relationship_evidence') IS NOT NULL
+                 THEN 'OK: relationship_evidence'
+                 ELSE 'MISSING: relationship_evidence' END AS tbl_018b;
+          SQL
+
+          OUTPUT=$(psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -f /tmp/verify.sql 2>&1)
+          echo "$OUTPUT"
+          {
+            echo ""
+            echo "### Verification"
+            echo ""
+            echo '```'
+            echo "$OUTPUT"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          if echo "$OUTPUT" | grep -q "MISSING:"; then
+            echo "::error::Verification found missing schema objects after apply."
+            exit 1
+          fi
+
+  backfill:
+    name: Backfill UNS paths (kg_entities + cmms_equipment)
+    needs: apply
+    if: inputs.mode == 'apply' && inputs.run_backfill == 'true'
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install backfill dependencies
+        run: |
+          # Backfill scripts import the same deps as mira-hub workers.
+          # Keep this list minimal — pin via requirements lookup once a
+          # tools/requirements.txt exists; today they only need psycopg + httpx.
+          python -m pip install --upgrade pip
+          pip install 'psycopg[binary]>=3.1' httpx
+
+      - name: Run kg_entities backfill (tools/uns_backfill.py)
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ ! -f tools/uns_backfill.py ]; then
+            echo "::error::tools/uns_backfill.py missing — was PR #1245 reverted?"
+            exit 1
+          fi
+          doppler run --project factorylm --config prd -- python tools/uns_backfill.py
+
+      - name: Run cmms_equipment backfill (tools/cmms_equipment_uns_backfill.py)
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ ! -f tools/cmms_equipment_uns_backfill.py ]; then
+            echo "::error::tools/cmms_equipment_uns_backfill.py missing — was PR #1245 reverted?"
+            exit 1
+          fi
+          doppler run --project factorylm --config prd -- python tools/cmms_equipment_uns_backfill.py


### PR DESCRIPTION
## Summary

Adds `.github/workflows/apply-migrations.yml` — a manually-triggered workflow that applies migrations 014–018 (merged in #1245 + #1253) against prod NeonDB.

**Merging this PR does NOT run any migrations.** It only adds the workflow. Migrations run on a separate `workflow_dispatch` trigger you fire after merge.

## Why a workflow instead of running psql directly

- Auditable — full log in Actions; deployment recorded under the `production` environment
- Reproducible — same psql version (16), same migration order, every time
- Reviewer-gateable — add required reviewers in Settings → Environments → production
- Idempotent SQL — all 014–018 use `IF NOT EXISTS` / `OR REPLACE`, so re-running is safe

## Workflow features

- **Inputs:**
  - `migrations` — comma list of prefixes (default `014,015,016,017,018`) or `all`
  - `mode` — `dry-run` (prints plan + first 60 lines of each file, no execution) or `apply`
  - `run_backfill` — `true` runs the second job (`tools/uns_backfill.py` + `tools/cmms_equipment_uns_backfill.py`) after apply
- **Per-file transaction:** `psql --single-transaction --set ON_ERROR_STOP=1`
- **Verification step:** after apply, queries actual schema objects declared in each migration:
  - 014 → `uns_slug(text)` function
  - 015 → `cmms_equipment.uns_path` column + 2 GIST indexes
  - 016 → `component_templates`, `component_template_sources` tables
  - 017 → `installed_component_instances` table
  - 018 → `relationship_proposals`, `relationship_evidence` tables
  - Verification queries extracted from the actual migration SQL, not invented
- **Concurrency:** `prod-migrations` group, no cancel-in-progress — two runs can't race

## Pre-requisite: one secret

```bash
# In Doppler dashboard or CLI:
doppler configs tokens create ci-apply-migrations --plain --project factorylm --config prd
# Then in this repo:
gh secret set DOPPLER_TOKEN
```

The workflow's first step fails fast with a clear error if `DOPPLER_TOKEN` is unset, so you can't accidentally run it half-configured.

## Suggested run sequence (after merge)

```bash
# 1. Dry-run first to see the plan
gh workflow run apply-migrations.yml -f mode=dry-run

# 2. Real apply (just migrations)
gh workflow run apply-migrations.yml -f mode=apply

# 3. After confirming schema, run backfills
gh workflow run apply-migrations.yml -f mode=apply -f run_backfill=true
```

(Or trigger from the Actions tab UI — same inputs.)

## Test plan

- [ ] CI passes on this PR (only adds a workflow file; existing jobs should be unaffected)
- [ ] After merge: `gh secret set DOPPLER_TOKEN` if not already set
- [ ] Dry-run shows all 5 files in order
- [ ] Apply run posts a green summary table with all 5 OK rows
- [ ] Verification step shows no `MISSING:` lines
- [ ] (Optional) Backfill job completes without errors

## Notes / open questions

- The `production` environment exists but has no protection rules today. Consider adding required reviewers there for an interactive approval gate before any prod-touching job runs.
- The advisor preferred a direct `DATABASE_URL` GitHub secret (simpler, more conventional for one-off migration jobs). Went with Doppler per the task spec + cluster-wide pattern. Easy swap if you want it later — change the Doppler step to `env: DATABASE_URL: ${{ secrets.DATABASE_URL }}` and drop the doppler install/auth steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)