### PR TITLE
fix(hooks): stop-gate emits approve not allow per Stop schema

### DIFF
--- a/tools/hooks/stop-gate.sh
+++ b/tools/hooks/stop-gate.sh
@@ -15,12 +15,12 @@
 set -uo pipefail
 
 if [ "${MIRA_SKIP_STOP_GATE:-0}" = "1" ]; then
-  echo '{"decision":"allow"}'
+  echo '{"decision":"approve"}'
   exit 0
 fi
 
 ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
-cd "$ROOT" 2>/dev/null || { echo '{"decision":"allow"}'; exit 0; }
+cd "$ROOT" 2>/dev/null || { echo '{"decision":"approve"}'; exit 0; }
 
 # Scope to what THIS branch added on top of main (not unrelated recent commits
 # from other people). Falls back to HEAD~5 if no main branch reference exists.
@@ -65,7 +65,7 @@ if [ -n "$CHANGED_HUB" ] && [ -f "mira-hub/package.json" ] && [ -d "mira-hub/nod
 fi
 
 if [ ${#FAILS[@]} -eq 0 ]; then
-  echo '{"decision":"allow"}'
+  echo '{"decision":"approve"}'
   exit 0
 fi
 


### PR DESCRIPTION
## Summary

`tools/hooks/stop-gate.sh` was emitting `{"decision":"allow"}` at session end. Claude Code's Stop event accepts `decision: "approve" | "block"` — `"allow"` is PreToolUse vocabulary. The harness validator rejected the output and printed:

> Hook JSON output validation failed — (root): Invalid input

at every session end.

## Effect
Harmless — the malformed output meant the gate didn't block, so sessions ended normally. Just noisy error logs.

## Fix
Three call sites in `tools/hooks/stop-gate.sh`: `"allow"` → `"approve"`. The block path on line 80 was already correct (`"decision":"block"`).

Verified `tools/hooks/prod-guard.sh` (PreToolUse) — it correctly uses `permissionDecision: "deny"`, not affected.

## Test plan
- [x] `bash tools/hooks/stop-gate.sh` emits `{"decision":"approve"}` and exits 0
- [x] Diff is 3 lines, only `"allow"` → `"approve"` (no other changes)
- [x] Scanned other hooks for same bug — only stop-gate.sh had it

🤖 Generated with [Claude Code](https://claude.com/claude-code)