### PR TITLE
fix(ops): pass --commit to backfill scripts in apply-migrations workflow

### DIFF
--- a/.github/workflows/apply-migrations.yml
+++ b/.github/workflows/apply-migrations.yml
@@ -301,7 +301,7 @@ jobs:
             echo "::error::tools/uns_backfill.py missing — was PR #1245 reverted?"
             exit 1
           fi
-          doppler run --project factorylm --config prd -- python tools/uns_backfill.py
+          doppler run --project factorylm --config prd -- python tools/uns_backfill.py --commit
 
       - name: Run cmms_equipment backfill (tools/cmms_equipment_uns_backfill.py)
         env:
@@ -312,4 +312,4 @@ jobs:
             echo "::error::tools/cmms_equipment_uns_backfill.py missing — was PR #1245 reverted?"
             exit 1
           fi
-          doppler run --project factorylm --config prd -- python tools/cmms_equipment_uns_backfill.py
+          doppler run --project factorylm --config prd -- python tools/cmms_equipment_uns_backfill.py --commit


### PR DESCRIPTION
## Summary

The 2026-05-15 production migration run completed \"successfully\" but the UNS backfill silently wrote **zero rows** — both backfill scripts default to dry-run and require \`--commit\` to actually write.

From the run log ([action #25903387377](https://github.com/Mikecranesync/MIRA/actions/runs/25903387377)):

\`\`\`
WARNING uns-backfill: DRY-RUN — skipping SQL pass. Pass --commit to apply.
INFO backfill: Found 266 distinct (tenant, manufacturer, model) triples
INFO backfill:   [DRY] would upsert 1 equipment, 1 manuals, link 417 chunks
... (repeated for every triple — nothing persisted)
\`\`\`

This patch adds \`--commit\` to both invocations in the \`backfill\` job.

## Why this matters

\`run_backfill=true\` was meant to opt **in** to writes. Default-dry-run on the script is reasonable for local invocations; defaulting-to-dry-run inside a workflow gated by a separate \`run_backfill=true\` input is a silent footgun.

## After this lands

Re-trigger the workflow:

\`\`\`bash
gh workflow run apply-migrations.yml -f mode=apply -f run_backfill=true
\`\`\`

Migrations 014-018 are already applied — the apply pass will short-circuit on \`NOTICE: relation \"…\" already exists, skipping\` for every object, and the verify step will pass (it already did on 2026-05-15). The **backfill job** will do the net-new work: 266 kg_entities triples + cmms_equipment.uns_path rows.

## Scope

- 2 lines changed in \`.github/workflows/apply-migrations.yml\`
- No script changes — both \`tools/uns_backfill.py\` and \`tools/cmms_equipment_uns_backfill.py\` keep dry-run-by-default for local safety
- No new inputs / config knobs (Karpathy: no speculative flexibility)

## Test plan

- [ ] CI passes (workflow-only diff; existing jobs unaffected)
- [ ] After merge, dry-run from Actions tab still works (\`mode=dry-run\` skips the backfill job entirely via existing \`if:\` guard — no behavior change)
- [ ] Real apply + backfill writes ~266 rows; verify with \`SELECT count(*) FROM kg_entities WHERE uns_path IS NOT NULL;\` and \`SELECT count(*) FROM cmms_equipment WHERE uns_path IS NOT NULL;\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)