### PR TITLE
fix(backfill): replace :p::type with CAST(:p AS type) — fixes prod backfill

### DIFF
--- a/mira-crawler/ingest/kg_writer.py
+++ b/mira-crawler/ingest/kg_writer.py
@@ -114,7 +114,7 @@ def upsert_entity(
                         (:tenant_id, :entity_type, :name,
                          cast(:properties AS jsonb),
                          cast(:source_chunk_id AS uuid),
-                         :uns_path::ltree)
+                         cast(:uns_path AS ltree))
                     ON CONFLICT (tenant_id, entity_type, name) DO UPDATE
                         SET properties = COALESCE(kg_entities.properties, '{}'::jsonb)
                                        || EXCLUDED.properties

--- a/tools/cmms_equipment_uns_backfill.py
+++ b/tools/cmms_equipment_uns_backfill.py
@@ -178,8 +178,8 @@ def run(tenant: str | None, batch_size: int, commit: bool, force: bool) -> Stats
                 c.execute(
                     text(
                         "UPDATE cmms_equipment "
-                        "   SET uns_path = :p::ltree "
-                        " WHERE id = :id::uuid"
+                        "   SET uns_path = CAST(:p AS ltree) "
+                        " WHERE id = CAST(:id AS uuid)"
                     ),
                     {"p": new_path, "id": asset_id},
                 )


### PR DESCRIPTION
## Summary

Backfill workflow run [#26039678995](https://github.com/Mikecranesync/MIRA/actions/runs/26039678995) (the first one to actually attempt writes, post #1383) revealed both backfill writers were emitting SQL that SQLAlchemy 2.x mis-parses:

\`\`\`
psycopg2.errors.SyntaxError: syntax error at or near \":\"
LINE 9:                          :uns_path::ltree)
                                          ^
\`\`\`

## Root cause

SQLAlchemy's \`text()\` bind-parameter parser can't disambiguate \`:p\` (bind) from \`::ltree\` (PostgreSQL cast operator). The text reaches psycopg verbatim, and psycopg rejects.

Failure pattern:
- \`kg_writer.upsert_entity\` (line 117) — \`:uns_path::ltree\` → every upsert silently failed inside its try/except (\"upsert_entity failed for equipment/X\"). Run stats: \`entities created: 0\`, \`entries orphaned: 34344\`.
- \`tools/cmms_equipment_uns_backfill.py\` (line 181, 182) — \`:p::ltree\` + \`:id::uuid\` → uncaught, crashed the step.

## Fix

\`CAST(:p AS type)\` is unambiguous and semantically identical:

\`\`\`python
# was:  SET uns_path = :p::ltree WHERE id = :id::uuid
# now:  SET uns_path = CAST(:p AS ltree) WHERE id = CAST(:id AS uuid)
\`\`\`

\`\`\`python
# was:  cast(:source_chunk_id AS uuid), :uns_path::ltree)
# now:  cast(:source_chunk_id AS uuid), cast(:uns_path AS ltree))
\`\`\`

## Out of scope

\`mira-crawler/tasks/component_template.py\` lines 162 + 204 have the same \`:p::ltree\` pattern. Leaving for a follow-up PR because:
- Not in the backfill path this task chases
- Tasks may have been working via a different SQLAlchemy version pinning
- Karpathy: surgical change

If component_template ingest is also broken in prod, same one-line CAST fix applies.

## Test plan

- [ ] CI green
- [ ] After merge: \`gh workflow run apply-migrations.yml -f mode=apply -f run_backfill=true\`
- [ ] kg_entities backfill writes ~266 entities (was 0)
- [ ] cmms_equipment backfill updates ~94 rows (was 0)
- [ ] No \`upsert_entity failed\` errors in the run log

🤖 Generated with [Claude Code](https://claude.com/claude-code)