### PR TITLE
fix(engine): KB-first general questions with conversation history

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -1276,7 +1276,9 @@ class Supervisor:
                 "safety",
                 "documentation",
             ):
-                return await self._handle_general_question(chat_id, message, state, trace_id)
+                return await self._handle_general_question(
+                    chat_id, message, state, trace_id, tenant_id=resolved_tenant
+                )
 
             if _router_intent == "greeting_or_chitchat" and state["state"] == "IDLE":
                 return self._greeting_response(state, chat_id, trace_id)
@@ -2963,37 +2965,167 @@ class Supervisor:
         "hz setpoint acceleration deceleration boost carrier fault code alarm reset".split()
     )
 
-    async def _handle_general_question(
-        self, chat_id: str, message: str, state: dict, trace_id: str
-    ) -> dict:
-        """Answer a general industrial question — uses RAG for equipment-specific specs."""
-        state = self._clear_diagnostic_carryover(chat_id, state, clear_photo=True)
-        asset = state.get("asset_identified", "")
-        msg_lower = message.lower()
-        needs_rag = asset and any(kw in msg_lower for kw in self._SPEC_KEYWORDS)
+    # Heuristic: looks like an industrial question that *should* resolve to a
+    # vendor/model. If we can't extract one, asking is better than guessing.
+    _INDUSTRIAL_HINTS_RE = re.compile(
+        r"\b(vfd|plc|hmi|scada|motor|fault|alarm|trip|modbus|profinet|"
+        r"ethernet/?ip|cip|rs[\- ]?485|rs[\- ]?232|contactor|relay|servo|"
+        r"encoder|nameplate|drive|f\d{2,4}|e\d{2,4}|oc\b|ol\b)\b",
+        re.IGNORECASE,
+    )
 
-        raw = ""
-        if needs_rag:
+    async def _handle_general_question(
+        self,
+        chat_id: str,
+        message: str,
+        state: dict,
+        trace_id: str,
+        *,
+        tenant_id: str | None = None,
+    ) -> dict:
+        """KB-first answer with conversation history.
+
+        Decision order:
+          1. Re-resolve equipment (manufacturer/model) from current message
+             plus recent user turns — every turn gets a fresh extraction.
+          2. If a vendor is identified and the KB has coverage → RAG worker,
+             so the reply carries citations.
+          3. Vendor identified but no KB coverage → hand off to the
+             documentation lookup path so the crawler fills the gap.
+          4. No vendor anywhere AND the question looks industrial → ask for
+             vendor/model rather than hallucinate.
+          5. Otherwise → answer from training knowledge with conversation
+             history threaded through. Disclose lack of docs when relevant.
+        """
+        # Don't wipe an active session photo for a general question — a
+        # clarifying ask mid-diagnostic shouldn't break the photo flow.
+        state = self._clear_diagnostic_carryover(chat_id, state, clear_photo=False)
+
+        ctx = state.get("context") or {}
+        history = ctx.get("history", [])
+        asset = state.get("asset_identified", "")
+
+        # 1) Re-extract equipment from the user's recent turns + current msg.
+        user_window = [
+            h.get("content", "") for h in history[-6:] if h.get("role") == "user"
+        ]
+        combined_for_resolve = " ".join([*user_window, message]).strip()
+        uns = resolve_uns_path(combined_for_resolve)
+        mfr = uns.manufacturer or ((ctx.get("uns_context") or {}).get("manufacturer") or "")
+        model = uns.model or ""
+
+        resolved_tenant = tenant_id or state.get("tenant_id") or ""
+
+        kb_covered = False
+        kb_reason = ""
+        if mfr:
             try:
