### PR TITLE
feat(hub): lock in Phase 2 slice 2 — vitest for decide endpoint + spec link to ADR-0013

### DIFF
--- a/docs/specs/maintenance-namespace-builder-spec.md
+++ b/docs/specs/maintenance-namespace-builder-spec.md
@@ -5,6 +5,7 @@
 **Owner:** Mike Harper / FactoryLM
 **Status:** Active — primary product-surface spec for the namespace-builder direction
 **Parent doctrine:** `docs/THEORY_OF_OPERATIONS.md`
+**Schema canonicalization:** [ADR-0013](../adr/0013-uns-namespace-builder-schema-canonicalization.md) — Hub `mira-hub/db/migrations/` owns product-surface schema; engine `docs/migrations/` owns kg_entities / kg_relationships.
 
 ## Purpose
 

--- a/mira-hub/src/app/api/proposals/[id]/decide/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/proposals/[id]/decide/__tests__/route.test.ts
@@ -1,0 +1,256 @@
+// Vitest coverage for POST /api/proposals/[id]/decide.
+//
+// Run: cd mira-hub && npx vitest run src/app/api/proposals
+//
+// Mocks the session helper and the tenant-context wrapper so each test
+// can drive a single code path through the route. Asserts observable
+// state (response status, response body, SQL the route produced, args
+// passed to the UPDATE) rather than implementation detail.
+//
+// Spec: docs/specs/maintenance-namespace-builder-spec.md §"Proposal queue"
+// ADR : docs/adr/0013-uns-namespace-builder-schema-canonicalization.md
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/session", () => ({
+  sessionOr401: vi.fn(),
+}));
+vi.mock("@/lib/tenant-context", () => ({
+  withTenantContext: vi.fn(),
+}));
+
+import { POST } from "../route";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+const VALID_UUID = "11111111-2222-3333-4444-555555555555";
+const TENANT_ID = "tenant-aaaa-bbbb";
+
+const goodSession = {
+  userId: "u_1",
+  tenantId: TENANT_ID,
+  email: "x@y",
+  status: "trial",
+  trialExpiresAt: null,
+};
+
+const baseProposal = {
+  id: VALID_UUID,
+  tenant_id: TENANT_ID,
+  source_entity_id: "src-uuid",
+  source_entity_type: "asset",
+  target_entity_id: "tgt-uuid",
+  target_entity_type: "component",
+  relationship_type: "HAS_COMPONENT",
+  confidence: 0.7,
+  status: "proposed",
+  created_by: "llm:groq",
+  reasoning: "manual page 42",
+};
+
+const makeReq = (body: unknown) =>
+  new Request(`https://hub.test/api/proposals/${VALID_UUID}/decide`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+
+const makeParams = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  process.env.NEON_DATABASE_URL = "postgres://test-only-not-used";
+});
+
+describe("POST /api/proposals/[id]/decide", () => {
+  it("returns 503 when NEON_DATABASE_URL is unset", async () => {
+    delete process.env.NEON_DATABASE_URL;
+    const res = await POST(makeReq({ decision: "verify" }), makeParams(VALID_UUID));
+    expect(res.status).toBe(503);
+  });
+
+  it("propagates a 401 NextResponse from the session helper", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await POST(makeReq({ decision: "verify" }), makeParams(VALID_UUID));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 on invalid UUID in the path", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    const res = await POST(makeReq({ decision: "verify" }), makeParams("not-a-uuid"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when body is missing decision", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    const res = await POST(makeReq({}), makeParams(VALID_UUID));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when decision is not 'verify' or 'reject'", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    const res = await POST(makeReq({ decision: "other" }), makeParams(VALID_UUID));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when proposal is not found (covers cross-tenant via RLS too)", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    vi.mocked(withTenantContext).mockImplementation(async (_tid, fn) => {
+      const client = { query: vi.fn(async () => ({ rows: [] })) };
+      return await fn(client as never);
+    });
+    const res = await POST(makeReq({ decision: "verify" }), makeParams(VALID_UUID));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 409 when proposal is already in a terminal state", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    vi.mocked(withTenantContext).mockImplementation(async (_tid, fn) => {
+      const client = {
+        query: vi.fn(async () => ({ rows: [{ ...baseProposal, status: "verified" }] })),
+      };
+      return await fn(client as never);
+    });
+    const res = await POST(makeReq({ decision: "verify" }), makeParams(VALID_UUID));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain("verified");
+  });
+
+  it("verify on a brand-new edge → INSERTs kg_relationships with approval_state='verified'", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    let updateProposalArgs: unknown[] = [];
+    let insertSql = "";
+    let insertCalls = 0;
+    let updateKgCalls = 0;
+
+    vi.mocked(withTenantContext).mockImplementation(async (_tid, fn) => {
+      const client = {
+        query: vi.fn(async (sql: string, args: unknown[]) => {
+          if (sql.includes("FROM relationship_proposals")) {
+            return { rows: [baseProposal] };
+          }
+          if (sql.includes("UPDATE relationship_proposals")) {
+            updateProposalArgs = args;
+            return { rows: [] };
+          }
+          if (sql.includes("FROM kg_relationships")) {
+            return { rows: [] }; // no existing edge
+          }
+          if (sql.includes("INSERT INTO kg_relationships")) {
+            insertSql = sql;
+            insertCalls++;
+            return { rows: [] };
+          }
+          if (sql.includes("UPDATE kg_relationships")) {
+            updateKgCalls++;
+            return { rows: [] };
+          }
+          return { rows: [] };
+        }),
+      };
+      return await fn(client as never);
+    });
+
+    const res = await POST(makeReq({ decision: "verify" }), makeParams(VALID_UUID));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      id: VALID_UUID,
+      decision: "verify",
+      status: "verified",
+    });
+
+    expect(updateProposalArgs[0]).toBe("verified");
+    expect(String(updateProposalArgs[1])).toContain("human:u_1");
+
+    expect(insertCalls).toBe(1);
+    expect(updateKgCalls).toBe(0);
+    expect(insertSql).toContain("INSERT INTO kg_relationships");
+    expect(insertSql).toContain("'verified'");
+  });
+
+  it("verify when kg_relationships row already exists → UPDATE not INSERT, confidence GREATEST", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    let insertCalls = 0;
+    let updateKgCalls = 0;
+    let updateKgConfidence: unknown = null;
+    let updateKgSql = "";
+
+    vi.mocked(withTenantContext).mockImplementation(async (_tid, fn) => {
+      const client = {
+        query: vi.fn(async (sql: string, args: unknown[]) => {
+          if (sql.includes("FROM relationship_proposals")) {
+            return { rows: [baseProposal] };
+          }
+          if (sql.includes("UPDATE relationship_proposals")) return { rows: [] };
+          if (sql.includes("FROM kg_relationships")) {
+            return { rows: [{ id: "existing-kg-id" }] };
+          }
+          if (sql.includes("INSERT INTO kg_relationships")) {
+            insertCalls++;
+            return { rows: [] };
+          }
+          if (sql.includes("UPDATE kg_relationships")) {
+            updateKgCalls++;
+            updateKgConfidence = args[0];
+            updateKgSql = sql;
+            return { rows: [] };
+          }
+          return { rows: [] };
+        }),
+      };
+      return await fn(client as never);
+    });
+
+    const res = await POST(makeReq({ decision: "verify" }), makeParams(VALID_UUID));
+    expect(res.status).toBe(200);
+
+    expect(insertCalls).toBe(0);
+    expect(updateKgCalls).toBe(1);
+    expect(updateKgConfidence).toBe(baseProposal.confidence);
+    expect(updateKgSql).toContain("approval_state = 'verified'");
+    expect(updateKgSql).toContain("GREATEST(confidence");
+  });
+
+  it("reject → flips status to 'rejected' with no kg_relationships write", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    let updateProposalArgs: unknown[] = [];
+    let kgWrites = 0;
+
+    vi.mocked(withTenantContext).mockImplementation(async (_tid, fn) => {
+      const client = {
+        query: vi.fn(async (sql: string, args: unknown[]) => {
+          if (sql.includes("FROM relationship_proposals")) {
+            return { rows: [baseProposal] };
+          }
+          if (sql.includes("UPDATE relationship_proposals")) {
+            updateProposalArgs = args;
+            return { rows: [] };
+          }
+          if (sql.includes("kg_relationships")) {
+            kgWrites++;
+            return { rows: [] };
+          }
+          return { rows: [] };
+        }),
+      };
+      return await fn(client as never);
+    });
+
+    const res = await POST(makeReq({ decision: "reject" }), makeParams(VALID_UUID));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      ok: true,
+      decision: "reject",
+      status: "rejected",
+    });
+
+    expect(updateProposalArgs[0]).toBe("rejected");
+    expect(String(updateProposalArgs[1])).toContain("human:u_1");
+    expect(kgWrites).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Lock-in PR for Phase 2 slice 2 (proposal mutations) shipped in PR #1332. Closes three durability gaps:

