### PR TITLE
fix(seeds): psycopg v3 notices — use add_notice_handler

### DIFF
--- a/tools/seeds/run_demo_seed.py
+++ b/tools/seeds/run_demo_seed.py
@@ -65,12 +65,14 @@ def run_seed(commit: bool) -> None:
     raw_sql = SEED_FILE.read_text(encoding="utf-8")
     sql = _strip_outer_tx(raw_sql)
     log.info("Connecting to NeonDB...")
+    notices: list[str] = []
     with psycopg.connect(get_database_url(), autocommit=False) as conn:
+        conn.add_notice_handler(lambda diag: notices.append(diag.message_primary or ""))
         with conn.cursor() as cur:
             log.info("Applying %s (%d bytes, outer BEGIN/COMMIT stripped)...", SEED_FILE.name, len(sql))
             cur.execute(sql)
-            for diag in conn.notices or []:
-                log.info("PG NOTICE: %s", diag.strip())
+            for msg in notices:
+                log.info("PG NOTICE: %s", msg.strip())
         if commit:
             conn.commit()
             log.info("✔ Seed committed.")


### PR DESCRIPTION
## Summary
- `tools/seeds/run_demo_seed.py` crashed post-execute on `conn.notices` (psycopg v3 removed it; psycopg2 attribute).
- Switch to `conn.add_notice_handler(...)` to capture PG NOTICEs into a local list.
- Seed SQL itself was always valid — only the runner's notice-collection step was broken.

## Test plan
Already verified on prod NeonDB with this patch (just now, on Charlie):
- [x] `--dry-run` succeeds, rolls back cleanly, prints all 6 verification notices
- [x] `--commit` succeeds, all 6 verification notices print
- [x] `--verify` returns ✔ on all 6 counts (templates=5, instances=5, kg_entities=14, proposals=12, evidence=6, relationships=12)

## Followup
- Followup to #1295.
- `kg_entities` count is 14, not 13 as README claims — separate doc issue, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)