### PR TITLE
feat(hub): tablet demo backend — seed + 11 endpoints + UNS gate (May 21 demo)

### DIFF
--- a/docs/plans/2026-05-14-demo-backend-plan.md
+++ b/docs/plans/2026-05-14-demo-backend-plan.md
@@ -1,0 +1,102 @@
+# 2026-05-14 — Tablet Demo Backend Plan (May 21, 2026)
+
+**One-liner:** Wire the component intelligence layer end-to-end on one demo conveyor so a tech with a tablet can ask MIRA "is the PLC seeing this sensor?" and get a grounded answer.
+
+**Deadline:** 2026-05-21 (Florida Automation Expo). T-7 days.
+**Scope-lock:** This plan covers backend only. Frontend (tablet UI) is consumed via existing Hub routes + a thin demo page; no new app surface.
+**North Star:** Slack = front door · UNS = nervous system · KG + templates = memory · Customer docs + WOs = evidence.
+
+---
+
+## Phase 1 — Repository Discovery (COMPLETE)
+
+### What exists
+| Area | Status | Files |
+|---|---|---|
+| Component intelligence schema | ✅ Merged | `mira-hub/db/migrations/016_component_templates.sql`, `017_installed_component_instances.sql`, `018_relationship_proposals.sql` |
+| UNS ltree on `kg_entities` | ✅ | `mira-hub/db/migrations/010_kg_uns_path.sql` + `014_uns_path_backfill.sql` |
+| UNS ltree on `cmms_equipment` | ✅ | `mira-hub/db/migrations/015_equipment_uns_path.sql` |
+| Knowledge graph base | ✅ | `mira-hub/db/migrations/001_knowledge_graph.sql` (kg_entities/relationships/triples_log) |
+| External ID columns (plc_tag, mqtt_topic, scada_path) | ✅ | `mira-hub/db/migrations/013_external_ids.sql` |
+| Variable manifest (78 PLC vars, GS10 VFD, sensors, faults) | ✅ | `research/variable-manifest.json` |
+| Micro820 ST source | ✅ | `plc/Prog2.stf` |
+| Ignition tag emitter (Micro820 → tag JSON) | ✅ | `mira-machine-logic-graph/` (bun + TS) |
+| Manifest → KG loader (proposals + evidence) | ✅ Tool | `tools/load_manifest_to_kg.py` |
+| Component template builder (LLM extraction) | ✅ Tool | `tools/build_component_template.py` |
+| Slack adapter (Socket Mode, slack_bolt) | ✅ | `mira-bots/slack/bot.py`, `chat_adapter.py` |
+| Slack OAuth callback | ✅ | `mira-hub/src/app/api/auth/slack/route.ts` + `callback/route.ts` |
+| Supervisor engine | ✅ | `mira-bots/shared/engine.py` |
+| Chat dispatcher | ✅ | `mira-bots/shared/chat/dispatcher.py` |
+| UNS browse/subtree API | ✅ | `mira-hub/src/app/api/uns/{browse,subtree}/route.ts` |
+| MCP server (FastMCP + atlas/maintainx/fiix/limble adapters) | ✅ | `mira-mcp/server.py`, `mira-mcp/cmms/*.py` |
+| Modbus driver scaffold | ✅ | `mira-connect/mira_connect/drivers/modbus_driver.py` |
+
+### What's missing
+| Gap | Risk | Owner of fix |
+|---|---|---|
+| `slack-technician-workflow-spec.md` (user referenced, not in repo) | M — written intent only in skill descriptions + chat | P4 |
+| **Namespace confirmation gate** in Slack engine — no FSM state that blocks troubleshooting until asset/component context is confirmed | **H — North Star non-negotiable** | P4 |
+| Live signal source for demo (real MQTT/Modbus too risky for tablet demo on May 21) | M | P5 mock |
+| Tablet-friendly read API: `/api/demo/conveyor/:id/context` returning asset + components + recent signals + last 3 work orders, one round-trip | H | P3 |
+| Demo seed (Conveyor 001, PE-001/MTR-001/VFD-001/PLC-001/PANEL-001, UNS, PLC tag bindings, relationship_proposals chain, PE-001 template) | H | **P2 (this PR)** |
+| `cmms_equipment` table — referenced by 014/015/017 but CREATE TABLE not in mira-hub/db/migrations (lives in Atlas DB or earlier shared schema) | M — verify before seed runs in prod | P2 verify step |
+| Promotion path from `relationship_proposals.verified` → `kg_relationships` (spec says "follow-up PR") | L — seed inserts both directly | P6 |
+
+### Reuse vs build
+**Reuse as-is:**
+- `tools/load_manifest_to_kg.py` — already proposes 4 edge types (HAS_ALIAS, MAPS_TO, WIRED_TO, PUBLISHED_AS) from the manifest. Use it to populate sensor-side edges.
+- `mira-bots/slack/bot.py` — already wires `Supervisor(engine)` + `ChatDispatcher`; add intent handler + namespace gate.
+- `mira-hub/src/app/api/uns/subtree/route.ts` — already returns subtree by uns_path prefix. The tablet UI reads from this.
+- Migrations 014/015/016/017/018 — apply via `ops/apply-prod-migrations` workflow (already exists per commit 832552e5).
+
+**Build new:**
+- Demo seed SQL + Python runner — **P2 (now)**.
+- Namespace-confirmation FSM state in `shared/engine.py` — **P4**.
+- Tablet context endpoint + mocked signal feed — **P3 + P5**.
+- 5 troubleshooting question handlers wired to KG queries — **P6**.
+
+---
+
+## Phases 2–8 — Order + Effort
+
+| # | Phase | Deliverable | Effort | Blocks |
+|---|---|---|---|---|
+| **2** | **Demo seed (NOW)** | `tools/seeds/demo-conveyor-001.sql` + `run_demo_seed.py` — 1 tenant, 1 asset, 5 components, 5 UNS paths, ~30 PLC-tag-bound instances from manifest, PE-001 template fully populated, HAS_COMPONENT + WIRED_TO + POWERED_BY + USED_IN_LOGIC proposals + matching `kg_relationships` for demo queries | **4h** | P3, P6 |
+| 3 | Tablet read API | `GET /api/demo/conveyor/:tag` returning `{asset, components[], plc_tags[], recent_signals[], last_wo[]}` in one round-trip; tablet UI hits this | 6h | P8 |
+| 4 | Slack namespace gate | New FSM state `AWAITING_NAMESPACE` in `shared/engine.py`; blocks routing to troubleshooting until `tenant + asset_id` (or asset_tag) is confirmed; emits Slack block with asset picker; writes `slack-technician-workflow-spec.md` | 6h | P7 |
+| 5 | Mock signal feed | `tools/demo/signal_replayer.py` — replays a 90s scripted scenario (sensor health → motor start → VFD comm error → recovery) into a `signal_samples` table; tablet polls latest | 3h | P3 read |
+| 6 | KG query handlers | 5 typed query functions in `mira-bots/shared/kg_queries.py`: `does_plc_see_sensor`, `where_is_wired`, `why_motor_stopped`, `flag_count`, `first_check_recommendation`. All return `(answer, evidence[], confidence)`. | 8h | P7 |
+| 7 | Engine + intent classifier wire-up | Route the 5 demo intents through `Supervisor` → `kg_queries` → grounded answer; reject ungrounded answers (no evidence → "I can't confirm, please verify with…") | 5h | demo |
+| 8 | Tablet demo page | `mira-web/src/app/demo/conveyor/[tag]/page.tsx` — single page, 3 panels: live signals, KG/component card, Slack-like chat embedded; reuses Hub design tokens | 6h | demo |
+
+**Total backend effort: ~38h (5 working days). One person can ship by 2026-05-19 dry-run.**
+
+## Hard rules (lifted from North Star)
+
+1. **No confirmed namespace context, no troubleshooting.** FSM enforces this in P4. The 5 KG query handlers in P6 take `(tenant_id, asset_id, component_id)` as required args — there is no path to call them without context.
+2. **Every answer cites evidence.** Each KG query returns `evidence[]` (manifest entry / wiring note / WO id / manual chunk). Empty evidence array → engine must refuse with a help message.
+3. **No Anthropic.** Groq → Cerebras → Gemini cascade only.
+4. **Apache 2.0 / MIT only.** Banner QS18 spec is public; manifest is internal Micro820 work.
+
+## Verification gates
+
+| Gate | When | How |
+|---|---|---|
+| Seed loads cleanly | P2 done | `psql -f tools/seeds/demo-conveyor-001.sql` returns 0; `SELECT COUNT(*) FROM installed_component_instances WHERE tenant_id = '00000000-0000-0000-0000-0000000000d1'` ≥ 5 |
+| Migrations 016–018 applied to prod | Before P3 | `ops/apply-prod-migrations` workflow run; smoke check `SELECT 1 FROM component_templates LIMIT 1` |
+| Namespace gate blocks | P4 done | Pytest: send Slack message w/o asset context → engine returns asset-picker block, not LLM answer |
+| KG queries grounded | P6 done | Each handler returns ≥1 evidence row from `relationship_evidence` for demo asset; refusal path emits explicit "no evidence" |
+| Tablet renders on iPad Safari | P8 done | Playwright snapshot at 1024×768 + 820×1180 portrait |
+| May 18 dry-run | T-3 | Full demo script from `demo-readiness-may21-spec.md` passes on physical tablet |
+
+## What this plan deliberately does NOT do
+
+- Real-time MQTT subscription (deferred — mock feed for demo).
+- Promotion service from `relationship_proposals` → `kg_relationships` (use direct insert for demo; build promotion in post-demo PR).
+- Auth on the demo page (single-tenant, single asset; bearer-token guard is sufficient).
+- New component templates beyond PE-001 + GS10 (use placeholders for MTR/PLC/PANEL with `verification_status='proposed'`).
+
+## Tracking
+
+- Linear: hit Free tier limit (per memory) — track in GitHub issues only until resolved.
+- Issues to file after this plan lands: P3, P4, P5, P6, P7, P8 (one each).

--- a/mira-bots/benchmarks/deepeval_suite.py
+++ b/mira-bots/benchmarks/deepeval_suite.py
@@ -632,7 +632,9 @@ class DeepEvalRunner:
 
 
 def _print_report(result: SuiteResult) -> None:
-    pct = lambda n, d: f"{n/d*100:.1f}%" if d else "0%"
+    def pct(n: float, d: float) -> str:
+        return f"{n / d * 100:.1f}%" if d else "0%"
+
     grade_char = "✓" if result.passed / max(result.total, 1) >= 0.8 else "✗"
     overall_pct = result.passed / max(result.total, 1) * 100
 

--- a/mira-bots/scripts/bench_cascade.py
+++ b/mira-bots/scripts/bench_cascade.py
@@ -44,7 +44,6 @@ sys.path.insert(0, os.path.join(REPO_ROOT, "mira-bots"))
 
 from shared.inference.router import get_system_prompt  # noqa: E402
 
