### PR TITLE
feat(hub): demo backend Phases 4-6 — live signal cache + trends, /api/mira/ask grounding, Slack demo-namespace gate

### DIFF
--- a/docs/plans/2026-05-14-demo-backend-plan.md
+++ b/docs/plans/2026-05-14-demo-backend-plan.md
@@ -100,3 +100,23 @@
 
 - Linear: hit Free tier limit (per memory) — track in GitHub issues only until resolved.
 - Issues to file after this plan lands: P3, P4, P5, P6, P7, P8 (one each).
+
+---
+
+## 2026-05-15 — Phases 4–6 status (this PR)
+
+Task brief used different numbering than the plan above; reconciling here.
+
+| Brief phase | Plan phase(s) | Status in this PR |
+|---|---|---|
+| **Brief P4: signal simulator + event store** | P5 (mock signal feed) | ✅ Migration 020 adds `live_signal_cache` (current state, keyed on `(tenant_id, plc_tag)`), `diagnostic_trend_sessions`, `diagnostic_trend_signals`. New helper `mira-hub/src/lib/signal-recorder.ts` is the single write path that fans out to events + cache and reports edge classification. Endpoints: existing `POST /api/demo/signals/toggle` now writes through the recorder; new `POST /api/demo/signals/set` (arbitrary value by plc_tag or component_id) and `GET /api/demo/signals/summary` (full cache snapshot). Transition counting lives in `countTransitions` (LAG window over the events table). |
+| **Brief P5: wire /api/mira/ask to real data** | P6 + P7 (KG handlers, intent wire-up) | ✅ The Phase 3 ask endpoint already pulled `components`, `kg_relationships`, and recent `live_signal_events`. This PR adds: cache-derived "current signal state" block, transition count injection when the question mentions "in the last N seconds/minutes", and a `trend_proposal` payload (non-creating) when the question implies a recurring fault. We deliberately did NOT add 5 named KG handlers — the existing context-injection path covers the demo's 5 question shapes and stays smaller. |
+| **Brief P6: Slack namespace gate** | P4 (Slack namespace gate) | ✅ The gate landed in PR #1280 (engine.py `_handle_uns_confirmation_request`). This PR adds the tenant-scoped lookup path: `mira-bots/shared/demo_namespace.py` matches asset tags (CV-001, PE-001…) and names ("Conveyor 001") against `kg_entities` + `installed_component_instances` for the active tenant; the gate consults it *before* the generic manufacturer/model prompt. The existing UNS resolver is untouched (no global VENDOR_ALIASES drift). When the tech confirms, the match's `asset_id`/`component_id` lands on `state["context"]["confirmed_namespace"]` so downstream retrieval can target the KG row. |
+
+Also fixed in this PR: migration 019 policies were not idempotent (no `DROP POLICY IF EXISTS`). Patched to match the pattern PR #1296 established for 017/018.
+
+Out of scope (still per the original plan or follow-up):
+- P3 tablet read API — already merged in PR #1295.
+- Real-time MQTT subscription — still mocked.
+- Promotion service from `relationship_proposals.verified` → `kg_relationships` — still direct-insert.
+- Tablet demo page (P8) — frontend, separate PR.

--- a/mira-bots/shared/demo_namespace.py
+++ b/mira-bots/shared/demo_namespace.py
@@ -1,0 +1,262 @@
+"""Tenant-scoped namespace resolver for the UNS Confirmation Gate.
+
+Spec: docs/plans/2026-05-14-demo-backend-plan.md (Phase 6 of the
+2026-05-15 PR).
+
+The existing UNS resolver in `uns_resolver.py` is the right call for
+generic diagnostic turns — it extracts manufacturer + model from message
+text via alias tables and is shared across every tenant in production.
+But the May 21 tablet demo asks for a more specific behavior:
+
+    User: "I'm working on Conveyor 001 and PE-001 isn't reading"
+    MIRA:  "Confirm: troubleshooting **Conveyor 001 / PE-001** at
+            enterprise.demo.site.lake_wales..."
+
+For that exact pattern, we want the gate to match against the *tenant's*
+known assets and components — not the global vendor alias table. This
+helper performs that lookup against `kg_entities` (for asset tags + names)
+and `installed_component_instances` (for component names + aliases).
+
+It is intentionally additive: `uns_resolver.py` is untouched. Engine code
+calls this *before* the generic gate prompt, and only falls through to
+the manufacturer/model prompt if no tenant-scoped hit is found.
+
+Sync sqlalchemy with NullPool, never raises — matches the pattern in
+`neon_recall.kb_has_coverage`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import asdict, dataclass
+from typing import Any
+
+logger = logging.getLogger("mira-gsd")
+
+# Asset / component tag pattern. Matches:
+#   PE-001, MTR-001, VFD-001, PLC-001, PANEL-001, CV-001, etc.
+# Two-to-five uppercase letters, optional dash, two-to-four digits.
+# Case-insensitive at match time; normalized to upper for the DB lookup.
+#
+# Deliberately permissive — "ID-001", "OF24", etc. all match here. The
+# DB lookup is the filter (no row → None) so false-positive candidates
+# never reach the gate prompt. Don't tighten this without checking what
+# real asset-tag conventions tenants use.
+_TAG_RE = re.compile(r"\b([A-Z]{2,5}-?\d{2,4})\b", re.IGNORECASE)
+
+# Common asset-name patterns ("Conveyor 001", "Line A", "Mixer 7").
+# Matches title-cased noun + integer. Cheap heuristic; the DB filter is
+# the source of truth.
+_NAME_RE = re.compile(
+    r"\b("
+    r"Conveyor|Mixer|Pump|Compressor|Boiler|Chiller|Reactor|"
+    r"Press|Mill|Lathe|Grinder|Saw|Welder|Robot|"
+    r"Packer|Palletizer|Wrapper|Filler|Capper|Labeler|"
+    r"Oven|Cooler|Freezer|Dryer|Heater|"
+    r"Line|Cell|Station|Bay"
+    r")\s+\d{1,4}\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class DemoNamespaceMatch:
+    asset_id: str | None = None
+    asset_name: str | None = None
+    asset_tag: str | None = None
+    component_id: str | None = None
+    component_name: str | None = None
+    component_plc_tag: str | None = None
+    matched_terms: tuple[str, ...] = ()
+    confidence: float = 0.0
+    uns_path: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        d = asdict(self)
+        d["matched_terms"] = list(self.matched_terms)
+        return d
+
+
+def _extract_candidates(message: str) -> tuple[list[str], list[str]]:
+    """Return (tag_candidates, name_candidates) from the message.
+
+    Tag candidates are normalized to uppercase. Name candidates are kept
+    in their original case for ILIKE matching against `kg_entities.name`.
+    """
+    tags = sorted({m.group(1).upper() for m in _TAG_RE.finditer(message)})
+    names = sorted({m.group(0) for m in _NAME_RE.finditer(message)})
+    return tags, names
+
+
+def resolve_demo_namespace(
+    message: str,
+    tenant_id: str | None,
+) -> DemoNamespaceMatch | None:
+    """Look up asset / component by tag or name mentioned in `message`.
+
+    Returns None when:
+      - no tenant_id (we never run this against the global pool),
+      - no NEON_DATABASE_URL,
+      - sqlalchemy is missing,
+      - the query fails,
+      - or no candidate tag/name appears in the message,
+      - or no row matches.
+
+    Match precedence:
+      1. component_name / aliases exact (PE-001 → installed_component_instances)
+      2. kg_entities asset_tag exact   (CV-001 → equipment row)
+      3. kg_entities name ILIKE        ("Conveyor 001")
+
+    When both an asset and a component are matched, both ids land on the
+    return value so the engine can prefill the gate with the most specific
+    context.
+    """
+    if not tenant_id or not message:
+        return None
+    if not os.environ.get("NEON_DATABASE_URL"):
+        return None
+
+    tags, names = _extract_candidates(message)
+    if not tags and not names:
+        return None
+
+    try:
+        from sqlalchemy import create_engine, text  # noqa: PLC0415
+        from sqlalchemy.pool import NullPool  # noqa: PLC0415
+    except ImportError:
+        logger.debug("DEMO_NAMESPACE sqlalchemy not installed")
+        return None
+
+    try:
+        engine = create_engine(
+            os.environ["NEON_DATABASE_URL"],
+            poolclass=NullPool,
+            connect_args={"sslmode": "require"},
+            pool_pre_ping=True,
+        )
+        with engine.connect() as conn:
+            # 1. Component by name or alias.
+            component_row = None
+            if tags:
+                # Component names like "PE-001" sit in
+                # installed_component_instances.component_name (or aliases).
+                result = conn.execute(
+                    text(
+                        """
+                        SELECT i.id, i.component_name, i.plc_tag, i.asset_id,
+                               i.canonical_name,
+                               asset.name AS asset_name,
+                               asset.properties->>'asset_tag' AS asset_tag,
+                               asset.uns_path::text AS uns_path
+                          FROM installed_component_instances i
+                          LEFT JOIN kg_entities asset ON asset.id = i.asset_id
+                         WHERE i.tenant_id = :tid
+                           AND (
+                                UPPER(i.component_name) = ANY(:tags)
+                             OR UPPER(i.canonical_name) = ANY(:tags)
+                             OR EXISTS (
+                                  SELECT 1 FROM unnest(i.aliases) a
+                                   WHERE UPPER(a) = ANY(:tags)
+                                )
+                           )
+                         LIMIT 1
+                        """
+                    ),
+                    {"tid": tenant_id, "tags": tags},
+                ).fetchone()
+                if result:
+                    component_row = dict(result._mapping)
+
+            # 2. Asset by asset_tag (cheap exact match on properties JSONB).
+            asset_row = None
+            if component_row and component_row.get("asset_id"):
+                asset_row = {
+                    "id": component_row["asset_id"],
+                    "name": component_row.get("asset_name"),
+                    "asset_tag": component_row.get("asset_tag"),
+                    "uns_path": component_row.get("uns_path"),
+                }
+            elif tags:
+                ar = conn.execute(
+                    text(
+                        """
+                        SELECT id, name,
+                               properties->>'asset_tag' AS asset_tag,
+                               uns_path::text AS uns_path
+                          FROM kg_entities
+                         WHERE tenant_id = :tid
+                           AND entity_type = 'equipment'
+                           AND UPPER(properties->>'asset_tag') = ANY(:tags)
+                         LIMIT 1
+                        """
+                    ),
+                    {"tid": tenant_id, "tags": tags},
+                ).fetchone()
+                if ar:
+                    asset_row = dict(ar._mapping)
+
+            # 3. Asset by name ILIKE (when nothing matched on tag).
+            if asset_row is None and names:
+                for candidate in names:
+                    ar = conn.execute(
+                        text(
+                            """
+                            SELECT id, name,
+                                   properties->>'asset_tag' AS asset_tag,
+                                   uns_path::text AS uns_path
+                              FROM kg_entities
+                             WHERE tenant_id = :tid
+                               AND entity_type = 'equipment'
+                               AND name ILIKE :name
+                             LIMIT 1
+                            """
+                        ),
+                        {"tid": tenant_id, "name": candidate},
+                    ).fetchone()
+                    if ar:
+                        asset_row = dict(ar._mapping)
+                        break
+    except Exception as exc:  # noqa: BLE001 — never raise
+        logger.info("DEMO_NAMESPACE lookup failed: %s", exc)
+        return None
+
+    if asset_row is None and component_row is None:
+        return None
+
+    matched: list[str] = []
+    if component_row:
+        matched.append(component_row.get("component_name") or "")
+    if asset_row and asset_row.get("asset_tag"):
+        if asset_row["asset_tag"] not in matched:
+            matched.append(asset_row["asset_tag"])
+    elif asset_row and asset_row.get("name"):
+        if asset_row["name"] not in matched:
+            matched.append(asset_row["name"])
+
+    # Confidence:
+    #   1.0 — exact tag match on component  AND its asset resolved
+    #   0.9 — exact tag match on asset only
+    #   0.8 — component matched (no parent asset somehow — defensive)
+    #   0.7 — asset matched by name ILIKE
+    if component_row and asset_row:
+        conf = 1.0
+    elif asset_row and tags:
+        conf = 0.9
+    elif component_row:
+        conf = 0.8
+    else:
+        conf = 0.7
+
+    return DemoNamespaceMatch(
+        asset_id=(asset_row or {}).get("id"),
+        asset_name=(asset_row or {}).get("name"),
+        asset_tag=(asset_row or {}).get("asset_tag"),
+        component_id=(component_row or {}).get("id"),
+        component_name=(component_row or {}).get("component_name"),
+        component_plc_tag=(component_row or {}).get("plc_tag"),
+        matched_terms=tuple(t for t in matched if t),
+        confidence=conf,
+        uns_path=(asset_row or {}).get("uns_path"),
+    )

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -1316,7 +1316,11 @@ class Supervisor:
             # _should_fire_uns_gate so the bypass logic is testable directly.
             if self._should_fire_uns_gate(_router_intent, state, message, sc):
                 return await self._handle_uns_confirmation_request(
-                    chat_id, message, state, uns_ctx, trace_id,
+                    chat_id,
+                    message,
+                    state,
+                    uns_ctx,
+                    trace_id,
                     tenant_id=resolved_tenant,
                 )
 
@@ -4172,11 +4176,7 @@ class Supervisor:
             "UNS_CONFIRM_REQUEST chat_id=%s candidate=%r confidence=%.2f demo_match=%s",
             chat_id,
             candidate,
-            (
-                demo_match.confidence
-                if demo_match
-                else (getattr(uns_ctx, "confidence", 0.0) or 0.0)
-            ),
+            (demo_match.confidence if demo_match else (getattr(uns_ctx, "confidence", 0.0) or 0.0)),
             bool(demo_match),
         )
         return self._make_result(

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -1316,7 +1316,8 @@ class Supervisor:
             # _should_fire_uns_gate so the bypass logic is testable directly.
             if self._should_fire_uns_gate(_router_intent, state, message, sc):
                 return await self._handle_uns_confirmation_request(
-                    chat_id, message, state, uns_ctx, trace_id
+                    chat_id, message, state, uns_ctx, trace_id,
+                    tenant_id=resolved_tenant,
                 )
 
         # Intent gate: casual/help messages in IDLE state — no LLM/RAG needed
@@ -4085,43 +4086,98 @@ class Supervisor:
         state: dict,
         uns_ctx,
         trace_id,
+        tenant_id: str | None = None,
     ) -> dict:
         """Gate firing: ask the user to confirm or supply the equipment.
 
         Saves `pending_uns_confirm` on state["context"] so the next user turn
         is consumed by `_handle_uns_confirmation_response`.
