### PR TITLE
fix(hub): P0 — edge-safe middleware (#1303)

### DIFF
--- a/mira-hub/src/middleware.ts
+++ b/mira-hub/src/middleware.ts
@@ -1,50 +1,81 @@
-import { withAuth, type NextRequestWithAuth } from "next-auth/middleware";
 import { NextResponse, type NextFetchEvent, type NextRequest } from "next/server";
-import crypto from "node:crypto";
+import { jwtDecrypt } from "jose";
 
-// Gate pages: authenticated users with non-approved status land here;
-// skip the status check when already on these pages to avoid redirect loops.
+// Next.js 16 middleware runs in the edge runtime. We must NOT import
+// `node:crypto` or `next-auth/middleware` here — both pull native modules
+// into the edge bundle and crash module evaluation with
+// "Failed to load external module node:crypto" (#1303).
+//
+// Edge runtime exposes `crypto.randomUUID()` and `crypto.subtle` as globals
+// (Web Crypto API). We use those for the CSP nonce and HKDF, and decrypt
+// the next-auth session JWE with top-level `jose` 5 (resolves to the
+// Web-Crypto build via the `worker` export condition).
+
 const GATE_PATHS = ["/pending-approval", "/upgrade", "/magic"];
+const SECURE_NAME = "__Secure-next-auth.session-token";
+const REGULAR_NAME = "next-auth.session-token";
+const HKDF_INFO = "NextAuth.js Generated Encryption Key";
 
-// withAuth's two-arg form: inner function runs ONLY when authorized (token exists).
-// The outer middleware handles the basePath root redirect before withAuth runs.
-const authMiddleware = withAuth(
-  function onAuthorized(req: NextRequestWithAuth) {
-    const token = req.nextauth?.token;
-    if (!token) return NextResponse.next();
+async function deriveKey(secret: string): Promise<Uint8Array> {
+  const enc = new TextEncoder();
+  const ikm = await crypto.subtle.importKey(
+    "raw",
+    enc.encode(secret),
+    "HKDF",
+    false,
+    ["deriveBits"],
+  );
+  // next-auth v4.24.14 uses salt="" by default; info matches @panva/hkdf call
+  // in next-auth/jwt/index.js (`"NextAuth.js Generated Encryption Key" + (salt ? ` (${salt})` : "")`).
+  const derived = await crypto.subtle.deriveBits(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: new Uint8Array(0),
+      info: enc.encode(HKDF_INFO),
+    },
+    ikm,
+    256,
+  );
+  return new Uint8Array(derived);
+}
 
-    const pathname = req.nextUrl.pathname;
-    if (GATE_PATHS.some(p => pathname.startsWith(p))) return NextResponse.next();
+async function decodeSessionJwt(
+  token: string,
+  secret: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const key = await deriveKey(secret);
+    const { payload } = await jwtDecrypt(token, key, { clockTolerance: 15 });
+    return payload as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
 
-    const status = String(token.status ?? "trial");
-
-    if (status === "pending") {
-      const url = req.nextUrl.clone();
-      url.pathname = "/pending-approval";
-      return NextResponse.redirect(url);
-    }
-
-    if (status === "expired") {
+function gateRedirect(req: NextRequest, status: string, trialExpiresAt: unknown): URL | null {
+  if (status === "pending") {
+    const url = req.nextUrl.clone();
+    url.pathname = "/pending-approval";
+    url.search = "";
+    return url;
+  }
+  if (status === "expired") {
+    const url = req.nextUrl.clone();
+    url.pathname = "/upgrade";
+    url.search = "";
+    return url;
+  }
+  if (status === "trial" && typeof trialExpiresAt === "string") {
+    if (new Date() > new Date(trialExpiresAt)) {
       const url = req.nextUrl.clone();
       url.pathname = "/upgrade";
-      return NextResponse.redirect(url);
+      url.search = "";
+      return url;
     }
-
-    if (status === "trial" && token.trialExpiresAt) {
-      if (new Date() > new Date(token.trialExpiresAt as string)) {
-        const url = req.nextUrl.clone();
-        url.pathname = "/upgrade";
-        return NextResponse.redirect(url);
-      }
-    }
-
-    return NextResponse.next();
-  },
-  {
-    pages: { signIn: "/login" },
-    secret: process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET,
-  },
-);
+  }
+  return null;
+}
 
 function buildCsp(nonce: string): string {
   return [
@@ -58,30 +89,64 @@ function buildCsp(nonce: string): string {
   ].join("; ");
 }
 
-export default async function middleware(req: NextRequest, ev: NextFetchEvent) {
-  // Basepath root → redirect to /feed. `redirect()` from a Server Component
-  // is silently swallowed in Next.js 16.2.4 standalone + basePath (response
-  // comes back chunked, 0 bytes, no Location header), so the redirect has
-  // to live here. /feed itself goes through authMiddleware below, so the
-  // auth gate is preserved.
-  if (req.nextUrl.pathname === "/") {
+// btoa is a global in the edge runtime; use it instead of Buffer for nonce encoding.
+function b64Nonce(raw: string): string {
+  return btoa(raw).replace(/=+$/, "");
+}
+
+export default async function middleware(req: NextRequest, _ev: NextFetchEvent) {
+  const pathname = req.nextUrl.pathname;
+
+  // Basepath root → /feed. `redirect()` from a Server Component is silently
+  // swallowed in Next.js 16.2.4 standalone + basePath (response comes back
+  // chunked, 0 bytes, no Location header), so the redirect has to live here.
+  if (pathname === "/") {
     const url = req.nextUrl.clone();
     url.pathname = "/feed";
+    url.search = "";
     return NextResponse.redirect(url);
   }
 
   // Per-request nonce for script-src CSP — removes unsafe-inline/unsafe-eval.
   // Forwarded as x-nonce request header so RootLayout can attach it to <Script>.
-  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const nonce = b64Nonce(crypto.randomUUID());
   const csp = buildCsp(nonce);
 
-  // Auth check runs on the original request (auth reads cookies, not x-nonce).
-  const authResult = await authMiddleware(req as NextRequestWithAuth, ev);
+  const cookieValue =
+    req.cookies.get(SECURE_NAME)?.value ?? req.cookies.get(REGULAR_NAME)?.value;
+  const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
 
-  // Auth issued a redirect (e.g. → /login) — stamp CSP and return as-is.
-  if (authResult && authResult.status >= 300 && authResult.status < 400) {
-    authResult.headers.set("Content-Security-Policy", csp);
-    return authResult;
+  // No cookie or no secret configured → bounce to /login with callback.
+  if (!cookieValue || !secret) {
+    const url = req.nextUrl.clone();
+    url.pathname = "/login";
+    url.search = "";
+    url.searchParams.set("callbackUrl", pathname);
+    const resp = NextResponse.redirect(url);
+    resp.headers.set("Content-Security-Policy", csp);
+    return resp;
+  }
+
+  const token = await decodeSessionJwt(cookieValue, secret);
+  if (!token) {
+    const url = req.nextUrl.clone();
+    url.pathname = "/login";
+    url.search = "";
+    url.searchParams.set("callbackUrl", pathname);
+    const resp = NextResponse.redirect(url);
+    resp.headers.set("Content-Security-Policy", csp);
+    return resp;
+  }
+
+  // Already on a gate page — let it render so the user can act.
+  if (!GATE_PATHS.some((p) => pathname.startsWith(p))) {
+    const status = String(token.status ?? "trial");
+    const redirectUrl = gateRedirect(req, status, token.trialExpiresAt);
+    if (redirectUrl) {
+      const resp = NextResponse.redirect(redirectUrl);
+      resp.headers.set("Content-Security-Policy", csp);
+      return resp;
+    }
   }
 
   // Pass through: forward nonce to server components + set CSP on response.


### PR DESCRIPTION
## Summary

Fixes #1303 — mira-hub 500 on all page routes due to node:crypto in edge bundle.

**Root cause:** Next.js 16 builds middleware to the edge runtime. `next-auth/middleware` v4 transitively requires next-auth's bundled jose 4 (the node build), which imports `node:crypto` at module evaluation. The edge runtime has no `node:crypto` module, so every gated route (\`/feed\`, \`/cmms\`, \`/workorders\`, \`/assets\`, ...) and all \`/api/cmms/*\` routes 500'd on the VPS. Container healthcheck only hit \`/api/health\` (excluded from the middleware matcher) so the container reported healthy.

**Fix:** Stop importing \`next-auth/middleware\`. Decode the session JWT inline:
- Web Crypto HKDF derives the AES-256-GCM key (salt=\"\", info=\"NextAuth.js Generated Encryption Key\" — matches @panva/hkdf's call in next-auth/jwt v4.24.14)
- Top-level \`jose\` 5.10.0 \`jwtDecrypt\` decrypts the JWE — resolves to the Web-Crypto build via the \`worker\` export condition, so the edge bundle has no node:crypto

Same gate semantics: pending → \`/pending-approval\`, expired/trial-expired → \`/upgrade\`, root → \`/feed\`, no-cookie → \`/login\` with callbackUrl.

## Verification

- \`npm run build\` clean. Edge bundle grep: \`grep -c node:crypto .next/server/edge/chunks/*.js\` → all 0
- Interop test: token encoded by next-auth/jwt (node) round-trips through the new Web-Crypto decode path — uid/tid/status/trialExpiresAt all preserved

## Test plan

- [ ] Deploy to VPS
- [ ] \`curl -I https://app.factorylm.com/hub/feed/\` → 307 to /login when unauth, 200 when auth
- [ ] Container logs show no \"Failed to load external module node:crypto\"
- [ ] Smoke: /hub/workorders, /hub/cmms, /hub/assets render

🤖 Generated with [Claude Code](https://claude.com/claude-code)