### PR TITLE
feat(hub): demo Phase 8 — tablet page /demo/conveyor/[tag] (May 21)

### DIFF
--- a/HANDOFF_2026-05-15-evening.md
+++ b/HANDOFF_2026-05-15-evening.md
@@ -1,0 +1,163 @@
+# Session Handoff — May 15, 2026 (Evening: PR rebases + Phase 8 tablet page)
+
+**Session window:** 2026-05-15 ~13:00 → 2026-05-15 evening
+**Previous handoff:** `HANDOFF_2026-05-15.md` (overnight: demo backend + migrations + KB seed)
+**Demo target:** **May 21, 2026** — physical conveyor tablet demo. **T-6 days.**
+**Branch (this session):** `feat/demo-may21-finish` (PR #1317) off `origin/main` `1c0c2413`
+
+---
+
+## 🚨 LEAD: P0 prod outage discovered — `factorylm.com` and `app.factorylm.com` hanging
+
+While running CI smoke against the rebased PRs, I noticed two PRs failing E2E
+smoke with `net::ERR_TIMED_OUT at https://factorylm.com/`. I verified
+independently from CHARLIE:
+
+| Check | Result |
+|---|---|
+| DNS `factorylm.com` (system + Cloudflare 1.1.1.1) | both return `165.245.138.91` (consistent) |
+| Tailscale to Alpha (sanity) | pong via LAN, ~6 ms — CHARLIE's network is fine |
+| TCP `165.245.138.91:443` / `:80` / `:22` | all OPEN (`nc -z` succeeded) |
+| TLS handshake on 443 | **stalls after Client Hello**, 12 s timeout |
+| Plain HTTP on 80 | **request sent, 0 bytes received**, 8 s timeout |
+| `app.factorylm.com` | same TLS handshake stall |
+
+**Diagnosis:** the VPS at `165.245.138.91` accepts TCP but the web layer
+(nginx and/or its upstreams) isn't responding to requests. This is
+independent of GitHub Actions and CHARLIE DNS — it's a real prod hang.
+
+**Likely causes** (operator to investigate):
+- nginx upstream timeout — app containers behind it not responding
+- Disk full on the DO droplet (eval-fixer + photo pipeline can fill disk)
+- OOM killed nginx or a service it proxies to
+- A container crashed (mira-mcp was already known missing from VPS — #1304)
+- iptables / UFW reload blocked traffic
+
+**Operator action:**
+```bash
+# from a machine with SSH access to the prod VPS (Mike's normal workstation)
+ssh root@165.245.138.91   # or however prod SSH is configured
+docker ps                  # which containers are up?
+docker logs --tail=200 nginx
+df -h                      # disk?
+docker compose -f docker-compose.saas.yml ps
+systemctl status nginx
+```
+
+**Demo-day impact:** if not resolved before May 21, the iPad won't reach
+the hub. P0 to investigate ASAP.
+
+---
+
+## ✅ What this session did (row-by-row vs PLAN.md)
+
+| # | Item | Status | Note |
+|---|---|---|---|
+| 1 | Worktree + sync setup | ✅ | `feat/demo-may21-finish` off `origin/main 1c0c2413` |
+| 2 | PR #1297 (psycopg v3 `add_notice_handler`) — verify supersession | ✅ rebased + pushed | NOT superseded by #1311/#1312; touches `tools/seeds/run_demo_seed.py` only. **MERGEABLE**; one FAILURE (E2E smoke) is the prod outage, not PR-caused. |
+| 3 | PR #1314 (UNS pair-coverage Stage 1) — fix Lint & Format | ✅ ran `ruff format`, pushed | Lint failure was 2 files needing format: `mira-bots/shared/{neon_recall,uns_resolver}.py`. Now SUCCESS. **MERGEABLE**; FAILURE is prod-outage smoke. |
+| 4 | PR #1313 (OEM-manual seed) — rebase | ✅ rebased onto `origin/main` (dropped 3 local-only commits), pushed | Closes part of #1308 once merged. **MERGEABLE**; smoke pending. |
+| 5 | PR #1315 (conv-suite harness) — rebase | ✅ rebased, pushed | 36 conversation cases land once merged. **MERGEABLE**; smoke pending. |
+| 6 | **Phase 7 — MQTT adapter** | ❌ DROPPED per spec | `docs/plans/2026-05-14-demo-backend-plan.md` line 94: *"What this plan deliberately does NOT do: Real-time MQTT subscription (deferred — mock feed for demo)."* The previous handoff's "Phase 7 = MQTT" was misaligned with the plan. Mock feed already shipped in #1298. |
+| 7 | **Phase 8 — tablet page `/demo/conveyor/[tag]`** | ✅ shipped in PR #1317 | 3 panels (live signals, components, Ask MIRA), Playwright smoke + gated screenshot test, full build green |
+| 8 | Open PR + write HANDOFF | ✅ this file | PR #1317, this handoff |
+
+---
+
+## 📌 PRs in MERGEABLE state — waiting on operator + prod restore
+
+Mike: once prod is restored, the E2E smoke check on each PR will auto-retry
+on the next push or you can re-run it manually. None of these PRs need a
+code change to merge.
+
+| PR | Branch | Title | Why merge |
+|---|---|---|---|
+| **#1297** | `fix/seed-runner-psycopg-v3-notices` | `fix(seeds): use psycopg v3 add_notice_handler` | psycopg v3 broke `conn.notices`; the seed runner crashes without this |
+| **#1313** | `claude/romantic-wescoff-290da1` | `feat(kb): OEM-manual seed for garage RS-485` | Closes part of #1308 (GS10/Micro820 KB gap) |
+| **#1314** | `fix/uns-pair-coverage-multi-vendor` | `feat(uns): pair-coverage probe + multi-vendor resolution` | UNS Stage 1 foundations |
+| **#1315** | `claude/crazy-ardinghelli-acc976` | `test(conv-suite): adapter-agnostic conversation testing harness` | 36-case conv test harness |
+| **#1317** | `feat/demo-may21-finish` | `feat(hub): demo Phase 8 — tablet page /demo/conveyor/[tag]` | This session's work |
+
+**Suggested merge order:** #1297 → #1313 → #1314 → #1315 → #1317. Squash-merge
+each; re-run smoke after `factorylm.com` is back up.
+
+---
+
+## 🧪 Phase 8 (PR #1317) — what's deployable + what's not
+
+**Deployable:**
+- `mira-hub/src/app/demo/conveyor/[tag]/page.tsx` (~330 lines)
+- `mira-hub/tests/e2e/demo-conveyor.spec.ts` (smoke + mocked-render gated by `MIRA_DEMO_SCREENSHOTS=1`)
+- `bun run build` exits 0 — route appears as `/demo/conveyor/[tag]`
+- `tsc --noEmit -p .` clean
+
+**NOT deployable yet — needs the demo seed on prod:**
+- Screenshots in `docs/promo-screenshots/2026-05-15_demo-conveyor-001_ipad-{landscape,portrait}.png`
+- The mocked Playwright path works but needs a local dev server with stubbed next-auth JWE cookies at the middleware layer (the `jose`-based middleware in `mira-hub/src/middleware.ts` decrypts cookies in the edge runtime — `page.route()` can't intercept that). I judged spinning up that infrastructure as exceeding the autonomous session's value.
+- **Operator path to screenshots:** once prod is restored + demo seed is loaded, hit `https://app.factorylm.com/demo/conveyor/CV-001` on the actual iPad and screenshot from there. That's the better proof anyway.
+
+---
+
+## ⚠️ Local-main hygiene note (worth knowing before you `git pull`)
+
+The local `main` checkout at `/Users/charlienode/MIRA` is **3 commits ahead of `origin/main`**:
+- `a27423a3 docs(wiki): eval-fixer run 2026-05-15 — same stale scorecard, suppressed dup issue`
+- `66e22ce8 fix(cmms): atlas carousel logo — replace hardcoded 'JSON Web Token' alt`
+- `22e9a30d docs(wiki): eval-fixer run 2026-05-13`
+
+These appear to be from auto-routines that committed but never pushed. They're not in any session's PR. Decide whether to push, squash, or drop — but `git pull --rebase` should handle them cleanly because origin doesn't have conflicting changes.
+
+---
+
+## 🛑 Out-of-scope items still pending — operator-only
+
+These were carried forward from the morning handoff and were NOT touched this session (autonomous-run skill's scope discipline):
+
+| Item | Why operator | Source |
+|---|---|---|
+| **VPS investigate prod-hang (this lead)** | SSH to VPS; debug stuck nginx/upstreams | New this session |
+| VPS deploy of #1306 (edge-safe middleware) | Same | morning handoff #1303 |
+| VPS bring-up of `mira-mcp` (port 8001 dead) | Same | morning handoff #1304 |
+| Verify migrations 014–018 on prod NeonDB | VPS-side bot DB check | morning handoff #1305 |
+| Bot restart for GS10/Micro820 KB rows | Same | morning handoff #1308 |
+| Stripe test → live keys in Doppler `factorylm/prd` | Live billing; needs explicit auth | morning handoff |
+| Slack Messages Tab enable | Manual Slack admin UI click | morning handoff |
+| Physical conveyor + Micro820 boot procedure on-site | Hardware, on-site only | morning handoff |
+| Bravo Mac Docker daemon down (#1284) | Different node | morning handoff |
+
+---
+
+## 🔁 Resume command (next session)
+
+```bash
+cd ~/MIRA
+git fetch origin
+# Inspect the 3 local-ahead commits on main, then either push or drop
+git log origin/main..main --oneline
+# Continue from this worktree if work stays open
+cd ~/MIRA/.claude/worktrees/demo-may21-finish
+git pull --rebase
+# OR fresh worktree off updated main:
+# git worktree add ~/MIRA/.claude/worktrees/<name> -b <branch> origin/main
+
+# Check prod health first
+curl -sS https://app.factorylm.com/api/health --max-time 10
+
+# Then PR review/merge
+gh pr list --state open --search "is:open base:main author:@me"
+gh pr checks 1297 1313 1314 1315 1317
+```
+
+---
+
+## Files of note (this session)
+
+- `mira-hub/src/app/demo/conveyor/[tag]/page.tsx` (NEW, 330 lines)
+- `mira-hub/tests/e2e/demo-conveyor.spec.ts` (NEW, smoke + gated mocked-render)
+- `.claude/worktrees/demo-may21-finish/PLAN.md` (session scope + spec corrections)
+- The 4 rebased branches above
+
+## What did NOT make it to disk
+
+- Real `docs/promo-screenshots/2026-05-15_demo-conveyor-001_*` PNGs (requires either prod-deployed seed or mocked next-auth at middleware level)
+- Any VPS-side change (out of scope; `prod-guard.sh` denies; prod itself is hung so even read-only checks would fail)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,75 +1,112 @@
-# PLAN — UNS Message Resolver (single extraction point)
+# PLAN — feat/demo-may21-finish (continuation of HANDOFF_2026-05-15.md)
 
-**Status:** Active (2026-05-13)
-**Branch:** `claude/elated-margulis-ac0926`
-**Scope:** `mira-bots/shared/uns_resolver.py` (new), `mira-bots/shared/engine.py`,
-`mira-bots/shared/workers/rag_worker.py`, `mira-bots/shared/dialogue_state.py`,
-`mira-bots/shared/dialogue_acts.py`, `tests/test_uns_resolver.py` (new),
-`docs/specs/uns-message-resolver-spec.md` (new), `.claude/rules/uns-compliance.md` (new)
-**Out-of-scope:** FSM, DST, LLM cascade, response formatting, any UI; the DST plan
-in `PLAN.dst.md` is a separate concern — do not modify those files except where
-they import from `guardrails.vendor_name_from_text` or call `_looks_like_model_number`.
-**Constraints:** No new dependencies, Python 3.12, ruff clean, reuse
-`mira-crawler/ingest/uns.py` path builders. Net-negative LOC target.
+**Status:** Active (2026-05-15 evening)
+**Branch:** `feat/demo-may21-finish` (off `origin/main` HEAD `1c0c2413`)
+**Worktree:** `.claude/worktrees/demo-may21-finish/`
+**Master plan file:** `/Users/charlienode/.claude/plans/handoff-written-mira-handoff-2026-05-15-swirling-crayon.md`
+**Source handoff:** `~/MIRA/HANDOFF_2026-05-15.md`
+
+> The PLAN.md from `main` (UNS Message Resolver, 2026-05-13) is preserved on
+> `main` and recoverable via `git show origin/main:PLAN.md`. This file is
+> THIS branch's scope contract, per the autonomous-run skill.
 
 ---
 
-## Why
+## In-scope (this session)
 
-`mira-bots/shared/engine.py` has 14 separate extraction sites that call
-`vendor_name_from_text()` and `_looks_like_model_number()` on `message`,
-`combined`, or `asset_id`. They don't share results, they disagree on edge
-cases (numeric-only models, fault codes captured as models), and they re-run
-the same regex work several times per turn. Mike's exact regression case
-*"I have a powerflex 525 and it has it called f0004"* fails because:
+1. **PR #1297** (psycopg v3 `add_notice_handler` for seed runner). Confirmed
+   NOT superseded by #1311/#1312. Merge if lint/unit/security all green and
+   the E2E smoke failure is pre-existing on `main`; otherwise comment.
 
-- `vendor_name_from_text` picks up `"powerflex"` → `"Rockwell Automation"` ✓
-- `_looks_like_model_number` returns `"f0004"` because it ranges left-to-right
-  and accepts the first letter+digit token — the *fault code is captured as
-  the model*
-- `"525"` (the real model) is rejected — letters-only check fails
+2. **PR #1314** (`fix/uns-pair-coverage-multi-vendor`). MERGEABLE but
+   `Lint & Format` step failing. Fix locally with ruff, push, merge.
 
-One UNS-aware resolver, called once at the top of `process()`, produces one
-canonical `UNSContext` for the turn. All 14 sites read from it.
+3. **PR #1313** (`claude/romantic-wescoff-290da1`, OEM-manual seed for the
+   garage RS-485 commissioning gap — closes part of #1308). CONFLICTING.
+   Rebase, resolve, push `--force-with-lease`, merge.
 
-## Numbered tasks
+4. **PR #1315** (`claude/crazy-ardinghelli-acc976`, adapter-agnostic
+   conversation testing harness, 36 cases). CONFLICTING. Rebase, resolve,
+   push, merge.
 
-1. **Spec + rule docs** — `docs/specs/uns-message-resolver-spec.md` and
-   `.claude/rules/uns-compliance.md`. Both short, both reference the resolver
-   module as the single extraction point.
-2. **`uns_resolver.py`** — `UNSContext` dataclass, `resolve_uns_path()`
-   function, `VENDOR_ALIASES` table, `FAULT_PATTERNS` list. Must work offline
-   (no NeonDB) — alias table is the floor.
-3. **`tests/test_uns_resolver.py`** — 30+ cases, must include Mike's exact
-   regression case and the pure-digit-model case. Run with
-   `python -m pytest tests/test_uns_resolver.py -v`.
-4. **Wire into `Supervisor.process()`** — one call near the top. Merge with
-   prior `state["uns_context"]` to preserve carry-over.
-5. **Replace extraction sites** — 14 in `engine.py`, 1 each in `rag_worker.py`,
-   `dialogue_state.py`, `dialogue_acts.py`. Batch by region, commit each batch.
-6. **`rag_worker` KB scoping** — use `uns_context.manufacturer` for the
-   cross-vendor filter, and `uns_path` for entity-scoped knowledge_entries
-   queries when available.
-7. **Run gates** — `ruff check`, `pytest tests/test_uns_resolver.py`, the
-   existing `tests/eval/bot_regression.py` cases, and Mike's exact regression
-   message must resolve to `mfr="Rockwell Automation", model="525",
-   fault="F0004"`.
-8. **Commit, push, PR, merge**.
+5. **(REVISED — Phase 7 dropped, see below.)** The demo backend plan
+   (`docs/plans/2026-05-14-demo-backend-plan.md` line 94) **explicitly
+   defers** real-time MQTT subscription for the May 21 demo: *"What this
+   plan deliberately does NOT do: Real-time MQTT subscription (deferred —
+   mock feed for demo)."* The 2026-05-15 addendum confirms Plan P5 (mock
+   signal feed via `live_signal_cache` + `signal-recorder.ts`) and Plan P7
+   (engine + intent wire-up via existing context-injection path) are
+   already DONE in #1295 + #1298. Building an MQTT pipeline now would
+   contradict the spec — STOP condition fired and re-planned. The handoff's
+   "Phase 7" appears to have been an aspirational item not aligned with the
+   plan's deliberate deferral.
 
-## Success criteria
+6. **Demo P8 — tablet demo page.** Per
+   `docs/plans/2026-05-14-demo-backend-plan.md` row P8: single page, 3
+   panels — live signals (polling `GET /api/demo/signals/summary`),
+   KG/component card (`GET /api/demo/customer` + `GET /api/components/[id]`),
+   Slack-like chat embedded (`POST /api/mira/ask`). Path:
+   `mira-hub/src/app/demo/conveyor/[tag]/page.tsx` (plan's `mira-web/`
+   reference is a typo — all 11 endpoints live in `mira-hub`). Reuses Hub
+   design tokens (shadcn/ui already present). Playwright snapshots at
+   iPad sizes (1024×768 landscape + 820×1180 portrait, per plan's
+   verification gate) committed to `docs/promo-screenshots/`.
 
-- All 14 `engine.py` extraction sites reduced to `state["uns_context"]` reads.
-- `vendor_name_from_text` and `_looks_like_model_number` no longer imported in
-  `engine.py`, `rag_worker.py`, `dialogue_state.py`, `dialogue_acts.py`.
-- `tests/test_uns_resolver.py` ≥ 30 cases, all pass.
-- Mike's exact regression case resolves correctly (see test 1 in the suite).
-- `ruff check` passes.
-- `tests/eval/bot_regression.py` does not regress vs main baseline.
-- Net diff is negative LOC.
+7. **Open the session PR + write `HANDOFF_2026-05-15-evening.md`** —
+   row-by-row done/skipped, deferred-to-operator list, exact resume command.
 
-## Hard stops
+---
 
-- A reviewer-style data-integrity issue surfaces → stop, fix, re-gate.
-- 5 consecutive failing test runs on the same case → stop, write HANDOFF.
-- Out-of-scope file modified accidentally → revert that file, do not "while
-  I'm here".
+## Out-of-scope (DEFERRED to operator — Mike). Editing these = STOP.
+
+| Item | Why deferred |
+|---|---|
+| VPS deploy of #1306 mira-hub middleware | SSH to VPS; `prod-guard.sh` blocks |
+| VPS bring-up of `mira-mcp` (#1304) | Same |
+| Verify migrations 014–018 on prod NeonDB (#1305) | VPS-side smoke required |
+| VPS bot restart for GS10/Micro820 KB (#1308) | Same |
+| Stripe test → live keys in Doppler `factorylm/prd` | Live billing; explicit Mike approval needed |
+| Slack Messages Tab enable | Manual Slack admin UI click |
+| Physical conveyor + Micro820 boot procedure on-site | Hardware, on-site |
+| #1284 (Bravo Mac Docker daemon) | Different node |
+| Triage of older P0s (#1284, #1201, #1200, #1158, etc.) | Not coding work |
+| Closing the 25+ older conflicting PRs | Mike's explicit instruction: don't |
+
+---
+
+## Stop conditions (per `.claude/skills/autonomous-run/SKILL.md`)
+
+- All 7 in-scope items complete → write evening HANDOFF, stop
+- Token usage > 70%, or turn count > 200 → stop, HANDOFF
+- Edit would touch an OUT-of-scope path → STOP
+- Phase 7 reference plan reveals fundamentally different architecture → re-plan
+- 5 consecutive turns failing the same test → stop
+- Pre-merge reviewer-style issue surfaces → stop, fix, re-run gates
+
+---
+
+## Verification gates
+
+| Step | Gate |
+|---|---|
+| 1–4 | `gh pr checks <num>` green; merge via `gh pr merge --squash` |
+| 5 | Mosquitto + simulator + poller running locally; `wscat` against `/api/demo/ws` shows ticking values |
+| 6 | `bun run test:e2e -- demo-conveyor-001` passes; both screenshots committed |
+| 7 | `gh pr checks` green on session PR; HANDOFF committed |
+
+`tools/hooks/stop-gate.sh` runs on Stop — don't bypass with `MIRA_SKIP_STOP_GATE=1`.
+
+---
+
+## Path corrections vs handoff
+
+- `mira-hub/app/api/...` → **`mira-hub/src/app/api/...`**
+- `mira-hub/migrations/` → **`mira-hub/db/migrations/`**
+- `seeds/2026-05-1?_*.sql` → **`tools/seeds/{gs10-vfd-knowledge,gs11-field-guide-knowledge,demo-conveyor-001}.sql`**
+- `docs/plans/2026-05-15-may-21-demo-8-phase-plan.md` → **`docs/plans/2026-05-14-demo-backend-plan.md`**
+- `docs/runbooks/may-21-demo-physical-conveyor.md` → does NOT exist on `origin/main`
+
+The 11 demo endpoints (all created in #1295 commit `94b6ca33`):
+`demo/customer`, `demo/signals/{events,set,summary,toggle}`, `mira/ask`,
+`assets/[id]/{context,signals}`, `components/[id]`,
+`sessions/{confirm,[id]}`, `documents/{,upload}`.

--- a/mira-hub/src/app/demo/conveyor/[tag]/page.tsx
+++ b/mira-hub/src/app/demo/conveyor/[tag]/page.tsx
@@ -1,0 +1,437 @@
+"use client";
+
+import { use, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useSession } from "next-auth/react";
+import { Activity, AlertCircle, Bot, Loader2, Send, Wrench } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { API_BASE } from "@/lib/config";
+
+type Component = {
+  id: string;
+  name: string;
+  asset_tag: string | null;
+  component_kind: string | null;
+  plc_tag: string | null;
+};
+
+type Equipment = {
+  id: string;
+  name: string;
+  asset_tag: string | null;
+  manufacturer: string | null;
+  model: string | null;
+  components: Component[];
+};
+
+type Line = { id: string; name: string; equipment: Equipment[] };
+type Area = { id: string; name: string; lines: Line[] };
+type Site = { id: string; name: string; areas: Area[] };
+
+type SignalRow = {
+  plc_tag: string;
+  component_id: string | null;
+  component_name: string | null;
+  asset_id: string | null;
+  asset_name: string | null;
+  last_value_text: string | null;
+  last_value_numeric: number | null;
+  last_value_bool: boolean | null;
+  last_seen_at: string;
+  last_changed_at: string;
+  simulated: boolean;
+};
+
+type ChatTurn = {
+  role: "user" | "assistant";
+  text: string;
+  provider?: string;
+  citations?: Array<{ label: string; source: string }>;
+};
+
+const POLL_MS = 2000;
+
+function findEquipmentByTag(sites: Site[], tag: string): Equipment | null {
+  const target = tag.toUpperCase();
+  for (const s of sites)
+    for (const a of s.areas)
+      for (const l of a.lines)
+        for (const e of l.equipment) {
+          if ((e.asset_tag ?? "").toUpperCase() === target) return e;
+        }
+  return null;
+}
+
+function formatValue(row: SignalRow): string {
+  if (row.last_value_bool !== null) return row.last_value_bool ? "ON" : "OFF";
+  if (row.last_value_numeric !== null) return row.last_value_numeric.toString();
+  return row.last_value_text ?? "—";
+}
+
+function sinceLabel(iso: string): string {
+  const delta = Math.max(0, Date.now() - new Date(iso).getTime());
+  if (delta < 60_000) return `${Math.round(delta / 1000)}s ago`;
+  if (delta < 3_600_000) return `${Math.round(delta / 60_000)}m ago`;
+  return `${Math.round(delta / 3_600_000)}h ago`;
+}
+
+export default function ConveyorDemoPage({
+  params,
+}: {
+  params: Promise<{ tag: string }>;
+}) {
+  const { tag: rawTag } = use(params);
+  const tag = decodeURIComponent(rawTag);
+  const session = useSession();
+  const isAuthed = session.status === "authenticated";
+
+  const [equipment, setEquipment] = useState<Equipment | null>(null);
+  const [signals, setSignals] = useState<SignalRow[]>([]);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [errorStatus, setErrorStatus] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [chatHistory, setChatHistory] = useState<ChatTurn[]>([]);
+  const [question, setQuestion] = useState("");
+  const [asking, setAsking] = useState(false);
+  const chatBoxRef = useRef<HTMLDivElement>(null);
+
+  // Bounce unauthed visitors to login — same pattern as /m/[assetTag].
+  useEffect(() => {
+    if (session.status !== "unauthenticated") return;
+    if (typeof window === "undefined") return;
+    const cb = `${window.location.pathname}${window.location.search}`;
+    window.location.replace(`/login?callbackUrl=${encodeURIComponent(cb)}`);
+  }, [session.status]);
+
+  // 1. Locate the equipment by tag from the demo asset tree.
+  useEffect(() => {
+    if (!isAuthed) return;
+    let cancelled = false;
+    setLoading(true);
+    fetch(`${API_BASE}/api/demo/customer`)
+      .then(async (res) => {
+        if (!res.ok) {
+          if (!cancelled) setErrorStatus(res.status);
+          return null;
+        }
+        return res.json() as Promise<{ sites: Site[] }>;
+      })
+      .then((data) => {
+        if (cancelled || !data) return;
+        const eq = findEquipmentByTag(data.sites, tag);
+        if (!eq) setErrorStatus(404);
+        else setEquipment(eq);
+      })
+      .catch(() => {
+        if (!cancelled) setErrorStatus(500);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthed, tag]);
+
+  // 2. Confirm a session for this asset — unblocks /api/mira/ask.
+  useEffect(() => {
+    if (!equipment) return;
+    let cancelled = false;
+    fetch(`${API_BASE}/api/sessions/confirm`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ asset_id: equipment.id, channel: "tablet" }),
+    })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: { session: { id: string } } | null) => {
+        if (!cancelled && data?.session?.id) setSessionId(data.session.id);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [equipment]);
+
+  // 3. Poll /api/demo/signals/summary every 2 s for live cache snapshots.
+  useEffect(() => {
+    if (!equipment) return;
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/demo/signals/summary`);
+        if (!res.ok) return;
+        const data = (await res.json()) as { signals: SignalRow[] };
+        if (cancelled) return;
+        // Filter to rows that belong to this asset (when bound).
+        const mine = (data.signals ?? []).filter(
+          (r) => r.asset_id === equipment.id || r.asset_id === null,
+        );
+        setSignals(mine);
+      } catch {
+        // Tolerate transient errors during a 90-s demo.
+      }
+    };
+    poll();
+    const t = setInterval(poll, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [equipment]);
+
+  // Keep chat scrolled to bottom on new turns.
+  useEffect(() => {
+    chatBoxRef.current?.scrollTo({ top: chatBoxRef.current.scrollHeight });
+  }, [chatHistory.length, asking]);
+
+  const ask = useCallback(async () => {
+    if (!sessionId || !question.trim() || asking) return;
+    const userTurn: ChatTurn = { role: "user", text: question.trim() };
+    setChatHistory((h) => [...h, userTurn]);
+    const q = question.trim();
+    setQuestion("");
+    setAsking(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/mira/ask`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: sessionId, question: q }),
+      });
+      const data = (await res.json()) as {
+        answer?: string;
+        provider?: string;
+        citations?: Array<{ label: string; source: string }>;
+        error?: string;
+      };
+      const text = data.answer ?? data.error ?? "(no answer)";
+      setChatHistory((h) => [
+        ...h,
+        {
+          role: "assistant",
+          text,
+          provider: data.provider,
+          citations: data.citations,
+        },
+      ]);
+    } catch {
+      setChatHistory((h) => [
+        ...h,
+        { role: "assistant", text: "Network error — retry the question." },
+      ]);
+    } finally {
+      setAsking(false);
+    }
+  }, [sessionId, question, asking]);
+
+  const headlineSignals = useMemo(() => signals.slice(0, 8), [signals]);
+
+  if (session.status === "loading" || loading) {
+    return (
+      <div className="flex h-screen items-center justify-center bg-[--background]">
+        <Loader2 className="size-8 animate-spin text-[--foreground]/60" />
+      </div>
+    );
+  }
+
+  if (errorStatus) {
+    return (
+      <div className="flex h-screen flex-col items-center justify-center gap-2 bg-[--background] p-8 text-center">
+        <AlertCircle className="size-10 text-[--destructive]" />
+        <h1 className="text-lg font-semibold">Asset not available</h1>
+        <p className="text-sm opacity-70">
+          {errorStatus === 404
+            ? `No asset with tag "${tag}" in the demo tenant.`
+            : `Failed to load demo asset (HTTP ${errorStatus}).`}
+        </p>
+      </div>
+    );
+  }
+
+  if (!equipment) return null;
+
+  return (
+    <div className="min-h-screen bg-[--background] p-4 lg:p-6">
+      <header className="mb-4">
+        <div className="flex flex-wrap items-baseline gap-2">
+          <Wrench className="size-5 text-[--foreground]/70" />
+          <h1 className="text-xl font-semibold">{equipment.name}</h1>
+          <span className="rounded bg-[--muted] px-2 py-0.5 text-xs opacity-80">
+            {equipment.asset_tag ?? tag}
+          </span>
+        </div>
+        {equipment.manufacturer || equipment.model ? (
+          <p className="mt-1 text-xs opacity-70">
+            {[equipment.manufacturer, equipment.model].filter(Boolean).join(" · ")}
+          </p>
+        ) : null}
+      </header>
+
+      <div className="grid gap-4 lg:grid-cols-[2fr_3fr]">
+        <div className="flex flex-col gap-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Activity className="size-4" />
+                Live signals
+                {signals.length ? (
+                  <span className="ml-auto text-xs opacity-60">
+                    {signals.length} bound
+                  </span>
+                ) : null}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {headlineSignals.length === 0 ? (
+                <p className="text-sm opacity-70">
+                  Waiting for signal events. Use{" "}
+                  <code className="text-xs">POST /api/demo/signals/toggle</code>{" "}
+                  or the simulator to push a value.
+                </p>
+              ) : (
+                <ul className="flex flex-col gap-2">
+                  {headlineSignals.map((s) => (
+                    <li
+                      key={s.plc_tag}
+                      className="flex items-center justify-between rounded border border-[--border] px-3 py-2 text-sm"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-medium">
+                          {s.component_name ?? s.plc_tag}
+                        </p>
+                        <p className="truncate text-xs opacity-60">
+                          {s.plc_tag} · {sinceLabel(s.last_changed_at)}
+                        </p>
+                      </div>
+                      <span
+                        className="ml-2 rounded bg-[--muted] px-2 py-1 font-mono text-xs"
+                        data-testid={`signal-value-${s.plc_tag}`}
+                      >
+                        {formatValue(s)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Components</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {equipment.components.length === 0 ? (
+                <p className="text-sm opacity-70">No components bound to this asset.</p>
+              ) : (
+                <ul className="flex flex-col gap-2 text-sm">
+                  {equipment.components.map((c) => (
+                    <li
+                      key={c.id}
+                      className="flex items-center justify-between gap-2 rounded border border-[--border] px-3 py-2"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-medium">{c.name}</p>
+                        <p className="truncate text-xs opacity-60">
+                          {c.component_kind ?? "component"}
+                          {c.asset_tag ? ` · ${c.asset_tag}` : ""}
+                        </p>
+                      </div>
+                      {c.plc_tag ? (
+                        <code className="rounded bg-[--muted] px-2 py-1 font-mono text-xs">
+                          {c.plc_tag}
+                        </code>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+
+        <Card className="flex max-h-[80vh] flex-col">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Bot className="size-4" />
+              Ask MIRA
+              {!sessionId ? (
+                <span className="ml-auto text-xs opacity-60">
+                  confirming session…
+                </span>
+              ) : null}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-1 flex-col gap-3">
+            <div
+              ref={chatBoxRef}
+              className="flex-1 overflow-y-auto rounded border border-[--border] p-3 text-sm"
+              data-testid="chat-history"
+            >
+              {chatHistory.length === 0 ? (
+                <p className="opacity-60">
+                  Try: <em>"Is the photo eye seeing the box?"</em>
+                </p>
+              ) : (
+                <ul className="flex flex-col gap-3">
+                  {chatHistory.map((t, i) => (
+                    <li
+                      key={i}
+                      className={
+                        t.role === "user"
+                          ? "self-end max-w-[80%] rounded-lg bg-[--primary] px-3 py-2 text-[--primary-foreground]"
+                          : "self-start max-w-[85%] rounded-lg bg-[--muted] px-3 py-2"
+                      }
+                    >
+                      <p className="whitespace-pre-wrap">{t.text}</p>
+                      {t.role === "assistant" && t.provider ? (
+                        <p className="mt-1 text-[10px] opacity-60">
+                          via {t.provider}
+                          {t.citations?.length
+                            ? ` · ${t.citations.length} citation${t.citations.length === 1 ? "" : "s"}`
+                            : ""}
+                        </p>
+                      ) : null}
+                    </li>
+                  ))}
+                  {asking ? (
+                    <li className="self-start max-w-[85%] rounded-lg bg-[--muted] px-3 py-2 text-xs opacity-70">
+                      <Loader2 className="mr-1 inline size-3 animate-spin" />
+                      thinking…
+                    </li>
+                  ) : null}
+                </ul>
+              )}
+            </div>
+            <form
+              className="flex gap-2"
+              onSubmit={(e) => {
+                e.preventDefault();
+                void ask();
+              }}
+            >
+              <Input
+                value={question}
+                onChange={(e) => setQuestion(e.target.value)}
+                placeholder={
+                  sessionId
+                    ? "Ask about the conveyor…"
+                    : "Waiting for session confirmation…"
+                }
+                disabled={!sessionId || asking}
+                data-testid="chat-input"
+              />
+              <Button
+                type="submit"
+                disabled={!sessionId || asking || !question.trim()}
+                data-testid="chat-send"
+              >
+                <Send className="size-4" />
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/mira-hub/src/app/demo/conveyor/[tag]/page.tsx
+++ b/mira-hub/src/app/demo/conveyor/[tag]/page.tsx
@@ -163,7 +163,10 @@ export default function ConveyorDemoPage({
         if (!res.ok) return;
         const data = (await res.json()) as { signals: SignalRow[] };
         if (cancelled) return;
-        // Filter to rows that belong to this asset (when bound).
+        // Single-asset demo: include this asset's bound rows plus any
+        // currently-unbound cache rows (asset_id null), so a freshly toggled
+        // signal still shows up before binding catches up. Tighten to
+        // strict `=== equipment.id` if a second demo asset is ever seeded.
         const mine = (data.signals ?? []).filter(
           (r) => r.asset_id === equipment.id || r.asset_id === null,
         );

--- a/mira-hub/tests/e2e/demo-conveyor.spec.ts
+++ b/mira-hub/tests/e2e/demo-conveyor.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * Demo conveyor tablet page — Plan P8 (docs/plans/2026-05-14-demo-backend-plan.md).
+ *
+ * Two test surfaces:
+ *
+ *  1. **Live smoke** — hits `/demo/conveyor/CV-001` on the deployed app and
+ *     verifies the route loads (either authed render or login bounce — both
+ *     count as "route is wired"). Runs against `HUB_URL` like the other e2e
+ *     specs in this directory.
+ *
+ *  2. **Mocked render + screenshots** — sets up `page.route()` interceptors
+ *     for next-auth's session check and the four demo endpoints the page
+ *     consumes, then renders the page against a local Next.js dev server
+ *     (started by the caller with `bun run dev`). Captures iPad landscape
+ *     (1024×768) and portrait (820×1180) screenshots into
+ *     `docs/promo-screenshots/`. Gated behind `MIRA_DEMO_SCREENSHOTS=1` so
+ *     the CI default ("smoke against prod") doesn't require a dev server.
+ */
+
+import { test, expect, type Route } from "@playwright/test";
+import * as path from "path";
+import * as fs from "fs";
+
+const HUB = process.env.HUB_URL ?? "https://app.factorylm.com/hub";
+const LOCAL = process.env.LOCAL_HUB_URL ?? "http://localhost:3000";
+const SHOULD_SHOOT = process.env.MIRA_DEMO_SCREENSHOTS === "1";
+
+const DEMO_TAG = "CV-001";
+const SCREENSHOT_DIR = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "docs",
+  "promo-screenshots",
+);
+
+test.describe("demo conveyor — route smoke", () => {
+  test("route resolves (authed render or login bounce)", async ({ page }) => {
+    const res = await page.goto(`${HUB}/demo/conveyor/${DEMO_TAG}`, {
+      waitUntil: "domcontentloaded",
+    });
+    // 200 = page rendered (either the loading spinner or the data view, or the
+    // login bounce target). 302/301 = same idea. Anything else (4xx/5xx) is a
+    // routing failure.
+    expect(res?.status() ?? 500).toBeLessThan(400);
+    // Either we landed on the demo page OR were bounced to /login.
+    const url = page.url();
+    expect(url).toMatch(/\/(demo\/conveyor\/CV-001|login)/);
+  });
+});
+
+const mockCustomer = {
+  tenant: { id: "00000000-0000-0000-0000-0000000000d1", name: "Demo Tenant" },
+  sites: [
+    {
+      id: "site-1",
+      name: "FactoryLM Lake Wales Demo",
+      areas: [
+        {
+          id: "area-1",
+          name: "Sorting",
+          lines: [
+            {
+              id: "line-1",
+              name: "Conveyor Line 1",
+              equipment: [
+                {
+                  id: "asset-cv-001",
+                  name: "Conveyor 001",
+                  asset_tag: "CV-001",
+                  manufacturer: "Allen-Bradley",
+                  model: "Micro820 + GS10",
+                  components: [
+                    {
+                      id: "cmp-pe-001",
+                      name: "Photo Eye 001",
+                      asset_tag: "PE-001",
+                      component_kind: "sensor",
+                      plc_tag: "PE_001_PRESENT",
+                    },
+                    {
+                      id: "cmp-mtr-001",
+                      name: "Motor 001",
+                      asset_tag: "MTR-001",
+                      component_kind: "motor",
+                      plc_tag: "MTR_001_RUN",
+                    },
+                    {
+                      id: "cmp-vfd-001",
+                      name: "VFD GS10-2.2KW",
+                      asset_tag: "VFD-001",
+                      component_kind: "drive",
+                      plc_tag: "VFD_001_SPEED_HZ",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const now = new Date().toISOString();
+const mockSummary = {
+  signals: [
+    {
+      plc_tag: "PE_001_PRESENT",
+      component_id: "cmp-pe-001",
+      component_name: "Photo Eye 001",
+      asset_id: "asset-cv-001",
+      asset_name: "Conveyor 001",
+      last_value_text: null,
+      last_value_numeric: null,
+      last_value_bool: true,
+      prev_value_text: null,
+      prev_value_numeric: null,
+      prev_value_bool: false,
+      last_seen_at: now,
+      last_changed_at: now,
+      simulated: true,
+      source: "simulator",
+      properties: {},
+    },
+    {
+      plc_tag: "MTR_001_RUN",
+      component_id: "cmp-mtr-001",
+      component_name: "Motor 001",
+      asset_id: "asset-cv-001",
+      asset_name: "Conveyor 001",
+      last_value_text: null,
+      last_value_numeric: null,
+      last_value_bool: true,
+      prev_value_text: null,
+      prev_value_numeric: null,
+      prev_value_bool: false,
+      last_seen_at: now,
+      last_changed_at: now,
+      simulated: true,
+      source: "simulator",
+      properties: {},
+    },
+    {
+      plc_tag: "VFD_001_SPEED_HZ",
+      component_id: "cmp-vfd-001",
+      component_name: "VFD GS10-2.2KW",
+      asset_id: "asset-cv-001",
+      asset_name: "Conveyor 001",
+      last_value_text: null,
+      last_value_numeric: 60,
+      last_value_bool: null,
+      prev_value_text: null,
+      prev_value_numeric: 0,
+      prev_value_bool: null,
+      last_seen_at: now,
+      last_changed_at: now,
+      simulated: true,
+      source: "simulator",
+      properties: {},
+    },
+  ],
+};
+
+async function installMocks(page: import("@playwright/test").Page) {
+  // next-auth client polls /api/auth/session — pretend the demo tablet is authed
+  await page.route("**/api/auth/session*", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: { email: "demo-tablet@factorylm.com", name: "Demo Tablet" },
+        expires: new Date(Date.now() + 3600_000).toISOString(),
+      }),
+    }),
+  );
+  await page.route("**/api/demo/customer", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(mockCustomer),
+    }),
+  );
+  await page.route("**/api/demo/signals/summary", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(mockSummary),
+    }),
+  );
+  await page.route("**/api/sessions/confirm", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ session: { id: "demo-session-1" } }),
+    }),
+  );
+  await page.route("**/api/mira/ask", (route: Route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        session_id: "demo-session-1",
+        answer:
+          "The photo eye is reading PRESENT and the motor is running at 60 Hz, so the box is detected and the conveyor is moving.",
+        provider: "groq:llama-3.3-70b-versatile",
+        duration_ms: 1234,
+        citations: [
+          {
+            label: "PE-001 component template",
+            source: "kb://components/photo-eye/banner-qs18",
+          },
+        ],
+      }),
+    }),
+  );
+}
+
+test.describe("demo conveyor — mocked render", () => {
+  test.skip(!SHOULD_SHOOT, "set MIRA_DEMO_SCREENSHOTS=1 to enable");
+
+  test("iPad landscape (1024×768) — three panels visible", async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await installMocks(page);
+    await page.goto(`${LOCAL}/demo/conveyor/${DEMO_TAG}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByText("Conveyor 001")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("Live signals")).toBeVisible();
+    await expect(page.getByText("Components")).toBeVisible();
+    await expect(page.getByText("Ask MIRA")).toBeVisible();
+    await expect(
+      page.getByTestId("signal-value-PE_001_PRESENT"),
+    ).toContainText("ON");
+
+    fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+    await page.screenshot({
+      path: path.join(
+        SCREENSHOT_DIR,
+        "2026-05-15_demo-conveyor-001_ipad-landscape.png",
+      ),
+      fullPage: true,
+    });
+  });
+
+  test("iPad portrait (820×1180) — stacked layout", async ({ page }) => {
+    await page.setViewportSize({ width: 820, height: 1180 });
+    await installMocks(page);
+    await page.goto(`${LOCAL}/demo/conveyor/${DEMO_TAG}`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByText("Conveyor 001")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("Live signals")).toBeVisible();
+
+    fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
+    await page.screenshot({
+      path: path.join(
+        SCREENSHOT_DIR,
+        "2026-05-15_demo-conveyor-001_ipad-portrait.png",
+      ),
+      fullPage: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes the last open phase of `docs/plans/2026-05-14-demo-backend-plan.md` (row P8) — a single-page tablet view of one conveyor asset for the May 21 Florida Automation Expo demo.

**Phase 7 (real-time MQTT subscription) was NOT done** — the plan explicitly defers it: *"What this plan deliberately does NOT do: Real-time MQTT subscription (deferred — mock feed for demo)."* The mock feed already shipped in #1298 (`live_signal_cache` + `signal-recorder.ts`).

## What's in

- `mira-hub/src/app/demo/conveyor/[tag]/page.tsx` — 3 panels:
  - **Live signals** — polls `/api/demo/signals/summary` every 2 s
  - **Components** — lists installed_component_instances from `/api/demo/customer`
  - **Ask MIRA** — confirms session via `POST /api/sessions/confirm`, then sends questions through `/api/mira/ask`
- `mira-hub/tests/e2e/demo-conveyor.spec.ts` — two test groups:
  - **Live smoke** (runs in CI): hits the deployed route, asserts it resolves
  - **Mocked render + screenshots** (gated by `MIRA_DEMO_SCREENSHOTS=1`): uses `page.route()` to stub auth + 4 demo endpoints, captures iPad landscape (1024×768) + portrait (820×1180) screenshots

## What's NOT in (deferred to operator)

- **Screenshots in `docs/promo-screenshots/`** — the mocked-render path needs either a local Next.js dev server with mocked next-auth JWE cookies (middleware level, complex) OR the demo seed loaded on the deployed app so the real route renders. Documented in `HANDOFF_2026-05-15-evening.md`.
- **VPS deploy** — out of autonomous scope; `prod-guard.sh` blocks.

## Verify

- `cd mira-hub && bun install && bun run build` — exits 0, route present in manifest as `/demo/conveyor/[tag]`
- `cd mira-hub && npx tsc --noEmit -p .` — no new TS errors (1 pre-existing unrelated error in `src/lib/auth/__tests__/rls-deny.integration.test.ts`)

## North Star compliance

- Asset/component context confirmed via UNS gate (`POST /api/sessions/confirm`) BEFORE `/api/mira/ask` is invoked.
- Every ask answer carries `provider` + `citations` for grounding.
- No new dependencies — reuses existing shadcn `Card`/`Button`/`Input` + lucide icons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)