### PR TITLE
fix(recall): run BM25 + fault streams when Ollama embed sidecar is down

### DIFF
--- a/mira-bots/shared/neon_recall.py
+++ b/mira-bots/shared/neon_recall.py
@@ -604,12 +604,18 @@ def _merge_results(
 
 
 def recall_knowledge(
-    embedding: list[float],
+    embedding: list[float] | None,
     tenant_id: str,
     limit: int = 3,
     query_text: str = "",
 ) -> list[dict]:
-    """Three-stage retrieval: vector + fault code ILIKE + product name ILIKE.
+    """Hybrid retrieval: vector + fault code + product name + BM25.
+
+    When `embedding` is None or empty (e.g. Ollama embed sidecar unreachable),
+    vector and product-name stages are skipped but BM25, structured fault, and
+    ILIKE-fault stages still run. Pre-fix the function early-returned []
+    whenever the embedding was missing, which short-circuited BM25 even
+    though it doesn't need an embedding — the GS11 demo regression.
 
     Returns a list of dicts with keys:
         content, manufacturer, model_number, equipment_type, source_type, similarity
@@ -625,8 +631,15 @@ def recall_knowledge(
             )
             recall_knowledge._warned_url = True
         return []
-    if not embedding or not tenant_id:
+    if not tenant_id:
         return []
+    has_embedding: bool = bool(embedding)
+    if not has_embedding:
+        logger.info(
+            "NEON_RECALL_NO_EMBEDDING tenant=%s — vector + product stages skipped, "
+            "lexical streams (BM25/fault/structured) still run",
+            tenant_id,
+        )
 
     try:
         from sqlalchemy import create_engine, text  # noqa: PLC0415
@@ -643,37 +656,43 @@ def recall_knowledge(
             pool_pre_ping=True,
         )
         with engine.connect() as conn:
-            # Stage 1: Dense vector search — searches tenant entries + shared OEM pool
-            vector_rows = (
-                conn.execute(
-                    text("""
-                    SELECT
-                        content,
-                        manufacturer,
-                        model_number,
-                        equipment_type,
-                        source_type,
-                        source_url,
-                        source_page,
-                        metadata,
-                        1 - (embedding <=> cast(:emb AS vector)) AS similarity
-                    FROM knowledge_entries
-                    WHERE (tenant_id = :tid OR tenant_id = :shared_tid)
-                      AND embedding IS NOT NULL
-                    ORDER BY embedding <=> cast(:emb AS vector)
-                    LIMIT :lim
-                """),
-                    {
-                        "emb": str(embedding),
-                        "tid": tenant_id,
-                        "shared_tid": SHARED_TENANT_ID,
-                        "lim": limit,
-                    },
+            # Stage 1: Dense vector search — searches tenant entries + shared OEM pool.
+            # Skipped when the embedding sidecar was unreachable (has_embedding=False);
+            # BM25 + structured-fault stages below carry the load in that case.
+            vector_results: list[dict] = []
+            if has_embedding:
+                vector_rows = (
+                    conn.execute(
+                        text("""
+                        SELECT
+                            content,
+                            manufacturer,
+                            model_number,
+                            equipment_type,
+                            source_type,
+                            source_url,
+                            source_page,
+                            metadata,
+                            1 - (embedding <=> cast(:emb AS vector)) AS similarity
+                        FROM knowledge_entries
+                        WHERE (tenant_id = :tid OR tenant_id = :shared_tid)
+                          AND embedding IS NOT NULL
+                        ORDER BY embedding <=> cast(:emb AS vector)
+                        LIMIT :lim
+                    """),
+                        {
+                            "emb": str(embedding),
+                            "tid": tenant_id,
+                            "shared_tid": SHARED_TENANT_ID,
+                            "lim": limit,
+                        },
+                    )
+                    .mappings()
+                    .fetchall()
                 )
-                .mappings()
-                .fetchall()
-            )
-            vector_results = [dict(r) for r in vector_rows if r["similarity"] >= MIN_SIMILARITY]
+                vector_results = [
+                    dict(r) for r in vector_rows if r["similarity"] >= MIN_SIMILARITY
+                ]
 
             # Stage 2: Fault code — structured lookup first, ILIKE fallback
             fault_codes = _extract_fault_codes(query_text)
@@ -710,10 +729,12 @@ def recall_knowledge(
                 if not structured_fault_results:
                     like_results = _like_search(conn, text, tenant_id, fault_codes, limit)
 
-            # Stage 3: Product name search (vector-reranked within product's manual)
+            # Stage 3: Product name search (vector-reranked within product's manual).
+            # Vector-rerank requires an embedding; if none, skip — BM25 still
+            # surfaces product-matching chunks via lexical match below.
             product_names = _extract_product_names(query_text)
             product_results: list[dict] = []
-            if product_names:
+            if product_names and has_embedding:
                 product_results = _product_search(
                     conn, text, tenant_id, product_names, embedding, limit
                 )

--- a/mira-bots/shared/neon_recall.py
+++ b/mira-bots/shared/neon_recall.py
@@ -690,9 +690,7 @@ def recall_knowledge(
                     .mappings()
                     .fetchall()
                 )
-                vector_results = [
-                    dict(r) for r in vector_rows if r["similarity"] >= MIN_SIMILARITY
-                ]
+                vector_results = [dict(r) for r in vector_rows if r["similarity"] >= MIN_SIMILARITY]
 
             # Stage 2: Fault code — structured lookup first, ILIKE fallback
             fault_codes = _extract_fault_codes(query_text)

--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -357,11 +357,11 @@ class RAGWorker:
                                 sub_queries = [embed_query]
 
                         if len(sub_queries) > 1:
+                            # Embed each sub-query; still call recall_knowledge
+                            # when embedding fails so BM25/fault streams run.
                             per_sub: list[list[dict]] = []
                             for sq in sub_queries:
                                 sq_emb = await self._embed_ollama(sq)
-                                if not sq_emb:
-                                    continue
                                 per_sub.append(
                                     _neon_recall.recall_knowledge(
                                         sq_emb,
@@ -377,12 +377,16 @@ class RAGWorker:
                             )
                         else:
                             embedding = await self._embed_ollama(embed_query)
-                            if embedding:
-                                neon_chunks = _neon_recall.recall_knowledge(
-                                    embedding,
-                                    effective_tenant,
-                                    query_text=embed_query,
-                                )
+                            # Call recall_knowledge unconditionally — it now
+                            # falls through to lexical streams when embedding
+                            # is None (Ollama sidecar down). Pre-fix this gate
+                            # short-circuited BM25 and produced NO_KB_COVERAGE
+                            # despite KB rows being lexically retrievable.
+                            neon_chunks = _neon_recall.recall_knowledge(
+                                embedding,
+                                effective_tenant,
+                                query_text=embed_query,
+                            )
 
                         if is_self_eval_enabled() and neon_chunks:
                             try:

--- a/mira-bots/tests/test_recall_no_embedding_fallthrough.py
+++ b/mira-bots/tests/test_recall_no_embedding_fallthrough.py
@@ -1,0 +1,109 @@
+"""Regression: recall_knowledge must run BM25/fault streams when embedding is None.
+
+Pre-fix the function early-returned `[]` whenever the embedding was missing,
+which short-circuited BM25 even though BM25 doesn't need an embedding. That
+produced the 2026-05-18 GS11 demo regression: Ollama embed sidecar (Bravo)
+was unreachable from the VPS, so every bot reply hit NO_KB_COVERAGE and
+fell back to generic-knowledge disclaimers despite GS10/GS11 manuals being
+fully seeded in NeonDB and lexically retrievable.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "mira-bots")
+
+os.environ.setdefault("NEON_DATABASE_URL", "postgresql://test:test@localhost/test")
+
+from shared import neon_recall  # noqa: E402
+from shared.neon_recall import recall_knowledge  # noqa: E402
+
+
+def _mock_engine_with_conn(conn: MagicMock) -> MagicMock:
+    engine = MagicMock()
+    engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    return engine
+
+
+def _patch_create_engine(engine):
+    """recall_knowledge does `from sqlalchemy import create_engine` *inside*
+    the function body (PLC0415), so we must patch the sqlalchemy module attr
+    rather than a shared.neon_recall attr."""
+    import sqlalchemy
+
+    return patch.object(sqlalchemy, "create_engine", return_value=engine)
+
+
+def test_recall_knowledge_blank_tenant_returns_empty():
+    out = recall_knowledge([0.1] * 4, "", query_text="modbus gs11")
+    assert out == []
+
+
+def test_recall_knowledge_none_embedding_still_calls_bm25():
+    """When embedding is None, vector stage is skipped but BM25 still runs."""
+    conn = MagicMock()
+    # BM25 returns one synthetic hit
+    bm25_rows = [
+        {
+            "content": "GS11 holding register 8192 = motor speed",
+            "manufacturer": "AutomationDirect",
+            "model_number": "GS11",
+            "equipment_type": "VFD",
+            "source_type": "manual",
+            "source_url": None,
+            "source_page": 42,
+            "metadata": {},
+            "similarity": 7.5,
+        }
+    ]
+    conn.execute.return_value.mappings.return_value.fetchall.return_value = bm25_rows
+    engine = _mock_engine_with_conn(conn)
+
+    with (
+        _patch_create_engine(engine),
+        patch.object(neon_recall, "_recall_bm25", return_value=bm25_rows) as bm25_spy,
+        patch.object(neon_recall, "recall_fault_code", return_value=[]),
+    ):
+        results = recall_knowledge(None, "tenant-1", query_text="modbus parameters gs11 drive")
+
+    # BM25 invoked exactly once
+    bm25_spy.assert_called_once()
+    # Result surfaces the BM25 hit
+    assert any(r.get("model_number") == "GS11" for r in results)
+
+
+def test_recall_knowledge_empty_list_embedding_treated_as_none():
+    conn = MagicMock()
+    conn.execute.return_value.mappings.return_value.fetchall.return_value = []
+    engine = _mock_engine_with_conn(conn)
+
+    with (
+        _patch_create_engine(engine),
+        patch.object(neon_recall, "_recall_bm25", return_value=[]) as bm25_spy,
+    ):
+        recall_knowledge([], "tenant-1", query_text="anything")
+
+    # Empty list embedding == no embedding → BM25 still runs
+    bm25_spy.assert_called_once()
+
+
+def test_recall_knowledge_with_embedding_calls_vector_and_bm25():
+    """Sanity: when embedding IS provided, both vector and BM25 paths fire."""
+    conn = MagicMock()
+    conn.execute.return_value.mappings.return_value.fetchall.return_value = []
+    engine = _mock_engine_with_conn(conn)
+
+    with (
+        _patch_create_engine(engine),
+        patch.object(neon_recall, "_recall_bm25", return_value=[]) as bm25_spy,
+    ):
+        recall_knowledge([0.1] * 4, "tenant-1", query_text="modbus gs11")
+
+    # BM25 still called when embedding present (hybrid retrieval)
+    bm25_spy.assert_called_once()
+    # And the vector SELECT was issued at least once
+    assert conn.execute.called


### PR DESCRIPTION
## Summary

PR #1382 fixed BM25 AND→OR semantics but the GS11 demo regression persisted because BM25 never executed. `recall_knowledge` early-returned `[]` whenever `embedding` was None, short-circuiting every lexical stream.

**Root cause chain** (verified live on VPS 165.245.138.91):

1. Bravo Tailscale unreachable from VPS → `_embed_ollama` returns `None` on all candidates (`100.86.236.11:11434` + `localhost:11434`, the latter has only `qwen2.5vl:7b` vision, no embedder)
2. `rag_worker` gates `recall_knowledge` behind `if embedding:` → skipped entirely
3. `neon_chunks = []` → `NO_KB_COVERAGE` log fires → bot falls back to "general industrial knowledge"

**Verified at DB layer** — BM25 works when called directly:

```
docker exec mira-bot-telegram python -c "from shared.neon_recall import _recall_bm25; …"
rows: 5
'Rockwell Automation' 'Bulletin 193 Overload Relay' 5.9
'Rockwell Automation' 'Bulletin 193 Overload Relay' 5.8
'AutomationDirect' '' 5.7
'AutomationDirect' '' 5.6
'AutomationDirect' '' 5.6
```

Cross-vendor filter would keep the 3 AutomationDirect rows for the GS11 query.

## Changes

- `mira-bots/shared/neon_recall.py`
  - `recall_knowledge(embedding: list[float] | None)` — gate only the **vector** + **product-rerank** stages on `has_embedding`. BM25, structured-fault, ILIKE-fault stages run unconditionally.
  - Removed early-return on missing embedding; now logs `NEON_RECALL_NO_EMBEDDING` and continues.
- `mira-bots/shared/workers/rag_worker.py`
  - Call `recall_knowledge` regardless of `_embed_ollama` result. Lexical streams are the demo safety net.
- `mira-bots/tests/test_recall_no_embedding_fallthrough.py` (new)
  - 4 regression tests assert BM25 fires with embedding=None, [], and present.

## Test plan

- [x] 4/4 new regression tests pass locally
- [x] 12/12 existing `neon_recall` / `kb_has_coverage` tests pass
- [x] Pre-existing test failures (email_adapter, start_command, tts) are unrelated import errors
- [ ] Deploy + re-ask GS11 Modbus question on Telegram: "What parameters do I need to write the word to the gs11 drive?" → expect AutomationDirect manual citation, not "general industrial knowledge"
- [ ] Check VPS bot logs for `NEON_RECALL_NO_EMBEDDING` (confirms fallthrough) + BM25 stream firing

## Follow-on ops (separate work, not in this PR)

- Restore Bravo Tailscale route from VPS, **or**
- Pull an embedding model onto VPS localhost Ollama (e.g. `nomic-embed-text`) so the existing fallback candidate actually works.

T-3 to Florida Automation Expo (2026-05-21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)