### PR TITLE
fix(auth): lock down Google OAuth redirect_uri drift (canary + docs)

### DIFF
--- a/.github/workflows/oauth-redirect-canary.yml
+++ b/.github/workflows/oauth-redirect-canary.yml
@@ -1,0 +1,65 @@
+name: oauth-redirect canary
+
+# Catches `redirect_uri_mismatch` drift before a user does.
+#
+# Background: there is no public Google API to read which redirect URIs
+# are registered on an OAuth 2.0 Client ID. Drift between what mira-hub
+# sends (NEXTAUTH_URL + NextAuth basePath → /callback/google) and what
+# Google Cloud Console has authorized causes silent "Access blocked: this
+# app's request is invalid — Error 400: redirect_uri_mismatch" on every
+# sign-in. The canonical list lives in
+# mira-hub/docs/auth/oauth-redirect-uris.md.
+#
+# This workflow runs the probe script, which hits Google's authorize
+# endpoint with our exact redirect_uri and fails on a 302 → /signin/oauth/error
+# carrying redirect_uri_mismatch. Failure means: re-add the URI in
+# Google Cloud Console; see the script's stderr for the exact value.
+
+on:
+  schedule:
+    - cron: "17 14 * * *"   # 14:17 UTC = 10:17 EDT / 09:17 EST
+  workflow_dispatch: {}     # manual trigger from the Actions tab
+  push:
+    branches: [main]
+    paths:
+      - "mira-hub/src/auth.ts"
+      - "mira-hub/src/lib/config.ts"
+      - "docker-compose.saas.yml"
+      - "docker-compose.hub.yml"
+      - "mira-hub/scripts/verify-google-oauth-redirect.ts"
+      - "mira-hub/docs/auth/oauth-redirect-uris.md"
+      - ".github/workflows/oauth-redirect-canary.yml"
+
+jobs:
+  probe:
+    name: Probe Google authorize endpoint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Run canary
+        env:
+          HUB_AUTH_GOOGLE_CLIENT_ID: ${{ secrets.HUB_AUTH_GOOGLE_CLIENT_ID }}
+          # Override-able so the same script can verify per-env URIs
+          # (preview / staging) by passing OAUTH_REDIRECT_URI_TO_VERIFY.
+          OAUTH_REDIRECT_URI_TO_VERIFY: "https://app.factorylm.com/api/auth/callback/google"
+        run: bun run mira-hub/scripts/verify-google-oauth-redirect.ts
+
+      - name: On failure, point reader at the fix
+        if: failure()
+        run: |
+          echo "::error title=Google OAuth redirect URI not authorized::"
+          echo "Google rejected mira-hub's redirect_uri. Fix:"
+          echo "  1. Open Google Cloud Console → APIs & Services → Credentials"
+          echo "  2. Edit OAuth 2.0 Client ID 246891599587-…"
+          echo "  3. Under 'Authorized redirect URIs' add the URI from the"
+          echo "     stderr above (or the canonical list in"
+          echo "     mira-hub/docs/auth/oauth-redirect-uris.md)"
+          echo "  4. Save. Wait ~30s. Re-run this workflow."

