### PR TITLE
fix(nginx): bump /hub/ proxy_read_timeout 60s → 120s to kill RSC 503s (WS2)

### DIFF
--- a/nginx-oracle.conf
+++ b/nginx-oracle.conf
@@ -97,7 +97,14 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 60s;
+        # RSC fetches (/hub/namespace/?_rsc=…) can stall on Next.js cold-start
+        # route compilation + the first uns_path tree query. The previous
+        # 60s read timeout was returning intermittent 502/503s on cold
+        # invocations of /namespace. 120s covers worst-case cold compile
+        # without masking a real upstream hang.
+        proxy_connect_timeout 15s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 120s;
         add_header Cache-Control "no-store" always;
     }
 


### PR DESCRIPTION
## Summary

WS2 of the 3-PR namespace-builder push. /hub/namespace/?_rsc=… returns intermittent 503s in prod — the hub location block had `proxy_read_timeout 60s`, too tight for a Next.js standalone cold-start + first uns_path tree query.

- `proxy_connect_timeout 15s` (fail fast if 3101 is actually down)
- `proxy_send_timeout 60s`
- `proxy_read_timeout 60s → 120s`

Other hub-adjacent locations stay untouched. 120s gives headroom for cold-compile + cold-pool DB roundtrip without masking a real upstream hang.

## Test plan

Post-deploy on Oracle VPS:

\`\`\`bash
for i in $(seq 1 50); do
  curl -s -o /dev/null -w "%{http_code}\n" \\
    "https://app.factorylm.com/hub/namespace/?_rsc=test-$i"
done | sort | uniq -c
# expect 50 × 200, 0 × 503
\`\`\`

Deploy mechanism: \`oracle-deploy.sh\` copies this conf to \`/etc/nginx/sites-available/factorylm\` then \`nginx -t && systemctl reload nginx\`.

## Out of scope

- Pre-warming the namespace tree query (e.g. a cron-warm at boot). Cheaper fix is the timeout bump; pre-warm can land if 120s still isn't enough after the next cold deploy.
- `nginx-oracle-v2.conf` and `nginx-phase2-live.conf` — leaving those for a follow-up audit; they may have the same gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)