### PR TITLE
fix(infra): mount ingest SQLite + photos volume in saas compose (#1219 regression)

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -98,6 +98,8 @@ services:
     ports:
       - "127.0.0.1:8002:8001"
     environment:
+      - MIRA_DB_PATH=/mira-db/mira.db
+      - PHOTOS_DIR=/mira-db/photos
       - NEON_DATABASE_URL=${NEON_DATABASE_URL}
       - MIRA_TENANT_ID=${MIRA_TENANT_ID}
       - OPENWEBUI_BASE_URL=http://mira-core-saas:8080
@@ -109,6 +111,8 @@ services:
       # Unit 3.5 — magic-inbox safety gates
       - RELEVANCE_GATE_ENABLED=${RELEVANCE_GATE_ENABLED:-}
       - GROQ_API_KEY=${GROQ_API_KEY:-}
+    volumes:
+      - /opt/mira/data/ingest:/mira-db
     networks:
       - mira-net
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- PR #1219 (`security(infra): Docker/nginx hardening bundle`) added `USER mira` (UID 1001) to `mira-core/mira-ingest/Dockerfile`, but the `mira-ingest` block in `docker-compose.saas.yml` was never updated with a matching volume mount or DB-path envs.
- Result: ingest fell back to in-image defaults (`/app/mira.db`, `/data/photos`) which are unwritable as UID 1001. Silent crash-loop since #1219 merged; surfaced 2026-05-15 when the daily VPS deploy recreated all three saas containers and `mira-ingest-saas` joined `mira-pipeline-saas` and `mira-mcp-saas` in a 300+ restart loop.
- This PR adds the missing 3 lines (2 env + 1 volume = 4 added lines total) so ingest mounts an isolated `/opt/mira/data/ingest` dir for its SQLite + photos. Mirrors the env-var convention already used by `mira-pipeline` and `mira-mcp` blocks in the same file.

The live VPS has had this fix applied for 2+ hours and ingest is `healthy` with `restartCount=0`. The `deploy-vps.yml` workflow does `git reset --hard origin/main` on every run — without this PR, the next deploy reverts the compose edit and the crash returns.

The accompanying UID/ownership issue on `/opt/mira/data` was fixed via `chown 1001:1001` on the host (separate from this PR, not git-tracked; documented as a follow-up).

## Spec reference

`N/A — bug fix`. References #1219 as the regression source. Companion PR #1321 (deploy-vps log service-name fix) is independent and touches a different file.

## Acceptance criteria verified

- [x] Yes — listed below
- [ ] N/A (justify in summary)

- [x] Diff is exactly 4 added lines, 0 removed (`git diff --numstat` = `4 0`).
- [x] `docker compose -f docker-compose.saas.yml config` parses without error (exit 0).
- [x] On VPS post-fix: `docker inspect mira-ingest-saas` shows `/opt/mira/data/ingest -> /mira-db` mount + `MIRA_DB_PATH=/mira-db/mira.db` + `PHOTOS_DIR=/mira-db/photos` env.
- [x] `mira.db` (12 KB) + `photos/` dir created at `/opt/mira/data/ingest/` owned by UID 1001 on first write.
- [x] `mira-ingest-saas` reached `healthy` within `start_period` (15s) and has been stable for 2+ hours (`restartCount=0`).
- [x] `mira-pipeline` and `mira-mcp` service blocks unchanged (no scope creep).

## Out of scope (follow-ups)

- Host chown for deploy idempotence — `chown 1001:1001` on `/opt/mira/data`, `mira.db`, `mem0/`, `agent-runs/`, `/opt/mira/mira-bridge/data/sessions/`. Host state, not git-tracked. To be captured as either `scripts/host_perm_setup.sh` called from `deploy-vps.yml` or doc in `wiki/nodes/vps.md`.
- PR #1321 — deploy-vps.yml log service-name fix, already open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)