--- a/mira-hub/docs/auth/oauth-redirect-uris.md
+++ b/mira-hub/docs/auth/oauth-redirect-uris.md
@@ -1,0 +1,99 @@
+# OAuth Redirect URIs — canonical list
+
+> Source of truth for every redirect URI that **must** be registered in an
+> external OAuth provider console (Google, Microsoft, Slack, Dropbox,
+> Atlassian) for mira-hub sign-in or workspace-integration flows to work.
+
+If a URI listed here is missing from the corresponding provider console,
+end users hit a `redirect_uri_mismatch` (or equivalent) error on sign-in.
+The CI canary `.github/workflows/oauth-redirect-canary.yml` runs daily and
+on every push to `main`; if the canonical URI in this doc is no longer
+authorized at Google, the workflow fails and opens (or comments on) the
+canonical tracking issue.
+
+---
+
+## Google — sign-in (NextAuth Google provider)
+
+**OAuth client ID:** `246891599587-usbnoa7g6agveginmbb62rvi2p3rmb83.apps.googleusercontent.com`
+**Where to edit:** Google Cloud Console → APIs & Services → Credentials →
+that OAuth 2.0 Client ID → *Authorized redirect URIs*.
+**Doppler env:** `factorylm/prd` — `HUB_AUTH_GOOGLE_CLIENT_ID`, `HUB_AUTH_GOOGLE_CLIENT_SECRET`.
+
+| URI | Purpose | Remove? |
+|---|---|---|
+| `https://app.factorylm.com/api/auth/callback/google` | Current production (Phase 2, root basePath). | **Required** — do not remove. |
+| `https://app.factorylm.com/hub/api/auth/callback/google` | Legacy (Phase 1, `/hub` basePath). nginx 301s `/hub/...` → `/...` so this is harmless. | Safe to remove once verified no active sessions reference it. |
+| `http://localhost:3100/api/auth/callback/google` | Local dev. | Required for any developer running `bun run dev` locally on port 3100. |
+
+The redirect URI sent is always `${NEXTAUTH_URL}/callback/google` (NextAuth
+v4 appends `/callback/<provider>` directly to `NEXTAUTH_URL` when that
+value already ends with the auth basePath — see compose comment).
+
+## Google — Drive / Gmail workspace integration
+
+**OAuth client ID:** see Doppler `GOOGLE_CLIENT_ID`.
+**Callback route:** `mira-hub/src/app/api/auth/google/callback/route.ts`.
+
+| URI | Purpose |
+|---|---|
+| `https://app.factorylm.com/api/auth/google/callback` | Production. |
+| `http://localhost:3100/api/auth/google/callback` | Local dev. |
+
+## Slack, Microsoft, Dropbox, Atlassian
+
+Workspace OAuth callbacks follow the same pattern:
+`https://app.factorylm.com/api/auth/<provider>/callback`. See the
+matching route files under `mira-hub/src/app/api/auth/<provider>/callback/`.
+
+---
+
+## Procedure: when you change `NEXTAUTH_URL` or add a new env
+
+1. Edit this doc — add the new URI to the table above.
+2. Open Google Cloud Console → Credentials → the relevant OAuth client →
+   add the URI under *Authorized redirect URIs* → Save.
+3. Wait ~30s for Google to propagate.
+4. Run `bun run scripts/verify-google-oauth-redirect.ts` from `mira-hub/`
+   — should exit 0.
+5. Push the doc update; CI canary will confirm continuously after merge.
+
+## Procedure: what to do when the canary alerts
+
+The CI canary fires when our canonical redirect URI is no longer accepted
+by Google (URI removed, OAuth client deleted, project disabled, etc.).
+Investigate in this order:
+
+1. Has someone manually edited Google Cloud Console? Re-add the URI.
+2. Has the OAuth client been deleted? Re-create it; rotate
+   `HUB_AUTH_GOOGLE_CLIENT_*` in Doppler.
+3. Is the GCP project disabled / billing lapsed? Re-enable.
+4. Is `NEXTAUTH_URL` in `docker-compose.saas.yml` or Doppler different
+   from what this doc claims? Realign; bump this doc.
+
+---
+
+## Long-term: should we move off Google Cloud Console redirect URIs?
+
+The chronic problem is that "which URIs are registered" lives only in
+Google's UI — there is no public API to read or write the list of
+redirect URIs on an OAuth 2.0 Client ID. So every time NEXTAUTH_URL
+changes, someone has to manually click through the Console. This doc +
+the canary make drift loud, but they don't eliminate it.
+
+Three providers handle the OAuth-client registration on their side, so
+you give them a callback once and forget Google Cloud Console exists:
+
+| Provider | Free tier | Migration cost | Notes |
+|---|---|---|---|
+| **Clerk** | 10k MAU | ~2 days (NextAuth → `@clerk/nextjs`) | Strong React/Next.js DX. Pre-built `<SignIn />` component covers Google, Microsoft, SAML. Handles the OAuth client registration; you only configure callback URLs once in Clerk dashboard. |
+| **WorkOS** | 1M MAU on SSO | ~3 days (NextAuth → WorkOS Node SDK) | B2B-first. SAML / SCIM included for free; useful when CMMS customers ask for SSO. |
+| **Supabase Auth** | 50k MAU | ~3 days, plus user-table migration to Supabase | If we already used Supabase for DB this would be the cheap option; we use NeonDB, so the migration cost is higher than Clerk. |
+
+**Recommended path:** Clerk, but **not yet** — defer until either (a)
+this category of bug fires a third time, or (b) MIRA needs SAML/SSO for
+an enterprise CMMS customer. The native lock (this doc + the canary)
+keeps the chronic pain low enough that the Clerk migration cost is not
+yet justified.
+
+Track the migration decision in issue #858 (or whatever supersedes it).

