### PR TITLE
fix(hub): namespace CounterLink renders stable DOM regardless of value (CRA-285)

### DIFF
--- a/mira-hub/src/app/(hub)/namespace/page.tsx
+++ b/mira-hub/src/app/(hub)/namespace/page.tsx
@@ -368,17 +368,23 @@ function Stat({ label, value }: { label: string; value: number }) {
 
 function CounterLink({ label, value, href }: { label: string; value: number; href: string }) {
   const isZero = value === 0;
-  if (isZero) {
-    return <Stat label={label} value={value} />;
-  }
   return (
     <Link
       href={href}
-      className="group flex items-center justify-between rounded px-2 py-1.5 hover:bg-blue-50"
+      className={`group flex items-center justify-between rounded px-2 py-1.5 ${
+        isZero ? "pointer-events-none cursor-default" : "hover:bg-blue-50"
+      }`}
+      aria-disabled={isZero}
+      tabIndex={isZero ? -1 : 0}
       data-testid="namespace-counter-link"
     >
-      <dt className="text-slate-500 group-hover:text-blue-700">{label}</dt>
-      <dd className="font-semibold text-slate-900 group-hover:text-blue-700">{value} →</dd>
+      <dt className={`${isZero ? "text-slate-500" : "text-slate-500 group-hover:text-blue-700"}`}>
+        {label}
+      </dt>
+      <dd className={`font-semibold text-slate-900 ${!isZero && "group-hover:text-blue-700"}`}>
+        {value}
+        {!isZero && " →"}
+      </dd>
     </Link>
   );
 }


### PR DESCRIPTION
Fixes #1356.

## Summary

CounterLink previously changed DOM type between renders: plain div when value === 0, Link when value > 0. This caused visual shimmer, screen reader inconsistency, and tab order variation.

Now CounterLink always renders as Link with stable DOM. When zero, it is non-interactive (pointer-events-none, cursor-default, aria-disabled, tabIndex=-1) and omits the arrow. Hover styling applies only when value > 0.

## Test results

- 211 tests pass (pre-existing failure unrelated to this fix)
- TypeScript clean
- No a11y regressions (consistent semantics + tab order across all states)