### PR TITLE
feat(uns): pair-coverage probe + multi-vendor resolution (Stage 1 foundations)

### DIFF
--- a/mira-bots/shared/neon_recall.py
+++ b/mira-bots/shared/neon_recall.py
@@ -832,9 +832,7 @@ def kb_has_coverage(vendor: str, model: str, tenant_id: str) -> tuple[bool, str]
 KB_PAIR_COVERAGE_MIN_CHUNKS = int(os.getenv("MIRA_KB_PAIR_COVERAGE_MIN_CHUNKS", "1"))
 
 
-def kb_has_pair_coverage(
-    vendor: str, model: str, tenant_id: str
-) -> tuple[bool, int]:
+def kb_has_pair_coverage(vendor: str, model: str, tenant_id: str) -> tuple[bool, int]:
     """Strict-pair coverage probe — does the KB have chunks tagged with BOTH
     this vendor AND this model?
 

--- a/mira-bots/shared/neon_recall.py
+++ b/mira-bots/shared/neon_recall.py
@@ -827,3 +827,88 @@ def kb_has_coverage(vendor: str, model: str, tenant_id: str) -> tuple[bool, str]
     except Exception as exc:
         logger.warning("kb_has_coverage failed: %s", exc)
         return False, f"error_{type(exc).__name__}"
+
+
+KB_PAIR_COVERAGE_MIN_CHUNKS = int(os.getenv("MIRA_KB_PAIR_COVERAGE_MIN_CHUNKS", "1"))
+
+
+def kb_has_pair_coverage(
+    vendor: str, model: str, tenant_id: str
+) -> tuple[bool, int]:
+    """Strict-pair coverage probe — does the KB have chunks tagged with BOTH
+    this vendor AND this model?
+
+    Distinct from ``kb_has_coverage`` (vendor-only). Used to catch chimeric
+    pairings like ("AutomationDirect", "820") — the resolver can name them,
+    but no row in ``knowledge_entries`` has them together, so the count is
+    zero and the caller drops the candidate before speaking it.
+
+    Returns (covered, count). ``covered`` is True when count ≥
+    ``KB_PAIR_COVERAGE_MIN_CHUNKS`` (default 1 — any chunk counts as proof
+    the pair exists). Tunable via ``MIRA_KB_PAIR_COVERAGE_MIN_CHUNKS``.
+
+    Never raises. Blank vendor or model returns (False, 0). Missing
+    NEON_DATABASE_URL returns (False, 0). Any DB error returns (False, -1)
+    so callers can distinguish "no rows" from "couldn't check" if they
+    want to fail open in failure scenarios.
+    """
+    vendor_clean = vendor.strip()
+    model_clean = model.strip()
+    if not vendor_clean or not model_clean:
+        return False, 0
+
+    url = os.environ.get("NEON_DATABASE_URL")
+    if not url:
+        return False, 0
+
+    try:
+        from sqlalchemy import create_engine, text  # noqa: PLC0415
+        from sqlalchemy.pool import NullPool  # noqa: PLC0415
+
+        engine = create_engine(
+            url,
+            poolclass=NullPool,
+            connect_args={"sslmode": "require"},
+            pool_pre_ping=True,
+        )
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    """
+                    SELECT COUNT(*) AS cnt
+                    FROM knowledge_entries
+                    WHERE (tenant_id = :tid OR tenant_id = :shared_tid)
+                      AND LOWER(manufacturer) LIKE LOWER(:vendor_pat)
+                      AND LOWER(model_number) LIKE LOWER(:model_pat)
+                      AND embedding IS NOT NULL
+                    """
+                ),
+                {
+                    "tid": tenant_id,
+                    "shared_tid": SHARED_TENANT_ID,
+                    "vendor_pat": f"%{vendor_clean}%",
+                    "model_pat": f"%{model_clean}%",
+                },
+            ).fetchone()
+        count = int(row[0]) if row else 0
+        covered = count >= KB_PAIR_COVERAGE_MIN_CHUNKS
+        if covered:
+            logger.info(
+                "KB_PAIR_COVERAGE_HIT vendor=%r model=%r count=%d threshold=%d",
+                vendor_clean,
+                model_clean,
+                count,
+                KB_PAIR_COVERAGE_MIN_CHUNKS,
+            )
+        else:
+            logger.info(
+                "KB_PAIR_COVERAGE_MISS vendor=%r model=%r count=%d threshold=%d",
+                vendor_clean,
+                model_clean,
+                count,
+                KB_PAIR_COVERAGE_MIN_CHUNKS,
+            )
+        return covered, count
+    except Exception as exc:
+        logger.warning("kb_has_pair_coverage failed: %s", exc)
+        return False, -1

--- a/mira-bots/shared/uns_resolver.py
+++ b/mira-bots/shared/uns_resolver.py
@@ -424,10 +424,7 @@ def _match_all_vendors(
         if pos < existing_pos or (pos == existing_pos and len(alias) > existing_len):
             best[canonical] = (alias, family, pos, len(alias))
 
-    results = [
-        (canon, alias, family, pos)
-        for canon, (alias, family, pos, _len) in best.items()
-    ]
+    results = [(canon, alias, family, pos) for canon, (alias, family, pos, _len) in best.items()]
     results.sort(key=lambda x: x[3])
     return results
 

--- a/mira-bots/shared/uns_resolver.py
+++ b/mira-bots/shared/uns_resolver.py
@@ -26,6 +26,7 @@ from typing import Any
 # subset of mira-crawler/ingest/uns.py the resolver needs. mira-bots cannot
 # import from mira-crawler (architecture contract, enforced in CI).
 from . import uns_paths as _uns
+from .neon_recall import kb_has_pair_coverage
 
 logger = logging.getLogger(__name__)
 
@@ -188,6 +189,45 @@ class UNSContext:
         return cls(**clean)
 
 
+@dataclass(frozen=True)
+class UNSResolution:
+    """Multi-candidate resolution result for messages that may name more than
+    one vendor (cross-vendor integration questions).
+
+    ``primary`` matches the legacy ``resolve_uns_path()`` semantics — the
+    first vendor encountered in message order — so callers that only care
+    about a single answer can read ``resolution.primary`` and ignore the
+    rest.
+
+    ``candidates`` is the validated list. Each entry is a ``UNSContext``
+    for one vendor named in the message, with its nearest model token,
+    after pair-coverage validation against the KB. Chimeric pairings (e.g.
+    "AutomationDirect" + "820" — no row in ``knowledge_entries`` has them
+    together) are dropped before the result is returned.
+
+    For single-vendor messages, ``candidates`` has one entry equal to
+    ``primary``. For messages with no recognized vendor, ``candidates`` is
+    empty and ``primary`` is the legacy fault-only or no-op result.
+    """
+
+    primary: UNSContext
+    candidates: tuple[UNSContext, ...] = ()
+
+    @property
+    def has_multi_vendor(self) -> bool:
+        seen = {c.manufacturer for c in self.candidates if c.manufacturer}
+        return len(seen) >= 2
+
+    def vendors(self) -> list[str]:
+        return [c.manufacturer for c in self.candidates if c.manufacturer]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "primary": self.primary.as_dict(),
+            "candidates": [c.as_dict() for c in self.candidates],
+        }
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
@@ -345,6 +385,51 @@ def _match_vendor(message_lower: str) -> tuple[str | None, str | None, str | Non
                 family = FAMILY_FROM_ALIAS.get(alias)
                 return mfr, alias, family
     return None, None, None
+
+
+def _match_all_vendors(
+    message_lower: str,
+) -> list[tuple[str, str, str | None, int]]:
+    """Find every distinct canonical vendor named in the message.
+
+    Returns a list of (canonical_mfr, alias_key_lower, family_token,
+    char_position) sorted by char_position (first-named vendor first).
+    Deduplicated by canonical manufacturer: if both "allen-bradley" and
+    "rockwell" appear, only the earliest position for "Rockwell Automation"
+    is returned. Longer-specific aliases win over shorter ones when both
+    match the same canonical vendor (e.g. "rockwell automation" preferred
+    over the bare "rockwell" at the same position).
+    """
+    # canonical -> (alias_lower, family_token, char_position, alias_length)
+    best: dict[str, tuple[str, str | None, int, int]] = {}
+    for alias in sorted(VENDOR_ALIASES.keys(), key=len, reverse=True):
+        canonical = VENDOR_ALIASES[alias]
+        family = FAMILY_FROM_ALIAS.get(alias)
+        if any(c in alias for c in " -"):
+            m = re.search(re.escape(alias), message_lower)
+        else:
+            m = re.search(rf"\b{re.escape(alias)}\b", message_lower)
+        if m is None:
+            continue
+        pos = m.start()
+        existing = best.get(canonical)
+        # Prefer the earliest position. On a position tie, prefer the longer
+        # (more specific) alias — this keeps "rockwell automation" winning
+        # over "rockwell" when both anchor at the same offset.
+        if existing is None:
+            best[canonical] = (alias, family, pos, len(alias))
+            continue
+        existing_pos = existing[2]
+        existing_len = existing[3]
+        if pos < existing_pos or (pos == existing_pos and len(alias) > existing_len):
+            best[canonical] = (alias, family, pos, len(alias))
+
+    results = [
+        (canon, alias, family, pos)
+        for canon, (alias, family, pos, _len) in best.items()
+    ]
+    results.sort(key=lambda x: x[3])
+    return results
 
 
 def _is_model_candidate(token: str, fault_raw_tokens: frozenset[str]) -> bool:
@@ -721,3 +806,116 @@ def resolve_uns_path(
     else:
         prior_obj = prior_ctx
     return _merge_with_prior(fresh, prior_obj)
+
+
+def resolve_uns_path_multi(
+    message: str,
+    tenant_id: str | None = None,
+    prior_ctx: UNSContext | dict[str, Any] | None = None,
+) -> UNSResolution:
+    """Multi-vendor resolution. Returns one ``UNSContext`` candidate per
+    distinct vendor named in the message, after pair-coverage validation
+    against the KB.
+
+    Use this when a message may name two pieces of equipment from different
+    OEMs — e.g. "connect my Micro 820 to an AutomationDirect GS11 over
+    Modbus". The legacy ``resolve_uns_path()`` only returns the first
+    vendor + one model and is responsible for the historical chimera bug
+    where a vendor from one product gets paired with a model number from
+    another.
+
+    Behaviour:
+      - For messages naming 0 or 1 vendors, this is a thin wrapper around
+        ``resolve_uns_path``: ``primary`` is the legacy result, and
+        ``candidates`` either has one entry (single vendor) or is empty
+        (no vendor recognized).
+      - For messages naming ≥2 distinct vendors, each vendor gets its own
+        ``UNSContext`` with the nearest model token after the vendor's
+        position. Each (vendor, model) pair is then validated by
+        ``kb_has_pair_coverage`` — pairs the KB has no rows for get their
+        model field cleared, so the caller never speaks "AutomationDirect
+        820" as if it were a real product.
+      - ``primary`` is the first candidate in message order, matching the
+        legacy single-vendor result for backward-compat semantics.
+
+    Pair validation requires ``tenant_id``. When tenant_id is None the
+    validator is skipped (the candidates list still reflects multi-vendor
+    detection, but chimeric models are not pruned). Callers in
+    diagnostic contexts should always pass tenant_id.
+    """
+    legacy_primary = resolve_uns_path(message, tenant_id=tenant_id, prior_ctx=prior_ctx)
+
+    if not message:
+        return UNSResolution(primary=legacy_primary, candidates=())
+
+    message_lower = message.lower()
+    vendor_matches = _match_all_vendors(message_lower)
+
+    if len(vendor_matches) <= 1:
+        # Single-vendor (or zero-vendor) message — legacy resolver result is
+        # canonical. The pair-coverage check is intentionally NOT applied here
+        # to keep this path zero-DB-latency for the common case; the engine's
+        # speak-time formatter (`_do_documentation_lookup` and friends) is
+        # where the strict pair check guards single-vendor chimeras.
+        candidates = (legacy_primary,) if legacy_primary.manufacturer else ()
+        return UNSResolution(primary=legacy_primary, candidates=candidates)
+
+    # Multi-vendor — derive a candidate per vendor, validate each pair.
+    fault_pairs = _extract_fault_codes(message)
+    fault_code, fault_raw, fault_raw_tokens = _pick_fault_code(fault_pairs, None)
+    category = _detect_category(message, has_fault=fault_code is not None)
+
+    candidates_list: list[UNSContext] = []
+    for canonical, alias_lower, family_token, _pos in vendor_matches:
+        model = _find_model_near_vendor(message, alias_lower, fault_raw_tokens)
+
+        # Strip alias-as-model false positives (mirrors the legacy resolver's
+        # defenses at the end of `resolve_uns_path`).
+        if model and alias_lower and model.lower() == alias_lower:
+            model = None
+        if model and alias_lower:
+            m_compact = re.sub(r"[^A-Za-z0-9]", "", model).lower()
+            a_compact = re.sub(r"[^A-Za-z0-9]", "", alias_lower).lower()
+            if m_compact == a_compact:
+                model = None
+
+        # Chimera filter — drop the model when (vendor, model) has no KB
+        # coverage. Keep the vendor so the caller can still offer vendor-
+        # level documentation.
+        if model and tenant_id is not None:
+            covered, count = kb_has_pair_coverage(canonical, model, tenant_id)
+            if not covered:
+                logger.info(
+                    "UNS_PAIR_DROPPED canonical=%r model=%r kb_count=%d",
+                    canonical,
+                    model,
+                    count,
+                )
+                model = None
+
+        uns_path = _build_uns_path(canonical, family_token, model, fault_code, category)
+        cand = UNSContext(
+            uns_path=uns_path,
+            manufacturer=canonical,
+            manufacturer_alias=alias_lower,
+            product_family=family_token,
+            model=model,
+            fault_code=fault_code,
+            fault_code_raw=fault_raw,
+            category=category,
+            site_path=None,
+            matched_entities=[],
+            matched_kb_count=0,
+            confidence=_confidence(canonical, model, fault_code, db_confirmed=False),
+        )
+        candidates_list.append(cand)
+
+    if not candidates_list:
+        return UNSResolution(primary=legacy_primary, candidates=())
+
+    logger.info(
+        "UNS_RESOLUTION_MULTI n=%d vendors=%s",
+        len(candidates_list),
+        [c.manufacturer for c in candidates_list],
+    )
+    return UNSResolution(primary=candidates_list[0], candidates=tuple(candidates_list))

--- a/mira-bots/tests/test_neon_recall_pair_coverage.py
+++ b/mira-bots/tests/test_neon_recall_pair_coverage.py
@@ -1,0 +1,161 @@
+"""Tests for kb_has_pair_coverage — the strict vendor+model KB probe.
+
+The legacy ``kb_has_coverage`` filters only by manufacturer, which lets
+chimeric pairs like ("AutomationDirect", "820") look covered (4,284
+AutomationDirect chunks exist; none of them have model "820"). The new
+function adds the model filter so the caller can detect chimeras.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "mira-bots")
+
+# Need NEON_DATABASE_URL set or kb_has_pair_coverage short-circuits to
+# (False, 0) before any SQL runs.
+os.environ.setdefault("NEON_DATABASE_URL", "postgres://test:test@localhost/test")
+
+from shared.neon_recall import kb_has_pair_coverage  # noqa: E402
+
+
+def _mock_engine_with_count(count: int):
+    """Build a MagicMock create_engine that returns the given row count."""
+    row = MagicMock()
+    row.__getitem__ = lambda self, idx: count
+    conn = MagicMock()
+    conn.execute.return_value.fetchone.return_value = row
+    engine = MagicMock()
+    engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    return engine
+
+
+def test_blank_vendor_returns_zero():
+    covered, count = kb_has_pair_coverage("", "820", "tenant-1")
+    assert covered is False
+    assert count == 0
+
+
+def test_blank_model_returns_zero():
+    covered, count = kb_has_pair_coverage("AutomationDirect", "", "tenant-1")
+    assert covered is False
+    assert count == 0
+
+
+def test_both_blank_returns_zero():
+    covered, count = kb_has_pair_coverage("", "", "tenant-1")
+    assert covered is False
+    assert count == 0
+
+
+def test_missing_neon_url_returns_zero():
+    with patch.dict(os.environ, {"NEON_DATABASE_URL": ""}):
+        covered, count = kb_has_pair_coverage("AutomationDirect", "820", "tenant-1")
+    assert covered is False
+    assert count == 0
+
+
+def test_pair_covered_when_count_meets_threshold():
+    """Default threshold is 1 — any non-zero count counts as 'pair exists'."""
+    with patch(
+        "sqlalchemy.create_engine", return_value=_mock_engine_with_count(7)
+    ):
+        covered, count = kb_has_pair_coverage(
+            "AutomationDirect", "GS11", "tenant-1"
+        )
+    assert covered is True
+    assert count == 7
+
+
+def test_pair_not_covered_when_count_is_zero():
+    """The chimera case: vendor exists, but no row pairs it with this model."""
+    with patch(
+        "sqlalchemy.create_engine", return_value=_mock_engine_with_count(0)
+    ):
+        covered, count = kb_has_pair_coverage(
+            "AutomationDirect", "820", "tenant-1"
+        )
+    assert covered is False
+    assert count == 0
+
+
+def test_threshold_is_configurable():
+    """Higher threshold via env var means more chunks needed to count as covered."""
+    with patch.dict(os.environ, {"MIRA_KB_PAIR_COVERAGE_MIN_CHUNKS": "10"}):
+        # Reload the module-level constant to pick up new env value
+        import importlib
+
+        from shared import neon_recall
+
+        importlib.reload(neon_recall)
+        with patch(
+            "sqlalchemy.create_engine",
+            return_value=_mock_engine_with_count(5),
+        ):
+            covered, count = neon_recall.kb_has_pair_coverage(
+                "AutomationDirect", "GS11", "tenant-1"
+            )
+        assert covered is False
+        assert count == 5
+
+        with patch(
+            "sqlalchemy.create_engine",
+            return_value=_mock_engine_with_count(12),
+        ):
+            covered, count = neon_recall.kb_has_pair_coverage(
+                "AutomationDirect", "GS11", "tenant-1"
+            )
+        assert covered is True
+        assert count == 12
+    # Reload one more time so test order doesn't leak the env mutation.
+    import importlib
+
+    from shared import neon_recall
+
+    importlib.reload(neon_recall)
+
+
+def test_db_error_returns_negative_one():
+    """DB failures distinguish 'couldn't check' (-1) from 'no rows' (0)."""
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("connection refused")
+
+    with patch("sqlalchemy.create_engine", side_effect=boom):
+        covered, count = kb_has_pair_coverage(
+            "AutomationDirect", "GS11", "tenant-1"
+        )
+    assert covered is False
+    assert count == -1
+
+
+def test_sql_filters_on_both_vendor_and_model():
+    """The bug fix: the SQL must reference both manufacturer AND model_number."""
+    captured = {}
+
+    def capture_execute(stmt, params):
+        captured["sql"] = str(stmt)
+        captured["params"] = params
+        row = MagicMock()
+        row.__getitem__ = lambda self, idx: 3
+        result = MagicMock()
+        result.fetchone.return_value = row
+        return result
+
+    conn = MagicMock()
+    conn.execute = capture_execute
+    engine = MagicMock()
+    engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+    with patch("sqlalchemy.create_engine", return_value=engine):
+        kb_has_pair_coverage("AutomationDirect", "GS11", "tenant-1")
+
+    sql = captured["sql"].lower()
+    assert "manufacturer" in sql
+    assert "model_number" in sql
+    assert captured["params"]["vendor_pat"] == "%AutomationDirect%"
+    assert captured["params"]["model_pat"] == "%GS11%"

