### PR TITLE
fix(ops): uns_backfill skips pure-comment chunks

### DIFF
--- a/tools/uns_backfill.py
+++ b/tools/uns_backfill.py
@@ -113,7 +113,12 @@ def _apply_sql_pass(engine) -> None:
         # SQLAlchemy's transaction is the only one in play.
         cleaned = sql.replace("BEGIN;", "").replace("COMMIT;", "")
         for stmt in _split_statements(cleaned):
-            if stmt.strip():
+            # Skip pure-whitespace/comment chunks — psycopg rejects empty queries.
+            # The migration trails with rollback notes that are all '--' comments.
+            if any(
+                s and not s.startswith('--')
+                for s in (line.strip() for line in stmt.splitlines())
+            ):
                 c.execute(text(stmt))
     log.info("SQL pass complete (migration 014)")
 


### PR DESCRIPTION
## Summary

Workflow run [#26038484443](https://github.com/Mikecranesync/MIRA/actions/runs/26038484443) (the first real-write backfill after #1366 added \`--commit\`) crashed on:

\`\`\`
psycopg2.ProgrammingError: can't execute an empty query
[SQL:
-- ─── Rollback ─────────────────────────────────────────────────────────
-- DROP VIEW IF EXISTS kg_entities_uns_orphans;]
\`\`\`

## Root cause

\`_split_statements()\` in \`tools/uns_backfill.py\` splits on \`;\` outside dollar-quoted blocks. Migration 014 ends with a rollback-notes block whose lines all start with \`--\`. Those land in their own chunks at EOF. The old guard \`if stmt.strip()\` let them through; psycopg rejected.

This was masked until #1366 added \`--commit\` — the prior dry-run path never reached \`_apply_sql_pass()\`.

## Fix

Filter line-by-line: execute the chunk only if any line is non-comment and non-whitespace.

\`\`\`python
if any(
    s and not s.startswith('--')
    for s in (line.strip() for line in stmt.splitlines())
):
    c.execute(text(stmt))
\`\`\`

## Verified locally

Against \`mira-hub/db/migrations/014_uns_path_backfill.sql\`:

\`\`\`
7 chunks total, 3 will execute, 4 skipped
  CREATE OR REPLACE FUNCTION uns_slug(value text) ...   (+ uns_kb_path + UPDATE, dollar-quoted)
  CREATE OR REPLACE VIEW kg_entities_uns_orphans
  COMMENT ON VIEW kg_entities_uns_orphans
  -- (skipped) rollback notes
\`\`\`

## After this lands

Re-trigger:
\`\`\`bash
gh workflow run apply-migrations.yml -f mode=apply -f run_backfill=true
\`\`\`

The \"Apply migrations\" job is a no-op (everything already-exists). The backfill job should complete this time and write the 266 entity triples + cmms_equipment.uns_path rows.

## Scope

5 lines added, 1 removed. No new abstractions. Same site, same guard pattern — just smarter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)