-                raw_resp = await self.rag.process(message, state, photo_b64=None, tenant_id=None)
+                kb_covered, kb_reason = kb_has_coverage(
+                    mfr, combined_for_resolve, resolved_tenant
+                )
+            except Exception as exc:
+                logger.warning("GENERAL_QUESTION_KB_PROBE_FAILURE error=%s", exc)
+
+        logger.info(
+            "GENERAL_QUESTION_GATE chat_id=%s mfr=%r model=%r kb_covered=%s reason=%r",
+            chat_id, mfr, model, kb_covered, kb_reason,
+        )
+
+        # 2) Vendor + KB coverage → answer through RAG (citations enforced).
+        if mfr and kb_covered:
+            if not asset:
+                state["asset_identified"] = f"{mfr}, {model}" if model else mfr
+            try:
+                raw_resp = await self.rag.process(
+                    message, state, photo_b64=None, tenant_id=resolved_tenant
+                )
                 parsed = self._parse_response(raw_resp)
                 raw = parsed.get("reply", "") if parsed else ""
+                if raw:
+                    reply = self._format_simple_response(
+                        raw,
+                        suggestions=[
+                            "Find documentation",
+                            "Log a work order",
+                            "Diagnose this asset",
+                        ],
+                    )
+                    self._record_exchange(chat_id, state, message, reply)
+                    tl_flush()
+                    return self._make_result(
+                        reply,
+                        self._infer_confidence(raw),
+                        trace_id,
+                        state.get("state", "IDLE"),
+                    )
             except Exception as exc:
-                logger.warning("GENERAL_QUESTION_RAG_FAILURE error=%s — falling back to LLM", exc)
+                logger.warning("GENERAL_QUESTION_RAG_FAILURE error=%s — falling through", exc)
 
