### PR TITLE
fix(retrieval): apply-ingest-migrations workflow + drop kb_has_coverage embedding filter (#1308)

### DIFF
--- a/.github/workflows/apply-ingest-migrations.yml
+++ b/.github/workflows/apply-ingest-migrations.yml
@@ -1,0 +1,208 @@
+name: Apply mira-ingest Migrations
+
+# Applies migrations under mira-core/mira-ingest/db/migrations/*.sql against
+# prod NeonDB. Sister workflow to apply-migrations.yml (which only targets
+# mira-hub/db/migrations/) — closes the orphan-migration gap that left
+# migration 006_knowledge_tsvector unapplied for weeks (#1308 root cause).
+#
+# Migrations in this directory may have a CONCURRENTLY index step that
+# CANNOT run inside a transaction. The runner therefore splits each file
+# on "-- Block 1" / "-- Block 2" comments and applies Block 1 inside a
+# psql -1 (single transaction) and Block 2 outside. Files without those
+# markers run as a single transaction.
+
+on:
+  workflow_dispatch:
+    inputs:
+      migrations:
+        description: 'Migration numbers to apply, comma-separated (e.g. "006" or "006,007"). Use "all" for every file in mira-core/mira-ingest/db/migrations/.'
+        required: true
+        default: '006'
+        type: string
+      mode:
+        description: 'dry-run = print plan + diagnostics. apply = actually run.'
+        required: true
+        default: 'dry-run'
+        type: choice
+        options:
+          - dry-run
+          - apply
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prod-ingest-migrations
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    name: Apply ingest migrations (${{ inputs.mode }})
+    runs-on: ubuntu-latest
+    environment: production
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Install psql 16 (parity with Neon)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends postgresql-client-16
+          psql --version
+
+      - name: Authenticate Doppler + resolve DATABASE_URL
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DOPPLER_TOKEN:-}" ]; then
+            echo "::error::DOPPLER_TOKEN secret not set."
+            exit 1
+          fi
+          DATABASE_URL="$(doppler secrets get NEON_DATABASE_URL --project factorylm --config prd --plain)"
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::NEON_DATABASE_URL empty after Doppler fetch — token scope wrong?"
+            exit 1
+          fi
+          echo "::add-mask::$DATABASE_URL"
+          echo "DATABASE_URL=$DATABASE_URL" >> "$GITHUB_ENV"
+
+      - name: Resolve migration file list
+        id: resolve
+        run: |
+          set -euo pipefail
+          MIG_DIR="mira-core/mira-ingest/db/migrations"
+          if [ ! -d "$MIG_DIR" ]; then
+            echo "::error::$MIG_DIR not found in checkout"
+            exit 1
+          fi
+          REQUESTED="${{ inputs.migrations }}"
+          FILES=()
+          if [ "$REQUESTED" = "all" ]; then
+            while IFS= read -r f; do
+              FILES+=("$f")
+            done < <(ls "$MIG_DIR"/*.sql | sort)
+          else
+            IFS=',' read -ra NUMS <<< "$REQUESTED"
+            for n in "${NUMS[@]}"; do
+              n_trimmed="$(echo "$n" | xargs)"
+              # match files starting with the number (e.g. "006_*.sql")
+              matched=( "$MIG_DIR"/${n_trimmed}_*.sql )
+              if [ ! -f "${matched[0]}" ]; then
+                echo "::error::No file matched: $MIG_DIR/${n_trimmed}_*.sql"
+                exit 1
+              fi
+              for m in "${matched[@]}"; do
+                FILES+=("$m")
+              done
+            done
+          fi
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "::error::Resolved zero migration files."
+            exit 1
+          fi
+          printf '%s\n' "${FILES[@]}" > .migration_plan
+          echo "Plan:"
+          cat .migration_plan
+
+      - name: Pre-flight — column existence check for tsvector
+        run: |
+          set -euo pipefail
+          psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -c "
+          SELECT column_name, data_type, is_generated
+            FROM information_schema.columns
+           WHERE table_name='knowledge_entries'
+             AND column_name IN ('embedding','content_tsv')
+           ORDER BY column_name;
+          " | tee /tmp/preflight.out
+          {
+            echo "## Pre-flight: knowledge_entries column probe"
+            echo ""
+            echo '```'
+            cat /tmp/preflight.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Plan summary
+        run: |
+          {
+            echo "## Plan"
+            echo ""
+            echo "Mode: \`${{ inputs.mode }}\`"
+            echo ""
+            echo "Files (in apply order):"
+            while IFS= read -r f; do
+              SIZE=$(wc -c < "$f" | tr -d ' ')
+              LINES=$(wc -l < "$f" | tr -d ' ')
+              echo "- \`$f\` (${SIZE} bytes, ${LINES} lines)"
+            done < .migration_plan
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Dry-run — show file headers only
+        if: inputs.mode == 'dry-run'
+        run: |
+          set -euo pipefail
+          while IFS= read -r f; do
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "#### $f" >> "$GITHUB_STEP_SUMMARY"
+            echo '```sql' >> "$GITHUB_STEP_SUMMARY"
+            head -60 "$f" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+          done < .migration_plan
+          echo "Dry-run complete — no SQL executed."
+
+      - name: Apply — split on Block 1 / Block 2 markers
+        if: inputs.mode == 'apply'
+        run: |
+          set -euo pipefail
+          while IFS= read -r f; do
+            echo "=== Applying $f ==="
+            if grep -q "^-- Block 1" "$f" && grep -q "^-- Block 2" "$f"; then
+              # Two-block file (CONCURRENTLY index pattern from 006_knowledge_tsvector.sql).
+              # Split on the literal "-- Block 2" comment marker.
+              awk '
+                /^-- Block 1/ {phase="b1"; next}
+                /^-- Block 2/ {phase="b2"; next}
+                phase=="b1" {print > "/tmp/block1.sql"}
+                phase=="b2" {print > "/tmp/block2.sql"}
+              ' "$f"
+              echo "--- Block 1 (transactional) ---"
+              psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -1 -f /tmp/block1.sql
+              echo "--- Block 2 (non-transactional; CONCURRENTLY index) ---"
+              psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -f /tmp/block2.sql
+              rm -f /tmp/block1.sql /tmp/block2.sql
+            else
+              echo "--- Single transaction ---"
+              psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -1 -f "$f"
+            fi
+            echo "=== $f applied OK ==="
+          done < .migration_plan
+
+      - name: Post-apply verification
+        if: inputs.mode == 'apply'
+        run: |
+          set -euo pipefail
+          psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -c "
+          SELECT column_name, data_type, is_generated
+            FROM information_schema.columns
+           WHERE table_name='knowledge_entries'
+             AND column_name IN ('embedding','content_tsv')
+           ORDER BY column_name;
+          " | tee /tmp/post.out
+          psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=1 -c "
+          SELECT COUNT(*) AS rows_with_content_tsv
+            FROM knowledge_entries
+           WHERE content_tsv IS NOT NULL;
+          " | tee -a /tmp/post.out
+          {
+            echo "## Post-apply verification"
+            echo ""
+            echo '```'
+            cat /tmp/post.out
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/mira-bots/shared/neon_recall.py
+++ b/mira-bots/shared/neon_recall.py
@@ -790,6 +790,13 @@ def kb_has_coverage(vendor: str, model: str, tenant_id: str) -> tuple[bool, str]
             pool_pre_ping=True,
         )
         with engine.connect() as conn:
+            # Drop the embedding-not-null filter — a row reachable only via
+            # BM25 (content_tsv) is still KB coverage, and the pre-check
+            # otherwise misses freshly-seeded rows whose embeddings haven't
+            # been backfilled yet (the #1308 demo blocker — seeded
+            # gs10/gs11 rows had NULL embeddings and were invisible to
+            # this pre-check, so the engine routed every Modbus question
+            # to the LLM hallucination fallback).
             row = conn.execute(
                 text(
                     """
@@ -797,7 +804,6 @@ def kb_has_coverage(vendor: str, model: str, tenant_id: str) -> tuple[bool, str]
                     FROM knowledge_entries
                     WHERE (tenant_id = :tid OR tenant_id = :shared_tid)
                       AND LOWER(manufacturer) LIKE LOWER(:vendor_pat)
-                      AND embedding IS NOT NULL
                     """
                 ),
                 {


### PR DESCRIPTION
Closes #1308 (pending the workflow run on prod and a re-test of the bot Q).

## Diagnosis recap (full detail in #1308 comment)

Live test against `https://app.factorylm.com/v1/chat/completions` (model `mira-diagnostic`) returns hallucinated register addresses for Mike's exact issue question. Two intersecting bugs sit between the gs10/gs11 seeds (applied 2026-05-15) and the answer Mike expects:

1. **`mira-core/mira-ingest/db/migrations/006_knowledge_tsvector.sql` has no automated runner.** `apply-migrations.yml` only targets `mira-hub/db/migrations/`. Without `content_tsv`, `_recall_bm25` errors silently and the 14 newly-seeded NULL-embedding rows are dark to retrieval.
2. **`kb_has_coverage` in `neon_recall.py` requires `embedding IS NOT NULL`.** That filter excludes the seeded rows from the pre-check, so the engine concludes "no KB coverage for AutomationDirect" and routes the whole question to the LLM hallucination path.

## What this PR ships

- **`apply-ingest-migrations.yml`** — sister workflow to `apply-migrations.yml`, targets `mira-core/mira-ingest/db/migrations/*.sql`, splits on `-- Block 1` / `-- Block 2` markers so `CREATE INDEX CONCURRENTLY` runs outside a transaction (006 needs this).
- **`mira-bots/shared/neon_recall.py:800`** — drop `AND embedding IS NOT NULL` from `kb_has_coverage`. A BM25-reachable row is still KB coverage. Comment expanded to explain the regression this prevents.

## What this PR does NOT ship

- Vector-stage embedding filter at line 641 is unchanged — pgvector cosine on null is undefined, that filter has to stay.
- No embedding backfill. Once tsvector exists, BM25 answers the question. Backfill is a follow-up for paraphrase recall hardening.
- No code change in `recall_knowledge` itself.

## Test plan

```bash
# 1. Verify column missing pre-apply
gh workflow run apply-ingest-migrations.yml -f migrations=006 -f mode=dry-run

# 2. Apply
gh workflow run apply-ingest-migrations.yml -f migrations=006 -f mode=apply

# 3. Re-run bot Q against prod
doppler run --project factorylm --config prd -- python .claude/scratchpad/test_1308_bot_q.py
```

Expected: response cites register 8192 + value 18 + FC06.

## Karpathy §3 — surgical

One workflow file added, one SQL filter dropped. No "while we're in here" refactor of the vector stage; no embedding backfill bundling. If the workflow + filter drop don't fully resolve #1308, the next PR adds embedding backfill — but we don't pay for that until we see the test fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)