### PR TITLE
fix(hub): disable nginx proxy_buffering on /hub/ to fix RSC 503s (#1345)

### DIFF
--- a/nginx-oracle.conf
+++ b/nginx-oracle.conf
@@ -97,14 +97,19 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        # RSC fetches (/hub/namespace/?_rsc=…) can stall on Next.js cold-start
-        # route compilation + the first uns_path tree query. The previous
-        # 60s read timeout was returning intermittent 502/503s on cold
-        # invocations of /namespace. 120s covers worst-case cold compile
-        # without masking a real upstream hang.
+        # RSC fetches (/hub/namespace/?_rsc=…) stream a React Flight payload
+        # from the standalone Next.js server. Two settings are load-bearing
+        # for that path:
+        #   - proxy_read_timeout 120s — covers cold-compile + first uns_path
+        #     tree query worst-case. 60s was returning intermittent 502/503s.
+        #   - proxy_buffering off    — nginx must not wait for the full body
+        #     before forwarding, otherwise the upstream RSC stream can hit
+        #     send_timeout/header_timeout while nginx accumulates chunks and
+        #     the client sees a 503. Closes #1345.
         proxy_connect_timeout 15s;
         proxy_send_timeout 60s;
         proxy_read_timeout 120s;
+        proxy_buffering off;
         add_header Cache-Control "no-store" always;
     }
 


### PR DESCRIPTION
Closes #1345.

## Summary

Adds `proxy_buffering off;` to the `/hub/` location block in `nginx-oracle.conf` so RSC streams (`/hub/namespace/?_rsc=…`) get forwarded chunk-by-chunk instead of buffered to completion. Buffering is the most plausible cause of the intermittent 503s Mike saw in the field (per the fix candidates in the issue body) — `proxy_read_timeout 120s` is already in place from a prior fix, so timeout is not the bottleneck.

## Files touched

- `nginx-oracle.conf` — 1 directive added inside the existing `location /hub/` block. Comment expanded to explain why both timeouts AND buffering matter for RSC paths.

## Test plan

- [ ] After Oracle deploy: `for i in $(seq 1 50); do curl -sf -o /dev/null -w '%{http_code} ' "https://app.factorylm.com/hub/namespace/?_rsc=t$i"; done` — confirm 50× 200 (zero 503s).
- [ ] Live: hard-reload `/namespace` 10× in DevTools with cache disabled — no 503 in Network tab.

## Deploy

`nginx-oracle.conf` is deployed by hand via `oracle-deploy.sh` (not by `deploy-vps.yml`). After merge:

```
scp nginx-oracle.conf <oracle-host>:/etc/nginx/sites-available/factorylm
ssh <oracle-host> 'sudo nginx -t && sudo systemctl reload nginx'
```

## Karpathy §3 — surgical

One directive added, one comment expanded. The 9 other `location` blocks in the same file were left alone; they don't stream RSC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)