### PR TITLE
feat(hub): pre-expo P0 demo fixes — Upload Document + Connect Google Drive

### DIFF
--- a/mira-hub/src/app/(hub)/assets/[id]/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, use, useEffect } from "react";
+import { useState, use, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import {
@@ -11,9 +11,12 @@ import {
 import { AssetChat } from "@/components/AssetChat";
 import { AssetIntelligencePanel } from "@/components/AssetIntelligencePanel";
 import { QrCodeModal } from "@/components/qr-code-modal";
+import { UploadPicker, type PickResult } from "@/components/UploadPicker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/providers/toast-provider";
+import { API_BASE } from "@/lib/config";
+import { Upload } from "lucide-react";
 
 /* ─── Mock data ─────────────────────────────────────────────────────── */
 const ASSETS: Record<string, {
@@ -244,7 +247,7 @@ export default function AssetDetailPage({ params }: { params: Promise<{ id: stri
           {activeTab === "overview"      && <OverviewTab asset={asset} onAskMira={() => setActiveTab("ask")} />}
           {activeTab === "activity"      && <ActivityTab />}
           {activeTab === "workorders"    && <WorkOrdersTab />}
-          {activeTab === "documents"     && <DocumentsTab />}
+          {activeTab === "documents"     && <DocumentsTab assetId={id} assetTag={asset.tag} />}
           {activeTab === "parts"         && <PartsTab />}
           {activeTab === "intelligence"  && <AssetIntelligencePanel assetId={id} />}
         </div>
@@ -383,31 +386,136 @@ function WorkOrdersTab() {
 }
 
 /* ─── Documents Tab ─────────────────────────────────────────────────── */
-function DocumentsTab() {
+type AssetDoc = {
+  sourceUrl: string;
+  title: string;
+  modelNumber: string | null;
+  equipmentType: string | null;
+  chunkCount: number;
+  lastIndexed: string | null;
+  verified: boolean;
+};
+
+function DocumentsTab({ assetId, assetTag }: { assetId: string; assetTag: string }) {
   const DOC_STATE_VARIANT: Record<string, "indexed" | "partial" | "superseded"> = {
     indexed: "indexed", partial: "partial", superseded: "superseded",
   };
-  // Map local ids to real doc ids (d01 format)
   const docIdMap: Record<string, string> = { d1: "d01", d2: "d02", d3: "d03", d4: "d09" };
+  const { toast } = useToast();
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [realDocs, setRealDocs] = useState<AssetDoc[] | null>(null);
+
+  const fetchDocs = useCallback(async () => {
+    try {
+      const res = await fetch(`${API_BASE}/api/assets/${assetId}/documents/`, { cache: "no-store" });
+      if (res.ok && !res.url.includes("/login")) {
+        const data = (await res.json()) as AssetDoc[];
+        if (Array.isArray(data)) setRealDocs(data);
+      }
+    } catch {
+      /* silent — falls back to mock list */
+    }
+  }, [assetId]);
+
+  useEffect(() => { void fetchDocs(); }, [fetchDocs]);
+
+  async function handleLocalFiles(files: File[], tag: string | null) {
+    for (const file of files) {
+      const form = new FormData();
+      form.append("file", file);
+      if (tag) form.append("assetTag", tag);
+      const res = await fetch(`${API_BASE}/api/uploads/local`, { method: "POST", body: form });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+        throw new Error(typeof body.error === "string" ? body.error : `Upload failed (${res.status})`);
+      }
+    }
+    toast(`Uploaded ${files.length} file${files.length === 1 ? "" : "s"} — parsing in background`, "success");
+    // Give the ingest pipeline a moment to register before refreshing.
+    setTimeout(() => { void fetchDocs(); }, 1500);
+  }
+
+  async function handleCloudPicks(results: PickResult[], tag: string | null) {
+    for (const r of results) {
+      await fetch(`${API_BASE}/api/uploads`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...r, assetTag: tag ?? undefined }),
+      });
+    }
+    toast(`Imported ${results.length} from cloud — parsing in background`, "success");
+    setTimeout(() => { void fetchDocs(); }, 1500);
+  }
+
+  // Prefer real docs when present; fall back to mock so demo data renders for assets
+  // that don't yet have knowledge_entries.
+  const useReal = realDocs !== null && realDocs.length > 0;
+
   return (
     <div className="space-y-3">
-      {DOCS_LIST.map((doc) => (
-        <Link key={doc.id} href={`/documents/${docIdMap[doc.id] ?? "d01"}`}>
-          <div className="card p-4 flex items-center gap-3 hover:shadow-md transition-shadow cursor-pointer">
-            <FileText className="w-8 h-8 flex-shrink-0 p-1.5 rounded-lg"
-              style={{ backgroundColor: "var(--surface-1)", color: "var(--foreground-muted)" }} />
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium truncate" style={{ color: "var(--foreground)" }}>{doc.name}</p>
-              <div className="flex items-center gap-2 mt-1 flex-wrap">
-                <Badge variant="outline" className="text-[10px]">{doc.category}</Badge>
-                <Badge variant={DOC_STATE_VARIANT[doc.state]} className="capitalize text-[10px]">{doc.state}</Badge>
-                <span className="text-[11px]" style={{ color: "var(--foreground-subtle)" }}>{doc.pages}p · {doc.date}</span>
+      <div className="flex items-center justify-between">
+        <p className="text-xs" style={{ color: "var(--foreground-muted)" }}>
+          {useReal
+            ? `${realDocs!.length} document${realDocs!.length === 1 ? "" : "s"} linked to this asset`
+            : `${DOCS_LIST.length} documents (demo)`}
+        </p>
+        <Button
+          size="sm"
+          onClick={() => setPickerOpen(true)}
+          data-testid="upload-document-button"
+          className="gap-1.5"
+        >
+          <Upload className="w-3.5 h-3.5" />
+          Upload Document
+        </Button>
+      </div>
+
+      {useReal
+        ? realDocs!.map((doc) => (
+            <div key={doc.sourceUrl} className="card p-4 flex items-center gap-3">
+              <FileText className="w-8 h-8 flex-shrink-0 p-1.5 rounded-lg"
+                style={{ backgroundColor: "var(--surface-1)", color: "var(--foreground-muted)" }} />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate" style={{ color: "var(--foreground)" }}>{doc.title}</p>
+                <div className="flex items-center gap-2 mt-1 flex-wrap">
+                  {doc.equipmentType && <Badge variant="outline" className="text-[10px]">{doc.equipmentType}</Badge>}
+                  <Badge variant={doc.verified ? "indexed" : "partial"} className="capitalize text-[10px]">
+                    {doc.verified ? "indexed" : "pending"}
+                  </Badge>
+                  <span className="text-[11px]" style={{ color: "var(--foreground-subtle)" }}>
+                    {doc.chunkCount} chunk{doc.chunkCount === 1 ? "" : "s"}
+                    {doc.lastIndexed ? ` · ${new Date(doc.lastIndexed).toISOString().slice(0,10)}` : ""}
+                  </span>
+                </div>
               </div>
             </div>
-            <ChevronRight className="w-4 h-4 flex-shrink-0" style={{ color: "var(--foreground-subtle)" }} />
-          </div>
-        </Link>
-      ))}
+          ))
+        : DOCS_LIST.map((doc) => (
+            <Link key={doc.id} href={`/documents/${docIdMap[doc.id] ?? "d01"}`}>
+              <div className="card p-4 flex items-center gap-3 hover:shadow-md transition-shadow cursor-pointer">
+                <FileText className="w-8 h-8 flex-shrink-0 p-1.5 rounded-lg"
+                  style={{ backgroundColor: "var(--surface-1)", color: "var(--foreground-muted)" }} />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate" style={{ color: "var(--foreground)" }}>{doc.name}</p>
+                  <div className="flex items-center gap-2 mt-1 flex-wrap">
+                    <Badge variant="outline" className="text-[10px]">{doc.category}</Badge>
+                    <Badge variant={DOC_STATE_VARIANT[doc.state]} className="capitalize text-[10px]">{doc.state}</Badge>
+                    <span className="text-[11px]" style={{ color: "var(--foreground-subtle)" }}>{doc.pages}p · {doc.date}</span>
+                  </div>
+                </div>
+                <ChevronRight className="w-4 h-4 flex-shrink-0" style={{ color: "var(--foreground-subtle)" }} />
+              </div>
+            </Link>
+          ))}
+
+      <UploadPicker
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onLocalFiles={handleLocalFiles}
+        onCloudPicks={handleCloudPicks}
+        defaultAssetTag={assetTag}
+        hideAssetPicker
+      />
     </div>
   );
 }

--- a/mira-hub/src/components/UploadPicker.tsx
+++ b/mira-hub/src/components/UploadPicker.tsx
@@ -110,11 +110,15 @@ export function UploadPicker({
   onClose,
   onLocalFiles,
   onCloudPicks,
+  defaultAssetTag = null,
+  hideAssetPicker = false,
 }: {
   open: boolean;
   onClose: () => void;
   onLocalFiles: (files: File[], assetTag: string | null) => void | Promise<void>;
   onCloudPicks: (results: PickResult[], assetTag: string | null) => void | Promise<void>;
+  defaultAssetTag?: string | null;
+  hideAssetPicker?: boolean;
 }) {
   const [googleReady, setGoogleReady] = useState(false);
   const [dropboxReady, setDropboxReady] = useState(false);
@@ -127,7 +131,12 @@ export function UploadPicker({
 
   const [assets, setAssets] = useState<Asset[]>([]);
   const [assetSearch, setAssetSearch] = useState("");
-  const [selectedAsset, setSelectedAsset] = useState<string | null>(null);
+  const [selectedAsset, setSelectedAsset] = useState<string | null>(defaultAssetTag);
+
+  // Re-sync when the consumer opens the picker for a different asset.
+  useEffect(() => {
+    if (open) setSelectedAsset(defaultAssetTag);
+  }, [open, defaultAssetTag]);
 
   useEffect(() => {
     if (!open) return;
@@ -285,7 +294,7 @@ export function UploadPicker({
             </button>
           </div>
 
-          {assets.length > 0 && (
+          {!hideAssetPicker && assets.length > 0 && (
             <div className="mb-3">
               <label className="text-xs font-medium" style={{ color: "var(--foreground-muted)" }}>
                 Link to asset (optional)
@@ -399,19 +408,30 @@ export function UploadPicker({
           </div>
 
           <div className="grid grid-cols-2 gap-2">
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={!googleAvailable || !pickerLoaded || uploading}
-              onClick={openGoogle}
-              title={!googleAvailable ? "Connect Google Workspace in Channels to enable" : undefined}
-            >
-              {googleAvailable && !pickerLoaded ? (
-                <><Loader2 className="w-3.5 h-3.5 animate-spin mr-1 inline" />Loading…</>
-              ) : (
-                "📁 From Google Drive"
-              )}
-            </Button>
+            {googleAvailable ? (
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={!pickerLoaded || uploading}
+                onClick={openGoogle}
+              >
+                {!pickerLoaded ? (
+                  <><Loader2 className="w-3.5 h-3.5 animate-spin mr-1 inline" />Loading…</>
+                ) : (
+                  "📁 From Google Drive"
+                )}
+              </Button>
+            ) : (
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => { window.location.href = "/hub/api/auth/google"; }}
+                title="Sign in with Google to pick files from Drive"
+                data-testid="connect-google-drive"
+              >
+                🔗 Connect Google Drive
+              </Button>
+            )}
             <Button
               variant="secondary"
               size="sm"
@@ -427,17 +447,17 @@ export function UploadPicker({
             </Button>
           </div>
 
-          {!googleAvailable && !dropboxAvailable && (
+          {!googleAvailable && (
             <p className="text-[11px] mt-2 text-center" style={{ color: "var(--foreground-subtle)" }}>
-              Connect Google Workspace or Dropbox in{" "}
+              Or manage all integrations in{" "}
               <Link
                 href="/hub/channels"
                 className="font-medium underline-offset-2 hover:underline"
                 style={{ color: "var(--brand-blue)" }}
               >
                 Channels
-              </Link>{" "}
-              to enable cloud picking.
+              </Link>
+              .
             </p>
           )}
 

--- a/mira-hub/tests/e2e/proof-hub-p0-demo-fixes.spec.ts
+++ b/mira-hub/tests/e2e/proof-hub-p0-demo-fixes.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Proof-of-work spec for the P0 pre-expo demo fixes (PR feat/hub-p0-demo-fixes).
+ *
+ * FIX 1 — /scan camera page + QR buttons (already shipped on origin/main in
+ *         commit dec5bb1f; this spec adds a regression check so it can't
+ *         silently break before the expo).
+ * FIX 2 — "Upload Document" button on /assets/[id] Documents tab → opens
+ *         UploadPicker pre-linked to the current asset (assetTag).
+ * FIX 3 — "Connect Google Drive" CTA inside UploadPicker when Google isn't
+ *         connected → navigates to /hub/api/auth/google to start OAuth.
+ *
+ * The hub login UI requires a real next-auth session; running the full
+ * authenticated DOM crawl from a stateless CI worker is flaky. We stick to
+ * request-level proofs (route exists, OAuth init redirects to Google) plus a
+ * source-file assertion that the data-testid hooks our new DOM actually ships.
+ * Eyeball verification of the rendered UI happens post-deploy on the demo
+ * tablet — that's the only environment that matters for the expo.
+ */
+import { test, expect } from "@playwright/test";
+import * as fs from "fs";
+import * as path from "path";
+
+const HUB = process.env.HUB_URL ?? "https://app.factorylm.com/hub";
+const OUT_DIR = path.resolve(process.cwd(), "test-results/proof-hub-p0-demo-fixes");
+const REPO_ROOT = path.resolve(__dirname, "../..");
+
+test.beforeAll(() => fs.mkdirSync(OUT_DIR, { recursive: true }));
+
+/* ─── FIX 1 — /scan route compiles ──────────────────────────────────── */
+
+test("FIX 1: /hub/scan route exists (not 404)", async ({ request }) => {
+  const res = await request.get(`${HUB}/scan/`, { maxRedirects: 0, failOnStatusCode: false });
+  expect(res.status()).not.toBe(404);
+  expect([200, 301, 307, 308]).toContain(res.status());
+});
+
+test("FIX 1: /hub/feed page references the /scan link in its FAB", async () => {
+  const feed = fs.readFileSync(
+    path.join(REPO_ROOT, "src/app/(hub)/feed/page.tsx"),
+    "utf8",
+  );
+  expect(feed).toMatch(/href:\s*["']\/scan["']/);
+});
+
+test("FIX 1: /hub/assets page uses a Link to /scan for Scan QR button", async () => {
+  const assets = fs.readFileSync(
+    path.join(REPO_ROOT, "src/app/(hub)/assets/page.tsx"),
+    "utf8",
+  );
+  expect(assets).toMatch(/<Link\s+href=["']\/scan["']/);
+});
+
+/* ─── FIX 2 — Upload Document button on asset detail ────────────────── */
+
+test("FIX 2: /hub/assets/1 route exists (not 404)", async ({ request }) => {
+  const res = await request.get(`${HUB}/assets/1/`, { maxRedirects: 0, failOnStatusCode: false });
+  expect(res.status()).not.toBe(404);
+});
+
+test("FIX 2: assets/[id] DocumentsTab ships data-testid='upload-document-button'", async () => {
+  const src = fs.readFileSync(
+    path.join(REPO_ROOT, "src/app/(hub)/assets/[id]/page.tsx"),
+    "utf8",
+  );
+  expect(src).toMatch(/data-testid=["']upload-document-button["']/);
+  // UploadPicker must be passed the asset tag so uploads pre-link to this asset.
+  expect(src).toMatch(/defaultAssetTag=\{assetTag\}/);
+});
+
+test("FIX 2: /hub/api/uploads/local accepts multipart (auth-redirects unauth, never 404)", async ({ request }) => {
+  const res = await request.post(`${HUB}/api/uploads/local/`, {
+    multipart: { file: { name: "x.pdf", mimeType: "application/pdf", buffer: Buffer.from("%PDF-1.4\n") } },
+    maxRedirects: 0,
+    failOnStatusCode: false,
+  });
+  expect(res.status()).not.toBe(404);
+  // Unauth → 301/307 (auth redirect) OR 401 from sessionOr401. Either proves the route exists.
+  expect([200, 201, 301, 307, 401]).toContain(res.status());
+});
+
+/* ─── FIX 3 — Connect Google Drive CTA ──────────────────────────────── */
+
+test("FIX 3: UploadPicker ships data-testid='connect-google-drive'", async () => {
+  const src = fs.readFileSync(
+    path.join(REPO_ROOT, "src/components/UploadPicker.tsx"),
+    "utf8",
+  );
+  expect(src).toMatch(/data-testid=["']connect-google-drive["']/);
+  // The CTA must route to the OAuth init endpoint.
+  expect(src).toMatch(/\/hub\/api\/auth\/google/);
+});
+
+test("FIX 3: /hub/api/auth/google OAuth init route exists (not 404)", async ({ request }) => {
+  const res = await request.get(`${HUB}/api/auth/google/`, {
+    maxRedirects: 0,
+    failOnStatusCode: false,
+  });
+  expect(res.status()).not.toBe(404);
+});
+
+/* ─── Smoke screenshot (no auth needed) ─────────────────────────────── */
+
+test("smoke: /hub/login renders without errors (proves middleware healthy)", async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (m) => { if (m.type() === "error") consoleErrors.push(m.text()); });
+  await page.goto(`${HUB}/login`, { waitUntil: "domcontentloaded", timeout: 20_000 });
+  await page.screenshot({ path: path.join(OUT_DIR, "smoke-login.png"), fullPage: true });
+  // Allow a few next-auth client-fetch warnings (a known pre-existing console noise).
+  expect(consoleErrors.length).toBeLessThan(5);
+});


### PR DESCRIPTION
## Summary

Three P0 fixes for the May 21 expo demo:

- **FIX 1 — /scan camera + Scan-QR buttons.** Already shipped on origin/main in dec5bb1f. This PR adds a regression check so the wiring can't silently break before the expo.
- **FIX 2 — \"Upload Document\" button on asset detail Documents tab.** DocumentsTab now accepts `assetId` + `assetTag` props, fetches real documents from `/api/assets/[id]/documents` (with the existing mock list as a graceful fallback for unseeded demo data), and exposes an \"Upload Document\" button that opens UploadPicker pre-linked to the current asset.
- **FIX 3 — Connect Google Drive CTA.** When Google isn't connected, the previously-disabled \"From Google Drive\" button is replaced with an enabled \"🔗 Connect Google Drive\" CTA that navigates to `/hub/api/auth/google` to start the OAuth flow. Same picker is used on `/knowledge` and on `/assets/[id]`, so one change fixes both surfaces.

## Files touched

- `mira-hub/src/components/UploadPicker.tsx` — adds `defaultAssetTag` + `hideAssetPicker` props and the Connect-Google-Drive CTA.
- `mira-hub/src/app/(hub)/assets/[id]/page.tsx` — DocumentsTab rewrite with real fetch + Upload Document button.
- `mira-hub/tests/e2e/proof-hub-p0-demo-fixes.spec.ts` — new proof spec (9 tests, all passing against prod).

## Test plan

- [x] `bun run test` — 257/257 unit tests pass.
- [x] `bun run build` — Next.js standalone build succeeds (all routes including `/scan`, `/assets/[id]`, `/knowledge` compile).
- [x] `bunx playwright test tests/e2e/proof-hub-p0-demo-fixes.spec.ts` — 9/9 pass against `https://app.factorylm.com/hub`.
- [x] `bunx tsc --noEmit` — no new type errors (one pre-existing unrelated TS2578 in `rls-deny.integration.test.ts` only).
- [ ] **Post-deploy eyeball check on demo tablet** (manual):
    1. `/hub/scan` opens the camera reticle (or manual-input fallback).
    2. `/hub/assets/<id>` → Documents tab shows an \"Upload Document\" button; tapping it opens the picker pre-linked to that asset.
    3. `/hub/knowledge` → \"Upload\" button → picker shows \"🔗 Connect Google Drive\" (since the playwright test tenant has no Google link); tapping it opens the Google OAuth consent screen.

## Notes

- Authenticated DOM verification was not added to the proof spec because the existing login fixture is flaky against the current production login UI (drifted from when the fixture was written). The fixture is not in this PR's scope; proof-spec leans on route checks + source-file assertions instead. For the expo, the proof is the deploy + Mike walking through the three flows on the demo tablet.
- The eslint rule `react-x/no-set-state-in-effect` fires twice on the new code, matching ~40 pre-existing instances across the codebase — not a CI blocker.
- Deploy: `gh workflow run deploy-vps.yml --ref main` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)