### PR TITLE
fix(migrations): idempotent CREATE POLICY

### DIFF
--- a/mira-hub/db/migrations/017_installed_component_instances.sql
+++ b/mira-hub/db/migrations/017_installed_component_instances.sql
@@ -74,6 +74,7 @@ CREATE INDEX IF NOT EXISTS idx_installed_instances_aliases
 -- Tenant isolation
 ALTER TABLE installed_component_instances ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS installed_instances_tenant ON installed_component_instances;
 CREATE POLICY installed_instances_tenant
     ON installed_component_instances
     USING (tenant_id = current_setting('app.current_tenant_id')::UUID);

--- a/mira-hub/db/migrations/018_relationship_proposals.sql
+++ b/mira-hub/db/migrations/018_relationship_proposals.sql
@@ -110,6 +110,7 @@ CREATE INDEX IF NOT EXISTS idx_rel_evidence_type
 -- Tenant isolation — RLS on the proposal table. Evidence inherits via cascade.
 ALTER TABLE relationship_proposals ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS rel_proposals_tenant ON relationship_proposals;
 CREATE POLICY rel_proposals_tenant
     ON relationship_proposals
     USING (
@@ -119,6 +120,7 @@ CREATE POLICY rel_proposals_tenant
 
 ALTER TABLE relationship_evidence ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS rel_evidence_tenant ON relationship_evidence;
 CREATE POLICY rel_evidence_tenant
     ON relationship_evidence
     USING (


### PR DESCRIPTION
DROP POLICY IF EXISTS before CREATE POLICY so migrations can be safely re-run