### PR TITLE
fix(ops): unblock self_healer cron (closes #1200 A1)

### DIFF
--- a/scripts/install_crons.sh
+++ b/scripts/install_crons.sh
@@ -38,6 +38,7 @@ cat > "$TMPFILE" << CRONTAB
 MIRA_DIR=$MIRA_DIR
 LOG_DIR=$LOG_DIR
 PATH=/usr/local/bin:/usr/bin:/bin
+MIRA_HEALER_ALLOW_ROOT=1
 
 # ─── DATA ENGINEERING ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Crontab `MIRA_HEALER_ALLOW_ROOT=1` so self_healer.py doesn't abort on root EUID.
- Closes #1200 A1: 502 wasn't healed because the cron-launched healer aborted every 15 min for ~6 hours (`refusing to run as root` in `/var/log/mira-agents/self_healer.log`).

## Why
Crontab runs as root, but `mira-crawler/agents/self_healer.py` line 348-350 exits if EUID==0 unless `MIRA_HEALER_ALLOW_ROOT=1`. The guard is appropriate for dev laptops, overprotective for the VPS where root is the only user with docker socket access anyway. Setting the env var keeps the actual blast-radius safety (docker-restart-only playbooks, no `docker rm`, no schema touches) without false-aborting.

## Evidence
```
$ ssh root@165.245.138.91 'tail -3 /var/log/mira-agents/self_healer.log'
2026-05-18T08:45:04 [ERROR] healer: refusing to run as root — set MIRA_HEALER_ALLOW_ROOT=1 to override
2026-05-18T09:00:05 [ERROR] healer: refusing to run as root — set MIRA_HEALER_ALLOW_ROOT=1 to override
```

## Deploy
After merge:
```
ssh root@165.245.138.91 'cd /opt/mira && git pull && bash scripts/install_crons.sh'
```
Verify after next 15-min mark that `/var/log/mira-agents/self_healer.log` no longer contains the "refusing to run as root" line.

## Test plan
- [x] Crontab block syntactically valid (sourced env var line)
- [ ] Live VPS: `grep MIRA_HEALER_ALLOW_ROOT /var/spool/cron/crontabs/root` returns the line
- [ ] After one cycle: self_healer.log shows actual healer activity instead of root-refusal