### PR TITLE
fix(infra): persist saas UID 1001 chown via host_perm_setup.sh on deploy

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -57,6 +57,12 @@ jobs:
           git fetch origin main
           git reset --hard origin/main
 
+          echo "=== Host permission setup (chown saas data dirs to UID 1001) ==="
+          # PR #1219 dropped root in mira-pipeline/mira-mcp/mira-ingest Dockerfiles.
+          # Host bind-mounts must match or containers crash-loop on SQLite WAL.
+          # Script is idempotent — safe on every deploy. See incident 2026-05-15.
+          bash scripts/host_perm_setup.sh
+
           # Resolve the rebuild list once so cleanup + build + up all agree.
           TARGETS="${SERVICES:-mira-pipeline mira-ingest mira-mcp mira-hub mira-cmms-sync}"
           echo "Rebuild targets: $TARGETS"

--- a/scripts/host_perm_setup.sh
+++ b/scripts/host_perm_setup.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# ============================================================
+# Host permission setup for SaaS containers (UID 1001 = mira)
+#
+# After PR #1219 added `USER mira` (UID 1001) to mira-pipeline,
+# mira-mcp, and mira-core/mira-ingest Dockerfiles, the host bind-
+# mounts under /opt/mira/data must be owned by 1001:1001 or the
+# containers crash-loop on SQLite WAL writes (incident 2026-05-15).
+#
+# This script is idempotent — safe to run on every deploy. It only
+# touches the specific paths the three saas containers write to.
+# It does NOT chown:
+#   /opt/mira/data/mira-bot-telegram/   (bot runs as root)
+#   /opt/mira/data/pdfs/                (ingest staging, root)
+#   /opt/mira/data/photo_batches.db*    (separate writer, root)
+#   /opt/mira/data/session_photos/      (root-owned by design)
+#   /opt/mira/data/_snapshots/          (manual backups, root)
+#
+# Invoked from .github/workflows/deploy-vps.yml between
+# `git reset --hard origin/main` and `docker compose up`.
+# ============================================================
+set -euo pipefail
+
+MIRA_UID="${MIRA_UID:-1001}"
+MIRA_GID="${MIRA_GID:-1001}"
+DATA_DIR="${DATA_DIR:-/opt/mira/data}"
+SESSIONS_DIR="${SESSIONS_DIR:-/opt/mira/mira-bridge/data/sessions}"
+
+echo "=== host_perm_setup: chowning SaaS data paths to $MIRA_UID:$MIRA_GID ==="
+
+# Parent data dir must be writable by UID 1001 so SQLite can create
+# *-wal and *-shm sibling files during WAL-mode bootstrap.
+chown "$MIRA_UID:$MIRA_GID" "$DATA_DIR"
+
+# pipeline + mcp primary DB
+[ -f "$DATA_DIR/mira.db" ]     && chown "$MIRA_UID:$MIRA_GID" "$DATA_DIR/mira.db"
+[ -f "$DATA_DIR/mira.db-wal" ] && chown "$MIRA_UID:$MIRA_GID" "$DATA_DIR/mira.db-wal"
+[ -f "$DATA_DIR/mira.db-shm" ] && chown "$MIRA_UID:$MIRA_GID" "$DATA_DIR/mira.db-shm"
+
+# pipeline subdirs (mem0 conversation memory + agent run logs)
+for sub in mem0 agent-runs; do
+  if [ -d "$DATA_DIR/$sub" ]; then
+    chown -R "$MIRA_UID:$MIRA_GID" "$DATA_DIR/$sub"
+  fi
+done
+
+# ingest's isolated data dir (created here so the mount has somewhere to land)
+mkdir -p "$DATA_DIR/ingest"
+chown -R "$MIRA_UID:$MIRA_GID" "$DATA_DIR/ingest"
+
+# pipeline's bridge-session recording path (separate tree)
+if [ -d "$SESSIONS_DIR" ]; then
+  chown -R "$MIRA_UID:$MIRA_GID" "$SESSIONS_DIR"
+fi
+
+echo "=== host_perm_setup: done ==="


### PR DESCRIPTION
## Summary

- PR #1219 added `USER mira` (UID 1001) to mira-pipeline / mira-mcp / mira-core/mira-ingest Dockerfiles. Host bind-mounts under `/opt/mira/data` stay root-owned across `git reset --hard` deploys, so every fresh container start fails with SQLite WAL errors until someone chowns by hand.
- Incident 2026-05-15: chat path was down for 5h before the chown was applied. After it was applied, the next auto-deploy (driven by #1321 merging) recreated containers but left the chown in place (host state survives `git reset`) — so pipeline + mcp came back healthy. Ingest only crashed because its compose entry was also missing a mount, which #1326 fixes.
- This PR captures the chown in git so the SaaS chat path survives a fresh deploy on a clean host as well as every routine deploy thereafter.

## Spec reference

`N/A — bug fix`. Pairs with #1326 (ingest volume mount + env) — together they make the saas stack deploy-idempotent.

## Acceptance criteria verified

- [x] Yes — listed below
- [ ] N/A (justify in summary)

- [x] `shellcheck scripts/host_perm_setup.sh` passes.
- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/deploy-vps.yml'))\"` parses without error.
- [x] Script is **idempotent** — `chown` is safe to repeat; `mkdir -p` for the ingest dir is safe to repeat.
- [x] Script is **surgical** — only touches paths the three saas containers write to:
  - chowns: `/opt/mira/data` (parent), `mira.db` (+ `-wal`/`-shm`), `mem0/`, `agent-runs/`, `ingest/` (created if missing), and `/opt/mira/mira-bridge/data/sessions/`.
  - explicitly does **NOT** chown: `/opt/mira/data/mira-bot-telegram/` (bot runs as root), `/opt/mira/data/pdfs/`, `photo_batches.db*`, `session_photos/`, `_snapshots/`.
- [x] Hook lands between `git reset --hard origin/main` (line 58) and `docker rm -f` (line 70), so by the time `docker compose up` runs, perms are correct on a fresh host AND on every subsequent deploy.

## Test plan

- [ ] After merge, next auto-deploy logs `=== Host permission setup ... ===` block before `Pre-deploy cleanup`.
- [ ] On VPS post-deploy: `ls -la /opt/mira/data/` shows `mira.db`, `mem0/`, `agent-runs/`, `ingest/` owned by `1001:1001`.
- [ ] On VPS post-deploy: `mira-bot-telegram/` and `pdfs/` still owned by `root:root` (unchanged — out of scope).
- [ ] `mira-pipeline-saas`, `mira-mcp-saas`, `mira-ingest-saas` all reach `healthy` on first start (no restart loop).

## Out of scope (separate work)

- The ingest compose mount itself is in PR #1326 (4-line diff to `docker-compose.saas.yml`). That PR must merge **before or with** this one for ingest to come back; this PR alone fixes pipeline + mcp but ingest still needs the mount.
- VPS git tree hygiene (`mira-crawler/cron/manual_queue.json` actively written by cron, leaks into `git status`) — separate narrow PR.
- Ingest's Ollama-unreachable warning (Bravo Tailscale offline; should point at VPS-local Ollama) — Doppler config change, separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)