### PR TITLE
fix(hub): uns.slugify returns null for empty input

### DIFF
--- a/mira-hub/src/app/api/wizard/[step]/route.ts
+++ b/mira-hub/src/app/api/wizard/[step]/route.ts
@@ -177,10 +177,18 @@ async function finishWizard(tenantId: string, userId: string) {
         return { kind: "incomplete" as const, missing: !site?.name ? "site" : "line" };
       }
 
-      const siteSlug = slugify(site.name);
-      const lineSlug = slugify(line.name);
       const sitePathStr = sitePath(site.name);
+      if (!sitePathStr) {
+        return { kind: "invalid_site_name" as const };
+      }
+
       const linePathStr = linePath(site.name, line.name);
+      if (!linePathStr) {
+        return { kind: "invalid_line_name" as const };
+      }
+
+      const siteSlug = slugify(site.name)!; // guaranteed non-null by sitePath check above
+      const lineSlug = slugify(line.name)!; // guaranteed non-null by linePath check above
 
       const siteRes = await c.query<{ id: string }>(
         `INSERT INTO kg_entities (tenant_id, entity_type, entity_id, name, properties, uns_path)
@@ -238,6 +246,12 @@ async function finishWizard(tenantId: string, userId: string) {
     }
     if (result.kind === "incomplete") {
       return NextResponse.json({ error: `missing payload: ${result.missing}` }, { status: 400 });
+    }
+    if (result.kind === "invalid_site_name") {
+      return NextResponse.json({ error: "site name is invalid for UNS path" }, { status: 400 });
+    }
+    if (result.kind === "invalid_line_name") {
+      return NextResponse.json({ error: "line name is invalid for UNS path" }, { status: 400 });
     }
     return NextResponse.json({ ok: true, ...result });
   } catch (err) {

--- a/mira-hub/src/lib/__tests__/uns.test.ts
+++ b/mira-hub/src/lib/__tests__/uns.test.ts
@@ -1,84 +1,129 @@
-import { describe, test, expect } from "vitest";
-import {
-  slugify,
-  sitePath,
-  linePath,
-  equipmentPath,
-  manufacturerPath,
-  modelPath,
-} from "../uns";
+import { describe, it, expect } from "vitest";
+import { slugify, sitePath, linePath, equipmentPath, manufacturerPath, modelPath } from "../uns";
 
-describe("uns.slugify", () => {
-  test("lowercases", () => {
-    expect(slugify("Plant 1")).toBe("plant_1");
+describe("uns", () => {
+  describe("slugify", () => {
+    it("returns null for empty string", () => {
+      expect(slugify("")).toBeNull();
+    });
+
+    it("returns null for non-alphanumeric chars only", () => {
+      expect(slugify("!!!")).toBeNull();
+      expect(slugify("   ")).toBeNull();
+    });
+
+    it("converts to lowercase", () => {
+      expect(slugify("PowerFlex")).toBe("powerflex");
+    });
+
+    it("collapses non-alphanumeric runs", () => {
+      expect(slugify("Power Flex 525")).toBe("power_flex_525");
+    });
+
+    it("strips leading and trailing underscores", () => {
+      expect(slugify("_PowerFlex_")).toBe("powerflex");
+    });
+
+    it("handles real-world examples", () => {
+      expect(slugify("Rockwell Automation")).toBe("rockwell_automation");
+    });
   });
 
-  test("collapses non-alphanumeric runs to single underscore", () => {
-    expect(slugify("Site A — Bay 3")).toBe("site_a_bay_3");
+  describe("sitePath", () => {
+    it("returns null for empty site name", () => {
+      expect(sitePath("")).toBeNull();
+    });
+
+    it("returns null for non-alphanumeric site name", () => {
+      expect(sitePath("!!!")).toBeNull();
+    });
+
+    it("builds valid site path", () => {
+      expect(sitePath("Detroit Plant")).toBe("enterprise.detroit_plant");
+    });
   });
 
-  test("strips leading/trailing underscore", () => {
-    expect(slugify("__hello world__")).toBe("hello_world");
+  describe("linePath", () => {
+    it("returns null for empty site", () => {
+      expect(linePath("", "Assembly")).toBeNull();
+    });
+
+    it("returns null for empty line", () => {
+      expect(linePath("Detroit Plant", "")).toBeNull();
+    });
+
+    it("returns null for non-alphanumeric site", () => {
+      expect(linePath("!!!", "Line 1")).toBeNull();
+    });
+
+    it("returns null for non-alphanumeric line", () => {
+      expect(linePath("Detroit Plant", "!!!")).toBeNull();
+    });
+
+    it("builds valid line path", () => {
+      expect(linePath("Detroit Plant", "Assembly Line 1")).toBe(
+        "enterprise.detroit_plant.assembly_line_1"
+      );
+    });
   });
 
-  test("caps at 64 chars", () => {
-    const long = "a".repeat(200);
-    expect(slugify(long).length).toBe(64);
+  describe("equipmentPath", () => {
+    it("returns null when parentPath is null", () => {
+      expect(equipmentPath(null, "Motor123")).toBeNull();
+    });
+
+    it("returns null when eqIdentifier is null", () => {
+      expect(equipmentPath("enterprise.detroit_plant.line_1", null)).toBeNull();
+    });
+
+    it("returns null when eqIdentifier is non-alphanumeric", () => {
+      expect(equipmentPath("enterprise.detroit_plant.line_1", "!!!")).toBeNull();
+    });
+
+    it("builds valid equipment path", () => {
+      expect(equipmentPath("enterprise.detroit_plant.line_1", "Motor-123")).toBe(
+        "enterprise.detroit_plant.line_1.motor_123"
+      );
+    });
   });
 
-  test("falls back to underscore for empty input", () => {
-    expect(slugify("")).toBe("_");
-    expect(slugify("!@#$%")).toBe("_");
+  describe("manufacturerPath", () => {
+    it("returns null for empty manufacturer", () => {
+      expect(manufacturerPath("")).toBeNull();
+    });
+
+    it("returns null for non-alphanumeric manufacturer", () => {
+      expect(manufacturerPath("!!!")).toBeNull();
+    });
+
+    it("builds valid manufacturer path", () => {
+      expect(manufacturerPath("Rockwell Automation")).toBe(
+        "enterprise.knowledge_base.rockwell_automation"
+      );
+    });
   });
 
-  test("matches SQL uns_slug semantics for typical CMMS strings", () => {
-    expect(slugify("Ingersoll Rand")).toBe("ingersoll_rand");
-    expect(slugify("PowerFlex 525")).toBe("powerflex_525");
-    expect(slugify("Air Compressor #1")).toBe("air_compressor_1");
-  });
-});
+  describe("modelPath", () => {
+    it("returns null for empty manufacturer", () => {
+      expect(modelPath("", "525")).toBeNull();
+    });
 
-describe("uns path builders", () => {
-  test("sitePath", () => {
-    expect(sitePath("Lake Wales Plant")).toBe("enterprise.lake_wales_plant");
-  });
+    it("returns null for empty model", () => {
+      expect(modelPath("Rockwell Automation", "")).toBeNull();
+    });
 
-  test("linePath under site", () => {
-    expect(linePath("Lake Wales Plant", "Line 3")).toBe(
-      "enterprise.lake_wales_plant.line_3",
-    );
-  });
+    it("returns null for non-alphanumeric manufacturer", () => {
+      expect(modelPath("!!!", "525")).toBeNull();
+    });
 
-  test("manufacturerPath under knowledge_base", () => {
-    expect(manufacturerPath("Rockwell Automation")).toBe(
-      "enterprise.knowledge_base.rockwell_automation",
-    );
-  });
+    it("returns null for non-alphanumeric model", () => {
+      expect(modelPath("Rockwell Automation", "!!!")).toBeNull();
+    });
 
-  test("modelPath under manufacturer", () => {
-    expect(modelPath("Rockwell Automation", "PowerFlex 525")).toBe(
-      "enterprise.knowledge_base.rockwell_automation.powerflex_525",
-    );
-  });
-});
-
-describe("equipmentPath", () => {
-  test("appends slug under parent line", () => {
-    expect(equipmentPath("enterprise.plant_a.line_1", "Compressor-7")).toBe(
-      "enterprise.plant_a.line_1.compressor_7",
-    );
-  });
-
-  test("returns null with no parent path", () => {
-    expect(equipmentPath(null, "Compressor-7")).toBeNull();
-  });
-
-  test("returns null with no equipment identifier", () => {
-    expect(equipmentPath("enterprise.plant_a.line_1", null)).toBeNull();
-    expect(equipmentPath("enterprise.plant_a.line_1", "")).toBeNull();
-  });
-
-  test("rejects identifier that slugifies to bare underscore", () => {
-    expect(equipmentPath("enterprise.plant_a.line_1", "!!!")).toBeNull();
+    it("builds valid model path", () => {
+      expect(modelPath("Rockwell Automation", "PowerFlex 525")).toBe(
+        "enterprise.knowledge_base.rockwell_automation.powerflex_525"
+      );
+    });
   });
 });

--- a/mira-hub/src/lib/knowledge-graph/cmms-sync.ts
+++ b/mira-hub/src/lib/knowledge-graph/cmms-sync.ts
@@ -233,6 +233,9 @@ async function mirrorKnowledgeEntities(
   for (const r of rows) {
     const mfr = r.manufacturer;
     const mfrPath = manufacturerPath(mfr);
+    // manufacturerPath returns null when the name slugs to empty (e.g., "!!!").
+    // Skip — SQL uns_slug() would have returned NULL for the same input.
+    if (!mfrPath) continue;
     if (!mfrSet.has(mfrPath)) {
       mfrSet.set(mfrPath, {
         entityType: "manufacturer",
@@ -244,6 +247,7 @@ async function mirrorKnowledgeEntities(
     }
     if (r.model) {
       const mPath = modelPath(mfr, r.model);
+      if (!mPath) continue;
       modelEntries.push({
         entityType: "model",
         entityId: mPath,

--- a/mira-hub/src/lib/uns.ts
+++ b/mira-hub/src/lib/uns.ts
@@ -18,31 +18,33 @@
 
 /**
  * Lowercase, collapse any run of non-alphanumeric chars to `_`, strip
- * leading/trailing `_`, cap at 64 chars, fall back to `_` for empty input.
+ * leading/trailing `_`, cap at 64 chars, return null for empty input.
  *
  * Matches:
- *   - SQL `uns_slug()` in migration 014
+ *   - SQL `uns_slug()` in migration 014 (returns NULL for empty)
  *   - the wizard helper that previously lived inline in
  *     `mira-hub/src/app/api/wizard/[step]/route.ts`
  */
-export function slugify(value: string): string {
-  return (
-    value
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "_")
-      .replace(/^_+|_+$/g, "")
-      .slice(0, 64) || "_"
-  );
+export function slugify(value: string): string | null {
+  const result = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 64);
+  return result.length > 0 ? result : null;
 }
 
 /** Compact UNS path for a site. */
-export function sitePath(site: string): string {
-  return `enterprise.${slugify(site)}`;
+export function sitePath(site: string): string | null {
+  const slug = slugify(site);
+  return slug ? `enterprise.${slug}` : null;
 }
 
 /** Compact UNS path for a line under a site. */
-export function linePath(site: string, line: string): string {
-  return `${sitePath(site)}.${slugify(line)}`;
+export function linePath(site: string, line: string): string | null {
+  const sPath = sitePath(site);
+  const lSlug = slugify(line);
+  return sPath && lSlug ? `${sPath}.${lSlug}` : null;
 }
 
 /**
@@ -56,19 +58,25 @@ export function linePath(site: string, line: string): string {
  * Returns `null` when both `parentPath` and `eqIdentifier` are absent — the
  * caller decides whether to skip the row or leave uns_path unset.
  */
-export function equipmentPath(parentPath: string | null, eqIdentifier: string | null): string | null {
+export function equipmentPath(
+  parentPath: string | null,
+  eqIdentifier: string | null
+): string | null {
   const slug = eqIdentifier ? slugify(eqIdentifier) : null;
-  if (!slug || slug === "_") return null;
+  if (!slug) return null;
   if (!parentPath) return null;
   return `${parentPath}.${slug}`;
 }
 
 /** Knowledge-base UNS path for a manufacturer node. */
-export function manufacturerPath(manufacturer: string): string {
-  return `enterprise.knowledge_base.${slugify(manufacturer)}`;
+export function manufacturerPath(manufacturer: string): string | null {
+  const slug = slugify(manufacturer);
+  return slug ? `enterprise.knowledge_base.${slug}` : null;
 }
 
 /** Knowledge-base UNS path for a model under a manufacturer. */
-export function modelPath(manufacturer: string, model: string): string {
-  return `${manufacturerPath(manufacturer)}.${slugify(model)}`;
+export function modelPath(manufacturer: string, model: string): string | null {
+  const mPath = manufacturerPath(manufacturer);
+  const mSlug = slugify(model);
+  return mPath && mSlug ? `${mPath}.${mSlug}` : null;
 }


### PR DESCRIPTION
## Summary

Updated `slugify()` to return `string | null` instead of falling back to `"_"`, ensuring TypeScript UNS path builders match SQL semantics byte-for-byte.

## Changes

- **uns.ts**: `slugify()` now returns `null` for empty input, matching SQL `uns_slug()`
- All path builders properly propagate null: `sitePath()`, `linePath()`, `equipmentPath()`, `manufacturerPath()`, `modelPath()`
- **wizard route**: Added validation for `sitePathStr` and `linePathStr` before proceeding; returns 400 errors for invalid names

## Testing

- 26 unit tests pass (uns.test.ts)
- TypeScript compilation succeeds
- Wizard route handles null cases with proper error responses

## Verification

```bash
npm test -- src/lib/__tests__/uns.test.ts  # 26 passed
npx tsc --noEmit                            # no errors
```