1. **Verifies engine migration 008 is applied in production NeonDB** (evidence below).
2. **Links the existing ADR-0013** from the namespace-builder spec header so contributors find it without a grep.
3. **Adds vitest coverage** for `POST /api/proposals/[id]/decide` — 10 cases including verify INSERT path, verify UPDATE-when-existing path, reject, all 400/404/409/503 branches.

## Premise correction

The goal that drove this PR assumed ADR-0013 didn't exist as a file. After cutting the branch I found it was already committed on `origin/main` via PR #1330 (`d1facd28`). My session-start `ls docs/adr/` was against stale local `main` (5 commits behind `origin/main`). This is the [`fetch_origin_before_state_claims`](memory) failure mode firing for the second time this week — re-flagging in memory.

So no new ADR is in this PR. The spec edit links to the existing one.

## Migration 008 verification evidence

Pulled `NEON_DATABASE_URL` from Doppler (`factorylm/prd`), ran read-only queries against `ep-purple-hall-ahimeyn0-pooler.c-3.us-east-1.aws.neon.tech`:

### Columns (all 6 present)

| table_name | column_name | data_type | default |
|---|---|---|---|
| kg_entities | approval_state | text | `'verified'::text` |
| kg_entities | evidence_summary | text | — |
| kg_entities | proposed_by | text | — |
| kg_relationships | approval_state | text | `'verified'::text` |
| kg_relationships | evidence_summary | text | — |
| kg_relationships | proposed_by | text | — |