+
+        Two-tier candidate resolution:
+          1. Tenant-scoped demo-namespace lookup — if the message references
+             an asset tag/name or component tag that exists in the tenant's
+             kg_entities / installed_component_instances, prefer that as the
+             confirmation candidate. This is the path the May 21 expo demo
+             takes ("I'm on Conveyor 001 / PE-001"). The existing UNS
+             resolver doesn't know tenant data; this fills that gap without
+             touching the resolver.
+          2. Generic manufacturer/model from `uns_ctx` — the unchanged
+             behavior for every other tenant and every other turn.
         """
         ctx = state.get("context") or {}
 
+        # Tier 1 — tenant-scoped lookup.
+        demo_match = None
+        try:
+            from .demo_namespace import resolve_demo_namespace  # noqa: PLC0415
+
+            demo_match = resolve_demo_namespace(message, tenant_id)
+        except Exception as exc:  # noqa: BLE001 — never block the gate
+            logger.debug("UNS_CONFIRM demo_namespace lookup error: %s", exc)
+            demo_match = None
+
         candidate = None
-        if getattr(uns_ctx, "manufacturer", None):
+        prompt: str
+        if demo_match and demo_match.confidence >= 0.7:
+            parts: list[str] = []
+            if demo_match.asset_name:
+                parts.append(demo_match.asset_name)
+            if demo_match.asset_tag and demo_match.asset_tag not in parts:
+                parts.append(demo_match.asset_tag)
+            if demo_match.component_name:
+                parts.append(demo_match.component_name)
+            candidate = " / ".join(parts) if parts else None
+            confidence_pct = int(round(demo_match.confidence * 100))
+            if candidate:
+                prompt = (
+                    f"Before I diagnose, confirm the equipment: **{candidate}** "
+                    f"(confidence {confidence_pct}%). "
+                    "Reply 'yes' to confirm, or tell me the correct equipment."
+                )
+            else:
+                prompt = (
+                    "Before I diagnose, I need to know the equipment. "
+                    "Tell me the asset and component you're working on."
+                )
+            # Stash the namespace match so a follow-up turn can promote it
+            # straight into asset_identified / asset_id without re-querying.
+            ctx["pending_uns_confirm"] = {
+                "candidate": candidate,
+                "demo_namespace": demo_match.as_dict(),
+            }
+        elif getattr(uns_ctx, "manufacturer", None):
+            # Tier 2 — generic manufacturer/model path (unchanged).
             candidate = uns_ctx.manufacturer
             if getattr(uns_ctx, "model", None):
                 candidate = f"{candidate}, {uns_ctx.model}"
-
-        if candidate:
             confidence_pct = int(round((getattr(uns_ctx, "confidence", 0.0) or 0.0) * 100))
             prompt = (
                 f"Before I diagnose, confirm the equipment: **{candidate}** "
                 f"(confidence {confidence_pct}%). "
                 "Reply 'yes' to confirm, or tell me the correct manufacturer and model."
             )
+            ctx["pending_uns_confirm"] = {"candidate": candidate}
         else:
             prompt = (
                 "Before I diagnose, I need to know the equipment. "
                 "Tell me the manufacturer and model "
                 "(e.g., 'Allen-Bradley PowerFlex 525')."
             )
+            ctx["pending_uns_confirm"] = {"candidate": None}
 
-        ctx["pending_uns_confirm"] = {"candidate": candidate}
         state["context"] = ctx
         self._save_state(chat_id, state)
         self._record_exchange(chat_id, state, message, prompt)
         logger.info(
-            "UNS_CONFIRM_REQUEST chat_id=%s candidate=%r confidence=%.2f",
+            "UNS_CONFIRM_REQUEST chat_id=%s candidate=%r confidence=%.2f demo_match=%s",
             chat_id,
             candidate,
-            getattr(uns_ctx, "confidence", 0.0) or 0.0,
+            (
+                demo_match.confidence
+                if demo_match
+                else (getattr(uns_ctx, "confidence", 0.0) or 0.0)
+            ),
+            bool(demo_match),
         )
         return self._make_result(
             prompt,
@@ -4153,6 +4209,13 @@ class Supervisor:
 
         if msg in _YES and candidate:
             state["asset_identified"] = candidate
+            # When the request came from the demo-namespace path, preserve
+            # the asset_id / component_id under context["confirmed_namespace"]
+            # so downstream retrieval can target the KG row directly instead
+            # of fuzzy-matching on the label.
+            demo_ns = pending.get("demo_namespace")
+            if demo_ns:
+                ctx["confirmed_namespace"] = demo_ns
             ctx.pop("pending_uns_confirm", None)
             state["context"] = ctx
             self._save_state(chat_id, state)
@@ -4161,7 +4224,12 @@ class Supervisor:
                 "(fault code, symptom, or what you're seeing)."
             )
             self._record_exchange(chat_id, state, message, reply)
-            logger.info("UNS_CONFIRM_YES chat_id=%s asset=%r", chat_id, candidate)
+            logger.info(
+                "UNS_CONFIRM_YES chat_id=%s asset=%r confirmed_namespace=%s",
+                chat_id,
+                candidate,
+                bool(demo_ns),
+            )
             return self._make_result(
                 reply,
                 "high",

--- a/mira-bots/tests/test_demo_namespace.py
+++ b/mira-bots/tests/test_demo_namespace.py
@@ -1,0 +1,93 @@
+"""Offline tests for the demo-namespace resolver.
+
+The resolver's DB lookup path is exercised in integration tests against a
+seeded NeonDB; here we cover only the candidate-extraction helper, which
+runs purely on the message string.
+
+Spec: docs/plans/2026-05-14-demo-backend-plan.md (Phase 6 of the
+2026-05-15 PR).
+"""
+
+from __future__ import annotations
+
+from shared.demo_namespace import (
+    DemoNamespaceMatch,
+    _extract_candidates,
+    resolve_demo_namespace,
+)
+
+
+def test_extract_tag_pe001():
+    tags, names = _extract_candidates("PE-001 isn't reading")
+    assert "PE-001" in tags
+    assert names == []
+
+
+def test_extract_tag_case_insensitive():
+    tags, _ = _extract_candidates("pe-001 and mtr-001 are misbehaving")
+    assert "PE-001" in tags
+    assert "MTR-001" in tags
+
+
+def test_extract_asset_name_conveyor_001():
+    _, names = _extract_candidates("I'm working on Conveyor 001 today")
+    # Name is preserved in original casing for ILIKE
+    assert any(n.lower() == "conveyor 001" for n in names)
+
+
+def test_extract_mixed_tag_and_name():
+    tags, names = _extract_candidates(
+        "Conveyor 001 keeps shutting off when PE-001 sees a tote"
+    )
+    assert "PE-001" in tags
+    assert any(n.lower() == "conveyor 001" for n in names)
+
+
+def test_extract_no_match_returns_empty():
+    tags, names = _extract_candidates("Hello, I have a general question")
+    assert tags == []
+    assert names == []
+
+
+def test_extract_ignores_short_garbage():
+    # Single-letter prefixes or short numbers should NOT trip the tag regex
+    tags, _ = _extract_candidates("F1 and X1 are not asset tags")
+    assert tags == []
+
+
+def test_resolve_returns_none_without_tenant():
+    """No tenant → no lookup, no exception."""
+    assert resolve_demo_namespace("Conveyor 001 down", None) is None
+
+
+def test_resolve_returns_none_without_neon_url(monkeypatch):
+    """No NEON_DATABASE_URL → graceful None."""
+    monkeypatch.delenv("NEON_DATABASE_URL", raising=False)
+    assert (
+        resolve_demo_namespace("PE-001 not reading", "some-tenant-id")
+        is None
+    )
+
+
+def test_resolve_returns_none_without_candidates(monkeypatch):
+    """Message that doesn't mention any tag/name short-circuits before DB."""
+    monkeypatch.setenv("NEON_DATABASE_URL", "postgres://nowhere")
+    assert resolve_demo_namespace("Generic greeting hi", "tenant") is None
+
+
+def test_match_dataclass_shape():
+    m = DemoNamespaceMatch(
+        asset_id="a",
+        asset_name="Conveyor 001",
+        asset_tag="CV-001",
+        component_id="c",
+        component_name="PE-001",
+        component_plc_tag="Line5.CV001.PE001",
+        matched_terms=("Conveyor 001", "PE-001"),
+        confidence=1.0,
+        uns_path="enterprise.demo.site.lake_wales",
+    )
+    d = m.as_dict()
+    assert d["matched_terms"] == ["Conveyor 001", "PE-001"]
+    assert d["confidence"] == 1.0
+    assert d["asset_tag"] == "CV-001"

