### PR TITLE
fix(ci): include Telegram + Slack bots in default deploy targets

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -64,7 +64,7 @@ jobs:
           bash scripts/host_perm_setup.sh
 
           # Resolve the rebuild list once so cleanup + build + up all agree.
-          TARGETS="${SERVICES:-mira-pipeline mira-ingest mira-mcp mira-hub mira-cmms-sync}"
+          TARGETS="${SERVICES:-mira-pipeline mira-ingest mira-mcp mira-hub mira-cmms-sync mira-bot-telegram mira-bot-slack}"
           echo "Rebuild targets: $TARGETS"
 
           echo "=== Pre-deploy cleanup: remove any stale containers blocking recreate ==="

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -1,5 +1,10 @@
 # Hot Cache — 2026-05-16 — CHARLIE
 
+## eval-fixer run — 2026-05-18
+- Scorecard: 48/57 passing (84%) — `tests/eval/runs/2026-05-06T0833-offline-text.md` (12 days stale, unchanged since 2026-05-06)
+- Action: filed #1373 (multi-cluster hard-stop hit), then closed as duplicate of #1217. Prior dupes: #1144, #1170, #1187, #1217, #1329.
+- **Nightly eval job still stalled** — same scorecard, same 9 fixtures, same 3 file_clusters (engine.py×7, guardrails.py×3, prompts×3). No new signal. Action needed: regenerate scorecard (`doppler run -- python3 tests/eval/offline_run.py --suite text`) or land a fix on one of the open issues before the next eval-fixer run will produce signal.
+
 ## eval-fixer run — 2026-05-16
 - Scorecard: 48/57 passing (84%) — `tests/eval/runs/2026-05-06T0833-offline-text.md` (10 days stale, unchanged since 2026-05-10)
 - Action: filed #1329, then closed it as duplicate of #1217. Prior dupes: #1144, #1170, #1187, #1217, #1329.


### PR DESCRIPTION
## Summary
- The default `TARGETS` list in `deploy-vps.yml` was missing `mira-bot-telegram` and `mira-bot-slack`
- Every normal `push → smoke → deploy` cycle skipped them, so bot containers ran stale code until someone manually fired `workflow_dispatch` with explicit services
- Symptom seen today: Telegram bot didn't pick up recent engine fixes despite multiple deploys to main

## Fix
Add both bots to the default services list. Manual hotfix path (`-f services="..."`) is unchanged.

## Test plan
- [x] Manual deploy of just the bots triggered separately (run 26026764572) to unstick Mike's testing right now
- [ ] After merge, next push to main should rebuild bots automatically — verify via `gh run list --workflow=deploy-vps.yml -L1` and `docker compose ps` on VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)