### PR TITLE
fix(ops): deploy-vps.yml — pass service name to compose logs

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -83,7 +83,7 @@ jobs:
           echo "mira-pipeline health: $STATUS"
           if [ "$STATUS" != "ok" ]; then
             echo "WARNING: health check returned $STATUS — check container logs"
-            doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml logs --tail=20 mira-pipeline-saas
+            doppler run --project factorylm --config prd -- docker compose -f docker-compose.saas.yml logs --tail=20 mira-pipeline
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- Line 86 of `.github/workflows/deploy-vps.yml` passed the container_name (`mira-pipeline-saas`) to `docker compose logs`, which wants the SERVICE name (`mira-pipeline`).
- Every failed deploy emitted \`no such service: mira-pipeline-saas\` and showed **zero** container log context, leaving CI blind to the actual crash cause.
- Witnessed on run [25927266047](https://github.com/Mikecranesync/MIRA/actions/runs/25927266047) (2026-05-15 15:50 UTC). The actual root cause (disk pressure + missing ingest volume mount + UID 1001 ownership) was only diagnosable by SSH'ing to the VPS, not from the workflow output.

This doesn't fix the crash — it makes the next failure visible.

## Test plan

- [ ] Next deploy that fails health check should emit `mira-pipeline | <log lines>` instead of `no such service: ...`
- [ ] `mira-hub` health-check fallback at line 100 is unchanged (its container_name happens to equal its service name, so no bug there)
- [ ] Successful deploy path is unchanged (this code only runs in the failure branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)