### PR TITLE
fix(infra): cap mira-docling memory to prevent VPS host OOM-deadlock

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -361,17 +361,15 @@ services:
   mira-docling:
     image: quay.io/docling-project/docling-serve:v1.16.1
     container_name: mira-docling-saas
+    mem_limit: 3g
+    memswap_limit: 3g
     ports:
       - "127.0.0.1:5001:5001"
     environment:
       - DOCLING_SERVE_PORT=5001
     networks:
       - mira-net
-    restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 2G
+    restart: on-failure:5
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
       interval: 30s


### PR DESCRIPTION
## Summary

- Add service-level `mem_limit: 3g` + `memswap_limit: 3g` to `mira-docling` in `docker-compose.saas.yml` — these are the keywords `docker compose up` actually reads. The existing `deploy.resources.limits.memory: 2G` was a Docker Swarm directive **silently ignored** in non-Swarm mode (production `docker inspect` showed `HostConfig.Memory=0`).
- Remove the no-op `deploy.resources` block (compose v2 rejects having both forms set on different values).
- Change `restart: unless-stopped` → `restart: on-failure:5` so a memory-leak cycle terminates instead of looping forever.

## Incident

On 2026-05-16 the production VPS (`165.245.138.91`, factorylm-prod, 7.8 GiB RAM) went unreachable for ~8.7 hours (12:29 → 21:09 UTC) until a manual power cycle. Root cause: `mira-docling-saas` had no enforced memory cap, climbed to ~6.8 GiB anon-rss, and was OOM-killed by the kernel three times (09:04, 10:19, 11:18 UTC). Each kill triggered `restart: unless-stopped`, the container reloaded, leaked again, was killed again. By 12:23 the kernel logged:

> ``rcu: Unless rcu_preempt kthread gets sufficient CPU time, OOM is now expected behavior.``

— a RCU stall under sustained OOM thrash. SSH/HTTP/ICMP all stopped responding. After power cycle, the same loop began within 7 minutes: host at 94% memory, swap full, docling at 5.8 GiB and 245% CPU, climbing.

## Live fix (already on box)

The same edit has been applied to `/opt/mira/docker-compose.saas.yml` on the VPS and `mira-docling-saas` recreated. Verified:

| Metric | Before patch | After patch |
|---|---|---|
| Host mem used | 7.3 / 7.8 GiB (94%) | 2.8 / 7.8 GiB (36%) |
| Host mem available | 133 MiB | 4.9 GiB |
| Swap | 4.0 / 4.0 GiB **full** | 2.7 / 4.0 GiB |
| docling mem | 5.8 GiB (75% of host) | 882 MiB (29% of cap) |
| docling `HostConfig.Memory` | 0 (unbounded) | 3221225472 (3 GiB) |
| docling restart policy | `unless-stopped:0` | `on-failure:5` |
| Container health | OOM loop | `(healthy)` |
| `app.factorylm.com/hub/` | 200 (timing out at host level) | 200 in <1s |

Smoke-tested: `POST /v1/convert/file` returns `status: success` in ~2s.

## Caveats / known limitations

- **3 GiB may be below docling's real working set.** Prior OOM-kill PIDs were at 6.5–6.8 GiB anon-rss. Whether that was legitimate use or a leak is unclear. With this fix, real OCR jobs that exceed 3 GiB will OOM-kill the container (recoverable, host stays up) up to 5 times, then docling stops. **The host-deadlock failure mode is fixed; ingest robustness under load is not yet verified at this cap.** Follow-up may need to raise to 5 GiB (tightens budget for other containers) or move docling off the 7.8 GiB VPS.
- **Branch divergence:** the deployed VPS branch (`feat/knowledge-growth-dashboard`) is 197 commits behind main, but the broken `docling` block is identical on both. This PR lands the fix on main; reconciling the deploy branch is a separate concern.
- Pattern referenced from PR #1143 (memory limits bundle).

## Test plan

- [x] Apply patch on VPS, recreate `mira-docling-saas`, confirm `HostConfig.Memory=3221225472`
- [x] Confirm container reaches `(healthy)` and `/health` returns 200
- [x] Smoke test `POST /v1/convert/file` with a tiny PDF → 200
- [x] Verify `app.factorylm.com/hub/` returns 200 and host load drops
- [ ] Process a real multi-page image-heavy PDF and observe `docker stats` + `docker events` for OOM (deferred — will surface on next real ingest cycle)
- [ ] Mirror this fix into `feat/knowledge-growth-dashboard` branch or reconcile that branch with main

🤖 Generated with [Claude Code](https://claude.com/claude-code)