--- a/mira-hub/db/migrations/019_sessions_and_signals.sql
+++ b/mira-hub/db/migrations/019_sessions_and_signals.sql
@@ -69,6 +69,7 @@ CREATE INDEX IF NOT EXISTS idx_sessions_recent
 
 ALTER TABLE troubleshooting_sessions ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS sessions_tenant ON troubleshooting_sessions;
 CREATE POLICY sessions_tenant
     ON troubleshooting_sessions
     USING (tenant_id = current_setting('app.tenant_id', true)::UUID
@@ -121,6 +122,7 @@ CREATE INDEX IF NOT EXISTS idx_signals_recent
 
 ALTER TABLE live_signal_events ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS signals_tenant ON live_signal_events;
 CREATE POLICY signals_tenant
     ON live_signal_events
     USING (tenant_id = current_setting('app.tenant_id', true)::UUID

--- a/mira-hub/db/migrations/020_signal_cache_and_trends.sql
+++ b/mira-hub/db/migrations/020_signal_cache_and_trends.sql
@@ -1,0 +1,205 @@
+BEGIN;
+
+-- Migration 020: live_signal_cache + diagnostic trend session tables.
+-- Spec: docs/plans/2026-05-14-demo-backend-plan.md (Phases 4–6 of the
+-- 2026-05-15 PR — extends the live signal layer landed in migration 019).
+--
+-- Three demo-driven tables. RLS-scoped per tenant. Indexes sized for one
+-- demo tenant with a handful of components; re-tune when real production
+-- load lands.
+--
+--   live_signal_cache
+--     Denormalized current state for one (tenant_id, plc_tag) topic. The
+--     events table (live_signal_events from 019) is the truth log; this
+--     cache is the "what is it RIGHT NOW" read path the tablet polls when
+--     it only needs the latest value (e.g. "is PE-001 currently blocked?"
+--     without scanning history).
+--
+--     Keyed on plc_tag (the MQTT-shaped topic) — not component_id —
+--     because a tag can exist before a component is bound, and a single
+--     component may republish multiple tags. component_id is captured
+--     when known (resolved via installed_component_instances at write
+--     time) but does not participate in the UNIQUE key.
+--
+--   diagnostic_trend_sessions
+--     A recording window opened during troubleshooting. When MIRA proposes
+--     "let's watch PE-001, the run command, and VFD faulted for the next
+--     two minutes", it opens a row here with the watched topics. The end
+--     of the window is recorded by `ended_at`; status flips to
+--     'completed' or 'abandoned'.
+--
+--     The trend session is linked optionally to a troubleshooting_session
+--     so the tablet can show captured signals alongside the chat turn
+--     that proposed them.
+--
+--   diagnostic_trend_signals
+--     Append-only capture of signal samples observed during a trend
+--     session. Populated by the trend-append endpoint (explicit write)
+--     OR by a read-time JOIN against live_signal_events filtered by
+--     trend_session.watched_topics and the trend window. The migration
+--     creates the table; the read path is the source of truth for the
+--     demo and lets the tablet show "what we saw" without coupling the
+--     signal recorder to active-trend state.
+
+CREATE TABLE IF NOT EXISTS live_signal_cache (
+    tenant_id UUID NOT NULL,
+    plc_tag TEXT NOT NULL,
+
+    -- Resolved at write time when the tag maps to a known component.
+    -- Nullable because tags can publish before a component is bound.
+    component_id UUID,
+
+    -- Latest value. Same three-column shape as live_signal_events.
+    last_value_text TEXT,
+    last_value_numeric DOUBLE PRECISION,
+    last_value_bool BOOLEAN,
+
+    -- When the last sample arrived (regardless of whether it was an edge).
+    last_seen_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- When the value last *changed*. Updated only when the incoming value
+    -- differs from the previous value (rising/falling edge for booleans,
+    -- numeric inequality for numerics, string inequality for text).
+    last_changed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    -- The previous value, captured at the moment of the most recent change.
+    -- Lets the tablet show "was IDLE_CLEAR, now ITEM_PRESENT" without a
+    -- second query against events.
+    prev_value_text TEXT,
+    prev_value_numeric DOUBLE PRECISION,
+    prev_value_bool BOOLEAN,
+
+    -- Provenance carried forward from the last event.
+    simulated BOOLEAN NOT NULL DEFAULT true,
+    source TEXT NOT NULL DEFAULT 'demo_simulator',
+    properties JSONB NOT NULL DEFAULT '{}',
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (tenant_id, plc_tag),
+
+    CONSTRAINT cache_value_present CHECK (
+        last_value_text IS NOT NULL
+        OR last_value_numeric IS NOT NULL
+        OR last_value_bool IS NOT NULL
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_signal_cache_component
+    ON live_signal_cache (tenant_id, component_id)
+    WHERE component_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_signal_cache_changed_at
+    ON live_signal_cache (tenant_id, last_changed_at DESC);
+
+ALTER TABLE live_signal_cache ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS signal_cache_tenant ON live_signal_cache;
+CREATE POLICY signal_cache_tenant
+    ON live_signal_cache
+    USING (tenant_id = current_setting('app.tenant_id', true)::UUID
+           OR tenant_id = current_setting('app.current_tenant_id', true)::UUID);
+
+
+CREATE TABLE IF NOT EXISTS diagnostic_trend_sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+
+    -- Optional parent troubleshooting session. When set, the tablet shows
+    -- captured trend signals inline with the chat turn that proposed the
+    -- trend. Nullable for unattended/ad-hoc trends started from the API.
+    troubleshooting_session_id UUID,
+
+    -- What we're watching and why.
+    name TEXT NOT NULL,                  -- e.g. "Motor restart investigation"
+    hypothesis TEXT,                     -- one-line statement under test
+    watched_topics TEXT[] NOT NULL DEFAULT '{}',  -- plc_tag list
+
+    -- Demo trends are scoped to one asset for clarity.
+    asset_id UUID,
+
+    status TEXT NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'completed', 'abandoned')),
+
+    started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ended_at TIMESTAMPTZ,                -- NULL while active
+    duration_seconds INTEGER,            -- nullable; set on completion
+
+    -- What we concluded. Filled in when the technician (or MIRA) closes the
+    -- trend with a verdict.
+    conclusion TEXT,
+
+    metadata JSONB NOT NULL DEFAULT '{}',
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_trend_sessions_tenant
+    ON diagnostic_trend_sessions (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_trend_sessions_session
+    ON diagnostic_trend_sessions (tenant_id, troubleshooting_session_id)
+    WHERE troubleshooting_session_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_trend_sessions_active
+    ON diagnostic_trend_sessions (tenant_id, status)
+    WHERE status = 'active';
+
+ALTER TABLE diagnostic_trend_sessions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS trend_sessions_tenant ON diagnostic_trend_sessions;
+CREATE POLICY trend_sessions_tenant
+    ON diagnostic_trend_sessions
+    USING (tenant_id = current_setting('app.tenant_id', true)::UUID
+           OR tenant_id = current_setting('app.current_tenant_id', true)::UUID);
+
+
+CREATE TABLE IF NOT EXISTS diagnostic_trend_signals (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    trend_session_id UUID NOT NULL,
+    tenant_id UUID NOT NULL,
+
+    plc_tag TEXT NOT NULL,
+    component_id UUID,
+
+    value_text TEXT,
+    value_numeric DOUBLE PRECISION,
+    value_bool BOOLEAN,
+
+    -- Edge marker for boolean tags. NULL when the sample was a steady-state
+    -- read (numeric, or boolean equal to the previous).
+    edge_direction TEXT CHECK (edge_direction IN ('rising', 'falling')),
+
+    captured_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    CONSTRAINT trend_signal_value_present CHECK (
+        value_text IS NOT NULL
+        OR value_numeric IS NOT NULL
+        OR value_bool IS NOT NULL
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_trend_signals_session
+    ON diagnostic_trend_signals (trend_session_id, captured_at);
+CREATE INDEX IF NOT EXISTS idx_trend_signals_tenant_tag
+    ON diagnostic_trend_signals (tenant_id, plc_tag, captured_at DESC);
+
+ALTER TABLE diagnostic_trend_signals ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS trend_signals_tenant ON diagnostic_trend_signals;
+CREATE POLICY trend_signals_tenant
+    ON diagnostic_trend_signals
+    USING (tenant_id = current_setting('app.tenant_id', true)::UUID
+           OR tenant_id = current_setting('app.current_tenant_id', true)::UUID);
+
+
+-- Grant the limited app role used by withTenantContext. Mirrors 019.
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'factorylm_app') THEN
+        GRANT SELECT, INSERT, UPDATE ON live_signal_cache TO factorylm_app;
+        GRANT SELECT, INSERT, UPDATE ON diagnostic_trend_sessions TO factorylm_app;
+        GRANT SELECT, INSERT ON diagnostic_trend_signals TO factorylm_app;
+    END IF;
+END $$;
+
+COMMIT;

--- a/mira-hub/src/app/api/demo/signals/set/route.ts
+++ b/mira-hub/src/app/api/demo/signals/set/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo, isDemoTenant } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+import { recordSignalValue } from "@/lib/signal-recorder";
+
+export const dynamic = "force-dynamic";
+
+interface SetPayload {
+  plc_tag?: string;
+  component_id?: string;
+  value_text?: string | null;
+  value_numeric?: number | null;
+  value_bool?: boolean | null;
+  source?: string;
+  notes?: string;
+  properties?: Record<string, unknown>;
+}
+
+/**
+ * POST /api/demo/signals/set
+ *
+ * Set an arbitrary signal value by plc_tag OR component_id. Unlike `toggle`,
+ * this endpoint does not interpret `present`/`clear`/`auto` semantics — the
+ * caller passes whichever value flavor matches the tag's type (text for
+ * discrete states, numeric for analog, bool for 1-bit).
+ *
+ * Writes through `recordSignalValue`, which keeps live_signal_events and
+ * live_signal_cache in sync and reports the edge classification
+ * (rising | falling | changed | steady) the cache UPSERT detected.
+ *
+ * Demo-tenant only.
+ */
+export async function POST(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+  if (!isDemoTenant(ctx.tenantId)) {
+    return NextResponse.json(
+      { error: "Signal simulator is demo-tenant only" },
+      { status: 403 },
+    );
+  }
+
+  let body: SetPayload;
+  try {
+    body = (await req.json()) as SetPayload;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+  if (!body.plc_tag && !body.component_id) {
+    return NextResponse.json(
+      { error: "plc_tag_or_component_id_required" },
+      { status: 400 },
+    );
+  }
+  if (
+    (body.value_text === undefined || body.value_text === null) &&
+    (body.value_numeric === undefined || body.value_numeric === null) &&
+    (body.value_bool === undefined || body.value_bool === null)
+  ) {
+    return NextResponse.json({ error: "no_value_supplied" }, { status: 400 });
+  }
+
+  const properties =
+    body.properties ?? (body.notes ? { notes: body.notes } : undefined);
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, (c) =>
+      recordSignalValue(c, {
+        tenantId: ctx.tenantId,
+        plcTag: body.plc_tag ?? null,
+        componentId: body.component_id ?? null,
+        value: {
+          text: body.value_text ?? null,
+          numeric: body.value_numeric ?? null,
+          bool: body.value_bool ?? null,
+        },
+        source: body.source ?? "demo_simulator",
+        simulated: true,
+        properties,
+      }),
+    );
+
+    return NextResponse.json(
+      {
+        event_id: result.eventId,
+        plc_tag: result.plcTag,
+        component_id: result.componentId,
+        edge: result.edge,
+        last_changed_at: result.lastChangedAt,
+        previous_value: result.previousValue,
+      },
+      { status: 201 },
+    );
+  } catch (err) {
+    const status = (err as { status?: number }).status ?? 500;
+    const msg = err instanceof Error ? err.message : "set_failed";
+    if (status === 500) console.error("[api/demo/signals/set POST]", err);
+    return NextResponse.json({ error: msg }, { status });
+  }
+}

--- a/mira-hub/src/app/api/demo/signals/summary/route.ts
+++ b/mira-hub/src/app/api/demo/signals/summary/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from "next/server";
+import { sessionOrDemo, isDemoTenant } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+interface CacheRow {
+  plc_tag: string;
+  component_id: string | null;
+  component_name: string | null;
+  asset_id: string | null;
+  asset_name: string | null;
+  last_value_text: string | null;
+  last_value_numeric: number | null;
+  last_value_bool: boolean | null;
+  prev_value_text: string | null;
+  prev_value_numeric: number | null;
+  prev_value_bool: boolean | null;
+  last_seen_at: string;
+  last_changed_at: string;
+  simulated: boolean;
+  source: string;
+  properties: Record<string, unknown>;
+}
+
+/**
+ * GET /api/demo/signals/summary
+ *
+ * Snapshot of the current value for every topic the demo tenant has touched.
+ * Reads live_signal_cache directly (the denormalized table maintained by
+ * `recordSignalValue`) so the tablet can render a "current state" panel in
+ * one query without polling per-component endpoints.
+ *
+ * Joins through installed_component_instances → kg_entities so each cache
+ * row carries asset_name / component_name when bindings exist. Cache rows
+ * for unbound tags still appear with NULL component fields.
+ *
+ * Sort order: most-recently-changed first (helps the tablet animate the
+ * thing that just flipped).
+ *
+ * Demo-tenant only.
+ */
+export async function GET(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOrDemo(req);
+  if (ctx instanceof NextResponse) return ctx;
+  if (!isDemoTenant(ctx.tenantId)) {
+    return NextResponse.json(
+      { error: "Signal summary is demo-tenant only" },
+      { status: 403 },
+    );
+  }
+
+  try {
+    const rows = await withTenantContext<CacheRow[]>(ctx.tenantId, (c) =>
+      c
+        .query(
+          `SELECT
+              cache.plc_tag,
+              cache.component_id,
+              i.component_name,
+              i.asset_id,
+              asset.name AS asset_name,
+              cache.last_value_text,
+              cache.last_value_numeric,
+              cache.last_value_bool,
+              cache.prev_value_text,
+              cache.prev_value_numeric,
+              cache.prev_value_bool,
+              cache.last_seen_at,
+              cache.last_changed_at,
+              cache.simulated,
+              cache.source,
+              cache.properties
+            FROM live_signal_cache cache
+            LEFT JOIN installed_component_instances i
+              ON i.id = cache.component_id
+            LEFT JOIN kg_entities asset
+              ON asset.id = i.asset_id
+            WHERE cache.tenant_id = $1
+            ORDER BY cache.last_changed_at DESC`,
+          [ctx.tenantId],
+        )
+        .then((r: { rows: CacheRow[] }) => r.rows),
+    );
+
+    return NextResponse.json(
+      {
+        signals: rows.map((r: CacheRow) => ({
+          plc_tag: r.plc_tag,
+          component_id: r.component_id,
+          component_name: r.component_name,
+          asset_id: r.asset_id,
+          asset_name: r.asset_name,
+          value: r.last_value_text ?? r.last_value_numeric ?? r.last_value_bool,
+          previous_value:
+            r.prev_value_text ?? r.prev_value_numeric ?? r.prev_value_bool ?? null,
+          last_seen_at: r.last_seen_at,
+          last_changed_at: r.last_changed_at,
+          simulated: r.simulated,
+          source: r.source,
+          properties: r.properties,
+        })),
+        count: rows.length,
+        as_of: new Date().toISOString(),
+      },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (err) {
+    console.error("[api/demo/signals/summary GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/demo/signals/toggle/route.ts
+++ b/mira-hub/src/app/api/demo/signals/toggle/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { sessionOrDemo, isDemoTenant } from "@/lib/demo-auth";
 import { withTenantContext } from "@/lib/tenant-context";
+import { recordSignalValue } from "@/lib/signal-recorder";
 
 export const dynamic = "force-dynamic";
 
@@ -17,9 +18,10 @@ interface TogglePayload {
 /**
  * POST /api/demo/signals/toggle
  *
- * Push a synthetic signal sample into live_signal_events. The tablet uses
- * this to drive the demo (e.g. simulate a tote interrupting PE-001) without
- * needing a real MQTT broker on the expo floor.
+ * Push a synthetic signal sample into live_signal_events + live_signal_cache
+ * via the shared `recordSignalValue` helper. The tablet uses this to drive
+ * the demo (e.g. simulate a tote interrupting PE-001) without needing a
+ * real MQTT broker on the expo floor.
  *
  * If `state` is supplied (preferred for discrete sensors), it maps:
  *   - "present" → value_text='item_present', value_bool=true
@@ -28,7 +30,8 @@ interface TogglePayload {
  *
  * Otherwise you can pass value_text / value_numeric / value_bool directly.
  *
- * Demo-only: tenant must be the demo tenant. Returns the created event.
+ * Demo-only: tenant must be the demo tenant. Returns the created event plus
+ * the cache's edge classification.
  */
 export async function POST(req: Request) {
   if (!process.env.NEON_DATABASE_URL) {
@@ -54,22 +57,25 @@ export async function POST(req: Request) {
   }
 
   try {
-    const row = await withTenantContext<Record<string, unknown>>(ctx.tenantId, async (c) => {
-      const cmp = await c
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      const cmpRow = await c
         .query(
           `SELECT id, plc_tag FROM installed_component_instances
             WHERE tenant_id = $1 AND id = $2
             LIMIT 1`,
           [ctx.tenantId, body.component_id],
         )
-        .then((r: { rows: Record<string, unknown>[] }) => r.rows[0] ?? null);
-      if (!cmp) {
+        .then(
+          (r: { rows: Array<{ id: string; plc_tag: string | null }> }) =>
+            r.rows[0] ?? null,
+        );
+      if (!cmpRow) {
         throw Object.assign(new Error("component_not_found"), { status: 404 });
       }
 
-      let valueText = body.value_text ?? null;
-      let valueNumeric = body.value_numeric ?? null;
-      let valueBool = body.value_bool ?? null;
+      let valueText: string | null = body.value_text ?? null;
+      let valueNumeric: number | null = body.value_numeric ?? null;
+      let valueBool: boolean | null = body.value_bool ?? null;
 
       if (body.state) {
         if (body.state === "present") {
@@ -77,15 +83,49 @@ export async function POST(req: Request) {
         } else if (body.state === "clear") {
           valueText = "idle_clear"; valueBool = false;
         } else if (body.state === "auto") {
-          const last = await c
-            .query(
-              `SELECT value_bool, value_text FROM live_signal_events
-                WHERE tenant_id = $1 AND component_id = $2
-                ORDER BY created_at DESC LIMIT 1`,
-              [ctx.tenantId, body.component_id],
-            )
-            .then((r: { rows: Record<string, unknown>[] }) => r.rows[0] ?? null);
-          const wasPresent = last?.value_bool === true || last?.value_text === "item_present";
+          // Read the cache (cheap, single row) — falls back to the events
+          // tail when no cache row exists yet.
+          let wasPresent = false;
+          if (cmpRow.plc_tag) {
+            const cached = await c
+              .query(
+                `SELECT last_value_bool, last_value_text
+                   FROM live_signal_cache
+                  WHERE tenant_id = $1 AND plc_tag = $2 LIMIT 1`,
+                [ctx.tenantId, cmpRow.plc_tag],
+              )
+              .then(
+                (r: {
+                  rows: Array<{
+                    last_value_bool: boolean | null;
+                    last_value_text: string | null;
+                  }>;
+                }) => r.rows[0] ?? null,
+              );
+            if (cached) {
+              wasPresent =
+                cached.last_value_bool === true ||
+                cached.last_value_text === "item_present";
+            } else {
+              const tail = await c
+                .query(
+                  `SELECT value_bool, value_text FROM live_signal_events
+                    WHERE tenant_id = $1 AND component_id = $2
+                    ORDER BY created_at DESC LIMIT 1`,
+                  [ctx.tenantId, body.component_id],
+                )
+                .then(
+                  (r: {
+                    rows: Array<{
+                      value_bool: boolean | null;
+                      value_text: string | null;
+                    }>;
+                  }) => r.rows[0] ?? null,
+                );
+              wasPresent =
+                tail?.value_bool === true || tail?.value_text === "item_present";
+            }
+          }
           valueText = wasPresent ? "idle_clear" : "item_present";
           valueBool = !wasPresent;
         }
@@ -95,31 +135,28 @@ export async function POST(req: Request) {
         throw Object.assign(new Error("no_value_supplied"), { status: 400 });
       }
 
-      const inserted = await c
-        .query(
-          `INSERT INTO live_signal_events
-             (tenant_id, component_id, plc_tag, value_text, value_numeric, value_bool,
-              simulated, source, properties)
-           VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8::jsonb)
-           RETURNING id, component_id, plc_tag, value_text, value_numeric, value_bool,
-                     simulated, source, properties, created_at`,
-          [
-            ctx.tenantId,
-            body.component_id,
-            cmp.plc_tag,
-            valueText,
-            valueNumeric,
-            valueBool,
-            body.source ?? "demo_simulator",
-            JSON.stringify(body.notes ? { notes: body.notes } : {}),
-          ],
-        )
-        .then((r: { rows: Record<string, unknown>[] }) => r.rows[0]);
-
-      return inserted;
+      return recordSignalValue(c, {
+        tenantId: ctx.tenantId,
+        componentId: body.component_id,
+        plcTag: cmpRow.plc_tag,
+        value: { text: valueText, numeric: valueNumeric, bool: valueBool },
+        source: body.source ?? "demo_simulator",
+        simulated: true,
+        properties: body.notes ? { notes: body.notes } : {},
+      });
     });
 
-    return NextResponse.json({ event: row }, { status: 201 });
+    return NextResponse.json(
+      {
+        event_id: result.eventId,
+        component_id: result.componentId,
+        plc_tag: result.plcTag,
+        edge: result.edge,
+        last_changed_at: result.lastChangedAt,
+        previous_value: result.previousValue,
+      },
+      { status: 201 },
+    );
   } catch (err) {
     const status = (err as { status?: number }).status ?? 500;
     const msg = err instanceof Error ? err.message : "toggle_failed";

--- a/mira-hub/src/app/api/mira/ask/route.ts
+++ b/mira-hub/src/app/api/mira/ask/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { sessionOrDemo } from "@/lib/demo-auth";
 import { withTenantContext } from "@/lib/tenant-context";
 import { cascadeComplete, type CascadeMessage } from "@/lib/llm/cascade";
+import { countTransitions } from "@/lib/signal-recorder";
 
 export const dynamic = "force-dynamic";
 
@@ -20,6 +21,56 @@ interface SessionRow {
   asset_tag: string | null;
   component_name: string | null;
   component_plc_tag: string | null;
+}
+
+/**
+ * "How many times in the last N {seconds|minutes}" → window in seconds.
+ *
+ * Demo cases:
+ *   "how many times did I flag it in the last minute" → 60
+ *   "transitions over the last 30 seconds"             → 30
+ *   "how often in the last 5 minutes"                  → 300
+ *
+ * Returns null when no recognizable window phrase is present.
+ */
+function parseTransitionWindow(q: string): number | null {
+  const m = q
+    .toLowerCase()
+    .match(/(?:last|past)\s+(?:(\d+)\s*)?(seconds?|secs?|minutes?|mins?|minute|min|second|sec)/);
+  if (!m) {
+    // Also catch the bare "in the last minute" phrasing (no number).
+    if (/last\s+minute\b/.test(q.toLowerCase())) return 60;
+    if (/last\s+second\b/.test(q.toLowerCase())) return 1;
+    return null;
+  }
+  const n = m[1] ? Number(m[1]) : 1;
+  const unit = m[2];
+  const isMinute = unit.startsWith("min");
+  return Math.max(1, isMinute ? n * 60 : n);
+}
+
+/**
+ * True when the question implies a recurring-fault investigation worth
+ * recording as a diagnostic trend. Demo trigger phrases include
+ * "keeps shutting off", "trips frequently", "intermittent", etc.
+ */
+function mentionsRecurringFailure(q: string): boolean {
+  const lower = q.toLowerCase();
+  return [
+    "keeps shutting off",
+    "keeps tripping",
+    "keeps faulting",
+    "keeps cutting out",
+    "trips frequently",
+    "trips occasionally",
+    "intermittent",
+    "shuts off",
+    "shuts down",
+    "won't stay running",
+    "wont stay running",
+    "stops randomly",
+    "stops occasionally",
+  ].some((phrase) => lower.includes(phrase));
 }
 
 /**
@@ -91,6 +142,15 @@ export async function POST(req: Request) {
     );
   }
 
+  // ── 1b. Question-pattern parsing ─────────────────────────────────────
+  // Extract two demo-specific signals from the question text so the
+  // grounding step can pre-compute facts the LLM otherwise can't:
+  //   - transitionWindowSec: "how many times in the last N seconds/minutes"
+  //   - proposeTrend       : "keeps shutting off", "trips frequently", etc.
+  // Both are cheap heuristics — the LLM still composes the final reply.
+  const transitionWindowSec = parseTransitionWindow(body.question);
+  const proposeTrend = mentionsRecurringFailure(body.question);
+
   // ── 2. Build grounding context ────────────────────────────────────────
   const grounding = await withTenantContext(ctx.tenantId, async (c) => {
     const asset = session.asset_id;
@@ -138,7 +198,68 @@ export async function POST(req: Request) {
       )
       .then((r: { rows: Record<string, unknown>[] }) => r.rows);
 
-    return { components, edges, recentSignals, focusComponentId: component };
+    // live_signal_cache snapshot for the current state of every topic on
+    // this asset — answers "is the PLC seeing X *right now*" without
+    // scanning the event log.
+    const currentSignals = await c
+      .query(
+        `SELECT cache.plc_tag,
+                cache.last_value_text, cache.last_value_numeric, cache.last_value_bool,
+                cache.last_changed_at, cache.last_seen_at,
+                i.component_name
+           FROM live_signal_cache cache
+           LEFT JOIN installed_component_instances i ON i.id = cache.component_id
+          WHERE cache.tenant_id = $1
+            AND (i.asset_id = $2 OR cache.component_id IS NULL)
+          ORDER BY cache.last_changed_at DESC`,
+        [ctx.tenantId, asset],
+      )
+      .then((r: { rows: Record<string, unknown>[] }) => r.rows);
+
+    // Pre-compute a transition count when the user asked "how many times…"
+    let transitionFact: {
+      topic: string;
+      component_name: string | null;
+      count: number;
+      window_seconds: number;
+    } | null = null;
+    if (transitionWindowSec) {
+      // Scope to the focus component if one is set, else fall back to the
+      // first component on the asset (the demo has a clear hero — PE-001).
+      const focus =
+        (components as Array<Record<string, unknown>>).find(
+          (cmp) => cmp.id === component,
+        ) ?? (components as Array<Record<string, unknown>>)[0];
+      const focusTag = (focus?.plc_tag as string | null) ?? null;
+      const focusId = (focus?.id as string | null) ?? null;
+      if (focusTag || focusId) {
+        try {
+          const tc = await countTransitions(c, {
+            tenantId: ctx.tenantId,
+            plcTag: focusTag,
+            componentId: focusTag ? null : focusId,
+            windowSeconds: transitionWindowSec,
+          });
+          transitionFact = {
+            topic: focusTag ?? focusId ?? "",
+            component_name: (focus?.component_name as string | null) ?? null,
+            count: tc.transitions,
+            window_seconds: tc.windowSeconds,
+          };
+        } catch (err) {
+          console.warn("[api/mira/ask] countTransitions failed", err);
+        }
+      }
+    }
+
+    return {
+      components,
+      edges,
+      recentSignals,
+      currentSignals,
+      focusComponentId: component,
+      transitionFact,
+    };
   });
 
   // ── 3. Compose system prompt with citations available to model ────────
@@ -197,12 +318,39 @@ export async function POST(req: Request) {
       );
     }
   }
+  const currentSignals = (grounding as { currentSignals?: Array<Record<string, unknown>> })
+    .currentSignals;
+  if (currentSignals && currentSignals.length > 0) {
+    lines.push(``, `## Current signal state ${cite(`live_signal_cache`)}`);
+    for (const s of currentSignals) {
+      const val =
+        s.last_value_text ?? s.last_value_numeric ?? s.last_value_bool;
+      lines.push(
+        `- ${s.component_name ? `${s.component_name as string} ` : ""}(${s.plc_tag as string}) = ${String(val)} since ${s.last_changed_at as string}`,
+      );
+    }
+  }
   if (grounding.recentSignals.length > 0) {
     lines.push(``, `## Recent signal samples (last 10) ${cite(`live_signal_events`)}`);
     for (const s of grounding.recentSignals as Array<Record<string, unknown>>) {
       const val = s.value_text ?? s.value_numeric ?? s.value_bool;
       lines.push(`- ${s.created_at as string} | ${s.component_name as string} (${s.plc_tag as string}) = ${String(val)}${s.simulated ? " [SIM]" : ""}`);
     }
+  }
+  const transitionFact = (grounding as {
+    transitionFact?: {
+      topic: string;
+      component_name: string | null;
+      count: number;
+      window_seconds: number;
+    } | null;
+  }).transitionFact;
+  if (transitionFact) {
+    lines.push(
+      ``,
+      `## Transition count ${cite(`live_signal_events window function`)}`,
+      `- ${transitionFact.component_name ?? transitionFact.topic} changed value ${transitionFact.count} time(s) in the last ${transitionFact.window_seconds} second(s).`,
+    );
   }
   lines.push(
     ``,
@@ -257,11 +405,42 @@ export async function POST(req: Request) {
     ),
   );
 
+  // ── 6. Diagnostic trend proposal ─────────────────────────────────────
+  // When the question implies a recurring fault, return a `trend_proposal`
+  // payload alongside the answer. The tablet UI can render an "Open trend
+  // session" affordance from this. The trend is NOT auto-created — the
+  // tablet calls a follow-up endpoint with the user's confirmation, which
+  // keeps unsolicited writes out of diagnostic_trend_sessions.
+  let trendProposal:
+    | {
+        name: string;
+        hypothesis: string;
+        watched_topics: string[];
+        suggested_duration_seconds: number;
+      }
+    | null = null;
+  if (proposeTrend) {
+    const componentRows = grounding.components as Array<Record<string, unknown>>;
+    const watchedTopics = componentRows
+      .map((cmp) => cmp.plc_tag as string | null)
+      .filter((tag): tag is string => Boolean(tag));
+    if (watchedTopics.length > 0) {
+      trendProposal = {
+        name: `Recurring-fault watch on ${session.asset_name ?? "asset"}`,
+        hypothesis: `User reports recurring failure (\"${body.question.slice(0, 120)}\"). Watching all bound PLC tags for transitions during a ${120}-second window to localize the first edge.`,
+        watched_topics: watchedTopics,
+        suggested_duration_seconds: 120,
+      };
+    }
+  }
+
   return NextResponse.json({
     session_id: session.id,
     answer: result.content,
     provider: result.provider,
     duration_ms: result.durationMs,
     citations: citationItems,
+    transition_fact: transitionFact ?? null,
+    trend_proposal: trendProposal,
   });
 }

--- a/mira-hub/src/lib/signal-recorder.ts
+++ b/mira-hub/src/lib/signal-recorder.ts
@@ -1,0 +1,336 @@
+/**
+ * Signal recorder — single write path for `live_signal_events` + `live_signal_cache`.
+ *
+ * `recordSignalValue` is the only function that should INSERT into
+ * live_signal_events. It also UPSERTs live_signal_cache with the latest
+ * value and detects edges (boolean transitions, numeric change, text change)
+ * so the cache row always carries `last_changed_at` and the previous value.
+ *
+ * Trend-session auto-capture is deliberately NOT wired here — keeping
+ * recorder and trends decoupled means the recorder can't break the trend
+ * read path or vice versa. `diagnostic_trend_signals` is populated by a
+ * JOIN at read time (live_signal_events filtered by trend.watched_topics
+ * and trend window) or by an explicit append endpoint.
+ *
+ * Spec: docs/plans/2026-05-14-demo-backend-plan.md (Phase 4 of the
+ * 2026-05-15 PR).
+ */
+
+import type { PoolClient } from "pg";
+
+export type SignalValue = {
+  text?: string | null;
+  numeric?: number | null;
+  bool?: boolean | null;
+};
+
+export interface RecordOptions {
+  tenantId: string;
+  plcTag?: string | null;       // either plcTag OR componentId required
+  componentId?: string | null;
+  value: SignalValue;
+  source?: string;              // default "demo_simulator"
+  simulated?: boolean;          // default true
+  properties?: Record<string, unknown>;
+}
+
+export interface RecordResult {
+  eventId: string;
+  plcTag: string | null;
+  componentId: string | null;
+  edge: "rising" | "falling" | "changed" | "steady";
+  lastChangedAt: string;        // ISO string from cache
+  previousValue: SignalValue | null;
+}
+
+function pickValueFlavor(v: SignalValue): "bool" | "numeric" | "text" | null {
+  if (v.bool !== undefined && v.bool !== null) return "bool";
+  if (v.numeric !== undefined && v.numeric !== null) return "numeric";
+  if (v.text !== undefined && v.text !== null) return "text";
+  return null;
+}
+
+function valuesEqual(a: SignalValue, b: SignalValue): boolean {
+  // Compare on whichever flavor the new value declared; the cache row may
+  // have multiple columns populated from prior writes, but only one is the
+  // authoritative reading for this signal's type.
+  if (a.bool !== undefined && a.bool !== null) return a.bool === b.bool;
+  if (a.numeric !== undefined && a.numeric !== null) return a.numeric === b.numeric;
+  if (a.text !== undefined && a.text !== null) return a.text === b.text;
+  return false;
+}
+
+/**
+ * Write one signal sample. Returns the event id, the resolved subject,
+ * and the detected edge classification:
+ *   - "rising"   : boolean transition false → true
+ *   - "falling"  : boolean transition true → false
+ *   - "changed"  : numeric or text value differs from previous
+ *   - "steady"   : value matches previous (no edge)
+ *
+ * The caller is the API endpoint layer (toggle / set). RLS is enforced by
+ * the surrounding `withTenantContext` transaction.
+ */
+export async function recordSignalValue(
+  client: PoolClient,
+  opts: RecordOptions,
+): Promise<RecordResult> {
+  const { tenantId, value } = opts;
+  let { plcTag, componentId } = opts;
+
+  if (!plcTag && !componentId) {
+    throw Object.assign(new Error("plcTag_or_componentId_required"), { status: 400 });
+  }
+  const flavor = pickValueFlavor(value);
+  if (!flavor) {
+    throw Object.assign(new Error("no_value_supplied"), { status: 400 });
+  }
+
+  // Resolve plcTag from componentId (or vice versa) when the caller only
+  // supplied one. The cache is keyed on plcTag; component_id is denormalized.
+  if (componentId && !plcTag) {
+    const r = await client.query<{ plc_tag: string | null }>(
+      `SELECT plc_tag FROM installed_component_instances
+        WHERE tenant_id = $1 AND id = $2 LIMIT 1`,
+      [tenantId, componentId],
+    );
+    plcTag = r.rows[0]?.plc_tag ?? null;
+    if (!plcTag) {
+      throw Object.assign(new Error("component_has_no_plc_tag"), { status: 400 });
+    }
+  } else if (plcTag && !componentId) {
+    const r = await client.query<{ id: string }>(
+      `SELECT id FROM installed_component_instances
+        WHERE tenant_id = $1 AND plc_tag = $2 LIMIT 1`,
+      [tenantId, plcTag],
+    );
+    componentId = r.rows[0]?.id ?? null;
+  }
+
+  const simulated = opts.simulated ?? true;
+  const source = opts.source ?? "demo_simulator";
+  const properties = opts.properties ?? {};
+
+  // 1. Insert the immutable event.
+  const eventRow = await client
+    .query<{ id: string }>(
+      `INSERT INTO live_signal_events
+         (tenant_id, component_id, plc_tag, value_text, value_numeric, value_bool,
+          simulated, source, properties)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
+       RETURNING id`,
+      [
+        tenantId,
+        componentId,
+        plcTag,
+        value.text ?? null,
+        value.numeric ?? null,
+        value.bool ?? null,
+        simulated,
+        source,
+        JSON.stringify(properties),
+      ],
+    )
+    .then((r: { rows: Array<{ id: string }> }) => r.rows[0]);
+
+  // 2. Read the existing cache row to compute edge + previous value.
+  type CacheRow = {
+    last_value_text: string | null;
+    last_value_numeric: number | null;
+    last_value_bool: boolean | null;
+  };
+  const prevRow: CacheRow | null = plcTag
+    ? await client
+        .query<CacheRow>(
+          `SELECT last_value_text, last_value_numeric, last_value_bool
+             FROM live_signal_cache
+            WHERE tenant_id = $1 AND plc_tag = $2 LIMIT 1`,
+          [tenantId, plcTag],
+        )
+        .then((r: { rows: CacheRow[] }) => r.rows[0] ?? null)
+    : null;
+
+  let edge: RecordResult["edge"];
+  let previousValue: SignalValue | null = null;
+  if (prevRow === null) {
+    edge = "changed"; // first sample for this topic — treat as a change so
+                     // last_changed_at gets stamped to now.
+  } else {
+    const prev: SignalValue = {
+      text: prevRow.last_value_text,
+      numeric: prevRow.last_value_numeric,
+      bool: prevRow.last_value_bool,
+    };
+    previousValue = prev;
+    if (valuesEqual(value, prev)) {
+      edge = "steady";
+    } else if (flavor === "bool") {
+      edge = value.bool === true ? "rising" : "falling";
+    } else {
+      edge = "changed";
+    }
+  }
+
+  // 3. UPSERT the cache. last_changed_at and prev_value_* only update on a
+  // real change; steady samples bump last_seen_at + properties only.
+  const upserted = await client
+    .query<{ last_changed_at: string }>(
+      edge === "steady"
+        ? `INSERT INTO live_signal_cache
+             (tenant_id, plc_tag, component_id,
+              last_value_text, last_value_numeric, last_value_bool,
+              simulated, source, properties)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb)
+           ON CONFLICT (tenant_id, plc_tag) DO UPDATE SET
+             -- COALESCE so a write that arrives before the component
+             -- binding resolves doesn't null a previously-known component_id.
+             component_id = COALESCE(EXCLUDED.component_id, live_signal_cache.component_id),
+             last_seen_at = now(),
+             simulated = EXCLUDED.simulated,
+             source = EXCLUDED.source,
+             properties = EXCLUDED.properties,
+             updated_at = now()
+           RETURNING last_changed_at::text AS last_changed_at`
+        : `INSERT INTO live_signal_cache
+             (tenant_id, plc_tag, component_id,
+              last_value_text, last_value_numeric, last_value_bool,
+              prev_value_text, prev_value_numeric, prev_value_bool,
+              simulated, source, properties,
+              last_seen_at, last_changed_at)
+           VALUES ($1, $2, $3, $4, $5, $6,
+                   $10, $11, $12,
+                   $7, $8, $9::jsonb,
+                   now(), now())
+           ON CONFLICT (tenant_id, plc_tag) DO UPDATE SET
+             -- COALESCE so a write that arrives before the component
+             -- binding resolves doesn't null a previously-known component_id.
+             component_id = COALESCE(EXCLUDED.component_id, live_signal_cache.component_id),
+             prev_value_text = live_signal_cache.last_value_text,
+             prev_value_numeric = live_signal_cache.last_value_numeric,
+             prev_value_bool = live_signal_cache.last_value_bool,
+             last_value_text = EXCLUDED.last_value_text,
+             last_value_numeric = EXCLUDED.last_value_numeric,
+             last_value_bool = EXCLUDED.last_value_bool,
+             simulated = EXCLUDED.simulated,
+             source = EXCLUDED.source,
+             properties = EXCLUDED.properties,
+             last_seen_at = now(),
+             last_changed_at = now(),
+             updated_at = now()
+           RETURNING last_changed_at::text AS last_changed_at`,
+      edge === "steady"
+        ? [
+            tenantId,
+            plcTag,
+            componentId,
+            value.text ?? null,
+            value.numeric ?? null,
+            value.bool ?? null,
+            simulated,
+            source,
+            JSON.stringify(properties),
+          ]
+        : [
+            tenantId,
+            plcTag,
+            componentId,
+            value.text ?? null,
+            value.numeric ?? null,
+            value.bool ?? null,
+            simulated,
+            source,
+            JSON.stringify(properties),
+            previousValue?.text ?? null,
+            previousValue?.numeric ?? null,
+            previousValue?.bool ?? null,
+          ],
+    )
+    .then((r: { rows: Array<{ last_changed_at: string }> }) => r.rows[0]);
+
+  return {
+    eventId: eventRow.id,
+    plcTag: plcTag ?? null,
+    componentId: componentId ?? null,
+    edge,
+    lastChangedAt: upserted.last_changed_at,
+    previousValue,
+  };
+}
+
+/**
+ * Count value transitions for a topic over a recent window. A "transition"
+ * is a row whose value differs from the immediately-prior row for the same
+ * topic (the rising and falling edges of a boolean, or any change in a
+ * numeric/text signal).
+ *
+ * Used to answer "how many times did I flag PE-001 in the last minute?".
+ *
+ * Returns the count and the window bounds. Uses a LAG window function so
+ * we don't need to maintain a transition counter column.
+ */
+export async function countTransitions(
+  client: PoolClient,
+  opts: {
+    tenantId: string;
+    plcTag?: string | null;
+    componentId?: string | null;
+    windowSeconds: number;
+  },
+): Promise<{
+  transitions: number;
+  windowSeconds: number;
+  windowStart: string;
+  windowEnd: string;
+  topic: string | null;
+}> {
+  const { tenantId, windowSeconds } = opts;
+  let topicFilter: { sql: string; param: string } | null = null;
+  if (opts.plcTag) {
+    topicFilter = { sql: "plc_tag = $2", param: opts.plcTag };
+  } else if (opts.componentId) {
+    topicFilter = { sql: "component_id = $2", param: opts.componentId };
+  }
+  if (!topicFilter) {
+    throw Object.assign(new Error("plcTag_or_componentId_required"), { status: 400 });
+  }
+
+  const { rows } = await client.query<{
+    transitions: string;
+    window_start: string;
+    window_end: string;
+  }>(
+    `WITH window_events AS (
+       SELECT
+         created_at,
+         value_text,
+         value_numeric,
+         value_bool,
+         LAG(value_text)    OVER (ORDER BY created_at) AS prev_text,
+         LAG(value_numeric) OVER (ORDER BY created_at) AS prev_numeric,
+         LAG(value_bool)    OVER (ORDER BY created_at) AS prev_bool
+       FROM live_signal_events
+       WHERE tenant_id = $1
+         AND ${topicFilter.sql}
+         AND created_at > now() - ($3::text || ' seconds')::interval
+     )
+     SELECT
+       count(*) FILTER (
+         WHERE prev_text    IS DISTINCT FROM value_text
+            OR prev_numeric IS DISTINCT FROM value_numeric
+            OR prev_bool    IS DISTINCT FROM value_bool
+       )::text AS transitions,
+       (now() - ($3::text || ' seconds')::interval)::text AS window_start,
+       (now())::text AS window_end
+       FROM window_events`,
+    [tenantId, topicFilter.param, String(windowSeconds)],
+  );
+
+  const row = rows[0] ?? { transitions: "0", window_start: "", window_end: "" };
+  return {
+    transitions: Number(row.transitions ?? "0"),
+    windowSeconds,
+    windowStart: row.window_start,
+    windowEnd: row.window_end,
+    topic: opts.plcTag ?? opts.componentId ?? null,
+  };
+}


### PR DESCRIPTION
## Summary

Closes Phases 4–6 of the May 21 tablet demo per
`docs/plans/2026-05-14-demo-backend-plan.md` (status section appended).

Builds on PR #1295 (Phase 3) which landed the Phase 3 tablet API +
migration 019 (troubleshooting_sessions + live_signal_events).

## What's in this PR

### Migration 020 — signal cache + trend tables
- `live_signal_cache` — denormalized current state per (tenant_id, plc_tag). PK on topic; component_id COALESCEd to survive late binding.
- `diagnostic_trend_sessions` — recording windows with watched_topics, hypothesis, status.
- `diagnostic_trend_signals` — append-only sample capture during a trend.
- All RLS-scoped per tenant; policies wrapped in `DROP POLICY IF EXISTS` (PR #1296 pattern).

Plus an idempotency patch to migration 019 (same pattern; safe for fresh DBs, no-op on prod where 019 already ran).

### Signal recorder (`mira-hub/src/lib/signal-recorder.ts`)
- `recordSignalValue` — single write path. Inserts event, reads cache, computes edge (rising/falling/changed/steady), UPSERTs cache with new last/prev values. last_changed_at advances only on a real change.
- `countTransitions` — LAG-window count over events for "how many times in the last N seconds".

### Demo signal endpoints
- `POST /api/demo/signals/toggle` (refactored to use recorder) — discrete present/clear/auto plus arbitrary values.
- `POST /api/demo/signals/set` (NEW) — set arbitrary value by plc_tag OR component_id.
- `GET /api/demo/signals/summary` (NEW) — full cache snapshot joined to component + asset names.

### `/api/mira/ask` wiring to NeonDB
The Phase 3 endpoint already pulled components, kg_relationships, and recent live_signal_events. This PR adds:
- Cache-derived "current signal state" block in the system prompt — answers "is the PLC seeing PE-001 *right now*".
- Transition count pre-computation when the question mentions "in the last N seconds/minutes" — injected as a single fact line + returned as `transition_fact`.
- `trend_proposal` payload (non-creating) when the question implies a recurring fault — tablet renders "Open trend session" affordance.

### Phase 6 — Slack demo-namespace gate
- New `mira-bots/shared/demo_namespace.py` extracts asset tags (`PE-001`, `CV-001`…) and names (`Conveyor 001`) from the message and queries `kg_entities` + `installed_component_instances` for the active tenant.
- `engine.py _handle_uns_confirmation_request` consults it *before* the generic manufacturer/model prompt; falls through unchanged when no match.
- `uns_resolver.py` UNTOUCHED — no global VENDOR_ALIASES drift.
- On `yes`, match lands on `state["context"]["confirmed_namespace"]` for downstream retrieval.

## Test plan

- [ ] `gh workflow run apply-migrations.yml -F migrations=020 -F mode=dry-run` then `mode=apply` against a staging DB
- [ ] `psql $NEON_DATABASE_URL -c "SELECT 1 FROM live_signal_cache LIMIT 1"` returns no rows (table exists, empty)
- [ ] `psql $NEON_DATABASE_URL -c "SELECT 1 FROM diagnostic_trend_sessions LIMIT 1"` ditto
- [ ] `curl -X POST $HUB/api/demo/signals/toggle -H "Authorization: Bearer \$DEMO_API_TOKEN" -d '{"component_id":"...PE-001 id...","state":"present"}'` returns `{edge: "rising"|"changed"|...}`
- [ ] `curl $HUB/api/demo/signals/summary -H "Authorization: Bearer \$DEMO_API_TOKEN"` returns the toggled signal with the new value
- [ ] `curl -X POST $HUB/api/sessions/confirm` then `curl -X POST $HUB/api/mira/ask -d '{"session_id":"...","question":"How many times did I flag PE-001 in the last minute?"}'` returns `transition_fact: { count: N }`
- [ ] Same flow with `"question":"Motor keeps shutting off"` returns `trend_proposal` with the asset's PLC tags as `watched_topics`
- [ ] `python -m pytest mira-bots/tests/test_demo_namespace.py` passes (offline candidate extraction)
- [ ] Slack: send "PE-001 isn't reading" to a fresh chat → gate fires with "Confirm equipment: Conveyor 001 / CV-001 / PE-001" rather than asking for manufacturer

🤖 Generated with [Claude Code](https://claude.com/claude-code)