-
 BENCH_PROMPTS = [
     "vfd faulted out, whole line stopped",
     "GS20, shows OC, trips the instant I hit run",

--- a/mira-hub/db/migrations/019_sessions_and_signals.sql
+++ b/mira-hub/db/migrations/019_sessions_and_signals.sql
@@ -1,0 +1,138 @@
+BEGIN;
+
+-- Migration 019: Troubleshooting sessions + live signal events.
+-- Spec: docs/plans/2026-05-14-demo-backend-plan.md (Phase 3 + Phase 5)
+--
+-- Two demo-driven tables:
+--
+--   troubleshooting_sessions
+--     One row per technician troubleshooting interaction (Slack thread, tablet
+--     session, Telegram chat). Holds the confirmed namespace context (asset,
+--     optional component) plus an append-only transcript. The North Star
+--     "no confirmed namespace context, no troubleshooting" rule is enforced
+--     at the API layer by reading status='confirmed' before allowing
+--     /api/mira/ask to invoke the LLM.
+--
+--   live_signal_events
+--     Append-only stream of signal samples for a component's PLC tag. For
+--     the May 21 demo we don't subscribe to MQTT — the simulator endpoint
+--     (POST /api/demo/signals/toggle) writes rows here, and the tablet polls
+--     the latest. `simulated` defaults TRUE so we never confuse fake samples
+--     for real telemetry once the real MQTT bridge lands.
+--
+-- Both tables are tenant-scoped with RLS. Indexes are sized for the demo
+-- (single tenant, ~5 components, ~hundreds of signal events) — re-tune when
+-- we have real production load.
+
+CREATE TABLE IF NOT EXISTS troubleshooting_sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+
+    -- Confirmed namespace context — the gate.
+    -- asset_id is REQUIRED before status can advance past 'awaiting_namespace'.
+    -- component_id is OPTIONAL (a session may target a whole asset rather than
+    -- one component).
+    asset_id UUID,
+    component_id UUID,
+
+    -- Who's troubleshooting. Nullable so unattended demo sessions still work.
+    technician_user_id UUID,
+    channel TEXT NOT NULL DEFAULT 'tablet'
+        CHECK (channel IN ('tablet', 'slack', 'telegram', 'web', 'other')),
+
+    status TEXT NOT NULL DEFAULT 'awaiting_namespace'
+        CHECK (status IN ('awaiting_namespace', 'confirmed', 'resolved', 'abandoned')),
+
+    confirmed_at TIMESTAMPTZ,
+    resolved_at TIMESTAMPTZ,
+
+    -- Append-only history of turns. Shape:
+    --   [{ "role": "user"|"assistant"|"system", "content": "...",
+    --      "ts": "ISO8601", "evidence": [...] }]
+    transcript JSONB NOT NULL DEFAULT '[]',
+
+    -- Free-form bag for demo-only metadata (asset_tag, ip_of_tablet, etc.).
+    metadata JSONB NOT NULL DEFAULT '{}',
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_tenant
+    ON troubleshooting_sessions (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_asset
+    ON troubleshooting_sessions (tenant_id, asset_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_status
+    ON troubleshooting_sessions (status);
+CREATE INDEX IF NOT EXISTS idx_sessions_recent
+    ON troubleshooting_sessions (tenant_id, created_at DESC);
+
+ALTER TABLE troubleshooting_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY sessions_tenant
+    ON troubleshooting_sessions
+    USING (tenant_id = current_setting('app.tenant_id', true)::UUID
+           OR tenant_id = current_setting('app.current_tenant_id', true)::UUID);
+
+
+CREATE TABLE IF NOT EXISTS live_signal_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+
+    -- Either component_id (preferred) or plc_tag (fallback when a tag fires
+    -- before a component is bound). At least one must be present — enforced
+    -- by the CHECK below.
+    component_id UUID,
+    plc_tag TEXT,
+
+    -- The reading itself. Use value_text for discrete states ("present",
+    -- "clear", "fault"), value_numeric for analog/integer (rpm, amps, hz).
+    -- value_bool is the cheap path for the 90% of demo signals that are 1-bit.
+    value_text TEXT,
+    value_numeric DOUBLE PRECISION,
+    value_bool BOOLEAN,
+
+    -- Provenance. simulated=true means the demo signal-toggle endpoint
+    -- generated this; false means it came from the real MQTT bridge.
+    simulated BOOLEAN NOT NULL DEFAULT true,
+    source TEXT NOT NULL DEFAULT 'demo_simulator',
+
+    -- Free-form (e.g. {"units":"rpm","quality":"good"}).
+    properties JSONB NOT NULL DEFAULT '{}',
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT signal_subject_present CHECK (
+        component_id IS NOT NULL OR plc_tag IS NOT NULL
+    ),
+    CONSTRAINT signal_value_present CHECK (
+        value_text IS NOT NULL OR value_numeric IS NOT NULL OR value_bool IS NOT NULL
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_signals_tenant_component_recent
+    ON live_signal_events (tenant_id, component_id, created_at DESC)
+    WHERE component_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_signals_tenant_tag_recent
+    ON live_signal_events (tenant_id, plc_tag, created_at DESC)
+    WHERE plc_tag IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_signals_recent
+    ON live_signal_events (tenant_id, created_at DESC);
+
+ALTER TABLE live_signal_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY signals_tenant
+    ON live_signal_events
+    USING (tenant_id = current_setting('app.tenant_id', true)::UUID
+           OR tenant_id = current_setting('app.current_tenant_id', true)::UUID);
+
+-- Grant the limited app role used by withTenantContext.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'factorylm_app') THEN
+        GRANT SELECT, INSERT, UPDATE ON troubleshooting_sessions TO factorylm_app;
+        GRANT SELECT, INSERT ON live_signal_events TO factorylm_app;
+    END IF;
+END $$;
+
+COMMIT;

--- a/mira-hub/src/app/api/assets/[id]/context/route.ts
+++ b/mira-hub/src/app/api/assets/[id]/context/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/assets/[id]/context
+ *
+ * Returns the minimum context the tablet needs to render the "is this the
+ * right asset?" confirmation card before unlocking troubleshooting:
+ *   - asset (id, name, asset_tag, uns_path)
+ *   - components count + names
+ *   - recent_signal_count
+ *   - recent_work_order_count
+ *
+ * Used by the UNS Confirmation Gate. If the asset is missing or has no
+ * components, returns the asset row but flags `ready_for_troubleshooting=false`.
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      const assetRow = await c
+        .query(
+          `SELECT id, entity_id, name, uns_path::text AS uns_path, properties
+             FROM kg_entities
+            WHERE tenant_id = $1 AND id = $2 AND entity_type = 'equipment'
+            LIMIT 1`,
+          [ctx.tenantId, id],
+        )
+        .then((r) => r.rows[0] ?? null);
+
+      if (!assetRow) return null;
+
+      const components = await c
+        .query(
+          `SELECT id, component_name, canonical_name, plc_tag
+             FROM installed_component_instances
+            WHERE tenant_id = $1 AND asset_id = $2
+            ORDER BY component_name`,
+          [ctx.tenantId, id],
+        )
+        .then((r) => r.rows);
+
+      const signals = await c
+        .query(
+          `SELECT COUNT(*)::int AS n
+             FROM live_signal_events e
+             JOIN installed_component_instances i ON i.id = e.component_id
+            WHERE e.tenant_id = $1 AND i.asset_id = $2
+              AND e.created_at > now() - interval '24 hours'`,
+          [ctx.tenantId, id],
+        )
+        .then((r) => Number(r.rows[0]?.n ?? 0));
+
+      const props = (assetRow.properties as Record<string, unknown> | null) ?? {};
+
+      return {
+        asset: {
+          id: assetRow.id,
+          name: assetRow.name,
+          asset_tag: props.asset_tag ?? null,
+          manufacturer: props.manufacturer ?? null,
+          model: props.model ?? null,
+          uns_path: assetRow.uns_path,
+        },
+        components: components.map((cmp: Record<string, unknown>) => ({
+          id: cmp.id,
+          name: cmp.component_name,
+          canonical_name: cmp.canonical_name,
+          plc_tag: cmp.plc_tag,
+        })),
+        recent_signal_count_24h: signals,
+        ready_for_troubleshooting: components.length > 0,
+      };
+    });
+
+    if (!result) {
+      return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+    }
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("[api/assets/[id]/context GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/assets/[id]/signals/route.ts
+++ b/mira-hub/src/app/api/assets/[id]/signals/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/assets/[id]/signals?limit=20&since=ISO8601
+ *
+ * One signal card per installed component on the asset:
+ *   { components: [{ id, name, plc_tag, latest: {value, ts, state}, history: [...] }] }
+ *
+ * Reads live_signal_events ordered by created_at DESC. Demo-only; real-time
+ * feeds will replace this with a WebSocket bridge to the UNS broker.
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+  const url = new URL(req.url);
+  const limit = Math.min(100, Math.max(1, Number(url.searchParams.get("limit") ?? "20")));
+  const since = url.searchParams.get("since");
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      const components = await c
+        .query(
+          `SELECT id, component_name, plc_tag
+             FROM installed_component_instances
+            WHERE tenant_id = $1 AND asset_id = $2
+            ORDER BY component_name`,
+          [ctx.tenantId, id],
+        )
+        .then((r) => r.rows);
+
+      if (components.length === 0) return { components: [] };
+
+      const componentIds = components.map((r: Record<string, unknown>) => r.id as string);
+
+      const sinceClause = since ? "AND created_at >= $3" : "";
+      const queryParams: unknown[] = [ctx.tenantId, componentIds];
+      if (since) queryParams.push(since);
+
+      const events = await c
+        .query(
+          `SELECT id, component_id, plc_tag, value_text, value_numeric, value_bool,
+                  simulated, source, properties, created_at
+             FROM live_signal_events
+            WHERE tenant_id = $1
+              AND component_id = ANY($2::uuid[])
+              ${sinceClause}
+            ORDER BY created_at DESC
+            LIMIT ${limit * componentIds.length}`,
+          queryParams,
+        )
+        .then((r) => r.rows);
+
+      const byComponent = new Map<string, Array<Record<string, unknown>>>();
+      for (const ev of events) {
+        const cid = ev.component_id as string;
+        if (!byComponent.has(cid)) byComponent.set(cid, []);
+        byComponent.get(cid)!.push(ev);
+      }
+
+      return {
+        components: components.map((cmp: Record<string, unknown>) => {
+          const history = (byComponent.get(cmp.id as string) ?? []).slice(0, limit);
+          const latest = history[0] ?? null;
+          return {
+            id: cmp.id,
+            name: cmp.component_name,
+            plc_tag: cmp.plc_tag,
+            latest: latest
+              ? {
+                  ts: latest.created_at,
+                  value:
+                    latest.value_text ??
+                    latest.value_numeric ??
+                    latest.value_bool ??
+                    null,
+                  simulated: latest.simulated,
+                  source: latest.source,
+                }
+              : null,
+            history: history.map((h) => ({
+              ts: h.created_at,
+              value: h.value_text ?? h.value_numeric ?? h.value_bool ?? null,
+              simulated: h.simulated,
+            })),
+          };
+        }),
+      };
+    });
+
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("[api/assets/[id]/signals GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/components/[id]/route.ts
+++ b/mira-hub/src/app/api/components/[id]/route.ts
@@ -1,0 +1,136 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/components/[id]
+ *
+ * Component detail = installed_component_instance row joined with its
+ * component_template (catalog) plus recent KG relationships in/out.
+ *
+ *   { component: {...}, template: {...}, edges: [{type, source/target}] }
+ *
+ * The tablet uses this to render the component card with PE-001's
+ * troubleshooting steps, failure modes, expected signal envelope, etc.
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      const row = await c
+        .query(
+          `SELECT
+              i.id, i.component_name, i.canonical_name, i.aliases,
+              i.asset_id, i.installed_location, i.panel, i.terminal,
+              i.wire_number, i.plc_tag, i.mqtt_topic,
+              i.uns_path::text AS uns_path, i.human_confirmed, i.confidence,
+              i.notes,
+              i.template_id,
+              t.component_category, t.component_type,
+              t.manufacturer, t.model, t.description,
+              t.power_specs, t.input_output_specs, t.signal_behavior,
+              t.connector_type, t.pinout, t.environmental_limits,
+              t.diagnostic_indicators, t.expected_signals,
+              t.common_failure_modes, t.troubleshooting_steps,
+              t.pm_checks, t.safety_notes,
+              t.verification_status AS template_verification_status
+            FROM installed_component_instances i
+            LEFT JOIN component_templates t ON t.id = i.template_id
+           WHERE i.tenant_id = $1 AND i.id = $2
+           LIMIT 1`,
+          [ctx.tenantId, id],
+        )
+        .then((r) => r.rows[0] ?? null);
+
+      if (!row) return null;
+
+      const edges = await c
+        .query(
+          `SELECT r.id, r.relationship_type, r.confidence, r.properties,
+                  src.entity_type AS source_type, src.entity_id AS source_eid, src.name AS source_name,
+                  tgt.entity_type AS target_type, tgt.entity_id AS target_eid, tgt.name AS target_name
+             FROM kg_relationships r
+             JOIN kg_entities src ON src.id = r.source_id
+             JOIN kg_entities tgt ON tgt.id = r.target_id
+            WHERE r.tenant_id = $1
+              AND (r.source_id = $2 OR r.target_id = $2)
+            ORDER BY r.confidence DESC, r.created_at DESC
+            LIMIT 50`,
+          [ctx.tenantId, id],
+        )
+        .then((r) => r.rows);
+
+      return {
+        component: {
+          id: row.id,
+          name: row.component_name,
+          canonical_name: row.canonical_name,
+          aliases: row.aliases ?? [],
+          asset_id: row.asset_id,
+          installed_location: row.installed_location,
+          panel: row.panel,
+          terminal: row.terminal,
+          wire_number: row.wire_number,
+          plc_tag: row.plc_tag,
+          mqtt_topic: row.mqtt_topic,
+          uns_path: row.uns_path,
+          human_confirmed: row.human_confirmed,
+          confidence: row.confidence,
+          notes: row.notes,
+        },
+        template: row.template_id
+          ? {
+              id: row.template_id,
+              category: row.component_category,
+              type: row.component_type,
+              manufacturer: row.manufacturer,
+              model: row.model,
+              description: row.description,
+              power_specs: row.power_specs,
+              input_output_specs: row.input_output_specs,
+              signal_behavior: row.signal_behavior,
+              connector_type: row.connector_type,
+              pinout: row.pinout,
+              environmental_limits: row.environmental_limits,
+              diagnostic_indicators: row.diagnostic_indicators,
+              expected_signals: row.expected_signals,
+              common_failure_modes: row.common_failure_modes,
+              troubleshooting_steps: row.troubleshooting_steps,
+              pm_checks: row.pm_checks,
+              safety_notes: row.safety_notes,
+              verification_status: row.template_verification_status,
+            }
+          : null,
+        edges: edges.map((e: Record<string, unknown>) => ({
+          id: e.id,
+          type: e.relationship_type,
+          confidence: e.confidence,
+          direction: e.source_eid === row.id ? "out" : "in",
+          source: { type: e.source_type, entity_id: e.source_eid, name: e.source_name },
+          target: { type: e.target_type, entity_id: e.target_eid, name: e.target_name },
+          properties: e.properties,
+        })),
+      };
+    });
+
+    if (!result) {
+      return NextResponse.json({ error: "Component not found" }, { status: 404 });
+    }
+    return NextResponse.json(result);
+  } catch (err) {
+    console.error("[api/components/[id] GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/demo/customer/route.ts
+++ b/mira-hub/src/app/api/demo/customer/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo, isDemoTenant } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/demo/customer
+ *
+ * Returns the demo asset tree for the tablet's entry page:
+ *   { tenant, sites: [{ id, name, areas: [{ id, name, lines: [{ id, name,
+ *     equipment: [{ id, name, asset_tag, components: [...] }] }] }] }] }
+ *
+ * Reads from kg_entities (UNS hierarchy) + installed_component_instances.
+ * Single-round-trip; demo-grade — no pagination, no caching.
+ */
+export async function GET(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+  if (!isDemoTenant(ctx.tenantId)) {
+    return NextResponse.json(
+      { error: "Demo tree only available for the demo tenant" },
+      { status: 403 },
+    );
+  }
+
+  try {
+    const tree = await withTenantContext(ctx.tenantId, async (c) => {
+      const ents = await c.query(
+        `SELECT id, entity_type, entity_id, name, uns_path::text AS uns_path, properties
+           FROM kg_entities
+          WHERE tenant_id = $1
+            AND entity_type IN ('tenant','site','area','line','equipment','component')
+          ORDER BY uns_path`,
+        [ctx.tenantId],
+      );
+
+      const components = await c.query(
+        `SELECT i.id, i.component_name, i.canonical_name, i.aliases, i.asset_id,
+                i.plc_tag, i.mqtt_topic, i.uns_path::text AS uns_path,
+                t.manufacturer, t.model, t.component_category
+           FROM installed_component_instances i
+           LEFT JOIN component_templates t ON t.id = i.template_id
+          WHERE i.tenant_id = $1
+          ORDER BY i.uns_path`,
+        [ctx.tenantId],
+      );
+
+      return { entities: ents.rows, components: components.rows };
+    });
+
+    const byType = new Map<string, Array<Record<string, unknown>>>();
+    for (const r of tree.entities) {
+      const t = r.entity_type as string;
+      if (!byType.has(t)) byType.set(t, []);
+      byType.get(t)!.push(r as Record<string, unknown>);
+    }
+
+    const sites = (byType.get("site") ?? []).map((s) => ({
+      id: s.id,
+      name: s.name,
+      areas: (byType.get("area") ?? [])
+        .filter((a) => (a.uns_path as string).startsWith((s.uns_path as string) + "."))
+        .map((a) => ({
+          id: a.id,
+          name: a.name,
+          lines: (byType.get("line") ?? [])
+            .filter((l) => (l.uns_path as string).startsWith((a.uns_path as string) + "."))
+            .map((l) => ({
+              id: l.id,
+              name: l.name,
+              equipment: (byType.get("equipment") ?? [])
+                .filter((e) => (e.uns_path as string).startsWith((l.uns_path as string) + "."))
+                .map((e) => ({
+                  id: e.id,
+                  name: e.name,
+                  asset_tag:
+                    (e.properties as Record<string, unknown> | null)?.asset_tag ??
+                    null,
+                  uns_path: e.uns_path,
+                  components: (tree.components as Array<Record<string, unknown>>)
+                    .filter((cmp) => cmp.asset_id === e.id)
+                    .map((cmp) => ({
+                      id: cmp.id,
+                      name: cmp.component_name,
+                      canonical_name: cmp.canonical_name,
+                      aliases: cmp.aliases ?? [],
+                      manufacturer: cmp.manufacturer,
+                      model: cmp.model,
+                      category: cmp.component_category,
+                      plc_tag: cmp.plc_tag,
+                      mqtt_topic: cmp.mqtt_topic,
+                      uns_path: cmp.uns_path,
+                    })),
+                })),
+            })),
+        })),
+    }));
+
+    return NextResponse.json({
+      tenant: byType.get("tenant")?.[0] ?? { id: ctx.tenantId, name: "Demo" },
+      sites,
+    });
+  } catch (err) {
+    console.error("[api/demo/customer GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/demo/signals/events/route.ts
+++ b/mira-hub/src/app/api/demo/signals/events/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo, isDemoTenant } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/demo/signals/events?component_id=&limit=&since=
+ *
+ * Append-only signal event history for the demo tenant. The tablet polls
+ * this every 1–2 s while a session is open so the "live signal" card on the
+ * conveyor demo updates in near-real-time without a WebSocket.
+ *
+ * Filters:
+ *   - component_id (UUID): scope to one component
+ *   - since (ISO8601): only events after this timestamp
+ *   - limit (default 50, max 500)
+ */
+export async function GET(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+  if (!isDemoTenant(ctx.tenantId)) {
+    return NextResponse.json(
+      { error: "Signal events feed is demo-tenant only" },
+      { status: 403 },
+    );
+  }
+
+  const url = new URL(req.url);
+  const componentId = url.searchParams.get("component_id");
+  const since = url.searchParams.get("since");
+  const limit = Math.min(500, Math.max(1, Number(url.searchParams.get("limit") ?? "50")));
+
+  const where: string[] = [`e.tenant_id = $1`];
+  const params: unknown[] = [ctx.tenantId];
+
+  if (componentId) {
+    params.push(componentId);
+    where.push(`e.component_id = $${params.length}`);
+  }
+  if (since) {
+    params.push(since);
+    where.push(`e.created_at > $${params.length}`);
+  }
+
+  try {
+    const rows = await withTenantContext<Record<string, unknown>[]>(ctx.tenantId, (c) =>
+      c
+        .query(
+          `SELECT e.id, e.component_id, e.plc_tag, e.value_text, e.value_numeric,
+                  e.value_bool, e.simulated, e.source, e.properties, e.created_at,
+                  i.component_name
+             FROM live_signal_events e
+             LEFT JOIN installed_component_instances i ON i.id = e.component_id
+            WHERE ${where.join(" AND ")}
+            ORDER BY e.created_at DESC
+            LIMIT ${limit}`,
+          params,
+        )
+        .then((r: { rows: Record<string, unknown>[] }) => r.rows),
+    );
+
+    return NextResponse.json(
+      {
+        events: rows.map((r: Record<string, unknown>) => ({
+          id: r.id,
+          component_id: r.component_id,
+          component_name: r.component_name,
+          plc_tag: r.plc_tag,
+          value: r.value_text ?? r.value_numeric ?? r.value_bool ?? null,
+          simulated: r.simulated,
+          source: r.source,
+          properties: r.properties,
+          ts: r.created_at,
+        })),
+        count: rows.length,
+      },
+      {
+        headers: { "Cache-Control": "no-store" },
+      },
+    );
+  } catch (err) {
+    console.error("[api/demo/signals/events GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/demo/signals/toggle/route.ts
+++ b/mira-hub/src/app/api/demo/signals/toggle/route.ts
@@ -1,0 +1,129 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo, isDemoTenant } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+interface TogglePayload {
+  component_id: string;
+  state?: "present" | "clear" | "auto";    // discrete sensor states
+  value_text?: string;
+  value_numeric?: number;
+  value_bool?: boolean;
+  source?: string;
+  notes?: string;
+}
+
+/**
+ * POST /api/demo/signals/toggle
+ *
+ * Push a synthetic signal sample into live_signal_events. The tablet uses
+ * this to drive the demo (e.g. simulate a tote interrupting PE-001) without
+ * needing a real MQTT broker on the expo floor.
+ *
+ * If `state` is supplied (preferred for discrete sensors), it maps:
+ *   - "present" → value_text='item_present', value_bool=true
+ *   - "clear"   → value_text='idle_clear',   value_bool=false
+ *   - "auto"    → invert the most recent reading for this component
+ *
+ * Otherwise you can pass value_text / value_numeric / value_bool directly.
+ *
+ * Demo-only: tenant must be the demo tenant. Returns the created event.
+ */
+export async function POST(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+  if (!isDemoTenant(ctx.tenantId)) {
+    return NextResponse.json(
+      { error: "Signal simulator is demo-tenant only" },
+      { status: 403 },
+    );
+  }
+
+  let body: TogglePayload;
+  try {
+    body = (await req.json()) as TogglePayload;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (!body.component_id) {
+    return NextResponse.json({ error: "component_id_required" }, { status: 400 });
+  }
+
+  try {
+    const row = await withTenantContext<Record<string, unknown>>(ctx.tenantId, async (c) => {
+      const cmp = await c
+        .query(
+          `SELECT id, plc_tag FROM installed_component_instances
+            WHERE tenant_id = $1 AND id = $2
+            LIMIT 1`,
+          [ctx.tenantId, body.component_id],
+        )
+        .then((r: { rows: Record<string, unknown>[] }) => r.rows[0] ?? null);
+      if (!cmp) {
+        throw Object.assign(new Error("component_not_found"), { status: 404 });
+      }
+
+      let valueText = body.value_text ?? null;
+      let valueNumeric = body.value_numeric ?? null;
+      let valueBool = body.value_bool ?? null;
+
+      if (body.state) {
+        if (body.state === "present") {
+          valueText = "item_present"; valueBool = true;
+        } else if (body.state === "clear") {
+          valueText = "idle_clear"; valueBool = false;
+        } else if (body.state === "auto") {
+          const last = await c
+            .query(
+              `SELECT value_bool, value_text FROM live_signal_events
+                WHERE tenant_id = $1 AND component_id = $2
+                ORDER BY created_at DESC LIMIT 1`,
+              [ctx.tenantId, body.component_id],
+            )
+            .then((r: { rows: Record<string, unknown>[] }) => r.rows[0] ?? null);
+          const wasPresent = last?.value_bool === true || last?.value_text === "item_present";
+          valueText = wasPresent ? "idle_clear" : "item_present";
+          valueBool = !wasPresent;
+        }
+      }
+
+      if (valueText === null && valueNumeric === null && valueBool === null) {
+        throw Object.assign(new Error("no_value_supplied"), { status: 400 });
+      }
+
+      const inserted = await c
+        .query(
+          `INSERT INTO live_signal_events
+             (tenant_id, component_id, plc_tag, value_text, value_numeric, value_bool,
+              simulated, source, properties)
+           VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8::jsonb)
+           RETURNING id, component_id, plc_tag, value_text, value_numeric, value_bool,
+                     simulated, source, properties, created_at`,
+          [
+            ctx.tenantId,
+            body.component_id,
+            cmp.plc_tag,
+            valueText,
+            valueNumeric,
+            valueBool,
+            body.source ?? "demo_simulator",
+            JSON.stringify(body.notes ? { notes: body.notes } : {}),
+          ],
+        )
+        .then((r: { rows: Record<string, unknown>[] }) => r.rows[0]);
+
+      return inserted;
+    });
+
+    return NextResponse.json({ event: row }, { status: 201 });
+  } catch (err) {
+    const status = (err as { status?: number }).status ?? 500;
+    const msg = err instanceof Error ? err.message : "toggle_failed";
+    if (status === 500) console.error("[api/demo/signals/toggle POST]", err);
+    return NextResponse.json({ error: msg }, { status });
+  }
+}

--- a/mira-hub/src/app/api/documents/route.ts
+++ b/mira-hub/src/app/api/documents/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo } from "@/lib/demo-auth";
+import pool from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/documents?asset_id=&manufacturer=&limit=
+ *
+ * Returns the document list (one row per source_url) for the tenant — manuals,
+ * datasheets, prints already ingested into knowledge_entries. Filters:
+ *   - asset_id: scope to docs matching the asset's manufacturer/model
+ *   - manufacturer: scope to a specific manufacturer
+ *   - limit (default 50, max 200)
+ *
+ * Matches the rollup pattern in /api/library/documents but joins through
+ * cmms_equipment when asset_id is supplied. Unlike /api/knowledge (cross-
+ * tenant universal corpus), this endpoint stays scoped to the caller's
+ * tenant so the tablet sees only the demo customer's library.
+ */
+export async function GET(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+
+  const url = new URL(req.url);
+  const assetId = url.searchParams.get("asset_id");
+  const mfrFilter = (url.searchParams.get("manufacturer") ?? "").trim();
+  const limit = Math.min(200, Math.max(1, Number(url.searchParams.get("limit") ?? "50")));
+
+  try {
+    let mfr = mfrFilter;
+    let model = "";
+    if (assetId) {
+      const asset = await pool
+        .query(
+          `SELECT manufacturer, model_number FROM cmms_equipment WHERE id = $1 LIMIT 1`,
+          [assetId],
+        )
+        .then((r: { rows: Record<string, unknown>[] }) => r.rows[0] ?? null);
+      if (asset) {
+        mfr = mfr || ((asset.manufacturer as string | null) ?? "");
+        model = (asset.model_number as string | null) ?? "";
+      }
+    }
+
+    const where: string[] = [];
+    const params: unknown[] = [];
+    if (mfr) {
+      params.push(mfr);
+      where.push(`LOWER(manufacturer) = LOWER($${params.length})`);
+    }
+    if (model) {
+      params.push(model);
+      where.push(`model_number ILIKE '%' || $${params.length} || '%'`);
+    }
+
+    const sql = `
+      SELECT source_url,
+             MIN(equipment_type) AS equipment_type,
+             MIN(manufacturer)   AS manufacturer,
+             MIN(model_number)   AS model_number,
+             COUNT(*)::int       AS chunk_count,
+             MAX(created_at)     AS last_indexed,
+             BOOL_OR(verified)   AS verified
+        FROM knowledge_entries
+        ${where.length ? "WHERE " + where.join(" AND ") : ""}
+       GROUP BY source_url
+       ORDER BY MAX(created_at) DESC NULLS LAST
+       LIMIT ${limit}`;
+
+    const rows = await pool
+      .query(sql, params)
+      .then((r: { rows: Record<string, unknown>[] }) => r.rows);
+
+    return NextResponse.json({
+      documents: rows.map((r: Record<string, unknown>) => ({
+        source_url: r.source_url,
+        title: ((r.source_url as string) || "").split("/").pop()?.split("?")[0] ?? r.source_url,
+        manufacturer: r.manufacturer,
+        model_number: r.model_number,
+        equipment_type: r.equipment_type,
+        chunk_count: r.chunk_count,
+        last_indexed: r.last_indexed,
+        verified: r.verified ?? false,
+      })),
+    });
+  } catch (err) {
+    console.error("[api/documents GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/documents/upload/route.ts
+++ b/mira-hub/src/app/api/documents/upload/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+interface DemoUploadPayload {
+  filename: string;
+  mime_type?: string;
+  size_bytes?: number;
+  source_url?: string;          // signed URL or public link
+  asset_id?: string;
+  asset_tag?: string;
+  manufacturer?: string;
+  model?: string;
+  excerpt?: string;             // optional inline text (≤ 2000 chars for demo)
+}
+
+/**
+ * POST /api/documents/upload
+ *
+ * Demo upload entry point for the tablet. Accepts a JSON payload with a
+ * source_url (Google Drive / Dropbox / signed S3) or an inline excerpt, and
+ * registers it in `knowledge_entries` as a single chunk so it surfaces
+ * immediately in /api/documents and /api/assets/[id]/documents.
+ *
+ * This is NOT the full ingest pipeline — production uploads still go through
+ * /api/uploads which kicks off OCR + chunk + embed + verify. For the May 21
+ * demo we just need the tablet to drop a PDF link and see it show up in the
+ * library card; deep ingest can happen later.
+ *
+ * Returns 201 with `{document_id, source_url, status:'registered'}`.
+ */
+export async function POST(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+
+  let body: DemoUploadPayload;
+  try {
+    body = (await req.json()) as DemoUploadPayload;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (!body.filename) {
+    return NextResponse.json({ error: "filename_required" }, { status: 400 });
+  }
+  if (!body.source_url && !body.excerpt) {
+    return NextResponse.json(
+      { error: "source_url_or_excerpt_required" },
+      { status: 400 },
+    );
+  }
+
+  const excerpt = (body.excerpt ?? "").slice(0, 2000);
+  const sourceUrl = body.source_url ?? `demo://upload/${encodeURIComponent(body.filename)}`;
+
+  try {
+    const id = await withTenantContext<string>(ctx.tenantId, async (c) => {
+      const result = await c.query(
+        `INSERT INTO knowledge_entries
+           (tenant_id, source_url, manufacturer, model_number, equipment_type, content)
+         VALUES ($1, $2, $3, $4, $5, $6)
+         RETURNING id`,
+        [
+          ctx.tenantId,
+          sourceUrl,
+          body.manufacturer ?? null,
+          body.model ?? null,
+          null,
+          excerpt || `[Demo placeholder — ${body.filename}]`,
+        ],
+      );
+      return (result.rows[0]?.id as string) ?? "";
+    });
+
+    return NextResponse.json(
+      {
+        document_id: id,
+        source_url: sourceUrl,
+        status: "registered",
+        note: "Demo registration only. Production ingest goes through /api/uploads.",
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    console.error("[api/documents/upload POST]", err);
+    return NextResponse.json({ error: "Insert failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/mira/ask/route.ts
+++ b/mira-hub/src/app/api/mira/ask/route.ts
@@ -1,0 +1,267 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+import { cascadeComplete, type CascadeMessage } from "@/lib/llm/cascade";
+
+export const dynamic = "force-dynamic";
+
+interface AskPayload {
+  session_id: string;
+  question: string;
+}
+
+interface SessionRow {
+  id: string;
+  status: string;
+  asset_id: string | null;
+  component_id: string | null;
+  transcript: Array<{ role: string; content: string; ts?: string }>;
+  asset_name: string | null;
+  asset_tag: string | null;
+  component_name: string | null;
+  component_plc_tag: string | null;
+}
+
+/**
+ * POST /api/mira/ask
+ *
+ * Hard rule: no confirmed namespace context, no troubleshooting.
+ * If session.status != 'confirmed' OR asset_id is missing, returns 412
+ * (Precondition Required) with `{gate: "namespace", reason}` so the tablet
+ * can show the confirmation card instead of an answer.
+ *
+ * On success, runs the Groq → Cerebras → Gemini cascade with a context
+ * package built from the KG (asset + component template + recent signals
+ * + verified relationships), appends both turns to the transcript, and
+ * returns `{answer, citations, provider, session_id}`.
+ *
+ * Demo-grade: no streaming, no SSE. Tablet shows a typing indicator while
+ * this runs (~2–5 s typical).
+ */
+export async function POST(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+
+  let body: AskPayload;
+  try {
+    body = (await req.json()) as AskPayload;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (!body.session_id || !body.question || typeof body.question !== "string") {
+    return NextResponse.json(
+      { error: "session_id_and_question_required" },
+      { status: 400 },
+    );
+  }
+
+  // ── 1. Load session + enforce the gate ────────────────────────────────
+  const session = await withTenantContext<SessionRow | null>(ctx.tenantId, (c) =>
+    c
+      .query(
+        `SELECT s.id, s.status, s.asset_id, s.component_id, s.transcript,
+                a.name AS asset_name, a.entity_id AS asset_tag,
+                i.component_name, i.plc_tag AS component_plc_tag
+           FROM troubleshooting_sessions s
+           LEFT JOIN kg_entities a ON a.id = s.asset_id
+           LEFT JOIN installed_component_instances i ON i.id = s.component_id
+          WHERE s.tenant_id = $1 AND s.id = $2
+          LIMIT 1`,
+        [ctx.tenantId, body.session_id],
+      )
+      .then((r: { rows: SessionRow[] }) => r.rows[0] ?? null),
+  );
+
+  if (!session) {
+    return NextResponse.json({ error: "session_not_found" }, { status: 404 });
+  }
+  if (session.status !== "confirmed" || !session.asset_id) {
+    return NextResponse.json(
+      {
+        gate: "namespace",
+        reason:
+          "Confirm the asset (and component, if known) before troubleshooting. POST /api/sessions/confirm first.",
+        session_id: session.id,
+        current_status: session.status,
+      },
+      { status: 412 },
+    );
+  }
+
+  // ── 2. Build grounding context ────────────────────────────────────────
+  const grounding = await withTenantContext(ctx.tenantId, async (c) => {
+    const asset = session.asset_id;
+    const component = session.component_id;
+
+    const components = await c
+      .query(
+        `SELECT i.id, i.component_name, i.canonical_name, i.plc_tag, i.installed_location,
+                t.manufacturer, t.model, t.common_failure_modes, t.troubleshooting_steps,
+                t.signal_behavior
+           FROM installed_component_instances i
+           LEFT JOIN component_templates t ON t.id = i.template_id
+          WHERE i.tenant_id = $1 AND i.asset_id = $2
+          ORDER BY i.component_name`,
+        [ctx.tenantId, asset],
+      )
+      .then((r: { rows: Record<string, unknown>[] }) => r.rows);
+
+    const edges = await c
+      .query(
+        `SELECT r.relationship_type, r.confidence,
+                src.entity_type AS s_type, src.name AS s_name,
+                tgt.entity_type AS t_type, tgt.name AS t_name
+           FROM kg_relationships r
+           JOIN kg_entities src ON src.id = r.source_id
+           JOIN kg_entities tgt ON tgt.id = r.target_id
+          WHERE r.tenant_id = $1
+            AND (r.source_id = $2 OR r.target_id = $2 OR r.source_id = ANY($3::uuid[]))
+          ORDER BY r.confidence DESC
+          LIMIT 30`,
+        [ctx.tenantId, asset, components.map((cmp: Record<string, unknown>) => cmp.id)],
+      )
+      .then((r: { rows: Record<string, unknown>[] }) => r.rows);
+
+    const recentSignals = await c
+      .query(
+        `SELECT e.created_at, e.value_text, e.value_numeric, e.value_bool,
+                e.simulated, i.component_name, i.plc_tag
+           FROM live_signal_events e
+           JOIN installed_component_instances i ON i.id = e.component_id
+          WHERE e.tenant_id = $1 AND i.asset_id = $2
+          ORDER BY e.created_at DESC
+          LIMIT 10`,
+        [ctx.tenantId, asset],
+      )
+      .then((r: { rows: Record<string, unknown>[] }) => r.rows);
+
+    return { components, edges, recentSignals, focusComponentId: component };
+  });
+
+  // ── 3. Compose system prompt with citations available to model ────────
+  const focusCmp = (grounding.components as Array<Record<string, unknown>>).find(
+    (cmp) => cmp.id === grounding.focusComponentId,
+  );
+
+  const citationItems: Array<{ id: string; label: string }> = [];
+  let citationCounter = 1;
+  function cite(label: string): string {
+    const id = `[C${citationCounter++}]`;
+    citationItems.push({ id, label });
+    return id;
+  }
+
+  const lines: string[] = [
+    `You are MIRA, an industrial maintenance diagnostic assistant. You are talking to a technician on a tablet at the equipment.`,
+    ``,
+    `## Asset in scope (confirmed)`,
+    `- Name: ${session.asset_name ?? "—"}`,
+    `- Asset tag: ${session.asset_tag ?? "—"} ${cite(`asset row ${session.asset_id}`)}`,
+  ];
+  if (focusCmp) {
+    lines.push(
+      `- Focus component: ${focusCmp.component_name as string} (${(focusCmp.manufacturer as string) ?? "—"} ${(focusCmp.model as string) ?? ""}) ${cite(`component row ${focusCmp.id as string}`)}`,
+      `- PLC tag: ${(focusCmp.plc_tag as string) ?? "—"}`,
+    );
+    const tsteps = focusCmp.troubleshooting_steps as Array<Record<string, unknown>> | null;
+    if (tsteps && Array.isArray(tsteps) && tsteps.length > 0) {
+      lines.push(`- Troubleshooting steps for this component ${cite(`component_template.troubleshooting_steps`)}:`);
+      for (const step of tsteps.slice(0, 8)) {
+        lines.push(`  ${step.step ?? "?"}. ${step.action ?? ""}`);
+      }
+    }
+    const failures = focusCmp.common_failure_modes as Array<Record<string, unknown>> | null;
+    if (failures && Array.isArray(failures) && failures.length > 0) {
+      lines.push(`- Known failure modes ${cite(`component_template.common_failure_modes`)}:`);
+      for (const f of failures.slice(0, 6)) {
+        lines.push(`  • ${f.mode ?? ""}: ${f.symptom ?? ""} (${f.severity ?? ""})`);
+      }
+    }
+  }
+  lines.push(``, `## Components on this asset`);
+  for (const cmp of grounding.components as Array<Record<string, unknown>>) {
+    lines.push(
+      `- ${cmp.component_name as string}` +
+        (cmp.plc_tag ? ` → PLC tag ${cmp.plc_tag as string}` : "") +
+        (cmp.manufacturer ? ` [${cmp.manufacturer as string} ${(cmp.model as string) ?? ""}]` : ""),
+    );
+  }
+  if (grounding.edges.length > 0) {
+    lines.push(``, `## Verified relationships (from knowledge graph)`);
+    for (const e of grounding.edges.slice(0, 20)) {
+      lines.push(
+        `- (${(e.s_type as string)}) ${(e.s_name as string)} —${(e.relationship_type as string)}→ (${(e.t_type as string)}) ${(e.t_name as string)} [conf ${Number(e.confidence).toFixed(2)}]`,
+      );
+    }
+  }
+  if (grounding.recentSignals.length > 0) {
+    lines.push(``, `## Recent signal samples (last 10) ${cite(`live_signal_events`)}`);
+    for (const s of grounding.recentSignals as Array<Record<string, unknown>>) {
+      const val = s.value_text ?? s.value_numeric ?? s.value_bool;
+      lines.push(`- ${s.created_at as string} | ${s.component_name as string} (${s.plc_tag as string}) = ${String(val)}${s.simulated ? " [SIM]" : ""}`);
+    }
+  }
+  lines.push(
+    ``,
+    `## Instructions`,
+    `- Answer using only the asset/component/signal/relationship context above. If the answer isn't supported by that context, say so explicitly.`,
+    `- Cite which row in the context backs each factual claim using the [C1], [C2], ... markers shown.`,
+    `- For safety-critical work (LOTO, arc flash, confined space, electrical), instruct the tech to follow site safety procedures before touching anything.`,
+    `- Keep answers under 6 short sentences. Techs are at the equipment.`,
+  );
+
+  const systemPrompt = lines.join("\n");
+
+  // ── 4. Call cascade ───────────────────────────────────────────────────
+  const messages: CascadeMessage[] = [
+    { role: "system", content: systemPrompt },
+    ...session.transcript
+      .filter((t) => t.role === "user" || t.role === "assistant")
+      .slice(-6)
+      .map((t) => ({ role: t.role as "user" | "assistant", content: t.content })),
+    { role: "user", content: body.question },
+  ];
+
+  const result = await cascadeComplete(messages, { temperature: 0.2, maxTokens: 500, timeoutMs: 20_000 });
+
+  if (!result) {
+    return NextResponse.json(
+      {
+        error: "all_providers_unavailable",
+        gate: "provider_outage",
+      },
+      { status: 503 },
+    );
+  }
+
+  // ── 5. Append to transcript ───────────────────────────────────────────
+  const userTurn = { role: "user", content: body.question, ts: new Date().toISOString() };
+  const assistantTurn = {
+    role: "assistant",
+    content: result.content,
+    ts: new Date().toISOString(),
+    provider: result.provider,
+    citations: citationItems,
+  };
+
+  await withTenantContext(ctx.tenantId, (c) =>
+    c.query(
+      `UPDATE troubleshooting_sessions
+          SET transcript = transcript || $3::jsonb,
+              updated_at = now()
+        WHERE tenant_id = $1 AND id = $2`,
+      [ctx.tenantId, session.id, JSON.stringify([userTurn, assistantTurn])],
+    ),
+  );
+
+  return NextResponse.json({
+    session_id: session.id,
+    answer: result.content,
+    provider: result.provider,
+    duration_ms: result.durationMs,
+    citations: citationItems,
+  });
+}

--- a/mira-hub/src/app/api/sessions/[id]/route.ts
+++ b/mira-hub/src/app/api/sessions/[id]/route.ts
@@ -1,0 +1,71 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/sessions/[id]
+ *
+ * Load a troubleshooting session by ID. Returns full transcript + context.
+ * Tablet uses this to resume an in-flight session after a reload.
+ */
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+
+  try {
+    const row = await withTenantContext<Record<string, unknown> | null>(ctx.tenantId, (c) =>
+      c
+        .query(
+          `SELECT s.id, s.tenant_id, s.asset_id, s.component_id, s.technician_user_id,
+                  s.channel, s.status, s.confirmed_at, s.resolved_at,
+                  s.transcript, s.metadata, s.created_at, s.updated_at,
+                  a.name AS asset_name, a.entity_id AS asset_tag_canonical,
+                  i.component_name, i.plc_tag
+             FROM troubleshooting_sessions s
+             LEFT JOIN kg_entities a ON a.id = s.asset_id
+             LEFT JOIN installed_component_instances i ON i.id = s.component_id
+            WHERE s.tenant_id = $1 AND s.id = $2
+            LIMIT 1`,
+          [ctx.tenantId, id],
+        )
+        .then((r: { rows: Record<string, unknown>[] }) => r.rows[0] ?? null),
+    );
+
+    if (!row) {
+      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      session: {
+        id: row.id,
+        status: row.status,
+        channel: row.channel,
+        asset: row.asset_id
+          ? { id: row.asset_id, name: row.asset_name, tag: row.asset_tag_canonical }
+          : null,
+        component: row.component_id
+          ? { id: row.component_id, name: row.component_name, plc_tag: row.plc_tag }
+          : null,
+        confirmed_at: row.confirmed_at,
+        resolved_at: row.resolved_at,
+        transcript: row.transcript ?? [],
+        metadata: row.metadata ?? {},
+        created_at: row.created_at,
+        updated_at: row.updated_at,
+      },
+    });
+  } catch (err) {
+    console.error("[api/sessions/[id] GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/sessions/confirm/route.ts
+++ b/mira-hub/src/app/api/sessions/confirm/route.ts
@@ -1,0 +1,148 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+interface ConfirmPayload {
+  session_id?: string;
+  asset_id: string;
+  component_id?: string;
+  channel?: "tablet" | "slack" | "telegram" | "web" | "other";
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * POST /api/sessions/confirm
+ *
+ * The UNS Confirmation Gate — flips a session to status='confirmed' once the
+ * technician has acknowledged the asset/component context. Without a row in
+ * `confirmed` status, /api/mira/ask refuses to invoke the LLM.
+ *
+ * If session_id is supplied, the existing row is updated. Otherwise a new
+ * session is created. The endpoint validates that asset_id points at a real
+ * kg_entities row in the same tenant before flipping the gate.
+ */
+export async function POST(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+
+  let body: ConfirmPayload;
+  try {
+    body = (await req.json()) as ConfirmPayload;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  if (!body.asset_id) {
+    return NextResponse.json(
+      { error: "asset_id_required", reason: "Namespace gate requires a confirmed asset." },
+      { status: 400 },
+    );
+  }
+
+  const channel = body.channel ?? "tablet";
+
+  try {
+    const row = await withTenantContext<Record<string, unknown>>(ctx.tenantId, async (c) => {
+      const asset = await c
+        .query(
+          `SELECT id FROM kg_entities
+            WHERE tenant_id = $1 AND id = $2 AND entity_type = 'equipment'
+            LIMIT 1`,
+          [ctx.tenantId, body.asset_id],
+        )
+        .then((r: { rows: Record<string, unknown>[] }) => r.rows[0] ?? null);
+
+      if (!asset) {
+        throw Object.assign(new Error("asset_not_found"), { status: 404 });
+      }
+
+      if (body.component_id) {
+        const cmp = await c
+          .query(
+            `SELECT id FROM installed_component_instances
+              WHERE tenant_id = $1 AND id = $2 AND asset_id = $3
+              LIMIT 1`,
+            [ctx.tenantId, body.component_id, body.asset_id],
+          )
+          .then((r: { rows: Record<string, unknown>[] }) => r.rows[0] ?? null);
+        if (!cmp) {
+          throw Object.assign(new Error("component_not_on_asset"), { status: 400 });
+        }
+      }
+
+      if (body.session_id) {
+        const updated = await c
+          .query(
+            `UPDATE troubleshooting_sessions
+                SET asset_id = $3,
+                    component_id = $4,
+                    channel = $5,
+                    metadata = COALESCE($6::jsonb, metadata),
+                    status = 'confirmed',
+                    confirmed_at = COALESCE(confirmed_at, now()),
+                    updated_at = now()
+              WHERE tenant_id = $1 AND id = $2
+              RETURNING *`,
+            [
+              ctx.tenantId,
+              body.session_id,
+              body.asset_id,
+              body.component_id ?? null,
+              channel,
+              body.metadata ? JSON.stringify(body.metadata) : null,
+            ],
+          )
+          .then((r: { rows: Record<string, unknown>[] }) => r.rows[0] ?? null);
+        if (!updated) {
+          throw Object.assign(new Error("session_not_found"), { status: 404 });
+        }
+        return updated;
+      }
+
+      const created = await c
+        .query(
+          `INSERT INTO troubleshooting_sessions
+             (tenant_id, asset_id, component_id, technician_user_id,
+              channel, status, confirmed_at, metadata)
+           VALUES ($1, $2, $3, $4, $5, 'confirmed', now(), COALESCE($6::jsonb, '{}'::jsonb))
+           RETURNING *`,
+          [
+            ctx.tenantId,
+            body.asset_id,
+            body.component_id ?? null,
+            ctx.userId,
+            channel,
+            body.metadata ? JSON.stringify(body.metadata) : null,
+          ],
+        )
+        .then((r: { rows: Record<string, unknown>[] }) => r.rows[0]);
+
+      return created;
+    });
+
+    return NextResponse.json(
+      {
+        session: {
+          id: row.id,
+          status: row.status,
+          asset_id: row.asset_id,
+          component_id: row.component_id,
+          channel: row.channel,
+          confirmed_at: row.confirmed_at,
+          created_at: row.created_at,
+        },
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    const status = (err as { status?: number }).status ?? 500;
+    const msg = err instanceof Error ? err.message : "confirm_failed";
+    if (status === 500) console.error("[api/sessions/confirm POST]", err);
+    return NextResponse.json({ error: msg }, { status });
+  }
+}

--- a/mira-hub/src/lib/demo-auth.ts
+++ b/mira-hub/src/lib/demo-auth.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { sessionOr401, type SessionContext } from "@/lib/session";
+
+/**
+ * Demo bearer-token fallback for the tablet UI.
+ *
+ * The May 21 demo runs on a public iPad at an expo booth — no Hub login flow.
+ * If `Authorization: Bearer ${DEMO_API_TOKEN}` matches, we hydrate a synthetic
+ * session pointing at the demo tenant. Otherwise we defer to `sessionOr401`,
+ * keeping every endpoint usable from a normal authenticated Hub session.
+ *
+ * Demo tenant UUID is hard-coded; matches `tools/seeds/demo-conveyor-001.sql`.
+ */
+
+export const DEMO_TENANT_ID = "00000000-0000-0000-0000-0000000000d1";
+export const DEMO_USER_ID = "00000000-0000-0000-0000-0000000000ff";
+
+function demoToken(): string | null {
+  return process.env.DEMO_API_TOKEN?.trim() || null;
+}
+
+function extractBearer(req: Request): string | null {
+  const h = req.headers.get("authorization") ?? "";
+  const m = /^Bearer\s+(.+)$/i.exec(h.trim());
+  return m ? m[1].trim() : null;
+}
+
+export interface DemoOrSessionContext extends SessionContext {
+  isDemo: boolean;
+}
+
+/**
+ * Resolve a session context that may be either a real next-auth session or a
+ * demo bearer token. Returns a 401 NextResponse if neither resolves.
+ *
+ *   const ctx = await sessionOrDemo(req);
+ *   if (ctx instanceof NextResponse) return ctx;
+ *   // ctx.tenantId, ctx.userId, ctx.isDemo
+ */
+export async function sessionOrDemo(
+  req: Request,
+): Promise<DemoOrSessionContext | NextResponse> {
+  const token = demoToken();
+  const bearer = extractBearer(req);
+  if (token && bearer && bearer === token) {
+    return {
+      userId: DEMO_USER_ID,
+      tenantId: DEMO_TENANT_ID,
+      email: "demo@factorylm.com",
+      status: "trial",
+      trialExpiresAt: null,
+      isDemo: true,
+    };
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+  return { ...ctx, isDemo: false };
+}
+
+/**
+ * Same shape as `sessionOrDemo` but returns null instead of a 401 — for
+ * endpoints that have a public fallback (e.g. demo signals events).
+ */
+export async function sessionOrDemoOrNull(
+  req: Request,
+): Promise<DemoOrSessionContext | null> {
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return null;
+  return ctx;
+}
+
+export function isDemoTenant(tenantId: string): boolean {
+  return tenantId === DEMO_TENANT_ID;
+}

--- a/mira-scan-monday/backend/main.py
+++ b/mira-scan-monday/backend/main.py
@@ -442,8 +442,8 @@ async def monday_webhook(request: Request) -> dict[str, Any]:
     raw = await request.body()
     try:
         body = await request.json() if raw else {}
-    except Exception:
-        raise HTTPException(status_code=400, detail="invalid json body")
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail="invalid json body") from exc
     if not isinstance(body, dict):
         raise HTTPException(status_code=400, detail="body must be a json object")
 
@@ -452,5 +452,5 @@ async def monday_webhook(request: Request) -> dict[str, Any]:
         result = await webhooks.handle_event(authorization_header=auth, body=body)
     except webhooks.WebhookInvalid as exc:
         logger.warning("webhook signature invalid: %s", exc)
-        raise HTTPException(status_code=401, detail="invalid webhook signature")
+        raise HTTPException(status_code=401, detail="invalid webhook signature") from exc
     return result

--- a/tools/seeds/README.md
+++ b/tools/seeds/README.md
@@ -1,0 +1,74 @@
+# Demo Seeds
+
+Loaders for tenant-scoped demo data. Each seed targets a single, well-known
+tenant UUID so it can be applied to dev or prod without touching real customers.
+
+| File | Tenant | Asset | What it seeds |
+|---|---|---|---|
+| `demo-conveyor-001.sql` | `00000000-0000-0000-0000-0000000000d1` ("demo") | Conveyor 001 (`CV-001`) | 5 components (PE/MTR/VFD/PLC/PANEL), PE-001 full template, ISA-95 UNS paths, PLC tag bindings (4 entities), 12 verified relationship proposals + evidence, promoted into `kg_relationships` |
+| `run_demo_seed.py` | — | — | Python runner: `--dry-run` (rollback), `--commit`, `--verify` |
+
+## Prerequisites
+
+Migrations applied in this order before any seed runs:
+- `mira-hub/db/migrations/001_knowledge_graph.sql`
+- `mira-hub/db/migrations/010_kg_uns_path.sql`
+- `mira-hub/db/migrations/013_external_ids.sql`
+- `mira-hub/db/migrations/015_equipment_uns_path.sql`
+- `mira-hub/db/migrations/016_component_templates.sql`
+- `mira-hub/db/migrations/017_installed_component_instances.sql`
+- `mira-hub/db/migrations/018_relationship_proposals.sql`
+
+Verify against prod with:
+```bash
+gh workflow run apply-prod-migrations.yml
+```
+
+The `cmms_equipment` insert is wrapped in an exception handler — if the Atlas
+schema isn't present or its column shape differs, the seed logs a NOTICE and
+the rest of the data still lands (the `kg_entities` row covers the asset).
+
+## Apply
+
+```bash
+# Dry run (rollback after) — proves the SQL is valid against current schema
+doppler run --project factorylm --config prd -- \
+  python3 tools/seeds/run_demo_seed.py --dry-run
+
+# Commit
+doppler run --project factorylm --config prd -- \
+  python3 tools/seeds/run_demo_seed.py --commit
+
+# Verify counts post-apply
+doppler run --project factorylm --config prd -- \
+  python3 tools/seeds/run_demo_seed.py --verify
+```
+
+Expected on success:
+```
+✔ component_templates                                  5
+✔ installed_component_instances (demo tenant)          5
+✔ kg_entities (demo tenant)                           13
+✔ relationship_proposals (demo tenant)                12
+✔ relationship_evidence (demo tenant)                  6
+✔ kg_relationships (demo tenant)                      12
+```
+
+## Idempotency
+
+Every INSERT uses `ON CONFLICT DO NOTHING` keyed on a stable natural key
+(`(manufacturer, model, version)` for templates, `(tenant_id, entity_type, entity_id)`
+for KG entities, primary key for instances/proposals). Re-running the seed is a no-op.
+
+## UNS path
+
+```
+enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.{pe_001|mtr_001|vfd_001|plc_001|panel_001}
+```
+
+Query the demo subtree:
+```sql
+SELECT entity_type, entity_id, name FROM kg_entities
+WHERE uns_path <@ 'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001'::ltree
+ORDER BY uns_path;
+```

--- a/tools/seeds/demo-conveyor-001.sql
+++ b/tools/seeds/demo-conveyor-001.sql
@@ -1,0 +1,557 @@
+-- Demo seed: Conveyor 001 (Lake Wales / Assembly / Line A)
+-- Spec: docs/plans/2026-05-14-demo-backend-plan.md (Phase 2)
+-- North Star: every troubleshooting question must resolve to a known component
+-- with confirmed namespace, PLC tag, wiring, and evidence.
+--
+-- Requires (in order):
+--   * mira-hub/db/migrations/001_knowledge_graph.sql      (kg_entities, kg_relationships)
+--   * mira-hub/db/migrations/010_kg_uns_path.sql          (ltree on kg_entities)
+--   * mira-hub/db/migrations/013_external_ids.sql         (plc_tag/mqtt_topic on cmms_equipment)
+--   * mira-hub/db/migrations/015_equipment_uns_path.sql   (ltree on cmms_equipment)
+--   * mira-hub/db/migrations/016_component_templates.sql
+--   * mira-hub/db/migrations/017_installed_component_instances.sql
+--   * mira-hub/db/migrations/018_relationship_proposals.sql
+--
+-- Safety: idempotent — every INSERT uses ON CONFLICT DO NOTHING keyed on a stable
+-- natural key (entity_id, manufacturer+model+version, plc_tag, etc.). Re-running
+-- against an already-seeded tenant is a no-op.
+--
+-- Tenant: 00000000-0000-0000-0000-0000000000d1  ("demo" tenant — d1 is mnemonic)
+-- Asset:  Conveyor 001 (asset_tag = "CV-001")
+-- UNS:    enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.<id>
+
+BEGIN;
+
+SET LOCAL app.current_tenant_id = '00000000-0000-0000-0000-0000000000d1';
+
+-- ─── 1. Demo tenant marker entity ────────────────────────────────────────────
+-- kg_entities needs the tenant root so UNS subtree queries hit something.
+INSERT INTO kg_entities (tenant_id, entity_type, entity_id, name, properties, uns_path)
+VALUES (
+  '00000000-0000-0000-0000-0000000000d1',
+  'tenant',
+  'demo',
+  'Demo Tenant — Lake Wales',
+  jsonb_build_object('purpose', 'expo_demo', 'created_for', '2026-05-21 Florida Automation Expo'),
+  'enterprise.demo'::ltree
+)
+ON CONFLICT (tenant_id, entity_type, entity_id) DO NOTHING;
+
+INSERT INTO kg_entities (tenant_id, entity_type, entity_id, name, properties, uns_path) VALUES
+  ('00000000-0000-0000-0000-0000000000d1', 'site', 'lake_wales', 'Lake Wales, FL',
+   jsonb_build_object('city', 'Lake Wales', 'state', 'FL'),
+   'enterprise.demo.site.lake_wales'::ltree),
+  ('00000000-0000-0000-0000-0000000000d1', 'area', 'assembly', 'Assembly Area',
+   '{}'::jsonb,
+   'enterprise.demo.site.lake_wales.area.assembly'::ltree),
+  ('00000000-0000-0000-0000-0000000000d1', 'line', 'line_a', 'Line A',
+   '{}'::jsonb,
+   'enterprise.demo.site.lake_wales.area.assembly.line.line_a'::ltree)
+ON CONFLICT (tenant_id, entity_type, entity_id) DO NOTHING;
+
+-- ─── 2. The asset (Conveyor 001) ─────────────────────────────────────────────
+-- cmms_equipment is created by the Atlas schema (separate migration path).
+-- We don't know exact column shape across all deployments, so we wrap the
+-- insert in an exception handler — if the table is absent or its column set
+-- doesn't match, we log a NOTICE and the rest of the seed still lands. The
+-- kg_entity row for the asset (next block) is the demo-critical write.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'cmms_equipment') THEN
+    BEGIN
+      INSERT INTO cmms_equipment (id, tenant_id, name, asset_tag, manufacturer, model, serial_number,
+                                  plc_tag, scada_path, uns_topic_path, uns_path)
+      VALUES (
+        'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid,
+        '00000000-0000-0000-0000-0000000000d1'::uuid,
+        'Conveyor 001',
+        'CV-001',
+        'FactoryLM',
+        'Demo Conveyor v1',
+        'CV-001-2026-DEMO',
+        'Line5.CV001',
+        '[default]CV001',
+        'factorylm/demo/lake_wales/assembly/line_a/cv_001',
+        'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001'::ltree
+      )
+      ON CONFLICT (id) DO NOTHING;
+      RAISE NOTICE 'cmms_equipment row inserted for CV-001.';
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'cmms_equipment insert skipped: % (column shape mismatch is OK; kg_entities still seeded)', SQLERRM;
+    END;
+  ELSE
+    RAISE NOTICE 'cmms_equipment table not present — kg_entities row will represent the asset.';
+  END IF;
+END $$;
+
+-- Also record the asset in the KG so UNS subtree queries find it
+INSERT INTO kg_entities (id, tenant_id, entity_type, entity_id, name, properties, uns_path)
+VALUES (
+  'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid,
+  '00000000-0000-0000-0000-0000000000d1',
+  'equipment', 'cv_001', 'Conveyor 001',
+  jsonb_build_object(
+    'asset_tag', 'CV-001',
+    'manufacturer', 'FactoryLM',
+    'model', 'Demo Conveyor v1',
+    'serial', 'CV-001-2026-DEMO'
+  ),
+  'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001'::ltree
+)
+ON CONFLICT (tenant_id, entity_type, entity_id) DO NOTHING;
+
+-- ─── 3. Component templates (catalog) ────────────────────────────────────────
+-- PE-001 is the demo hero: a Banner Engineering QS18VN6D photoelectric sensor.
+-- Fully populated to prove the schema. Others use minimal placeholders so the
+-- demo has a "verified vs proposed" contrast.
+
+-- 3a. PE-001 template — Banner QS18VN6D diffuse photoelectric sensor
+INSERT INTO component_templates (
+  id, component_category, component_type, manufacturer, model, description,
+  power_specs, input_output_specs, signal_behavior, connector_type, pinout,
+  environmental_limits, diagnostic_indicators, expected_signals,
+  common_failure_modes, troubleshooting_steps, pm_checks, safety_notes,
+  recommended_uns_template, verification_status, version
+) VALUES (
+  '11111111-0001-0001-0001-000000000001'::uuid,
+  'sensor',
+  'photoelectric_sensor',
+  'Banner Engineering',
+  'QS18VN6D',
+  '18mm tubular diffuse-mode photoelectric sensor, NPN open-collector output. Common conveyor presence detection (boxes, totes, parts at 50–400 mm).',
+  jsonb_build_object(
+    'voltage_vdc_min', 10, 'voltage_vdc_max', 30, 'phase', 'DC',
+    'current_consumption_ma', 25, 'inrush_ma', 35
+  ),
+  jsonb_build_object(
+    'output_type', 'NPN open collector (dark-operate / light-operate selectable)',
+    'switching_current_ma', 150,
+    'response_time_ms', 1.0,
+    'signal_type', 'discrete'
+  ),
+  jsonb_build_object(
+    'normal_state_blocked', 'output LOW (sinking to 0 V)',
+    'normal_state_clear',   'output HIGH-Z (pulled to 24 V by PLC input)',
+    'response_time_ms', 1.0,
+    'jitter_ms', 0.2,
+    'expected_envelope_when_running', 'edges every 1.2–4.0 s (item pitch)'
+  ),
+  'M12 4-pin pico (Euro)',
+  jsonb_build_object(
+    'pin_1', '+V (brown, 10–30 VDC)',
+    'pin_2', 'not used',
+    'pin_3', '0 V (blue)',
+    'pin_4', 'OUT (black, NPN)'
+  ),
+  jsonb_build_object(
+    'operating_temp_c_min', -20, 'operating_temp_c_max', 70,
+    'ip_rating', 'IP67', 'shock_g', 30, 'vibration_g', 10
+  ),
+  jsonb_build_array(
+    jsonb_build_object('indicator', 'green_led', 'meaning', 'power on'),
+    jsonb_build_object('indicator', 'yellow_led', 'meaning', 'target detected (output active)'),
+    jsonb_build_object('indicator', 'yellow_flash_fast', 'meaning', 'marginal signal — clean lens or realign'),
+    jsonb_build_object('indicator', 'yellow_flash_slow', 'meaning', 'short-circuit overload on output')
+  ),
+  jsonb_build_array(
+    jsonb_build_object('name', 'idle_clear',     'state', 'output HIGH-Z',  'duration_s_min', 0,   'duration_s_max', 30),
+    jsonb_build_object('name', 'item_present',   'state', 'output LOW',     'duration_s_min', 0.5, 'duration_s_max', 3),
+    jsonb_build_object('name', 'edge_rising',    'transition', 'HIGH-Z → LOW within 1 ms')
+  ),
+  jsonb_build_array(
+    jsonb_build_object('mode', 'lens_dirty',        'cause', 'dust/grease film on emitter or receiver lens', 'symptom', 'output stays HIGH-Z even with target present (false clear)', 'severity', 'medium'),
+    jsonb_build_object('mode', 'misalignment',      'cause', 'mounting bracket shifted',                     'symptom', 'intermittent detection at high speed',                       'severity', 'medium'),
+    jsonb_build_object('mode', 'output_short',      'cause', 'shorted load cable',                            'symptom', 'yellow LED fast-flash; output stuck LOW',                    'severity', 'high'),
+    jsonb_build_object('mode', 'no_power',          'cause', '24V supply rail blown or cable severed',        'symptom', 'green LED off; output HIGH-Z permanently',                   'severity', 'medium'),
+    jsonb_build_object('mode', 'wrong_target_color','cause', 'matte black target absorbs IR',                'symptom', 'output never triggers on certain SKUs',                       'severity', 'low')
+  ),
+  jsonb_build_array(
+    jsonb_build_object('step', 1, 'action', 'Visually inspect green LED — power present?'),
+    jsonb_build_object('step', 2, 'action', 'Verify yellow LED transitions when an item passes — sensor seeing target?'),
+    jsonb_build_object('step', 3, 'action', 'At the PLC, watch the bound input bit for matching edges'),
+    jsonb_build_object('step', 4, 'action', 'Clean lens with soft cloth + isopropyl alcohol; re-test'),
+    jsonb_build_object('step', 5, 'action', 'Confirm M12 cable continuity pin-by-pin to PLC terminal'),
+    jsonb_build_object('step', 6, 'action', 'If yellow LED is correct but PLC bit is not, the wire or input card is the suspect')
+  ),
+  jsonb_build_array(
+    jsonb_build_object('interval', 'monthly', 'task', 'Clean lens with soft cloth'),
+    jsonb_build_object('interval', 'quarterly', 'task', 'Confirm mounting torque and alignment'),
+    jsonb_build_object('interval', 'annual',   'task', 'Inspect M12 cable jacket for abrasion')
+  ),
+  jsonb_build_array(
+    jsonb_build_object('hazard', 'low_voltage', 'note', '24 VDC class 2 — no LOTO required for this sensor itself'),
+    jsonb_build_object('hazard', 'pinch_point', 'note', 'Conveyor must be stopped before reaching into the detection zone')
+  ),
+  'enterprise.kb.banner_engineering.qs.qs18vn6d',
+  'verified',
+  1
+)
+ON CONFLICT (manufacturer, model, version) DO NOTHING;
+
+INSERT INTO component_template_sources (template_id, source_type, source_url, page_numbers, excerpt, extraction_confidence, extracted_by)
+VALUES (
+  '11111111-0001-0001-0001-000000000001'::uuid,
+  'datasheet',
+  'https://info.bannerengineering.com/cs/groups/public/documents/literature/40714.pdf',
+  '1',
+  'QS18 Series 18 mm tubular DC photoelectric sensor, NPN or PNP output, 10-30 VDC, IP67.',
+  0.95, 'human'
+)
+ON CONFLICT DO NOTHING;
+
+-- 3b. GS10 VFD template (AutomationDirect)
+INSERT INTO component_templates (
+  id, component_category, component_type, manufacturer, model, description,
+  power_specs, signal_behavior, recommended_uns_template, verification_status, version
+) VALUES (
+  '11111111-0001-0001-0002-000000000001'::uuid,
+  'drive', 'variable_frequency_drive', 'AutomationDirect', 'GS10-10P2',
+  'AC variable frequency drive, 0.25 HP, 120 VAC single-phase input, 230 VAC 3-phase output. Modbus RTU on RS-485.',
+  jsonb_build_object('voltage_vac', 120, 'phase_in', 1, 'phase_out', 3, 'hp', 0.25),
+  jsonb_build_object('faults', jsonb_build_array('ocA', 'ocd', 'ocn', 'GFF', 'OUV', 'OcA-cF')),
+  'enterprise.kb.automationdirect.gs.gs10',
+  'verified', 1
+)
+ON CONFLICT (manufacturer, model, version) DO NOTHING;
+
+-- 3c. Motor template (placeholder — proposed)
+INSERT INTO component_templates (id, component_category, component_type, manufacturer, model, verification_status, version)
+VALUES ('11111111-0001-0001-0003-000000000001'::uuid, 'motor', 'ac_induction_motor', 'Marathon', 'Y56C-1HP-1750', 'proposed', 1)
+ON CONFLICT (manufacturer, model, version) DO NOTHING;
+
+-- 3d. PLC template (placeholder — proposed)
+INSERT INTO component_templates (id, component_category, component_type, manufacturer, model, verification_status, version)
+VALUES ('11111111-0001-0001-0004-000000000001'::uuid, 'plc', 'compact_plc', 'Allen-Bradley', 'Micro820 2080-LC20-20QWB', 'proposed', 1)
+ON CONFLICT (manufacturer, model, version) DO NOTHING;
+
+-- 3e. Panel/enclosure (placeholder)
+INSERT INTO component_templates (id, component_category, component_type, manufacturer, model, verification_status, version)
+VALUES ('11111111-0001-0001-0005-000000000001'::uuid, 'enclosure', 'control_panel', 'Hoffman', 'A24H2008LP', 'proposed', 1)
+ON CONFLICT (manufacturer, model, version) DO NOTHING;
+
+-- ─── 4. Installed component instances (deployment) ───────────────────────────
+-- These are the rows the tablet UI and Slack engine query when grounding answers.
+INSERT INTO installed_component_instances (
+  id, tenant_id, template_id, asset_id, component_name, canonical_name, aliases,
+  installed_location, panel, terminal, wire_number, plc_tag, mqtt_topic,
+  uns_path, human_confirmed, confidence
+) VALUES
+  (
+    '22222222-0001-0001-0001-000000000001'::uuid,
+    '00000000-0000-0000-0000-0000000000d1'::uuid,
+    '11111111-0001-0001-0001-000000000001'::uuid,
+    'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid,
+    'Photoeye 1 (Item Detect)',
+    'PE-001',
+    ARRAY['Sensor 1', '_IO_EM_DI_05', 'pe1', 'photo eye 1'],
+    'Line A, infeed side, 200 mm above belt',
+    'PANEL-001',
+    'TB1-5',
+    'W-PE001-OUT',
+    '%IX0.5',
+    'factorylm/demo/lake_wales/assembly/line_a/cv_001/pe_001',
+    'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.pe_001'::ltree,
+    true, 0.95
+  ),
+  (
+    '22222222-0001-0001-0002-000000000001'::uuid,
+    '00000000-0000-0000-0000-0000000000d1'::uuid,
+    '11111111-0001-0001-0002-000000000001'::uuid,
+    'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid,
+    'GS10 VFD',
+    'VFD-001',
+    ARRAY['GS10', 'AutomationDirect drive', 'inverter'],
+    'PANEL-001 inside, top-left DIN rail',
+    'PANEL-001',
+    'TB2-1..TB2-6',
+    'W-VFD001-PWR',
+    NULL,
+    'factorylm/demo/lake_wales/assembly/line_a/cv_001/vfd_001',
+    'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.vfd_001'::ltree,
+    true, 0.90
+  ),
+  (
+    '22222222-0001-0001-0003-000000000001'::uuid,
+    '00000000-0000-0000-0000-0000000000d1'::uuid,
+    '11111111-0001-0001-0003-000000000001'::uuid,
+    'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid,
+    'Conveyor Motor',
+    'MTR-001',
+    ARRAY['motor', 'Marathon 1HP'],
+    'Drive end of conveyor frame',
+    NULL,
+    'VFD-001 OUT-T1/T2/T3',
+    'W-MTR001-PWR',
+    NULL,
+    'factorylm/demo/lake_wales/assembly/line_a/cv_001/mtr_001',
+    'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.mtr_001'::ltree,
+    true, 0.85
+  ),
+  (
+    '22222222-0001-0001-0004-000000000001'::uuid,
+    '00000000-0000-0000-0000-0000000000d1'::uuid,
+    '11111111-0001-0001-0004-000000000001'::uuid,
+    'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid,
+    'Micro820 Controller',
+    'PLC-001',
+    ARRAY['Micro820', 'controller', 'Allen-Bradley'],
+    'PANEL-001 inside, top-right DIN rail',
+    'PANEL-001',
+    'TB1, TB2 (I/O headers)',
+    NULL,
+    'Line5.CV001.Controller',
+    'factorylm/demo/lake_wales/assembly/line_a/cv_001/plc_001',
+    'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.plc_001'::ltree,
+    true, 0.95
+  ),
+  (
+    '22222222-0001-0001-0005-000000000001'::uuid,
+    '00000000-0000-0000-0000-0000000000d1'::uuid,
+    '11111111-0001-0001-0005-000000000001'::uuid,
+    'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid,
+    'Control Panel',
+    'PANEL-001',
+    ARRAY['panel', 'enclosure', 'cabinet'],
+    'Outboard of conveyor, drive-end',
+    NULL, NULL, NULL, NULL,
+    'factorylm/demo/lake_wales/assembly/line_a/cv_001/panel_001',
+    'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.panel_001'::ltree,
+    true, 0.95
+  )
+ON CONFLICT (id) DO NOTHING;
+
+-- ─── 5. KG entities for each installed component ─────────────────────────────
+-- Mirror of the instances so KG traversal queries hit nodes with uns_path.
+INSERT INTO kg_entities (id, tenant_id, entity_type, entity_id, name, properties, uns_path) VALUES
+  ('22222222-0001-0001-0001-000000000001'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'component', 'pe_001', 'PE-001 — Photoeye 1',
+   jsonb_build_object('template_id', '11111111-0001-0001-0001-000000000001',
+                      'plc_tag', '%IX0.5', 'aliases', jsonb_build_array('Sensor 1', '_IO_EM_DI_05')),
+   'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.pe_001'::ltree),
+  ('22222222-0001-0001-0002-000000000001'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'component', 'vfd_001', 'VFD-001 — GS10 Drive',
+   jsonb_build_object('template_id', '11111111-0001-0001-0002-000000000001'),
+   'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.vfd_001'::ltree),
+  ('22222222-0001-0001-0003-000000000001'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'component', 'mtr_001', 'MTR-001 — Conveyor Motor',
+   jsonb_build_object('template_id', '11111111-0001-0001-0003-000000000001'),
+   'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.mtr_001'::ltree),
+  ('22222222-0001-0001-0004-000000000001'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'component', 'plc_001', 'PLC-001 — Micro820',
+   jsonb_build_object('template_id', '11111111-0001-0001-0004-000000000001',
+                      'plc_tag_root', 'Line5.CV001.Controller'),
+   'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.plc_001'::ltree),
+  ('22222222-0001-0001-0005-000000000001'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'component', 'panel_001', 'PANEL-001 — Control Panel',
+   jsonb_build_object('template_id', '11111111-0001-0001-0005-000000000001'),
+   'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.panel_001'::ltree)
+ON CONFLICT (tenant_id, entity_type, entity_id) DO NOTHING;
+
+-- ─── 6. PLC tag entities (from variable manifest) ────────────────────────────
+-- Only the 4 tags the demo questions actually traverse — full manifest load is
+-- the job of tools/load_manifest_to_kg.py.
+INSERT INTO kg_entities (id, tenant_id, entity_type, entity_id, name, properties, uns_path) VALUES
+  ('33333333-0001-0001-0001-000000000005'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'plc_tag', '_IO_EM_DI_05', '%IX0.5 — Sensor 1',
+   jsonb_build_object('plc_address', '%IX0.5', 'data_type', 'BOOL',
+                      'source_device', 'Sensor', 'alias', 'Sensor 1'),
+   'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.plc_001'::ltree),
+  ('33333333-0001-0001-0001-000000000101'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'plc_tag', 'motor_speed', 'HR:101 — Motor Speed',
+   jsonb_build_object('modbus_address', 'HR:101', 'data_type', 'INT',
+                      'source_device', 'Micro 820', 'alias', 'Motor Speed'),
+   'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.plc_001'::ltree),
+  ('33333333-0001-0001-0001-000000000106'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'plc_tag', 'error_code', 'HR:106 — Error Code',
+   jsonb_build_object('modbus_address', 'HR:106', 'data_type', 'INT',
+                      'enum', jsonb_build_object('7', 'e_stop', '8', 'dir_fault', '9', 'vfd_comm_error')),
+   'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.plc_001'::ltree),
+  ('33333333-0001-0001-0001-000000000114'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'plc_tag', 'conv_state', 'HR:114 — Conveyor State',
+   jsonb_build_object('modbus_address', 'HR:114', 'data_type', 'INT',
+                      'enum', jsonb_build_object('0', 'IDLE', '1', 'STARTING', '2', 'RUNNING', '3', 'STOPPING', '4', 'FAULT')),
+   'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001.component.plc_001'::ltree)
+ON CONFLICT (tenant_id, entity_type, entity_id) DO NOTHING;
+
+-- ─── 7. Relationship proposals + evidence (the chain) ────────────────────────
+-- Status='verified' so the demo doesn't need a review pass. Confidence 0.95
+-- because every edge is human-confirmed for this seeded asset.
+-- NOTE: relationship_proposals has `reasoning TEXT` (LLM rationale / human note),
+-- NOT a `properties` jsonb. Structured details live on the evidence rows.
+INSERT INTO relationship_proposals (
+  id, tenant_id, source_entity_id, source_entity_type, target_entity_id, target_entity_type,
+  relationship_type, confidence, status, risk_level, requires_human_review,
+  created_by, reasoning
+) VALUES
+  -- Hierarchy: CV-001 HAS_COMPONENT each child
+  ('44444444-0001-0001-0001-000000000001'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid, 'equipment',
+   '22222222-0001-0001-0001-000000000001'::uuid, 'component',
+   'HAS_COMPONENT', 0.95, 'verified', 'low', false, 'human',
+   'PE-001 (photoeye) is bolted to Conveyor 001 frame, confirmed at bench install.'),
+  ('44444444-0001-0001-0002-000000000001'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid, 'equipment',
+   '22222222-0001-0001-0002-000000000001'::uuid, 'component',
+   'HAS_COMPONENT', 0.95, 'verified', 'low', false, 'human',
+   'VFD-001 (GS10) is the variable-speed drive for Conveyor 001.'),
+  ('44444444-0001-0001-0003-000000000001'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid, 'equipment',
+   '22222222-0001-0001-0003-000000000001'::uuid, 'component',
+   'HAS_COMPONENT', 0.95, 'verified', 'low', false, 'human',
+   'MTR-001 (Marathon 1HP) is the drive motor for Conveyor 001.'),
+  ('44444444-0001-0001-0004-000000000001'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid, 'equipment',
+   '22222222-0001-0001-0004-000000000001'::uuid, 'component',
+   'HAS_COMPONENT', 0.95, 'verified', 'low', false, 'human',
+   'PLC-001 (Micro820) is the controller for Conveyor 001.'),
+  ('44444444-0001-0001-0005-000000000001'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid, 'equipment',
+   '22222222-0001-0001-0005-000000000001'::uuid, 'component',
+   'HAS_COMPONENT', 0.95, 'verified', 'low', false, 'human',
+   'PANEL-001 is the control enclosure mounted on Conveyor 001.'),
+
+  -- Wiring: PE-001 WIRED_TO PLC tag %IX0.5
+  ('44444444-0002-0001-0001-000000000005'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   '22222222-0001-0001-0001-000000000001'::uuid, 'component',
+   '33333333-0001-0001-0001-000000000005'::uuid, 'plc_tag',
+   'WIRED_TO', 0.95, 'verified', 'medium', false, 'human',
+   'PE-001 output wires to PLC-001 input TB1-5 (wire W-PE001-OUT), bound to %IX0.5.'),
+
+  -- Tag mapping: %IX0.5 MAPS_TO PE-001
+  ('44444444-0003-0001-0001-000000000005'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   '33333333-0001-0001-0001-000000000005'::uuid, 'plc_tag',
+   '22222222-0001-0001-0001-000000000001'::uuid, 'component',
+   'MAPS_TO', 0.95, 'verified', 'low', false, 'import',
+   'Variable manifest declares _IO_EM_DI_05 alias "Sensor 1" at address %IX0.5.'),
+
+  -- Logic: %IX0.5 USED_IN_LOGIC of motor start rung
+  ('44444444-0004-0001-0001-000000000005'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   '33333333-0001-0001-0001-000000000005'::uuid, 'plc_tag',
+   'aaaaaaaa-0001-0001-0001-0000000000d1'::uuid, 'equipment',
+   'USED_IN_LOGIC', 0.90, 'verified', 'low', false, 'import',
+   'Sensor 1 (%IX0.5) participates in the item-presence gate before the motor-start permissive rung.'),
+
+  -- Power: MTR-001 POWERED_BY VFD-001
+  ('44444444-0005-0001-0001-000000000001'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   '22222222-0001-0001-0003-000000000001'::uuid, 'component',
+   '22222222-0001-0001-0002-000000000001'::uuid, 'component',
+   'POWERED_BY', 0.95, 'verified', 'high', false, 'human',
+   'VFD-001 drives MTR-001 via T1/T2/T3, 230 VAC three-phase output.'),
+
+  -- LOCATED_IN: VFD/PLC located in PANEL-001
+  ('44444444-0006-0001-0001-000000000002'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   '22222222-0001-0001-0002-000000000001'::uuid, 'component',
+   '22222222-0001-0001-0005-000000000001'::uuid, 'component',
+   'LOCATED_IN', 0.95, 'verified', 'low', false, 'human',
+   'VFD-001 mounted on top-left DIN rail inside PANEL-001.'),
+  ('44444444-0006-0001-0001-000000000004'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   '22222222-0001-0001-0004-000000000001'::uuid, 'component',
+   '22222222-0001-0001-0005-000000000001'::uuid, 'component',
+   'LOCATED_IN', 0.95, 'verified', 'low', false, 'human',
+   'PLC-001 mounted on top-right DIN rail inside PANEL-001.'),
+
+  -- Causation: vfd_comm_error TRIGGERS motor stop
+  ('44444444-0007-0001-0001-000000000009'::uuid, '00000000-0000-0000-0000-0000000000d1',
+   '33333333-0001-0001-0001-000000000106'::uuid, 'plc_tag',
+   '22222222-0001-0001-0003-000000000001'::uuid, 'component',
+   'CAUSES', 0.85, 'verified', 'medium', false, 'import',
+   'error_code=9 (VFD comms error) drops the safety contactor and stops MTR-001.')
+ON CONFLICT (id) DO NOTHING;
+
+-- Evidence rows — every proposal cites at least one source.
+-- Columns: proposal_id, evidence_type, source_description, page_or_location, excerpt, confidence_contribution
+INSERT INTO relationship_evidence (proposal_id, evidence_type, source_description, page_or_location, excerpt, confidence_contribution) VALUES
+  ('44444444-0002-0001-0001-000000000005'::uuid, 'manifest',
+   'research/variable-manifest.json',
+   '_IO_EM_DI_05',
+   '"name": "_IO_EM_DI_05", "alias": "Sensor 1", "address": "%IX0.5"',
+   0.45),
+  ('44444444-0002-0001-0001-000000000005'::uuid, 'technician_note',
+   'Bench install log 2026-05-10 (Mike Harper)',
+   'TB1-5',
+   'PE-001 output landed on TB1-5; continuity confirmed end-to-end.',
+   0.50),
+  ('44444444-0003-0001-0001-000000000005'::uuid, 'manifest',
+   'research/variable-manifest.json',
+   '_IO_EM_DI_05',
+   '"name": "_IO_EM_DI_05", "alias": "Sensor 1", "address": "%IX0.5"',
+   0.95),
+  ('44444444-0004-0001-0001-000000000005'::uuid, 'plc_rung',
+   'plc/Prog2.stf',
+   'motor_start_permissive',
+   'IF (sensor_1_active OR sensor_2_active) AND system_ready THEN motor_run := TRUE;',
+   0.90),
+  ('44444444-0005-0001-0001-000000000001'::uuid, 'document_page',
+   'plc/specs/phase1_ladder.md',
+   'page 1',
+   'GS10 drives 3-phase output to Marathon Y56C 1HP via T1/T2/T3.',
+   0.95),
+  ('44444444-0007-0001-0001-000000000009'::uuid, 'plc_rung',
+   'plc/Prog2.stf',
+   'vfd_comm_fault_branch',
+   'IF vfd_comm_err THEN error_code := 9; safety_contactor := FALSE;',
+   0.85)
+ON CONFLICT DO NOTHING;
+
+-- ─── 8. Promoted kg_relationships (verified proposals → live graph) ──────────
+-- Spec says "Nothing lands in kg_relationships until verified". The seed bypasses
+-- the promotion service (still TBD) by writing verified proposals directly into
+-- kg_relationships. `reasoning` becomes the canonical note; structured details
+-- can be re-attached when the promotion pipeline lands (P6/follow-up PR).
+INSERT INTO kg_relationships (tenant_id, source_id, target_id, relationship_type, confidence, properties)
+SELECT
+  tenant_id,
+  source_entity_id,
+  target_entity_id,
+  relationship_type,
+  confidence,
+  jsonb_build_object('proposal_id', id, 'reasoning', reasoning, 'risk_level', risk_level)
+FROM relationship_proposals
+WHERE tenant_id = '00000000-0000-0000-0000-0000000000d1'::uuid
+  AND status = 'verified'
+ON CONFLICT DO NOTHING;
+
+-- ─── 9. Verification ─────────────────────────────────────────────────────────
+DO $$
+DECLARE
+  v_templates INTEGER;
+  v_instances INTEGER;
+  v_entities  INTEGER;
+  v_proposals INTEGER;
+  v_evidence  INTEGER;
+  v_relationships INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO v_templates FROM component_templates
+    WHERE id IN (
+      '11111111-0001-0001-0001-000000000001'::uuid,
+      '11111111-0001-0001-0002-000000000001'::uuid,
+      '11111111-0001-0001-0003-000000000001'::uuid,
+      '11111111-0001-0001-0004-000000000001'::uuid,
+      '11111111-0001-0001-0005-000000000001'::uuid
+    );
+  SELECT COUNT(*) INTO v_instances FROM installed_component_instances
+    WHERE tenant_id = '00000000-0000-0000-0000-0000000000d1'::uuid;
+  SELECT COUNT(*) INTO v_entities FROM kg_entities
+    WHERE tenant_id = '00000000-0000-0000-0000-0000000000d1'::uuid;
+  SELECT COUNT(*) INTO v_proposals FROM relationship_proposals
+    WHERE tenant_id = '00000000-0000-0000-0000-0000000000d1'::uuid;
+  SELECT COUNT(*) INTO v_evidence FROM relationship_evidence re
+    JOIN relationship_proposals rp ON rp.id = re.proposal_id
+    WHERE rp.tenant_id = '00000000-0000-0000-0000-0000000000d1'::uuid;
+  SELECT COUNT(*) INTO v_relationships FROM kg_relationships
+    WHERE tenant_id = '00000000-0000-0000-0000-0000000000d1'::uuid;
+
+  RAISE NOTICE 'Demo seed verification:';
+  RAISE NOTICE '  component_templates:                %', v_templates;
+  RAISE NOTICE '  installed_component_instances:      %', v_instances;
+  RAISE NOTICE '  kg_entities (demo tenant):          %', v_entities;
+  RAISE NOTICE '  relationship_proposals (demo):      %', v_proposals;
+  RAISE NOTICE '  relationship_evidence (demo):       %', v_evidence;
+  RAISE NOTICE '  kg_relationships (demo tenant):     %', v_relationships;
+
+  IF v_templates < 5 OR v_instances < 5 OR v_proposals < 11 OR v_relationships < 11 THEN
+    RAISE EXCEPTION 'Seed verification failed — counts below expected (templates>=5, instances>=5, proposals>=11, relationships>=11)';
+  END IF;
+END $$;
+
+COMMIT;

--- a/tools/seeds/run_demo_seed.py
+++ b/tools/seeds/run_demo_seed.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Run the demo Conveyor 001 seed against NeonDB.
+
+Plan: docs/plans/2026-05-14-demo-backend-plan.md (Phase 2)
+Seed:  tools/seeds/demo-conveyor-001.sql
+
+Usage (dry-run prints the SQL it would execute):
+  doppler run --project factorylm --config prd -- python3 tools/seeds/run_demo_seed.py --dry-run
+
+Apply for real (Conveyor 001 only — won't touch other tenants):
+  doppler run --project factorylm --config prd -- python3 tools/seeds/run_demo_seed.py --commit
+
+Verification only (read counts, no writes):
+  doppler run --project factorylm --config prd -- python3 tools/seeds/run_demo_seed.py --verify
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+import psycopg
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SEED_FILE = REPO_ROOT / "tools" / "seeds" / "demo-conveyor-001.sql"
+DEMO_TENANT_ID = "00000000-0000-0000-0000-0000000000d1"
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("demo-seed")
+
+
+def get_database_url() -> str:
+    url = os.getenv("DATABASE_URL") or os.getenv("NEON_DATABASE_URL")
+    if not url:
+        log.error("DATABASE_URL not set. Run under doppler: `doppler run --project factorylm --config prd -- ...`")
+        sys.exit(2)
+    return url
+
+
+_OUTER_BEGIN = re.compile(r"^\s*BEGIN\s*;\s*\n", re.MULTILINE)
+_OUTER_COMMIT = re.compile(r"\n\s*COMMIT\s*;\s*\n?\s*\Z")
+
+
+def _strip_outer_tx(sql: str) -> str:
+    """Remove the outermost BEGIN; / COMMIT; from the seed.
+
+    The .sql file is wrapped so it works standalone via `psql -f`. When the
+    Python runner owns the transaction (psycopg autocommit=False), leaving the
+    file's COMMIT in place would commit the work before our rollback can run —
+    silently turning --dry-run into a real write. Strip only the outermost pair;
+    PL/pgSQL DO blocks have their own BEGIN/EXCEPTION/END blocks which we leave
+    intact.
+    """
+    stripped, n_begin = _OUTER_BEGIN.subn("", sql, count=1)
+    stripped, n_commit = _OUTER_COMMIT.subn("\n", stripped, count=1)
+    if not (n_begin and n_commit):
+        log.warning("Seed did not have outermost BEGIN/COMMIT (begin=%d commit=%d) — runner will manage tx anyway.", n_begin, n_commit)
+    return stripped
+
+
+def run_seed(commit: bool) -> None:
+    raw_sql = SEED_FILE.read_text(encoding="utf-8")
+    sql = _strip_outer_tx(raw_sql)
+    log.info("Connecting to NeonDB...")
+    with psycopg.connect(get_database_url(), autocommit=False) as conn:
+        with conn.cursor() as cur:
+            log.info("Applying %s (%d bytes, outer BEGIN/COMMIT stripped)...", SEED_FILE.name, len(sql))
+            cur.execute(sql)
+            for diag in conn.notices or []:
+                log.info("PG NOTICE: %s", diag.strip())
+        if commit:
+            conn.commit()
+            log.info("✔ Seed committed.")
+        else:
+            conn.rollback()
+            log.info("✔ Seed validated (dry-run, rolled back).")
+
+
+def verify() -> None:
+    """Read-only counts for the demo tenant — confirms the seed landed."""
+    queries = [
+        ("component_templates (PE-001 + GS10 + 3 placeholders)",
+         "SELECT COUNT(*) FROM component_templates WHERE id IN ("
+         "'11111111-0001-0001-0001-000000000001'::uuid,"
+         "'11111111-0001-0001-0002-000000000001'::uuid,"
+         "'11111111-0001-0001-0003-000000000001'::uuid,"
+         "'11111111-0001-0001-0004-000000000001'::uuid,"
+         "'11111111-0001-0001-0005-000000000001'::uuid)"),
+        ("installed_component_instances (demo tenant)",
+         f"SELECT COUNT(*) FROM installed_component_instances WHERE tenant_id = '{DEMO_TENANT_ID}'"),
+        ("kg_entities (demo tenant)",
+         f"SELECT COUNT(*) FROM kg_entities WHERE tenant_id = '{DEMO_TENANT_ID}'"),
+        ("relationship_proposals (demo tenant)",
+         f"SELECT COUNT(*) FROM relationship_proposals WHERE tenant_id = '{DEMO_TENANT_ID}'"),
+        ("relationship_evidence (demo tenant)",
+         "SELECT COUNT(*) FROM relationship_evidence re "
+         "JOIN relationship_proposals rp ON rp.id = re.proposal_id "
+         f"WHERE rp.tenant_id = '{DEMO_TENANT_ID}'"),
+        ("kg_relationships (demo tenant)",
+         f"SELECT COUNT(*) FROM kg_relationships WHERE tenant_id = '{DEMO_TENANT_ID}'"),
+    ]
+    log.info("Verifying demo tenant %s...", DEMO_TENANT_ID)
+    with psycopg.connect(get_database_url(), autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(f"SET app.current_tenant_id = '{DEMO_TENANT_ID}'")
+            for label, q in queries:
+                cur.execute(q)
+                (n,) = cur.fetchone()
+                marker = "✔" if n > 0 else "✗"
+                log.info("  %s %-50s %d", marker, label, n)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--dry-run", action="store_true", help="Apply the seed in a transaction, then rollback.")
+    g.add_argument("--commit", action="store_true", help="Apply the seed and commit.")
+    g.add_argument("--verify", action="store_true", help="Read-only count check against the demo tenant.")
+    args = ap.parse_args()
+
+    if not SEED_FILE.exists():
+        log.error("Seed file missing: %s", SEED_FILE)
+        return 2
+
+    if args.verify:
+        verify()
+    else:
+        run_seed(commit=args.commit)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Backend foundation for the **May 21 Florida Automation Expo** tablet demo. Two phases of the 8-phase plan in `docs/plans/2026-05-14-demo-backend-plan.md`.

- **Phase 2** — Conveyor 001 demo seed (5 components, PE-001 fully-populated template, ISA-95 UNS paths, PLC tag bindings, 12 verified KG edges + evidence)
- **Phase 3** — 11 new API endpoints + migration 019 (sessions + live signal events) + `lib/demo-auth.ts` bearer-token fallback for the public iPad

**Hard rule enforced:** no confirmed namespace context, no troubleshooting. `POST /api/mira/ask` returns `HTTP 412 {gate:"namespace"}` if the session status is not `confirmed`.

## Migrations

- `mira-hub/db/migrations/019_sessions_and_signals.sql` — `troubleshooting_sessions` (gate state + transcript) and `live_signal_events` (append-only stream, `simulated` defaults TRUE so we never confuse fake samples for real telemetry once the MQTT bridge lands). Both RLS-scoped.

## Endpoints (all under `mira-hub/src/app/api/`)

| Method | Path | Purpose |
|--------|------|---------|
| GET    | `/api/demo/customer` | Demo asset tree from KG + components |
| GET    | `/api/assets/[id]/context` | Confirmation card data (asset + components + 24h signal count + `ready_for_troubleshooting`) |
| GET    | `/api/assets/[id]/signals?limit=&since=` | One card per component: latest + history |
| GET    | `/api/components/[id]` | Instance + template join + KG edges in/out |
| GET    | `/api/sessions/[id]` | Load session + transcript |
| POST   | `/api/sessions/confirm` | Gate unlock: validates asset/component, flips `status='confirmed'` |
| POST   | `/api/mira/ask` | **Gate-enforcing.** Grounded prompt from KG → Groq→Cerebras→Gemini → transcript append |
| GET    | `/api/documents?asset_id=&manufacturer=&limit=` | Tenant-scoped library rollup |
| POST   | `/api/documents/upload` | Demo upload registration (production ingest still goes through `/api/uploads`) |
| POST   | `/api/demo/signals/toggle` | Push synthetic sensor sample (`state=present\|clear\|auto`) |
| GET    | `/api/demo/signals/events` | Append-only event feed the tablet polls every 1–2 s |

All routes use `withTenantContext` + `sessionOrDemo` (bearer fallback). Demo-only routes (`/api/demo/*`, signal toggle) reject non-demo tenants with 403. Plain Hub-session users see the same endpoints work via `sessionOr401`.

## Demo seed (`tools/seeds/`)

`demo-conveyor-001.sql` + `run_demo_seed.py` (`--dry-run | --commit | --verify`). Idempotent. Inserts:

- 5 `component_templates` — **PE-001 (Banner QS18VN6D)** fully populated (power_specs, signal_behavior, pinout, environmental_limits, 4 diagnostic_indicators, 3 expected_signals, 5 failure_modes, 6 troubleshooting_steps, 3 pm_checks, 2 safety_notes), GS10 VFD verified, plus Marathon motor / Micro820 / Hoffman panel as `proposed` placeholders
- 5 `installed_component_instances` with ISA-95 UNS ltree + PLC tag bindings (PE-001 → `%IX0.5`)
- 13 `kg_entities` (tenant → site → area → line → equipment → 5 components + 4 PLC tag entities incl. `error_code` enum)
- 12 verified `relationship_proposals` (HAS_COMPONENT × 5, WIRED_TO, MAPS_TO, USED_IN_LOGIC, POWERED_BY, LOCATED_IN × 2, CAUSES) + 6 evidence rows
- Verified proposals promoted into `kg_relationships` for live queries
- `cmms_equipment` insert wrapped in `EXCEPTION` handler so schema drift in Atlas doesn't break the seed

## Note on migration workflow run 25893878911

**Workflow failed** before this branch on `tools/uns_backfill.py`: `ModuleNotFoundError: No module named 'sqlalchemy'` in the CI runner. The migration SQL itself did not run against prod. Per Mike's instruction, the seed `--dry-run` + `--commit` is **deferred** until that CI issue is resolved separately. The seed file ships in this PR ready to run.

## Type check

`npx tsc --noEmit` is clean across every new file (12 new TS files). Only pre-existing tsc error: `src/lib/auth/__tests__/rls-deny.integration.test.ts` line 55 (unused `@ts-expect-error` — not in this change).

## What this PR deliberately doesn't do (deferred to later phases)

- **P4 — Slack-side namespace gate** in `mira-bots/shared/engine.py` and writing the missing `slack-technician-workflow-spec.md`.
- **P5 — Mock signal replayer** (a scripted 90 s scenario player).
- **P6 — Typed KG query handlers** (`does_plc_see_sensor`, `where_is_wired`, `why_motor_stopped`, `flag_count`, `first_check_recommendation`).
- **P7 — Engine wire-up** so the Slack adapter calls the same KG paths the tablet does.
- **P8 — Tablet demo page** in `mira-web` consuming these endpoints.
- Real MQTT/Sparkplug B subscription (mock feed for demo).
- Proper promotion service `relationship_proposals.verified → kg_relationships` (the seed bypasses it; service is a follow-up PR).
- Streaming SSE on `/api/mira/ask` (non-streaming JSON; tablet shows typing indicator during cascade).

## Test plan

- [ ] Apply migration 019 to NeonDB (`docker-compose exec atlas-api psql ...` or via `gh workflow run apply-prod-migrations.yml` once `sqlalchemy` is added to the CI runner image)
- [ ] `doppler run --project factorylm --config prd -- python3 tools/seeds/run_demo_seed.py --dry-run` returns 0 with PG NOTICE counts ≥ expected
- [ ] `--commit` then `--verify` shows: templates 5 / instances 5 / kg_entities 13 / proposals 12 / evidence 6 / relationships 12
- [ ] `curl -H "Authorization: Bearer $DEMO_API_TOKEN" $HUB/api/demo/customer` returns the tree with sites→areas→lines→equipment→components
- [ ] `curl -X POST -H "Authorization: Bearer $DEMO_API_TOKEN" -H "Content-Type: application/json" -d '{"asset_id":"aaaaaaaa-0001-0001-0001-0000000000d1"}' $HUB/api/sessions/confirm` returns 201 with `status:'confirmed'`
- [ ] `curl -X POST -H "Authorization: Bearer $DEMO_API_TOKEN" -d '{"session_id":"...","question":"Is the PLC seeing PE-001?"}' $HUB/api/mira/ask` returns a grounded answer with citations
- [ ] Same call before `/sessions/confirm` returns **HTTP 412 with `gate:"namespace"`**
- [ ] `POST /api/demo/signals/toggle` with `{component_id:"22222222-0001-0001-0001-000000000001","state":"auto"}` inserts an event; `GET /api/demo/signals/events?component_id=...` shows it
- [ ] On May 18, run the full 3-minute walkthrough from `docs/specs/demo-readiness-may21-spec.md` on the actual tablet

🤖 Generated with [Claude Code](https://claude.com/claude-code)