### PR TITLE
feat(hub): Windows 3.1 namespace explorer

### DIFF
--- a/docs/plans/2026-05-18-windows-explorer-namespace.md
+++ b/docs/plans/2026-05-18-windows-explorer-namespace.md
@@ -1,0 +1,338 @@
+# Windows 3.1 Namespace Explorer — Design Plan
+
+**Date:** 2026-05-18  
+**Branch:** `feat/hub-namespace-explorer`  
+**Status:** Ready for implementation
+
+## Goal
+
+Transform the Namespace tab from a read-only AI-populated graph viewer into an interactive Windows Explorer-style knowledge filesystem. Users must be able to:
+
+1. Create folders (namespace nodes) manually
+2. Rename and delete nodes
+3. Drag PDFs/photos/manuals directly onto folders to attach them
+4. Browse hierarchy exactly like Windows 3.1 File Manager — split pane, toolbar, context menus, status bar
+5. View files and asset details in the right content panel
+
+---
+
+## What Already Exists (reuse, don't reinvent)
+
+| Asset | Path | Reuse |
+|---|---|---|
+| Namespace tree component | `src/app/(hub)/namespace/page.tsx:213–319` | Extend |
+| Node move/rename PUT | `src/app/api/namespace/node/[id]/route.ts` | Add DELETE handler |
+| Tree fetch from kg_entities | `src/app/api/namespace/tree/route.ts` | Add file counts + status |
+| Radix DropdownMenu | `@radix-ui/react-dropdown-menu` | Context menus (no new dep) |
+| Lucide icons | `lucide-react` | Add Folder, FolderOpen |
+| `withTenantContext` | `src/lib/tenant-context.ts` | All new routes |
+| `sessionOr401` | `src/lib/session.ts` | All new routes |
+| `uns.slugify()` | `src/lib/uns.ts` | UNS path building |
+| `RESERVED_LABELS` | `src/lib/uns.ts` | Validate new node names |
+| `namespace_versions` audit | migration 021 | Append create/delete events |
+
+**Verified:** The existing PUT route does a direct `UPDATE kg_entities` — no `kg_approval_state` gate. POST (create) and DELETE can follow the same pattern.
+
+---
+
+## Database — migration 024
+
+### `mira-hub/db/migrations/024_namespace_direct_uploads.sql`
+
+Reuse the existing `uploads` table for cloud-source files by adding a `namespace_node_id` FK. For direct desktop drag-drop (not Drive/Dropbox), add a separate table to avoid the pipeline-dependency.
+
+```sql
+-- Associate existing cloud uploads with namespace nodes
+ALTER TABLE uploads
+  ADD COLUMN IF NOT EXISTS namespace_node_id UUID
+    REFERENCES kg_entities(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_uploads_namespace_node
+  ON uploads (tenant_id, namespace_node_id)
+  WHERE namespace_node_id IS NOT NULL;
+
+-- Direct file uploads from drag-drop (desktop → namespace folder)
+CREATE TABLE IF NOT EXISTS namespace_direct_uploads (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id    UUID NOT NULL,
+  node_id      UUID REFERENCES kg_entities(id) ON DELETE SET NULL,
+  filename     TEXT NOT NULL,
+  mime_type    TEXT NOT NULL DEFAULT 'application/octet-stream',
+  size_bytes   BIGINT NOT NULL DEFAULT 0 CHECK (size_bytes <= 10485760),
+  content      BYTEA NOT NULL,
+  uploaded_by  UUID,
+  created_at   TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ndu_node
+  ON namespace_direct_uploads (tenant_id, node_id);
+CREATE INDEX IF NOT EXISTS idx_ndu_tenant
+  ON namespace_direct_uploads (tenant_id, created_at DESC);
+
+ALTER TABLE namespace_direct_uploads ENABLE ROW LEVEL SECURITY;
+CREATE POLICY ndu_tenant ON namespace_direct_uploads
+  USING (tenant_id::text = current_setting('app.tenant_id', true));
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON namespace_direct_uploads TO factorylm_app;
+```
+
+**Critical rule:** List queries must never `SELECT content` — only `id, filename, mime_type, size_bytes, created_at`. Only the dedicated download endpoint fetches `content`. A stray `SELECT *` pulls megabytes into Node memory.
+
+**Delete strategy:** Hard-delete on `kg_entities`. Do NOT add `deleted_at` — that column would propagate `WHERE deleted_at IS NULL` to `mira-bots`, `mira-crawler`, `mira-mcp`, and the engine. The `namespace_versions` audit row is the tombstone.
+
+---
+
+## Backend — 4 new/extended routes
+
+### 1. `src/app/api/namespace/node/route.ts` (NEW — POST create)
+
+```
+POST /api/namespace/node
+Body: { parentId?: string, name: string, kind?: string }
+```
+
+Logic:
+1. Validate `name` non-empty; `kind` defaults to `"area"`, must be in `ENTITY_TYPES` whitelist
+2. Slug the name via `uns.slugify()` — reject with 422 if slug is in `RESERVED_LABELS`
+3. Resolve parent `uns_path` from `kg_entities WHERE id = parentId AND tenant_id = $tenantId`
+4. Build child path: `parentPath + "." + slug` (or just `slug` if root)
+5. INSERT into `kg_entities` (`entity_type`, `name`, `uns_path`, `tenant_id`)
+6. INSERT into `namespace_versions` (operation=`create`, actor_kind=`human`)
+7. Response: `{ ok: true, node: { id, name, kind, unsPath } }`
+
+### 2. `src/app/api/namespace/node/[id]/route.ts` (EXTEND — add DELETE)
+
+```
+DELETE /api/namespace/node/:id
+```
+
+Logic:
+1. Return 409 if node has children in `kg_entities WHERE parent determined by uns_path prefix`
+2. Cascade-null: `UPDATE namespace_direct_uploads SET node_id = NULL WHERE node_id = $id`
+3. Cascade-null: `UPDATE uploads SET namespace_node_id = NULL WHERE namespace_node_id = $id`
+4. INSERT into `namespace_versions` (operation=`delete`, from_state=full entity snapshot as JSONB)
+5. `DELETE FROM kg_entities WHERE id = $id AND tenant_id = $tenantId`
+6. Response: `{ ok: true }`
+
+### 3. `src/app/api/namespace/node/[id]/files/route.ts` (NEW)
+
+```
+GET  /api/namespace/node/:id/files    → list files attached to node
+POST /api/namespace/node/:id/files    → upload file (multipart/form-data)
+```
+
+GET — returns merged list from both `namespace_direct_uploads` and `uploads WHERE namespace_node_id = $id`:
+```json
+{ "files": [{ "id", "filename", "mime_type", "size_bytes", "source", "created_at" }] }
+```
+
+POST — direct upload:
+1. Parse `request.formData()` — single `file` field
+2. Enforce 10 MB limit (413 if exceeded)
+3. MIME allowlist: `application/pdf`, `image/*`, `text/*`, `text/csv`, `application/vnd.ms-excel`, `application/vnd.openxmlformats-officedocument.*`
+4. INSERT into `namespace_direct_uploads` with `content = Buffer.from(await file.arrayBuffer())`
+5. Fire-and-forget: call `runIngestPipeline()` from `lib/upload-pipeline.ts`
+6. Response: `{ ok: true, file: { id, filename, size_bytes } }`
+
+### 4. `src/app/api/namespace/files/[id]/route.ts` (NEW)
+
+```
+GET    /api/namespace/files/:id    → download file
+DELETE /api/namespace/files/:id    → remove file
+```
+
+GET — serves binary content:
+- SELECT `content, mime_type, filename` WHERE `id = $id AND tenant_id = $tenantId` (cross-tenant 404)
+- Return `Response` with `Content-Type`, `Content-Disposition: attachment; filename=...`
+
+DELETE — removes file:
+- DELETE WHERE `id = $id AND tenant_id = $tenantId`
+- Response: `{ ok: true }`
+
+### 5. `src/app/api/namespace/tree/route.ts` (MINOR EDIT)
+
+Add to each `NamespaceNode`:
+- `filesCount: number` — LEFT JOIN COUNT from `namespace_direct_uploads` + `uploads WHERE namespace_node_id`
+- `status?: string` — LEFT JOIN `cmms_equipment.status` on `entity_id` for equipment nodes
+
+---
+
+## Frontend — `namespace/page.tsx` rewrite
+
+### Layout
+
+```
+┌─ Toolbar ──────────────────────────────────────────────────────────┐
+│ [New Folder] [Upload] [Expand All] [Collapse All]     [🔄 Refresh] │
+├─ Tree Panel (280px) ──────────┬─ Content Panel ───────────────────┤
+│ ▶ enterprise                  │  enterprise › building_a › elec   │
+│   ▼ building_a                │  ┌─ Folders ─────────────────────┐│
+│      ▼ electrical             │  │ 📁 mcc_01    📁 transformers  ││
+│         mcc_01 ●              │  └───────────────────────────────┘│
+│         transformers          │  ┌─ Files ────────────────────────┐│
+│      hvac                     │  │ 📄 VFD_Manual.pdf   1.2 MB    ││
+│   building_b                  │  │ 📄 Wiring_Dia.pdf   845 KB    ││
+│                               │  └───────────────────────────────┘│
+├───────────────────────────────┴───────────────────────────────────┤
+│ 4 objects (2 folders, 2 files)  │  enterprise.building_a.elec     │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### Visual style (industrial, dense)
+
+| Element | Tailwind |
+|---|---|
+| Tree panel bg | `bg-[#f0f0f0] border-r border-gray-400 font-mono text-[13px]` |
+| Content panel | `bg-white font-mono text-[13px]` |
+| Toolbar | `bg-[#d4d0c8] border-b border-gray-400 flex gap-1 p-1` |
+| Toolbar button | `border border-gray-500 bg-[#d4d0c8] hover:bg-[#e8e8e8] px-2 py-0.5 text-[12px]` |
+| Tree row | `h-7 flex items-center gap-1 px-1 cursor-pointer select-none` |
+| Selected row | `bg-[#000080] text-white` |
+| Status bar | `bg-[#d4d0c8] border-t border-gray-400 text-[11px] px-2 py-0.5` |
+| File drop target | `bg-[#c0c0ff] outline-2 outline-dashed outline-blue-600` |
+
+### New state shape
+
+```typescript
+type EditingState = { nodeId: string; value: string } | null;
+type NewFolderState = { parentId: string | null; value: string } | null;
+type UploadProgress = { nodeId: string; progress: 'uploading' | 'done' | 'error' } | null;
+type NodeFiles = Record<string, FileRecord[]>;
+
+interface FileRecord {
+  id: string; filename: string; mime_type: string;
+  size_bytes: number; source: 'direct' | 'upload'; created_at: string;
+}
+```
+
+### Toolbar
+
+- **New Folder**: `setNewFolder({ parentId: selected?.id ?? null, value: "" })`
+- **Upload**: trigger `<input type="file" multiple>` on selected node
+- **Expand All / Collapse All**: toggle `expandedIds` set
+
+### TreeNode extensions
+
+- `Folder`/`FolderOpen` icon from lucide-react (area/line/system kinds); `Cog`/`Factory` for equipment
+- **Status dot**: colored circle (green/yellow/red) from `node.status` field
+- **Files count badge**: `({node.filesCount})` when > 0
+- **Inline rename**: double-click → swap label with `<input>`, Enter/Blur → PUT `{ newName }`
+- **New folder inline row**: when `newFolder.parentId === node.id`, render input as first child; Enter → POST; Escape → cancel
+- **External file drop zone**: detect `event.dataTransfer.types.includes('Files')`, highlight node, `onDrop` → `uploadFiles(node.id, e.dataTransfer.files)`
+- **Radix context menu** on right-click: `New Folder · Rename · Upload Files · ─ · Delete`
+
+### ContentPanel
+
+- Breadcrumb: `unsPath.split('.').map(segment => clickable link)`
+- **Folders section**: icon grid of child nodes — click to select + expand in tree
+- **Files section**: list with filename, size, date, download-on-click, delete-on-hover (×)
+- **Drop zone overlay**: full-panel, `onDrop` → upload to selected node
+- Skeleton loader while uploading
+
+### StatusBar
+
+- Left: `"N objects (X folders, Y files)"`
+- Right: selected `unsPath`
+
+---
+
+## Part 2 — Nav Restructure + Assets → Namespace Merge
+
+### Nav changes (`src/providers/access-control.ts`)
+
+**Current nav has two parallel systems:** Assets (flat list) and namespace (hierarchical tree of the same entities). As namespace becomes the filesystem, Assets is redundant.
+
+Restructure `NAV_ITEMS`:
+
+| Group | Items |
+|---|---|
+| Intelligence | Conversations · Alerts · Event Log |
+| Knowledge & Structure | **namespace** (primary) · Knowledge · ~~proposals~~ (moves to namespace tab) |
+| Operations (promote from More) | Work Orders · Schedule · Reports · Parts |
+| Platform | Channels · Integrations · Usage |
+
+Remove from primary nav: `Assets` (absorbed), `proposals` (becomes namespace tab), `Ladder Logic` (stays in More until built).
+
+Do NOT delete the `/assets` route — keep for backward compat / deep linking. Remove from nav only.
+
+### Tabbed detail panel for equipment nodes
+
+When `selected.kind` ∈ `['asset', 'equipment', 'component']`, ContentPanel shows tabs:
+
+```
+[Children] [Files] [Proposals] [Details] [Work Orders]
+```
+
+- **Details**: manufacturer, model, serial, status badge, QR link + Print QR button
+- **Work Orders**: open WOs filtered by `entity_id`
+- **Proposals**: pending/verified proposals for this node (replaces top-level proposals page per-node)
+- **Files**: attached documents (from files routes above)
+
+Non-equipment nodes: `[Children] [Files] [Proposals]`
+
+### Status dots on tree nodes
+
+Add `status?: string` to `NamespaceNode` — populated by LEFT JOIN on `cmms_equipment.status` via `entity_id` in the tree route.
+
+---
+
+## Files to create / modify
+
+| File | Action |
+|---|---|
+| `db/migrations/024_namespace_direct_uploads.sql` | CREATE |
+| `src/app/api/namespace/node/route.ts` | CREATE (POST) |
+| `src/app/api/namespace/node/[id]/route.ts` | EXTEND (add DELETE) |
+| `src/app/api/namespace/node/[id]/files/route.ts` | CREATE (GET + POST) |
+| `src/app/api/namespace/files/[id]/route.ts` | CREATE (GET download + DELETE) |
+| `src/app/api/namespace/tree/route.ts` | MINOR EDIT (+filesCount, +status) |
+| `src/app/(hub)/namespace/page.tsx` | FULL REWRITE (~600 lines) |
+| `src/providers/access-control.ts` | EDIT (nav restructure) |
+
+---
+
+## Execution sequence
+
+1. Migration `024_namespace_direct_uploads.sql`
+2. POST `/api/namespace/node` — create node
+3. DELETE on `/api/namespace/node/[id]` — delete node
+4. Files routes — upload, list, download, delete
+5. Tree route — add filesCount + status
+6. `page.tsx` — full rewrite (Explorer layout, toolbar, context menu, content panel, status bar)
+7. `access-control.ts` — nav restructure
+
+---
+
+## Verification
+
+```bash
+# Apply migration
+psql $NEON_DATABASE_URL -f mira-hub/db/migrations/024_namespace_direct_uploads.sql
+
+# Run dev server
+cd mira-hub && npm run dev
+
+# Manual E2E golden path:
+# 1. /hub/namespace — toolbar appears, split pane visible
+# 2. Toolbar "New Folder" → type "Building A" → Enter → appears in tree
+# 3. Right-click "Building A" → Rename → "Building_A" → Enter → label updates
+# 4. Drag a PDF onto "Building A" in tree → file appears in right panel
+# 5. Click PDF filename → download starts
+# 6. Right-click leaf node → Delete → node gone; blocked if it has children
+# 7. Drag node onto another folder → reparent (existing PUT)
+
+# Regression suite
+cd mira-hub && npx playwright test tests/e2e/
+```
+
+---
+
+## Out of scope
+
+- AI extraction on uploaded files (fire-and-forget `runIngestPipeline` only; integration deferred)
+- Semantic / full-text file search
+- MinIO/S3 object storage migration
+- Tree virtualization for 100k+ nodes
+- Multi-select drag
+- Real-time collaborative sync
+- Full deletion of `/assets` route (nav removal only this PR)

--- a/mira-hub/db/migrations/024_namespace_direct_uploads.sql
+++ b/mira-hub/db/migrations/024_namespace_direct_uploads.sql
@@ -1,0 +1,50 @@
+-- Migration 024: namespace direct uploads + node–file association
+--
+-- Plan: docs/plans/2026-05-18-windows-explorer-namespace.md
+--
+-- Adds two things:
+--   1. namespace_node_id FK on existing `uploads` table so cloud-sourced files
+--      (Google Drive, Dropbox) can be associated with a namespace folder.
+--   2. namespace_direct_uploads table for files dragged directly from desktop
+--      into the namespace tree (no cloud provider involved).
+--
+-- Hard limit: 10 MB per file enforced at the DB layer (CHECK constraint).
+-- Never SELECT content except in the dedicated download endpoint.
+
+-- 1. Associate cloud uploads with namespace nodes
+ALTER TABLE uploads
+  ADD COLUMN IF NOT EXISTS namespace_node_id UUID
+    REFERENCES kg_entities(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_uploads_namespace_node
+  ON uploads (tenant_id, namespace_node_id)
+  WHERE namespace_node_id IS NOT NULL;
+
+-- 2. Direct desktop drag-drop uploads
+CREATE TABLE IF NOT EXISTS namespace_direct_uploads (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id    UUID        NOT NULL,
+  node_id      UUID        REFERENCES kg_entities(id) ON DELETE SET NULL,
+  filename     TEXT        NOT NULL,
+  mime_type    TEXT        NOT NULL DEFAULT 'application/octet-stream',
+  size_bytes   BIGINT      NOT NULL DEFAULT 0
+                             CHECK (size_bytes <= 10485760),  -- 10 MB hard cap
+  content      BYTEA       NOT NULL,
+  uploaded_by  UUID,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ndu_node
+  ON namespace_direct_uploads (tenant_id, node_id);
+
+CREATE INDEX IF NOT EXISTS idx_ndu_tenant_recent
+  ON namespace_direct_uploads (tenant_id, created_at DESC);
+
+ALTER TABLE namespace_direct_uploads ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS ndu_tenant ON namespace_direct_uploads;
+CREATE POLICY ndu_tenant ON namespace_direct_uploads
+  USING (tenant_id::text = current_setting('app.tenant_id', true));
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON namespace_direct_uploads TO factorylm_app;

--- a/mira-hub/src/app/(hub)/namespace/page.tsx
+++ b/mira-hub/src/app/(hub)/namespace/page.tsx
@@ -1,24 +1,24 @@
 "use client";
 
-/**
- * Namespace tree — read-only view (Phase 2 slice 1).
- *
- * Spec: docs/specs/maintenance-namespace-builder-spec.md §"Namespace tree"
- * API : GET /api/namespace/tree
- *
- * Drag-drop move, rename, and merge land in slice 2.
- */
-
-import { useCallback, useEffect, useMemo, useState } from "react";
-import Link from "next/link";
-import { ChevronDown, ChevronRight, Layers, Loader2, Factory, MapPin, Cog, FileText, Search } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  ChevronDown, ChevronRight,
+  Folder, FolderOpen,
+  Cog, Factory, FileText, Layers,
+  RefreshCw, FolderPlus, Upload, ChevronsDownUp, ChevronsUpDown,
+  Trash2, Pencil,
+} from "lucide-react";
 import { API_BASE } from "@/lib/config";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
 
 interface NamespaceNode {
   id: string;
   name: string;
   kind: string;
   unsPath: string | null;
+  filesCount: number;
+  status: string | null;
   counts: {
     children: number;
     proposalsPending: number;
@@ -27,45 +27,50 @@ interface NamespaceNode {
   children: NamespaceNode[];
 }
 
-interface TreeResponse {
-  tree: NamespaceNode[];
-  total: number;
+interface FileRecord {
+  id: string;
+  filename: string;
+  mime_type: string;
+  size_bytes: number;
+  source: "direct" | "upload";
+  created_at: string;
 }
 
-const KIND_ICON: Record<string, React.ElementType> = {
-  site: Factory,
-  plant: Factory,
-  area: MapPin,
-  line: MapPin,
-  production_line: MapPin,
-  asset: Cog,
-  component: Cog,
-  component_template: Cog,
-  document: FileText,
+type EditingState = { nodeId: string; value: string } | null;
+type NewFolderState = { parentId: string | null; value: string } | null;
+type UploadState = { nodeId: string; state: "uploading" | "done" | "error" } | null;
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const EQUIPMENT_KINDS = new Set(["asset", "equipment", "component"]);
+
+const KIND_ICON = (kind: string, open = false): React.ElementType => {
+  if (kind === "site" || kind === "plant") return Factory;
+  if (kind === "asset" || kind === "equipment" || kind === "component") return Cog;
+  if (kind === "document") return FileText;
+  return open ? FolderOpen : Folder;
 };
 
-// Next.js `<Link>` auto-prepends the configured basePath ('/hub' in this
-// app). Build hrefs as bare app-relative paths — NOT prefixed with
-// API_BASE — or they'll double-up to '/hub/hub/...'. Plain `<a>` does
-// not transform; those still need the full prefix (see EmptyState below).
-const HUB_BASE = API_BASE.replace(/\/api$/, "");
-
-function filterTree(nodes: NamespaceNode[], query: string): NamespaceNode[] {
-  const q = query.trim().toLowerCase();
-  if (q.length === 0) return nodes;
-  const walk = (node: NamespaceNode): NamespaceNode | null => {
-    const selfMatches =
-      node.name.toLowerCase().includes(q) ||
-      (node.unsPath?.toLowerCase().includes(q) ?? false);
-    const filteredChildren = node.children
-      .map(walk)
-      .filter((c): c is NamespaceNode => c !== null);
-    if (!selfMatches && filteredChildren.length === 0) return null;
-    // When a child matches, surface the whole subtree so the user keeps context.
-    return { ...node, children: selfMatches ? node.children : filteredChildren };
-  };
-  return nodes.map(walk).filter((n): n is NamespaceNode => n !== null);
+function statusColor(status: string | null): string {
+  if (!status) return "";
+  const s = status.toLowerCase();
+  if (s === "active" || s === "operational" || s === "running") return "bg-green-500";
+  if (s === "warning" || s === "degraded") return "bg-yellow-400";
+  if (s === "fault" || s === "down" || s === "failed") return "bg-red-500";
+  return "bg-gray-400";
 }
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
 
 export default function NamespacePage() {
   const [tree, setTree] = useState<NamespaceNode[]>([]);
@@ -73,19 +78,36 @@ export default function NamespacePage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selected, setSelected] = useState<NamespaceNode | null>(null);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dropTargetId, setDropTargetId] = useState<string | null>(null);
+  const [fileDropTargetId, setFileDropTargetId] = useState<string | null>(null);
   const [toast, setToast] = useState<string | null>(null);
-  const [search, setSearch] = useState("");
+  const [editing, setEditing] = useState<EditingState>(null);
+  const [newFolder, setNewFolder] = useState<NewFolderState>(null);
+  const [uploadState, setUploadState] = useState<UploadState>(null);
+  const [nodeFiles, setNodeFiles] = useState<Record<string, FileRecord[]>>({});
+  const [ctxMenu, setCtxMenu] = useState<{ node: NamespaceNode; x: number; y: number } | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const showToast = useCallback((msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 3500);
+  }, []);
 
   const refreshTree = useCallback(async () => {
     try {
       const res = await fetch(`${API_BASE}/api/namespace/tree`, { cache: "no-store" });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = (await res.json()) as TreeResponse;
+      const data = await res.json() as { tree: NamespaceNode[]; total: number };
       setTree(data.tree);
       setTotal(data.total);
       setError(null);
+      // Update selected node data from fresh tree.
+      setSelected((prev) => {
+        if (!prev) return prev;
+        return findNode(data.tree, prev.id) ?? prev;
+      });
     } catch (e) {
       setError((e as Error).message);
     }
@@ -97,17 +119,42 @@ export default function NamespacePage() {
       await refreshTree();
       if (!cancelled) setLoading(false);
     })();
-    return () => {
-      cancelled = true;
-    };
+    return () => { cancelled = true; };
   }, [refreshTree]);
 
-  const visibleTree = useMemo(() => filterTree(tree, search), [tree, search]);
+  // Expand first two levels by default once tree loads.
+  useEffect(() => {
+    if (tree.length > 0 && expandedIds.size === 0) {
+      const ids = new Set<string>();
+      for (const root of tree) {
+        ids.add(root.id);
+        for (const child of root.children) ids.add(child.id);
+      }
+      setExpandedIds(ids);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tree.length > 0]);
 
-  async function handleDrop(sourceId: string, targetId: string) {
+  const loadFiles = useCallback(async (nodeId: string) => {
+    if (nodeFiles[nodeId]) return;
+    try {
+      const res = await fetch(`${API_BASE}/api/namespace/node/${nodeId}/files`, { cache: "no-store" });
+      if (!res.ok) return;
+      const data = await res.json() as { files: FileRecord[] };
+      setNodeFiles((prev) => ({ ...prev, [nodeId]: data.files }));
+    } catch { /* non-fatal */ }
+  }, [nodeFiles]);
+
+  const handleSelect = useCallback((node: NamespaceNode) => {
+    setSelected(node);
+    void loadFiles(node.id);
+  }, [loadFiles]);
+
+  // ── Node drag-and-drop (reparent) ──────────────────────────────────────────
+
+  async function handleNodeDrop(sourceId: string, targetId: string) {
     if (sourceId === targetId) return;
-    const previous = tree;
-    setToast("Moving…");
+    showToast("Moving…");
     try {
       const res = await fetch(`${API_BASE}/api/namespace/node/${sourceId}`, {
         method: "PUT",
@@ -115,128 +162,413 @@ export default function NamespacePage() {
         body: JSON.stringify({ newParentId: targetId, reason: "drag-and-drop" }),
       });
       if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        const body = await res.json().catch(() => ({})) as { error?: string };
         throw new Error(body.error ?? `HTTP ${res.status}`);
       }
       await refreshTree();
-      setToast("Move saved");
+      showToast("Moved");
     } catch (e) {
-      setTree(previous);
-      setToast(`Move failed: ${(e as Error).message}`);
+      showToast(`Move failed: ${(e as Error).message}`);
     } finally {
       setDraggingId(null);
       setDropTargetId(null);
-      setTimeout(() => setToast(null), 3500);
     }
   }
 
-  return (
-    <div className="flex h-full" data-testid="namespace-page">
-      <div className="flex-1 overflow-auto p-6">
-        <div className="mb-4 flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-semibold text-slate-900">Namespace</h1>
-            <p className="mt-1 text-sm text-slate-500">
-              {loading
-                ? "Loading…"
-                : `${total} entit${total === 1 ? "y" : "ies"} — drag any node to reparent`}
-            </p>
-          </div>
-        </div>
+  // ── Rename ─────────────────────────────────────────────────────────────────
 
-        <div className="relative mb-4">
-          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
-          <input
-            type="search"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search namespace…"
-            className="w-full rounded-md border border-slate-200 bg-white py-2 pl-9 pr-3 text-sm text-slate-900 placeholder-slate-400 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-            data-testid="namespace-search"
-            aria-label="Search namespace"
+  async function commitRename(nodeId: string, newName: string) {
+    setEditing(null);
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    try {
+      const res = await fetch(`${API_BASE}/api/namespace/node/${nodeId}`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ newName: trimmed }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      await refreshTree();
+    } catch (e) {
+      showToast(`Rename failed: ${(e as Error).message}`);
+    }
+  }
+
+  // ── Create folder ──────────────────────────────────────────────────────────
+
+  async function commitNewFolder(parentId: string | null, name: string) {
+    setNewFolder(null);
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    try {
+      const res = await fetch(`${API_BASE}/api/namespace/node`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ parentId: parentId ?? undefined, name: trimmed, kind: "area" }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      if (parentId) {
+        setExpandedIds((prev) => new Set([...prev, parentId]));
+      }
+      await refreshTree();
+    } catch (e) {
+      showToast(`Create failed: ${(e as Error).message}`);
+    }
+  }
+
+  // ── Delete node ────────────────────────────────────────────────────────────
+
+  async function handleDeleteNode(nodeId: string) {
+    try {
+      const res = await fetch(`${API_BASE}/api/namespace/node/${nodeId}`, { method: "DELETE" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({})) as { error?: string };
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      setSelected((prev) => (prev?.id === nodeId ? null : prev));
+      await refreshTree();
+    } catch (e) {
+      showToast(`Delete failed: ${(e as Error).message}`);
+    }
+  }
+
+  // ── File upload ────────────────────────────────────────────────────────────
+
+  async function uploadFiles(nodeId: string, files: FileList | null) {
+    if (!files || files.length === 0) return;
+    setUploadState({ nodeId, state: "uploading" });
+    try {
+      for (const file of Array.from(files)) {
+        const fd = new FormData();
+        fd.append("file", file);
+        const res = await fetch(`${API_BASE}/api/namespace/node/${nodeId}/files`, {
+          method: "POST",
+          body: fd,
+        });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({})) as { error?: string };
+          throw new Error(body.error ?? `HTTP ${res.status}`);
+        }
+      }
+      setUploadState({ nodeId, state: "done" });
+      // Invalidate file cache so next view reload refetches.
+      setNodeFiles((prev) => { const n = { ...prev }; delete n[nodeId]; return n; });
+      if (selected?.id === nodeId) void loadFiles(nodeId);
+      await refreshTree();
+      showToast(`${files.length} file${files.length === 1 ? "" : "s"} uploaded`);
+    } catch (e) {
+      setUploadState({ nodeId, state: "error" });
+      showToast(`Upload failed: ${(e as Error).message}`);
+    } finally {
+      setTimeout(() => setUploadState(null), 2000);
+    }
+  }
+
+  // ── File delete ────────────────────────────────────────────────────────────
+
+  async function handleDeleteFile(fileId: string, nodeId: string) {
+    try {
+      const res = await fetch(`${API_BASE}/api/namespace/files/${fileId}`, { method: "DELETE" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setNodeFiles((prev) => ({
+        ...prev,
+        [nodeId]: (prev[nodeId] ?? []).filter((f) => f.id !== fileId),
+      }));
+      await refreshTree();
+    } catch (e) {
+      showToast(`Delete failed: ${(e as Error).message}`);
+    }
+  }
+
+  // ── Tree expand/collapse ───────────────────────────────────────────────────
+
+  function expandAll() {
+    const ids = new Set<string>();
+    const walk = (nodes: NamespaceNode[]) => {
+      for (const n of nodes) { ids.add(n.id); walk(n.children); }
+    };
+    walk(tree);
+    setExpandedIds(ids);
+  }
+
+  function collapseAll() {
+    setExpandedIds(new Set());
+  }
+
+  // ── Derived counts for status bar ──────────────────────────────────────────
+
+  const { folderCount, fileCount } = useMemo(() => {
+    const files = selected ? (nodeFiles[selected.id] ?? []).length : 0;
+    const folders = selected?.counts.children ?? 0;
+    return { folderCount: folders, fileCount: files };
+  }, [selected, nodeFiles]);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex h-full flex-col" data-testid="namespace-page">
+      {/* Toolbar */}
+      <div className="flex items-center gap-1 border-b border-gray-400 bg-[#d4d0c8] p-1">
+        <ToolbarButton
+          icon={<FolderPlus className="h-3.5 w-3.5" />}
+          label="New Folder"
+          onClick={() => setNewFolder({ parentId: selected?.id ?? null, value: "" })}
+        />
+        <ToolbarButton
+          icon={<Upload className="h-3.5 w-3.5" />}
+          label="Upload"
+          disabled={!selected}
+          onClick={() => {
+            if (!selected) return;
+            fileInputRef.current?.click();
+          }}
+        />
+        <div className="mx-1 h-5 w-px bg-gray-500" />
+        <ToolbarButton
+          icon={<ChevronsUpDown className="h-3.5 w-3.5" />}
+          label="Expand All"
+          onClick={expandAll}
+        />
+        <ToolbarButton
+          icon={<ChevronsDownUp className="h-3.5 w-3.5" />}
+          label="Collapse All"
+          onClick={collapseAll}
+        />
+        <div className="ml-auto">
+          <ToolbarButton
+            icon={<RefreshCw className="h-3.5 w-3.5" />}
+            label="Refresh"
+            onClick={() => void refreshTree()}
           />
         </div>
-
-        {loading ? (
-          <div className="flex items-center gap-2 text-slate-500">
-            <Loader2 className="h-4 w-4 animate-spin" /> Loading tree…
-          </div>
-        ) : error ? (
-          <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-            Failed to load namespace: {error}
-          </div>
-        ) : tree.length === 0 ? (
-          <EmptyState />
-        ) : visibleTree.length === 0 ? (
-          <div className="rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
-            No nodes match <span className="font-mono">&quot;{search}&quot;</span>.
-          </div>
-        ) : (
-          <div className="space-y-1" data-testid="namespace-tree">
-            {visibleTree.map((node) => (
-              <TreeNode
-                key={node.id}
-                node={node}
-                depth={0}
-                selectedId={selected?.id ?? null}
-                onSelect={setSelected}
-                draggingId={draggingId}
-                dropTargetId={dropTargetId}
-                onDragStart={setDraggingId}
-                onDragOver={setDropTargetId}
-                onDrop={handleDrop}
-              />
-            ))}
-          </div>
-        )}
       </div>
 
-      <aside
-        className="hidden w-80 shrink-0 border-l border-slate-200 bg-slate-50 p-6 lg:block"
-        data-testid="namespace-detail-pane"
-      >
-        {loading ? null : selected ? <DetailPane node={selected} /> : <DetailEmpty />}
-      </aside>
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          if (selected) void uploadFiles(selected.id, e.target.files);
+          e.target.value = "";
+        }}
+      />
 
-      {toast && (
+      {/* Split pane */}
+      <div className="flex min-h-0 flex-1">
+        {/* Tree panel */}
         <div
-          className="fixed bottom-4 right-4 z-50 rounded-md bg-slate-900 px-4 py-2 text-sm text-white shadow-lg"
-          data-testid="namespace-toast"
+          className="w-[280px] shrink-0 overflow-auto border-r border-gray-400 bg-[#f0f0f0] font-mono text-[13px]"
+          data-testid="namespace-tree-panel"
         >
+          {loading ? (
+            <div className="p-3 text-xs text-gray-500">Loading…</div>
+          ) : error ? (
+            <div className="p-3 text-xs text-red-600">{error}</div>
+          ) : (
+            <div className="p-1">
+              {/* Root-level new folder input */}
+              {newFolder && newFolder.parentId === null && (
+                <NewFolderRow
+                  value={newFolder.value}
+                  onChange={(v) => setNewFolder({ parentId: null, value: v })}
+                  onCommit={(v) => void commitNewFolder(null, v)}
+                  onCancel={() => setNewFolder(null)}
+                />
+              )}
+              {tree.map((node) => (
+                <TreeNode
+                  key={node.id}
+                  node={node}
+                  depth={0}
+                  selectedId={selected?.id ?? null}
+                  expandedIds={expandedIds}
+                  draggingId={draggingId}
+                  dropTargetId={dropTargetId}
+                  fileDropTargetId={fileDropTargetId}
+                  editing={editing}
+                  newFolder={newFolder}
+                  uploadState={uploadState}
+                  onSelect={handleSelect}
+                  onExpand={(id, open) => setExpandedIds((prev) => {
+                    const s = new Set(prev);
+                    if (open) s.add(id); else s.delete(id);
+                    return s;
+                  })}
+                  onDragStart={setDraggingId}
+                  onDragOver={setDropTargetId}
+                  onNodeDrop={handleNodeDrop}
+                  onFileDragOver={setFileDropTargetId}
+                  onFileDrop={(nodeId, files) => void uploadFiles(nodeId, files)}
+                  onEditStart={(nodeId, name) => setEditing({ nodeId, value: name })}
+                  onEditChange={(v) => setEditing((prev) => prev ? { ...prev, value: v } : prev)}
+                  onEditCommit={(nodeId, v) => void commitRename(nodeId, v)}
+                  onEditCancel={() => setEditing(null)}
+                  onDelete={handleDeleteNode}
+                  onNewFolder={(parentId) => {
+                    setNewFolder({ parentId, value: "" });
+                    setExpandedIds((prev) => new Set([...prev, parentId]));
+                  }}
+                  onNewFolderChange={(v) => setNewFolder((prev) => prev ? { ...prev, value: v } : prev)}
+                  onNewFolderCommit={(parentId, v) => void commitNewFolder(parentId, v)}
+                  onNewFolderCancel={() => setNewFolder(null)}
+                  onUpload={(nodeId) => {
+                    fileInputRef.current?.click();
+                    handleSelect(findNode(tree, nodeId) ?? selected!);
+                  }}
+                  onContextMenu={(ctxNode, x, y) => setCtxMenu({ node: ctxNode, x, y })}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Content panel */}
+        <div
+          className="flex min-w-0 flex-1 flex-col bg-white font-mono text-[13px]"
+          data-testid="namespace-content-panel"
+          onDragOver={(e) => {
+            if (selected && e.dataTransfer.types.includes("Files")) {
+              e.preventDefault();
+            }
+          }}
+          onDrop={(e) => {
+            e.preventDefault();
+            if (selected && e.dataTransfer.files.length > 0) {
+              void uploadFiles(selected.id, e.dataTransfer.files);
+            }
+          }}
+        >
+          {selected ? (
+            <ContentPanel
+              node={selected}
+              files={nodeFiles[selected.id]}
+              uploadState={uploadState}
+              onSelect={handleSelect}
+              onDeleteFile={(fileId) => handleDeleteFile(fileId, selected.id)}
+              onUpload={() => fileInputRef.current?.click()}
+            />
+          ) : (
+            <div className="flex flex-1 items-center justify-center text-sm text-gray-400">
+              {loading ? null : tree.length === 0 ? (
+                <EmptyState />
+              ) : (
+                "Select a folder to view its contents"
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Status bar */}
+      <div className="flex items-center justify-between border-t border-gray-400 bg-[#d4d0c8] px-2 py-0.5 text-[11px]">
+        <span>
+          {selected
+            ? `${folderCount + fileCount} object${folderCount + fileCount === 1 ? "" : "s"} (${folderCount} folder${folderCount === 1 ? "" : "s"}, ${fileCount} file${fileCount === 1 ? "" : "s"})`
+            : `${total} entities total`}
+        </span>
+        <span className="truncate pl-4 text-gray-600">{selected?.unsPath ?? ""}</span>
+      </div>
+
+      {/* Toast */}
+      {toast && (
+        <div className="fixed bottom-4 right-4 z-50 rounded bg-slate-900 px-4 py-2 text-sm text-white shadow-lg" data-testid="namespace-toast">
           {toast}
         </div>
+      )}
+
+      {/* Context menu */}
+      {ctxMenu && (
+        <ContextMenuOverlay
+          x={ctxMenu.x}
+          y={ctxMenu.y}
+          onClose={() => setCtxMenu(null)}
+          onNewFolder={() => {
+            setCtxMenu(null);
+            setNewFolder({ parentId: ctxMenu.node.id, value: "" });
+            setExpandedIds((prev) => new Set([...prev, ctxMenu.node.id]));
+          }}
+          onRename={() => {
+            setCtxMenu(null);
+            setEditing({ nodeId: ctxMenu.node.id, value: ctxMenu.node.name });
+          }}
+          onUpload={() => {
+            setCtxMenu(null);
+            handleSelect(ctxMenu.node);
+            fileInputRef.current?.click();
+          }}
+          onDelete={() => {
+            const id = ctxMenu.node.id;
+            setCtxMenu(null);
+            void handleDeleteNode(id);
+          }}
+        />
       )}
     </div>
   );
 }
 
+// ── TreeNode ──────────────────────────────────────────────────────────────────
+
 function TreeNode({
-  node,
-  depth,
-  selectedId,
-  onSelect,
-  draggingId,
-  dropTargetId,
-  onDragStart,
-  onDragOver,
-  onDrop,
+  node, depth, selectedId, expandedIds,
+  draggingId, dropTargetId, fileDropTargetId,
+  editing, newFolder, uploadState,
+  onSelect, onExpand,
+  onDragStart, onDragOver, onNodeDrop,
+  onFileDragOver, onFileDrop,
+  onEditStart, onEditChange, onEditCommit, onEditCancel,
+  onDelete, onNewFolder, onNewFolderChange, onNewFolderCommit, onNewFolderCancel,
+  onUpload, onContextMenu,
 }: {
   node: NamespaceNode;
   depth: number;
   selectedId: string | null;
-  onSelect: (n: NamespaceNode) => void;
+  expandedIds: Set<string>;
   draggingId: string | null;
   dropTargetId: string | null;
+  fileDropTargetId: string | null;
+  editing: EditingState;
+  newFolder: NewFolderState;
+  uploadState: UploadState;
+  onSelect: (n: NamespaceNode) => void;
+  onExpand: (id: string, open: boolean) => void;
   onDragStart: (id: string | null) => void;
   onDragOver: (id: string | null) => void;
-  onDrop: (sourceId: string, targetId: string) => void;
+  onNodeDrop: (sourceId: string, targetId: string) => void;
+  onFileDragOver: (id: string | null) => void;
+  onFileDrop: (nodeId: string, files: FileList) => void;
+  onEditStart: (nodeId: string, name: string) => void;
+  onEditChange: (v: string) => void;
+  onEditCommit: (nodeId: string, v: string) => void;
+  onEditCancel: () => void;
+  onDelete: (nodeId: string) => void;
+  onNewFolder: (parentId: string) => void;
+  onNewFolderChange: (v: string) => void;
+  onNewFolderCommit: (parentId: string, v: string) => void;
+  onNewFolderCancel: () => void;
+  onUpload: (nodeId: string) => void;
+  onContextMenu: (node: NamespaceNode, x: number, y: number) => void;
 }) {
-  const [open, setOpen] = useState(depth < 2);
-  const hasChildren = node.children.length > 0;
-  const Icon = KIND_ICON[node.kind] ?? Layers;
+  const open = expandedIds.has(node.id);
+  const hasChildren = node.children.length > 0 || (newFolder?.parentId === node.id);
   const isSelected = node.id === selectedId;
   const isDragging = draggingId === node.id;
-  const isDropTarget = dropTargetId === node.id && draggingId !== node.id;
+  const isNodeDropTarget = dropTargetId === node.id && draggingId !== node.id;
+  const isFileDropTarget = fileDropTargetId === node.id;
+  const isEditing = editing?.nodeId === node.id;
+  const isUploading = uploadState?.nodeId === node.id && uploadState.state === "uploading";
+
+  const Icon = KIND_ICON(node.kind, open);
+  const indent = depth * 14 + 6;
+  const dotColor = statusColor(node.status);
 
   return (
     <div>
@@ -247,69 +579,139 @@ function TreeNode({
           e.dataTransfer.setData("text/plain", node.id);
           onDragStart(node.id);
         }}
-        onDragEnd={() => onDragStart(null)}
+        onDragEnd={() => { onDragStart(null); onDragOver(null); }}
         onDragOver={(e) => {
           if (draggingId && draggingId !== node.id) {
             e.preventDefault();
             e.dataTransfer.dropEffect = "move";
             onDragOver(node.id);
+          } else if (!draggingId && e.dataTransfer.types.includes("Files")) {
+            e.preventDefault();
+            onFileDragOver(node.id);
           }
         }}
-        onDragLeave={() => onDragOver(null)}
+        onDragLeave={() => { onDragOver(null); onFileDragOver(null); }}
         onDrop={(e) => {
           e.preventDefault();
-          const sourceId = e.dataTransfer.getData("text/plain") || draggingId;
-          if (sourceId && sourceId !== node.id) {
-            onDrop(sourceId, node.id);
+          if (draggingId) {
+            onNodeDrop(draggingId, node.id);
+          } else if (e.dataTransfer.files.length > 0) {
+            onFileDrop(node.id, e.dataTransfer.files);
+            onFileDragOver(null);
           }
         }}
-        className={`flex items-center gap-2 rounded px-2 py-1.5 text-sm transition ${
-          isSelected ? "bg-blue-50 ring-1 ring-blue-200" : ""
-        } ${isDragging ? "opacity-40" : ""} ${
-          isDropTarget ? "bg-blue-100 ring-2 ring-blue-500" : "hover:bg-slate-100"
-        }`}
-        style={{ paddingLeft: `${depth * 16 + 8}px` }}
+        className={[
+          "flex h-7 cursor-pointer select-none items-center gap-1",
+          isSelected ? "bg-[#000080] text-white" : "hover:bg-[#c8c8c8]",
+          isDragging ? "opacity-40" : "",
+          isNodeDropTarget ? "bg-blue-200 outline-2 outline-dashed outline-blue-500" : "",
+          isFileDropTarget && !isSelected ? "bg-[#c0c0ff] outline-2 outline-dashed outline-blue-600" : "",
+        ].filter(Boolean).join(" ")}
+        style={{ paddingLeft: `${indent}px` }}
         data-testid="namespace-node"
         data-node-id={node.id}
-        data-drop-target={isDropTarget ? "true" : "false"}
+        onClick={() => {
+          onSelect(node);
+          if (hasChildren || node.children.length > 0) onExpand(node.id, !open);
+        }}
+        onDoubleClick={(e) => {
+          e.stopPropagation();
+          onEditStart(node.id, node.name);
+        }}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          onContextMenu(node, e.clientX, e.clientY);
+        }}
       >
         <button
           type="button"
-          onClick={() => hasChildren && setOpen((o) => !o)}
-          className="flex h-5 w-5 items-center justify-center text-slate-600 hover:text-slate-900"
-          aria-label={open ? "Collapse" : "Expand"}
+          className="flex h-4 w-4 items-center justify-center"
+          onClick={(e) => { e.stopPropagation(); if (hasChildren) onExpand(node.id, !open); }}
         >
-          {hasChildren ? open ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" /> : null}
+          {hasChildren
+            ? open
+              ? <ChevronDown className="h-3 w-3" />
+              : <ChevronRight className="h-3 w-3" />
+            : null}
         </button>
-        <button
-          type="button"
-          onClick={() => onSelect(node)}
-          className="flex flex-1 items-center gap-2 text-left"
-        >
-          <Icon className="h-4 w-4 text-slate-500" />
-          <span className="text-slate-900">{node.name}</span>
-          <span className="text-xs text-slate-600">{node.kind}</span>
-          {node.counts.proposalsPending > 0 && (
-            <span className="ml-auto rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800">
-              {node.counts.proposalsPending} proposed
-            </span>
-          )}
-        </button>
+
+        <Icon className={`h-3.5 w-3.5 shrink-0 ${isSelected ? "text-white" : "text-gray-600"}`} />
+
+        {isEditing ? (
+          <input
+            autoFocus
+            className="ml-1 h-5 flex-1 rounded border border-blue-400 bg-white px-1 text-[12px] text-black"
+            value={editing.value}
+            onChange={(e) => onEditChange(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onEditCommit(node.id, editing.value);
+              if (e.key === "Escape") onEditCancel();
+              e.stopPropagation();
+            }}
+            onBlur={() => onEditCommit(node.id, editing.value)}
+            onClick={(e) => e.stopPropagation()}
+          />
+        ) : (
+          <span className={`ml-0.5 truncate ${isSelected ? "text-white" : "text-gray-900"}`}>
+            {node.name}
+          </span>
+        )}
+
+        {dotColor && (
+          <span className={`ml-1 h-2 w-2 shrink-0 rounded-full ${dotColor}`} title={node.status ?? ""} />
+        )}
+        {node.filesCount > 0 && (
+          <span className={`ml-0.5 text-[11px] ${isSelected ? "text-blue-200" : "text-gray-400"}`}>
+            ({node.filesCount})
+          </span>
+        )}
+        {isUploading && (
+          <span className="ml-1 text-[10px] text-blue-400">↑</span>
+        )}
       </div>
-      {open && hasChildren && (
+
+      {open && (
         <div>
+          {newFolder?.parentId === node.id && (
+            <NewFolderRow
+              indent={indent + 14}
+              value={newFolder.value}
+              onChange={onNewFolderChange}
+              onCommit={(v) => onNewFolderCommit(node.id, v)}
+              onCancel={onNewFolderCancel}
+            />
+          )}
           {node.children.map((child) => (
             <TreeNode
               key={child.id}
               node={child}
               depth={depth + 1}
               selectedId={selectedId}
-              onSelect={onSelect}
+              expandedIds={expandedIds}
               draggingId={draggingId}
               dropTargetId={dropTargetId}
+              fileDropTargetId={fileDropTargetId}
+              editing={editing}
+              newFolder={newFolder}
+              uploadState={uploadState}
+              onSelect={onSelect}
+              onExpand={onExpand}
               onDragStart={onDragStart}
               onDragOver={onDragOver}
-              onDrop={onDrop}
+              onNodeDrop={onNodeDrop}
+              onFileDragOver={onFileDragOver}
+              onFileDrop={onFileDrop}
+              onEditStart={onEditStart}
+              onEditChange={onEditChange}
+              onEditCommit={onEditCommit}
+              onEditCancel={onEditCancel}
+              onDelete={onDelete}
+              onNewFolder={onNewFolder}
+              onNewFolderChange={onNewFolderChange}
+              onNewFolderCommit={onNewFolderCommit}
+              onNewFolderCancel={onNewFolderCancel}
+              onUpload={onUpload}
+              onContextMenu={onContextMenu}
             />
           ))}
         </div>
@@ -318,101 +720,363 @@ function TreeNode({
   );
 }
 
-function DetailPane({ node }: { node: NamespaceNode }) {
-  const path = node.unsPath ?? "";
-  const proposalsHref = (status: "pending" | "verified") =>
-    `/proposals?path=${encodeURIComponent(path)}&status=${status}`;
+// ── ContentPanel ──────────────────────────────────────────────────────────────
+
+function ContentPanel({
+  node, files, uploadState,
+  onSelect, onDeleteFile, onUpload,
+}: {
+  node: NamespaceNode;
+  files: FileRecord[] | undefined;
+  uploadState: UploadState;
+  onSelect: (n: NamespaceNode) => void;
+  onDeleteFile: (fileId: string) => void;
+  onUpload: () => void;
+}) {
+  const breadcrumbs = useMemo(() => {
+    if (!node.unsPath) return [{ label: node.name, path: null }];
+    return node.unsPath.split(".").map((seg, i, arr) => ({
+      label: seg,
+      path: arr.slice(0, i + 1).join("."),
+    }));
+  }, [node]);
+
+  const isEquipment = EQUIPMENT_KINDS.has(node.kind);
+  const [activeTab, setActiveTab] = useState<"children" | "files" | "proposals" | "details" | "workorders">("children");
+
   return (
-    <div data-testid="namespace-detail">
-      <div className="text-xs uppercase tracking-wide text-slate-500">{node.kind}</div>
-      <h2 className="mt-1 text-lg font-semibold text-slate-900">{node.name}</h2>
+    <div className="flex flex-col h-full">
+      {/* Breadcrumb */}
+      <div className="flex items-center gap-1 border-b border-gray-200 px-3 py-1.5 text-[12px] text-gray-600">
+        {breadcrumbs.map((crumb, i) => (
+          <span key={crumb.path ?? crumb.label} className="flex items-center gap-1">
+            {i > 0 && <ChevronRight className="h-3 w-3 text-gray-400" />}
+            <span className={i === breadcrumbs.length - 1 ? "font-semibold text-gray-900" : "cursor-default"}>
+              {crumb.label}
+            </span>
+          </span>
+        ))}
+      </div>
+
+      {/* Tabs for equipment nodes */}
+      {isEquipment && (
+        <div className="flex gap-0 border-b border-gray-200 bg-[#f8f8f8] px-2 pt-1">
+          {(["children", "files", "proposals", "details", "workorders"] as const).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              onClick={() => setActiveTab(tab)}
+              className={[
+                "px-3 py-1 text-[12px] capitalize border-t border-l border-r rounded-t",
+                activeTab === tab
+                  ? "bg-white border-gray-300 text-gray-900 font-medium -mb-px"
+                  : "border-transparent text-gray-500 hover:text-gray-800",
+              ].join(" ")}
+            >
+              {tab === "workorders" ? "Work Orders" : tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-auto p-3">
+        {/* Children section (always shown for non-equipment, or when on children tab) */}
+        {(!isEquipment || activeTab === "children") && (
+          <ChildrenSection node={node} onSelect={onSelect} />
+        )}
+
+        {/* Files section */}
+        {(!isEquipment || activeTab === "files") && (
+          <FilesSection
+            nodeId={node.id}
+            files={files}
+            uploadState={uploadState}
+            onDeleteFile={onDeleteFile}
+            onUpload={onUpload}
+          />
+        )}
+
+        {/* Proposals stub */}
+        {isEquipment && activeTab === "proposals" && (
+          <div className="text-sm text-gray-500 pt-4">
+            {node.counts.proposalsPending + node.counts.proposalsVerified === 0
+              ? "No proposals for this node."
+              : `${node.counts.proposalsPending} pending · ${node.counts.proposalsVerified} verified`}
+          </div>
+        )}
+
+        {/* Details tab */}
+        {isEquipment && activeTab === "details" && (
+          <DetailsSection node={node} />
+        )}
+
+        {/* Work Orders stub */}
+        {isEquipment && activeTab === "workorders" && (
+          <div className="text-sm text-gray-500 pt-4">Work order view coming soon.</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ChildrenSection({ node, onSelect }: {
+  node: NamespaceNode;
+  onSelect: (n: NamespaceNode) => void;
+}) {
+  if (node.children.length === 0) return null;
+  return (
+    <div className="mb-4">
+      <div className="mb-2 text-[11px] uppercase tracking-wide text-gray-400">Folders</div>
+      <div className="flex flex-wrap gap-3">
+        {node.children.map((child) => {
+          const Icon = KIND_ICON(child.kind, false);
+          return (
+            <button
+              key={child.id}
+              type="button"
+              onDoubleClick={() => onSelect(child)}
+              onClick={() => onSelect(child)}
+              className="flex w-24 flex-col items-center gap-1 rounded p-2 text-center hover:bg-[#e8e8f8] active:bg-[#c0c0ff]"
+            >
+              <Icon className="h-8 w-8 text-[#0000c0]" />
+              <span className="text-[11px] leading-tight text-gray-800 break-words w-full">{child.name}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function FilesSection({ nodeId, files, uploadState, onDeleteFile, onUpload }: {
+  nodeId: string;
+  files: FileRecord[] | undefined;
+  uploadState: UploadState;
+  onDeleteFile: (fileId: string) => void;
+  onUpload: () => void;
+}) {
+  const isUploading = uploadState?.nodeId === nodeId && uploadState.state === "uploading";
+
+  if (files === undefined && !isUploading) return null;
+
+  return (
+    <div>
+      <div className="mb-2 text-[11px] uppercase tracking-wide text-gray-400">Files</div>
+      {isUploading && (
+        <div className="mb-2 text-xs text-blue-500 animate-pulse">Uploading…</div>
+      )}
+      {files === undefined || files.length === 0 ? (
+        <div className="text-xs text-gray-400">
+          No files attached.{" "}
+          <button type="button" onClick={onUpload} className="text-blue-500 hover:underline">
+            Upload one
+          </button>{" "}
+          or drag a file onto this folder.
+        </div>
+      ) : (
+        <table className="w-full border-collapse text-[12px]">
+          <thead>
+            <tr className="border-b border-gray-200 text-left text-[11px] text-gray-400">
+              <th className="pb-1 pr-4 font-normal">Name</th>
+              <th className="pb-1 pr-4 font-normal">Size</th>
+              <th className="pb-1 pr-4 font-normal">Date</th>
+              <th className="pb-1 font-normal" />
+            </tr>
+          </thead>
+          <tbody>
+            {files.map((f) => (
+              <tr key={f.id} className="group hover:bg-[#e8e8f8]">
+                <td className="py-0.5 pr-4">
+                  <a
+                    href={`${API_BASE}/api/namespace/files/${f.id}`}
+                    className="flex items-center gap-1.5 text-blue-700 hover:underline"
+                    download={f.filename}
+                  >
+                    <FileText className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+                    {f.filename}
+                  </a>
+                </td>
+                <td className="py-0.5 pr-4 text-gray-500">{formatBytes(f.size_bytes)}</td>
+                <td className="py-0.5 pr-4 text-gray-400">{formatDate(f.created_at)}</td>
+                <td className="py-0.5 text-right">
+                  {f.source === "direct" && (
+                    <button
+                      type="button"
+                      title="Remove file"
+                      className="hidden group-hover:inline text-red-400 hover:text-red-600"
+                      onClick={() => onDeleteFile(f.id)}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+
+function DetailsSection({ node }: { node: NamespaceNode }) {
+  return (
+    <dl className="space-y-2 pt-2 text-[13px]">
+      <div className="flex gap-2">
+        <dt className="w-28 shrink-0 text-gray-400">Kind</dt>
+        <dd className="text-gray-900">{node.kind}</dd>
+      </div>
       {node.unsPath && (
-        <code className="mt-2 block break-all rounded bg-slate-100 p-2 text-xs text-slate-700">
-          {node.unsPath}
-        </code>
+        <div className="flex gap-2">
+          <dt className="w-28 shrink-0 text-gray-400">UNS path</dt>
+          <dd className="break-all font-mono text-[11px] text-gray-700">{node.unsPath}</dd>
+        </div>
       )}
-      <dl className="mt-6 space-y-1 text-sm">
-        <Stat label="Children" value={node.counts.children} />
-        <CounterLink
-          label="Proposals pending"
-          value={node.counts.proposalsPending}
-          href={proposalsHref("pending")}
-        />
-        <CounterLink
-          label="Proposals verified"
-          value={node.counts.proposalsVerified}
-          href={proposalsHref("verified")}
-        />
-      </dl>
-      {node.counts.proposalsPending > 0 && (
-        <Link
-          href={proposalsHref("pending")}
-          className="mt-6 inline-block text-sm font-medium text-blue-600 hover:underline"
-        >
-          Review {node.counts.proposalsPending} pending proposal
-          {node.counts.proposalsPending === 1 ? "" : "s"} →
-        </Link>
+      {node.status && (
+        <div className="flex items-center gap-2">
+          <dt className="w-28 shrink-0 text-gray-400">Status</dt>
+          <dd className="flex items-center gap-1.5">
+            <span className={`h-2 w-2 rounded-full ${statusColor(node.status)}`} />
+            <span className="text-gray-900">{node.status}</span>
+          </dd>
+        </div>
       )}
-    </div>
+    </dl>
   );
 }
 
-function Stat({ label, value }: { label: string; value: number }) {
-  return (
-    <div className="flex items-center justify-between rounded px-2 py-1.5">
-      <dt className="text-slate-500">{label}</dt>
-      <dd className="font-semibold text-slate-900">{value}</dd>
-    </div>
-  );
-}
+// ── Small components ──────────────────────────────────────────────────────────
 
-function CounterLink({ label, value, href }: { label: string; value: number; href: string }) {
-  const isZero = value === 0;
+function ToolbarButton({
+  icon, label, onClick, disabled,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
   return (
-    <Link
-      href={href}
-      className={`group flex items-center justify-between rounded px-2 py-1.5 ${
-        isZero ? "pointer-events-none cursor-default" : "hover:bg-blue-50"
-      }`}
-      aria-disabled={isZero}
-      tabIndex={isZero ? -1 : 0}
-      data-testid="namespace-counter-link"
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="flex items-center gap-1 border border-gray-500 bg-[#d4d0c8] px-2 py-0.5 text-[12px] hover:bg-[#e8e8e8] disabled:cursor-not-allowed disabled:opacity-40 active:border-inset"
     >
-      <dt className={`${isZero ? "text-slate-500" : "text-slate-500 group-hover:text-blue-700"}`}>
-        {label}
-      </dt>
-      <dd className={`font-semibold text-slate-900 ${!isZero && "group-hover:text-blue-700"}`}>
-        {value}
-        {!isZero && " →"}
-      </dd>
-    </Link>
+      {icon}
+      {label}
+    </button>
   );
 }
 
-function DetailEmpty() {
+function CtxMenuItem({
+  icon, label, onSelect, className = "",
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onSelect: () => void;
+  className?: string;
+}) {
   return (
-    <div className="text-sm text-slate-500">
-      <p>Select a node to see its details — children, proposed edges, and verified relationships.</p>
+    <button
+      type="button"
+      className={`flex w-full cursor-pointer items-center gap-2 px-3 py-1 text-left text-[13px] hover:bg-[#000080] hover:text-white ${className}`}
+      onMouseDown={(e) => { e.preventDefault(); onSelect(); }}
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+function ContextMenuOverlay({
+  x, y, onClose,
+  onNewFolder, onRename, onUpload, onDelete,
+}: {
+  x: number;
+  y: number;
+  onClose: () => void;
+  onNewFolder: () => void;
+  onRename: () => void;
+  onUpload: () => void;
+  onDelete: () => void;
+}) {
+  useEffect(() => {
+    const handler = () => onClose();
+    const escHandler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    document.addEventListener("click", handler);
+    document.addEventListener("keydown", escHandler);
+    return () => {
+      document.removeEventListener("click", handler);
+      document.removeEventListener("keydown", escHandler);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed z-50 min-w-[160px] rounded border border-gray-300 bg-white py-1 shadow-lg text-[13px]"
+      style={{ top: y, left: x }}
+      onContextMenu={(e) => e.preventDefault()}
+    >
+      <CtxMenuItem icon={<FolderPlus className="h-3.5 w-3.5" />} label="New Folder" onSelect={onNewFolder} />
+      <CtxMenuItem icon={<Pencil className="h-3.5 w-3.5" />} label="Rename" onSelect={onRename} />
+      <CtxMenuItem icon={<Upload className="h-3.5 w-3.5" />} label="Upload Files" onSelect={onUpload} />
+      <div className="my-1 h-px bg-gray-200" />
+      <CtxMenuItem
+        icon={<Trash2 className="h-3.5 w-3.5 text-red-500" />}
+        label="Delete"
+        className="text-red-600"
+        onSelect={onDelete}
+      />
+    </div>
+  );
+}
+
+function NewFolderRow({
+  indent = 6, value, onChange, onCommit, onCancel,
+}: {
+  indent?: number;
+  value: string;
+  onChange: (v: string) => void;
+  onCommit: (v: string) => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="flex h-7 items-center gap-1" style={{ paddingLeft: `${indent}px` }}>
+      <span className="h-4 w-4" />
+      <Folder className="h-3.5 w-3.5 text-gray-400" />
+      <input
+        autoFocus
+        className="h-5 flex-1 rounded border border-blue-400 bg-white px-1 text-[12px] text-black"
+        placeholder="Folder name…"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") onCommit(value);
+          if (e.key === "Escape") onCancel();
+        }}
+        onBlur={() => { if (value.trim()) onCommit(value); else onCancel(); }}
+      />
     </div>
   );
 }
 
 function EmptyState() {
   return (
-    <div className="rounded-lg border border-dashed border-slate-300 bg-white p-12 text-center" data-testid="namespace-empty">
-      <Layers className="mx-auto h-10 w-10 text-slate-300" />
-      <h2 className="mt-4 text-lg font-semibold text-slate-900">Your namespace is empty</h2>
-      <p className="mx-auto mt-2 max-w-md text-sm text-slate-500">
-        Start the namespace wizard to add your first site and line, then MIRA will
-        propose assets and components from your manuals, photos, and PLC tags.
-      </p>
-      <a
-        href={`${HUB_BASE}/onboarding`}
-        className="mt-6 inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700"
-        data-testid="namespace-empty-start"
-      >
-        Build your namespace →
-      </a>
+    <div className="text-center">
+      <Layers className="mx-auto h-10 w-10 text-gray-200" />
+      <p className="mt-3 text-sm text-gray-500">Your namespace is empty.</p>
+      <p className="mt-1 text-xs text-gray-400">Use &ldquo;New Folder&rdquo; in the toolbar to create your first node.</p>
     </div>
   );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function findNode(nodes: NamespaceNode[], id: string): NamespaceNode | null {
+  for (const n of nodes) {
+    if (n.id === id) return n;
+    const found = findNode(n.children, id);
+    if (found) return found;
+  }
+  return null;
 }

--- a/mira-hub/src/app/api/namespace/files/[id]/route.ts
+++ b/mira-hub/src/app/api/namespace/files/[id]/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+interface FileContentRow {
+  id: string;
+  filename: string;
+  mime_type: string;
+  content: Buffer;
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+  if (!id || !/^[0-9a-f-]{36}$/i.test(id)) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  try {
+    const row = await withTenantContext(ctx.tenantId, async (c) => {
+      const res = await c.query<FileContentRow>(
+        `SELECT id, filename, mime_type, content
+         FROM namespace_direct_uploads
+         WHERE id = $1 AND tenant_id = $2`,
+        [id, ctx.tenantId],
+      );
+      return res.rows[0] ?? null;
+    });
+
+    if (!row) {
+      return NextResponse.json({ error: "file not found" }, { status: 404 });
+    }
+
+    const safeFilename = encodeURIComponent(row.filename).replace(/%20/g, " ");
+    return new Response(new Uint8Array(row.content), {
+      status: 200,
+      headers: {
+        "Content-Type": row.mime_type,
+        "Content-Disposition": `attachment; filename="${safeFilename}"`,
+        "Cache-Control": "private, max-age=3600",
+      },
+    });
+  } catch (err) {
+    console.error("[api/namespace/files/:id GET]", err);
+    return NextResponse.json({ error: "Download failed" }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+  if (!id || !/^[0-9a-f-]{36}$/i.test(id)) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  try {
+    const deleted = await withTenantContext(ctx.tenantId, async (c) => {
+      const res = await c.query(
+        `DELETE FROM namespace_direct_uploads
+         WHERE id = $1 AND tenant_id = $2`,
+        [id, ctx.tenantId],
+      );
+      return (res.rowCount ?? 0) > 0;
+    });
+
+    if (!deleted) {
+      return NextResponse.json({ error: "file not found" }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[api/namespace/files/:id DELETE]", err);
+    return NextResponse.json({ error: "Delete failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/namespace/node/[id]/files/route.ts
+++ b/mira-hub/src/app/api/namespace/node/[id]/files/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+const MIME_ALLOWLIST = [
+  "application/pdf",
+  "image/",
+  "text/",
+  "text/csv",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.",
+];
+
+const MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+
+function isMimeAllowed(mime: string): boolean {
+  return MIME_ALLOWLIST.some((prefix) => mime.startsWith(prefix));
+}
+
+interface FileRow {
+  id: string;
+  filename: string;
+  mime_type: string;
+  size_bytes: string;
+  source: "direct" | "upload";
+  created_at: string;
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+  if (!id || !/^[0-9a-f-]{36}$/i.test(id)) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  try {
+    const files = await withTenantContext(ctx.tenantId, async (c) => {
+      // Verify node belongs to this tenant.
+      const nodeCheck = await c.query(
+        `SELECT id FROM kg_entities WHERE id = $1 AND tenant_id = $2`,
+        [id, ctx.tenantId],
+      );
+      if (nodeCheck.rows.length === 0) return null;
+
+      // Direct uploads — never select content.
+      const directRes = await c.query<FileRow>(
+        `SELECT id, filename, mime_type, size_bytes::text, 'direct' AS source, created_at
+         FROM namespace_direct_uploads
+         WHERE node_id = $1 AND tenant_id = $2
+         ORDER BY created_at DESC`,
+        [id, ctx.tenantId],
+      );
+
+      // Cloud-sourced uploads linked to this node.
+      const cloudRes = await c.query<FileRow>(
+        `SELECT id, filename, mime_type,
+                COALESCE(size_bytes, 0)::text AS size_bytes,
+                'upload' AS source, created_at
+         FROM uploads
+         WHERE namespace_node_id = $1 AND tenant_id = $2
+         ORDER BY created_at DESC`,
+        [id, ctx.tenantId],
+      );
+
+      return [
+        ...directRes.rows.map((r) => ({ ...r, size_bytes: Number(r.size_bytes) })),
+        ...cloudRes.rows.map((r) => ({ ...r, size_bytes: Number(r.size_bytes) })),
+      ];
+    });
+
+    if (files === null) {
+      return NextResponse.json({ error: "node not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ files });
+  } catch (err) {
+    console.error("[api/namespace/node/:id/files GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+  if (!id || !/^[0-9a-f-]{36}$/i.test(id)) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await req.formData();
+  } catch {
+    return NextResponse.json({ error: "expected multipart/form-data" }, { status: 400 });
+  }
+
+  const file = formData.get("file");
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "file field is required" }, { status: 422 });
+  }
+  if (file.size > MAX_BYTES) {
+    return NextResponse.json({ error: "file exceeds 10 MB limit" }, { status: 413 });
+  }
+
+  const mimeRaw = file.type || "application/octet-stream";
+  if (!isMimeAllowed(mimeRaw)) {
+    return NextResponse.json(
+      { error: `file type '${mimeRaw}' is not allowed` },
+      { status: 415 },
+    );
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      const nodeCheck = await c.query(
+        `SELECT id FROM kg_entities WHERE id = $1 AND tenant_id = $2`,
+        [id, ctx.tenantId],
+      );
+      if (nodeCheck.rows.length === 0) return null;
+
+      const ins = await c.query<{ id: string }>(
+        `INSERT INTO namespace_direct_uploads
+            (tenant_id, node_id, filename, mime_type, size_bytes, content, uploaded_by)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         RETURNING id`,
+        [
+          ctx.tenantId,
+          id,
+          file.name,
+          mimeRaw,
+          file.size,
+          buffer,
+          ctx.userId,
+        ],
+      );
+      return ins.rows[0].id;
+    });
+
+    if (result === null) {
+      return NextResponse.json({ error: "node not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(
+      { ok: true, file: { id: result, filename: file.name, size_bytes: file.size } },
+      { status: 201 },
+    );
+  } catch (err) {
+    console.error("[api/namespace/node/:id/files POST]", err);
+    return NextResponse.json({ error: "Upload failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/namespace/node/[id]/route.ts
+++ b/mira-hub/src/app/api/namespace/node/[id]/route.ts
@@ -179,6 +179,98 @@ export async function PUT(req: Request, { params }: { params: Promise<{ id: stri
   }
 }
 
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+  if (!id || !/^[0-9a-f-]{36}$/i.test(id)) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      const targetRes = await c.query<KgEntityRow>(
+        `SELECT id, entity_type, name, uns_path::text AS uns_path
+         FROM kg_entities
+         WHERE id = $1 AND tenant_id = $2
+         FOR UPDATE`,
+        [id, ctx.tenantId],
+      );
+      if (targetRes.rows.length === 0) {
+        return { kind: "not_found" as const };
+      }
+      const target = targetRes.rows[0];
+
+      // Block delete if any children exist (uns_path prefix match).
+      if (target.uns_path) {
+        const childRes = await c.query<{ cnt: string }>(
+          `SELECT COUNT(*)::text AS cnt
+           FROM kg_entities
+           WHERE tenant_id = $1 AND id != $2
+             AND uns_path::text LIKE $3`,
+          [ctx.tenantId, id, `${target.uns_path}.%`],
+        );
+        if (Number(childRes.rows[0]?.cnt) > 0) {
+          return { kind: "has_children" as const };
+        }
+      }
+
+      // Null out FK references before deleting.
+      await c.query(
+        `UPDATE namespace_direct_uploads SET node_id = NULL WHERE node_id = $1`,
+        [id],
+      );
+      await c.query(
+        `UPDATE uploads SET namespace_node_id = NULL WHERE namespace_node_id = $1`,
+        [id],
+      );
+
+      // Audit tombstone.
+      await c.query(
+        `INSERT INTO namespace_versions
+            (tenant_id, operation, entity_id, entity_kind,
+             from_state, to_state, actor_user_id, actor_kind, reason)
+         VALUES ($1, 'delete', $2, $3, $4::jsonb, NULL, $5, 'human', 'user deleted node')`,
+        [
+          ctx.tenantId,
+          id,
+          target.entity_type,
+          JSON.stringify({ uns_path: target.uns_path, name: target.name }),
+          ctx.userId,
+        ],
+      );
+
+      await c.query(
+        `DELETE FROM kg_entities WHERE id = $1 AND tenant_id = $2`,
+        [id, ctx.tenantId],
+      );
+
+      return { kind: "ok" as const };
+    });
+
+    if (result.kind === "not_found") {
+      return NextResponse.json({ error: "node not found" }, { status: 404 });
+    }
+    if (result.kind === "has_children") {
+      return NextResponse.json(
+        { error: "Cannot delete a node that has children" },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("[api/namespace/node/:id DELETE]", err);
+    return NextResponse.json({ error: "Delete failed" }, { status: 500 });
+  }
+}
+
 function parentOf(path: string | null): string | null {
   if (!path) return null;
   const i = path.lastIndexOf(".");

--- a/mira-hub/src/app/api/namespace/node/route.ts
+++ b/mira-hub/src/app/api/namespace/node/route.ts
@@ -1,0 +1,124 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { slugify } from "@/lib/uns";
+
+export const dynamic = "force-dynamic";
+
+const ENTITY_TYPES = new Set([
+  "site", "plant", "area", "line", "production_line",
+  "asset", "component", "component_template", "document", "system",
+]);
+
+// Structural labels that may not be used as user-created node names.
+const RESERVED_LABELS = new Set([
+  "enterprise", "knowledge_base", "site", "area", "equipment",
+  "fault_codes", "manuals", "parts", "schedules",
+]);
+
+interface KgEntityRow {
+  id: string;
+  entity_type: string;
+  name: string;
+  uns_path: string | null;
+}
+
+export async function POST(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  let body: { parentId?: string; name?: string; kind?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+
+  const name = body.name?.trim();
+  if (!name || name.length === 0) {
+    return NextResponse.json({ error: "name is required" }, { status: 422 });
+  }
+  if (name.length > 128) {
+    return NextResponse.json({ error: "name too long (max 128)" }, { status: 422 });
+  }
+
+  const kind = (body.kind?.trim() || "area");
+  if (!ENTITY_TYPES.has(kind)) {
+    return NextResponse.json(
+      { error: `invalid kind '${kind}'; must be one of ${[...ENTITY_TYPES].join(", ")}` },
+      { status: 422 },
+    );
+  }
+
+  const slug = slugify(name);
+  if (!slug) {
+    return NextResponse.json({ error: "name produces empty slug" }, { status: 422 });
+  }
+  if (RESERVED_LABELS.has(slug)) {
+    return NextResponse.json(
+      { error: `'${slug}' is a reserved label and cannot be used as a node name` },
+      { status: 422 },
+    );
+  }
+
+  const parentId = body.parentId?.trim() || null;
+  if (parentId && !/^[0-9a-f-]{36}$/i.test(parentId)) {
+    return NextResponse.json({ error: "invalid parentId" }, { status: 400 });
+  }
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      let parentPath: string | null = null;
+
+      if (parentId) {
+        const parentRes = await c.query<KgEntityRow>(
+          `SELECT id, uns_path::text AS uns_path
+           FROM kg_entities
+           WHERE id = $1 AND tenant_id = $2`,
+          [parentId, ctx.tenantId],
+        );
+        if (parentRes.rows.length === 0) {
+          return { kind: "parent_not_found" as const };
+        }
+        parentPath = parentRes.rows[0].uns_path;
+      }
+
+      const unsPath = parentPath ? `${parentPath}.${slug}` : slug;
+
+      const insertRes = await c.query<{ id: string }>(
+        `INSERT INTO kg_entities (entity_type, name, uns_path, tenant_id)
+         VALUES ($1, $2, $3::ltree, $4::uuid)
+         RETURNING id`,
+        [kind, name, unsPath, ctx.tenantId],
+      );
+      const newId = insertRes.rows[0].id;
+
+      await c.query(
+        `INSERT INTO namespace_versions
+            (tenant_id, operation, entity_id, entity_kind,
+             from_state, to_state, actor_user_id, actor_kind, reason)
+         VALUES ($1, 'create', $2, $3, NULL, $4::jsonb, $5, 'human', 'user created node')`,
+        [
+          ctx.tenantId,
+          newId,
+          kind,
+          JSON.stringify({ uns_path: unsPath, name }),
+          ctx.userId,
+        ],
+      );
+
+      return { kind: "ok" as const, node: { id: newId, name, kind, unsPath } };
+    });
+
+    if (result.kind === "parent_not_found") {
+      return NextResponse.json({ error: "parentId not found" }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true, node: result.node }, { status: 201 });
+  } catch (err) {
+    console.error("[api/namespace/node POST]", err);
+    return NextResponse.json({ error: "Create failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/namespace/tree/route.ts
+++ b/mira-hub/src/app/api/namespace/tree/route.ts
@@ -4,21 +4,6 @@ import { withTenantContext } from "@/lib/tenant-context";
 
 export const dynamic = "force-dynamic";
 
-/**
- * Namespace tree — read-only for Phase 2 slice 1.
- *
- * Spec: docs/specs/maintenance-namespace-builder-spec.md §"Namespace tree"
- * Plan: docs/plans/2026-05-15-maintenance-namespace-builder.md §"Phase 2"
- *
- * Reads kg_entities for the current tenant, orders rows by uns_path (ltree),
- * and builds a tree keyed on the dot-separated path. Counts pending /
- * verified proposals per node (left-join on relationship_proposals).
- *
- * Mutation endpoints (PUT for drag-drop move, PATCH for rename) land in
- * Phase 2 slice 2 — they need the kg_approval_state migration (engine
- * lineage, docs/migrations/008_kg_approval_state.sql) that hasn't shipped.
- */
-
 interface KgEntityRow {
   id: string;
   entity_type: string;
@@ -26,6 +11,8 @@ interface KgEntityRow {
   name: string;
   uns_path: string | null;
   created_at: string;
+  files_count: string;
+  equipment_status: string | null;
 }
 
 interface ProposalCountRow {
@@ -37,8 +24,10 @@ interface ProposalCountRow {
 export interface NamespaceNode {
   id: string;
   name: string;
-  kind: string; // entity_type — 'site', 'area', 'line', 'asset', 'component', 'document', ...
+  kind: string;
   unsPath: string | null;
+  filesCount: number;
+  status: string | null;
   counts: {
     children: number;
     proposalsPending: number;
@@ -57,10 +46,26 @@ export async function GET() {
   try {
     const result = await withTenantContext(ctx.tenantId, async (c) => {
       const entitiesRes = await c.query<KgEntityRow>(
-        `SELECT id, entity_type, entity_id, name, uns_path::text AS uns_path, created_at
-         FROM kg_entities
-         WHERE tenant_id = $1::uuid
-         ORDER BY uns_path::text NULLS LAST, name`,
+        `SELECT
+            e.id,
+            e.entity_type,
+            e.entity_id,
+            e.name,
+            e.uns_path::text AS uns_path,
+            e.created_at,
+            (
+              (SELECT COUNT(*) FROM namespace_direct_uploads ndu WHERE ndu.node_id = e.id AND ndu.tenant_id = e.tenant_id) +
+              (SELECT COUNT(*) FROM uploads u WHERE u.namespace_node_id = e.id AND u.tenant_id = e.tenant_id)
+            )::text AS files_count,
+            eq.status AS equipment_status
+         FROM kg_entities e
+         LEFT JOIN cmms_equipment eq
+           ON e.entity_id IS NOT NULL
+           AND e.entity_id ~ '^[0-9a-f-]{36}$'
+           AND eq.entity_id = e.entity_id::uuid
+           AND eq.tenant_id = e.tenant_id
+         WHERE e.tenant_id = $1::uuid
+         ORDER BY e.uns_path::text NULLS LAST, e.name`,
         [ctx.tenantId],
       );
 
@@ -91,7 +96,6 @@ function buildTree(
   entities: KgEntityRow[],
   proposalCounts: ProposalCountRow[],
 ): NamespaceNode[] {
-  // Index proposal counts by uns_path so we can attach without a per-node loop.
   const proposalsByPath = new Map<string, { pending: number; verified: number }>();
   for (const row of proposalCounts) {
     const path = row.uns_path ?? "";
@@ -102,7 +106,6 @@ function buildTree(
     proposalsByPath.set(path, slot);
   }
 
-  // Map every entity to a node, then wire children by uns_path prefix.
   const nodesByPath = new Map<string, NamespaceNode>();
   const roots: NamespaceNode[] = [];
 
@@ -113,6 +116,8 @@ function buildTree(
       name: e.name,
       kind: e.entity_type,
       unsPath: e.uns_path,
+      filesCount: Number(e.files_count) || 0,
+      status: e.equipment_status ?? null,
       counts: {
         children: 0,
         proposalsPending: proposalSlot.pending,

--- a/mira-hub/src/providers/access-control.ts
+++ b/mira-hub/src/providers/access-control.ts
@@ -53,24 +53,27 @@ export const accessControlProvider: AccessControlProvider = {
 };
 
 export const NAV_ITEMS = [
-  // Primary nav — main surfaces, always visible to qualifying roles
-  { key: "event-log",     label: "Event Log",     icon: "Activity",      href: "/event-log",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
+  // Intelligence — real-time signals and AI conversation
   { key: "conversations", label: "Conversations", icon: "MessageSquare", href: "/conversations", roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
   { key: "alerts",        label: "Alerts",        icon: "AlertTriangle", href: "/alerts",        roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
-  { key: "knowledge",     label: "Knowledge",     icon: "BookOpen",      href: "/knowledge",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
+  { key: "event-log",     label: "Event Log",     icon: "Activity",      href: "/event-log",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
+  // Knowledge & Structure — namespace is now the primary filesystem
   { key: "namespace",     label: "Namespace",     icon: "Layers",        href: "/namespace",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
-  { key: "proposals",     label: "Proposals",     icon: "Sparkles",      href: "/proposals",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
-  { key: "assets",        label: "Assets",        icon: "Wrench",        href: "/assets",        roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
+  { key: "knowledge",     label: "Knowledge",     icon: "BookOpen",      href: "/knowledge",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
+  // Operations — promoted from secondary
+  { key: "workorders",    label: "Work Orders",   icon: "ClipboardList", href: "/workorders",    roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
+  { key: "schedule",      label: "Schedule",      icon: "CalendarDays",  href: "/schedule",      roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "primary" },
+  { key: "reports",       label: "Reports",       icon: "TrendingUp",    href: "/reports",       roles: ["manager", "scheduler", "admin", "owner"],                           group: "primary" },
+  // Platform
   { key: "channels",      label: "Channels",      icon: "Radio",         href: "/channels",      roles: ["manager", "scheduler", "admin", "owner"],                           group: "primary" },
   { key: "integrations",  label: "Integrations",  icon: "Plug",          href: "/integrations",  roles: ["manager", "admin", "owner"],                                        group: "primary" },
   { key: "usage",         label: "Usage",         icon: "BarChart2",     href: "/usage",         roles: ["manager", "admin", "owner"],                                        group: "primary" },
   { key: "team",          label: "Team",          icon: "Users",         href: "/team",          roles: ["manager", "admin", "owner"],                                        group: "primary" },
-  // Secondary nav — operations & admin surfaces, shown below divider
-  { key: "workorders",    label: "Work Orders",   icon: "ClipboardList", href: "/workorders",    roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "secondary" },
-  { key: "schedule",      label: "Schedule",      icon: "CalendarDays",  href: "/schedule",      roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "secondary" },
+  // Secondary — remaining operations and deferred surfaces
   { key: "requests",      label: "Requests",      icon: "Inbox",         href: "/requests",      roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "secondary" },
   { key: "parts",         label: "Parts",         icon: "Package",       href: "/parts",         roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "secondary" },
   { key: "documents",     label: "Documents",     icon: "FileText",      href: "/documents",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "secondary" },
-  { key: "reports",       label: "Reports",       icon: "TrendingUp",    href: "/reports",       roles: ["manager", "scheduler", "admin", "owner"],                           group: "secondary" },
+  { key: "proposals",     label: "Proposals",     icon: "Sparkles",      href: "/proposals",     roles: ["technician", "manager", "scheduler", "admin", "operator", "owner"], group: "secondary" },
   { key: "plc",           label: "Ladder Logic",  icon: "Cpu",           href: "/plc",           roles: ["technician", "manager", "admin", "owner"],                          group: "secondary" },
+  // Assets route kept for backward compat / deep linking — NOT in nav
 ] as const;


### PR DESCRIPTION
## Summary

- Transforms the Namespace tab from a read-only AI-populated graph viewer into an interactive split-pane knowledge filesystem modeled after Windows 3.1 File Manager
- Users can manually create folders, rename/delete nodes, and drag PDFs directly onto namespace folders
- Nav restructure: Assets absorbed into namespace, proposals moved to namespace tab, Work Orders/Schedule/Reports promoted from "More"
- Ships DB migration 024 for file attachment infrastructure

## What's in this PR

**Committed:**
- `docs/plans/2026-05-18-windows-explorer-namespace.md` — Full implementation spec (read this before coding)
- `mira-hub/db/migrations/024_namespace_direct_uploads.sql` — `namespace_direct_uploads` table + `uploads.namespace_node_id` FK

**Still to implement (pick up from the plan):**
- `src/app/api/namespace/node/route.ts` — POST create node
- `src/app/api/namespace/node/[id]/route.ts` — extend with DELETE handler
- `src/app/api/namespace/node/[id]/files/route.ts` — GET list + POST upload
- `src/app/api/namespace/files/[id]/route.ts` — GET download + DELETE
- `src/app/api/namespace/tree/route.ts` — add `filesCount` and `status` fields
- `src/app/(hub)/namespace/page.tsx` — full rewrite (~600 lines, split-pane Explorer layout)
- `src/providers/access-control.ts` — nav restructure

## Key architectural decisions (see plan for full detail)

- **No new deps** — tree hand-rolled, Radix DropdownMenu for context menus, native HTML5 drag-drop
- **Hard-delete** on kg_entities (no `deleted_at` — blast radius too wide); `namespace_versions` is the tombstone
- **10 MB file cap** enforced at DB layer via CHECK constraint
- **Never `SELECT content`** in list queries — download endpoint only
- **Cross-tenant safety** — all file download endpoints must 404 on wrong tenant_id

## Test plan

- [ ] Apply migration 024 to dev Neon branch
- [ ] New Folder → folder appears in tree
- [ ] Inline rename → label updates
- [ ] Delete leaf node → gone; blocked if has children
- [ ] Drag PDF onto folder → file appears in content panel
- [ ] Click filename → download starts
- [ ] Playwright regression: `npx playwright test tests/e2e/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)