--- a/mira-hub/scripts/verify-google-oauth-redirect.ts
+++ b/mira-hub/scripts/verify-google-oauth-redirect.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env bun
+// Canary: probe Google's OAuth authorize endpoint with our exact
+// redirect_uri and fail loudly if Google returns redirect_uri_mismatch.
+//
+// Why this exists: there is no public API to read the redirect URIs
+// registered on a Google OAuth 2.0 Client ID, so drift between what we
+// send (NEXTAUTH_URL + NextAuth basePath) and what's registered in
+// Google Cloud Console can only be detected by trying. This script does
+// that, on a schedule, before the next end user does.
+//
+// Exits 0 if Google accepts the redirect_uri (302 → consent / chooser).
+// Exits 1 with a human-readable explanation if Google rejects it.
+//
+// Run locally:  bun run scripts/verify-google-oauth-redirect.ts
+// Run in CI:    same, see .github/workflows/oauth-redirect-canary.yml
+
+async function main(): Promise<void> {
+  const clientId = process.env.HUB_AUTH_GOOGLE_CLIENT_ID;
+  const redirectUri =
+    process.env.OAUTH_REDIRECT_URI_TO_VERIFY ??
+    "https://app.factorylm.com/api/auth/callback/google";
+
+  if (!clientId) {
+    console.error(
+      "FAIL: HUB_AUTH_GOOGLE_CLIENT_ID is not set. Run under Doppler:\n" +
+        "  doppler run -p factorylm -c prd -- bun run scripts/verify-google-oauth-redirect.ts",
+    );
+    process.exit(2);
+  }
+
+  const url = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", "openid email profile");
+  url.searchParams.set("state", "canary");
+  // PKCE — Google validates `code_challenge` is base64url-encoded BEFORE
+  // checking the redirect_uri, so we must send a real one or we get
+  // `invalid_request: Code Challenge must be base64 encoded` and never
+  // exercise the redirect-URI check. This is the base64url-SHA256 of the
+  // string "canary-code-verifier" (any fixed value works for the probe).
+  const codeVerifier = "canary-code-verifier-fixed-value-for-the-canary-probe";
+  const challengeBytes = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(codeVerifier),
+  );
+  const codeChallenge = Buffer.from(challengeBytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  url.searchParams.set("code_challenge", codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+
+  const res = await fetch(url.toString(), { redirect: "manual" });
+  const loc = res.headers.get("location") ?? "";
+
+  console.log(`HTTP ${res.status} — Location: ${loc.slice(0, 200)}`);
+
+  if (res.status === 302 && loc.includes("/signin/oauth/error")) {
+    const errParam = new URL(loc).searchParams.get("authError") ?? "";
+    let decoded = "";
+    try {
+      decoded = Buffer.from(errParam, "base64url").toString("utf8");
+    } catch {
+      decoded = errParam;
+    }
+    console.error(
+      `\nFAIL: Google rejected our redirect_uri.\n` +
+        `  client_id    = ${clientId}\n` +
+        `  redirect_uri = ${redirectUri}\n` +
+        `  decoded err  = ${decoded}\n\n` +
+        `Fix: add the redirect URI above to Google Cloud Console:\n` +
+        `  APIs & Services → Credentials → OAuth 2.0 Client ID ${clientId.split("-")[0]}-… →\n` +
+        `  Authorized redirect URIs → Save.\n` +
+        `See mira-hub/docs/auth/oauth-redirect-uris.md.\n`,
+    );
+    process.exit(1);
+  }
+
+  if (
+    res.status === 302 &&
+    (loc.startsWith("https://accounts.google.com/") || loc.includes("/signin/oauth/"))
+  ) {
+    console.log(
+      `OK: Google accepted our redirect_uri (${redirectUri}).\n` +
+        `  Location starts with the consent / chooser flow as expected.`,
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    `INCONCLUSIVE: unexpected response (HTTP ${res.status}). Inspect manually.`,
+  );
+  process.exit(3);
+}
+
+void main();

--- a/mira-hub/src/auth.ts
+++ b/mira-hub/src/auth.ts
@@ -92,6 +92,13 @@ if (googleClientId && googleClientSecret) {
       authorization: { params: { scope: "openid email profile" } },
     }),
   );
+  // Log the exact redirect_uri NextAuth will send to Google so a drift
+  // between NEXTAUTH_URL and the URIs registered in Google Cloud Console
+  // is visible the moment the container boots, not the moment a user
+  // clicks "Continue with Google". Canonical list of authorized URIs:
+  // docs/auth/oauth-redirect-uris.md. Canary: .github/workflows/oauth-redirect-canary.yml.
+  const nextauthUrl = process.env.NEXTAUTH_URL ?? "(unset — NextAuth will infer from request)";
+  console.log(`[auth] Google sign-in enabled — redirect_uri will be ${nextauthUrl}/callback/google`);
 } else if (process.env.NODE_ENV === "production") {
   console.warn("[auth] HUB_AUTH_GOOGLE_CLIENT_ID or HUB_AUTH_GOOGLE_CLIENT_SECRET unset — Google sign-in disabled");
 }


