### PR TITLE
chore(claude): operating structure — .claude/, marketplace, Playwright MCP

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,111 @@
+{
+  "name": "mira-local",
+  "owner": {
+    "name": "MIRA",
+    "email": "harperhousebuyers@gmail.com"
+  },
+  "plugins": [
+    {
+      "name": "ruff-lsp",
+      "description": "Ruff linter + formatter as an LSP server (uses `ruff server`).",
+      "source": "./.claude-plugin/plugins/ruff-lsp",
+      "lspServers": {
+        "ruff": {
+          "command": "ruff",
+          "args": ["server"],
+          "extensionToLanguage": {
+            ".py": "python",
+            ".pyi": "python"
+          }
+        }
+      }
+    },
+    {
+      "name": "yaml-lsp",
+      "description": "yaml-language-server with schema validation for Compose, GitHub Actions, and Doppler configs.",
+      "source": "./.claude-plugin/plugins/yaml-lsp",
+      "lspServers": {
+        "yaml": {
+          "command": "yaml-language-server",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".yml": "yaml",
+            ".yaml": "yaml"
+          }
+        }
+      }
+    },
+    {
+      "name": "sql-lsp",
+      "description": "PostgreSQL Language Server (postgres-language-server) — Postgres-aware syntax checking for NeonDB migrations and schemas.",
+      "source": "./.claude-plugin/plugins/sql-lsp",
+      "lspServers": {
+        "sql": {
+          "command": "postgres-language-server",
+          "args": [],
+          "extensionToLanguage": {
+            ".sql": "sql"
+          }
+        }
+      }
+    },
+    {
+      "name": "dockerfile-lsp",
+      "description": "dockerfile-language-server-nodejs for the 16 Dockerfiles in MIRA.",
+      "source": "./.claude-plugin/plugins/dockerfile-lsp",
+      "lspServers": {
+        "dockerfile": {
+          "command": "docker-langserver",
+          "args": ["--stdio"],
+          "extensionToLanguage": {
+            ".dockerfile": "dockerfile"
+          }
+        }
+      }
+    },
+    {
+      "name": "toml-lsp",
+      "description": "Taplo TOML language server for pyproject.toml and .gitleaks.toml.",
+      "source": "./.claude-plugin/plugins/toml-lsp",
+      "lspServers": {
+        "taplo": {
+          "command": "taplo",
+          "args": ["lsp", "stdio"],
+          "extensionToLanguage": {
+            ".toml": "toml"
+          }
+        }
+      }
+    },
+    {
+      "name": "shell-lsp",
+      "description": "bash-language-server (uses shellcheck) for the 26 shell scripts in MIRA.",
+      "source": "./.claude-plugin/plugins/shell-lsp",
+      "lspServers": {
+        "bash": {
+          "command": "bash-language-server",
+          "args": ["start"],
+          "extensionToLanguage": {
+            ".sh": "shellscript",
+            ".bash": "shellscript"
+          }
+        }
+      }
+    },
+    {
+      "name": "markdown-lsp",
+      "description": "Marksman markdown LSP for the wiki/ Obsidian vault.",
+      "source": "./.claude-plugin/plugins/markdown-lsp",
+      "lspServers": {
+        "marksman": {
+          "command": "marksman",
+          "args": ["server"],
+          "extensionToLanguage": {
+            ".md": "markdown",
+            ".markdown": "markdown"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/.claude-plugin/plugins/dockerfile-lsp/README.md
+++ b/.claude-plugin/plugins/dockerfile-lsp/README.md
@@ -1,0 +1,14 @@
+# dockerfile-lsp
+
+Wires dockerfile-language-server-nodejs for the 16 Dockerfiles in MIRA.
+
+## Install
+`npm install -g dockerfile-language-server-nodejs`
+Binary: `docker-langserver`
+
+## Filename matching limitation
+Claude Code's `extensionToLanguage` matches by file extension, but most Dockerfiles in MIRA are named just `Dockerfile` (no extension). This plugin currently matches `.dockerfile` suffix only. To make filename `Dockerfile` files trigger the LSP, either:
+1. Rename to `<service>.Dockerfile`, or
+2. File a follow-up to extend Claude Code's matcher to support full-filename patterns.
+
+For now, this plugin covers `.dockerfile`-suffixed files. Standard `Dockerfile` (no extension) files will not trigger the LSP automatically.

--- a/.claude-plugin/plugins/markdown-lsp/README.md
+++ b/.claude-plugin/plugins/markdown-lsp/README.md
@@ -1,0 +1,7 @@
+# markdown-lsp
+
+Marksman LSP for MIRA's wiki/ Obsidian vault and docs/ tree.
+Validates `[[wikilinks]]` and relative link targets.
+
+## Install
+`brew install marksman`

--- a/.claude-plugin/plugins/ruff-lsp/README.md
+++ b/.claude-plugin/plugins/ruff-lsp/README.md
@@ -1,0 +1,14 @@
+# ruff-lsp
+
+Wires `ruff server` (Ruff's built-in LSP, since ruff 0.4.5) into Claude Code.
+
+## Install
+ruff is already installed via Homebrew (or `pip install ruff`).
+Verify: `ruff --version` (need >= 0.4.5).
+
+## What it surfaces
+- Lint diagnostics from rules enabled in `pyproject.toml [tool.ruff.lint]`
+- Format-on-edit hints (matches `ruff format`)
+
+## Why not pip's `ruff-lsp` package?
+That package is deprecated. `ruff server` is the maintained LSP.

--- a/.claude-plugin/plugins/shell-lsp/README.md
+++ b/.claude-plugin/plugins/shell-lsp/README.md
@@ -1,0 +1,7 @@
+# shell-lsp
+
+bash-language-server with shellcheck integration for MIRA's
+26 install/deploy/smoke shell scripts.
+
+## Install
+`npm install -g bash-language-server && brew install shellcheck`

--- a/.claude-plugin/plugins/sql-lsp/README.md
+++ b/.claude-plugin/plugins/sql-lsp/README.md
@@ -1,0 +1,14 @@
+# sql-lsp
+
+PostgreSQL Language Server for the 16 .sql files in MIRA, including NeonDB migrations and HNSW index definitions.
+
+## Install
+`brew install postgres-language-server`
+
+## Why postgres-language-server over sqls?
+The original plan called for `sqls`, which is not available via brew or npm on macOS and requires Go (not installed on this system). `postgres-language-server` is a strictly better fit for MIRA since our database is NeonDB (Postgres), providing Postgres-aware syntax checking and validation.
+
+## Features
+- Postgres-specific syntax validation on `.sql` files
+- Catches errors like malformed DDL, invalid function calls before apply-time
+- Supports all Postgres versions including modern extensions (HNSW, jsonb operations, etc.)

--- a/.claude-plugin/plugins/toml-lsp/README.md
+++ b/.claude-plugin/plugins/toml-lsp/README.md
@@ -1,0 +1,7 @@
+# toml-lsp
+
+Taplo TOML LSP — validates pyproject.toml, .gitleaks.toml,
+and any other TOML configs.
+
+## Install
+`brew install taplo`

--- a/.claude-plugin/plugins/yaml-lsp/README.md
+++ b/.claude-plugin/plugins/yaml-lsp/README.md
@@ -1,0 +1,14 @@
+# yaml-lsp
+
+Wires yaml-language-server into Claude Code for the 130+ YAML files in MIRA.
+
+## Install
+`npm install -g yaml-language-server`
+
+## Schema associations
+yaml-language-server auto-detects schemas for:
+- `docker-compose*.yml` → Compose schema
+- `.github/workflows/*.yml` → GitHub Actions schema
+
+For MIRA-specific schemas (e.g. `mira_copy/prompts/*.yaml`), add
+`# yaml-language-server: $schema=...` directive at top of file.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,147 @@
+# MIRA — Product & Architecture Operating Guide
+
+> Companion to root `CLAUDE.md` (which is the **build-state + repo map**). This file is the **product rules** Claude Code must honor while editing this codebase.
+
+## What MIRA is
+
+**MIRA** (Maintenance Intelligence Resource Agent) is an industrial maintenance intelligence system. The product wedge is a **Slack-first maintenance copilot** that grounds every answer in the customer's real factory context.
+
+It is **not** a generic chatbot. It is **not** a SCADA or CMMS replacement. It is a focused, grounded troubleshooting and ingestion assistant for plant maintenance technicians.
+
+## North Star architecture
+
+| Layer | Role | Lives in |
+|---|---|---|
+| **Slack / ChatOps** | Front door — where the technician talks | `mira-bots/slack/bot.py` (slack-bolt AsyncApp, Socket Mode) |
+| **Maintenance intelligence** | The brain — engine, FSM, grounding, classifier | `mira-bots/shared/engine.py` (Supervisor / GSD engine) |
+| **UNS / MQTT / Sparkplug B** | Live nervous system — real plant context | `mira-crawler/ingest/uns.py`, `mira-relay/`, `ignition/` |
+| **Component templates + KG** | Memory — reusable asset/component knowledge | NeonDB `kg_entities` + `kg_relationships` (migrations 004/005) |
+| **Customer docs + work orders** | Evidence — what we cite | `mira-crawler/ingest/`, `mira-mcp/server.py` (CMMS tools), `mira-cmms/` (Atlas) |
+
+Future interfaces (Teams, Telegram, email) are valid, but **Slack is the first product wedge**. Telegram/email adapters at `mira-bots/{telegram,email}/` exist but follow Slack's contract, not the other way around.
+
+## The non-negotiable UNS location-confirmation gate
+
+**MIRA must not begin troubleshooting until it has resolved the technician's work context inside the Unified Namespace or asset namespace.**
+
+Required flow (enforced in `mira-bots/shared/engine.py`):
+
+1. Receive technician message.
+2. Extract candidate `asset`, `area`, `line`, `machine`, `component`, `symptom`, `fault_code`.
+3. Search the UNS (`uns_resolver.resolve_uns_path()` per `docs/specs/uns-message-resolver-spec.md`).
+4. Identify candidate context(s).
+5. Gather evidence (UNS hit, work-order history, manual reference, PLC tag, prior session, technician hint).
+6. **Send a confirmation message** identifying site / area / line / machine / asset / component / fault, evidence used, confidence level, and a confirmation question.
+7. **Wait for confirmation or correction.**
+8. Only then enter troubleshooting / live-assist mode.
+
+A code path that begins troubleshooting before step 7 is a **bug**. The `mira-run-hallucination-audit` command exists to find such paths.
+
+## Grounded troubleshooting
+
+MIRA must ground every claim in at least one of:
+
+- UNS / asset namespace
+- MQTT / live tag data (when available)
+- PLC tag map
+- Customer manuals
+- Wiring diagrams
+- Work-order history
+- Verified knowledge-graph relationships
+- Technician confirmation
+- Admin-approved component profile
+
+Existing groundedness hooks Claude must preserve and use:
+
+- `mira-bots/shared/citation_compliance.py` — every reply should be grounded
+- `mira-bots/shared/engine.py` — 1–5 groundedness scoring, low-groundedness episode tracking, KB-gap admission prompts
+- `mira-bots/shared/benchmark_db.py` — `evidence_utilization`, `evidence_packet`
+
+If a feature change can lower groundedness scores, surface that in the PR.
+
+## Ingestion pipelines
+
+Manual/PDF/photo ingestion flows through `mira-crawler/ingest/` (and `mira-core/mira-ingest/` for the photo/RAG API). Rules:
+
+1. **Preserve source.** Every extracted fact carries a page/section reference where the source supports it.
+2. **Don't invent missing data.** Mark unknown fields `unknown`, not best-guess.
+3. **Flag ambiguous extractions.** A `confidence` field is mandatory.
+4. **Tag every chunk with a UNS path.** Use `mira-crawler/ingest/uns.py` builders — don't reinvent. See `.claude/rules/uns-compliance.md`.
+5. **De-dup before insert.** `mira-crawler/ingest/dedup.py` exists; use it.
+6. **Normalize into component profiles** when the source supports a complete profile (see component-profile-builder skill).
+
+## Component profiles
+
+Component profiles are the reusable SaaS asset. They follow the schema in `.claude/skills/component-profile-builder/SKILL.md`. Hard rules:
+
+- **Evidence-based.** Every field traces to a manual, tag map, work order, or technician confirmation.
+- **Verified vs proposed.** Unverified relationships go in `proposed_relationships`, not `verified_relationships`. Promotion requires admin/technician sign-off.
+- **Per-instance vs per-model.** A profile attached to one asset is per-instance; a reusable model template (e.g., `PowerFlex 525`) is per-model. Don't conflate them.
+
+## Knowledge graph proposals
+
+MIRA writes to `kg_entities` and `kg_relationships` (NeonDB; see `docs/migrations/004_kg_entities.sql`, `005_kg_relationships.sql`). Rules:
+
+- **Never silently assert new relationships.** Status is one of `proposed`, `verified`, `rejected`, `needs_review`.
+- **Store evidence with every relationship** (source doc + page, or work-order id, or technician confirmation id).
+- **Include confidence** (numeric or low/medium/high — match the surrounding column convention).
+- **Don't pollute.** If evidence is weak, propose; don't auto-verify.
+
+Promotion from `proposed` → `verified` is an admin action, not an automatic one. Code paths that auto-verify without admin review are bugs.
+
+## Slack technician UX
+
+Technicians read on a phone in a noisy plant. Optimize for that.
+
+- **Be direct.** Short paragraphs. No corporate language.
+- **Lead with suspected context.** Site → asset → component → fault — in that order.
+- **Show evidence.** Bulleted, three items max.
+- **Ask for confirmation** before troubleshooting (see UNS gate above).
+- **Action-oriented steps only after context is confirmed.**
+- **Never pretend to know plant context without evidence.** If you don't know, say so and ask.
+
+See `.claude/skills/slack-technician-ux-writer/SKILL.md` for sample message templates.
+
+## Rules for code changes
+
+- **Conventional Commits**: `feat/fix/security/docs/refactor/test/chore/BREAKING`. Scope hint: module name (`feat(slack):`, `fix(uns):`, `fix(engine):`).
+- **No LangChain, TensorFlow, n8n** — see PRD §4 in root CLAUDE.md.
+- **Doppler for secrets** — `factorylm/prd`. Never `.env` files in git.
+- **Python: ruff + httpx + `Optional[X]` (3.12 target)** — see `.claude/rules/python-standards.md`.
+- **Security boundaries** — see `.claude/rules/security-boundaries.md` (PII sanitization, safety keywords, Doppler).
+- **UNS compliance** — see `.claude/rules/uns-compliance.md` (every asset row has `uns_path` or `equipment_entity_id` FK).
+- **Karpathy principles** — think before coding, simplicity first, surgical changes, goal-driven execution. See `.claude/rules/karpathy-principles.md`.
+- **Don't break the UNS confirmation gate.** Run `mira-run-hallucination-audit` after engine/bot edits.
+
+## Testing expectations
+
+- **5-regime test framework** in `tests/` (regime1_telethon through regime6_sidecar, plus regime7_ignition). Pre-commit watcher: `tools/eval_watch.py` against `tests/eval/watch_set.txt`.
+- **Golden cases**: `tests/golden_factorylm.csv`, `tests/golden_hybrid.csv` — diagnostic engine truth set.
+- **New troubleshooting features**: add a golden case. Tweaking the gate? Add one or more.
+- **No "trust me" reviews** — Karpathy principle 4 (`evidence beats assertion`) + Cluster Law 1 (`evidence-only completion`).
+- **For UI changes** — Screenshot Rule (`docs/promo-screenshots/`).
+
+## Do not do
+
+- ❌ **Build a generic chatbot.** MIRA answers grounded maintenance questions, nothing else.
+- ❌ **Begin troubleshooting before the UNS gate confirms.**
+- ❌ **Invent plant data, PLC tag meaning, work-order history, fault codes, or manual references.** Always cite.
+- ❌ **Auto-promote `proposed` → `verified`** in the knowledge graph.
+- ❌ **Replace SCADA, replace CMMS, or expose arbitrary PLC writes.** That's out of scope. See `.claude/skills/mira-saas-scope-guard/SKILL.md`.
+- ❌ **Add a LangChain/n8n abstraction over the LLM call** (PRD §4).
+- ❌ **Reintroduce Anthropic as a provider** — removed PR #610, never reintroduce. Cascade is Groq → Cerebras → Gemini.
+- ❌ **Skip the screenshot rule** for visible mira-web UI changes.
+
+## Cross-references
+
+- Root `CLAUDE.md` — build state, ports, env vars, repo map
+- `.claude/rules/uns-compliance.md` — UNS data-shape enforcement
+- `.claude/rules/security-boundaries.md` — secrets, PII, safety keywords
+- `.claude/rules/python-standards.md` — ruff, httpx, NeonDB, async
+- `.claude/rules/karpathy-principles.md` — coding behavior
+- `docs/specs/uns-kg-unification-spec.md` — UNS authority (710 lines)
+- `docs/specs/mira-component-intelligence-architecture.md` — component intelligence architecture
+- `docs/specs/uns-message-resolver-spec.md` — how bot messages resolve to UNS paths
+- `.claude/skills/<name>/SKILL.md` — task-specific operating guides
+- `.claude/commands/<name>.md` — repeatable workflows
+- `.claude/mcp/<name>-spec.md` — MCP server contracts

--- a/.claude/commands/mira-create-demo-plant.md
+++ b/.claude/commands/mira-create-demo-plant.md
@@ -1,0 +1,86 @@
+# /mira-create-demo-plant
+
+Generate a realistic demo plant dataset for evals, screenshots, and SaaS onboarding demos. Demo data must be clearly marked **demo/fake** and live alongside existing seed fixtures.
+
+## Required demo scenario
+
+The canonical demo (already scripted in `marketing/comic-pipeline/` and `docs/specs/mira-component-intelligence-architecture.md`):
+
+```
+Site:      Stardust Racers (Garage Factory)
+Area:      Conveyor Lab
+Line:      Line 5
+Asset:     Conveyor Section B16
+Component: Occupancy Sensor B16.2 (Banner Q4X, photoeye)
+PLC tag:   1.SOC_B16_2
+Fault:     1.SOC B16.2 OCCUPIED TOO LONG
+Pattern:   14 repeats in 6 months
+Fix:       Reset at Panel B16 (no parts required)
+UNS path:  enterprise.stardust_racers.site.garage_factory.area.conveyor_lab.line.line5.work_cell.conveyor_b16.pe_b16_2
+```
+
+This scenario MUST appear in the generated dataset.
+
+## What this command generates
+
+1. **UNS hierarchy** — JSON or SQL seed for `kg_entities` rows covering:
+   enterprise → tenant → site → area → line → work_cell → asset → component for at least 2 lines and 5 assets. Tagged with `is_demo: true` (or equivalent).
+
+2. **Component profiles** — at least 3 fully-fleshed profiles per the `component-profile-builder` schema:
+   - Occupancy Sensor B16.2 (the star)
+   - Conveyor motor + VFD
+   - Sortation diverter
+
+3. **PLC tags** — CSV / JSON tag exports covering ~30 tags across one Micro820 PLC. Includes `1.SOC_B16_2`, `Conveyor_B16_Run`, `Conveyor_B16_Fault`, VFD tags (`HR100..HR102` from root CLAUDE.md), with verified mappings to components.
+
+4. **MQTT / Sparkplug topics** — sample topic strings matching the UNS paths (read-side; this is mock data, no live broker).
+
+5. **Manuals** — 1–2 short PDF stubs (synthetic) or markdown stand-ins under `mira-core/data/demo/manuals/`. Include realistic PM tables, troubleshooting tables, fault-code tables for the demo components.
+
+6. **Work-order history** — 14+ work orders against the Occupancy Sensor B16.2 asset, covering 6 months, 11 of which are reset-only. Includes 2 unrelated assets so the "repeat-failure" detector has something to filter.
+
+7. **Knowledge-graph relationships** — `verified` and `proposed` examples covering: asset→component (HasComponent), component→fault (HasFaultMode), tag→component (DescribesComponent), manual→component (DocumentsComponent), wo→fault (ResolvesFault).
+
+## Where to place fixtures
+
+Match existing seed-file conventions in the repo:
+
+- `mira-core/data/demo/` — JSON seed files (extends pattern in `mira-core/data/seed_cases.json`)
+- `mira-bots/scripts/seed_demo_plant.py` — Python loader that reads the JSON and writes to NeonDB (extends pattern in `seed_kb.py`, `seed_device_kb.py`)
+- `mira-core/data/demo/manuals/` — synthetic manual PDFs / markdown
+- `tests/fixtures/demo_plant/` — eval-side copies for golden cases
+- `tools/seedance-scenarios.yaml` — already references demo scenes; add the B16 scenario if not present
+
+## How demo data is marked
+
+- Every row gets `is_demo: true` (NeonDB column) **or** all entity ids carry a `demo_` prefix
+- A top-level `DEMO_PLANT.md` in `mira-core/data/demo/` describing the plant, the scenarios, and how to load/unload them
+- Loader script `seed_demo_plant.py` accepts `--clean` to remove demo rows before reseeding
+
+## Tests
+
+- Add a pytest under `tests/fixtures/demo_plant/test_demo_plant_loads.py` that:
+  - Runs the loader against a test DB
+  - Verifies the 14 work-orders + repeat-failure detector returns the right pattern
+  - Verifies the UNS resolver returns Line 5 / Conveyor B16 / PE-B16-2 for the message `"B16.2 won't clear"`
+  - Verifies the confirmation message contains "Occupancy Sensor B16.2" and "1.SOC B16.2 OCCUPIED TOO LONG"
+
+## Constraints
+
+- **No real customer data.** All names, IDs, manuals are synthetic.
+- **Mark every row demo.** Don't pollute production tenants.
+- **Don't ship real Banner/Rockwell PDFs** — write summary stand-ins that look like manuals but cite "DEMO" in headers.
+- **One PR per dataset bump.** Keep diffs surveyable.
+
+## Verification
+
+- Run `python mira-bots/scripts/seed_demo_plant.py --dry-run` — should print row counts per table without writing.
+- `pytest tests/fixtures/demo_plant/` — passes.
+- After running with `--apply`, a Slack message "B16.2 won't clear" should trigger the full confirmation gate with the right context.
+
+## Cross-references
+
+- `docs/specs/mira-component-intelligence-architecture.md` — canonical B16 scenario
+- `marketing/comic-pipeline/scripts/storyboard_v1.yaml` — visual storyboard
+- `.claude/skills/uns-location-gate-designer/SKILL.md` — gate flow that consumes this data
+- `.claude/skills/component-profile-builder/SKILL.md` — profile schema

--- a/.claude/commands/mira-generate-component-template.md
+++ b/.claude/commands/mira-generate-component-template.md
@@ -1,0 +1,73 @@
+# /mira-generate-component-template
+
+Generate a reusable component-profile template for a given component type. Marks unknown values as `unknown` rather than inventing them.
+
+## Input
+
+- `component_type` (required) — e.g. `photoeye`, `vfd`, `contactor`, `proximity_sensor`, `inductive_sensor`, `flow_meter`, `pressure_transducer`, `servo_drive`, `pneumatic_cylinder`, `solenoid_valve`, `motor_starter`, `plc_io_card`, `relay`, `temperature_sensor`, `level_sensor`
+- `manufacturer` (optional)
+- `model` (optional)
+
+## Output schema (must match `component-profile-builder` skill)
+
+```yaml
+component_type:         # required, lowercase, underscore-separated
+manufacturer:           # unknown if not provided
+model:                  # unknown if not provided
+asset_context:          # list of UNS paths where this component appears (empty if generic template)
+normal_states:          # list of {name, indicator, description}
+failure_modes:          # list of {name, symptoms, common_causes, severity}
+fault_codes:            # list of {code, description, source}
+plc_tags:               # list of {tag_pattern, datatype, semantics_hint, confidence: proposed}
+mqtt_topics:            # list of {topic_pattern, payload_hint}
+wiring_references:      # list of {ref, description, source}
+manual_references:      # list of {doc_pattern, section_hint}
+maintenance_tasks:      # list of {task, interval, tools, parts}
+inspection_intervals:   # list of {check, interval}
+spare_parts:            # list of {part_number, description, vendor}
+known_fixes:            # list of {symptom, action, evidence}
+safety_notes:           # list of strings — LOTO, arc flash, lift, confined space if applicable
+related_components:     # list of {component_type, relation}
+verified_relationships: []
+proposed_relationships: # list of {target, relation, evidence, confidence}
+evidence:               # list of {type, source} — what the template was built from
+confidence:             # overall confidence: template (low until customer-validated)
+```
+
+## What this command does
+
+1. **Look up prior templates** for the same `component_type` in `docs/component-templates/` (or wherever templates live in the repo — discover dynamically). If one exists, surface it instead of regenerating.
+2. **Use evidence-based defaults** drawn from:
+   - Existing MIRA-ingested manuals (search `mira-crawler/ingest/` for matching docs)
+   - Generic public knowledge MARKED `confidence: proposed` (so it's not mistaken for verified)
+   - Common PLC tag naming conventions (Allen-Bradley, Banner, Siemens style)
+3. **Mark unknowns explicitly.** Don't fabricate fault codes or PLC tag patterns. If unsure, list `unknown` and let downstream ingestion populate them.
+4. **Include 1–3 known failure modes** from public component datasheets (with `source: public_datasheet` evidence).
+5. **Write the template** to `docs/component-templates/<component_type>/<manufacturer>_<model>.yaml` (or `<component_type>/generic.yaml` if mfr/model unknown).
+6. **Append the template path to an index file** at `docs/component-templates/INDEX.md`.
+
+## Special cases
+
+- `photoeye` / `proximity_sensor` / `occupancy_sensor` — include the B16.2 scenario hints (see `/mira-create-demo-plant`) as a usage example.
+- `vfd` — include MODBUS holding-register hints (e.g. `HR100=speed_rpm`) from root `CLAUDE.md` industrial system map. Mark `confidence: proposed`.
+- `contactor` / `relay` — include arc-flash safety note.
+
+## Constraints
+
+- **Never invent fault codes.** If you don't have a manual that lists them, the field is `unknown` with `confidence: proposed`.
+- **Never assume PLC tag meaning.** Provide tag *patterns* with `semantics_hint` + `confidence: proposed`.
+- **Generic templates start at low confidence.** Customer-specific instances graduate to higher confidence after technician/admin review.
+- **One template per file.** No multi-component bundles.
+
+## Verification
+
+- The generated YAML loads via `yaml.safe_load()`.
+- `confidence` field is present everywhere it's expected.
+- Index file lists the new template.
+- `grep -i "unknown" docs/component-templates/<file>` shows the unknown fields (sanity check that you didn't invent data).
+
+## Cross-references
+
+- `.claude/skills/component-profile-builder/SKILL.md` — full schema authority
+- `.claude/skills/manual-ingestion-extractor/SKILL.md` — how extraction populates templates
+- `docs/specs/mira-component-intelligence-architecture.md`

--- a/.claude/commands/mira-map-codebase.md
+++ b/.claude/commands/mira-map-codebase.md
@@ -1,0 +1,57 @@
+# /mira-map-codebase
+
+Produce or refresh a high-level map of the MIRA codebase, the critical product flow, and visible gaps.
+
+## What this command does
+
+1. **Walk top-level directories** under `/Users/charlienode/MIRA/`. Skip `node_modules/`, `.venv/`, `__pycache__/`, `dist/`, `build/`, `.claude/worktrees/`, `tools/lead-hunter/.hourly_state.json` and other generated artifacts.
+2. **Group modules** by role:
+   - **chat front-doors** — `mira-bots/{slack,telegram,email,gchat,reddit}/`
+   - **engine / brain** — `mira-bots/shared/`, `mira-sidecar/` (legacy), `mira-pipeline/`
+   - **MCP** — `mira-mcp/`
+   - **ingestion** — `mira-crawler/`, `mira-core/mira-ingest/`
+   - **UNS / live** — `mira-relay/`, `ignition/`, `plc/`
+   - **storage** — NeonDB migrations in `docs/migrations/`, `mira-hub/db/migrations/`
+   - **web / SaaS** — `mira-web/`, `mira-hub/`
+   - **CMMS** — `mira-cmms/`
+   - **ops / observability** — `mira-ops/`
+   - **fixtures / tools** — `tests/`, `tools/`, `mira-bots/scripts/`, `mira-core/data/`
+3. **Trace the MIRA-critical flow** (use `/mira-trace-technician-flow` for the deep version) and list each hop's file path.
+4. **Identify missing architecture pieces** against `.claude/CLAUDE.md`:
+   - Is the UNS resolver wired into the Slack handler?
+   - Is the confirmation-gate enforced before troubleshooting?
+   - Are KG writes going through `kg_writer.py`?
+   - Are ingest chunks tagged with `uns_path`?
+   - Are work-order creates draft-first?
+5. **Identify technical debt**:
+   - Anthropic mentions (should be 0 — removed PR #610)
+   - LangChain / n8n / TensorFlow imports (banned per PRD §4)
+   - Hardcoded IPs or secrets (vs Doppler)
+   - `:latest` / `:main` Docker tags (use pinned digests)
+   - `mira-sidecar/` legacy references that still block sunset
+6. **Identify tests** covering each module — count per-module test files, flag any module with `tests/` empty or absent.
+7. **Write or update `docs/codebase-map.md`** with:
+   - Section per module group with paths + 1-line role
+   - "Critical path" subsection
+   - "Gaps vs `.claude/CLAUDE.md`" subsection
+   - "Tech debt / cleanup" subsection
+   - "Tests by module" table
+   - Date stamp at top
+
+## Output requirements
+
+- Cite real file paths, never invented ones.
+- If a module is empty or deferred (`mira-connect/`, `mira-hud/`), call that out.
+- Keep total file under 400 lines — link out to deep specs, don't duplicate.
+- Do not run destructive operations. Read-only walk.
+
+## Sub-agents
+
+Use `Explore` agents for parallel `ls`/`grep` work when the repo is large; never read whole large files when a `head` will do.
+
+## Verification
+
+After writing `docs/codebase-map.md`:
+- `wc -l docs/codebase-map.md` — sanity-check size
+- `grep -c '^##' docs/codebase-map.md` — confirm section count
+- Cross-check the "Critical path" against the actual file paths via `ls`

--- a/.claude/commands/mira-run-hallucination-audit.md
+++ b/.claude/commands/mira-run-hallucination-audit.md
@@ -1,0 +1,81 @@
+# /mira-run-hallucination-audit
+
+Find places where MIRA might answer without grounding. Reports risk patterns, evidence-citation coverage, and concrete code-level fixes.
+
+## What this command does
+
+### 1. Grep for risk language
+
+Search prompts, agents, engine code, response-generation code for patterns that often produce ungrounded output:
+
+- Risk words in prompt templates: `assume`, `probably`, `likely`, `default`, `usually`, `typically`, `most`, `generally`, `in general`
+- Hardcoded fake plant context: any string literal like `"Site A"`, `"Line 1"`, `"Pump-001"` outside of `tests/` or fixtures
+- "Helpful" fallbacks: `else: return "I think..."` or similar that respond before grounding
+- Format strings that pass user message directly to LLM without UNS resolve first
+
+Run across:
+- `mira-bots/shared/` (engine, guardrails, intent classifier, prompt templates)
+- `mira-bots/{slack,telegram,email,gchat,reddit}/` (handlers)
+- `mira-pipeline/` (pipeline-side prompt assembly)
+- `mira-sidecar/` (legacy — flag for sunset, don't fix)
+- `mira-mcp/` (tool responses)
+- `mira-crawler/ingest/` (extraction prompts — check for invention)
+- `prompts/` if present
+- `agents/` if present
+
+### 2. Verify evidence citation in response paths
+
+For every code path that emits a final answer to a user, confirm it:
+- Cites at least one source: UNS path, doc reference, work-order ID, PLC tag, KG relationship, or technician confirmation
+- Goes through `mira-bots/shared/citation_compliance.py`
+- Increments `evidence_utilization` in `mira-bots/shared/benchmark_db.py`
+
+Flag any code path that emits a final answer WITHOUT those.
+
+### 3. Verify the UNS confirmation gate
+
+Use `/mira-trace-technician-flow` output (or run it inline). Flag any bypass path.
+
+### 4. Check ingestion for invention
+
+In `mira-crawler/ingest/`:
+- Any extraction prompt that says "if not found, generate a reasonable value" — that's invention. Replace with `unknown` + low confidence.
+- Any embedder that fills missing manufacturer/model from filename guesses without confidence marker.
+- Any KG write that defaults to `verified` instead of `proposed`.
+
+### 5. Score risk per finding
+
+- **P0** — code path can ship an ungrounded answer to a technician's Slack.
+- **P1** — code path can ship an ungrounded answer to a non-customer surface (eval, internal dashboard, draft work order).
+- **P2** — code path uses risk language in a prompt but downstream guardrails likely catch it.
+- **P3** — style / lint, not a functional risk.
+
+## Output
+
+Write or update `docs/hallucination-audit.md` with:
+
+1. Date stamp + branch + git short SHA.
+2. **Summary** — count by P0/P1/P2/P3.
+3. **Findings table** — file:line, category, risk, suggested fix (1 line).
+4. **UNS gate verification** — pass/fail + the file:line that enforces it (or doesn't).
+5. **Evidence citation coverage** — % of response paths that cite. Aim for 100% in production paths.
+6. **Suggested code changes** — concrete diffs as fenced blocks. Do NOT apply automatically. Surface to the user / PR reviewer for approval.
+
+## Constraints
+
+- **Read-only.** Surface findings, don't auto-edit.
+- **Avoid false-positives in tests/fixtures.** Suppress matches under `tests/`, `fixtures/`, `seed_*.py`, `marketing/`.
+- **Cite real file:line.** Use `grep -n`.
+
+## Verification
+
+- `grep -c '^P0\|^P1' docs/hallucination-audit.md` — finding counts in the report.
+- `grep -i "UNS gate" docs/hallucination-audit.md` — gate verification is present.
+
+## Cross-references
+
+- `.claude/CLAUDE.md` — grounded troubleshooting rules
+- `mira-bots/shared/citation_compliance.py`
+- `mira-bots/shared/engine.py` — groundedness scoring
+- `mira-bots/shared/benchmark_db.py` — evidence tracking
+- `.claude/skills/knowledge-graph-proposer/SKILL.md` — proposed vs verified discipline

--- a/.claude/commands/mira-trace-technician-flow.md
+++ b/.claude/commands/mira-trace-technician-flow.md
@@ -1,0 +1,56 @@
+# /mira-trace-technician-flow
+
+Trace the full technician request flow from Slack event → MIRA's final response. Identify every code hop, confirm the UNS confirmation gate sits before troubleshooting, and flag any path where troubleshooting can start without confirmed context.
+
+## What this command does
+
+1. **Start in `mira-bots/slack/bot.py`** — find the Slack Bolt event handler that receives a message.
+2. **Trace through `chat_adapter.py`** → the platform-neutral message envelope.
+3. **Enter the engine layer** — `mira-bots/shared/engine.py` (Supervisor / GSD engine). Note FSM state transitions.
+4. **Locate asset-context parsing** — where the message is parsed for asset/line/area/machine/component/symptom/fault hints. Likely calls `uns_resolver` per `docs/specs/uns-message-resolver-spec.md`.
+5. **Locate the UNS lookup** — calls into `mira-crawler/ingest/uns.py`, `kg_entities`, or the future `mira-uns-mcp`.
+6. **Find the confirmation-gate** — the code path that:
+   - Builds the confirmation message (site/area/line/machine/asset/component/fault + evidence + confidence + confirmation question)
+   - Sends it to Slack
+   - Waits for technician confirm/correct
+   - Only then transitions FSM to a troubleshooting state
+7. **Find the troubleshooting entry** — the code that actually produces troubleshooting advice (grounded answer generation).
+8. **Walk the response path back to Slack** — final formatting, citation rendering, send.
+
+## What to flag
+
+- **Any path that reaches troubleshooting without passing through the confirmation gate.** This is a bug, regardless of guardrails downstream.
+- **Any path that emits an answer without `evidence_packet` or `evidence_utilization` populated** — see `mira-bots/shared/benchmark_db.py` + `citation_compliance.py`.
+- **Any place where asset context is inferred from message text alone, without calling the UNS resolver.**
+- **Any code that hardcodes a fake site/line/asset** (Stardust Racers strings outside of demo fixtures).
+- **Any place where the FSM can short-circuit the gate** (default routes, error-path bypasses, prompt-injection shortcuts).
+- **Any place where a CMMS write (work-order create) happens without a draft step.**
+
+## Output
+
+Write or update `docs/technician-flow-trace.md` with:
+
+1. **Top-level diagram** (mermaid sequence diagram) — Slack → adapter → engine → uns_resolver → confirmation → technician → troubleshoot → response.
+2. **Step-by-step table** — each hop with file path + function name + 1-line description.
+3. **Confirmation gate verification** — yes/no + the exact file:line that enforces it.
+4. **Bypass risks** — every flagged path, with file:line, the type of bypass, and a suggested fix.
+5. **Suggested fixes** — concrete diff outline per risk (don't apply diffs, just propose).
+6. Date stamp at top.
+
+## Constraints
+
+- **Read-only.** This command does not modify code.
+- **Cite real file:line.** Use `grep -n`. Never invent line numbers.
+- **Don't simulate the LLM** to "test" the flow — just trace the code.
+
+## Verification
+
+- `grep -n "engine.py" docs/technician-flow-trace.md` — confirm the engine is in the trace.
+- `grep -n "uns_resolver\|resolve_uns_path" docs/technician-flow-trace.md` — confirm UNS hop is identified.
+- `grep -n "confirmation" docs/technician-flow-trace.md` — confirm gate is in the trace.
+
+## Cross-references
+
+- `.claude/CLAUDE.md` — UNS gate definition
+- `.claude/skills/uns-location-gate-designer/SKILL.md` — required flow
+- `docs/specs/uns-message-resolver-spec.md` — resolver authority

--- a/.claude/mcp/README.md
+++ b/.claude/mcp/README.md
@@ -1,0 +1,42 @@
+# MIRA MCP Plan
+
+This directory specifies which MCP servers Claude Code should reach for when working on MIRA, and proposes 5 custom MIRA-specific MCP servers.
+
+> Custom MCPs MUST start **read-only**. Write tools — especially anything touching live plant data, MQTT topics, or work-order creation — are gated behind explicit admin/technician approval. See each spec.
+
+## Already useful (existing, generic MCPs)
+
+| Server | Why it helps MIRA |
+|---|---|
+| **GitHub** | PR review, issue triage, commit history, branch ops. Use `gh` CLI when MCP is unavailable. |
+| **Postgres** | Direct NeonDB inspection — `kg_entities`, `kg_relationships`, `cmms_equipment`, migrations. Read-only by default. |
+| **Filesystem** | Cross-module reads — manuals in `mira-crawler/`, tag exports in `ignition/`, fixtures in `mira-core/data/`. |
+| **Slack** | Read/post in technician channels — useful for replaying a real Slack thread into the engine for debugging. Restricted to debug channels. |
+| **Google Drive** | Customer-uploaded manuals land in Drive before ingestion. Skim manifests before `mira-crawler` picks them up. |
+| **Playwright** | Browser automation for `web-review` skill, screenshot capture (replaces ad-hoc Chrome headless), CMMS UI testing. Configured in `.mcp.json` as of 2026-05-14. |
+
+## Proposed custom MIRA MCPs
+
+Five servers, each scoped to one product surface. Read-only first.
+
+| Spec | Surface | Read-only tools | Write tools (gated) |
+|---|---|---|---|
+| `mira-uns-mcp-spec.md` | Unified Namespace lookup | `search_namespace`, `get_asset`, `list_children`, `get_related_components`, `get_live_tags`, `resolve_location_hint`, `get_candidate_contexts` | none (read-only) |
+| `mira-component-graph-mcp-spec.md` | Component knowledge graph | `find_component`, `search_components`, `get_relationships` | `propose_relationship`, `mark_relationship_verified`, `mark_relationship_rejected` (admin-gated) |
+| `mira-doc-ingestion-mcp-spec.md` | Manuals / docs | `list_documents`, `search_documents`, `extract_manual_sections`, `get_document_chunks`, `extract_maintenance_schedule`, `extract_troubleshooting_table` | `link_document_to_component` (admin-gated) |
+| `mira-work-order-mcp-spec.md` | Work orders / CMMS | `search_work_orders`, `get_failure_history`, `get_common_fixes`, `get_repeat_failures` | `create_draft_work_order` (draft only — explicit approval to commit) |
+| `mira-plc-map-mcp-spec.md` | PLC tag map | `list_plcs`, `search_tags`, `get_tag`, `find_tags_by_component`, `get_logic_references` | `propose_tag_component_mapping` (proposed status, requires confirmation) |
+
+## Cross-cutting safety rules
+
+1. **No live-write to MQTT, PLCs, or SCADA from any MCP server.** That's a different system and out of MIRA's scope.
+2. **No auto-verify.** Every write tool that proposes a relationship/mapping persists with status `proposed`. Promotion to `verified` is a separate admin action.
+3. **Evidence + confidence in every return.** Read tools return `{result, evidence: [...], confidence: low|medium|high}`. Consumers can decide whether the response is good enough.
+4. **Tenant isolation.** Every tool takes (or infers from auth) a `tenant_id`; cross-tenant reads are rejected.
+5. **PII / sanitization.** Tag values, work-order notes, technician messages may contain PII or IPs. Pass through `mira-bots/shared/inference/router.py:sanitize_context` before logging.
+
+## Implementation notes
+
+- The existing `mira-mcp/server.py` (FastMCP 3.2) already implements a subset — `cmms_create_work_order`, `cmms_get_asset`, equipment diagnostics. The custom MCPs above are organized by **product surface**, not 1:1 with code modules. Consolidate into `mira-mcp/` rather than spawning new repos unless there's a strong reason.
+- Start every new MCP server as a sub-module under `mira-mcp/` with its own tool registration block. Share auth + tenant resolution.
+- Each MCP spec in this directory defines: tool name, signature, semantics, evidence/confidence shape, safety notes.

--- a/.claude/mcp/mira-component-graph-mcp-spec.md
+++ b/.claude/mcp/mira-component-graph-mcp-spec.md
@@ -1,0 +1,76 @@
+# mira-component-graph-mcp — Spec
+
+MCP server exposing the component knowledge graph. Read tools are unrestricted; write tools require admin context and persist as `proposed`.
+
+**Status:** proposed.
+**Underlying data:** NeonDB tables `kg_entities`, `kg_relationships` (`docs/migrations/004_kg_entities.sql`, `005_kg_relationships.sql`).
+**Auth:** tenant scope required; admin role required for the three `mark_*` / `propose_*` write tools.
+
+## Relationship statuses
+
+```
+proposed     — created by ingestion, LLM proposal, or technician hint; not yet trusted
+needs_review — flagged by quality check; awaits human eyes
+verified     — admin/technician confirmed; safe to ground answers on
+rejected     — admin/technician rejected; do not propose again with same evidence
+```
+
+## Tools
+
+### `find_component(component_id: str) -> Component`
+One component by id. 404 if missing.
+
+```jsonc
+{
+  "id": "...",
+  "name": "Occupancy Sensor B16.2",
+  "manufacturer": "Banner",
+  "model": "Q4X",
+  "uns_path": "...",
+  "evidence": [...],
+  "confidence": "verified|proposed|..."
+}
+```
+
+### `search_components(query: str, tenant_id?: str, limit?: int = 10) -> list[Component]`
+Free-text component search; backed by `kg_entities` name + tag fields.
+
+### `get_relationships(component_id: str, status?: str) -> list[Relationship]`
+Edges touching this component. Optionally filter by status.
+
+```jsonc
+{
+  "id": "rel_...",
+  "source": "component:pe_b16_2",
+  "target": "fault:1.SOC_B16_2.OCCUPIED_TOO_LONG",
+  "relation": "HasFaultMode",
+  "status": "verified",
+  "evidence": [{"type": "manual", "doc_id": "...", "page": 42}],
+  "confidence": "high",
+  "created_by": "...",
+  "verified_by": "..."
+}
+```
+
+### `propose_relationship(source: str, target: str, relation: str, evidence: list, tenant_id?: str) -> Relationship`
+Write — persists with status `proposed`. Tenant + admin gated.
+
+### `mark_relationship_verified(id: str, verified_by: str) -> Relationship`
+Admin only. Promotes `proposed` → `verified`.
+
+### `mark_relationship_rejected(id: str, rejected_by: str, reason: str) -> Relationship`
+Admin only. Sets status `rejected`.
+
+## Safety
+
+- **No silent assertions.** Write tools never create a relationship at `verified` directly.
+- **Evidence required on every proposal.** Empty `evidence` → reject the call.
+- **Confidence required.**
+- **Tenant isolation.** Cross-tenant lookups return 403.
+- **Audit trail.** Every status change appends to `kg_relationship_audit` (or equivalent — match existing schema).
+
+## Cross-references
+
+- `.claude/skills/knowledge-graph-proposer/SKILL.md`
+- `.claude/skills/component-profile-builder/SKILL.md`
+- `docs/specs/uns-kg-unification-spec.md`

--- a/.claude/mcp/mira-doc-ingestion-mcp-spec.md
+++ b/.claude/mcp/mira-doc-ingestion-mcp-spec.md
@@ -1,0 +1,91 @@
+# mira-doc-ingestion-mcp — Spec
+
+MCP server exposing manual / document ingestion. Mostly read-only — `link_document_to_component` is the one write tool and is admin-gated.
+
+**Status:** proposed.
+**Underlying code:** `mira-crawler/ingest/` (`chunker.py`, `converter.py`, `embedder.py`, `kg_writer.py`, `dedup.py`).
+**Auth:** tenant scope required.
+
+## Tools
+
+### `list_documents(asset_id?: str, tenant_id?: str, kind?: str) -> list[Document]`
+List manuals / drawings / specs for an asset (or all). `kind` ∈ `manual|drawing|spec|datasheet|misc`.
+
+```jsonc
+{
+  "id": "doc_...",
+  "kind": "manual",
+  "name": "Banner Q4X Datasheet",
+  "asset_links": [...],
+  "uns_paths": [...],
+  "pages": 38,
+  "source": "google_drive|upload|crawl",
+  "ingested_at": "...",
+  "confidence": "high"
+}
+```
+
+### `search_documents(query: str, tenant_id?: str, limit?: int = 10) -> list[Hit]`
+Hybrid vector + lexical search across ingested chunks.
+
+```jsonc
+{
+  "doc_id": "...",
+  "page": 12,
+  "chunk_id": "...",
+  "snippet": "...",
+  "score": 0.83,
+  "evidence_type": "manual_section"
+}
+```
+
+### `extract_manual_sections(document_id: str) -> list[Section]`
+Returns the structural outline (chapter → section → subsection) per `mira-crawler/ingest/chunker.py`. Useful before deciding what to extract.
+
+### `get_document_chunks(document_id: str, topic?: str) -> list[Chunk]`
+Topic filter (`troubleshooting|pm|wiring|safety|...`). Returns chunks tagged for that topic.
+
+### `extract_maintenance_schedule(document_id: str) -> list[Task]`
+Extracts the PM table (interval, task, target, tools). Calls `manual-ingestion-extractor` logic.
+
+```jsonc
+{
+  "interval": "every 250h",
+  "task": "Inspect chain tension",
+  "target_component_hint": "Conveyor chain B16",
+  "tools": ["torque wrench"],
+  "source": {"doc_id": "...", "page": 17},
+  "confidence": "high|medium|low"
+}
+```
+
+### `extract_troubleshooting_table(document_id: str) -> list[Row]`
+Symptom → cause → action rows.
+
+```jsonc
+{
+  "symptom": "Sensor flickers",
+  "possible_causes": ["misalignment", "dirty lens"],
+  "actions": ["realign", "clean with isopropyl"],
+  "source": {"doc_id": "...", "page": 22},
+  "confidence": "medium"
+}
+```
+
+### `link_document_to_component(document_id: str, component_id: str, evidence: list, tenant_id?: str) -> Link`
+Write — admin-gated. Persists with status `proposed` if not admin; auto `verified` if admin context confirmed.
+
+## Safety
+
+- **Preserve source.** Every extraction includes `{doc_id, page}` (or section ref).
+- **No invention.** Missing fields → `unknown`, not best-guess.
+- **Flag ambiguity.** Low-confidence rows tagged with `confidence: low` and a `notes` field.
+- **De-dup on insert.** Use `mira-crawler/ingest/dedup.py`.
+- **UNS tagging.** Every chunk carries a `uns_path` per `.claude/rules/uns-compliance.md`.
+
+## Cross-references
+
+- `.claude/skills/manual-ingestion-extractor/SKILL.md`
+- `.claude/skills/component-profile-builder/SKILL.md`
+- `mira-crawler/ingest/uns.py` — path builders
+- `docs/specs/uns-kg-unification-spec.md`

--- a/.claude/mcp/mira-plc-map-mcp-spec.md
+++ b/.claude/mcp/mira-plc-map-mcp-spec.md
@@ -1,0 +1,91 @@
+# mira-plc-map-mcp — Spec
+
+MCP server exposing PLC tag inventory + proposed component mappings. Tag *meaning* is never assumed from the name alone.
+
+**Status:** proposed.
+**Underlying data:** PLC programs in `plc/ccw/` (Structured Text, MicroLogix configs), Ignition tag exports in `ignition/`, optional CSV tag exports from customer onboarding.
+**Auth:** tenant scope required; admin role required for `propose_tag_component_mapping` commit-to-verified path.
+
+## Tools
+
+### `list_plcs(tenant_id?: str) -> list[PLC]`
+PLCs known for a tenant.
+
+```jsonc
+{
+  "id": "plc_micro820_1",
+  "name": "Conveyor Lab Micro820",
+  "vendor": "Rockwell",
+  "model": "Micro820",
+  "address": "192.168.1.100:502",
+  "uns_path": "enterprise.stardust_racers.site.garage_factory.area.conveyor_lab.line.line5.plc.micro820_1",
+  "tag_count": 142,
+  "source": "ccw|ignition_export|csv_upload",
+  "confidence": "verified"
+}
+```
+
+### `search_tags(query: str, plc_id?: str, limit?: int = 20) -> list[Tag]`
+Free-text tag search across all PLCs (or scoped).
+
+### `get_tag(tag_id: str) -> Tag`
+
+```jsonc
+{
+  "id": "tag_conveyor_b16_run",
+  "name": "Conveyor_B16_Run",
+  "plc_id": "...",
+  "data_type": "BOOL",
+  "address": "%I0/12",
+  "scope": "local|global",
+  "format": "allen_bradley|local_io|structured_text|csv_export",
+  "comments": ["// Run command for conveyor B16"],
+  "proposed_component_id": null,
+  "verified_component_id": "...",
+  "evidence": [{"type": "ladder_comment", "ref": "MainProgram.Conveyor_B16.rung12"}],
+  "confidence": "verified|proposed|none"
+}
+```
+
+### `find_tags_by_component(component_id: str) -> list[Tag]`
+All tags currently mapped (verified OR proposed) to a component.
+
+### `propose_tag_component_mapping(tag_id: str, component_id: str, evidence: list, tenant_id?: str) -> Mapping`
+Write. Persists with status `proposed` unless admin context promotes to `verified`. Empty `evidence` → reject.
+
+### `get_logic_references(tag_id: str) -> list[LogicRef]`
+Where this tag is read/written in the ST/ladder/FBD program. Useful for inferring meaning safely.
+
+```jsonc
+{
+  "tag_id": "...",
+  "program": "MainProgram",
+  "block": "Conveyor_B16_FB",
+  "rung_or_line": 12,
+  "operation": "OUT",
+  "context_snippet": "Conveyor_B16_Run := Conveyor_B16_Start AND NOT Conveyor_B16_Fault;"
+}
+```
+
+## Tag formats supported
+
+- Allen-Bradley structured tags (`AOI_Conveyor.Status.Run`)
+- Local I/O (`%I0/12`, `%Q0/3`)
+- Structured Text variables
+- Ladder/FBD function-block references
+- Generic PLC CSV tag exports (vendor-agnostic)
+
+## Safety
+
+- **Never assume physical meaning from a tag name.** A tag named `Pump_1_Run` may be a flag, a counter, an HMI display var, or unused. Always cite a drawing, PLC comment, naming convention, manual ref, or technician confirmation before mapping.
+- **Distinguish verified vs proposed.** Bot-derived mappings start as `proposed`.
+- **Confidence required** on every mapping.
+- **Read-only on live PLC.** This MCP does NOT write to a PLC under any circumstance.
+- **Audit trail.** Mapping status changes log to `plc_tag_mapping_audit`.
+
+## Cross-references
+
+- `.claude/skills/plc-tag-mapper/SKILL.md`
+- `plc/ccw/` — Micro820 ST programs and tag config
+- `ignition/` — Ignition tag exports
+- `docs/specs/sparkplug-uns-bridge-spec.md` — how Sparkplug tags map to UNS

--- a/.claude/mcp/mira-uns-mcp-spec.md
+++ b/.claude/mcp/mira-uns-mcp-spec.md
@@ -1,0 +1,80 @@
+# mira-uns-mcp — Spec
+
+MCP server exposing the Unified Namespace for read-only lookup. Powers the UNS location-confirmation gate.
+
+**Status:** proposed. Read-only.
+**Underlying data:** `kg_entities` (NeonDB), `mira-crawler/ingest/uns.py` builders, optionally MQTT/Ignition tag streams for `get_live_tags`.
+**Auth:** tenant scope inferred from caller; cross-tenant denied.
+
+## Tools
+
+### `search_namespace(query: str, tenant_id?: str, limit?: int = 10) -> list[Match]`
+Free-text → UNS path candidates. Wraps `uns_resolver.resolve_uns_path()`.
+
+```jsonc
+// Match
+{
+  "uns_path": "enterprise.stardust_racers.site.garage_factory.area.conveyor_lab.line.line5.work_cell.conveyor_b16.pe_b16_2",
+  "kind": "asset|component|line|area|site",
+  "name": "Occupancy Sensor B16.2",
+  "evidence": [{"type": "tag_hint", "value": "B16.2"}, {"type": "history", "value": "14 prior tickets"}],
+  "confidence": "high"
+}
+```
+
+### `get_asset(path: str) -> Asset`
+Resolve a single UNS path. Returns metadata + parents + child slugs. 404 if not found.
+
+```jsonc
+{
+  "uns_path": "...",
+  "kind": "asset",
+  "name": "...",
+  "manufacturer": "...",
+  "model": "...",
+  "parent_path": "...",
+  "child_paths": [...],
+  "evidence": [...],
+  "confidence": "verified"
+}
+```
+
+### `list_children(path: str) -> list[Asset]`
+ISA-95 children one level down.
+
+### `get_related_components(path: str) -> list[Component]`
+Components attached to an asset/cell.
+
+### `get_live_tags(path: str) -> list[TagSample]`
+Most recent values for tags tied to an asset. Returns `null` when no tag stream is configured for the tenant — **don't fabricate**.
+
+```jsonc
+{
+  "tag": "Conveyor_B16_Run",
+  "value": 0,
+  "ts": "2026-05-13T17:30:01Z",
+  "source": "ignition|mqtt|sqlite_relay",
+  "confidence": "live"
+}
+```
+
+### `resolve_location_hint(message: str, tenant_id?: str) -> list[Candidate]`
+Extracts asset/line/component/fault hints from a free-text technician message. Returns ranked candidates. Cites `docs/specs/uns-message-resolver-spec.md`.
+
+### `get_candidate_contexts(message: str, tenant_id?: str, k: int = 3) -> list[Context]`
+Higher-level: returns up to k full `(site, area, line, asset, component, fault, evidence, confidence)` tuples ready for the Slack confirmation message.
+
+## Safety
+
+- **Read-only.** No mutators.
+- **No troubleshooting answers.** This MCP returns context only — engine layer decides whether to enter troubleshooting after technician confirmation.
+- **No live-write to MQTT.** `get_live_tags` is read-side only.
+- **Evidence required.** Every return includes `evidence: list[{type, value}]`.
+- **Confidence required.** Every return includes `confidence: low|medium|high|verified|live`.
+
+## Cross-references
+
+- `docs/specs/uns-kg-unification-spec.md` — ISA-95 hierarchy authority
+- `docs/specs/uns-message-resolver-spec.md` — resolver logic
+- `.claude/rules/uns-compliance.md` — data-shape rules
+- `.claude/skills/uns-location-gate-designer/SKILL.md` — flow that consumes this MCP

--- a/.claude/mcp/mira-work-order-mcp-spec.md
+++ b/.claude/mcp/mira-work-order-mcp-spec.md
@@ -1,0 +1,84 @@
+# mira-work-order-mcp — Spec
+
+MCP server exposing CMMS work-order history and a single **draft-only** write tool.
+
+**Status:** proposed. Some tools already exist in `mira-mcp/server.py` (cmms_create_work_order, cmms_list_work_orders); this spec defines the proper boundary.
+**Underlying data:** Atlas CMMS (`mira-cmms/`, REST API at `atlas-api:8080`), and `cmms_*` tables in NeonDB.
+**Auth:** tenant scope required; explicit approval token required to **commit** a draft work order.
+
+## Tools
+
+### `search_work_orders(asset_id: str, query?: str, status?: str, limit?: int = 20) -> list[WorkOrder]`
+Asset-scoped search. Status ∈ `open|in_progress|done|cancelled`.
+
+```jsonc
+{
+  "id": "wo_...",
+  "asset_id": "...",
+  "uns_path": "...",
+  "status": "done",
+  "title": "Reset Conveyor B16",
+  "description": "...",
+  "fault_code": "1.SOC_B16_2.OCCUPIED_TOO_LONG",
+  "parts_used": [],
+  "duration_minutes": 4,
+  "technician": "...",
+  "created_at": "...",
+  "closed_at": "..."
+}
+```
+
+### `get_failure_history(asset_id: str, since?: str) -> FailureSummary`
+Aggregates work-order history into a maintenance picture.
+
+```jsonc
+{
+  "asset_id": "...",
+  "uns_path": "...",
+  "window": "6 months",
+  "total_failures": 14,
+  "top_failure_modes": [{"mode": "OCCUPIED_TOO_LONG", "count": 14}],
+  "mtbf_hours": 312,
+  "common_fixes": [{"action": "Reset at Panel B16", "count": 11}],
+  "parts_replaced": [],
+  "reset_only_events": 11,
+  "evidence": [{"type": "work_order_history", "count": 14}],
+  "confidence": "high"
+}
+```
+
+### `get_common_fixes(asset_id: str) -> list[Fix]`
+Top resolutions by frequency, with confidence.
+
+### `get_repeat_failures(asset_id: str, min_count: int = 3) -> list[RepeatPattern]`
+Components/faults repeating ≥ N times. Useful for "this asset has a chronic problem" surfacing.
+
+### `create_draft_work_order(asset_id: str, issue: str, recommended_action: str, evidence: list, tenant_id?: str) -> Draft`
+Write — **creates a DRAFT only**, never a live work order. Status = `draft`, requires a separate `commit_draft_work_order(draft_id, approver)` (defined elsewhere or via Atlas API) to become a real work order. Preserves source work-order references in `evidence`.
+
+```jsonc
+{
+  "draft_id": "draft_...",
+  "asset_id": "...",
+  "title": "...",
+  "description": "...",
+  "evidence": [{"type": "wo_history", "wo_ids": [...]}],
+  "status": "draft",
+  "created_by": "mira-bot",
+  "requires_approval_by": "technician|admin"
+}
+```
+
+## Safety
+
+- **Draft only by default.** No tool here creates a live work order without an explicit, separate commit step.
+- **Preserve source.** `evidence` always carries the prior work-order IDs that justify the draft.
+- **No retroactive edits.** Closed work orders are immutable; the tool cannot rewrite them.
+- **Tenant isolation.**
+- **PII sanitization.** Technician notes may contain names/emails — sanitize before logging.
+
+## Cross-references
+
+- `.claude/skills/work-order-history-miner/SKILL.md`
+- `mira-mcp/server.py` — existing CMMS tools
+- `mira-cmms/CLAUDE.md` — Atlas CMMS integration

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -106,14 +106,12 @@
     "code-simplifier@claude-plugins-official": true,
     "context7@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true,
-    "codex@openai-codex": true,
     "skill-creator@claude-plugins-official": true,
-    "stripe@claude-plugins-official": true,
+    "stripe@claude-plugins-official": false,
     "typescript-lsp@claude-plugins-official": true,
-    "compound-engineering@compound-engineering-plugin": true,
     "pyright-lsp@claude-plugins-official": true,
-    "context-mode@context-mode": true,
-    "ralph-loop@claude-plugins-official": true,
+    "context-mode@context-mode": false,
+    "ralph-loop@claude-plugins-official": false,
     "linear@claude-plugins-official": true
   }
 }

--- a/.claude/skills/component-profile-builder/SKILL.md
+++ b/.claude/skills/component-profile-builder/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: component-profile-builder
+description: Use when turning manuals, BOMs, PLC tags, wiring diagrams, work orders, and technician notes into reusable component profiles. Triggers on edits to `mira-crawler/ingest/`, manual ingestion flows, or when a customer onboarding spec arrives.
+---
+
+# Component Profile Builder
+
+A **component profile** is the reusable unit of maintenance memory. It captures everything we know about a component — generic at the model level, specific at the instance level — so future troubleshooting can ground in it.
+
+Profiles are the SaaS asset. Build them with discipline.
+
+## Target schema (YAML; matches `/mira-generate-component-template`)
+
+```yaml
+component_type:           # required, lowercase, underscore-separated, e.g. occupancy_sensor
+manufacturer:             # e.g. Banner — "unknown" if not extracted
+model:                    # e.g. Q4X — "unknown" if not extracted
+asset_context:            # list of UNS paths where this component instance appears
+  - enterprise.stardust_racers.site.garage_factory.area.conveyor_lab.line.line5.work_cell.conveyor_b16.pe_b16_2
+
+normal_states:
+  - name: clear
+    indicator: "DO output LOW"
+    description: "No object in beam"
+  - name: occupied
+    indicator: "DO output HIGH"
+    description: "Object detected in beam"
+
+failure_modes:
+  - name: occupied_too_long
+    symptoms: ["1.SOC B16.2 OCCUPIED TOO LONG fault on HMI"]
+    common_causes: ["jammed product", "misalignment", "dirty lens"]
+    severity: line_stop
+
+fault_codes:
+  - code: "1.SOC_B16_2.OCCUPIED_TOO_LONG"
+    description: "Beam occupied beyond threshold"
+    source: {doc_id: "...", page: 14}
+
+plc_tags:
+  - tag_pattern: "*.SOC_B*_*"
+    datatype: BOOL
+    semantics_hint: "occupied flag"
+    confidence: proposed
+
+mqtt_topics:
+  - topic_pattern: "spBv1.0/{group}/DDATA/{node}/conveyor_b16/pe_b16_2"
+    payload_hint: "boolean occupied flag"
+
+wiring_references:
+  - ref: "Panel B16, terminal X3-7"
+    description: "Sensor DO wired to PLC %I0/12"
+    source: {drawing_id: "...", sheet: 4}
+
+manual_references:
+  - doc_pattern: "Banner Q4X manual"
+    section_hint: "Troubleshooting / Output"
+
+maintenance_tasks:
+  - task: "Clean lens"
+    interval: "monthly"
+    tools: ["isopropyl wipe"]
+    parts: []
+
+inspection_intervals:
+  - check: "Alignment LED steady green"
+    interval: "weekly"
+
+spare_parts:
+  - part_number: "Q4XTBLD-Q8"
+    description: "Banner Q4X 4-pin replacement"
+    vendor: "Banner"
+
+known_fixes:
+  - symptom: "OCCUPIED_TOO_LONG repeats"
+    action: "Reset at Panel B16, then realign sensor"
+    evidence: {work_orders: ["wo_..."], confirmed_by: "..."}
+
+safety_notes:
+  - "LOTO Panel B16 disconnect before mechanical adjustment"
+
+related_components:
+  - component_type: conveyor_motor
+    relation: shares_line
+  - component_type: vfd
+    relation: drives_motor
+
+verified_relationships:
+  - target: "fault:1.SOC_B16_2.OCCUPIED_TOO_LONG"
+    relation: HasFaultMode
+    evidence: [{type: manual, doc_id: "...", page: 14}, {type: wo_history, count: 14}]
+    confidence: high
+    verified_by: "..."
+
+proposed_relationships:
+  - target: "component:conveyor_motor_b16"
+    relation: SharesLine
+    evidence: [{type: ladder_comment, ref: "MainProgram.Conveyor_B16.rung12"}]
+    confidence: medium
+
+evidence:
+  - {type: manual,      doc_id: "...", section: "Troubleshooting"}
+  - {type: wo_history,  asset_id: "...", count: 14}
+  - {type: technician,  user_id: "...", message_id: "..."}
+
+confidence: high     # overall — template (low) | proposed (medium) | verified (high)
+```
+
+## Hard rules
+
+1. **Evidence-based.** Every populated field carries a `source` (or `evidence`) reference. No naked facts.
+2. **Unverified relationships go in `proposed_relationships`, not `verified_relationships`.** Promotion requires technician/admin sign-off.
+3. **Mark unknowns explicitly.** `unknown` (string) for missing fields. Don't best-guess.
+4. **Per-instance vs per-model.** A profile attached to an instance (a specific PE-B16-2) lives at `asset_context: [<uns_path>]`. A reusable model template has `asset_context: []`. Don't conflate.
+5. **No invention from filename.** A manual named `Banner_Q4X_Manual.pdf` doesn't justify writing `manufacturer: Banner, model: Q4X` unless the manual content confirms it.
+6. **UNS-tagged.** Profile entities live in `kg_entities` with `uns_path` populated (see `.claude/rules/uns-compliance.md`).
+
+## Build flow
+
+1. **Identify component_type** — from message context, manual title, or PLC tag prefix.
+2. **Search existing templates** — `docs/component-templates/<component_type>/`. Reuse where possible.
+3. **Extract from manuals** — call `manual-ingestion-extractor` skill to pull fault codes, PM schedule, troubleshooting table.
+4. **Pull from PLC tag map** — call `plc-tag-mapper` skill to find tags pointing at this component.
+5. **Mine work-order history** — call `work-order-history-miner` skill for known fixes + failure patterns.
+6. **Draft profile** — fill schema above. Unknowns stay `unknown`.
+7. **Score confidence** — overall is the **min** of populated-field confidences. A single low-confidence field caps the whole profile.
+8. **Propose relationships** — via `knowledge-graph-proposer` skill / `mira-component-graph-mcp`. Never auto-verify.
+
+## SaaS value
+
+Component profiles are the **moat**:
+- A new customer onboarding with PowerFlex 525 + Banner Q4X + Festo MS6 should reuse existing profiles, not start from zero.
+- Profiles graduate from `template` → `proposed` → `verified` as field evidence accumulates.
+- The graveyard of verified profiles is what makes MIRA hard to compete with after 12 months of customers.
+
+## Cross-references
+
+- `.claude/skills/manual-ingestion-extractor/SKILL.md`
+- `.claude/skills/plc-tag-mapper/SKILL.md`
+- `.claude/skills/work-order-history-miner/SKILL.md`
+- `.claude/skills/knowledge-graph-proposer/SKILL.md`
+- `.claude/mcp/mira-component-graph-mcp-spec.md`
+- `.claude/commands/mira-generate-component-template.md`
+- `docs/specs/mira-component-intelligence-architecture.md`

--- a/.claude/skills/knowledge-graph-proposer/SKILL.md
+++ b/.claude/skills/knowledge-graph-proposer/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: knowledge-graph-proposer
+description: Use when MIRA needs to propose, verify, or reject relationships in the knowledge graph. Triggers on edits to `mira-crawler/ingest/kg_writer.py`, MCP tools that touch `kg_relationships`, or whenever a feature would create new edges in the graph.
+---
+
+# Knowledge-Graph Proposer
+
+Help MIRA build a knowledge graph safely. The graph is in `kg_entities` + `kg_relationships` (NeonDB; migrations 004 + 005 in `docs/migrations/`).
+
+The graph is high-value because answers cite it as evidence. Poisoning the graph poisons every downstream answer. **Defend it.**
+
+## Relationship types
+
+| Relation | Example |
+|---|---|
+| `HasComponent` | asset → component (Conveyor B16 → PE-B16-2) |
+| `DescribesComponent` | tag → component (1.SOC_B16_2 → PE-B16-2) |
+| `HasFaultMode` | component → fault (PE-B16-2 → OCCUPIED_TOO_LONG) |
+| `DocumentsComponent` | manual → component (Banner Q4X manual → PE-B16-2) |
+| `ResolvesFault` | work-order → fault (WO-1234 → OCCUPIED_TOO_LONG) |
+| `RequiresPart` | component/fault → part (PE-B16-2 → Q4XTBLD-Q8) |
+| `WiresTo` | component → circuit (PE-B16-2 → Drawing-7-Sheet-4-Term-X3-7) |
+
+Other relations (`SharesLine`, `DrivesMotor`, `FeedsAsset`) are allowed but must justify their semantics with a one-line definition stored alongside.
+
+## Statuses
+
+```
+proposed     — created by ingestion, LLM proposal, or technician hint; not yet trusted
+needs_review — flagged by quality checks; awaits human eyes
+verified     — admin/technician confirmed; safe to cite as evidence in answers
+rejected     — admin/technician rejected; do not re-propose with same evidence
+```
+
+## Hard rules
+
+1. **Never silently assert new relationships.** Every write call persists a row with explicit `status`.
+2. **Default status is `proposed`** unless admin context promotes it directly to `verified`.
+3. **Store evidence with every relationship.** Empty evidence → reject the proposal at the API boundary.
+4. **Include confidence** (`low|medium|high` or numeric per existing column convention).
+5. **Tenant isolation.** Relationships are per-tenant; don't cross-pollinate.
+6. **Audit trail.** Every status change appends to `kg_relationship_audit` (or equivalent).
+7. **Don't auto-promote on weak signals.** A thumbs-up emoji is not confirmation. Require a button click or explicit text.
+8. **Idempotent.** Re-proposing the same (source, target, relation) with the same evidence should update, not duplicate.
+
+## Evidence types (use these strings)
+
+- `manual` — `{type: manual, doc_id, page}`
+- `wiring_drawing` — `{type: wiring_drawing, drawing_id, sheet}`
+- `plc_comment` / `ladder_comment` / `st_reference` — `{type: ..., ref}`
+- `naming_convention` — `{type: naming_convention, ref}`
+- `wo_history` — `{type: wo_history, wo_ids: [...], count}`
+- `technician_confirm` — `{type: technician_confirm, user_id, session_id, message_id}`
+- `admin_approval` — `{type: admin_approval, user_id, ts}`
+- `public_datasheet` — `{type: public_datasheet, source}` (lowest trust — generic only)
+
+## Anti-patterns (these poison the graph)
+
+- Writing `verified` relationships directly from ingestion (extraction is `proposed` by definition)
+- Inferring `HasComponent` from filename without manual evidence
+- Promoting on the first weak hint
+- Creating new relation types without a written semantics
+- Skipping the audit log
+- Allowing the same (source, target, relation) to exist twice
+- Cross-tenant writes
+- Rejecting without a `reason`
+
+## Promotion workflow
+
+1. **propose** — Ingestion, LLM proposal, or technician hint creates row with status `proposed` + evidence + confidence
+2. **review queue** — Admin UI surfaces `proposed` and `needs_review` rows ranked by impact (high-confidence, high-traffic asset first)
+3. **verify** — Admin/technician clicks ✅; status → `verified`; audit row written; record `verified_by` + `verified_at`
+4. **reject** — Admin/technician clicks ❌ + provides reason; status → `rejected`; audit row written; future re-propose with same evidence rejected
+
+`needs_review` is for the quality-check job to flag relationships that look wrong (e.g., a `HasComponent` from a sensor to a different sensor — likely an error).
+
+## What to do when invoked
+
+1. Identify the proposal source — ingestion, miner, technician hint
+2. Verify evidence is present and non-empty
+3. Verify confidence is set
+4. Verify the relationship type is in the allowed set
+5. Verify idempotency — check for existing (source, target, relation) row
+6. Persist as `proposed` (or `verified` if admin context)
+7. Append audit row
+8. If proposal volume is high, group into an admin review batch
+
+## Cross-references
+
+- `mira-crawler/ingest/kg_writer.py` — KG persistence
+- `docs/migrations/004_kg_entities.sql`, `005_kg_relationships.sql` — schema
+- `.claude/mcp/mira-component-graph-mcp-spec.md`
+- `.claude/skills/component-profile-builder/SKILL.md`
+- `.claude/skills/work-order-history-miner/SKILL.md`
+- `.claude/skills/plc-tag-mapper/SKILL.md`
+- `.claude/rules/uns-compliance.md`

--- a/.claude/skills/manual-ingestion-extractor/SKILL.md
+++ b/.claude/skills/manual-ingestion-extractor/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: manual-ingestion-extractor
+description: Use when extracting structured maintenance data from manuals, datasheets, or wiring PDFs. Triggers on edits to `mira-crawler/ingest/`, new customer doc uploads, or when a manual ingestion run produces unusual extractions.
+---
+
+# Manual Ingestion Extractor
+
+Pull structured maintenance data from manuals/PDFs so MIRA can ground answers in real documentation.
+
+Underlying pipeline lives in `mira-crawler/ingest/` (`chunker.py`, `converter.py`, `embedder.py`, `kg_writer.py`, `dedup.py`). Use those — don't reinvent.
+
+## What to extract
+
+1. **Periodic maintenance schedules** — interval, task, target component, tools, parts
+2. **Lubrication intervals** — sub-case of PM; track separately so tribology-aware logic can use it
+3. **Inspection steps** — visual checks, measurements, expected values, tolerances
+4. **Safety warnings** — LOTO, arc flash, PPE, confined space, lift, hot work
+5. **Troubleshooting tables** — symptom → cause → action rows
+6. **Fault codes** — code → description, source page, optional reset procedure
+7. **Wiring references** — terminal blocks, panel/cabinet location, drawing sheet refs
+8. **Parts lists** — part number, vendor, description, BOM context
+9. **Torque specs** — fastener size → torque value → unit, ordered by section
+10. **Consumables** — oils, grease, gaskets, filters with grade specs
+11. **Recommended PM calendar entries** — derived from #1, normalized to a calendar form
+12. **Component metadata** — manufacturer, model, serial pattern, certifications (UL, CE, ATEX)
+13. **Operating limits** — temperature, pressure, voltage, current, RPM ranges
+14. **Alarm codes** — distinct from fault codes (alarms = warnings; faults = stops)
+15. **Reset procedures** — explicit steps to clear a fault or alarm
+
+## Rules
+
+- **Preserve source.** Every extracted record carries `{doc_id, page}` (or `section` if pagination unreliable). Use `mira-crawler/ingest/chunker.py` section-aware splitting.
+- **Don't invent missing data.** A manual that doesn't list fault codes → don't extrapolate from related manuals. Leave the field empty / `unknown`.
+- **Flag low-confidence extractions.** If the section header was ambiguous, mark `confidence: low` and add a `notes` field describing the ambiguity.
+- **De-dup.** Use `mira-crawler/ingest/dedup.py` before insert; manuals re-uploaded with minor changes should not duplicate rows.
+- **Normalize into component profiles.** When extraction supports a complete profile, hand off to `component-profile-builder`. When only partial, leave as raw chunks tagged with the component id.
+- **UNS-tag every chunk.** `uns_path` is mandatory per `.claude/rules/uns-compliance.md`.
+- **No filename inference.** A file named `PF525_Manual.pdf` doesn't justify writing manufacturer/model in extraction output without internal evidence.
+- **Preserve tables.** Use the table-detection path in `converter.py`; don't flatten tables into prose.
+
+## Confidence buckets
+
+- **high** — extracted from a structured table or section header explicitly labeling the data ("Section 4: Maintenance Schedule")
+- **medium** — extracted from prose with consistent format across the manual
+- **low** — extracted from one-off prose, OCR'd image, ambiguous section, or partial scan
+- Always include `confidence` per record. Records below `medium` need a `notes` field.
+
+## Output shape (per record)
+
+```jsonc
+{
+  "kind": "pm_task|fault_code|wiring_ref|parts|torque|...",
+  "data": { /* kind-specific */ },
+  "source": {"doc_id": "...", "page": 17, "section": "Chapter 4 — Maintenance"},
+  "confidence": "high|medium|low",
+  "notes": "optional: why low confidence",
+  "uns_paths": ["enterprise...."],   // empty if generic template
+  "component_link": "component:..."  // null if not linked
+}
+```
+
+## Anti-patterns (these introduce hallucinations)
+
+- Filling unknown fields with "typical" values from training data
+- Promoting a `confidence: low` extraction to higher confidence without re-verification
+- Skipping the source citation to keep the JSON shorter
+- Merging two manuals from different model years without noting the discrepancy
+- Inferring fault-code meaning from numeric prefix patterns
+
+## What to do when invoked
+
+1. Locate the manual(s) — `mira-core/data/`, `mira-core/scripts/`, customer-uploaded paths
+2. Run conversion + chunking via existing pipeline (don't replace it)
+3. For each of the 15 extraction categories, produce records per the schema above
+4. Cite real pages — use `pdfplumber` page index when present
+5. Hand off to `component-profile-builder` if extraction is complete enough
+6. Write extraction summary to `docs/ingestion-runs/<doc_id>-<date>.md` (audit trail)
+
+## Cross-references
+
+- `mira-crawler/ingest/chunker.py` — section-aware splitting
+- `mira-crawler/ingest/converter.py` — docling + pdfplumber
+- `mira-crawler/ingest/embedder.py` — vector embeddings
+- `mira-crawler/ingest/kg_writer.py` — KG persistence
+- `mira-crawler/ingest/dedup.py` — content de-dup
+- `.claude/skills/component-profile-builder/SKILL.md`
+- `.claude/mcp/mira-doc-ingestion-mcp-spec.md`
+- `.claude/rules/uns-compliance.md`

--- a/.claude/skills/mira-architecture-guardian/SKILL.md
+++ b/.claude/skills/mira-architecture-guardian/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: mira-architecture-guardian
+description: Use whenever a feature request, refactor proposal, or PR could expand MIRA outside its product wedge or break the grounded-by-default contract. Keeps Claude aligned with the North Star: Slack = front door, UNS/MQTT = nervous system, KG + component templates = memory, customer docs + work orders = evidence.
+---
+
+# MIRA Architecture Guardian
+
+## When to invoke
+
+- Any new feature, refactor, or scope change touching `mira-bots/`, `mira-pipeline/`, `mira-mcp/`, `mira-crawler/`, `mira-cmms/`, or `mira-web/`.
+- Any PR that adds a new front door (web chat, REST endpoint, voice, etc.) — verify it preserves the Slack-first contract.
+- Any commit that touches the FSM, the engine, or the response generator — verify grounding remains intact.
+- Any time a request sounds like "make MIRA do X" where X is generic.
+
+## Architecture invariants
+
+1. **MIRA is not a generic AI chatbot.** It answers grounded maintenance questions. If a request would produce un-grounded chitchat, push back.
+2. **Slack is the front door.** Other adapters (Telegram, email, gchat, reddit) follow Slack's contract — same engine, same gate, same grounding. Slack is not optional.
+3. **UNS / MQTT is the live context layer.** Plant context comes from `mira-crawler/ingest/uns.py` + the `mira-relay/` + Ignition tag streams. New context sources must integrate here, not bypass.
+4. **Component templates + knowledge graph are memory.** Reusable knowledge lives in `kg_entities` + `kg_relationships`. Per-tenant per-instance specifics extend the templates.
+5. **Customer docs and work orders are evidence.** Ingestion (manuals, drawings, work-order history) is what makes answers groundable. Never ungrounded.
+6. **All troubleshooting is grounded.** No answer without at least one cited source (UNS / docs / PLC tag / work order / KG / technician confirmation / admin-approved profile).
+7. **Prefer asking for confirmation over guessing.** A confirmation question is cheaper than a wrong answer in a plant.
+
+## Watch for feature creep
+
+Push back when a request smells like:
+
+- "Make MIRA respond to anything" → generic chatbot drift.
+- "Have MIRA write to the PLC" → out of scope, safety-critical.
+- "Have MIRA replace our CMMS / SCADA / historian" → out of scope (see `.claude/skills/mira-saas-scope-guard/SKILL.md`).
+- "Skip the confirmation prompt, it's annoying" → breaks the load-bearing UNS gate. Hard no without a written exception.
+- "Auto-verify proposed relationships" → pollutes the graph. Hard no.
+- "Add a LangChain/n8n layer to make this easier" → banned (PRD §4).
+
+## What to do when invoked
+
+1. Re-read `.claude/CLAUDE.md` (product rules) and the relevant module CLAUDE.md (build state).
+2. Identify which invariant the change might affect.
+3. If the change preserves invariants → approve, suggest where to put code, point at conventions.
+4. If the change risks an invariant → state which invariant + why + propose a smaller/safer scope.
+5. If the change is out of product scope → suggest deferring to a non-MIRA module or a follow-up after the wedge is proven.
+
+## Outputs
+
+- Concrete file paths for new code (don't drop code into random places).
+- Cross-references to relevant skills/commands/specs.
+- A 1–3 sentence written justification for the recommendation that the user can paste into a PR description.
+
+## Cross-references
+
+- `.claude/CLAUDE.md` — product rules
+- `.claude/skills/mira-saas-scope-guard/SKILL.md` — scope classifier
+- `.claude/skills/uns-location-gate-designer/SKILL.md` — gate flow
+- `.claude/skills/slack-technician-ux-writer/SKILL.md` — UX contract
+- `docs/specs/mira-component-intelligence-architecture.md` — North Star architecture

--- a/.claude/skills/mira-saas-scope-guard/SKILL.md
+++ b/.claude/skills/mira-saas-scope-guard/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: mira-saas-scope-guard
+description: Use whenever a feature request, customer ask, or PR proposes expanding MIRA's surface area. Classifies requests as Core SaaS / Adjacent / Defer to prevent feature creep and keep the product sellable as a focused maintenance-intelligence wedge.
+---
+
+# MIRA SaaS Scope Guard
+
+Prevent feature creep. Keep the product sellable as a focused industrial-maintenance-intelligence SaaS.
+
+The product wedge is **a Slack-first maintenance copilot that grounds answers in real factory context**. Anything outside that needs strong justification.
+
+## Three tiers
+
+### Core SaaS (do this)
+
+These are the wedge. New features in these areas are usually good:
+
+- Slack technician copilot
+- UNS location-confirmation gate
+- Manual ingestion (PDFs, drawings, datasheets)
+- Component profile generation
+- Work-order history mining
+- PLC tag mapping
+- Knowledge graph proposals (proposed → verified flow)
+- Maintenance troubleshooting assistance (grounded)
+- Demo plant generation (for onboarding + evals)
+
+### Adjacent but careful (think hard, scope tight)
+
+These connect MIRA to the broader factory stack. They unlock value but expand surface area — do them with **explicit per-tenant scope**, read-first, and a clear off-ramp:
+
+- MQTT live monitoring (read-side; no writes)
+- Sparkplug B integration (read-side; protocol bridge)
+- Ignition integration (tag exports + read; no control)
+- CMMS integration (Atlas, MaintainX, Fiix — REST read first, draft writes only)
+- Customer-specific onboarding (paid, time-boxed, generates reusable profiles)
+
+### Defer (don't build these)
+
+These break the wedge. Push back hard:
+
+- Full SCADA replacement
+- Full CMMS replacement (we integrate, we don't replace)
+- Arbitrary PLC control (writes to live equipment)
+- Generic executive dashboards (we're not Power BI)
+- Custom consulting-only dashboards (one-off, not reusable)
+- Uncontrolled write access to live equipment (safety-critical)
+- Generic chatbot functionality (we're not ChatGPT for factories)
+- Voice-only interfaces as primary surface (Slack first)
+- Public-facing marketing-driven content generation (not the product)
+- Compliance / audit reporting as primary product (adjacent at best)
+
+## Classifier flow
+
+When invoked on a request:
+
+1. **State the request in one sentence.** "Customer wants MIRA to display real-time tank levels on a tablet."
+2. **Identify what it touches.** UI surface, MQTT layer, MCP, KG, ingestion, etc.
+3. **Classify** — Core / Adjacent / Defer.
+4. **If Core** — approve, point at the right module + skill.
+5. **If Adjacent** — approve with constraints (read-first, draft-only, scoped, time-boxed).
+6. **If Defer** — push back with the reason + suggest a scoped subset that IS in scope (e.g., "Real-time tank levels = no, but level alerts grounded in PM history = yes").
+
+## Sample classifications
+
+| Request | Tier | Reason |
+|---|---|---|
+| "Auto-fill component profiles from a photo upload" | **Core** | Ingestion + profile building. Build it. |
+| "Slack technician asks 'why won't Conveyor_B16_Run turn on?'" | **Core** | UNS gate + grounded answer. Build it. |
+| "Read live VFD speed from Modbus and include in answer" | **Adjacent** | Read-side, tag-mapped. OK with safety review. |
+| "Show real-time downtime dashboard on a wall TV" | **Defer** | Generic dashboard. Not the wedge. |
+| "Have MIRA send commands to the conveyor (stop, reset)" | **Defer** | PLC writes. Safety-critical. Out. |
+| "Replace the customer's CMMS with MIRA-native work orders" | **Defer** | We integrate, we don't replace. |
+| "Add Teams + Telegram support" | **Core/Adjacent** | Telegram exists; Teams = adjacent. Same engine. |
+| "Build a marketing chatbot for the factorylm.com homepage" | **Defer** | Not the product. |
+| "Audit-report PDF generator" | **Defer / Adjacent** | Defer unless tied to component-profile evidence chain. |
+| "Detect repeat failures and suggest PM additions" | **Core** | Work-order miner. Build it. |
+
+## What to do when invoked
+
+1. Read the request carefully — is it a feature, a customer ask, or a PR?
+2. Run the classifier flow above
+3. Output the classification + 1–3 sentence justification + suggested scoped version if not Core
+4. Cross-reference the right module and skill so the work goes to the right place
+
+## Cross-references
+
+- `.claude/CLAUDE.md` — product rules
+- `.claude/skills/mira-architecture-guardian/SKILL.md` — architecture-level pushback
+- `.claude/skills/uns-location-gate-designer/SKILL.md` — gate that anchors the wedge
+- Root `CLAUDE.md` — current modules + deferred ones (mira-hud, mira-prototype archived; mira-connect deferred)

--- a/.claude/skills/plc-tag-mapper/SKILL.md
+++ b/.claude/skills/plc-tag-mapper/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: plc-tag-mapper
+description: Use when mapping PLC tags to physical components and UNS paths. Triggers on edits to `plc/`, `mira-connect/`, `ignition/`, or when a customer onboarding includes a PLC tag CSV export.
+---
+
+# PLC Tag Mapper
+
+Convert messy PLC tag names into structured mappings to physical components and UNS paths — without ever assuming meaning from the name alone.
+
+## Mapping shape
+
+```
+PLC tag → probable physical meaning → physical component → UNS path → evidence → confidence
+```
+
+Persisted as:
+
+```jsonc
+{
+  "tag_id": "tag_conveyor_b16_run",
+  "tag_name": "Conveyor_B16_Run",
+  "plc_id": "plc_micro820_1",
+  "datatype": "BOOL",
+  "address": "%I0/12",
+  "probable_meaning": "run command for conveyor B16",
+  "component_id": "component:conveyor_b16",
+  "uns_path": "enterprise.stardust_racers...conveyor_b16",
+  "evidence": [
+    {"type": "ladder_comment",     "ref": "MainProgram.Conveyor_B16.rung12"},
+    {"type": "naming_convention",  "ref": "<Asset>_<Component>_<Action> per docs/specs/plc-naming.md"},
+    {"type": "technician_confirm", "user_id": "...", "session_id": "..."}
+  ],
+  "confidence": "verified|proposed|low",
+  "status": "verified|proposed|needs_review|rejected"
+}
+```
+
+## Hard rules
+
+1. **Never assume physical meaning from a tag name alone.** `Pump_1_Run` could be a control, a flag, an HMI display var, or unused. Only map after at least one evidence type from:
+   - Drawings (with sheet ref)
+   - PLC comments / rung comments / function-block comments
+   - Documented naming convention (cite the spec)
+   - Manual reference
+   - Technician confirmation
+   - Admin-approved mapping
+2. **Verified vs proposed.** Mappings start as `proposed`. Promotion to `verified` requires admin/technician sign-off.
+3. **Confidence required** on every mapping.
+4. **Don't write to PLCs.** This skill is read-side only. PLC writes are explicitly out of scope.
+5. **UNS-tag every mapping.** `uns_path` mandatory.
+
+## Tag formats supported
+
+- **Allen-Bradley structured** — `AOI_Conveyor.Status.Run`, `Program:MainProgram.Local:1.O.Data.0`
+- **Local I/O** — `%I0/12`, `%Q0/3`, `%MW100`
+- **Structured Text variables** — `Conveyor_B16_Run`, `Conveyor_B16_Fault`
+- **Ladder / FBD function-block references** — `Conveyor_B16_FB.Run`
+- **CSV tag exports** — vendor-agnostic; expect columns like `tag_name, data_type, address, comment`
+- **Ignition tag exports** — JSON / CSV from `ignition/` exports; preserve folder structure as scope hint
+
+## What to do when invoked
+
+1. Locate the tag source — `plc/ccw/` (Micro820 ST), `ignition/`, customer CSV
+2. Parse tag inventory — name, datatype, address, comment, scope
+3. **For each tag**:
+   - Search PLC source for rung/line where it's read or written → evidence: `ladder_comment` or `st_reference`
+   - Check naming-convention spec if one exists for this customer
+   - Search for the tag name in manual ingestion output (sometimes manuals reference tag tables)
+   - Cross-reference with any technician confirmation history
+4. **Generate proposed mappings** — never verified-by-default. Persist via `propose_tag_component_mapping` (mira-plc-map-mcp) or directly into `kg_entities`+`kg_relationships` with status `proposed`.
+5. **For ambiguous tags**, generate a confirmation question for the technician: "Is `Conveyor_B16_Run` the run command for the Section B16 conveyor motor?"
+6. **Maintain a mapping audit log** — every status change tracked.
+
+## Naming convention helpers (use as evidence, not as truth)
+
+| Pattern | Hint | Example |
+|---|---|---|
+| `<Asset>_<Component>_<Action>` | Generic AB-style | `Conveyor_B16_Run` |
+| `<Line>.SOC_<Asset>_<Idx>` | Sortation occupancy sensor | `1.SOC_B16_2` |
+| `*_FB.*` | Function block | `Conveyor_B16_FB.Status` |
+| `HR<n>` (Modbus holding reg) | VFD / drive | `HR100=motor_speed` |
+| `%I` / `%Q` | Discrete I/O | `%I0/12 = digital input bit 12` |
+| `*_Run`, `*_Stop`, `*_Fault` | Common control suffixes | self-explanatory |
+| `*_Cmd`, `*_PV`, `*_SP` | Command, process value, setpoint | analog control |
+
+These patterns provide **evidence type `naming_convention`**, not verified meaning. Confirmation still required.
+
+## Anti-patterns (these are bugs)
+
+- Auto-mapping `Pump_1_Run` to a pump component because the name says "Pump"
+- Promoting a mapping to `verified` after one technician thumbs-up reaction (require explicit text/button confirm)
+- Mapping a tag to multiple components silently — flag for `needs_review`
+- Carrying tag mappings across customer tenants — these are per-tenant
+- Inferring datatype from name when source export already declares it
+
+## Cross-references
+
+- `plc/ccw/` — Micro820 Structured Text + tag config
+- `ignition/` — Ignition tag exports
+- `.claude/mcp/mira-plc-map-mcp-spec.md`
+- `.claude/skills/component-profile-builder/SKILL.md`
+- `.claude/skills/knowledge-graph-proposer/SKILL.md`
+- `docs/specs/sparkplug-uns-bridge-spec.md` — Sparkplug → UNS mapping

--- a/.claude/skills/slack-technician-ux-writer/SKILL.md
+++ b/.claude/skills/slack-technician-ux-writer/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: slack-technician-ux-writer
+description: Use when designing or editing how MIRA replies in Slack. Triggers on edits to `mira-bots/slack/bot.py`, response formatters, or any prompt template that produces Slack output.
+---
+
+# Slack Technician UX Writer
+
+Technicians read MIRA on a phone in a noisy plant with greasy hands. Optimize for that — not for marketing copy.
+
+## Voice + structure rules
+
+- **Be direct.** No "Great question!" / "Happy to help!" / "As an AI...". Cut.
+- **Short paragraphs.** Two to three lines maximum per block.
+- **Lead with suspected context.** Site → asset → component → fault, in that order. Then evidence. Then ask.
+- **Show evidence.** Three bullets, not more.
+- **Ask for confirmation before troubleshooting** (the UNS gate).
+- **Avoid corporate language.** "Please consider", "as appropriate", "respectively", "leverage" — cut.
+- **Avoid long explanations unless requested.** A technician wants the fix, not a textbook chapter.
+- **Action-oriented steps only after context is confirmed.** Until confirmed: identify + ask. After confirmed: give numbered steps.
+- **Never pretend to know plant context without evidence.** If unknown, say "I don't see this asset in the namespace — can you confirm the line and section?"
+- **No emojis as decoration.** Reactions yes, decoration no.
+
+## Sample style — confirmation message
+
+```
+I found a likely match:
+
+Line 5 / Conveyor Section B16 / Occupancy Sensor B16.2 (Banner Q4X)
+
+Fault:
+1.SOC B16.2 OCCUPIED TOO LONG
+
+Evidence:
+• Your message mentioned "B16.2"
+• PLC fault code matches 1.SOC_B16_2
+• Work-order history shows 14 repeats in 6 months
+
+Confirm this is the asset before I troubleshoot.
+```
+
+## Sample style — troubleshooting steps (after confirmation)
+
+```
+OK — here's what's worked 11 of the last 14 times:
+
+1. Reset at Panel B16 (red button, hold 3s)
+2. Watch the sensor — if it clears, you're done
+3. If it re-faults within 5 minutes, realign the lens:
+   • Loosen Q4X bracket
+   • Aim the beam at the center of the reflector
+   • Tighten and re-test
+
+Parts: none expected.
+
+If this is the third reset today, flag it — the sensor may need replacement (Banner Q4XTBLD-Q8).
+```
+
+## Sample style — low-confidence ("I'm not sure")
+
+```
+I'm not sure which asset you mean. The "conveyor" string matches:
+
+• Line 5 / Conveyor Section B16
+• Line 3 / Conveyor Section B22
+
+Which one?
+```
+
+## Sample style — out-of-scope
+
+```
+That's a PLC logic change — outside what I can help with.
+The Conveyor_B16 program changes go through CCW with a sign-off.
+Want me to pull the current rung 12 logic for context?
+```
+
+## Sample style — KB gap admission
+
+```
+I don't have a manual for this model yet. Best I can do:
+
+• Work-order history shows 2 similar issues fixed by replacing the contactor
+• No PM record for this asset
+
+Can you confirm the manufacturer + model? I'll ingest the manual and remember it.
+```
+
+## What to do when invoked
+
+1. Locate the response formatter — `mira-bots/slack/bot.py` or the engine's `format_response` function in `mira-bots/shared/`
+2. Identify the message type — confirmation, troubleshooting, low-confidence, out-of-scope, KB-gap
+3. Apply the structure rules + match a sample style above
+4. Render via Slack block-kit where useful (buttons for confirm, emoji reactions for thumbs-up flow)
+5. Verify the response cites at least one evidence source (UNS path / doc / WO / KG / technician)
+6. Add a golden case in `tests/golden_factorylm.csv` for the new message shape
+
+## Anti-patterns (these annoy technicians)
+
+- Wall-of-text responses
+- Apologizing repeatedly ("Sorry I didn't catch that")
+- Re-asking for info you already have
+- Generic "Have you tried turning it off and on?" without grounding
+- Using corporate jargon ("leverage", "synergy", "optimal")
+- Citing your own confidence as evidence ("I'm 87% sure" — show evidence instead)
+- Long preambles before the answer
+
+## Cross-references
+
+- `mira-bots/slack/bot.py` — Slack adapter
+- `mira-bots/shared/engine.py` — response generation entry
+- `.claude/skills/uns-location-gate-designer/SKILL.md` — the gate that comes before the message
+- `.claude/CLAUDE.md` — product rules
+- `mira-bots/shared/citation_compliance.py` — evidence enforcement

--- a/.claude/skills/uns-location-gate-designer/SKILL.md
+++ b/.claude/skills/uns-location-gate-designer/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: uns-location-gate-designer
+description: Use when designing, modifying, or reviewing the technician flow where MIRA must locate the asset/component/fault context before troubleshooting. Enforces the non-negotiable confirmation gate. Triggers on edits to `mira-bots/slack/bot.py`, `mira-bots/shared/engine.py`, the FSM, or any new front door.
+---
+
+# UNS Location-Gate Designer
+
+## The non-negotiable rule
+
+**MIRA must not begin troubleshooting until it has resolved the technician's work context inside the Unified Namespace or asset namespace AND the technician has confirmed.**
+
+A code path that emits troubleshooting advice before the gate is a **bug**. The audit command `/mira-run-hallucination-audit` exists to find these.
+
+## Required flow (8 steps)
+
+1. **Receive technician message** at the Slack adapter (`mira-bots/slack/bot.py`).
+2. **Extract candidates** — asset, line, area, machine, component, symptom, fault_code — from message text + thread context + user profile.
+3. **Search the UNS / asset namespace** via `uns_resolver.resolve_uns_path()` per `docs/specs/uns-message-resolver-spec.md`. Backed by `kg_entities` (NeonDB) and `mira-crawler/ingest/uns.py` builders.
+4. **Identify candidate contexts** — top K (default 3) ranked tuples of `(site, area, line, asset, component, fault, evidence)`.
+5. **Gather evidence** — for the top candidate, attach: message hint, work-order history hit, PLC tag match, manual reference, prior session context, technician hint.
+6. **Send the confirmation message** to Slack — see template below.
+7. **Wait** for confirmation, correction, or "different asset". Implement a timeout + re-prompt cycle.
+8. **Only after confirmation, enter troubleshooting mode.** FSM transition: `awaiting_context` → `troubleshooting`.
+
+## Confirmation message template
+
+```
+I think you are working on:
+
+Site:       Stardust Racers / Garage Factory
+Area:       Conveyor Lab
+Line:       Line 5
+Asset:      Conveyor Section B16
+Component:  Occupancy Sensor B16.2 (Banner Q4X)
+Fault/Symptom: 1.SOC B16.2 OCCUPIED TOO LONG
+
+Evidence:
+• Your message mentioned "B16.2"
+• PLC fault code matches 1.SOC_B16_2
+• Work-order history shows 14 repeats in 6 months
+
+Confidence: high
+
+Confirm this is correct before I troubleshoot.
+[ ✅ Yes ]   [ ✏️ Different asset ]   [ ❌ Wrong, let me clarify ]
+```
+
+Slack rendering uses block-kit; the engine returns a structured payload that the adapter renders.
+
+## Confidence buckets
+
+- **high** — UNS match + at least one other corroborating evidence (work-order, tag, prior session).
+- **medium** — UNS match alone, or multiple weak hints.
+- **low** — only message-text hint, no UNS match. In this case, **ask** rather than show a candidate.
+
+## Edge cases to handle
+
+- **No UNS match at all** → don't fabricate. Ask the technician for asset/line/component context.
+- **Multiple equally-likely candidates** → present top 2 side-by-side and ask the technician to pick.
+- **Technician corrects the candidate** → record the correction as evidence for future inference, transition to `troubleshooting` with the corrected context.
+- **Technician changes asset mid-thread** → reset the gate, don't carry context across asset changes (`_clear_diagnostic_carryover` per memory).
+- **Quick repeat fault on same asset** → use prior-session context as evidence, but **still confirm**. The gate is cheap.
+
+## Anti-patterns (these are bugs)
+
+- Returning troubleshooting advice on the first message without confirmation.
+- Defaulting to "common asset" or "Line 1" or any other guess.
+- Marking confidence high without a UNS match.
+- Skipping the gate when the technician uses imperative language ("just tell me how to fix the conveyor").
+- Auto-verifying the candidate after a thumbs-up emoji reaction (require text confirm or explicit button click).
+
+## What to do when invoked
+
+1. Locate the gate enforcement code (likely in `mira-bots/shared/engine.py` FSM `awaiting_context` state).
+2. Verify each of the 8 steps is implemented.
+3. Verify the confirmation message contains all required fields.
+4. Verify the FSM cannot reach the troubleshooting state without passing through the gate.
+5. If gaps exist, propose minimal patches with file:line.
+6. Add or update golden cases in `tests/golden_factorylm.csv` covering each edge case above.
+
+## Cross-references
+
+- `mira-bots/slack/bot.py` — Slack entry point
+- `mira-bots/shared/engine.py` — FSM + Supervisor
+- `mira-bots/shared/guardrails.py` — safety keyword + escalation
+- `docs/specs/uns-message-resolver-spec.md` — resolver authority
+- `docs/specs/uns-kg-unification-spec.md` — UNS schema
+- `.claude/mcp/mira-uns-mcp-spec.md` — proposed MCP server for UNS lookup
+- `.claude/skills/slack-technician-ux-writer/SKILL.md` — message style

--- a/.claude/skills/work-order-history-miner/SKILL.md
+++ b/.claude/skills/work-order-history-miner/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: work-order-history-miner
+description: Use when extracting maintenance intelligence from CMMS work-order history. Triggers on edits to `mira-mcp/server.py` CMMS tools, Atlas CMMS integration in `mira-cmms/`, or when a customer onboarding includes a CMMS export.
+---
+
+# Work-Order History Miner
+
+Turn raw CMMS work-order history into the intelligence MIRA needs to ground troubleshooting and propose component-profile updates.
+
+## What to identify
+
+1. **Repeated failures** — same asset + failure-mode-cluster occurring above a threshold (default 3 in 6 months)
+2. **Common fixes** — most-frequent resolutions per asset/component
+3. **Reset-only events** — work orders closed with no parts replaced and short duration → flags chronic nuisance vs real failure
+4. **Replaced parts** — frequency-ranked, by component
+5. **MTBF** (mean time between failures) — per asset or per component
+6. **Downtime patterns** — failures clustered by day-of-week, shift, or season
+7. **Technician notes** — free-text comments; extract actionable phrases
+8. **Likely root causes** — clusters of (symptom, action, success) into root-cause hypotheses
+9. **Recurring nuisance faults** — high-frequency, low-effort, line-stop-causing faults
+10. **Parts that should be watched** — parts replaced N+ times, or parts with replacement intervals shorter than expected
+11. **PM opportunities** — failures that would have been prevented by an existing PM done correctly
+12. **Useful KB entries** — fixes that should be turned into knowledge-graph relationships
+
+## Output shape (per finding)
+
+```jsonc
+{
+  "asset_id": "...",
+  "uns_path": "...",
+  "component_id": "...",
+  "finding_kind": "repeat_failure|common_fix|reset_only|...",
+  "summary": "Occupancy Sensor B16.2 has 14 OCCUPIED_TOO_LONG faults in 6 months; 11 closed reset-only",
+  "evidence": [
+    {"type": "wo_history", "wo_ids": ["wo_...", "wo_..."]},
+    {"type": "duration_pattern", "median_minutes": 4}
+  ],
+  "recommended_kg_relationship": {
+    "source": "component:pe_b16_2",
+    "target": "fault:1.SOC_B16_2.OCCUPIED_TOO_LONG",
+    "relation": "HasChronicFault",
+    "status": "proposed",
+    "confidence": "high"
+  },
+  "recommended_component_profile_update": {
+    "field": "known_fixes",
+    "value": {"symptom": "OCCUPIED_TOO_LONG repeats", "action": "Reset at Panel B16, then realign", "evidence_wo_ids": [...]}
+  },
+  "confidence": "high|medium|low"
+}
+```
+
+## Rules
+
+- **Preserve source.** Every finding cites the work-order IDs it came from.
+- **Component-link before relationship.** Findings need a `component_id` (or `asset_id` fallback) — orphaned findings stay in a review queue.
+- **Proposed by default.** Recommended KG relationships start as `proposed`. Never auto-verify.
+- **Tenant isolation.** Findings are per-tenant; don't cross-pollinate insights.
+- **Don't write to closed work orders.** They're immutable.
+- **Draft new work orders, don't commit them.** If a finding suggests a new work order (e.g., "schedule a sensor replacement"), call `create_draft_work_order`, not a live create.
+
+## Useful aggregations
+
+| Aggregation | Why it matters |
+|---|---|
+| `count(wo) GROUP BY (asset_id, failure_mode) HAVING count >= 3` | Repeat failures |
+| `wo.parts_used = [] AND wo.duration_minutes < 10` | Reset-only events |
+| `lag(wo.created_at) OVER (PARTITION BY asset_id ORDER BY created_at)` | MTBF |
+| `EXTRACT(DOW FROM wo.created_at)` | Day-of-week patterns (shift correlation) |
+| `wo.parts_used` exploded with frequency rank | Parts churn |
+| `LEFT JOIN pm_schedule ON asset_id` | PM coverage gaps |
+
+## What to do when invoked
+
+1. Identify the CMMS surface — Atlas CMMS REST (`atlas-api:8080`), MaintainX via Nango (per memory), or other tenant CMMS
+2. Pull work-order history scoped to the relevant asset(s) — via `mira-mcp/server.py` `cmms_list_work_orders` or `mira-work-order-mcp` `search_work_orders`
+3. Run the aggregations above
+4. Generate findings per schema
+5. Propose KG relationships → hand off to `knowledge-graph-proposer` skill
+6. Propose component-profile updates → hand off to `component-profile-builder` skill
+7. Write a mining report at `docs/work-order-mining/<asset_id>-<date>.md` (audit trail)
+
+## Anti-patterns
+
+- Drawing conclusions from < 3 work orders (insufficient signal)
+- Promoting "common fix" to `verified` without technician confirmation
+- Aggregating across tenants (tenant isolation)
+- Inventing failure-mode names that don't appear in the work-order data
+- Mining notes that contain PII without sanitization
+
+## Cross-references
+
+- `mira-mcp/server.py` — existing `cmms_*` tools
+- `mira-cmms/` — Atlas CMMS integration
+- `.claude/mcp/mira-work-order-mcp-spec.md`
+- `.claude/skills/component-profile-builder/SKILL.md`
+- `.claude/skills/knowledge-graph-proposer/SKILL.md`

--- a/.mcp.json
+++ b/.mcp.json
@@ -29,6 +29,16 @@
         "./wiki"
       ],
       "env": {}
+    },
+    "playwright": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp@latest",
+        "--headless"
+      ],
+      "env": {}
     }
   }
 }


### PR DESCRIPTION
## Summary

Three independent session artifacts bundled into one PR. Markdown + config only — no code changes, no tests touched.

### 1. `.claude/` build (21 files, ~1840 lines)
MIRA-specific operating guide for Claude Code agents:
- **`.claude/CLAUDE.md`** — product rules: North Star, UNS confirmation gate, grounded-troubleshooting contract, ingestion rules, component-profile rules, KG proposal rules, Slack UX, do-not-do list. Companion to (not replacement for) root `CLAUDE.md`.
- **9 skills** under `.claude/skills/<name>/SKILL.md`: `mira-architecture-guardian`, `uns-location-gate-designer`, `component-profile-builder`, `manual-ingestion-extractor`, `plc-tag-mapper`, `work-order-history-miner`, `slack-technician-ux-writer`, `knowledge-graph-proposer`, `mira-saas-scope-guard`.
- **5 commands** under `.claude/commands/`: `mira-map-codebase`, `mira-trace-technician-flow`, `mira-run-hallucination-audit`, `mira-create-demo-plant`, `mira-generate-component-template`.
- **6 MCP specs** under `.claude/mcp/`: `README` + 5 proposed servers (`mira-uns-mcp`, `mira-component-graph-mcp`, `mira-doc-ingestion-mcp`, `mira-work-order-mcp`, `mira-plc-map-mcp`). Read-only first; write tools admin-gated.

### 2. `.claude-plugin/marketplace.json` + 7 plugin READMEs
Restores the `mira-local` LSP marketplace (ruff / yaml / sql / dockerfile / toml / shell / markdown). Previously only on the unmerged `feat/lsp-claude-code` branch — `/reload-plugins` complained on main about a missing marketplace.

### 3. `.mcp.json` — Playwright MCP added
`@playwright/mcp@latest --headless` joins sqlite / sequential-thinking / obsidian. Unlocks the `web-review` skill properly and replaces ad-hoc Chrome headless shelling we've been doing in this codebase.

### 4. `.claude/settings.json` — plugin enable/disable adjustments
User-driven during this session: disabled `stripe`, `codex`, `compound-engineering`, `context-mode`, `ralph-loop`.

## How Claude Code uses this on `main`

- `.claude/CLAUDE.md` auto-loads on session start alongside root `CLAUDE.md` and `.claude/rules/*`.
- Skills auto-trigger on matching file paths (e.g., editing `mira-bots/slack/bot.py` fires `slack-technician-ux-writer` + `uns-location-gate-designer`).
- Commands invoked via `/mira-map-codebase`, `/mira-trace-technician-flow`, etc. — each writes an output doc into `docs/` for human review.
- MCP specs are reference docs for building the actual servers under `mira-mcp/` (read-only first).

## MIRA-critical gaps these surface (next-step recommendations, NOT in this PR)

1. **B16 demo scenario** is scripted in `docs/specs/mira-component-intelligence-architecture.md` + `marketing/comic-pipeline/` but has no seed fixtures. → `/mira-create-demo-plant`
2. **UNS confirmation-gate enforcement** in code is unclear. → `/mira-trace-technician-flow`
3. **Hallucination audit** never run on engine. → `/mira-run-hallucination-audit`
4. **5 custom MCP servers specified but not built.** All start as read-only sub-modules under `mira-mcp/`.
5. **Component-template directory** doesn't exist yet — `/mira-generate-component-template` writes to `docs/component-templates/`.

## Test plan

- [x] All 21 markdown files validate as readable
- [x] `wc -l` total: ~1,840 lines
- [x] Harness picked up new skills + commands (visible in skills list this session)
- [x] `.mcp.json` validates as JSON (verified earlier)
- [x] `marketplace.json` validates (7 plugins, valid sources)
- [ ] Reviewer: spot-check 2-3 SKILL.md files for accuracy against real file paths
- [ ] Reviewer: confirm `.claude/CLAUDE.md` rules don't contradict root `CLAUDE.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)