### PR TITLE
fix(nginx): proxy_read_timeout coverage — root, ingest, mira-web, Phase 2 confs

### DIFF
--- a/nginx-oracle-v2.conf
+++ b/nginx-oracle-v2.conf
@@ -157,7 +157,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 60s;
+        proxy_connect_timeout 15s; # mira-hub connection establishment
+        proxy_send_timeout 60s; # mira-hub request body transmission
+        proxy_read_timeout 120s; # mira-hub response streaming (SSE, long-lived requests)
         add_header Cache-Control "no-store" always;
     }
 

--- a/nginx-oracle.conf
+++ b/nginx-oracle.conf
@@ -120,6 +120,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 120s; # Open WebUI uses SSE/streaming responses; sustains long replies
     }
 
     # mira-ingest API
@@ -132,6 +133,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 120s; # Async PDF/document processing; OCR and ingest can be slow
     }
 
     # QR test station — no-cache (mira-web :3200)
@@ -142,6 +144,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        proxy_read_timeout 60s; # QR station endpoints have standard RPC latency
     }
 
     # mira-mcp REST API
@@ -153,6 +156,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s; # Knowledge graph queries have bounded latency
     }
 
     # QR scan + admin routes (mira-web :3200)
@@ -164,6 +168,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         add_header Cache-Control "no-store, no-cache, must-revalidate" always;
         add_header Service-Worker-Allowed "/" always;
+        proxy_read_timeout 60s; # mira-web QR scan + lookup endpoints
     }
 
     location /admin/ {
@@ -172,6 +177,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s; # mira-web admin endpoints
     }
 
     listen 443 ssl http2; # managed by Certbot

--- a/nginx-phase2-live.conf
+++ b/nginx-phase2-live.conf
@@ -302,7 +302,9 @@ Sitemap: https://app.factorylm.com/sitemap.xml
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_read_timeout 60s;
+        proxy_connect_timeout 15s; # mira-hub connection establishment
+        proxy_send_timeout 60s; # mira-hub request body transmission
+        proxy_read_timeout 120s; # mira-hub response streaming (SSE, long-lived requests)
         add_header Cache-Control "no-store" always;
         add_header X-Robots-Tag "noindex, nofollow" always;
     }


### PR DESCRIPTION
## Summary
Closes #1354 and #1355: adds explicit `proxy_read_timeout` and companion timeouts across all nginx configs to eliminate the 30s nginx default fallback.

## Changes
- **nginx-oracle.conf**: root location (120s for Open WebUI SSE); /api/ingest/ (120s for async PDF); /qr-test, /api/mcp/, /m/, /admin/ (60s for standard RPC)
- **nginx-oracle-v2.conf**: root location upgraded from 60s to full trio (proxy_connect_timeout 15s, proxy_send_timeout 60s, proxy_read_timeout 120s)
- **nginx-phase2-live.conf**: root location upgraded with same trio as v2

## Rationale
- **Root (Open WebUI / mira-hub)**: 120s read timeout handles streaming responses and long-lived requests (SSE)
- **/api/ingest/**: 120s for async document processing and OCR
- **mira-web endpoints** (/qr-test, /api/mcp/, /m/, /admin/): 60s for standard RPC latency
- **All**: Explicit values prevent silent fallback to nginx 30s default; comments document the why for future maintenance

## Testing
`nginx -t` will run on Oracle VPS during deploy via `oracle-deploy.sh`. No local test possible without nginx install.