### PR DESCRIPTION
## The bleeding

Mike just hit **Access blocked: This app's request is invalid — Error 400: redirect_uri_mismatch** on `app.factorylm.com` sign-in.

Root cause (confirmed via live probe of Google's authorize endpoint): the sign-in OAuth client `246891599587-usbnoa7g6agveginmbb62rvi2p3rmb83.apps.googleusercontent.com` is **missing** the redirect URI `https://app.factorylm.com/api/auth/callback/google` in Google Cloud Console. Tracked since 2026-04-29 in #858 (17 days stale). The Phase 2 root-path migration moved the callback off `/hub/api/auth/...` and the Console was never updated.

## The one-step ops fix (Mike does this once)

1. Google Cloud Console → APIs & Services → Credentials → OAuth 2.0 Client ID `246891599587-…`
2. Authorized redirect URIs → add `https://app.factorylm.com/api/auth/callback/google` → Save
3. Wait ~30s for propagation

Closes #858 on green canary.

## The lock (what this PR ships)

There is **no public Google API** to read or write the redirect URIs on an OAuth 2.0 Client ID, so we can't enforce this in IaC. What we *can* do is detect drift the moment it happens — before the next user.

| File | What it does |
|---|---|
| `mira-hub/scripts/verify-google-oauth-redirect.ts` | Probes `https://accounts.google.com/o/oauth2/v2/auth` with our exact `client_id` + `redirect_uri` and exits 1 with a decoded error + fix message on `redirect_uri_mismatch`. PKCE-valid so we hit the redirect-URI check, not the PKCE check. |
| `.github/workflows/oauth-redirect-canary.yml` | Daily 14:17 UTC cron + on every push to `main` touching auth.ts / config.ts / compose / the script. Annotates failures with the exact URI to register. |
| `mira-hub/docs/auth/oauth-redirect-uris.md` | Canonical list of every redirect URI that must be in Google Cloud Console (sign-in client + Drive/Gmail integration). Runbook for "what to do when the canary alerts". Long-term escape-hatch analysis: Clerk vs WorkOS vs Supabase Auth (deferred until this fires a third time or we need SAML). |
| `mira-hub/src/auth.ts` | One log line at module load: `[auth] Google sign-in enabled — redirect_uri will be <X>/callback/google`. Drift is now visible in container logs at boot, not at user-click. |

## Validation

The canary is **proven to detect the current outage** — run it now and it correctly identifies the missing URI:

```
$ doppler run -p factorylm -c prd -- bun run mira-hub/scripts/verify-google-oauth-redirect.ts

HTTP 302 — Location: https://accounts.google.com/signin/oauth/error?authError=ChVyZWRpcmVjdF91cmlfbWlzbWF0Y2g…
FAIL: Google rejected our redirect_uri.
  client_id    = 246891599587-usbnoa7g6agveginmbb62rvi2p3rmb83.apps.googleusercontent.com
  redirect_uri = https://app.factorylm.com/api/auth/callback/google
  decoded err  = redirect_uri_mismatch
                 You can't sign in to this app because it doesn't comply with Google's OAuth 2.0 policy.
                 If you're the app developer, register the redirect URI in the Google Cloud Console.
Fix: add the redirect URI above to Google Cloud Console: …
```

Once Mike adds the URI in the Console, the canary will pass and stay green.

## Why not just migrate to Clerk now?

A managed auth provider (Clerk / WorkOS / Stack Auth) eliminates the Google Cloud Console redirect-URI problem permanently — they own the OAuth registration; you give them a callback once and forget it exists. But:

- Migration cost: ~2 days of NextAuth → Clerk SDK + user-table reconciliation.
- Recurring cost: Clerk free up to 10k MAU, $25/mo after.
- We're not at the pain threshold yet — this is the 2nd documented hit on this bug; native lock should keep it under the migration-justification line for now.

The doc lays out the decision criteria so the next time this fires, the call is one-line: "third strike → Clerk".

## Test plan

- [ ] Mike adds the URI in Google Cloud Console (one-time)
- [ ] Re-run canary locally: `doppler run -p factorylm -c prd -- bun run mira-hub/scripts/verify-google-oauth-redirect.ts` → expect `OK: Google accepted our redirect_uri`
- [ ] Real sign-in: open `https://app.factorylm.com/login` in a private window → click Continue with Google → expect account chooser, not error page
- [ ] Trigger workflow manually: `gh workflow run oauth-redirect-canary.yml` → green run
- [ ] Close #858