### Indexes (all 4 present)

```
public|kg_entities|kg_ent_approval_state|btree (tenant_id, approval_state)
public|kg_entities|kg_ent_verified_only|btree (tenant_id, entity_type) WHERE (approval_state = 'verified')
public|kg_relationships|kg_rel_approval_state|btree (tenant_id, approval_state)
public|kg_relationships|kg_rel_verified_only|btree (tenant_id, relationship_type) WHERE (approval_state = 'verified')
```

Verdict: **mig 008 is fully applied in prod NeonDB**. No deploy gap.

## Test plan

- [x] `cd mira-hub && npx vitest run src/app/api/proposals` → 10/10 pass (306ms)
- [x] `npm run build` → exits 0, route list intact
- [ ] CI checks match `main` baseline
- [ ] Review the vitest mocking pattern (mocks `@/lib/session` + `@/lib/tenant-context`, asserts SQL contents + UPDATE args)

## What this does NOT touch (per goal scope-lock)

- UI changes in `mira-hub/src/app/(hub)/`
- The bigger proposal→decide→kg_relationships integration test against a real NeonDB branch (file as a follow-up)
- Mig 008, 018, or 021 themselves
- Phase 3 work, VPS chat-path port-back, Stripe/SaaS/lead-hunter

🤖 Generated with [Claude Code](https://claude.com/claude-code)