### PR TITLE
ops: land 3 VPS-only CRA-129 commits on main (CRA-283)

### DIFF
--- a/mira-bots/docker-compose.yml
+++ b/mira-bots/docker-compose.yml
@@ -25,6 +25,7 @@ x-bot-common-env: &bot-common-env
   LANGFUSE_PUBLIC_API_KEY: ${LANGFUSE_PUBLIC_API_KEY:-}
   LANGFUSE_HOST: ${LANGFUSE_HOST:-}
   LANGFUSE_BASE_URL: ${LANGFUSE_BASE_URL:-}
+  ADMIN_TELEGRAM_IDS: ${ADMIN_TELEGRAM_IDS:-}
 
 services:
   telegram-bot:

--- a/mira-bots/docker-compose.yml
+++ b/mira-bots/docker-compose.yml
@@ -10,6 +10,9 @@ x-bot-common-env: &bot-common-env
   MIRA_TENANT_ID: ${MIRA_TENANT_ID:-}
   VISION_MODEL: ${VISION_MODEL:-qwen2.5vl:7b}
   INFERENCE_BACKEND: ${INFERENCE_BACKEND:-cloud}
+  OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+  OPENROUTER_MODEL: ${OPENROUTER_MODEL:-meta-llama/llama-3.3-70b-instruct:free}
+  OPENROUTER_VISION_MODEL: ${OPENROUTER_VISION_MODEL:-meta-llama/llama-4-scout-17b-16e-instruct:free}
   GROQ_API_KEY: ${GROQ_API_KEY:-}
   GROQ_MODEL: ${GROQ_MODEL:-llama-3.3-70b-versatile}
   GROQ_VISION_MODEL: ${GROQ_VISION_MODEL:-meta-llama/llama-4-scout-17b-16e-instruct}

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -915,6 +915,26 @@ async def _startup(application: Application) -> None:
     # alert fires once via ntfy.sh.
     _outbox_client = AtlasCMMSClient()  # reads MCP_BASE_URL + MCP_REST_API_KEY
 
+    # Startup connectivity check — surfaces Atlas/MCP misconfiguration before demo.
+    try:
+        async with httpx.AsyncClient(timeout=5) as _probe:
+            _probe_url = _outbox_client.base_url.rstrip("/") + "/health"
+            _r = await _probe.get(_probe_url, headers=_outbox_client._headers())
+            if _r.status_code < 300:
+                logger.info("Atlas/MCP probe OK (%s)", _probe_url)
+            else:
+                logger.warning(
+                    "Atlas/MCP probe returned HTTP %d — WO creation may fail. "
+                    "Check MCP_BASE_URL and MCP_REST_API_KEY in Doppler.",
+                    _r.status_code,
+                )
+    except Exception as _probe_exc:
+        logger.warning(
+            "Atlas/MCP probe failed (%s) — WO creation will use outbox fallback. "
+            "Check that mira-mcp is running and MCP_BASE_URL is correct.",
+            _probe_exc,
+        )
+
     async def _outbox_submit(payload: dict) -> dict:
         try:
             return await _outbox_client._post_work_order(payload)
@@ -939,19 +959,42 @@ async def _startup(application: Application) -> None:
     )
 
 
+_conflict_count = 0
+_CONFLICT_EXIT_THRESHOLD = 5  # 5 × 15s = 75s of silence before hard exit
+
+
 async def _conflict_error_handler(update: object, context) -> None:
-    """On 409 Conflict sleep 15s and let PTB retry — avoids crash-restart loop."""
+    """On 409 Conflict: sleep 15s and retry, but exit after 5 consecutive conflicts.
+
+    Without a hard exit the bot loops silently forever and drops every message —
+    a demo killer if a stale CHARLIE poller is running. After _CONFLICT_EXIT_THRESHOLD
+    consecutive conflicts the container exits so restart: unless-stopped surfaces the
+    problem to ops and the log makes the fix obvious.
+    """
     import asyncio
 
     from telegram.error import Conflict as TGConflict
 
+    global _conflict_count
     if isinstance(context.error, TGConflict):
+        _conflict_count += 1
         logger.warning(
-            "409 Conflict during polling — another session is active. "
-            "Sleeping 15s and retrying (do NOT call getUpdates externally while bot is running)."
+            "409 Conflict during polling (%d/%d) — another session is active. "
+            "Fix: SSH to each node and run: docker stop mira-bot-telegram. "
+            "Then restart this container only on the primary node (VPS).",
+            _conflict_count,
+            _CONFLICT_EXIT_THRESHOLD,
         )
+        if _conflict_count >= _CONFLICT_EXIT_THRESHOLD:
+            logger.error(
+                "409 Conflict limit reached (%d) — exiting so restart:unless-stopped "
+                "surfaces this to ops. Kill the competing poller on CHARLIE first.",
+                _CONFLICT_EXIT_THRESHOLD,
+            )
+            raise SystemExit(1)
         await asyncio.sleep(15)
         return  # let PTB retry getUpdates
+    _conflict_count = 0  # reset on any successful update
     raise context.error
 
 


### PR DESCRIPTION
## Summary

Lands the 3 commits that were sitting only on `factorylm-prod:/opt/mira-deploy-cra` and never reached origin:

- `c5facfc5` — `fix(telegram): hard-exit on persistent 409 conflicts + Atlas startup probe (CRA-129)`
- `f82be170` — `fix(bots): wire ADMIN_TELEGRAM_IDS into compose env — admin bypass was silently missing (CRA-129)`
- `0b1c1269` (now `eacc14ac` on this branch) — `ops(vps): preserve OPENROUTER env stubs in mira-bots compose` — env-only no-op; can be reverted if/when upstream OpenRouter integration lands

Cherry-picked onto fresh `origin/main` (no auto-merge conflicts; touched lines were in different sections of `mira-bots/docker-compose.yml`).

## Why now

VPS deploy was 119 commits behind `origin/main`. Upgrading 6 days before the 2026-05-21 Florida Expo demo gives runway to debug regressions; landing the upgrade cold on demo day would be worse. The actual bot rebuild + redeploy was executed against this branch on `factorylm-prod` already — bot is healthy, cascade enabled (groq → cerebras → gemini), 0 × 409 conflicts since restart.

## Side-finding

Two compose files were defining `telegram-bot`: `/opt/mira/docker-compose.saas.yml` (project `mira`, was managing the running container) and `/opt/mira-deploy-cra/mira-bots/docker-compose.yml` (project `mira-bots`, where the cherry-picks were applied). Post-rebuild the new container is managed by `mira-bots`. Need to remove the stale `telegram-bot` block from the saas compose file to avoid future conflicts. Tracking as a follow-up on CRA-283.

## Closes

- CRA-283 (this work)
- CRA-272 (superseded — original demo-branch recipe is invalid because demo branch is now 185 commits behind main)

## Linear

https://linear.app/cranesync/issue/CRA-283