### PR TITLE
fix(ops): apply-seeds.yml — surface psql errors instead of swallowing them

### DIFF
--- a/.github/workflows/apply-seeds.yml
+++ b/.github/workflows/apply-seeds.yml
@@ -106,10 +106,12 @@ jobs:
            WHERE tenant_id = :'tid';
           SQL
 
-          OUTPUT=$(psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 \
-                        -v tid="${{ inputs.tenant_id }}" \
-                        -f /tmp/preflight.sql 2>&1)
-          echo "$OUTPUT"
+          set +e
+          psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 \
+               -v "tid=${{ inputs.tenant_id }}" \
+               -f /tmp/preflight.sql 2>&1 | tee /tmp/preflight.out
+          PSQL_EXIT=${PIPESTATUS[0]}
+          set -e
           {
             echo "## Pre-flight diagnostic"
             echo ""
@@ -118,9 +120,13 @@ jobs:
             echo "Tenant id under test: \`${{ inputs.tenant_id }}\`"
             echo ""
             echo '```'
-            echo "$OUTPUT"
+            cat /tmp/preflight.out
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$PSQL_EXIT" -ne 0 ]; then
+            echo "::error::psql pre-flight failed with exit $PSQL_EXIT — see step output above for the actual error"
+            exit "$PSQL_EXIT"
+          fi
 
       - name: Resolve seed file list
         id: resolve
@@ -263,15 +269,21 @@ jobs:
              AND created_at > now() - interval '15 minutes';
           SQL
 
-          OUTPUT=$(psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 \
-                        -v tid="${{ inputs.tenant_id }}" \
-                        -f /tmp/postcheck.sql 2>&1)
-          echo "$OUTPUT"
+          set +e
+          psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 \
+               -v "tid=${{ inputs.tenant_id }}" \
+               -f /tmp/postcheck.sql 2>&1 | tee /tmp/postcheck.out
+          PSQL_EXIT=${PIPESTATUS[0]}
+          set -e
           {
             echo ""
             echo "### Post-apply row counts"
             echo ""
             echo '```'
-            echo "$OUTPUT"
+            cat /tmp/postcheck.out
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$PSQL_EXIT" -ne 0 ]; then
+            echo "::error::psql post-check failed with exit $PSQL_EXIT"
+            exit "$PSQL_EXIT"
+          fi


### PR DESCRIPTION
## Summary
- Pre-flight + post-check used `OUTPUT=\$(psql ... 2>&1)` under `set -e`. When psql exited non-zero, the subshell exit triggered `set -e` before `echo \"\$OUTPUT\"` ran — error text never reached the workflow log. Run 25911229064 exited code 3 with zero error context.
- Switch to `psql ... 2>&1 | tee /tmp/*.out` with `PIPESTATUS[0]` captured under `set +e`, then re-exit with the captured code. Output is now visible in the log AND in `\$GITHUB_STEP_SUMMARY` regardless of psql's exit.
- Drop unneeded `\` line-continuation inside the quoted `-v "tid=..."` arg.

Cherry-pick of 97b49b40 from `fix/apply-seeds-error-visibility`. Original author/date preserved.

## Test plan
- [ ] Merge, then `gh workflow run apply-seeds.yml -f mode=apply -f tenant_id=mike-garage-demo`
- [ ] Inspect step \"Pre-flight diagnostic\" output — psql error (whatever caused exit 3) should now be visible
- [ ] If error is `:'tid'`-substitution-related, address in a follow-up commit informed by the actual error text

🤖 Generated with [Claude Code](https://claude.com/claude-code)