### PR TITLE
fix(hub): wire /scan camera flow + repoint broken QR buttons

### DIFF
--- a/mira-hub/src/app/(hub)/assets/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/page.tsx
@@ -489,9 +489,11 @@ function AssetsPageInner() {
               <Printer className="w-3.5 h-3.5" />
               Print QR Labels
             </Link>
-            <Button size="sm" className="gap-1.5">
-              <QrCode className="w-3.5 h-3.5" />
-              {tCommon("scanQr")}
+            <Button asChild size="sm" className="gap-1.5">
+              <Link href="/scan">
+                <QrCode className="w-3.5 h-3.5" />
+                {tCommon("scanQr")}
+              </Link>
             </Button>
           </div>
         </div>

--- a/mira-hub/src/app/(hub)/feed/page.tsx
+++ b/mira-hub/src/app/(hub)/feed/page.tsx
@@ -223,7 +223,7 @@ export default function FeedPage() {
           <div className="flex flex-col items-end gap-2 mb-1 animate-in fade-in slide-in-from-bottom-2 duration-150">
             {[
               { label: tWorkorders("new"), icon: ClipboardList,     href: "/workorders/new" },
-              { label: tFeed("scanQr"),    icon: QrCode,            href: "#" },
+              { label: tFeed("scanQr"),    icon: QrCode,            href: "/scan" },
               { label: tFeed("newRequest"), icon: MessageSquarePlus, href: "/requests/new" },
               { label: "New Asset",        icon: Cog,               href: "/assets?create=1" },
             ].map((action) => (

--- a/mira-hub/src/app/(hub)/scan/page.tsx
+++ b/mira-hub/src/app/(hub)/scan/page.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { AlertCircle, Keyboard, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { extractAssetTag } from "@/lib/scan-target";
+
+type ScanState = "starting" | "scanning" | "denied" | "unsupported" | "error";
+
+type BarcodeDetectorCtor = new (opts?: { formats?: string[] }) => {
+  detect: (source: CanvasImageSource) => Promise<Array<{ rawValue: string }>>;
+};
+
+export default function ScanPage() {
+  const router = useRouter();
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const rafRef = useRef<number | null>(null);
+  const [state, setState] = useState<ScanState>("starting");
+  const [error, setError] = useState<string | null>(null);
+  const [manual, setManual] = useState("");
+
+  const stop = useCallback(() => {
+    if (rafRef.current !== null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    if (streamRef.current) {
+      streamRef.current.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    }
+  }, []);
+
+  const start = useCallback(async () => {
+    setError(null);
+    if (typeof window === "undefined") return;
+    const Detector = (window as unknown as { BarcodeDetector?: BarcodeDetectorCtor })
+      .BarcodeDetector;
+    if (!Detector || !navigator.mediaDevices?.getUserMedia) {
+      setState("unsupported");
+      return;
+    }
+    setState("starting");
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: { ideal: "environment" } },
+        audio: false,
+      });
+      streamRef.current = stream;
+      const v = videoRef.current;
+      if (!v) {
+        stream.getTracks().forEach((t) => t.stop());
+        return;
+      }
+      v.srcObject = stream;
+      await v.play().catch(() => null);
+      const detector = new Detector({ formats: ["qr_code"] });
+      setState("scanning");
+
+      const tick = async () => {
+        if (!videoRef.current || !streamRef.current) return;
+        try {
+          if (videoRef.current.readyState >= 2) {
+            const results = await detector.detect(videoRef.current);
+            if (results.length > 0) {
+              const tag = extractAssetTag(results[0].rawValue);
+              if (tag) {
+                stop();
+                router.push(`/m/${encodeURIComponent(tag)}`);
+                return;
+              }
+            }
+          }
+        } catch {
+          // Frame decode error — common when motion-blurred. Keep trying.
+        }
+        rafRef.current = requestAnimationFrame(tick);
+      };
+      rafRef.current = requestAnimationFrame(tick);
+    } catch (e) {
+      const err = e as DOMException;
+      if (err.name === "NotAllowedError" || err.name === "PermissionDeniedError") {
+        setState("denied");
+      } else if (err.name === "NotFoundError" || err.name === "OverconstrainedError") {
+        setState("error");
+        setError("No camera was found on this device.");
+      } else {
+        setState("error");
+        setError(err.message || "Could not start the camera.");
+      }
+    }
+  }, [router, stop]);
+
+  useEffect(() => {
+    // Defer to a microtask so the synchronous setState calls inside start()
+    // (when BarcodeDetector is unsupported or before the first await) don't
+    // cascade renders directly from the effect body.
+    queueMicrotask(() => {
+      void start();
+    });
+    return stop;
+  }, [start, stop]);
+
+  function submitManual(e: React.FormEvent) {
+    e.preventDefault();
+    const tag = extractAssetTag(manual);
+    if (!tag) return;
+    stop();
+    router.push(`/m/${encodeURIComponent(tag)}`);
+  }
+
+  const manualValid = extractAssetTag(manual) !== null;
+  const showCamera = state === "starting" || state === "scanning";
+
+  return (
+    <div className="max-w-md mx-auto px-4 py-6">
+      <h1 className="text-2xl font-semibold mb-1" style={{ color: "var(--foreground)" }}>
+        Scan an asset
+      </h1>
+      <p className="text-sm mb-4" style={{ color: "var(--foreground-muted)" }}>
+        Point your camera at a MIRA QR label to anchor your next action to that
+        asset.
+      </p>
+
+      {showCamera ? (
+        <div className="relative aspect-square w-full overflow-hidden rounded-2xl bg-black">
+          <video
+            ref={videoRef}
+            className="w-full h-full object-cover"
+            playsInline
+            muted
+            aria-label="Camera viewfinder"
+          />
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div
+              className="w-2/3 aspect-square border-2 border-white/80 rounded-2xl"
+              style={{ boxShadow: "0 0 0 9999px rgba(0,0,0,0.35)" }}
+            />
+          </div>
+          <div className="absolute bottom-3 left-3 right-3 text-center text-white text-xs font-medium">
+            {state === "starting" ? "Starting camera…" : "Scanning for QR codes…"}
+          </div>
+        </div>
+      ) : null}
+
+      {state === "denied" ? (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 flex gap-3">
+          <AlertCircle className="h-5 w-5 text-amber-700 shrink-0" />
+          <div>
+            <p className="font-semibold text-amber-900">Camera permission denied</p>
+            <p className="text-sm text-amber-800 mt-1">
+              Enable camera access in your browser&apos;s site settings, then
+              reload — or type the asset tag below.
+            </p>
+            <Button size="sm" variant="outline" className="mt-3" onClick={start}>
+              <RefreshCw className="w-3.5 h-3.5 mr-1.5" /> Try again
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {state === "unsupported" ? (
+        <div className="rounded-lg border border-slate-200 bg-slate-50 p-4 flex gap-3">
+          <Keyboard className="h-5 w-5 text-slate-700 shrink-0" />
+          <div>
+            <p className="font-semibold text-slate-900">
+              In-page scanning isn&apos;t available here
+            </p>
+            <p className="text-sm text-slate-700 mt-1">
+              This browser doesn&apos;t support in-page QR decoding. Type the
+              asset tag below, or scan the label with your phone&apos;s default
+              camera app — it will open the asset directly.
+            </p>
+          </div>
+        </div>
+      ) : null}
+
+      {state === "error" ? (
+        <div className="rounded-lg border border-rose-200 bg-rose-50 p-4 flex gap-3">
+          <AlertCircle className="h-5 w-5 text-rose-700 shrink-0" />
+          <div>
+            <p className="font-semibold text-rose-900">Couldn&apos;t start the camera</p>
+            <p className="text-sm text-rose-800 mt-1">{error ?? "Unknown error"}</p>
+            <Button size="sm" variant="outline" className="mt-2" onClick={start}>
+              <RefreshCw className="w-3.5 h-3.5 mr-1.5" /> Try again
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      <form onSubmit={submitManual} className="mt-5">
+        <label
+          className="block text-xs uppercase tracking-wide mb-1"
+          style={{ color: "var(--foreground-muted)" }}
+          htmlFor="scan-manual"
+        >
+          Or enter the asset tag manually
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="scan-manual"
+            type="text"
+            inputMode="text"
+            autoCapitalize="characters"
+            placeholder="e.g. VFD-07"
+            value={manual}
+            onChange={(e) => setManual(e.target.value)}
+            className="flex-1 h-11 rounded-lg border px-3 font-mono text-sm"
+            style={{ borderColor: "var(--border)", backgroundColor: "var(--surface-0)" }}
+          />
+          <Button type="submit" size="lg" disabled={!manualValid}>
+            Open
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/mira-hub/src/lib/__tests__/scan-target.test.ts
+++ b/mira-hub/src/lib/__tests__/scan-target.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { extractAssetTag } from "../scan-target";
+
+describe("extractAssetTag", () => {
+  it("extracts a tag from the canonical app.factorylm.com URL", () => {
+    expect(extractAssetTag("https://app.factorylm.com/m/VFD-07")).toBe("VFD-07");
+  });
+
+  it("strips query strings and fragments", () => {
+    expect(extractAssetTag("https://app.factorylm.com/m/PUMP-03?ref=label")).toBe("PUMP-03");
+    expect(extractAssetTag("https://app.factorylm.com/m/COMP-01#section")).toBe("COMP-01");
+  });
+
+  it("accepts path-only form", () => {
+    expect(extractAssetTag("/m/VFD-07")).toBe("VFD-07");
+    expect(extractAssetTag("m/VFD-07")).toBe("VFD-07");
+  });
+
+  it("accepts a raw asset tag (hand-typed fallback)", () => {
+    expect(extractAssetTag("VFD-07")).toBe("VFD-07");
+    expect(extractAssetTag("EQ-9X4K2P7Q")).toBe("EQ-9X4K2P7Q");
+  });
+
+  it("trims whitespace", () => {
+    expect(extractAssetTag("  VFD-07  ")).toBe("VFD-07");
+  });
+
+  it("decodes percent-encoded tags", () => {
+    expect(extractAssetTag("https://app.factorylm.com/m/VFD%2D07")).toBe("VFD-07");
+  });
+
+  it("rejects a URL that doesn't point at an asset", () => {
+    expect(extractAssetTag("https://app.factorylm.com/feed")).toBeNull();
+    expect(extractAssetTag("https://example.com/")).toBeNull();
+  });
+
+  it("rejects empty and whitespace-only input", () => {
+    expect(extractAssetTag("")).toBeNull();
+    expect(extractAssetTag("   ")).toBeNull();
+  });
+
+  it("rejects tags containing path-traversal characters", () => {
+    // ASSET_TAG_REGEX only allows alnum + underscore + dash; a tag like
+    // "../etc" or one containing slashes/dots must not pass through.
+    expect(extractAssetTag("../etc")).toBeNull();
+    expect(extractAssetTag("https://app.factorylm.com/m/..%2Fetc")).toBeNull();
+    expect(extractAssetTag("foo.bar")).toBeNull();
+  });
+
+  it("rejects tags that exceed the 64-char limit", () => {
+    const tooLong = "A".repeat(65);
+    expect(extractAssetTag(tooLong)).toBeNull();
+  });
+});

--- a/mira-hub/src/lib/scan-target.ts
+++ b/mira-hub/src/lib/scan-target.ts
@@ -1,0 +1,41 @@
+// Resolve a raw QR-scan payload to an asset tag we can route to.
+//
+// QR labels we generate encode `https://app.factorylm.com/m/<TAG>` (see the
+// qr-onboarding skill), so the URL form is the common case. We also accept
+// a `/m/<TAG>` path-only string and — as a fallback for hand-typed input or
+// older stickers — a raw tag that satisfies ASSET_TAG_REGEX.
+
+import { ASSET_TAG_REGEX } from "./asset-tag";
+
+export function extractAssetTag(raw: string): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+
+  try {
+    const url = new URL(trimmed);
+    const match = url.pathname.match(/\/m\/([^/?#]+)/);
+    if (match) {
+      const candidate = safeDecode(match[1]);
+      return ASSET_TAG_REGEX.test(candidate) ? candidate : null;
+    }
+    return null;
+  } catch {
+    // not a URL, fall through to path/raw forms
+  }
+
+  const pathMatch = trimmed.match(/^\/?m\/([^/?#]+)/);
+  if (pathMatch) {
+    const candidate = safeDecode(pathMatch[1]);
+    return ASSET_TAG_REGEX.test(candidate) ? candidate : null;
+  }
+
+  return ASSET_TAG_REGEX.test(trimmed) ? trimmed : null;
+}
+
+function safeDecode(s: string): string {
+  try {
+    return decodeURIComponent(s);
+  } catch {
+    return s;
+  }
+}


### PR DESCRIPTION
## Summary

The **Scan QR** entry in the `/hub/feed` FAB had `href="#"` and the matching button on `/hub/assets` was a bare `<Button>` with no handler — both no-ops. They now route to a new `/hub/scan` page that opens the rear camera, decodes via the native `BarcodeDetector` API, and pushes `/m/<assetTag>` — anchoring whatever the technician does next (Ask MIRA / Create WO / View manuals) to that asset's UNS namespace.

This is the minimal extension of MIRA's existing QR pipeline (`asset_qr_tags`, `qr-onboarding` skill, Avery 5163/5160 labels, `/m/[assetTag]` mobile asset page) that PR #1324's evaluation recommended — no new dependencies, no forks.

## Changes

- **`src/app/(hub)/scan/page.tsx`** — client page: rear-facing camera, reticle overlay, native `BarcodeDetector` poll loop with QR-only filter, graceful fallbacks for `denied` / `unsupported` / `error`, and a manual asset-tag input form for Firefox / older browsers.
- **`src/lib/scan-target.ts`** — shared QR-payload → asset-tag extractor. Reuses `ASSET_TAG_REGEX` from `asset-tag.ts` so path-traversal (`../etc`), oversized, and malformed payloads are rejected.
- **`src/lib/__tests__/scan-target.test.ts`** — 10 vitest cases: canonical URL, query/fragment, path-only, raw tag, percent-encoded, whitespace, rejected payloads, length cap.
- **`src/app/(hub)/feed/page.tsx`** — FAB Scan QR → `/scan` (was `"#"`).
- **`src/app/(hub)/assets/page.tsx`** — toolbar Scan QR is now an `asChild` Link to `/scan` (was a bare `<Button>` with no handler).

## Browser support

`BarcodeDetector` is native in modern Chrome / Edge / Safari 17+. Firefox and older Safari fall through to the manual-input form. No new npm dependency was added.

## Verification

- `npx tsc --noEmit` — clean on changed files (the one pre-existing TS error in `rls-deny.integration.test.ts` is unrelated)
- `npx eslint <changed files>` — clean
- `npx vitest run src/lib/__tests__/scan-target.test.ts` — **10/10 passed**

## Test plan

- [ ] On a phone, tap the **+** FAB on `/hub/feed`, then **Scan QR** → camera permission prompt appears
- [ ] Point at a MIRA-generated QR label (`https://app.factorylm.com/m/<tag>`) → page navigates to the `/m/<tag>` asset view
- [ ] Verify the **Ask MIRA / Create WO / View manuals** buttons on `/m/<tag>` are pre-filled with the scanned asset's tag and id
- [ ] On a desktop browser without rear camera, verify the manual asset-tag input still routes correctly
- [ ] On Firefox, verify the unsupported-state copy shows and manual input still works
- [ ] Verify camera permission denied / `NotAllowedError` shows the retry button