### PR TITLE
fix(saas): remove stale mira-bot-telegram block — superseded by mira-bots/ (CRA-283 follow-up)

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -256,55 +256,6 @@ services:
       retries: 3
       start_period: 15s
 
-  mira-bot-telegram:
-    build:
-      context: .
-      dockerfile: mira-bots/telegram/Dockerfile
-    container_name: mira-bot-telegram
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-    environment:
-      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
-      - MIRA_DB_PATH=/mira-db/mira.db
-      - OPENWEBUI_BASE_URL=http://mira-core-saas:8080
-      - OPENWEBUI_API_KEY=${OPENWEBUI_API_KEY:-}
-      - KNOWLEDGE_COLLECTION_ID=${KNOWLEDGE_COLLECTION_ID:-}
-      - NEON_DATABASE_URL=${NEON_DATABASE_URL:-}
-      - MIRA_TENANT_ID=${MIRA_TENANT_ID:-}
-      - ADMIN_TELEGRAM_IDS=${ADMIN_TELEGRAM_IDS:-}
-      - VISION_MODEL=qwen2.5vl:7b
-      - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
-      - INFERENCE_BACKEND=cloud
-      - GROQ_API_KEY=${GROQ_API_KEY:-}
-      - GROQ_MODEL=llama-3.3-70b-versatile
-      - GROQ_VISION_MODEL=meta-llama/llama-4-scout-17b-16e-instruct
-      - CEREBRAS_API_KEY=${CEREBRAS_API_KEY:-}
-      - CEREBRAS_MODEL=llama3.1-8b
-      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
-      - GEMINI_MODEL=${GEMINI_MODEL:-gemini-2.5-flash}
-      - GEMINI_VISION_MODEL=${GEMINI_VISION_MODEL:-gemini-2.5-flash}
-      - MCP_REST_API_KEY=${MCP_REST_API_KEY:-}
-      - MCP_BASE_URL=http://mira-mcp-saas:8001
-      - SESSION_RECORDING_PATH=/data/sessions
-      - NTFY_URL=${NTFY_URL:-https://ntfy.sh}
-      - NTFY_TOPIC=${NTFY_TOPIC:-mira-factorylm-alerts}
-    volumes:
-      - /opt/mira/data:/mira-db
-      - /opt/mira/mira-bridge/data/sessions:/data/sessions
-    networks:
-      - mira-net
-    restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
-    healthcheck:
-      test: ["CMD", "sh", "-c", "cat /proc/1/cmdline | tr '\\0' ' ' | grep -q 'bot.py'"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
-
   mira-bot-slack:
     build:
       context: ./mira-bots


### PR DESCRIPTION
## Summary

Remove the `mira-bot-telegram` service block from `docker-compose.saas.yml`. It has been superseded by `mira-bots/docker-compose.yml` after the CRA-283 upgrade (PR #1322 + the live deploy on `factorylm-prod` 2026-05-15 ~22:07 UTC).

## Why

Two compose files were both defining `mira-bot-telegram`:

| File | Compose project | Status |
|---|---|---|
| `docker-compose.saas.yml` | `mira` | was managing the running container, now stale |
| `mira-bots/docker-compose.yml` | `mira-bots` | now manages the running container (multi-platform bot rollup) |

After CRA-283 rebuilt the bot via `mira-bots/`, the saas-file block became dead config. A future `docker compose -f docker-compose.saas.yml up -d` would hit a container name collision (`mira-bot-telegram` already in use by another project) and fail noisily, OR silently re-create the container under the wrong project label.

## Scope

- Removes 49 lines (the entire `mira-bot-telegram:` block, lines 259–307).
- Leaves the adjacent `mira-bot-slack:` block untouched — that's a separate decision; if/when Slack also migrates to `mira-bots/`, a follow-up PR can remove it the same way.
- YAML parses clean after the removal (`yaml.safe_load` passes).
- Zero references to `mira-bot-telegram` remain in this file.

## Verification

```bash
# from a fresh checkout of this branch
python -c "import yaml; yaml.safe_load(open('docker-compose.saas.yml', encoding='utf-8'))"  # OK
grep -c 'mira-bot-telegram' docker-compose.saas.yml  # 0
docker compose -f docker-compose.saas.yml config >/dev/null  # OK
```

## Related

- Linear: [CRA-283](https://linear.app/cranesync/issue/CRA-283)
- PR #1322 (lands the 3 VPS-only CRA-129 commits on `main` — the upgrade that revealed this duplication)
- Issue #1320 (the original P1 backlog issue)

## Risk

Low. If any deploy depends on `docker compose -f docker-compose.saas.yml up -d telegram-bot`, that command will fail after this merges. Mitigation: that path was already broken (the container name was taken by the `mira-bots`-project container after CRA-283). Anyone hitting that error should switch to `docker compose -f mira-bots/docker-compose.yml up -d telegram-bot`.