--- a/mira-bots/tests/test_uns_resolver_multi_vendor.py
+++ b/mira-bots/tests/test_uns_resolver_multi_vendor.py
@@ -1,0 +1,197 @@
+"""Tests for resolve_uns_path_multi — multi-vendor UNS resolution with KB
+pair-coverage validation (the chimera filter).
+
+Triggering bug: "Connect my Micro 820 to an AutomationDirect GS11 VFD..."
+was producing the fabricated product name "AutomationDirect 820" because
+the legacy resolver greedily picked one vendor + one digit-bearing token
+without validating they belong together.
+
+This file covers:
+  * Multi-vendor messages return one candidate per vendor.
+  * Chimeric (vendor, model) pairs get their model field cleared when the
+    KB has zero rows for the pair.
+  * Single-vendor messages remain backward-compatible.
+  * The existing resolve_uns_path() return type is unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, "mira-bots")
+
+os.environ.setdefault("NEON_DATABASE_URL", "postgres://test:test@localhost/test")
+
+from shared.uns_resolver import (  # noqa: E402
+    UNSContext,
+    UNSResolution,
+    _match_all_vendors,
+    resolve_uns_path,
+    resolve_uns_path_multi,
+)
+
+# ---------------------------------------------------------------------------
+# _match_all_vendors — the multi-vendor detection primitive
+# ---------------------------------------------------------------------------
+
+
+def test_match_all_vendors_returns_multiple_when_two_named():
+    msg = (
+        "i want to connect my micro 820 to an automationdirect gs11 vfd "
+        "using rs485 modbus"
+    )
+    matches = _match_all_vendors(msg)
+    canonicals = [m[0] for m in matches]
+    # AutomationDirect is recognized; "micro" is not yet in the alias table
+    # (Rockwell Micro 8xx aliases are a follow-up). Once added, this test
+    # will exercise Rockwell as well — for now we verify the multi-vendor
+    # primitive correctly returns AutomationDirect's match info.
+    assert "AutomationDirect" in canonicals
+
+
+def test_match_all_vendors_dedupes_canonical():
+    """Two aliases that map to the same canonical vendor return one entry."""
+    msg = "allen-bradley rockwell powerflex 525"
+    matches = _match_all_vendors(msg)
+    canonicals = [m[0] for m in matches]
+    # All three aliases map to "Rockwell Automation"
+    assert canonicals == ["Rockwell Automation"]
+
+
+def test_match_all_vendors_sorted_by_position():
+    msg = "siemens drive and a yaskawa controller and an abb meter"
+    matches = _match_all_vendors(msg)
+    canonicals = [m[0] for m in matches]
+    assert canonicals == ["Siemens", "Yaskawa", "ABB"]
+
+
+def test_match_all_vendors_two_distinct_canonicals():
+    """Cross-vendor message: both vendors surface."""
+    msg = "powerflex 525 connected to a gs10 drive"
+    matches = _match_all_vendors(msg)
+    canonicals = sorted(m[0] for m in matches)
+    assert canonicals == ["AutomationDirect", "Rockwell Automation"]
+
+
+def test_match_all_vendors_empty_for_no_match():
+    matches = _match_all_vendors("the motor is making noise")
+    assert matches == []
+
+
+# ---------------------------------------------------------------------------
+# resolve_uns_path_multi — wraps resolve_uns_path with multi-vendor candidates
+# ---------------------------------------------------------------------------
+
+
+def test_single_vendor_message_returns_one_candidate():
+    """Backward-compat shape: one vendor in → one candidate out, primary
+    matches resolve_uns_path()."""
+    legacy = resolve_uns_path("PowerFlex 525 F0004")
+    resolution = resolve_uns_path_multi("PowerFlex 525 F0004")
+    assert isinstance(resolution, UNSResolution)
+    assert resolution.primary.manufacturer == legacy.manufacturer
+    assert resolution.primary.model == legacy.model
+    assert resolution.primary.fault_code == legacy.fault_code
+    assert len(resolution.candidates) == 1
+    assert resolution.has_multi_vendor is False
+
+
+def test_zero_vendor_message_returns_empty_candidates():
+    resolution = resolve_uns_path_multi("Motor hums but won't turn")
+    assert resolution.primary.manufacturer is None
+    assert resolution.candidates == ()
+    assert resolution.has_multi_vendor is False
+
+
+def test_two_vendor_message_returns_two_candidates_without_tenant():
+    """Without tenant_id the chimera filter is skipped, but the multi-vendor
+    structure is still produced."""
+    resolution = resolve_uns_path_multi("PowerFlex 525 connected to GS10")
+    assert resolution.has_multi_vendor is True
+    vendors = sorted(resolution.vendors())
+    assert vendors == ["AutomationDirect", "Rockwell Automation"]
+
+
+def test_chimera_filter_clears_model_when_pair_has_no_kb_rows():
+    """The headline test: a (vendor, model) pair with zero KB coverage
+    must have its model field cleared so the engine never speaks it.
+
+    Scenario mirrors Mike's actual chimera message: one vendor's product
+    has real KB coverage; the other pair is the chimera the filter must
+    block.
+    """
+
+    def fake_pair_coverage(vendor: str, model: str, tenant_id: str):
+        # The covered pair: AutomationDirect + GS11 (4,284 chunks in prod).
+        if vendor == "AutomationDirect" and model == "GS11":
+            return True, 4284
+        # The chimera: Rockwell Automation + 525 in this test setup has no
+        # rows (the engine integration PR will treat unsupported pairs as
+        # "drop the model, keep the vendor").
+        return False, 0
+
+    with patch(
+        "shared.uns_resolver.kb_has_pair_coverage", side_effect=fake_pair_coverage
+    ):
+        resolution = resolve_uns_path_multi(
+            "PowerFlex 525 connected to AutomationDirect GS11",
+            tenant_id="t-1",
+        )
+
+    rockwell = next(
+        c for c in resolution.candidates if c.manufacturer == "Rockwell Automation"
+    )
+    auto_direct = next(
+        c for c in resolution.candidates if c.manufacturer == "AutomationDirect"
+    )
+    # Chimera filter dropped the model for the unsupported pair.
+    assert rockwell.model is None
+    # The covered pair keeps its model.
+    assert auto_direct.model == "GS11"
+
+
+def test_chimera_filter_keeps_vendor_when_model_dropped():
+    """Even when the model is dropped, the vendor stays so the caller can
+    offer vendor-level documentation."""
+
+    def fake_pair_coverage(vendor: str, model: str, tenant_id: str):
+        return False, 0  # Nothing has coverage
+
+    with patch(
+        "shared.uns_resolver.kb_has_pair_coverage", side_effect=fake_pair_coverage
+    ):
+        resolution = resolve_uns_path_multi(
+            "PowerFlex 525 connected to AutomationDirect GS11",
+            tenant_id="t-1",
+        )
+
+    for cand in resolution.candidates:
+        assert cand.manufacturer is not None  # vendor preserved
+        assert cand.model is None  # chimera-filtered
+
+
+def test_resolve_uns_path_unchanged_for_backward_compat():
+    """The legacy resolve_uns_path return type must remain UNSContext, not
+    UNSResolution. Every existing call site reads .manufacturer / .model /
+    etc. directly on the result.
+    """
+    ctx = resolve_uns_path("PowerFlex 525 F0004")
+    assert isinstance(ctx, UNSContext)
+    assert ctx.manufacturer == "Rockwell Automation"
+    assert ctx.model == "525"
+    assert ctx.fault_code == "F0004"
+
+
+def test_primary_is_first_candidate_in_message_order():
+    """Primary must reflect message-order so any caller defaulting to
+    `.primary` gets the same vendor the legacy resolver would have picked.
+    """
+    # Position-wise, "powerflex" comes before "gs10" in this message.
+    resolution = resolve_uns_path_multi("PowerFlex 525 wired into GS10")
+    assert resolution.primary.manufacturer == "Rockwell Automation"
+
+    # Flip the order; primary follows.
+    resolution2 = resolve_uns_path_multi("GS10 connected to a PowerFlex 525")
+    assert resolution2.primary.manufacturer == "AutomationDirect"


### PR DESCRIPTION
## Summary

Stage 1 of the UNS unification plan ([`docs/specs/uns-kg-unification-spec.md`](docs/specs/uns-kg-unification-spec.md), approved 2026-05-07). **Foundations only** — this PR adds primitives the engine integration PR (next) will call. Zero existing engine call sites change here.

**The bug to stop.** On 2026-05-15 the bot replied *"I have the **AutomationDirect 820** manual indexed"* to Mike's question about connecting a Micro 820 (Allen-Bradley) to a GS11 (AutomationDirect). The resolver paired one vendor with another vendor's model number; the doc-lookup formatter spoke it without validation. There is no AutomationDirect 820.

**The fix shape.** Two new primitives the engine will use to refuse to speak chimeras:

1. `kb_has_pair_coverage(vendor, model, tenant_id) → (bool, int)` — SQL filters on BOTH `manufacturer LIKE` AND `model_number LIKE`. Chimeric pairs return count=0.
2. `resolve_uns_path_multi(message, tenant_id, prior_ctx) → UNSResolution` — returns one candidate per distinct vendor named in the message. Each (vendor, model) pair is validated via `kb_has_pair_coverage`; chimeric pairs have their model field cleared, vendor preserved.

The legacy `resolve_uns_path()` is **unchanged** — every existing call site (8 in engine, 2 in dialogue layer, 82 tests) keeps working.

## Files changed

| File | Change |
|---|---|
| `mira-bots/shared/neon_recall.py` | + `kb_has_pair_coverage`, + `KB_PAIR_COVERAGE_MIN_CHUNKS` env knob (default 1) |
| `mira-bots/shared/uns_resolver.py` | + `UNSResolution` dataclass, + `_match_all_vendors`, + `resolve_uns_path_multi`. Imports `kb_has_pair_coverage` from neon_recall (no cycle). |
| `mira-bots/tests/test_neon_recall_pair_coverage.py` | New — 9 tests |
| `mira-bots/tests/test_uns_resolver_multi_vendor.py` | New — 12 tests |

## What this PR explicitly does NOT do

- **Engine call sites are NOT rewired.** `_do_documentation_lookup` will still speak whatever the legacy resolver returns until the engine integration PR lands. This means the chimera reply itself is unchanged in production after this merge — the primitives just become available.
- **The Allen-Bradley \"Micro 8xx\" PLC family is not yet in the alias table.** The multi-vendor primitive finds AutomationDirect in Mike's specific message but not Allen-Bradley until \"micro 820\" / \"micro 850\" / etc. get added. Tracked as a follow-up; deliberately kept out for diff discipline.

## Test plan

- [x] `mira-bots/tests/test_neon_recall_pair_coverage.py` — 9 / 9 pass
- [x] `mira-bots/tests/test_uns_resolver_multi_vendor.py` — 12 / 12 pass
- [x] `tests/test_uns_resolver.py` — 82 / 82 still pass (backward-compat smoke)
- [x] `mira-bots/tests/test_engine*.py` — 113 / 113 still pass (no engine code changed)
- [x] `ruff check` clean across all touched files
- [ ] Manual verify on prod: after engine integration PR also lands, replay Mike's exact \"Micro 820 + GS11\" question. Expect no \"AutomationDirect 820\" in the reply.

## Plan reference

[`~/.claude/plans/i-dont-understand-why-playful-zephyr.md`](https://github.com/Mikecranesync/MIRA/blob/main/docs/plans/i-dont-understand-why-playful-zephyr.md) (local plan file; full Stage 1-5 unification roadmap aligned with `docs/specs/uns-kg-unification-spec.md`).

## Stages remaining

| Stage | What | When |
|---|---|---|
| 1a — Foundations | This PR | ✅ Open |
| 1b — Engine integration | Wire `_do_documentation_lookup` + `_handle_general_question` to use `kb_has_pair_coverage` + `resolve_uns_path_multi`. Multi-vendor RAG composition. | Next PR |
| 2 — Ingest writes to KG | Wire `mira-crawler/ingest/store.py` to call `kg_writer.register_equipment_and_manual`. Backfill 74K chunks. | After 1b |
| 3 — UNS path enforcement on KG | Add `uns_path ltree` column, `default_uns_path` helper | After 2 |
| 4 — Hub KG read API | Build `mira-hub/api/internal/kg/*` endpoints | After 3 |
| 5 — Bot uses KG via MCP | Replace local SQL probes with MCP calls | After 4 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)