### PR TITLE
fix(recall): BM25 OR-fanout — plainto_tsquery ANDed every term, killing KB hits

### DIFF
--- a/mira-bots/shared/neon_recall.py
+++ b/mira-bots/shared/neon_recall.py
@@ -444,28 +444,40 @@ def _recall_bm25(
     cosine similarity used elsewhere). BM25 scores feed RRF by rank, not by
     magnitude, so the scale mismatch is irrelevant to fusion.
 
-    Returns [] if query_text is blank or the query fails — never raises.
-    The `content_tsv @@ plainto_tsquery(...)` predicate acts as a hard gate:
-    no match → no row, so MIN_SIMILARITY filtering is not applied here.
-    Searches both the caller's tenant entries and the shared OEM pool.
+    Query construction: OR-fanout via `to_tsquery('english', 't1 | t2 | …')`.
+    plainto_tsquery ANDs every term — fatal for maintenance queries like
+    "modbus parameters word write GS11 drive" where no single doc contains
+    all six. OR-joining means a doc matches if ANY token hits; ts_rank_cd
+    still rewards docs that match MORE tokens, so multi-term matches rank
+    higher than single-term ones. Tokens are stripped to `\\w+` to keep the
+    tsquery parser-safe (no need to escape `&|!():*`).
+
+    Returns [] if query_text is blank, has no usable tokens, or the query
+    fails — never raises. The tsquery `@@` predicate is a hard gate, so
+    MIN_SIMILARITY filtering is not applied here. Searches both the caller's
+    tenant entries and the shared OEM pool.
     """
     if not query_text or not query_text.strip():
         return []
+    tokens = re.findall(r"\w+", query_text)
+    if not tokens:
+        return []
+    ts_query = " | ".join(tokens)
     try:
         rows = (
             conn.execute(
                 text_fn(
                     "SELECT content, manufacturer, model_number, equipment_type, "
                     "source_type, source_url, source_page, metadata, "
-                    "ts_rank_cd(content_tsv, plainto_tsquery('english', :q)) AS similarity "
+                    "ts_rank_cd(content_tsv, to_tsquery('english', :tsq)) AS similarity "
                     "FROM knowledge_entries "
                     "WHERE (tenant_id = :tid OR tenant_id = :shared_tid) "
-                    "  AND content_tsv @@ plainto_tsquery('english', :q) "
+                    "  AND content_tsv @@ to_tsquery('english', :tsq) "
                     "ORDER BY similarity DESC "
                     "LIMIT :lim"
                 ),
                 {
-                    "q": query_text,
+                    "tsq": ts_query,
                     "tid": tenant_id,
                     "shared_tid": SHARED_TENANT_ID,
                     "lim": limit,

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -1,5 +1,10 @@
 # Hot Cache — 2026-05-16 — CHARLIE
 
+## eval-fixer run — 2026-05-18
+- Scorecard: 48/57 passing (84%) — `tests/eval/runs/2026-05-06T0833-offline-text.md` (12 days stale, unchanged since 2026-05-06)
+- Action: filed #1373 (multi-cluster hard-stop hit), then closed as duplicate of #1217. Prior dupes: #1144, #1170, #1187, #1217, #1329.
+- **Nightly eval job still stalled** — same scorecard, same 9 fixtures, same 3 file_clusters (engine.py×7, guardrails.py×3, prompts×3). No new signal. Action needed: regenerate scorecard (`doppler run -- python3 tests/eval/offline_run.py --suite text`) or land a fix on one of the open issues before the next eval-fixer run will produce signal.
+
 ## eval-fixer run — 2026-05-16
 - Scorecard: 48/57 passing (84%) — `tests/eval/runs/2026-05-06T0833-offline-text.md` (10 days stale, unchanged since 2026-05-10)
 - Action: filed #1329, then closed it as duplicate of #1217. Prior dupes: #1144, #1170, #1187, #1217, #1329.


### PR DESCRIPTION
## Summary
- `_recall_bm25` used `plainto_tsquery('english', :q)` which ANDs every term — a query like `modbus parameters word write GS11 drive` requires a single doc to contain ALL six tokens. Real maintenance chunks never do, so BM25 returned `[]` for nearly every realistic query and recall fell back to vector-only.
- Switch to `to_tsquery('english', 't1 | t2 | …')` with OR-joined `\w+` tokens. Docs match if ANY token hits; `ts_rank_cd` still rewards docs that match MORE tokens.
- Strip tokens to `\w+` so we never hand the tsquery parser `&|!():*` (no escaping needed).
- Return `[]` when no usable tokens remain after cleaning.

## Root cause
This is why MIRA stopped finding KB data on Telegram for multi-word industrial queries — the BM25 stream of the hybrid recall (vector + product + BM25 + LIKE → RRF) was silently contributing nothing.

## Test plan
- [x] Existing tests pass: `pytest mira-bots/tests/test_hybrid_retrieval.py` (13/13)
- [x] Blank-query / whitespace-only guards still return `[]` (unchanged)
- [x] New no-usable-tokens guard returns `[]` (e.g. query `"!!!---"`)
- [ ] After deploy, re-test on Telegram with `modbus parameters word write GS11 drive` and confirm KB hits surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)