### PR TITLE
fix(hub,db): GRANT factorylm_app on namespace + proposals + component tables

### DIFF
--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## [1.6.1] - 2026-05-18
+### Fixed
+- DB migration 023 grants `factorylm_app` SELECT/INSERT/UPDATE on relationship_proposals, relationship_evidence, component_templates, component_template_sources, installed_component_instances, health_scores, wizard_progress, namespace_versions. Fixes HTTP 500 on /api/namespace/tree, /api/proposals, /api/readiness, /api/components/[id] and related routes — same RLS-role grant gap that #1345/#1343/#1344 surfaced. Requires `gh workflow run "Apply Prod Migrations"` after merge.
+
 ## [1.6.0] - 2026-05-17
 ### Removed
 - Actions tab removed from primary nav and mobile bottom tabs (mock-data only, no backend)

--- a/mira-hub/db/migrations/023_grant_app_namespace_tables.sql
+++ b/mira-hub/db/migrations/023_grant_app_namespace_tables.sql
@@ -1,0 +1,46 @@
+-- 023_grant_app_namespace_tables.sql
+-- Fix HTTP 500s on /api/namespace/tree, /api/proposals, /api/readiness,
+-- /api/components/[id], /api/wizard/[step], and the namespace node PUT/PATCH
+-- routes ("permission denied for table ...").
+--
+-- Root cause: same pattern as the 011 fix for /api/library/tree. The hub's
+-- tenant-context.ts switches the session to the limited `factorylm_app` role
+-- so RLS tenant_isolation policies are enforced. Migrations 016/017/018/021
+-- created their tables and RLS policies, but never granted SELECT/INSERT/
+-- UPDATE on those tables to factorylm_app — so every hub query against them
+-- returns a Postgres ACL error before RLS even runs.
+--
+-- Grant scope per route's actual usage:
+--   relationship_proposals       SELECT (list), INSERT (LLM proposer),
+--                                UPDATE (proposal decide → status change)
+--   relationship_evidence        SELECT (proposal detail), INSERT (collector)
+--   component_templates          SELECT only — catalog is shared/read-only
+--                                from the hub. Template writes happen via
+--                                ingest workers running as neondb_owner.
+--   component_template_sources   SELECT — provenance read by the hub.
+--   installed_component_instances SELECT (list/detail), INSERT (onboarding),
+--                                UPDATE (rename / rebind to template).
+--   health_scores                SELECT (widget), INSERT (recompute write-
+--                                through), UPDATE (refresh).
+--   wizard_progress              SELECT (resume), INSERT (start), UPDATE
+--                                (advance step / complete).
+--   namespace_versions           SELECT (audit feed), INSERT (drag-drop /
+--                                rename). Append-only — no UPDATE/DELETE.
+--
+-- Safe to re-run.
+
+BEGIN;
+
+GRANT SELECT, INSERT, UPDATE         ON relationship_proposals          TO factorylm_app;
+GRANT SELECT, INSERT                 ON relationship_evidence           TO factorylm_app;
+
+GRANT SELECT                         ON component_templates             TO factorylm_app;
+GRANT SELECT                         ON component_template_sources      TO factorylm_app;
+
+GRANT SELECT, INSERT, UPDATE         ON installed_component_instances   TO factorylm_app;
+
+GRANT SELECT, INSERT, UPDATE         ON health_scores                   TO factorylm_app;
+GRANT SELECT, INSERT, UPDATE         ON wizard_progress                 TO factorylm_app;
+GRANT SELECT, INSERT                 ON namespace_versions              TO factorylm_app;
+
+COMMIT;

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Migrations 016/017/018/021 created tables + RLS policies but **never granted** SELECT/INSERT/UPDATE on them to `factorylm_app`. The hub's `withTenantContext` does `SET LOCAL ROLE factorylm_app`, so every query against those tables returns `permission denied` before RLS even runs.

Same bug pattern as the 011 fix for `/api/library/tree`.

## Routes unblocked

| Route | Was | Now |
|---|---|---|
| `GET /api/namespace/tree` | 500 (#1345 / demo centerpiece) | reads relationship_proposals + kg_entities |
| `GET /api/proposals` | 500 | reads relationship_proposals |
| `POST /api/proposals/[id]/decide` | 500 | updates status |
| `GET /api/readiness` | 500 (/feed widget) | reads health_scores |
| `POST /api/readiness/recalculate` | 500 | upserts health_scores |
| `GET /api/components/[id]` | 500 | reads installed_component_instances + component_templates |
| `POST/GET /api/wizard/[step]` | 500 | reads/upserts wizard_progress |
| `PUT/PATCH /api/namespace/node/[id]` | 500 (Phase 2 slice 2) | appends to namespace_versions |

## Grant scope per route usage

| Table | Grants |
|---|---|
| `relationship_proposals` | SELECT, INSERT, UPDATE |
| `relationship_evidence` | SELECT, INSERT |
| `component_templates` | SELECT (catalog is shared/read-only from hub) |
| `component_template_sources` | SELECT |
| `installed_component_instances` | SELECT, INSERT, UPDATE |
| `health_scores` | SELECT, INSERT, UPDATE |
| `wizard_progress` | SELECT, INSERT, UPDATE |
| `namespace_versions` | SELECT, INSERT (append-only) |

## Verification

1. Merge → `gh workflow run "Apply Prod Migrations"`.
2. Auth as `playwright@factorylm.com`, open `https://app.factorylm.com/hub/namespace/` — tree renders (not empty/error).
3. Open `https://app.factorylm.com/hub/proposals/` — list renders without 500.
4. Open `https://app.factorylm.com/hub/feed/` — readiness widget renders.
5. Re-run `mira-hub/tests/e2e/audit-2026-05-17-pre-expo.spec.ts` — items 1/2/3/4 of TL;DR table should clear.

## Test plan

- [ ] PR build + CI checks green
- [ ] Merge to `main`
- [ ] `gh workflow run "Apply Prod Migrations"` succeeds (last successful 2026-05-15; #1366 made it commit-flagged)
- [ ] `gh workflow run deploy-vps.yml` if not auto-triggered
- [ ] Auth-pass audit re-run against prod — 4 of 7 P0/P1 items resolved (`/usage` is `work_orders` — separate; `/uploads` is ingest pipeline — separate)
- [ ] Tag `mira-hub/v1.6.1` after merge

## Refs

- #1345 (RSC 503 / namespace empty)
- #1343 (cmms-sync no uns_path — adjacent but separate)
- #1344 (knowledge_entries mirror — adjacent but separate)
- #1370 (pre-expo audit, P0 items 1+2 in auth-pass table)
- Plan: `docs/plans/2026-05-15-maintenance-namespace-builder.md` (Phase 2)
- Pattern source: `db/migrations/011_grant_app_kb_access.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)