### PR TITLE
feat(hub): wire Namespace + Proposals into sidebar nav

### DIFF
--- a/mira-hub/src/components/layout/sidebar.tsx
+++ b/mira-hub/src/components/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import {
   Wrench, Radio, Plug, BarChart2, Users, Settings,
   ClipboardList, CalendarDays, Inbox, Package, FileText, TrendingUp,
   Factory, ChevronLeft, ChevronRight, LogOut, Sun, Moon, HelpCircle, Cpu,
+  Layers, Sparkles,
 } from "lucide-react";
 import { restartTour } from "@/components/onboarding/tour";
 import { cn } from "@/lib/utils";
@@ -20,7 +21,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   Activity, MessageSquare, Zap, AlertTriangle, BookOpen,
   Wrench, Radio, Plug, BarChart2, Users, Settings,
   ClipboardList, CalendarDays, Inbox, Package, FileText, TrendingUp,
-  Cpu,
+  Cpu, Layers, Sparkles,
 };
 
 type NavItemProps = {

--- a/mira-hub/src/providers/access-control.ts
+++ b/mira-hub/src/providers/access-control.ts
@@ -59,6 +59,8 @@ export const NAV_ITEMS = [
   { key: "actions",       label: "Actions",       icon: "Zap",           href: "/actions",       roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
   { key: "alerts",        label: "Alerts",        icon: "AlertTriangle", href: "/alerts",        roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
   { key: "knowledge",     label: "Knowledge",     icon: "BookOpen",      href: "/knowledge",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
+  { key: "namespace",     label: "Namespace",     icon: "Layers",        href: "/namespace",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
+  { key: "proposals",     label: "Proposals",     icon: "Sparkles",      href: "/proposals",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
   { key: "assets",        label: "Assets",        icon: "Wrench",        href: "/assets",        roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
   { key: "channels",      label: "Channels",      icon: "Radio",         href: "/channels",      roles: ["manager", "scheduler", "admin", "owner"],                           group: "primary" },
   { key: "integrations",  label: "Integrations",  icon: "Plug",          href: "/integrations",  roles: ["manager", "admin", "owner"],                                        group: "primary" },


### PR DESCRIPTION
## Summary

- Adds `Namespace` (/namespace) and `Proposals` (/proposals) entries to the Hub sidebar.
- Pages already exist under `mira-hub/src/app/(hub)/` (shipped in #1332) but weren't linked from the nav.
- Visible to all roles: technician, manager, scheduler, admin, operator, owner.

## Why now

Tonight's deploy of #1330 (UNS confirmation gate) doesn't write to Hub-rendered tables directly, but `mira-crawler/ingest/kg_writer.py` and the `/api/proposals/:id/decide` endpoint will populate `kg_entities` and `relationship_proposals` as conversation + ingest traffic flows. Users need clickable Hub pages to watch that data accumulate — that's this PR.

## Test plan

- [ ] CI passes (typecheck, lint, vitest)
- [ ] After merge + deploy to app.factorylm.com: sidebar shows `Namespace` and `Proposals` entries between `Knowledge` and `Assets`
- [ ] /namespace and /proposals load (already do — verified via git tree on origin/main)
- [ ] Icons render (Layers / Sparkles from lucide-react)

🤖 Generated with [Claude Code](https://claude.com/claude-code)