### PR TITLE
feat(hub): Phase 3 slice 0 — onboarding wizard that seeds first kg_entities

### DIFF
--- a/mira-hub/src/app/(hub)/namespace/page.tsx
+++ b/mira-hub/src/app/(hub)/namespace/page.tsx
@@ -326,8 +326,16 @@ function EmptyState() {
       <Layers className="mx-auto h-10 w-10 text-slate-300" />
       <h2 className="mt-4 text-lg font-semibold text-slate-900">Your namespace is empty</h2>
       <p className="mx-auto mt-2 max-w-md text-sm text-slate-500">
-        Upload a manual, run a photo walk, or import a PLC tag list. MIRA will propose entities here.
+        Start the namespace wizard to add your first site and line, then MIRA will
+        propose assets and components from your manuals, photos, and PLC tags.
       </p>
+      <a
+        href={`${API_BASE.replace("/api", "")}/onboarding`}
+        className="mt-6 inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700"
+        data-testid="namespace-empty-start"
+      >
+        Build your namespace →
+      </a>
     </div>
   );
 }

--- a/mira-hub/src/app/(hub)/onboarding/page.tsx
+++ b/mira-hub/src/app/(hub)/onboarding/page.tsx
@@ -1,0 +1,511 @@
+"use client";
+
+/**
+ * Namespace onboarding wizard — Phase 3 slice 0.
+ *
+ * Spec: docs/specs/maintenance-namespace-builder-spec.md §"Onboarding wizard"
+ * Plan: docs/plans/2026-05-15-maintenance-namespace-builder.md (Phase 3)
+ *
+ * Minimum 3-step flow:
+ *   1. Company  — company name
+ *   2. Site     — first site name + optional location
+ *   3. Line     — first production line name + optional description
+ *   → Finish creates kg_entities (site + line) with uns_path values,
+ *     writes namespace_versions audit rows, redirects to /namespace.
+ *
+ * Slice 1 will add area, equipment, tag-import CSV.
+ */
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, ArrowRight, Building2, Factory, Loader2, MapPin, Sparkles } from "lucide-react";
+import { API_BASE } from "@/lib/config";
+
+type StepId = "company" | "site" | "line" | "review";
+
+interface CompanyPayload { name: string }
+interface SitePayload    { name: string; location?: string }
+interface LinePayload    { name: string; description?: string }
+interface AllPayloads {
+  company?: CompanyPayload;
+  site?: SitePayload;
+  line?: LinePayload;
+}
+
+const STEPS: { id: StepId; label: string; icon: React.ElementType }[] = [
+  { id: "company", label: "Company",        icon: Building2 },
+  { id: "site",    label: "First site",     icon: MapPin },
+  { id: "line",    label: "First line",     icon: Factory },
+  { id: "review",  label: "Review & finish", icon: Sparkles },
+];
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const [activeStep, setActiveStep] = useState<StepId>("company");
+  const [payloads, setPayloads] = useState<AllPayloads>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [finishing, setFinishing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Resume from server: read whatever step the user was last on.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`${API_BASE}/api/wizard/company`, { cache: "no-store" });
+        if (cancelled) return;
+        if (!res.ok) {
+          if (res.status !== 401) setError(`Failed to load progress: HTTP ${res.status}`);
+          return;
+        }
+        const data = await res.json();
+        if (cancelled) return;
+        if (data.status === "completed") {
+          router.replace("/namespace");
+          return;
+        }
+        const restored: AllPayloads = data.stepPayloads ?? {};
+        setPayloads(restored);
+        const current = String(data.currentStep ?? "company");
+        const known: StepId[] = ["company", "site", "line", "review"];
+        setActiveStep(known.includes(current as StepId) ? (current as StepId) : "review");
+      } catch (e) {
+        if (!cancelled) setError((e as Error).message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  async function saveStep(stepId: Exclude<StepId, "review">, value: Record<string, unknown>) {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/wizard/${stepId}`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(value),
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+    } catch (e) {
+      setError((e as Error).message);
+      throw e;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function finish() {
+    setFinishing(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/wizard/finish`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string; sitePath?: string };
+      if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+      router.replace("/namespace");
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setFinishing(false);
+    }
+  }
+
+  function advance(next: StepId) {
+    setActiveStep(next);
+  }
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-slate-500">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin" /> Loading wizard…
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 p-6 sm:p-10" data-testid="onboarding-page">
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900">Build your namespace</h1>
+        <p className="mt-1 max-w-2xl text-sm text-slate-500">
+          A namespace gives MIRA the factory context to ground every answer. We&apos;ll start
+          with one site and one line — you can add more later from the namespace tab.
+        </p>
+      </header>
+
+      <Stepper active={activeStep} payloads={payloads} />
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700" data-testid="onboarding-error">
+          {error}
+        </div>
+      )}
+
+      <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        {activeStep === "company" && (
+          <CompanyStep
+            value={payloads.company}
+            saving={saving}
+            onSubmit={async (value) => {
+              await saveStep("company", value as unknown as Record<string, unknown>);
+              setPayloads((p) => ({ ...p, company: value }));
+              advance("site");
+            }}
+          />
+        )}
+        {activeStep === "site" && (
+          <SiteStep
+            value={payloads.site}
+            saving={saving}
+            onBack={() => advance("company")}
+            onSubmit={async (value) => {
+              await saveStep("site", value as unknown as Record<string, unknown>);
+              setPayloads((p) => ({ ...p, site: value }));
+              advance("line");
+            }}
+          />
+        )}
+        {activeStep === "line" && (
+          <LineStep
+            value={payloads.line}
+            saving={saving}
+            onBack={() => advance("site")}
+            onSubmit={async (value) => {
+              await saveStep("line", value as unknown as Record<string, unknown>);
+              setPayloads((p) => ({ ...p, line: value }));
+              advance("review");
+            }}
+          />
+        )}
+        {activeStep === "review" && (
+          <ReviewStep
+            payloads={payloads}
+            finishing={finishing}
+            onBack={() => advance("line")}
+            onFinish={finish}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Stepper({ active, payloads }: { active: StepId; payloads: AllPayloads }) {
+  return (
+    <ol className="flex flex-wrap gap-2 sm:gap-3" data-testid="onboarding-stepper">
+      {STEPS.map((s, i) => {
+        const done = isStepDone(s.id, payloads);
+        const isActive = s.id === active;
+        const Icon = s.icon;
+        return (
+          <li key={s.id} className="flex items-center gap-2">
+            <div
+              className={`flex h-8 w-8 items-center justify-center rounded-full border text-xs font-medium ${
+                isActive
+                  ? "border-blue-500 bg-blue-50 text-blue-600"
+                  : done
+                    ? "border-emerald-300 bg-emerald-50 text-emerald-700"
+                    : "border-slate-200 bg-white text-slate-400"
+              }`}
+              data-testid={`stepper-${s.id}`}
+              data-active={isActive ? "true" : "false"}
+              data-done={done ? "true" : "false"}
+            >
+              <Icon className="h-4 w-4" />
+            </div>
+            <span className={`text-sm ${isActive ? "font-semibold text-slate-900" : "text-slate-500"}`}>
+              {s.label}
+            </span>
+            {i < STEPS.length - 1 && <span className="hidden text-slate-300 sm:inline">→</span>}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function isStepDone(id: StepId, p: AllPayloads): boolean {
+  if (id === "company") return !!p.company?.name;
+  if (id === "site")    return !!p.site?.name;
+  if (id === "line")    return !!p.line?.name;
+  return false;
+}
+
+function CompanyStep({
+  value,
+  saving,
+  onSubmit,
+}: {
+  value: CompanyPayload | undefined;
+  saving: boolean;
+  onSubmit: (v: CompanyPayload) => Promise<void>;
+}) {
+  const [name, setName] = useState(value?.name ?? "");
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        if (!name.trim()) return;
+        await onSubmit({ name: name.trim() });
+      }}
+      className="space-y-4"
+      data-testid="step-company"
+    >
+      <Field
+        label="Company name"
+        hint="Used as the namespace root label. You can rename it later."
+      >
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Harper Industries"
+          required
+          maxLength={200}
+          autoFocus
+          data-testid="input-company-name"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </Field>
+      <NavButtons rightLabel="Continue" rightLoading={saving} disableRight={!name.trim()} />
+    </form>
+  );
+}
+
+function SiteStep({
+  value,
+  saving,
+  onBack,
+  onSubmit,
+}: {
+  value: SitePayload | undefined;
+  saving: boolean;
+  onBack: () => void;
+  onSubmit: (v: SitePayload) => Promise<void>;
+}) {
+  const [name, setName] = useState(value?.name ?? "");
+  const [location, setLocation] = useState(value?.location ?? "");
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        if (!name.trim()) return;
+        await onSubmit({ name: name.trim(), location: location.trim() || undefined });
+      }}
+      className="space-y-4"
+      data-testid="step-site"
+    >
+      <Field label="First site" hint="A plant, factory, or facility you operate.">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Lake Wales Plant"
+          required
+          maxLength={200}
+          autoFocus
+          data-testid="input-site-name"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </Field>
+      <Field label="Location (optional)">
+        <input
+          type="text"
+          value={location}
+          onChange={(e) => setLocation(e.target.value)}
+          placeholder="e.g. Lake Wales, FL"
+          maxLength={200}
+          data-testid="input-site-location"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </Field>
+      <NavButtons
+        leftLabel="Back"
+        onLeft={onBack}
+        rightLabel="Continue"
+        rightLoading={saving}
+        disableRight={!name.trim()}
+      />
+    </form>
+  );
+}
+
+function LineStep({
+  value,
+  saving,
+  onBack,
+  onSubmit,
+}: {
+  value: LinePayload | undefined;
+  saving: boolean;
+  onBack: () => void;
+  onSubmit: (v: LinePayload) => Promise<void>;
+}) {
+  const [name, setName] = useState(value?.name ?? "");
+  const [description, setDescription] = useState(value?.description ?? "");
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault();
+        if (!name.trim()) return;
+        await onSubmit({ name: name.trim(), description: description.trim() || undefined });
+      }}
+      className="space-y-4"
+      data-testid="step-line"
+    >
+      <Field label="First production line" hint="MIRA proposes assets and components under this line.">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Sorting Line"
+          required
+          maxLength={200}
+          autoFocus
+          data-testid="input-line-name"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </Field>
+      <Field label="What does it produce? (optional)">
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="e.g. Sorts incoming product by height before packaging"
+          maxLength={500}
+          rows={3}
+          data-testid="input-line-description"
+          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        />
+      </Field>
+      <NavButtons
+        leftLabel="Back"
+        onLeft={onBack}
+        rightLabel="Continue"
+        rightLoading={saving}
+        disableRight={!name.trim()}
+      />
+    </form>
+  );
+}
+
+function ReviewStep({
+  payloads,
+  finishing,
+  onBack,
+  onFinish,
+}: {
+  payloads: AllPayloads;
+  finishing: boolean;
+  onBack: () => void;
+  onFinish: () => Promise<void>;
+}) {
+  const siteSlug = slugify(payloads.site?.name ?? "");
+  const lineSlug = slugify(payloads.line?.name ?? "");
+  return (
+    <div className="space-y-4" data-testid="step-review">
+      <p className="text-sm text-slate-600">
+        Confirm and we&apos;ll seed your namespace with one site and one line. You can
+        rename, move, or expand from the namespace tab right after.
+      </p>
+      <dl className="space-y-2 rounded-md bg-slate-50 p-4 text-sm">
+        <Pair k="Company"  v={payloads.company?.name ?? "—"} />
+        <Pair k="Site"     v={payloads.site?.name ?? "—"} />
+        {payloads.site?.location && <Pair k="Location" v={payloads.site.location} />}
+        <Pair k="Line"     v={payloads.line?.name ?? "—"} />
+        {payloads.line?.description && <Pair k="Produces" v={payloads.line.description} />}
+      </dl>
+      <div className="rounded-md border border-blue-100 bg-blue-50 p-3 text-xs text-blue-900">
+        <strong>Namespace preview:</strong>
+        <div className="mt-2 space-y-1 font-mono">
+          <div>enterprise.{siteSlug || "<site>"}</div>
+          <div className="pl-4">enterprise.{siteSlug || "<site>"}.{lineSlug || "<line>"}</div>
+        </div>
+      </div>
+      <NavButtons
+        leftLabel="Back"
+        onLeft={onBack}
+        rightLabel="Create namespace"
+        rightLoading={finishing}
+        rightTestId="onboarding-finish"
+        onRight={onFinish}
+      />
+    </div>
+  );
+}
+
+function Pair({ k, v }: { k: string; v: string }) {
+  return (
+    <div className="flex">
+      <dt className="w-28 shrink-0 text-slate-500">{k}</dt>
+      <dd className="text-slate-900">{v}</dd>
+    </div>
+  );
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-sm font-medium text-slate-900">{label}</span>
+      {children}
+      {hint && <span className="mt-1 block text-xs text-slate-500">{hint}</span>}
+    </label>
+  );
+}
+
+function NavButtons({
+  leftLabel,
+  onLeft,
+  rightLabel,
+  onRight,
+  rightLoading,
+  rightTestId,
+  disableRight,
+}: {
+  leftLabel?: string;
+  onLeft?: () => void;
+  rightLabel: string;
+  onRight?: () => void;
+  rightLoading?: boolean;
+  rightTestId?: string;
+  disableRight?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between pt-2">
+      {leftLabel ? (
+        <button
+          type="button"
+          onClick={onLeft}
+          className="inline-flex items-center gap-1 text-sm font-medium text-slate-600 hover:text-slate-900"
+          data-testid="onboarding-back"
+        >
+          <ArrowLeft className="h-4 w-4" /> {leftLabel}
+        </button>
+      ) : (
+        <span />
+      )}
+      <button
+        type={onRight ? "button" : "submit"}
+        onClick={onRight}
+        disabled={rightLoading || disableRight}
+        className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+        data-testid={rightTestId ?? "onboarding-next"}
+      >
+        {rightLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+        {rightLabel}
+        {!rightLoading && <ArrowRight className="h-4 w-4" />}
+      </button>
+    </div>
+  );
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "").slice(0, 64) || "_";
+}

