### PR TITLE
feat(hub): migration 024 — kg_entities.source_chunk_id provenance column

### DIFF
--- a/mira-hub/db/migrations/024_kg_source_chunk_id.sql
+++ b/mira-hub/db/migrations/024_kg_source_chunk_id.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+-- Migration 024: add `source_chunk_id` provenance column to kg_entities and
+-- kg_relationships.
+--
+-- mira-crawler/ingest/kg_writer.py:upsert_entity (line ~117) and
+-- upsert_relationship (line ~172) both INSERT into a `source_chunk_id`
+-- column. The hub canonical schema (mira-hub/db/migrations/001_knowledge_graph.sql)
+-- never declared it; the column lives only in the engine-side
+-- docs/migrations/004_kg_entities.sql which is not authoritative under
+-- ADR-0013.
+--
+-- Result before this migration: every kg_writer.upsert_entity call against
+-- prod NeonDB failed with `UndefinedColumn: column "source_chunk_id" of
+-- relation "kg_entities" does not exist` (swallowed by kg_writer's try/except,
+-- so callers see "entity upsert returned no id" — see tools/uns_backfill.py
+-- workflow run 26040357126).
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS. Safe to re-run.
+
+ALTER TABLE kg_entities      ADD COLUMN IF NOT EXISTS source_chunk_id UUID;
+ALTER TABLE kg_relationships ADD COLUMN IF NOT EXISTS source_chunk_id UUID;
+
+COMMIT;
+
+-- ─── Rollback ─────────────────────────────────────────────────────────
+-- ALTER TABLE kg_entities      DROP COLUMN IF EXISTS source_chunk_id;
+-- ALTER TABLE kg_relationships DROP COLUMN IF EXISTS source_chunk_id;


### PR DESCRIPTION
## Summary

Adds a tiny migration that surfaces a column the existing code already writes to.

\`mira-crawler/ingest/kg_writer.py:upsert_entity\` (line 117) and \`upsert_relationship\` (line 172) both INSERT \`source_chunk_id\`. The hub canonical schema (\`mira-hub/db/migrations/001_knowledge_graph.sql\`) never declared the column. Per **ADR-0013** the hub side is authoritative, so prod NeonDB simply doesn't have it.

## Symptom

Workflow run [#26040357126](https://github.com/Mikecranesync/MIRA/actions/runs/26040357126) — final UNS backfill run after PRs #1383 + #1384 landed — completed green but with \`entities created: 0\` / \`entries orphaned: 34344\`. Log showed:

\`\`\`
ERROR mira-crawler.kg_writer: upsert_entity failed for equipment/ACH580:
  (psycopg2.errors.UndefinedColumn) column \"source_chunk_id\" of relation
  \"kg_entities\" does not exist
\`\`\`

\`kg_writer\` swallowed every error inside its try/except, so the caller saw the muted \"equipment upsert returned no id\" warning. Cascade hides the real cause.

## Fix

\`\`\`sql
ALTER TABLE kg_entities      ADD COLUMN IF NOT EXISTS source_chunk_id UUID;
ALTER TABLE kg_relationships ADD COLUMN IF NOT EXISTS source_chunk_id UUID;
\`\`\`

Idempotent. No FK constraint added (the column is provenance metadata, allowed to point at rows that may be archived). No index added — it's write-only in current code, no reads observed across \`mira-hub/src/\`, \`mira-crawler/\`, \`mira-bots/\`, \`mira-mcp/\`, \`tools/\`. Add later if a query needs it.

## Alternative considered

Drop \`source_chunk_id\` from \`kg_writer.upsert_entity\` instead. Rejected because the column is a real provenance link (entity ↔ source knowledge_entries chunk) and the loss would matter the moment KG traversal needs to surface citations. Adding a nullable column has zero downside.

## After this lands

\`\`\`bash
gh workflow run apply-migrations.yml -f mode=apply \\
    -f migrations=024 -f run_backfill=true
\`\`\`

Apply pass = single \`ADD COLUMN IF NOT EXISTS\`. Backfill pass should then write the 266 entity triples (was 0).

## Test plan

- [ ] CI green
- [ ] Apply step shows \"ALTER TABLE\" (or \"NOTICE: column already exists, skipping\" on re-run)
- [ ] Backfill step shows \`entities created: ≈266\`, \`entries linked: ≈10k+\`
- [ ] Spot-check: \`SELECT count(*) FROM kg_entities WHERE source_chunk_id IS NOT NULL;\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)