### PR TITLE
fix(ops): add psycopg2-binary to apply-migrations backfill deps

### DIFF
--- a/.github/workflows/apply-migrations.yml
+++ b/.github/workflows/apply-migrations.yml
@@ -287,8 +287,10 @@ jobs:
           # Backfill scripts import the same deps as mira-hub workers.
           # Keep this list minimal — pin via requirements lookup once a
           # tools/requirements.txt exists; today they only need psycopg + httpx.
+          # psycopg2-binary needed because tools/uns_backfill.py uses bare
+          # postgresql:// URLs that SQLAlchemy resolves to the psycopg2 driver.
           python -m pip install --upgrade pip
-          pip install 'psycopg[binary]>=3.1' httpx 'sqlalchemy>=2.0'
+          pip install 'psycopg2-binary>=2.9' 'psycopg[binary]>=3.1' httpx 'sqlalchemy>=2.0'
 
       - name: Run kg_entities backfill (tools/uns_backfill.py)
         env:


### PR DESCRIPTION
## Summary

- Adds `psycopg2-binary>=2.9` to the apply-migrations backfill dependency install
- Fixes failed runs [25896187069](https://github.com/Mikecranesync/MIRA/actions/runs/25896187069) + [25896784107](https://github.com/Mikecranesync/MIRA/actions/runs/25896784107) — `tools/uns_backfill.py` exits with `ModuleNotFoundError: No module named 'psycopg2'`
- Root cause: SQLAlchemy `create_engine("postgresql://...")` resolves to the legacy psycopg2 driver by default; workflow only installed psycopg v3

## Test plan

- [ ] Re-run "Apply Prod Migrations" with `mode=apply` + `run_backfill=true` after merge
- [ ] Verify backfill job hits NeonDB (psql apply step already succeeds; only the python backfill step fails)
- [ ] Confirm no regression for non-backfill path (`run_backfill=false`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)