-        if not raw:
-            asset_ctx = f" The current equipment is: {asset}." if asset else ""
-            system = (
-                "You are MIRA, an industrial maintenance assistant."
-                f"{asset_ctx} "
-                "Answer this question concisely and accurately using your training knowledge. "
-                "Keep the reply under 120 words."
+        # 3) Vendor identified but no KB coverage → kick off doc lookup/crawl.
+        if mfr and not kb_covered:
+            return await self._do_documentation_lookup(
+                chat_id,
+                message,
+                state,
+                trace_id,
+                resolved_tenant,
+                vendor_override=mfr,
+                model_override=model,
+            )
+
+        # 4) Industrial-flavored question with no resolvable vendor → ask.
+        looks_industrial = bool(self._INDUSTRIAL_HINTS_RE.search(message))
+        if looks_industrial and not asset:
+            clarify_system = (
+                "You are MIRA, an industrial maintenance assistant. The "
+                "technician asked a question but the manufacturer and model "
+                "haven't been identified. Reply in ≤2 short sentences: "
+                "acknowledge what you understood, then ask for the missing "
+                "piece (manufacturer and/or model). Do NOT try to answer the "
+                "question yet — getting the docs requires knowing the asset."
             )
             try:
-                raw = await self._call_llm_direct(message, system=system)
+                raw = await self._call_llm_direct(
+                    message, system=clarify_system, history=history
+                )
             except Exception as exc:
-                logger.warning("GENERAL_QUESTION_LLM_FAILURE error=%s", exc)
-                raw = "I can help with that — could you give me a bit more context?"
+                logger.warning("GENERAL_QUESTION_CLARIFY_FAILURE error=%s", exc)
+                raw = (
+                    "Which equipment is this — manufacturer and model? "
+                    "Once I know, I'll pull the docs and walk you through it."
+                )
+            reply = self._format_simple_response(
+                raw,
+                suggestions=[
+                    "Send a nameplate photo",
+                    "Type the model number",
+                    "Describe the symptom",
+                ],
+            )
+            self._record_exchange(chat_id, state, message, reply)
+            tl_flush()
+            return self._make_result(reply, "none", trace_id, state.get("state", "IDLE"))
+
+        # 5) Truly general question → answer with history. Disclose missing
+        #    docs when an asset is known but the KB doesn't cover it.
+        asset_ctx = f" The current equipment is: {asset}." if asset else ""
+        disclosure = (
+            " You do not have documentation for this in your knowledge base — "
+            "say so up front, then answer from general training knowledge."
+            if asset and not kb_covered
+            else ""
+        )
+        system = (
+            "You are MIRA, an industrial maintenance assistant."
+            f"{asset_ctx}{disclosure} "
+            "Answer the technician's question concisely and accurately, using "
+            "the conversation history for context. Keep it under 120 words."
+        )
+        try:
+            raw = await self._call_llm_direct(message, system=system, history=history)
+        except Exception as exc:
+            logger.warning("GENERAL_QUESTION_LLM_FAILURE error=%s", exc)
+            raw = "I can help with that — could you give me a bit more context?"
 
         reply = self._format_simple_response(
             raw,
@@ -3315,7 +3447,9 @@ class Supervisor:
         if kind == DISPATCH_ASK_PROCEDURAL:
             return await self._handle_instructional_question(chat_id, message, state, trace_id)
         if kind == DISPATCH_ASK_GENERAL:
-            return await self._handle_general_question(chat_id, message, state, trace_id)
+            return await self._handle_general_question(
+                chat_id, message, state, trace_id, tenant_id=resolved_tenant
+            )
 
         # Priority 7 — greeting in IDLE
         if kind == DISPATCH_GREET and state.get("state", "IDLE") == "IDLE":
@@ -3599,13 +3733,32 @@ class Supervisor:
             reply, self._infer_confidence(reply), trace_id, state.get("state", "IDLE")
         )
 
-    async def _call_llm_direct(self, message: str, system: str = "") -> str:
-        """One-shot LLM call via the existing inference router. Returns plain text."""
+    async def _call_llm_direct(
+        self,
+        message: str,
+        system: str = "",
+        history: list[dict] | None = None,
+    ) -> str:
+        """LLM call via the inference router. Threads conversation history.
+
+        Pass ``history`` (the ``context.history`` list of {role, content}
+        dicts) to give the stateless LLM the same illusion of memory that
+        ChatGPT/Claude/Gemini provide — older turns get token-budget-trimmed
+        and spliced between the system prompt and the current user message.
+        """
+        from .workers.rag_worker import _trim_history_by_tokens
+
         messages: list[dict] = []
         if system:
             messages.append({"role": "system", "content": system})
+        if history:
+            for entry in _trim_history_by_tokens(history):
+                role = entry.get("role")
+                content = entry.get("content")
+                if role in ("user", "assistant") and content:
+                    messages.append({"role": role, "content": content})
         messages.append({"role": "user", "content": message})
-        raw, _usage = await self.router.complete(messages, max_tokens=300)
+        raw, _usage = await self.router.complete(messages, max_tokens=600)
         return raw.strip() if raw else "I'm not sure — can you give me more context?"
 
     async def _do_documentation_lookup(

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -3006,9 +3006,7 @@ class Supervisor:
         asset = state.get("asset_identified", "")
 
         # 1) Re-extract equipment from the user's recent turns + current msg.
-        user_window = [
-            h.get("content", "") for h in history[-6:] if h.get("role") == "user"
-        ]
+        user_window = [h.get("content", "") for h in history[-6:] if h.get("role") == "user"]
         combined_for_resolve = " ".join([*user_window, message]).strip()
         uns = resolve_uns_path(combined_for_resolve)
         mfr = uns.manufacturer or ((ctx.get("uns_context") or {}).get("manufacturer") or "")
@@ -3020,15 +3018,17 @@ class Supervisor:
         kb_reason = ""
         if mfr:
             try:
-                kb_covered, kb_reason = kb_has_coverage(
-                    mfr, combined_for_resolve, resolved_tenant
-                )
+                kb_covered, kb_reason = kb_has_coverage(mfr, combined_for_resolve, resolved_tenant)
             except Exception as exc:
                 logger.warning("GENERAL_QUESTION_KB_PROBE_FAILURE error=%s", exc)
 
         logger.info(
             "GENERAL_QUESTION_GATE chat_id=%s mfr=%r model=%r kb_covered=%s reason=%r",
-            chat_id, mfr, model, kb_covered, kb_reason,
+            chat_id,
+            mfr,
+            model,
+            kb_covered,
+            kb_reason,
         )
 
         # 2) Vendor + KB coverage → answer through RAG (citations enforced).
@@ -3085,9 +3085,7 @@ class Supervisor:
                 "question yet — getting the docs requires knowing the asset."
             )
             try:
-                raw = await self._call_llm_direct(
-                    message, system=clarify_system, history=history
-                )
+                raw = await self._call_llm_direct(message, system=clarify_system, history=history)
             except Exception as exc:
                 logger.warning("GENERAL_QUESTION_CLARIFY_FAILURE error=%s", exc)
                 raw = (

--- a/mira-bots/tests/test_engine_general_question.py
+++ b/mira-bots/tests/test_engine_general_question.py
@@ -1,0 +1,222 @@
+"""Tests for _handle_general_question — KB-first decision tree + history threading."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, "mira-bots")
+
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy-token-for-testing")
+os.environ.setdefault("OPENWEBUI_BASE_URL", "http://localhost:8080")
+os.environ.setdefault("OPENWEBUI_API_KEY", "")
+os.environ.setdefault("KNOWLEDGE_COLLECTION_ID", "dummy-collection")
+
+from shared.engine import Supervisor
+
+
+@pytest.fixture
+def supervisor(tmp_path):
+    db_path = str(tmp_path / "test.db")
+    with patch.dict("os.environ", {"INFERENCE_BACKEND": "local"}):
+        with patch("shared.engine.VisionWorker"):
+            with patch("shared.engine.NameplateWorker"):
+                with patch("shared.engine.RAGWorker"):
+                    with patch("shared.engine.PrintWorker"):
+                        with patch("shared.engine.PLCWorker"):
+                            with patch("shared.engine.NemotronClient"):
+                                with patch("shared.engine.InferenceRouter"):
+                                    sup = Supervisor(
+                                        db_path=db_path,
+                                        openwebui_url="http://localhost:3000",
+                                        api_key="test-key",
+                                        collection_id="test-collection",
+                                    )
+    sup.router = MagicMock()
+    sup.router.complete = AsyncMock(return_value=("answer body", {}))
+    sup.rag = MagicMock()
+    sup.rag.process = AsyncMock(return_value={"reply": "RAG ANSWER WITH CITATIONS"})
+    return sup
+
+
+def _state(history=None, asset=""):
+    return {
+        "state": "IDLE",
+        "exchange_count": 0,
+        "asset_identified": asset,
+        "fault_category": None,
+        "final_state": None,
+        "context": {"history": list(history or [])},
+    }
+
+
+def test_call_llm_direct_threads_history(supervisor):
+    history = [
+        {"role": "user", "content": "first question"},
+        {"role": "assistant", "content": "first answer"},
+    ]
+
+    asyncio.run(
+        supervisor._call_llm_direct("second question", system="sys", history=history)
+    )
+
+    sent = supervisor.router.complete.call_args.args[0]
+    roles = [m["role"] for m in sent]
+    contents = [m["content"] for m in sent]
+    assert roles == ["system", "user", "assistant", "user"]
+    assert contents[0] == "sys"
+    assert "first question" in contents
+    assert "first answer" in contents
+    assert contents[-1] == "second question"
+
+
+def test_call_llm_direct_without_history_is_two_messages(supervisor):
+    asyncio.run(supervisor._call_llm_direct("hi", system="sys"))
+    sent = supervisor.router.complete.call_args.args[0]
+    assert [m["role"] for m in sent] == ["system", "user"]
+
+
+def test_general_question_routes_to_rag_when_kb_covered(supervisor):
+    state = _state()
+
+    with patch(
+        "shared.engine.resolve_uns_path",
+        return_value=MagicMock(manufacturer="Allen-Bradley", model="Micro 820"),
+    ), patch(
+        "shared.engine.kb_has_coverage", return_value=(True, "kb_42_chunks")
+    ), patch.object(supervisor, "_record_exchange"), patch.object(
+        supervisor, "_save_state"
+    ), patch.object(
+        supervisor, "_parse_response", side_effect=lambda r: r if isinstance(r, dict) else {"reply": ""}
+    ):
+        result = asyncio.run(
+            supervisor._handle_general_question(
+                "telegram:1",
+                "how do I configure the Micro 820 for Modbus?",
+                state,
+                "trace-1",
+                tenant_id="t1",
+            )
+        )
+
+    supervisor.rag.process.assert_awaited_once()
+    assert "RAG ANSWER WITH CITATIONS" in result["reply"]
+
+
+def test_general_question_hands_off_to_doc_lookup_when_no_coverage(supervisor):
+    state = _state()
+
+    doc_mock = AsyncMock(return_value={"reply": "DOC_LOOKUP_REPLY"})
+    with patch(
+        "shared.engine.resolve_uns_path",
+        return_value=MagicMock(manufacturer="AutomationDirect", model="GS11"),
+    ), patch(
+        "shared.engine.kb_has_coverage", return_value=(False, "kb_only_0_chunks")
+    ), patch.object(supervisor, "_do_documentation_lookup", new=doc_mock):
+        result = asyncio.run(
+            supervisor._handle_general_question(
+                "telegram:1",
+                "wire a GS11 over rs485",
+                state,
+                "trace-1",
+                tenant_id="t1",
+            )
+        )
+
+    doc_mock.assert_awaited_once()
+    # Confirm vendor + model were threaded into the doc lookup
+    call_kwargs = doc_mock.call_args.kwargs
+    assert call_kwargs["vendor_override"] == "AutomationDirect"
+    assert call_kwargs["model_override"] == "GS11"
+    assert result["reply"] == "DOC_LOOKUP_REPLY"
+
+
+def test_general_question_asks_clarifier_when_industrial_no_vendor(supervisor):
+    state = _state()
+
+    with patch(
+        "shared.engine.resolve_uns_path",
+        return_value=MagicMock(manufacturer="", model=""),
+    ), patch(
+        "shared.engine.kb_has_coverage", return_value=(False, "no_vendor")
+    ), patch.object(supervisor, "_record_exchange"), patch.object(
+        supervisor, "_save_state"
+    ):
+        result = asyncio.run(
+            supervisor._handle_general_question(
+                "telegram:1",
+                "the VFD is throwing an OC fault",
+                state,
+                "trace-1",
+                tenant_id="t1",
+            )
+        )
+
+    sent = supervisor.router.complete.call_args.args[0]
+    system_msg = sent[0]["content"]
+    # The clarifier system prompt must direct the LLM to ask for vendor/model,
+    # not answer the question.
+    assert "manufacturer" in system_msg.lower()
+    assert "model" in system_msg.lower()
+    assert result["reply"]
+
+
+def test_general_question_answers_freely_when_truly_general(supervisor):
+    history = [
+        {"role": "user", "content": "earlier question"},
+        {"role": "assistant", "content": "earlier answer"},
+    ]
+    state = _state(history=history)
+
+    with patch(
+        "shared.engine.resolve_uns_path",
+        return_value=MagicMock(manufacturer="", model=""),
+    ), patch.object(supervisor, "_record_exchange"), patch.object(
+        supervisor, "_save_state"
+    ):
+        asyncio.run(
+            supervisor._handle_general_question(
+                "telegram:1",
+                "what does PID stand for?",
+                state,
+                "trace-1",
+                tenant_id="t1",
+            )
+        )
+
+    sent = supervisor.router.complete.call_args.args[0]
+    contents = [m["content"] for m in sent]
+    # History must be threaded through — the regression that started this whole
+    # fix is the LLM not seeing prior turns.
+    assert "earlier question" in contents
+    assert "earlier answer" in contents
+
+
+def test_general_question_does_not_clear_session_photo(supervisor):
+    """Asking a clarifier mid-photo-diagnostic must not wipe the photo."""
+    state = _state()
+    state["context"]["photo_turn"] = 3  # simulate active session photo
+
+    with patch(
+        "shared.engine.resolve_uns_path",
+        return_value=MagicMock(manufacturer="", model=""),
+    ), patch.object(supervisor, "_record_exchange"), patch.object(
+        supervisor, "_save_state"
+    ), patch.object(
+        supervisor, "_clear_session_photo"
+    ) as clear_photo:
+        asyncio.run(
+            supervisor._handle_general_question(
+                "telegram:1",
+                "what does PID stand for?",
+                state,
+                "trace-1",
+                tenant_id="t1",
+            )
+        )
+    clear_photo.assert_not_called()
+    assert state["context"].get("photo_turn") == 3


### PR DESCRIPTION
## Summary
Fixes MIRA's amnesia on `general_question`-routed turns observed in the FactoryLM Diagnose Telegram channel at 06:12 UTC (chat `8445149012`). Three failure modes, one patch.

## What was broken

From `docker logs mira-bot-telegram --tail 200`:

```
06:12:38  Received: "connect micro 820 to gs11 vfd over rs485 modbus with CCW. How?"
06:12:40  LLM_CALL provider=groq model=llama-3.3-70b input=112 output=112
06:12:41  sendMessage  (answer with zero citations, no docs consulted)
```

`input=112` is the smoking gun — barely a system prompt + the user's one message. No conversation history. No RAG. No `NEON_RECALL` line. The reply was a generic LLM hallucination that didn't ground on any document, despite the message naming three pieces of industrial equipment.

## Root cause (file:line)

- **`_handle_general_question`** at `mira-bots/shared/engine.py:2946` — only consulted the KB when `asset_identified` was already set AND the message contained one of ~10 hard-coded spec keywords. Cold questions naming a vendor + model fell through to `_call_llm_direct`.
- **`_call_llm_direct`** at `mira-bots/shared/engine.py:3578-3585` — built a 2-element message list and ignored conversation history entirely. Stateless LLM call.
- **`_clear_diagnostic_carryover(..., clear_photo=True)`** — wiped session photos for any general question, breaking mid-diagnostic clarifications.

For comparison, the RAG worker (`workers/rag_worker.py:642-644`) and `_handle_instructional_question` (`engine.py:3553-3556`) both pass history. Just this one handler didn't.

## The fix

Five-step decision tree in `_handle_general_question`:

1. Re-resolve manufacturer/model from current message + last 6 user turns (so MIRA recovers vendor context every turn).
2. Vendor + KB has coverage → route through `self.rag.process` so the reply carries citations.
3. Vendor identified but no KB coverage → hand off to `_do_documentation_lookup` (kicks the crawler off).
4. No vendor anywhere AND the message looks industrial (regex hits `vfd|plc|modbus|fault|F0004|OC|…`) → ask one clarifier for vendor + model. Don't hallucinate.
5. Truly general question (no industrial vocabulary, no resolved vendor) → answer from training knowledge **with history threaded through**.

`_call_llm_direct` now accepts an optional `history` kwarg, uses the same `_trim_history_by_tokens` helper the RAG worker uses, and splices prior turns between the system prompt and the current user message. This is the canonical pattern every major chat platform uses (ChatGPT, Claude.ai, Gemini) — stateless model + client maintains the array, re-sent each turn.

Both call sites (`engine.py:1268` and `engine.py:3294`) now pass `tenant_id=resolved_tenant` so KB coverage probes hit the right tenant.

## Compatible with UNS Confirmation Gate (#1280)

The recently merged gate fires on `diagnose_equipment` intent. This patch operates on `general_question` — different lane. Both paths now share the same spirit: when no asset is confirmed, **ask** instead of guessing.

## What's NOT in scope

Mike's stated principle is "≥80% confidence backed by docs". This patch uses `kb_has_coverage` (boolean) as the gate, not a calibrated 0-100% confidence score. A real confidence scorer (LLM-as-judge on draft reply vs retrieved chunks, or top-k similarity-weighted) is a follow-up.

`_handle_instructional_question` still uses a fixed `history[-6:]` window rather than the token-budget trimmer. Worth a small follow-up to unify.

## Test plan

- [x] 7 new tests in `mira-bots/tests/test_engine_general_question.py` cover each branch of the decision tree
- [x] 102 existing engine tests still pass (`test_engine.py`, `test_engine_dst_integration.py`, `test_engine_tenant_kwargs.py`, `test_conversation_continuity.py`)
- [x] `ruff check` clean
- [ ] Deploy: `gh workflow run deploy-vps.yml -f services=mira-bot-telegram`
- [ ] Manual verify in Telegram: ask a cold vendor+model question — confirm `NEON_RECALL` line appears in logs and reply contains citations
- [ ] Manual verify follow-up: ask a clarifying question mid-photo-diagnostic — confirm photo is NOT wiped

🤖 Generated with [Claude Code](https://claude.com/claude-code)