--- a/mira-hub/src/app/api/wizard/[step]/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/wizard/[step]/__tests__/route.test.ts
@@ -1,0 +1,133 @@
+// Vitest coverage for /api/wizard/[step].
+//
+// Run: cd mira-hub && npx vitest run src/app/api/wizard
+//
+// Mocks session + tenant-context so each test drives one code path.
+// Spec: docs/specs/maintenance-namespace-builder-spec.md §"Onboarding wizard"
+// Plan: docs/plans/2026-05-15-maintenance-namespace-builder.md (Phase 3 slice 0)
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/session", () => ({ sessionOr401: vi.fn() }));
+vi.mock("@/lib/tenant-context", () => ({ withTenantContext: vi.fn() }));
+
+import { GET, POST } from "../route";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+const TENANT_ID = "tenant-aaaa-bbbb";
+const goodSession = {
+  userId: "user_1",
+  tenantId: TENANT_ID,
+  email: "x@y",
+  status: "trial",
+  trialExpiresAt: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEON_DATABASE_URL = "postgres://test";
+  (sessionOr401 as ReturnType<typeof vi.fn>).mockResolvedValue(goodSession);
+});
+
+function makeReq(body: unknown): Request {
+  return new Request("http://test/api/wizard/site", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function paramsFor(step: string) {
+  return { params: Promise.resolve({ step }) };
+}
+
+describe("GET /api/wizard/:step", () => {
+  it("returns not_started when no row exists", async () => {
+    (withTenantContext as ReturnType<typeof vi.fn>).mockImplementation(async (_t, fn) =>
+      fn({ query: vi.fn().mockResolvedValue({ rows: [] }) }),
+    );
+    const res = await GET(new Request("http://test"), paramsFor("company"));
+    expect(res.status).toBe(200);
+    const body = await (res as NextResponse).json();
+    expect(body.status).toBe("not_started");
+    expect(body.currentStep).toBe("company");
+    expect(body.stepPayloads).toEqual({});
+  });
+
+  it("returns 400 for unknown step", async () => {
+    const res = await GET(new Request("http://test"), paramsFor("not-a-step"));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/wizard/:step", () => {
+  it("400s when step payload is invalid", async () => {
+    const res = await POST(makeReq({ name: "" }), paramsFor("site"));
+    expect(res.status).toBe(400);
+    const body = await (res as NextResponse).json();
+    expect(body.error).toMatch(/site name required/);
+  });
+
+  it("400s when company name exceeds 200 chars", async () => {
+    const res = await POST(makeReq({ name: "x".repeat(201) }), paramsFor("company"));
+    expect(res.status).toBe(400);
+  });
+
+  it("upserts wizard_progress and advances to next step", async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [{ current_step: "line", status: "in_progress", step_payloads: { site: { name: "Lake Wales" } } }],
+    });
+    (withTenantContext as ReturnType<typeof vi.fn>).mockImplementation(async (_t, fn) => fn({ query }));
+
+    const res = await POST(makeReq({ name: "Lake Wales", location: "FL" }), paramsFor("site"));
+    expect(res.status).toBe(200);
+    const body = await (res as NextResponse).json();
+    expect(body.ok).toBe(true);
+    expect(body.currentStep).toBe("line");
+    expect(query).toHaveBeenCalledTimes(1);
+
+    const [sql, args] = query.mock.calls[0];
+    expect(sql).toMatch(/INSERT INTO wizard_progress/);
+    expect(args[1]).toBe("line");
+    expect(args[2]).toBe("site");
+    expect(JSON.parse(args[3])).toEqual({ name: "Lake Wales", location: "FL" });
+  });
+
+  it("finish inserts site + line kg_entities, writes audit rows, marks completed", async () => {
+    const query = vi.fn()
+      .mockResolvedValueOnce({ rows: [{ step_payloads: { site: { name: "Lake Wales" }, line: { name: "Sorting Line" } } }] })
+      .mockResolvedValueOnce({ rows: [{ id: "site-uuid-1" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "line-uuid-2" }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    (withTenantContext as ReturnType<typeof vi.fn>).mockImplementation(async (_t, fn) => fn({ query }));
+
+    const res = await POST(makeReq({}), paramsFor("finish"));
+    expect(res.status).toBe(200);
+    const body = await (res as NextResponse).json();
+    expect(body.ok).toBe(true);
+    expect(body.sitePath).toBe("enterprise.lake_wales");
+    expect(body.linePath).toBe("enterprise.lake_wales.sorting_line");
+
+    const sqls = query.mock.calls.map(([s]) => s as string);
+    expect(sqls[0]).toMatch(/FROM wizard_progress[\s\S]+FOR UPDATE/);
+    expect(sqls[1]).toMatch(/INSERT INTO kg_entities/);
+    expect(sqls[2]).toMatch(/INSERT INTO kg_entities/);
+    expect(sqls[3]).toMatch(/INSERT INTO namespace_versions/);
+    expect(sqls[4]).toMatch(/INSERT INTO namespace_versions/);
+    expect(sqls[5]).toMatch(/UPDATE wizard_progress[\s\S]+'completed'/);
+  });
+
+  it("finish 400s when site or line payload is missing", async () => {
+    const query = vi.fn().mockResolvedValueOnce({ rows: [{ step_payloads: { site: { name: "Only Site" } } }] });
+    (withTenantContext as ReturnType<typeof vi.fn>).mockImplementation(async (_t, fn) => fn({ query }));
+
+    const res = await POST(makeReq({}), paramsFor("finish"));
+    expect(res.status).toBe(400);
+    const body = await (res as NextResponse).json();
+    expect(body.error).toMatch(/missing payload: line/);
+  });
+});

--- a/mira-hub/src/app/api/wizard/[step]/route.ts
+++ b/mira-hub/src/app/api/wizard/[step]/route.ts
@@ -1,0 +1,250 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Onboarding wizard — slice 0.
+ *
+ * Spec : docs/specs/maintenance-namespace-builder-spec.md §"Onboarding wizard"
+ * Plan : docs/plans/2026-05-15-maintenance-namespace-builder.md (Phase 3
+ *        deliverable #1, slice 0 — minimum 3-step flow that creates
+ *        a tenant's first site + first line as kg_entities so /namespace
+ *        renders something instead of the empty state).
+ *
+ * Endpoints
+ *   GET  /api/wizard/[step]   → returns current wizard_progress row
+ *                                (or { status: 'not_started' } if none)
+ *   POST /api/wizard/[step]   → saves payload for that step into
+ *                                wizard_progress.step_payloads[step]
+ *   POST /api/wizard/finish   → reads saved payloads, inserts kg_entities
+ *                                (site + line) with uns_path values, writes
+ *                                namespace_versions rows, marks wizard
+ *                                completed.
+ *
+ * Slice 0 step ids: 'company', 'site', 'line', 'finish'. Slice 1 adds
+ * 'area', 'asset', tag-import.
+ */
+
+interface CompanyPayload { name: string }
+interface SitePayload    { name: string; location?: string }
+interface LinePayload    { name: string; description?: string }
+type StepPayload = CompanyPayload | SitePayload | LinePayload | Record<string, unknown>;
+
+interface WizardRow {
+  id: string;
+  current_step: string;
+  status: string;
+  step_payloads: Record<string, StepPayload>;
+  started_at: string;
+  completed_at: string | null;
+}
+
+const STEPS = ["company", "site", "line", "finish"] as const;
+type Step = typeof STEPS[number];
+
+function isStep(s: string): s is Step {
+  return (STEPS as readonly string[]).includes(s);
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "").slice(0, 64) || "_";
+}
+
+function nextStep(step: Step): Step {
+  const i = STEPS.indexOf(step);
+  return STEPS[Math.min(i + 1, STEPS.length - 1)];
+}
+
+export async function GET(_req: Request, { params }: { params: Promise<{ step: string }> }) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+  const { step } = await params;
+  if (!isStep(step)) return NextResponse.json({ error: "unknown step" }, { status: 400 });
+
+  try {
+    const row = await withTenantContext(ctx.tenantId, async (c) => {
+      const r = await c.query<WizardRow>(
+        `SELECT id, current_step, status, step_payloads, started_at::text, completed_at::text
+           FROM wizard_progress
+          WHERE tenant_id = $1 AND wizard_kind = 'namespace_onboarding'`,
+        [ctx.tenantId],
+      );
+      return r.rows[0] ?? null;
+    });
+    if (!row) return NextResponse.json({ status: "not_started", currentStep: STEPS[0], stepPayloads: {} });
+    return NextResponse.json({
+      status: row.status,
+      currentStep: row.current_step,
+      stepPayloads: row.step_payloads,
+      startedAt: row.started_at,
+      completedAt: row.completed_at,
+    });
+  } catch (err) {
+    console.error("[api/wizard GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request, { params }: { params: Promise<{ step: string }> }) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+  const { step } = await params;
+  if (!isStep(step)) return NextResponse.json({ error: "unknown step" }, { status: 400 });
+
+  let body: Record<string, unknown>;
+  try { body = await req.json(); } catch { body = {}; }
+
+  if (step === "finish") {
+    return finishWizard(ctx.tenantId, ctx.userId);
+  }
+
+  const validated = validateStep(step, body);
+  if (validated.kind === "invalid") {
+    return NextResponse.json({ error: validated.error }, { status: 400 });
+  }
+
+  try {
+    const next = nextStep(step);
+    const row = await withTenantContext(ctx.tenantId, async (c) => {
+      const r = await c.query<WizardRow>(
+        `INSERT INTO wizard_progress
+              (tenant_id, wizard_kind, status, current_step, step_payloads, updated_at)
+         VALUES ($1, 'namespace_onboarding', 'in_progress', $2, jsonb_build_object($3::text, $4::jsonb), now())
+         ON CONFLICT (tenant_id, wizard_kind) DO UPDATE
+              SET current_step  = EXCLUDED.current_step,
+                  step_payloads = wizard_progress.step_payloads || jsonb_build_object($3::text, $4::jsonb),
+                  updated_at    = now()
+         RETURNING id, current_step, status, step_payloads, started_at::text, completed_at::text`,
+        [ctx.tenantId, next, step, JSON.stringify(validated.value)],
+      );
+      return r.rows[0];
+    });
+    return NextResponse.json({ ok: true, currentStep: row.current_step, stepPayloads: row.step_payloads });
+  } catch (err) {
+    console.error("[api/wizard POST]", err);
+    return NextResponse.json({ error: "Save failed" }, { status: 500 });
+  }
+}
+
+type Validated =
+  | { kind: "valid"; value: StepPayload }
+  | { kind: "invalid"; error: string };
+
+function validateStep(step: Step, body: Record<string, unknown>): Validated {
+  if (step === "company") {
+    const name = String(body.name ?? "").trim();
+    if (!name) return { kind: "invalid", error: "company name required" };
+    if (name.length > 200) return { kind: "invalid", error: "company name too long" };
+    return { kind: "valid", value: { name } };
+  }
+  if (step === "site") {
+    const name = String(body.name ?? "").trim();
+    if (!name) return { kind: "invalid", error: "site name required" };
+    if (name.length > 200) return { kind: "invalid", error: "site name too long" };
+    const location = body.location ? String(body.location).trim().slice(0, 200) : undefined;
+    return { kind: "valid", value: { name, location } };
+  }
+  if (step === "line") {
+    const name = String(body.name ?? "").trim();
+    if (!name) return { kind: "invalid", error: "line name required" };
+    if (name.length > 200) return { kind: "invalid", error: "line name too long" };
+    const description = body.description ? String(body.description).trim().slice(0, 500) : undefined;
+    return { kind: "valid", value: { name, description } };
+  }
+  return { kind: "invalid", error: "no validator for step" };
+}
+
+async function finishWizard(tenantId: string, userId: string) {
+  try {
+    const result = await withTenantContext(tenantId, async (c) => {
+      const r = await c.query<{ step_payloads: Record<string, StepPayload> }>(
+        `SELECT step_payloads
+           FROM wizard_progress
+          WHERE tenant_id = $1 AND wizard_kind = 'namespace_onboarding'
+          FOR UPDATE`,
+        [tenantId],
+      );
+      if (r.rows.length === 0) return { kind: "no_progress" as const };
+      const payloads = r.rows[0].step_payloads ?? {};
+      const site = payloads.site as SitePayload | undefined;
+      const line = payloads.line as LinePayload | undefined;
+      if (!site?.name || !line?.name) {
+        return { kind: "incomplete" as const, missing: !site?.name ? "site" : "line" };
+      }
+
+      const siteSlug = slugify(site.name);
+      const lineSlug = slugify(line.name);
+      const sitePath = `enterprise.${siteSlug}`;
+      const linePath = `enterprise.${siteSlug}.${lineSlug}`;
+
+      const siteRes = await c.query<{ id: string }>(
+        `INSERT INTO kg_entities (tenant_id, entity_type, entity_id, name, properties, uns_path)
+         VALUES ($1, 'site', $2, $3, $4::jsonb, $5::ltree)
+         ON CONFLICT (tenant_id, entity_type, entity_id) DO UPDATE
+            SET name = EXCLUDED.name,
+                uns_path = EXCLUDED.uns_path,
+                updated_at = now()
+         RETURNING id`,
+        [tenantId, siteSlug, site.name, JSON.stringify({ location: site.location ?? null, source: "onboarding_wizard" }), sitePath],
+      );
+      const siteId = siteRes.rows[0].id;
+
+      const lineRes = await c.query<{ id: string }>(
+        `INSERT INTO kg_entities (tenant_id, entity_type, entity_id, name, properties, uns_path)
+         VALUES ($1, 'line', $2, $3, $4::jsonb, $5::ltree)
+         ON CONFLICT (tenant_id, entity_type, entity_id) DO UPDATE
+            SET name = EXCLUDED.name,
+                uns_path = EXCLUDED.uns_path,
+                updated_at = now()
+         RETURNING id`,
+        [tenantId, lineSlug, line.name, JSON.stringify({ description: line.description ?? null, source: "onboarding_wizard" }), linePath],
+      );
+      const lineId = lineRes.rows[0].id;
+
+      for (const [entityId, entityKind, path, displayName] of [
+        [siteId, "site", sitePath, site.name],
+        [lineId, "line", linePath, line.name],
+      ] as const) {
+        await c.query(
+          `INSERT INTO namespace_versions
+                (tenant_id, operation, entity_id, entity_kind,
+                 from_state, to_state,
+                 actor_user_id, actor_kind, reason)
+           VALUES ($1, 'create', $2, $3, NULL, $4::jsonb, $5, 'human', 'onboarding wizard')`,
+          [tenantId, entityId, entityKind, JSON.stringify({ uns_path: path, name: displayName }), userId],
+        );
+      }
+
+      await c.query(
+        `UPDATE wizard_progress
+            SET status = 'completed',
+                current_step = 'finish',
+                completed_at = now(),
+                updated_at = now()
+          WHERE tenant_id = $1 AND wizard_kind = 'namespace_onboarding'`,
+        [tenantId],
+      );
+
+      return { kind: "ok" as const, siteId, lineId, sitePath, linePath };
+    });
+
+    if (result.kind === "no_progress") {
+      return NextResponse.json({ error: "wizard not started" }, { status: 400 });
+    }
+    if (result.kind === "incomplete") {
+      return NextResponse.json({ error: `missing payload: ${result.missing}` }, { status: 400 });
+    }
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    console.error("[api/wizard finish]", err);
+    return NextResponse.json({ error: "Finish failed" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Why

Phase 2 shipped the `/namespace` tab (tree, drag-drop, detail pane, proposals visual, audit log) but deliberately capped at list/move/rename — entity creation was deferred to Phase 3. That meant every tenant hit the `EmptyState` until ingest organically populated `kg_entities`. Mike's tenant included.

This slice ships the minimum onboarding flow so a tenant goes from signup to a populated namespace tab in three forms.

## What's in this PR

**New route** `/onboarding` (`mira-hub/src/app/(hub)/onboarding/page.tsx`)
- 3-step wizard: Company → Site → Line → Review/Finish
- Stepper UI with persistent progress (resume mid-wizard works)
- All `data-testid` hooks for follow-up Playwright

**New API** `/api/wizard/[step]` (`mira-hub/src/app/api/wizard/[step]/route.ts`)
- `GET /api/wizard/:step` — reads `wizard_progress` row, returns `not_started` if none
- `POST /api/wizard/:step` — upserts step payload into `step_payloads` JSONB, advances `current_step`
- `POST /api/wizard/finish` — reads saved payloads and:
  - `INSERT INTO kg_entities` for the site (uns_path `enterprise.<site_slug>`)
  - `INSERT INTO kg_entities` for the line (uns_path `enterprise.<site>.<line>`)
  - `INSERT INTO namespace_versions` audit row per create (operation='create', actor='human')
  - `UPDATE wizard_progress SET status='completed'`

All writes go through `withTenantContext` so RLS policies are enforced.

**UX wire-up**
- `/namespace` EmptyState CTA now points at `/onboarding` instead of "upload a manual" text.

**Tests** (`mira-hub/src/app/api/wizard/[step]/__tests__/route.test.ts`)
- 7 vitest cases — GET not_started, unknown step 400, POST validation, POST advance, finish flow asserts SQL order (`kg_entities` ×2 → `namespace_versions` ×2 → `UPDATE wizard_progress`), finish-with-missing-payload guard.
- All 7 pass locally.

## Schema (already on origin/main)

| Table | Migration |
|---|---|
| `wizard_progress` | `mira-hub/db/migrations/021_namespace_builder.sql` |
| `namespace_versions` | `mira-hub/db/migrations/021_namespace_builder.sql` |
| `kg_entities` + `uns_path::ltree` | `mira-hub/db/migrations/001_knowledge_graph.sql` + `010_kg_uns_path.sql` |
| `kg_*.approval_state` | `docs/migrations/008_kg_approval_state.sql` |

No new migrations in this PR.

## Out of scope (slice 1)

- Area + asset + component steps
- Tag-import CSV pipeline (`/api/v1/ingestion/tag-import`)
- QR capture flow (`/m/[assetTag]/capture`)
- `middleware.ts` redirect for trial users to `/onboarding` on first login

## Test plan

- [ ] CI passes (typecheck, lint, vitest, hub build)
- [ ] After deploy: hit `/onboarding`, complete all 3 steps, click "Create namespace"
- [ ] `/namespace` now renders 2 rows (site as root, line as child) instead of EmptyState
- [ ] `wizard_progress.status = 'completed'` for the test tenant
- [ ] 2 rows in `namespace_versions` with operation='create'

Spec: `docs/specs/maintenance-namespace-builder-spec.md` §"Onboarding wizard"
Plan: `docs/plans/2026-05-15-maintenance-namespace-builder.md` (Phase 3, slice 0)
ADR: `docs/adr/0013-uns-namespace-builder-schema-canonicalization.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)