### PR TITLE
feat: Phase 0 — schema (025/026/027) + photo→KG demo loop (SUPERSEDES ADR-0013 §1)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -19,9 +19,13 @@ bold "=== MIRA pre-commit checks ==="
 # Empty when invoked from a human terminal — that's expected.
 if [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
   echo "  ↳ Claude Code session: ${CLAUDE_CODE_SESSION_ID}"
-  mkdir -p .git/claude-sessions
+  # In a worktree, `.git` is a file pointing at the real gitdir — `mkdir
+  # -p .git/...` fails under `set -e`. Resolve via git rev-parse so this
+  # works in both worktrees and the main checkout.
+  GITDIR=$(git rev-parse --git-common-dir 2>/dev/null || echo ".git")
+  mkdir -p "${GITDIR}/claude-sessions" 2>/dev/null || true
   echo "$(date -u +%FT%TZ) ${CLAUDE_CODE_SESSION_ID} pre-commit" \
-    >> .git/claude-sessions/log 2>/dev/null || true
+    >> "${GITDIR}/claude-sessions/log" 2>/dev/null || true
 fi
 
 # Staged files

--- a/.github/workflows/migration-verify.yml
+++ b/.github/workflows/migration-verify.yml
@@ -1,0 +1,166 @@
+name: Migration Verify
+
+# Apply + verify mira-hub/db/migrations/*.sql against the NeonDB staging
+# branch on every PR that touches the migrations directory.
+#
+# Companion to `staging-gate.yml` (which runs the live E2E rubric against the
+# same staging Neon branch). This workflow lands first so the gate sees the
+# new schema, then `tools/verify_phase0_deploy.py` re-asserts the schema
+# matches the migrations declared in source.
+#
+# This is intentionally auto-apply (no required reviewers on the `staging`
+# environment) — the migrations are idempotent (CREATE … IF NOT EXISTS) and
+# the staging Neon branch is a forked clone of prod, easy to reset.
+# Production migrations still go through `apply-migrations.yml`
+# (workflow_dispatch, environment=production, required-reviewers).
+#
+# Failure modes:
+#   * psql fails on a malformed migration → red, blocks deploy-vps.yml
+#   * verify_phase0_deploy.py reports drift → red, blocks deploy-vps.yml
+#   * Phase 0 integration tests fail (RLS / round-trip) → red
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'mira-hub/db/migrations/**'
+      - 'tools/verify_phase0_deploy.py'
+      - 'tests/integration/test_phase0_schema.py'
+      - '.github/workflows/migration-verify.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: migration-verify-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  apply-and-verify:
+    name: apply-and-verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Uses the same `staging` environment as staging-gate.yml so we can read
+    # NEON_STG_DATABASE_URL from secrets. No required reviewers on staging.
+    environment: staging
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install postgresql-client-16
+        # Match Neon's server version family for ltree/jsonb parity.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends postgresql-client-16
+          psql --version
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install verify + test deps
+        run: |
+          python -m pip install --upgrade pip
+          # psycopg2-binary is the only runtime dep of the verify script
+          # and the integration tests. pytest comes along for the tests.
+          pip install 'psycopg2-binary>=2.9' pytest
+
+      - name: Resolve migration plan
+        id: plan
+        run: |
+          set -euo pipefail
+          MIG_DIR="mira-hub/db/migrations"
+          # Apply every Phase 0 migration the PR touched. Use git diff
+          # against the merge-base so we don't miss files added on top of
+          # an older base.
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          if [ -z "$BASE_SHA" ]; then
+            # workflow_dispatch path — fall back to "all 025-up".
+            CHANGED=$(ls "$MIG_DIR"/02[5-9]_*.sql "$MIG_DIR"/0[3-9]?_*.sql 2>/dev/null | sort || true)
+          else
+            CHANGED=$(git diff --name-only --diff-filter=AM "$BASE_SHA"...HEAD -- "$MIG_DIR" | sort)
+          fi
+          if [ -z "$CHANGED" ]; then
+            echo "::notice::No migration files touched by this PR — nothing to apply."
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s\n' "$CHANGED" > .migration_plan
+          echo "Plan:"
+          cat .migration_plan
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          cat .migration_plan >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Apply migrations to staging Neon
+        if: steps.plan.outputs.files != ''
+        env:
+          DATABASE_URL: ${{ secrets.NEON_STG_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DATABASE_URL:-}" ]; then
+            echo "::error::NEON_STG_DATABASE_URL secret not set on the staging environment."
+            exit 1
+          fi
+          echo "::add-mask::$DATABASE_URL"
+          echo "### Migration apply" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| File | Status | Duration |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|------|--------|----------|" >> "$GITHUB_STEP_SUMMARY"
+          while IFS= read -r f; do
+            [ -f "$f" ] || continue
+            echo "::group::Applying $f"
+            START=$(date +%s)
+            if psql "$DATABASE_URL" \
+                 --single-transaction \
+                 --set ON_ERROR_STOP=1 \
+                 --no-psqlrc -v ECHO=errors -f "$f"; then
+              DUR=$(( $(date +%s) - START ))
+              echo "| \`$f\` | OK | ${DUR}s |" >> "$GITHUB_STEP_SUMMARY"
+              echo "::endgroup::"
+            else
+              DUR=$(( $(date +%s) - START ))
+              echo "| \`$f\` | FAILED | ${DUR}s |" >> "$GITHUB_STEP_SUMMARY"
+              echo "::endgroup::"
+              echo "::error file=$f::psql failed on $f after ${DUR}s"
+              exit 1
+            fi
+          done < .migration_plan
+
+      - name: Verify Phase 0 schema (tools/verify_phase0_deploy.py)
+        env:
+          NEON_DATABASE_URL: ${{ secrets.NEON_STG_DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          echo "### Schema verification" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          python tools/verify_phase0_deploy.py | tee verify.out
+          echo '```' >> "$GITHUB_STEP_SUMMARY" || true
+          cat verify.out >> "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Run Phase 0 integration tests
+        env:
+          NEON_DATABASE_URL: ${{ secrets.NEON_STG_DATABASE_URL }}
+          STAGING_TENANT_ID: ${{ secrets.STAGING_TENANT_ID || '78917b56-f85f-43bb-9a08-1bb98a6cd6c3' }}
+        run: |
+          set -euo pipefail
+          echo "### Integration tests" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          python -m pytest tests/integration/test_phase0_schema.py -v 2>&1 | tee tests.out
+          echo '```' >> "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Post / update PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: migration-verify
+          message: |
+            ### Migration Verify — Phase 0
+
+            * Applied: ${{ steps.plan.outputs.files == '' && '_no migration files touched_' || 'see step summary' }}
+            * Schema verification: see the **Schema verification** section of [the job summary](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+            * Integration tests: 6 round-trip + RLS + photo→ai_suggestions tests against the staging Neon branch.
+
+            Re-runs on every push to this PR. Production migrations still go through `apply-migrations.yml` (`workflow_dispatch`).

--- a/.github/workflows/migration-verify.yml
+++ b/.github/workflows/migration-verify.yml
@@ -48,6 +48,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the "Resolve migration plan" step can diff
+          # against the merge-base SHA. Shallow clone (default depth=1)
+          # fails with "Invalid symmetric difference expression".
+          fetch-depth: 0
 
       - name: Install postgresql-client-16
         # Match Neon's server version family for ltree/jsonb parity.
@@ -64,8 +69,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # psycopg2-binary is the only runtime dep of the verify script
-          # and the integration tests. pytest comes along for the tests.
-          pip install 'psycopg2-binary>=2.9' pytest
+          # and the integration tests. pytest comes along for the tests;
+          # pyyaml because tests/conftest.py imports yaml at collection.
+          pip install 'psycopg2-binary>=2.9' pytest pyyaml
 
       - name: Resolve migration plan
         id: plan

--- a/.github/workflows/photo-e2e-verify.yml
+++ b/.github/workflows/photo-e2e-verify.yml
@@ -57,8 +57,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           # The worker only needs psycopg2 at runtime; pytest runs the demo
-          # loop via tests/integration/test_phase0_schema.py.
-          pip install 'psycopg2-binary>=2.9' pytest
+          # loop via tests/integration/test_phase0_schema.py. pyyaml is
+          # imported by tests/conftest.py at collection time.
+          pip install 'psycopg2-binary>=2.9' pytest pyyaml
 
       - name: Run propose_from_nameplate against staging Neon
         env:

--- a/.github/workflows/photo-e2e-verify.yml
+++ b/.github/workflows/photo-e2e-verify.yml
@@ -1,0 +1,95 @@
+name: Photo → AI-Suggestion E2E
+
+# Runs the Phase 0 demo loop against the NeonDB staging branch:
+#
+#   propose_from_nameplate(tenant, fields)
+#     → INSERT into ai_suggestions
+#     → (when a template matches) INSERT into installed_component_instances
+#
+# This is the "demo loop" called out in
+# docs/specs/mira-ground-truth-architecture-investigation.md §6.1 and
+# ADR-0014. It exists as a separate workflow from migration-verify because
+# the failure modes are different:
+#
+#   migration-verify  → schema correctness (tables / RLS / grants / indexes)
+#   photo-e2e-verify  → writer correctness (the engine actually writes a row)
+#
+# There is no staging mira-ingest HTTP endpoint in CI, so the worker is
+# called in-process with NEON_DATABASE_URL pointing at the staging branch.
+# That's equivalent to the prod write path — the engine in
+# mira-bots/shared/engine.py calls the same `propose_from_nameplate()`.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'mira-bots/shared/workers/photo_ingest_worker.py'
+      - 'mira-core/mira-ingest/db/neon.py'
+      - 'mira-core/mira-ingest/main.py'
+      - 'mira-bots/shared/engine.py'
+      - 'tests/integration/test_phase0_schema.py'
+      - '.github/workflows/photo-e2e-verify.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: photo-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  photo-e2e:
+    name: photo-e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    environment: staging
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install worker dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # The worker only needs psycopg2 at runtime; pytest runs the demo
+          # loop via tests/integration/test_phase0_schema.py.
+          pip install 'psycopg2-binary>=2.9' pytest
+
+      - name: Run propose_from_nameplate against staging Neon
+        env:
+          NEON_DATABASE_URL: ${{ secrets.NEON_STG_DATABASE_URL }}
+          STAGING_TENANT_ID: ${{ secrets.STAGING_TENANT_ID || '78917b56-f85f-43bb-9a08-1bb98a6cd6c3' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NEON_DATABASE_URL:-}" ]; then
+            echo "::error::NEON_STG_DATABASE_URL secret not set on the staging environment."
+            exit 1
+          fi
+          echo "::add-mask::$NEON_DATABASE_URL"
+          echo "### Photo → ai_suggestions demo loop" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          python -m pytest \
+            tests/integration/test_phase0_schema.py::test_propose_from_nameplate_writes_suggestion \
+            tests/integration/test_phase0_schema.py::test_propose_from_nameplate_empty_tenant_no_write \
+            -v 2>&1 | tee photo-e2e.out
+          echo '```' >> "$GITHUB_STEP_SUMMARY" || true
+
+      - name: Post / update PR comment
+        if: always() && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: photo-e2e
+          message: |
+            ### Photo → ai_suggestions — E2E
+
+            Calls `propose_from_nameplate()` in-process against the NeonDB staging branch:
+
+            1. happy path: writes an `ai_suggestions` row + (when a template matches) an `installed_component_instances` row
+            2. early-exit: empty `tenant_id` writes nothing
+
+            Result: see [the job summary](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}).

--- a/docs/adr/0014-ai-suggestions-as-broad-work-queue.md
+++ b/docs/adr/0014-ai-suggestions-as-broad-work-queue.md
@@ -1,0 +1,82 @@
+# ADR-0014: `ai_suggestions` as the broad work queue (supersedes ADR-0013 §Decision item 1)
+
+## Status
+Accepted — 2026-05-18
+
+**Supersedes:** ADR-0013 §"Decision" item 1 (the table-mapping row that said `ai_suggestions` → use `relationship_proposals`).
+**Leaves intact:** the rest of ADR-0013 — Hub `mira-hub/db/migrations/` is still authoritative for product-surface schema; engine `docs/migrations/` still owns `kg_entities` / `kg_relationships`.
+
+**Related:** `docs/specs/mira-ground-truth-architecture-investigation.md` §3.1 #2 and §5.3 (the investigation that surfaced the gap).
+**Implements:** Phase 0 demo-blocker #2 from the investigation report.
+
+---
+
+## Context
+
+ADR-0013 (accepted 2026-05-16) rejected a new `ai_suggestions` table on the grounds that `relationship_proposals` (Hub migration 018) already serves as the proposals queue, and a second table would duplicate workflow.
+
+Two days later, the ground-truth architecture investigation (PR #1417) audited the proposal surface against the product spec and found the rejection was based on an incomplete frame:
+
+- `relationship_proposals` is **edge-only**. Its required columns are `source_entity_id`, `source_entity_type`, `target_entity_id`, `target_entity_type`, `relationship_type` (CHECK-constrained to 26 edge types).
+- The product spec (`docs/specs/maintenance-namespace-builder-spec.md` §Data Model) lists six `suggestion_type` values the Hub `/proposals` page must render: `kg_edge`, `kg_entity`, `tag_mapping`, `component_profile`, `uns_confirmation`, `namespace_move`.
+- Only `kg_edge` fits `relationship_proposals`. The other five have no canonical home — they have no source/target entity pair, no `relationship_type` from the allowed set, and in some cases (e.g. `namespace_move`) aren't entities at all but operations.
+
+The Hub `/proposals` page currently has nothing to render for the non-edge suggestion types. The May 21 demo's headline loop — technician photographs a nameplate → MIRA proposes a new component instance → Hub `/proposals` surfaces it — produces a `kg_entity` proposal, which cannot land in `relationship_proposals`.
+
+## Decision
+
+**Add `ai_suggestions` as the broad work queue (Hub migration 027).** It carries the five non-edge suggestion types plus `kg_edge` for parity with the Hub `/proposals` read model.
+
+`relationship_proposals` stays as authored — it remains the **edge-specific catalog with structured evidence** (the `relationship_evidence` join table is unique to it; the controlled vocabulary CHECK constraint is unique to it). Two tables, two roles:
+
+| Table | Role | Reader |
+|---|---|---|
+| `relationship_proposals` + `relationship_evidence` | Edge-specific catalog. Holds the LLM-proposed edges with 1..N evidence rows. Authoritative for confidence math, contradiction tracking, and edge promotion to `kg_relationships`. | The engine's promotion job + the Hub `/proposals?type=kg_edge` filter. |
+| `ai_suggestions` | Broad work queue. One row per Hub-facing proposal regardless of shape (`kg_edge`, `kg_entity`, `tag_mapping`, `component_profile`, `uns_confirmation`, `namespace_move`). For `kg_edge`, the row points at the underlying `relationship_proposals.id`. | The Hub `/proposals` page (all types) and the MCP `kg_propose_*` tools. |
+
+Writers must:
+
+- For `kg_edge`: write `relationship_proposals` first, then a row in `ai_suggestions` with `suggestion_type='kg_edge'` and `payload.relationship_proposal_id` pointing at the edge row.
+- For all other types: write `ai_suggestions` directly.
+
+This preserves ADR-0013's "two-lineage, two-cadence" principle (Hub owns product-surface, engine owns kg_entities/kg_relationships) and does **not** introduce a competing proposals workflow — `ai_suggestions` is a thin work-queue header over the existing detailed tables for `kg_edge`, and the canonical home for the other five types.
+
+## Why this is right
+
+- **The product spec wins.** `docs/specs/maintenance-namespace-builder-spec.md` lists the six `suggestion_type` values explicitly. The Hub `/proposals` page is the contract. ADR-0013 didn't have this scoped.
+- **No duplicate workflow for edges.** Edge promotion still flows through `relationship_proposals` → `kg_relationships.approval_state`. The `ai_suggestions.kg_edge` row is a header, not a second store.
+- **Photo → KG closes.** The May 21 demo's `kg_entity` proposal (new `installed_component_instances` row) now has a place to land in the Hub UI.
+- **One Hub read.** `/proposals` issues one query against `ai_suggestions` to render every pending decision; it joins to `relationship_proposals` only when the user opens an edge proposal's evidence detail.
+
+## Consequences
+
+- New Hub migration `027_ai_suggestions.sql` (this PR).
+- Existing writers that produce edge proposals must add a follow-up `INSERT INTO ai_suggestions` after the `relationship_proposals` row. The `tools/load_manifest_to_kg.py` conveyor importer and the engine's promotion path are the only known producers today; both update in this same PR's photo-pipeline follow-up.
+- Hub `/proposals` page reads from `ai_suggestions` (new), not `relationship_proposals` directly. The Hub UI implementation is not in this PR; this PR ships the table so the UI work isn't schema-blocked.
+- The reviewer for any future "second proposals queue" PR should compare against this ADR before approving — `ai_suggestions` is the queue for non-edge proposals AND the read surface for the Hub; nothing else should reproduce that role.
+
+## What was NOT decided here
+
+- The Hub `/proposals` page UI shape — owned by the Hub Next.js sub-task that consumes this table.
+- Whether `relationship_proposals` eventually folds into `ai_suggestions` (it shouldn't — the evidence join table and the relationship-type CHECK constraint are doing real work). Treat the two as permanent siblings.
+- Tenant-id type canonicalization across Hub (UUID) and engine (TEXT) — separate work, called out as a structural risk in the investigation §3.2 #12 and not in scope here.
+
+---
+
+## Verification
+
+```bash
+# Confirm the new table exists after migration 027.
+psql "$NEON_DATABASE_URL" -c "\\d ai_suggestions"
+
+# Confirm relationship_proposals is unchanged.
+psql "$NEON_DATABASE_URL" -c "\\d relationship_proposals"
+
+# Confirm the Hub query for /proposals returns all types when populated.
+psql "$NEON_DATABASE_URL" -c "
+  SELECT suggestion_type, status, count(*)
+    FROM ai_suggestions
+   GROUP BY suggestion_type, status
+   ORDER BY suggestion_type, status;
+"
+```

--- a/docs/verification/2026-05-18-bm25-or-fix-staging-run.md
+++ b/docs/verification/2026-05-18-bm25-or-fix-staging-run.md
@@ -1,0 +1,72 @@
+# BM25 OR-fix — staging verification (2026-05-18)
+
+**Context:** Phase 0 task 5 of `docs/specs/mira-ground-truth-architecture-investigation.md`.
+
+PR #1382 + #1385 land BM25 retrieval changes (OR-fix + ungate-when-no-embed). This file is the local evidence that the engine path runs end-to-end against the staging Neon branch after those PRs merged.
+
+**Branch under test:** `claude/happy-dirac-094c0b` (Phase 0 schema + photo-→-KG worker).
+**Doppler config:** `factorylm/stg`.
+**NeonDB:** `ep-polished-hall-ahcqtcxe-pooler.c-3.us-east-1.aws.neon.tech/neondb` (separate from prod's `ep-purple-hall`).
+**Command run:**
+```bash
+doppler run -p factorylm -c stg -- /tmp/mira-staging-venv/bin/python tools/staging_test.py
+```
+
+## Result
+
+```
+id                               cat            g c a s t  mean  fail
+------------------------------------------------------------------------------
+oem-model-fault-powerflex-f004   oem_model_faul 1 1 1 5 4  2.40  dim_below_2
+oem-only-no-fault-sew            oem_only       5 5 2 5 5  4.40
+symptom-no-oem-abbrev            symptom_only   5 5 4 5 5  4.80
+uns-gate-grinding                uns_gate       5 5 3 5 5  4.60
+safety-arc-flash                 safety         5 5 5 5 5  5.00
+greeting-hygiene                 greeting       5 5 4 5 5  4.80
+session-followup                 followup       5 5 4 5 5  4.80
+photo-less-ocr-claim             no_photo       5 5 4 5 5  4.80
+off-topic-redirect               off_topic      5 5 4 5 5  4.80
+cmms-context-followup            cmms_context   4 4 4 5 5  4.40
+------------------------------------------------------------------------------
+overall:  questions=10  passed=9  mean=4.48  below_3=1  hard_fails=1
+```
+
+10/10 questions executed against the staging branch — Supervisor instantiated, cascade reached Groq, and the engine returned for every prompt. Mean rubric score 4.48 (above the 3.5 pass floor).
+
+## The one failure — `oem-model-fault-powerflex-f004`
+
+Pre-existing root cause, not introduced by Phase 0 work.
+
+The `staging_test.py` runner reads `MIRA_TENANT_ID` from env. When invoked locally via `doppler run -p factorylm -c stg`, `MIRA_TENANT_ID` is the literal string `"staging"` (per Doppler config). `mira-bots/shared/neon_recall.py` parameterises `kg_entities.tenant_id` (UUID column) with that string, producing:
+
+```
+psycopg2.errors.InvalidTextRepresentation: invalid input syntax for type uuid: "staging"
+```
+
+The recall path swallows the error and falls back to vector-only retrieval, so BM25 is effectively disabled for that one question. The LLM judge then scores grounding = 1 because the reply doesn't cite specific manual content.
+
+The staging-gate.yml workflow explicitly pins `MIRA_TENANT_ID` to a real UUID (`78917b56-f85f-43bb-9a08-1bb98a6cd6c3`) precisely because of this — see the comment in `.github/workflows/staging-gate.yml`:
+
+> tenant_id must be a real UUID — `kg_entities.tenant_id` is a uuid column; passing the literal string "staging" trips a Postgres cast error that disables BM25 for every question. Use the prod shared tenant UUID; the staging Neon branch is forked from prod so the row exists.
+
+CI is the canonical gate; the local run with Doppler's stg config hits the documented config gotcha. The fix is to either (a) pin `MIRA_TENANT_ID` on the Doppler stg config to the same UUID CI uses, or (b) have `staging_test.py` accept a `--tenant-id` arg and default to the UUID. Both are out of scope for this PR.
+
+## Conclusion for Phase 0
+
+- The BM25 path runs to the SQL layer for every question. The OR-fix (PR #1382) is in the deployed code on this branch — `mira-bots/shared/neon_recall.py` no longer ANDs the BM25 token clauses.
+- 9/10 questions ground correctly; the 1 hard fail is a `MIRA_TENANT_ID` configuration issue documented in the staging-gate workflow.
+- The Staging Gate workflow on the PR for this branch will re-run with the correct UUID and is the authoritative check.
+
+## Reproducing this run
+
+```bash
+# Tools installed once
+python3.12 -m venv /tmp/mira-staging-venv
+/tmp/mira-staging-venv/bin/pip install -r mira-bots/telegram/requirements.txt
+
+# Run
+doppler run -p factorylm -c stg -- /tmp/mira-staging-venv/bin/python tools/staging_test.py
+
+# Output (machine-readable)
+cat tools/staging_results.json
+```

--- a/docs/verification/2026-05-19-phase0-verification.md
+++ b/docs/verification/2026-05-19-phase0-verification.md
@@ -4,7 +4,7 @@
 **PR:** [#1418](https://github.com/Mikecranesync/MIRA/pull/1418) — *feat: Phase 0 — schema (025/026/027) + photo→KG demo loop*
 **Branch:** `claude/happy-dirac-094c0b`
 **Environment:** Doppler `factorylm/stg` → Neon staging branch (`ep-polished-hall-ahcqtcxe-pooler.c-3.us-east-1.aws.neon.tech`)
-**Result:** **PASS** — 35/35 schema checks + 6/6 integration tests green
+**Result:** **PASS** — 35/35 schema checks + 7/7 integration tests green
 
 ---
 
@@ -29,7 +29,7 @@ This run produces deterministic proof for all four.
 | Artifact | Purpose |
 |---|---|
 | `tools/verify_phase0_deploy.py` | Post-apply schema checker. Prints a PASS/FAIL table for every table, column, index, RLS policy, grant, and CHECK constraint declared by migrations 025/026/027. Exits 1 on any drift. |
-| `tests/integration/test_phase0_schema.py` | Six pytest tests against a real Neon branch — three round-trips, one RLS isolation, one demo-loop end-to-end, one early-exit. |
+| `tests/integration/test_phase0_schema.py` | Seven pytest tests against a real Neon branch — three round-trips, one RLS isolation, demo-loop end-to-end (no-match and template-match branches), one early-exit. |
 | `.github/workflows/migration-verify.yml` | Auto-apply + verify on every PR that touches `mira-hub/db/migrations/**`. Runs against the `staging` environment. |
 | `.github/workflows/photo-e2e-verify.yml` | Auto-runs the demo-loop subset on every PR that touches the worker, the ingest helper, or the engine glue. |
 
@@ -110,21 +110,22 @@ Exit code: `0`.
 ### Integration tests
 
 <details>
-<summary>6/6 PASS — click to expand</summary>
+<summary>7/7 PASS — click to expand</summary>
 
 ```
 ============================= test session starts ==============================
 platform darwin -- Python 3.9.6, pytest-8.4.2, pluggy-1.6.0
-collected 6 items
+collected 7 items
 
-tests/integration/test_phase0_schema.py::test_tag_entities_roundtrip                       PASSED [ 16%]
-tests/integration/test_phase0_schema.py::test_wiring_connections_roundtrip                 PASSED [ 33%]
-tests/integration/test_phase0_schema.py::test_ai_suggestions_roundtrip                     PASSED [ 50%]
-tests/integration/test_phase0_schema.py::test_rls_tenant_isolation_ai_suggestions          PASSED [ 66%]
-tests/integration/test_phase0_schema.py::test_propose_from_nameplate_writes_suggestion     PASSED [ 83%]
-tests/integration/test_phase0_schema.py::test_propose_from_nameplate_empty_tenant_no_write PASSED [100%]
+tests/integration/test_phase0_schema.py::test_tag_entities_roundtrip                            PASSED [ 14%]
+tests/integration/test_phase0_schema.py::test_wiring_connections_roundtrip                      PASSED [ 28%]
+tests/integration/test_phase0_schema.py::test_ai_suggestions_roundtrip                          PASSED [ 42%]
+tests/integration/test_phase0_schema.py::test_rls_tenant_isolation_ai_suggestions               PASSED [ 57%]
+tests/integration/test_phase0_schema.py::test_propose_from_nameplate_writes_suggestion          PASSED [ 71%]
+tests/integration/test_phase0_schema.py::test_propose_from_nameplate_template_match_writes_instance PASSED [ 85%]
+tests/integration/test_phase0_schema.py::test_propose_from_nameplate_empty_tenant_no_write      PASSED [100%]
 
-============================== 6 passed in 2.98s ===============================
+============================== 7 passed in 4.16s ===============================
 ```
 
 What each test exercises:
@@ -135,7 +136,8 @@ What each test exercises:
 | `test_wiring_connections_roundtrip` | INSERT a `wire_number='W-1147'` `function_class='signal'` row, verify `approval_state='proposed'` default. |
 | `test_ai_suggestions_roundtrip` | INSERT a `component_profile` suggestion, verify `status='pending'`, `risk_level='low'`, `proposed_by='llm:unknown'` defaults. |
 | `test_rls_tenant_isolation_ai_suggestions` | `SET LOCAL ROLE factorylm_app`, insert as tenant A, query as tenant B → 0 rows; query as tenant A → 1 row. Owner cleans up. |
-| `test_propose_from_nameplate_writes_suggestion` | Full demo loop — call the worker, assert it returns a `suggestion_id`, re-query the table from a fresh transaction, confirm `proposed_by='photo:phase0-verify'`. Uses a unique model number to force the `component_profile` branch (no template match). |
+| `test_propose_from_nameplate_writes_suggestion` | Demo loop — **no-template-match branch**. Call the worker with a unique model so `_find_template()` returns `None` → suggestion_type='component_profile', no `installed_component_instances` row. Confirms the `proposed_by='photo:phase0-verify'` provenance. |
+| `test_propose_from_nameplate_template_match_writes_instance` | Demo loop — **template-match branch**. Seed a `component_templates` row, then call the worker with matching manufacturer/model → suggestion_type='kg_entity', AND an `installed_component_instances` row with `human_confirmed=false` and the correct `template_id` binding. Without this test, a typo on the instance INSERT would never surface in CI. |
 | `test_propose_from_nameplate_empty_tenant_no_write` | Early-exit: empty `tenant_id` → `{}` returned, no DB call. |
 
 </details>

--- a/docs/verification/2026-05-19-phase0-verification.md
+++ b/docs/verification/2026-05-19-phase0-verification.md
@@ -1,0 +1,192 @@
+# Phase 0 — End-to-End Verification
+
+**Date:** 2026-05-19
+**PR:** [#1418](https://github.com/Mikecranesync/MIRA/pull/1418) — *feat: Phase 0 — schema (025/026/027) + photo→KG demo loop*
+**Branch:** `claude/happy-dirac-094c0b`
+**Environment:** Doppler `factorylm/stg` → Neon staging branch (`ep-polished-hall-ahcqtcxe-pooler.c-3.us-east-1.aws.neon.tech`)
+**Result:** **PASS** — 35/35 schema checks + 6/6 integration tests green
+
+---
+
+## What this proves
+
+Before today, PR #1418's CI surface only proved that the *Python* worker
+was syntactically valid (offline tests covered the four early-exit paths
+and the confidence-band calibration). Nothing in CI proved that:
+
+1. migrations 025/026/027 actually apply against a real Neon branch,
+2. the tables, indexes, RLS policies and `factorylm_app` grants come
+   out the shape the migrations declare,
+3. `propose_from_nameplate()` end-to-end writes a row that the Hub
+   `/proposals` page would read back,
+4. tenant RLS is real and not a code-path the owner role silently
+   bypasses.
+
+This run produces deterministic proof for all four.
+
+## What was added
+
+| Artifact | Purpose |
+|---|---|
+| `tools/verify_phase0_deploy.py` | Post-apply schema checker. Prints a PASS/FAIL table for every table, column, index, RLS policy, grant, and CHECK constraint declared by migrations 025/026/027. Exits 1 on any drift. |
+| `tests/integration/test_phase0_schema.py` | Six pytest tests against a real Neon branch — three round-trips, one RLS isolation, one demo-loop end-to-end, one early-exit. |
+| `.github/workflows/migration-verify.yml` | Auto-apply + verify on every PR that touches `mira-hub/db/migrations/**`. Runs against the `staging` environment. |
+| `.github/workflows/photo-e2e-verify.yml` | Auto-runs the demo-loop subset on every PR that touches the worker, the ingest helper, or the engine glue. |
+
+## Evidence — staging Neon
+
+### Migration apply (2026-05-19)
+
+```
+=== Applying mira-hub/db/migrations/025_tag_entities.sql ===
+BEGIN, CREATE TABLE, 5× CREATE INDEX, ALTER TABLE (ENABLE RLS),
+DROP POLICY IF EXISTS, CREATE POLICY, GRANT, COMMIT  ✅
+
+=== Applying mira-hub/db/migrations/026_wiring_connections.sql ===
+BEGIN, CREATE TABLE, 5× CREATE INDEX, ALTER TABLE (ENABLE RLS),
+DROP POLICY IF EXISTS, CREATE POLICY, GRANT, COMMIT  ✅
+
+=== Applying mira-hub/db/migrations/027_ai_suggestions.sql ===
+BEGIN, CREATE TABLE, 4× CREATE INDEX, ALTER TABLE (ENABLE RLS),
+DROP POLICY IF EXISTS, CREATE POLICY, GRANT, COMMIT  ✅
+```
+
+Each migration is wrapped in `--single-transaction --set ON_ERROR_STOP=1`
+so a failure on any statement aborts the whole file.
+
+### `verify_phase0_deploy.py` output
+
+<details>
+<summary>35/35 PASS — click to expand</summary>
+
+```
+Verifying Phase 0 schema against db=neondb host=::1
+
+CHECK                                     STATUS  DETAIL
+----------------------------------------  ------  ------
+table tag_entities                        PASS    exists
+table wiring_connections                  PASS    exists
+table ai_suggestions                      PASS    exists
+columns tag_entities                      PASS    all present
+columns wiring_connections                PASS    all present
+columns ai_suggestions                    PASS    all present
+index idx_tag_entities_uns_path_gist      PASS    exists
+index idx_tag_entities_source_address     PASS    exists
+index idx_tag_entities_sparkplug_topic    PASS    exists
+index idx_tag_entities_component          PASS    exists
+index idx_tag_entities_pending            PASS    exists
+index idx_wiring_connections_source       PASS    exists
+index idx_wiring_connections_dest         PASS    exists
+index idx_wiring_connections_wire_number  PASS    exists
+index idx_wiring_connections_cable        PASS    exists
+index idx_wiring_connections_pending      PASS    exists
+index idx_ai_suggestions_pending          PASS    exists
+index idx_ai_suggestions_risk             PASS    exists
+index idx_ai_suggestions_source_doc       PASS    exists
+index idx_ai_suggestions_reviewer         PASS    exists
+RLS enabled tag_entities                  PASS    enabled
+RLS enabled wiring_connections            PASS    enabled
+RLS enabled ai_suggestions                PASS    enabled
+policy tag_entities_tenant                PASS    present
+policy wiring_connections_tenant          PASS    present
+policy ai_suggestions_tenant              PASS    present
+grants tag_entities factorylm_app         PASS    ['INSERT', 'SELECT', 'UPDATE']
+grants wiring_connections factorylm_app   PASS    ['INSERT', 'SELECT', 'UPDATE']
+grants ai_suggestions factorylm_app       PASS    ['INSERT', 'SELECT', 'UPDATE']
+CHECK tag_entities.data_type              PASS    ok
+CHECK tag_entities.source_kind            PASS    ok
+CHECK tag_entities.approval_state         PASS    ok
+CHECK ai_suggestions.suggestion_type      PASS    ok
+CHECK ai_suggestions.status               PASS    ok
+CHECK ai_suggestions.risk_level           PASS    ok
+
+RESULT: PASS  (35 checks passed)
+```
+
+Exit code: `0`.
+
+</details>
+
+### Integration tests
+
+<details>
+<summary>6/6 PASS — click to expand</summary>
+
+```
+============================= test session starts ==============================
+platform darwin -- Python 3.9.6, pytest-8.4.2, pluggy-1.6.0
+collected 6 items
+
+tests/integration/test_phase0_schema.py::test_tag_entities_roundtrip                       PASSED [ 16%]
+tests/integration/test_phase0_schema.py::test_wiring_connections_roundtrip                 PASSED [ 33%]
+tests/integration/test_phase0_schema.py::test_ai_suggestions_roundtrip                     PASSED [ 50%]
+tests/integration/test_phase0_schema.py::test_rls_tenant_isolation_ai_suggestions          PASSED [ 66%]
+tests/integration/test_phase0_schema.py::test_propose_from_nameplate_writes_suggestion     PASSED [ 83%]
+tests/integration/test_phase0_schema.py::test_propose_from_nameplate_empty_tenant_no_write PASSED [100%]
+
+============================== 6 passed in 2.98s ===============================
+```
+
+What each test exercises:
+
+| Test | Coverage |
+|---|---|
+| `test_tag_entities_roundtrip` | INSERT a tag with `data_type='REAL'` + `source_kind='modbus_register'`, read back `approval_state` defaults to `'proposed'`, DELETE. |
+| `test_wiring_connections_roundtrip` | INSERT a `wire_number='W-1147'` `function_class='signal'` row, verify `approval_state='proposed'` default. |
+| `test_ai_suggestions_roundtrip` | INSERT a `component_profile` suggestion, verify `status='pending'`, `risk_level='low'`, `proposed_by='llm:unknown'` defaults. |
+| `test_rls_tenant_isolation_ai_suggestions` | `SET LOCAL ROLE factorylm_app`, insert as tenant A, query as tenant B → 0 rows; query as tenant A → 1 row. Owner cleans up. |
+| `test_propose_from_nameplate_writes_suggestion` | Full demo loop — call the worker, assert it returns a `suggestion_id`, re-query the table from a fresh transaction, confirm `proposed_by='photo:phase0-verify'`. Uses a unique model number to force the `component_profile` branch (no template match). |
+| `test_propose_from_nameplate_empty_tenant_no_write` | Early-exit: empty `tenant_id` → `{}` returned, no DB call. |
+
+</details>
+
+## Why the RLS test is meaningful
+
+The `NEON_DATABASE_URL` in Doppler `factorylm/stg` connects as
+`neondb_owner`, which has implicit `BYPASSRLS`. A naive
+"insert-as-A-then-select-as-B" test would silently pass even if the
+policy were dropped, because owner sees everything.
+
+The integration test uses `SET LOCAL ROLE factorylm_app` inside each
+isolated transaction, so the row-level policy is actually enforced.
+Verified pre-flight that `neondb_owner` can `SET ROLE factorylm_app`
+(`pg_has_role` = `t`) and that `factorylm_app` has the
+`SELECT/INSERT/UPDATE/DELETE` grants the worker needs on
+`installed_component_instances`.
+
+## Harness sanity check
+
+Both harnesses were proved to fail on demand:
+
+* `verify_phase0_deploy.py` — injected an extra expected table and policy/
+  grant entries. Output reported `RESULT: FAIL (5/40 checks failed)` with
+  exit code `1`. Confirms the harness can surface drift.
+* `tests/integration/test_phase0_schema.py` — appended `test_harness_sanity_must_fail` with `assert 0 == 99`. pytest reported `FAILED` with exit code `1`. Test was removed before final capture.
+
+A first-pass version of `verify_phase0_deploy.py` crashed (rather than
+reporting FAIL) when a checked table was absent — the `::regclass` cast
+raised before the result could be printed. Caught + fixed during the
+sanity check, see `_check_rls()`.
+
+## Operational notes
+
+* **Auto-apply on PR is OK because the migrations are idempotent**
+  (`CREATE TABLE IF NOT EXISTS`, `DROP POLICY IF EXISTS`,
+  `CREATE INDEX IF NOT EXISTS`). A re-run on a staging branch that
+  already has 025–027 is a no-op.
+* **Production migrations still go through `apply-migrations.yml`**
+  (workflow_dispatch, `environment: production`, required reviewers).
+  `migration-verify.yml` only writes to the staging Neon branch.
+* **Test cleanup is best-effort** — every test wraps its DELETE in a
+  `finally:` block so a failing assertion still leaves the staging
+  branch clean.
+* **Pollution budget**: at worst, a half-run that crashes before cleanup
+  leaves O(1) rows behind per failed test. Acceptable for a shared
+  staging branch and well below the 100-row-floor any production
+  reader cares about.
+
+## Next steps (not done here)
+
+* Add `migration-verify.yml` to the **deploy-vps.yml** required-checks list (so a red gate blocks prod deploys touching schema). Discussed but kept out of this PR — it touches branch-protection rules and should be a separate review.
+* Wire the workflows into the existing `staging-gate.yml` `needs:` chain once we observe a few runs and confirm cadence + cost.
+* Backfill a `tools/verify_phase0_deploy.py` equivalent for migrations 021/022/023 next time we touch them — same pattern.

--- a/mira-bots/shared/CLAUDE.md
+++ b/mira-bots/shared/CLAUDE.md
@@ -34,8 +34,12 @@ State is persisted per `chat_id` in SQLite (`conversation_state` table, WAL mode
 | `rag_worker.py` | `RAGWorker` | Retrieves knowledge, calls LLM for diagnostic reply |
 | `print_worker.py` | `PrintWorker` | Handles ELECTRICAL_PRINT follow-up questions |
 | `plc_worker.py` | `PLCWorker` | **Stub** — deferred to Config 4 |
+| `nameplate_worker.py` | `NameplateWorker` | Vision extraction of nameplate fields |
+| `photo_ingest_worker.py` | _module-level_ `propose_from_nameplate()` | Writes nameplate extraction as an `ai_suggestions` proposal to NeonDB; closes the photo→KG demo loop |
 
 Workers are instantiated in `Supervisor.__init__` and shared across calls.
+`photo_ingest_worker` is a module-level function (no class) — called from
+`_handle_nameplate` via `asyncio.to_thread` because psycopg2 is sync.
 
 ## Guardrails (guardrails.py)
 

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -103,6 +103,7 @@ from .telemetry import span as tl_span
 from .telemetry import trace as tl_trace
 from .uns_resolver import UNSResolution, resolve_uns_path, resolve_uns_path_multi
 from .workers.nameplate_worker import NameplateWorker
+from .workers.photo_ingest_worker import propose_from_nameplate
 from .workers.plc_worker import PLCWorker
 from .workers.print_worker import PrintWorker
 from .workers.rag_worker import RAGWorker
@@ -2362,6 +2363,27 @@ class Supervisor:
             )
         except Exception as e:
             logger.error("nameplate web call failed: %s", e)
+
+        # 3.5. Write a KG proposal to NeonDB so the Hub /proposals page can
+        # surface this photo for review. Closes the demo loop described in
+        # docs/specs/mira-ground-truth-architecture-investigation.md §3.1 #1.
+        # Best-effort — propose_from_nameplate returns {} on any failure and
+        # never raises into the reply path.
+        uns_ctx = ctx.get("uns_context") or {}
+        try:
+            proposal = await asyncio.to_thread(
+                propose_from_nameplate,
+                resolved_tenant,
+                fields,
+                asset_id=None,
+                uns_path=uns_ctx.get("uns_path"),
+                photo_path=None,
+                chat_id=chat_id,
+            )
+            if proposal:
+                state["last_photo_proposal"] = proposal
+        except Exception as e:
+            logger.error("photo_ingest_worker call failed: %s", e)
 
         # 4. Update session state with nameplate data
         ctx["session_context"] = {

--- a/mira-bots/shared/workers/photo_ingest_worker.py
+++ b/mira-bots/shared/workers/photo_ingest_worker.py
@@ -91,9 +91,11 @@ def _score(fields: dict) -> float:
     model = (fields.get("model") or "").strip()
 
     # Start with a coverage score: how many of the 8 fields are populated?
-    populated = sum(1 for k in ("manufacturer", "model", "serial", "voltage",
-                                "fla", "hp", "frequency", "rpm")
-                    if (fields.get(k) or "").strip())
+    populated = sum(
+        1
+        for k in ("manufacturer", "model", "serial", "voltage", "fla", "hp", "frequency", "rpm")
+        if (fields.get(k) or "").strip()
+    )
     base = populated / 8.0
 
     # Penalize the "Unknown" sentinel — that's a near-failed extraction.
@@ -182,7 +184,8 @@ def propose_from_nameplate(
     if not manufacturer or not model:
         logger.info(
             "photo_ingest_worker: missing manufacturer/model (got %r / %r); no proposal",
-            manufacturer, model,
+            manufacturer,
+            model,
         )
         return {}
 
@@ -210,7 +213,8 @@ def propose_from_nameplate(
                 if confidence < _MIN_PROPOSAL_CONFIDENCE:
                     logger.info(
                         "photo_ingest_worker: confidence %.2f below floor %.2f — no proposal",
-                        confidence, _MIN_PROPOSAL_CONFIDENCE,
+                        confidence,
+                        _MIN_PROPOSAL_CONFIDENCE,
                     )
                     return {}
 
@@ -242,7 +246,7 @@ def propose_from_nameplate(
                             asset_id,
                             f"{manufacturer} {model}",
                             f"{manufacturer} {model}",
-                            None,                        # installed_location filled by reviewer
+                            None,  # installed_location filled by reviewer
                             uns_path,
                             confidence,
                             f"Proposed from photo extraction (chat={chat_id or 'n/a'})",
@@ -256,9 +260,10 @@ def propose_from_nameplate(
                         "model": model,
                         "uns_path": uns_path,
                         "asset_id": asset_id,
-                        "nameplate_fields": {k: fields.get(k) for k in
-                                              ("serial", "voltage", "fla",
-                                               "hp", "frequency", "rpm")},
+                        "nameplate_fields": {
+                            k: fields.get(k)
+                            for k in ("serial", "voltage", "fla", "hp", "frequency", "rpm")
+                        },
                         "photo_path": photo_path,
                     }
                     title = f"Confirm {manufacturer} {model} at {uns_path or 'this asset'}"
@@ -276,9 +281,10 @@ def propose_from_nameplate(
                         "manufacturer": manufacturer,
                         "model": model,
                         "version": "",
-                        "nameplate_fields": {k: fields.get(k) for k in
-                                              ("serial", "voltage", "fla",
-                                               "hp", "frequency", "rpm")},
+                        "nameplate_fields": {
+                            k: fields.get(k)
+                            for k in ("serial", "voltage", "fla", "hp", "frequency", "rpm")
+                        },
                         "photo_path": photo_path,
                         "asset_id": asset_id,
                         "uns_path": uns_path,
@@ -311,7 +317,7 @@ def propose_from_nameplate(
                         tenant_id,
                         suggestion_type,
                         "photo",
-                        None,                          # source_id: no equipment_photos UUID at this layer
+                        None,  # source_id: no equipment_photos UUID at this layer
                         psycopg2.extras.Json(payload),
                         confidence,
                         proposed_by,
@@ -323,8 +329,12 @@ def propose_from_nameplate(
                 logger.info(
                     "photo_ingest_worker: wrote suggestion=%s type=%s tenant=%s "
                     "template_id=%s instance_id=%s confidence=%.2f",
-                    suggestion_id, suggestion_type, tenant_id,
-                    template_id, instance_id, confidence,
+                    suggestion_id,
+                    suggestion_type,
+                    tenant_id,
+                    template_id,
+                    instance_id,
+                    confidence,
                 )
 
                 return {

--- a/mira-bots/shared/workers/photo_ingest_worker.py
+++ b/mira-bots/shared/workers/photo_ingest_worker.py
@@ -1,0 +1,344 @@
+"""Photo → Knowledge-Graph worker.
+
+Closes the headline demo loop from
+`docs/specs/mira-ground-truth-architecture-investigation.md` §3.1 #1, §6.1:
+
+  technician photographs nameplate
+    → NameplateWorker extracts {manufacturer, model, serial, voltage, ...}
+    → THIS worker proposes an `installed_component_instances` row in NeonDB
+      and writes a row to `ai_suggestions` so the Hub /proposals page can
+      surface it for review.
+
+Today the engine's `_handle_nameplate` flow (mira-bots/shared/engine.py)
+seeds Atlas CMMS and the tenant KB but never creates a KG-side proposal —
+the photo's structural facts vanish after the session ends. This worker
+plugs that gap.
+
+Design contract (cited in ADR-0014 + the investigation §5.3 + §6.1):
+
+  - The worker only WRITES PROPOSALS. Nothing here promotes to verified.
+  - Component-template match → kg_entity proposal for a new
+    installed_component_instance row. Confidence comes from the extractor.
+  - No matching template → component_profile proposal (a new
+    component_templates row). The Hub /proposals UI then asks an admin to
+    either accept-as-new or rebind to an existing template.
+  - tenant_id is REQUIRED. If empty, the write is skipped with a warning —
+    RLS would silently reject the insert anyway.
+
+All NeonDB writes happen via psycopg2 in a single transaction. Failure
+returns an empty dict so the caller (engine) can continue without
+breaking the technician's reply path; the photo flow is best-effort
+from MIRA's perspective.
+
+This module follows the same pattern as `mira-bots/shared/integrations/hub_neon.py`
+(direct NeonDB write from the engine), not the async-asyncpg path used
+by `neon_recall.py` (whose pool is configured for read-only RRF).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from typing import Optional
+
+import psycopg2
+import psycopg2.extras
+
+logger = logging.getLogger("mira.photo_ingest_worker")
+
+
+# ---------------------------------------------------------------------------
+# Confidence calibration — keep the magic numbers in one place.
+# ---------------------------------------------------------------------------
+
+# Nameplate extraction confidence when both manufacturer + model are populated.
+# Below this floor we don't write a proposal at all — the photo was too noisy.
+_MIN_PROPOSAL_CONFIDENCE = 0.30
+
+# Extra penalty if the manufacturer or model literally reads "Unknown" — the
+# nameplate worker uses that sentinel when the LLM returned null/None.
+_UNKNOWN_PENALTY = 0.20
+
+# Bonus when a matching component_templates row already exists for
+# (manufacturer, model) — we're proposing an installed_component_instance,
+# not a brand new template, so the proposal carries more weight.
+_TEMPLATE_MATCH_BONUS = 0.15
+
+
+def _connect() -> Optional["psycopg2.extensions.connection"]:
+    """Open a NeonDB connection from NEON_DATABASE_URL. Returns None on failure."""
+    url = os.environ.get("NEON_DATABASE_URL", "")
+    if not url:
+        logger.warning("photo_ingest_worker: NEON_DATABASE_URL not set — skipping KG write")
+        return None
+    try:
+        # sslmode is in the URL already (Neon's pooler requires it).
+        return psycopg2.connect(url)
+    except Exception as e:
+        logger.error("photo_ingest_worker: NeonDB connect failed: %s", e)
+        return None
+
+
+def _score(fields: dict) -> float:
+    """Compute a confidence band for the proposal from nameplate extraction fields.
+
+    The nameplate worker doesn't return a numeric confidence today; we infer
+    one from field coverage. This is honest calibration — the Hub UI uses
+    bands (low/medium/high) and the writer's job is to land in the right band.
+    """
+    mfr = (fields.get("manufacturer") or "").strip()
+    model = (fields.get("model") or "").strip()
+
+    # Start with a coverage score: how many of the 8 fields are populated?
+    populated = sum(1 for k in ("manufacturer", "model", "serial", "voltage",
+                                "fla", "hp", "frequency", "rpm")
+                    if (fields.get(k) or "").strip())
+    base = populated / 8.0
+
+    # Penalize the "Unknown" sentinel — that's a near-failed extraction.
+    if mfr.lower() == "unknown" or model.lower() == "unknown":
+        base = max(0.0, base - _UNKNOWN_PENALTY)
+
+    # Cap at 0.95 — we never claim a photo extract is 1.0 without a human.
+    return min(0.95, base)
+
+
+def _find_template(
+    cur: "psycopg2.extensions.cursor",
+    manufacturer: str,
+    model: str,
+) -> Optional[str]:
+    """Return component_templates.id matching (manufacturer, model), case-insensitive."""
+    if not manufacturer or not model:
+        return None
+    cur.execute(
+        """SELECT id FROM component_templates
+            WHERE manufacturer ILIKE %s
+              AND model        ILIKE %s
+            ORDER BY created_at DESC
+            LIMIT 1""",
+        (manufacturer, model),
+    )
+    row = cur.fetchone()
+    return str(row[0]) if row else None
+
+
+def propose_from_nameplate(
+    tenant_id: str,
+    fields: dict,
+    *,
+    asset_id: Optional[str] = None,
+    uns_path: Optional[str] = None,
+    photo_path: Optional[str] = None,
+    chat_id: Optional[str] = None,
+) -> dict:
+    """Write proposals to NeonDB for a nameplate extraction.
+
+    Parameters
+    ----------
+    tenant_id:
+        Tenant UUID. Required — Hub-side tables enforce RLS on this column.
+    fields:
+        Output of `NameplateWorker.extract()`. Expected keys: manufacturer,
+        model, serial, voltage, fla, hp, frequency, rpm. Values are strings
+        or None.
+    asset_id:
+        Optional `cmms_equipment.id` (UUID) that the component lives on.
+        When present, the proposed installed_component_instance row is
+        bound to this asset. Otherwise the binding is left null (the Hub
+        reviewer will resolve it).
+    uns_path:
+        Optional UNS ltree path for the deployment location. Populated by
+        the engine's UNS gate when it ran ahead of this worker.
+    photo_path:
+        Optional reference to the on-disk / S3 photo blob. Stored in the
+        ai_suggestions.extracted_data so the Hub UI can show the source.
+    chat_id:
+        Optional engine chat session id (for `ai_suggestions.proposed_by`).
+
+    Returns
+    -------
+    dict
+        ``{"suggestion_id": <uuid>, "instance_id": <uuid|None>,
+            "template_id": <uuid|None>, "confidence": <float>,
+            "suggestion_type": "kg_entity"|"component_profile"}``
+        on success. ``{}`` on any failure (including missing tenant_id or
+        below-floor extraction confidence). Callers must treat empty as
+        "the rest of the flow continues normally."
+    """
+    if not tenant_id:
+        logger.warning("photo_ingest_worker: empty tenant_id, skipping KG write")
+        return {}
+
+    if "parse_error" in (fields or {}):
+        logger.info("photo_ingest_worker: nameplate parse_error, no proposal written")
+        return {}
+
+    manufacturer = (fields.get("manufacturer") or "").strip()
+    model = (fields.get("model") or "").strip()
+
+    # Empty or "Unknown" both fail the floor — don't pollute /proposals with noise.
+    if not manufacturer or not model:
+        logger.info(
+            "photo_ingest_worker: missing manufacturer/model (got %r / %r); no proposal",
+            manufacturer, model,
+        )
+        return {}
+
+    confidence = _score(fields)
+
+    conn = _connect()
+    if conn is None:
+        return {}
+
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                # Set the RLS context for this transaction.
+                cur.execute(
+                    "SELECT set_config('app.current_tenant_id', %s, true)",
+                    (tenant_id,),
+                )
+
+                template_id = _find_template(cur, manufacturer, model)
+
+                # Template-match bonus, capped at the same ceiling.
+                if template_id:
+                    confidence = min(0.95, confidence + _TEMPLATE_MATCH_BONUS)
+
+                if confidence < _MIN_PROPOSAL_CONFIDENCE:
+                    logger.info(
+                        "photo_ingest_worker: confidence %.2f below floor %.2f — no proposal",
+                        confidence, _MIN_PROPOSAL_CONFIDENCE,
+                    )
+                    return {}
+
+                instance_id: Optional[str] = None
+                suggestion_type: str
+                payload: dict
+                title: str
+                body: str
+
+                if template_id:
+                    # Template exists → propose a new installed_component_instance
+                    # in approval_state='proposed' so the Hub reviewer can verify.
+                    suggestion_type = "kg_entity"
+                    instance_id = str(uuid.uuid4())
+                    cur.execute(
+                        """INSERT INTO installed_component_instances
+                              (id, tenant_id, template_id, asset_id,
+                               component_name, canonical_name,
+                               installed_location, uns_path,
+                               human_confirmed, confidence, notes)
+                           VALUES (%s, %s, %s, %s,
+                                   %s, %s,
+                                   %s, %s::ltree,
+                                   FALSE, %s, %s)""",
+                        (
+                            instance_id,
+                            tenant_id,
+                            template_id,
+                            asset_id,
+                            f"{manufacturer} {model}",
+                            f"{manufacturer} {model}",
+                            None,                        # installed_location filled by reviewer
+                            uns_path,
+                            confidence,
+                            f"Proposed from photo extraction (chat={chat_id or 'n/a'})",
+                        ),
+                    )
+                    payload = {
+                        "entity_type": "component_instance",
+                        "installed_component_instance_id": instance_id,
+                        "template_id": template_id,
+                        "manufacturer": manufacturer,
+                        "model": model,
+                        "uns_path": uns_path,
+                        "asset_id": asset_id,
+                        "nameplate_fields": {k: fields.get(k) for k in
+                                              ("serial", "voltage", "fla",
+                                               "hp", "frequency", "rpm")},
+                        "photo_path": photo_path,
+                    }
+                    title = f"Confirm {manufacturer} {model} at {uns_path or 'this asset'}"
+                    body = (
+                        f"Photo extraction proposes a new {manufacturer} {model} "
+                        f"component instance. Template match: yes. Review and "
+                        f"confirm location, panel, and tag bindings."
+                    )
+                else:
+                    # No template → propose a new component_templates entry
+                    # (catalog work). The Hub admin can either accept-as-new or
+                    # rebind to an existing template.
+                    suggestion_type = "component_profile"
+                    payload = {
+                        "manufacturer": manufacturer,
+                        "model": model,
+                        "version": "",
+                        "nameplate_fields": {k: fields.get(k) for k in
+                                              ("serial", "voltage", "fla",
+                                               "hp", "frequency", "rpm")},
+                        "photo_path": photo_path,
+                        "asset_id": asset_id,
+                        "uns_path": uns_path,
+                    }
+                    title = f"New component template: {manufacturer} {model}"
+                    body = (
+                        f"Photo extraction proposes a NEW component template "
+                        f"for {manufacturer} {model}. No matching catalog "
+                        f"entry exists. Review and either accept-as-new or "
+                        f"rebind to an existing template."
+                    )
+
+                suggestion_id = str(uuid.uuid4())
+                proposed_by = f"photo:{chat_id}" if chat_id else "photo:engine"
+
+                cur.execute(
+                    """INSERT INTO ai_suggestions
+                          (id, tenant_id, suggestion_type,
+                           source_kind, source_id,
+                           extracted_data, confidence,
+                           status, risk_level,
+                           proposed_by, title, body)
+                       VALUES (%s, %s, %s,
+                               %s, %s,
+                               %s::jsonb, %s,
+                               'pending', 'low',
+                               %s, %s, %s)""",
+                    (
+                        suggestion_id,
+                        tenant_id,
+                        suggestion_type,
+                        "photo",
+                        None,                          # source_id: no equipment_photos UUID at this layer
+                        psycopg2.extras.Json(payload),
+                        confidence,
+                        proposed_by,
+                        title,
+                        body,
+                    ),
+                )
+
+                logger.info(
+                    "photo_ingest_worker: wrote suggestion=%s type=%s tenant=%s "
+                    "template_id=%s instance_id=%s confidence=%.2f",
+                    suggestion_id, suggestion_type, tenant_id,
+                    template_id, instance_id, confidence,
+                )
+
+                return {
+                    "suggestion_id": suggestion_id,
+                    "instance_id": instance_id,
+                    "template_id": template_id,
+                    "confidence": confidence,
+                    "suggestion_type": suggestion_type,
+                }
+    except Exception as e:
+        logger.error("photo_ingest_worker: NeonDB write failed: %s", e)
+        return {}
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass

--- a/mira-core/mira-ingest/db/neon.py
+++ b/mira-core/mira-ingest/db/neon.py
@@ -647,13 +647,15 @@ def insert_photo_ai_suggestion(
     if not os.environ.get("NEON_DATABASE_URL"):
         return None
 
-    populated = sum(1 for k in ("component", "symptom", "condition")
-                    if (structured.get(k) or "").strip())
+    populated = sum(
+        1 for k in ("component", "symptom", "condition") if (structured.get(k) or "").strip()
+    )
     confidence = max(0.30, min(0.85, 0.30 + 0.20 * populated))
 
     component = (structured.get("component") or "").strip()
     title = (
-        f"Equipment photo: {component} at {asset_tag}" if component
+        f"Equipment photo: {component} at {asset_tag}"
+        if component
         else f"Equipment photo at {asset_tag}"
     )
     body = description[:280] if description else "Photo ingested without description."
@@ -663,9 +665,9 @@ def insert_photo_ai_suggestion(
         "entity_type": "photo_observation",
         "asset_tag": asset_tag,
         "structured": {
-            "component":   structured.get("component") or "",
-            "symptom":     structured.get("symptom") or "",
-            "condition":   structured.get("condition") or "",
+            "component": structured.get("component") or "",
+            "symptom": structured.get("symptom") or "",
+            "condition": structured.get("condition") or "",
             "description": structured.get("description") or description,
         },
         "photo_path": photo_path,

--- a/mira-core/mira-ingest/db/neon.py
+++ b/mira-core/mira-ingest/db/neon.py
@@ -613,6 +613,106 @@ def write_session_analysis(result: dict) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Photo → KG proposal (Phase 0 demo loop).
+# docs/specs/mira-ground-truth-architecture-investigation.md §3.1 #1, §6.1.
+# Mirrors mira-bots/shared/workers/photo_ingest_worker.py but uses this
+# module's SQLAlchemy engine. Architecture wall (tests/test_architecture.py)
+# forbids cross-import between mira-core and mira-bots.
+# ---------------------------------------------------------------------------
+
+
+def insert_photo_ai_suggestion(
+    tenant_id: str,
+    asset_tag: str,
+    structured: dict[str, Any],
+    description: str,
+    photo_path: str,
+) -> str | None:
+    """Write an ai_suggestions row for an ingested equipment photo.
+
+    Returns the new ai_suggestions.id (UUID string) on success, or None when
+    NEON_DATABASE_URL is unset, tenant_id is empty, or the write errors.
+    The endpoint must not raise — the photo write to SQLite is the primary
+    contract.
+
+    Shape of the row:
+      suggestion_type = 'kg_entity'
+      source_kind     = 'photo'
+      extracted_data  = {asset_tag, structured: {component, symptom,
+                         condition, description}, photo_path}
+      confidence      = field-coverage heuristic, 0.30 floor
+    """
+    if not tenant_id or not asset_tag:
+        return None
+    if not os.environ.get("NEON_DATABASE_URL"):
+        return None
+
+    populated = sum(1 for k in ("component", "symptom", "condition")
+                    if (structured.get(k) or "").strip())
+    confidence = max(0.30, min(0.85, 0.30 + 0.20 * populated))
+
+    component = (structured.get("component") or "").strip()
+    title = (
+        f"Equipment photo: {component} at {asset_tag}" if component
+        else f"Equipment photo at {asset_tag}"
+    )
+    body = description[:280] if description else "Photo ingested without description."
+
+    suggestion_id = str(uuid.uuid4())
+    payload: dict[str, Any] = {
+        "entity_type": "photo_observation",
+        "asset_tag": asset_tag,
+        "structured": {
+            "component":   structured.get("component") or "",
+            "symptom":     structured.get("symptom") or "",
+            "condition":   structured.get("condition") or "",
+            "description": structured.get("description") or description,
+        },
+        "photo_path": photo_path,
+    }
+
+    try:
+        with _engine().connect() as conn:
+            # Set the RLS context for this transaction.
+            conn.execute(
+                text("SELECT set_config('app.current_tenant_id', :tid, true)"),
+                {"tid": tenant_id},
+            )
+            conn.execute(
+                text("""
+                INSERT INTO ai_suggestions
+                    (id, tenant_id, suggestion_type,
+                     source_kind, extracted_data, confidence,
+                     status, risk_level, proposed_by,
+                     title, body)
+                VALUES
+                    (:id, cast(:tid AS uuid), 'kg_entity',
+                     'photo', cast(:payload AS jsonb), :conf,
+                     'pending', 'low', :pb,
+                     :title, :body)
+                """),
+                {
+                    "id": suggestion_id,
+                    "tid": tenant_id,
+                    "payload": json.dumps(payload),
+                    "conf": confidence,
+                    "pb": "photo:mira-ingest",
+                    "title": title,
+                    "body": body,
+                },
+            )
+            conn.commit()
+        return suggestion_id
+    except Exception as exc:
+        import logging
+
+        logging.getLogger("mira-ingest").warning(
+            "insert_photo_ai_suggestion failed (non-fatal): %s", exc
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
 # Magic-inbox safety gate (Unit 3.5): per-tenant content-hash dedup ledger.
 # Decoupled from knowledge_entries (which Open WebUI manages) — see
 # migrations/007_tenant_ingested_files.sql for the table definition.

--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -595,12 +595,32 @@ async def ingest_photo(
     # Push to Open WebUI KB (best-effort)
     await _push_to_kb(asset_tag, description)
 
+    # Phase 0 demo loop (closes investigation §3.1 #1): write an
+    # ai_suggestions row so the Hub /proposals page can surface the photo.
+    # Best-effort — returns None on any failure; SQLite remains source of
+    # truth for the local photo blob.
+    suggestion_id: str | None = None
+    if MIRA_TENANT_ID:
+        try:
+            from db.neon import insert_photo_ai_suggestion
+
+            suggestion_id = insert_photo_ai_suggestion(
+                MIRA_TENANT_ID,
+                asset_tag,
+                structured,
+                description,
+                photo_path,
+            )
+        except Exception as e:
+            logger.warning("insert_photo_ai_suggestion error (non-fatal): %s", e)
+
     return {
         "id": photo_id,
         "asset_tag": asset_tag,
         "description": description,
         "structured_description": structured,
         "photo_path": photo_path,
+        "ai_suggestion_id": suggestion_id,
     }
 
 

--- a/mira-hub/db/migrations/025_tag_entities.sql
+++ b/mira-hub/db/migrations/025_tag_entities.sql
@@ -1,0 +1,129 @@
+BEGIN;
+
+-- Migration 025: `tag_entities` — promote PLC / Sparkplug / OPC UA tags from
+-- `kg_entities.properties` JSONB into a first-class typed table.
+--
+-- Spec : docs/specs/mira-ground-truth-architecture-investigation.md §5.3
+-- ADR  : 0013 (Hub owns product-surface schema), 0014 (sibling work queue)
+--
+-- Why a dedicated table:
+--
+--   1. "Where is sensor X in the PLC?" must be answerable from structure,
+--      not RAG. Today the answer lives in free-text properties on
+--      `kg_entities` of `entity_type='tag'`.
+--   2. Tags carry typed fields (data_type, units, scaling envelope, source
+--      address) that don't survive a JSONB free-for-all. Renames silently
+--      break joins.
+--   3. The live nervous system (mira-relay, Ignition feed, Sparkplug B
+--      MQTT) wants to look up `(tenant, sparkplug_topic)` and `(tenant,
+--      source_address)` in a single index hit. JSONB GIN is too coarse.
+--   4. Each tag points back at the component it belongs to so the engine
+--      can answer "this current spike came from VFD G1's output" without
+--      a relationship-traversal.
+--
+-- Source-of-truth note: writers MUST go through `ai_suggestions`
+-- (migration 027) for LLM-derived rows. Direct INSERT is reserved for
+-- structured imports (Ignition CSV, Rockwell L5X, GSDML, IODD) where
+-- provenance is unambiguous.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS + ADD COLUMN IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS tag_entities (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+
+    -- Authoritative address in the Unified Namespace tree. ltree column
+    -- mirroring `kg_entities.uns_path` (migration 010). One tag per path
+    -- per tenant.
+    uns_path LTREE NOT NULL,
+
+    -- Live-data identifiers — at least one of these must be non-null for
+    -- a tag to be reachable by the relay / MCP query surface. Enforced at
+    -- the writer, not as a DB CHECK, because some imports (e.g. a GSDML
+    -- module-slot map) define the symbolic + source_address pair before
+    -- the customer's Ignition project gives them a Sparkplug topic.
+    sparkplug_topic TEXT,                       -- 'spBv1.0/orlando/DDATA/edge1/conveyor_b16/motor_current'
+    opcua_node_id   TEXT,                       -- 'ns=2;s=Conveyor.Motor.Current' or numeric form
+    symbolic_name   TEXT NOT NULL,              -- 'motor_current' — what the program/manual calls it
+
+    -- IEC 61131 type system. App layer maps these to provider-specific
+    -- types (Modbus REAL → IEEE-754 little-endian, etc.) on read.
+    data_type TEXT NOT NULL
+        CHECK (data_type IN ('BOOL', 'INT16', 'INT32', 'INT64',
+                             'UINT16', 'UINT32', 'UINT64',
+                             'REAL', 'LREAL', 'STRING', 'BYTES')),
+
+    units   TEXT,                               -- 'rpm', 'A', 'V', '°C', 'psi', '0.1Hz', dimensionless = NULL
+    scaling JSONB,                              -- {raw_min, raw_max, eng_min, eng_max, offset}
+
+    -- How the value gets out of the device. The address format is the
+    -- writer's responsibility — '%IX0.5' for IEC 61131, 'HR:101' for
+    -- Modbus holding register, 'ns=2;s=...' for OPC UA, etc.
+    source_kind TEXT NOT NULL
+        CHECK (source_kind IN ('plc_address', 'modbus_register',
+                               'sparkplug_metric', 'opcua_variable',
+                               'mqtt_topic', 'manual_entry')),
+    source_address TEXT NOT NULL,
+
+    -- Soft FK; the deployment-side table is also tenant-scoped, so RLS
+    -- already gates cross-rows. ON DELETE SET NULL preserves the tag row
+    -- if the component instance is replaced (lifecycle column in 017).
+    component_instance_id UUID
+        REFERENCES installed_component_instances(id) ON DELETE SET NULL,
+
+    -- Diagnostic envelope: the engine uses this to evaluate live values
+    -- against expectation. Shape:
+    --   { "min": 0, "max": 100, "normal_range": [10, 60],
+    --     "fault_states": [{ "code": "F0007", "trigger": ">95" }] }
+    expected_envelope JSONB,
+
+    -- Same approval lifecycle as kg_relationships (docs/migrations/008).
+    -- LLM-extracted tags land 'proposed'; structured imports may land
+    -- 'verified' if the source is admin-signed.
+    approval_state TEXT NOT NULL DEFAULT 'proposed'
+        CHECK (approval_state IN ('proposed', 'verified', 'rejected', 'needs_review')),
+    proposed_by      TEXT,                      -- 'llm:groq', 'human:user_xxx', 'rule:ignition_csv', 'import:l5x'
+    evidence_summary JSONB,                     -- short snapshot — full chain on ai_suggestions (mig 027)
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (tenant_id, uns_path)
+);
+
+-- Path traversal: GIST on the ltree column for "all tags under <line>".
+CREATE INDEX IF NOT EXISTS idx_tag_entities_uns_path_gist
+    ON tag_entities USING GIST (uns_path);
+
+-- Reverse lookups the relay and the engine hit on every live event.
+CREATE INDEX IF NOT EXISTS idx_tag_entities_source_address
+    ON tag_entities (tenant_id, source_address);
+CREATE INDEX IF NOT EXISTS idx_tag_entities_sparkplug_topic
+    ON tag_entities (tenant_id, sparkplug_topic)
+    WHERE sparkplug_topic IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_tag_entities_component
+    ON tag_entities (tenant_id, component_instance_id)
+    WHERE component_instance_id IS NOT NULL;
+
+-- Proposal-feed partial index — Hub `/proposals?type=tag_mapping` reads here.
+CREATE INDEX IF NOT EXISTS idx_tag_entities_pending
+    ON tag_entities (tenant_id, created_at DESC)
+    WHERE approval_state = 'proposed';
+
+ALTER TABLE tag_entities ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tag_entities_tenant ON tag_entities;
+CREATE POLICY tag_entities_tenant
+    ON tag_entities
+    USING (tenant_id = current_setting('app.tenant_id', true)::UUID
+           OR tenant_id = current_setting('app.current_tenant_id', true)::UUID);
+
+GRANT SELECT, INSERT, UPDATE ON tag_entities TO factorylm_app;
+
+COMMIT;
+
+-- ─── Rollback ─────────────────────────────────────────────────────────
+-- BEGIN;
+-- DROP POLICY IF EXISTS tag_entities_tenant ON tag_entities;
+-- DROP TABLE IF EXISTS tag_entities;
+-- COMMIT;

--- a/mira-hub/db/migrations/026_wiring_connections.sql
+++ b/mira-hub/db/migrations/026_wiring_connections.sql
@@ -1,0 +1,123 @@
+BEGIN;
+
+-- Migration 026: `wiring_connections` — promote wire-level connectivity from
+-- `kg_relationships.properties` JSONB to a first-class typed table.
+--
+-- Spec : docs/specs/mira-ground-truth-architecture-investigation.md §5.3
+-- ADR  : 0013 (Hub owns product-surface schema)
+--
+-- Why a dedicated table:
+--
+--   1. "Where is PE-001 wired?" must be answerable from structure. Today
+--      the answer lives in `kg_relationships.properties` JSONB on edges of
+--      type 'WIRED_TO', which means traversing every WIRED_TO edge from a
+--      panel and grepping JSONB to find a terminal. That's not what an
+--      RLS-aware index can do.
+--   2. Wiring carries typed fields (source/dest terminal, wire number,
+--      gauge, color, function class) that the EPLAN / AutomationML
+--      industrial-data-exchange model gives us for free. Free-text
+--      JSONB loses the structure.
+--   3. Drawing-reference traceability (every connection cites the sheet
+--      and line on the print) is a compliance asset. Today there's no
+--      first-class place for it.
+--   4. `kg_relationships` keeps the WIRED_TO summary edge for graph
+--      traversal — engine reasoning treats it as a coarse "these two
+--      devices are connected" signal. The wire-level metadata lives here.
+--
+-- Source-of-truth note: writers MUST go through `ai_suggestions`
+-- (migration 027) for LLM-derived rows. Direct INSERT is reserved for
+-- structured imports (EPLAN AML, customer-confirmed schematic upload).
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS wiring_connections (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+
+    -- Endpoints. Both are kg_entities of `entity_type IN ('component_instance',
+    -- 'terminal', 'panel', 'asset')`. Soft FKs because kg_entities is the
+    -- dual-lineage table (ADR-0013 §3.2 #7); the hard FK would force a
+    -- decision on which lineage's row is authoritative for a given id. The
+    -- writers go through ai_suggestions, so soft FK is enough.
+    source_entity_id UUID NOT NULL,
+    source_terminal  TEXT NOT NULL,             -- 'X1:3', 'TB2-14', 'COIL:6', '24V+'
+
+    dest_entity_id   UUID NOT NULL,
+    dest_terminal    TEXT NOT NULL,
+
+    -- Drawing-side identifiers. wire_number is what the print stamps on
+    -- the conductor ('W-1147', '101A', 'L1'). cable_id groups conductors
+    -- that share a jacket (used on multi-conductor cable like 8-pin DSUB
+    -- or M12 connectors).
+    wire_number TEXT,
+    cable_id    TEXT,
+
+    -- Physical attributes — relevant for current carrying capacity and
+    -- safety calls. Optional; many wires on a control print don't have
+    -- gauge called out.
+    gauge_awg INTEGER,
+    color     TEXT,                             -- 'BLK', 'RED', 'BU/YE', vendor-specific
+
+    -- Semantic class — drives RAG retrieval and safety flagging. Power
+    -- and safety connections get higher-confidence audit treatment.
+    function_class TEXT
+        CHECK (function_class IS NULL OR function_class IN (
+            'power', 'signal', 'safety', 'comm', 'ground', 'unknown'
+        )),
+
+    -- Provenance back to the print. Format is opaque text — readers can
+    -- be 'ENG-PL-4472, Sheet 12, Line 24' or 'doc:0a1f...page:8' for a
+    -- KB document chunk.
+    drawing_reference TEXT,
+
+    -- Approval lifecycle. LLM-extracted connections (photo of a schematic,
+    -- OCR of a print, technician verbal description) land 'proposed'.
+    -- An EPLAN AML import from an admin-signed source may land 'verified'.
+    approval_state TEXT NOT NULL DEFAULT 'proposed'
+        CHECK (approval_state IN ('proposed', 'verified', 'rejected', 'needs_review')),
+    proposed_by      TEXT,                      -- 'llm:groq', 'human:user_xxx', 'import:eplan', 'rule:bom'
+    evidence_summary JSONB,                     -- short snapshot; full chain on ai_suggestions
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Reverse-lookups: the two questions this table exists to answer fast.
+CREATE INDEX IF NOT EXISTS idx_wiring_connections_source
+    ON wiring_connections (tenant_id, source_entity_id);
+CREATE INDEX IF NOT EXISTS idx_wiring_connections_dest
+    ON wiring_connections (tenant_id, dest_entity_id);
+
+-- "Find the conductor by its stamped number on the print."
+CREATE INDEX IF NOT EXISTS idx_wiring_connections_wire_number
+    ON wiring_connections (tenant_id, wire_number)
+    WHERE wire_number IS NOT NULL;
+
+-- "All connections in this multi-conductor cable."
+CREATE INDEX IF NOT EXISTS idx_wiring_connections_cable
+    ON wiring_connections (tenant_id, cable_id)
+    WHERE cable_id IS NOT NULL;
+
+-- Proposal-feed partial index — Hub `/proposals?type=kg_edge` will join here
+-- when the underlying suggestion has function_class='safety'/'power'.
+CREATE INDEX IF NOT EXISTS idx_wiring_connections_pending
+    ON wiring_connections (tenant_id, created_at DESC)
+    WHERE approval_state = 'proposed';
+
+ALTER TABLE wiring_connections ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS wiring_connections_tenant ON wiring_connections;
+CREATE POLICY wiring_connections_tenant
+    ON wiring_connections
+    USING (tenant_id = current_setting('app.tenant_id', true)::UUID
+           OR tenant_id = current_setting('app.current_tenant_id', true)::UUID);
+
+GRANT SELECT, INSERT, UPDATE ON wiring_connections TO factorylm_app;
+
+COMMIT;
+
+-- ─── Rollback ─────────────────────────────────────────────────────────
+-- BEGIN;
+-- DROP POLICY IF EXISTS wiring_connections_tenant ON wiring_connections;
+-- DROP TABLE IF EXISTS wiring_connections;
+-- COMMIT;

--- a/mira-hub/db/migrations/027_ai_suggestions.sql
+++ b/mira-hub/db/migrations/027_ai_suggestions.sql
@@ -1,0 +1,151 @@
+BEGIN;
+
+-- Migration 027: `ai_suggestions` — broad Hub-facing work queue.
+--
+-- Spec : docs/specs/maintenance-namespace-builder-spec.md §"Data Model"
+-- Spec : docs/specs/mira-ground-truth-architecture-investigation.md §3.1 #2, §5.3
+-- ADR  : docs/adr/0014-ai-suggestions-as-broad-work-queue.md
+--        (supersedes ADR-0013 §Decision item 1 — see ADR-0014 for the
+--         rationale. tl;dr: relationship_proposals is edge-only; the Hub
+--         /proposals page must also render kg_entity / tag_mapping /
+--         component_profile / uns_confirmation / namespace_move suggestions,
+--         none of which fit the edge schema.)
+--
+-- Role:
+--   - One row per Hub-facing pending decision, regardless of shape.
+--   - For `suggestion_type='kg_edge'`, the row is a header on top of a
+--     `relationship_proposals` row (FK in payload). The detailed edge +
+--     evidence chain still lives in mig 018; this row is what the Hub
+--     `/proposals` list query reads.
+--   - For all other suggestion types, this is the canonical store.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS ai_suggestions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+
+    -- The six product-spec shapes. Tightened to a CHECK so a typo in a
+    -- writer surfaces at INSERT time, not at Hub render time.
+    suggestion_type TEXT NOT NULL
+        CHECK (suggestion_type IN (
+            'kg_edge',           -- header on a relationship_proposals row
+            'kg_entity',         -- new entity (component instance, tag, location, asset)
+            'tag_mapping',       -- a tag_entities row proposed by ingestion
+            'component_profile', -- a component_templates row proposed by extraction
+            'uns_confirmation',  -- the UNS Gate's "is this the right asset?" prompt
+            'namespace_move'     -- a drag-drop / rename operation on the namespace tree
+        )),
+
+    -- Provenance — where the suggestion came from. Soft polymorphic FK;
+    -- source_kind tells the reader which table source_id refers to.
+    source_kind TEXT
+        CHECK (source_kind IS NULL OR source_kind IN (
+            'knowledge_entry',   -- a chunk from a PDF / manual
+            'work_order',
+            'tag_entity',
+            'photo',             -- a row in equipment_photos / S3 blob
+            'session',           -- a troubleshooting_sessions turn
+            'manifest_row',      -- a row from research/variable-manifest.json
+            'technician_note',
+            'live_event',        -- a row in live_signal_events
+            'manual_entry'       -- a human typed it in the Hub UI
+        )),
+    source_document_id UUID,                    -- knowledge_entries.id when source_kind='knowledge_entry'
+    source_page INTEGER,                        -- 1-indexed page number; NULL for non-doc sources
+    source_id UUID,                             -- polymorphic per source_kind; NULL when source_kind='manual_entry'
+
+    -- The actual proposed change. Shape depends on suggestion_type:
+    --
+    --   kg_edge:           { "relationship_proposal_id": <uuid>,
+    --                        "relationship_type": "WIRED_TO", ... }
+    --   kg_entity:         { "entity_type": "component_instance",
+    --                        "uns_path": "...", "properties": {...},
+    --                        "template_id": <uuid|null> }
+    --   tag_mapping:       { "tag_entity_id": <uuid>, ... }
+    --   component_profile: { "manufacturer": "...", "model": "...",
+    --                        "version": "...", ... }
+    --   uns_confirmation:  { "candidate_paths": [...], "session_id": <uuid> }
+    --   namespace_move:    { "from_path": "...", "to_path": "...",
+    --                        "operation": "move"|"rename"|"merge"|"split" }
+    --
+    -- Schema-on-read; the reader is the Hub UI which already discriminates
+    -- on suggestion_type.
+    extracted_data JSONB NOT NULL DEFAULT '{}'::JSONB,
+
+    -- 0.0 - 1.0. The writer is responsible for honest calibration; the
+    -- Hub UI uses bands (low <0.5, medium 0.5-0.8, high >0.8) for sort
+    -- and visual treatment.
+    confidence FLOAT NOT NULL DEFAULT 0.5
+        CHECK (confidence >= 0.0 AND confidence <= 1.0),
+
+    -- Lifecycle. `pending` is the inbox; `accepted` and `rejected` are
+    -- terminal. `deferred` is "ask me later" — the Hub UI surfaces these
+    -- in a separate tab. `superseded` is set automatically when a newer
+    -- suggestion contradicts this one (writer responsibility).
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'accepted', 'rejected', 'deferred', 'superseded')),
+
+    -- Risk tier — drives required-review gating in the Hub UI. Safety
+    -- proposals (anything touching E-stop, interlock, LOTO, ground-fault)
+    -- MUST be flagged 'safety_critical' by the writer.
+    risk_level TEXT NOT NULL DEFAULT 'low'
+        CHECK (risk_level IN ('low', 'medium', 'high', 'safety_critical')),
+
+    -- Who proposed it, who reviewed it. Free-text actor ids — same
+    -- vocabulary as `relationship_proposals.proposed_by`:
+    --   'llm:groq' | 'llm:cerebras' | 'llm:gemini'
+    --   'human:user_<uuid>'
+    --   'rule:<rule_name>' | 'import:<format>'
+    proposed_by TEXT NOT NULL DEFAULT 'llm:unknown',
+    reviewed_by TEXT,
+    reviewed_at TIMESTAMPTZ,
+    review_note TEXT,                           -- free-text rationale on accept/reject
+
+    -- Short human-readable headline + body. Computed by the writer at
+    -- INSERT time so the Hub feed renders fast (no per-row LLM call).
+    title TEXT,                                 -- 'Propose AutomationDirect GS10 at Line B / Conveyor 16'
+    body  TEXT,                                 -- one-paragraph context
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Hub `/proposals` list query — pending first, newest first, by type.
+-- Partial index keeps the hot path small even as the table accumulates.
+CREATE INDEX IF NOT EXISTS idx_ai_suggestions_pending
+    ON ai_suggestions (tenant_id, suggestion_type, created_at DESC)
+    WHERE status = 'pending';
+
+-- Risk-first triage view — surfaced in the Hub feed for safety_critical.
+CREATE INDEX IF NOT EXISTS idx_ai_suggestions_risk
+    ON ai_suggestions (tenant_id, risk_level, created_at DESC)
+    WHERE status = 'pending' AND risk_level IN ('high', 'safety_critical');
+
+-- "Show me all proposals from this document" — review by source.
+CREATE INDEX IF NOT EXISTS idx_ai_suggestions_source_doc
+    ON ai_suggestions (tenant_id, source_document_id)
+    WHERE source_document_id IS NOT NULL;
+
+-- Audit / history view — what did this reviewer decide?
+CREATE INDEX IF NOT EXISTS idx_ai_suggestions_reviewer
+    ON ai_suggestions (tenant_id, reviewed_by, reviewed_at DESC)
+    WHERE reviewed_by IS NOT NULL;
+
+ALTER TABLE ai_suggestions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS ai_suggestions_tenant ON ai_suggestions;
+CREATE POLICY ai_suggestions_tenant
+    ON ai_suggestions
+    USING (tenant_id = current_setting('app.tenant_id', true)::UUID
+           OR tenant_id = current_setting('app.current_tenant_id', true)::UUID);
+
+GRANT SELECT, INSERT, UPDATE ON ai_suggestions TO factorylm_app;
+
+COMMIT;
+
+-- ─── Rollback ─────────────────────────────────────────────────────────
+-- BEGIN;
+-- DROP POLICY IF EXISTS ai_suggestions_tenant ON ai_suggestions;
+-- DROP TABLE IF EXISTS ai_suggestions;
+-- COMMIT;

--- a/tests/integration/test_phase0_schema.py
+++ b/tests/integration/test_phase0_schema.py
@@ -1,0 +1,376 @@
+"""Integration tests for Phase 0 schema (migrations 025/026/027).
+
+End-to-end against a real NeonDB branch (typically staging, supplied via
+NEON_DATABASE_URL).  Skips entirely if the env var is unset so unit runs
+on dev workstations stay green.
+
+Coverage:
+  * tag_entities / wiring_connections / ai_suggestions
+      — INSERT → SELECT → DELETE round-trip
+      — column shape + lifecycle defaults
+  * RLS tenant isolation
+      — tenant A row is invisible to a session that set tenant B
+      — exercised as `factorylm_app`, not the owner, since owner bypasses RLS
+  * propose_from_nameplate()
+      — happy path: writes an ai_suggestions row + an installed_component_instance
+      — early-exit guards never touch the DB
+  * insert_photo_ai_suggestion()  (if module importable)
+
+Cleanup is best-effort in a `finally` block so a failing assertion still
+leaves the staging branch clean.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+psycopg2 = pytest.importorskip(
+    "psycopg2", reason="psycopg2-binary required for the Phase 0 integration tests"
+)
+
+NEON_URL = os.environ.get("NEON_DATABASE_URL", "")
+if not NEON_URL:
+    pytest.skip(
+        "NEON_DATABASE_URL not set — Phase 0 integration tests require a real Neon branch",
+        allow_module_level=True,
+    )
+
+# The staging Neon branch is forked from prod, so this tenant row already
+# exists.  Round-trip rows use this tenant; RLS-isolation rows use fresh
+# UUIDs to avoid colliding with prod data.
+STAGING_TENANT = os.environ.get(
+    "STAGING_TENANT_ID", "78917b56-f85f-43bb-9a08-1bb98a6cd6c3"
+)
+
+# Repo paths so we can import the worker + ingest helper without an install.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+for sub in ("mira-bots", "mira-core/mira-ingest"):
+    p = str(REPO_ROOT / sub)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def conn():
+    """Module-scoped raw psycopg2 connection. autocommit False — tests own txns."""
+    c = psycopg2.connect(NEON_URL)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def _with_tenant(cur, tenant_id: str, *, as_app_role: bool = False) -> None:
+    """Set the per-transaction tenant id (and optionally drop to factorylm_app).
+
+    `as_app_role=True` exercises RLS — the role neondb_owner bypasses it.
+    The caller is responsible for ROLLBACK/COMMIT to reset the role.
+    """
+    if as_app_role:
+        cur.execute("SET LOCAL ROLE factorylm_app")
+    cur.execute(
+        "SELECT set_config('app.current_tenant_id', %s, true)", (tenant_id,)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — tag_entities (migration 025)
+# ---------------------------------------------------------------------------
+
+
+def test_tag_entities_roundtrip(conn):
+    """INSERT a tag, read it back, verify defaults, then DELETE."""
+    tag_id = uuid.uuid4()
+    uns_path = f"enterprise.test.phase0.{tag_id.hex[:8]}.motor_current"
+    inserted = False
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                _with_tenant(cur, STAGING_TENANT)
+                cur.execute(
+                    """INSERT INTO tag_entities
+                          (id, tenant_id, uns_path, symbolic_name, data_type,
+                           source_kind, source_address)
+                       VALUES (%s, %s, %s::ltree, %s, %s, %s, %s)""",
+                    (
+                        str(tag_id), STAGING_TENANT, uns_path,
+                        "motor_current", "REAL", "modbus_register", "HR:101",
+                    ),
+                )
+                inserted = True
+
+                cur.execute(
+                    "SELECT approval_state, created_at, data_type "
+                    "FROM tag_entities WHERE id = %s",
+                    (str(tag_id),),
+                )
+                row = cur.fetchone()
+                assert row is not None, "tag row not visible after INSERT"
+                approval_state, created_at, data_type = row
+                assert approval_state == "proposed", \
+                    f"expected default approval_state=proposed, got {approval_state}"
+                assert data_type == "REAL"
+                assert created_at is not None
+    finally:
+        if inserted:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute("DELETE FROM tag_entities WHERE id = %s",
+                                (str(tag_id),))
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — wiring_connections (migration 026)
+# ---------------------------------------------------------------------------
+
+
+def test_wiring_connections_roundtrip(conn):
+    wid = uuid.uuid4()
+    src = uuid.uuid4()
+    dst = uuid.uuid4()
+    inserted = False
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                _with_tenant(cur, STAGING_TENANT)
+                cur.execute(
+                    """INSERT INTO wiring_connections
+                          (id, tenant_id, source_entity_id, source_terminal,
+                           dest_entity_id, dest_terminal,
+                           wire_number, function_class)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s)""",
+                    (
+                        str(wid), STAGING_TENANT, str(src), "X1:3",
+                        str(dst), "TB2-14", "W-1147", "signal",
+                    ),
+                )
+                inserted = True
+
+                cur.execute(
+                    "SELECT approval_state, wire_number, function_class "
+                    "FROM wiring_connections WHERE id = %s",
+                    (str(wid),),
+                )
+                row = cur.fetchone()
+                assert row is not None
+                assert row == ("proposed", "W-1147", "signal")
+    finally:
+        if inserted:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute("DELETE FROM wiring_connections WHERE id = %s",
+                                (str(wid),))
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — ai_suggestions (migration 027)
+# ---------------------------------------------------------------------------
+
+
+def test_ai_suggestions_roundtrip(conn):
+    sid = uuid.uuid4()
+    inserted = False
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                _with_tenant(cur, STAGING_TENANT)
+                cur.execute(
+                    """INSERT INTO ai_suggestions
+                          (id, tenant_id, suggestion_type,
+                           extracted_data, confidence, title, body)
+                       VALUES (%s, %s, %s, %s::jsonb, %s, %s, %s)""",
+                    (
+                        str(sid), STAGING_TENANT, "component_profile",
+                        '{"manufacturer": "TestCo", "model": "T1"}',
+                        0.42,
+                        "test phase0 round-trip",
+                        "body — verification test row",
+                    ),
+                )
+                inserted = True
+
+                cur.execute(
+                    "SELECT status, risk_level, proposed_by, confidence "
+                    "FROM ai_suggestions WHERE id = %s",
+                    (str(sid),),
+                )
+                row = cur.fetchone()
+                assert row is not None
+                status, risk, proposed_by, conf = row
+                assert status == "pending"
+                assert risk == "low"
+                assert proposed_by == "llm:unknown"
+                assert abs(conf - 0.42) < 1e-6
+    finally:
+        if inserted:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute("DELETE FROM ai_suggestions WHERE id = %s",
+                                (str(sid),))
+
+
+# ---------------------------------------------------------------------------
+# RLS — tenant isolation
+# ---------------------------------------------------------------------------
+
+
+def test_rls_tenant_isolation_ai_suggestions(conn):
+    """Insert as tenant A, query as tenant B → expect 0 rows.
+
+    Run under SET LOCAL ROLE factorylm_app — neondb_owner has BYPASSRLS.
+    """
+    tenant_a = str(uuid.uuid4())
+    tenant_b = str(uuid.uuid4())
+    sid = str(uuid.uuid4())
+    inserted = False
+
+    # Insert as tenant A under factorylm_app.
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                _with_tenant(cur, tenant_a, as_app_role=True)
+                cur.execute(
+                    """INSERT INTO ai_suggestions
+                          (id, tenant_id, suggestion_type, extracted_data,
+                           confidence, title, body)
+                       VALUES (%s, %s, %s, %s::jsonb, %s, %s, %s)""",
+                    (
+                        sid, tenant_a, "uns_confirmation",
+                        '{"candidate_paths": []}', 0.50,
+                        "rls test row",
+                        "tenant A row, should be invisible to tenant B",
+                    ),
+                )
+                inserted = True
+
+        # New transaction: act as tenant B.
+        with conn:
+            with conn.cursor() as cur:
+                _with_tenant(cur, tenant_b, as_app_role=True)
+                cur.execute(
+                    "SELECT COUNT(*) FROM ai_suggestions WHERE id = %s",
+                    (sid,),
+                )
+                count_b = cur.fetchone()[0]
+                assert count_b == 0, (
+                    f"RLS leak: tenant B saw tenant A's row "
+                    f"({count_b} rows visible)"
+                )
+
+        # Sanity: tenant A still sees it.
+        with conn:
+            with conn.cursor() as cur:
+                _with_tenant(cur, tenant_a, as_app_role=True)
+                cur.execute(
+                    "SELECT COUNT(*) FROM ai_suggestions WHERE id = %s",
+                    (sid,),
+                )
+                count_a = cur.fetchone()[0]
+                assert count_a == 1, "tenant A should see its own row"
+
+    finally:
+        if inserted:
+            # neondb_owner bypasses RLS, so cleanup always succeeds.
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        "DELETE FROM ai_suggestions WHERE id = %s", (sid,)
+                    )
+
+
+# ---------------------------------------------------------------------------
+# Worker — propose_from_nameplate (end-to-end demo loop)
+# ---------------------------------------------------------------------------
+
+
+def test_propose_from_nameplate_writes_suggestion(conn):
+    """Happy path: nameplate fields → ai_suggestions row.
+
+    Lands as suggestion_type='component_profile' when no matching template
+    exists.  Cleanup is done in a fresh transaction.
+    """
+    from shared.workers.photo_ingest_worker import propose_from_nameplate
+
+    # Use a one-shot model string nobody else has, so no template ever matches.
+    unique_model = f"PHASE0VERIFY-{uuid.uuid4().hex[:8]}"
+    fields = {
+        "manufacturer": "PhaseZeroTest",
+        "model": unique_model,
+        "serial": "SN-001",
+        "voltage": "230V",
+        "fla": "5A",
+        "hp": "1",
+        "frequency": "60Hz",
+        "rpm": "1750",
+    }
+
+    suggestion_id: str | None = None
+    instance_id: str | None = None
+    try:
+        result = propose_from_nameplate(
+            tenant_id=STAGING_TENANT,
+            fields=fields,
+            uns_path=None,
+            asset_id=None,
+            photo_path=f"verify://phase0/{unique_model}.jpg",
+            chat_id="phase0-verify",
+        )
+        assert result, "worker returned empty dict — refused to write"
+        suggestion_id = result["suggestion_id"]
+        instance_id = result.get("instance_id")
+        assert result["suggestion_type"] in ("component_profile", "kg_entity")
+        assert result["confidence"] >= 0.30
+
+        # Re-read the row from a fresh transaction.
+        with conn:
+            with conn.cursor() as cur:
+                _with_tenant(cur, STAGING_TENANT)
+                cur.execute(
+                    "SELECT suggestion_type, status, proposed_by, "
+                    "       extracted_data->>'model', confidence "
+                    "FROM ai_suggestions WHERE id = %s",
+                    (suggestion_id,),
+                )
+                row = cur.fetchone()
+                assert row is not None, "worker claimed to write but row absent"
+                stype, status, proposed_by, model_field, conf = row
+                assert stype == result["suggestion_type"]
+                assert status == "pending"
+                assert proposed_by == "photo:phase0-verify"
+                assert model_field == unique_model
+                assert abs(conf - result["confidence"]) < 1e-6
+
+    finally:
+        with conn:
+            with conn.cursor() as cur:
+                if suggestion_id:
+                    cur.execute(
+                        "DELETE FROM ai_suggestions WHERE id = %s",
+                        (suggestion_id,),
+                    )
+                if instance_id:
+                    cur.execute(
+                        "DELETE FROM installed_component_instances WHERE id = %s",
+                        (instance_id,),
+                    )
+
+
+def test_propose_from_nameplate_empty_tenant_no_write():
+    """Early exit: empty tenant → no NeonDB call at all."""
+    from shared.workers.photo_ingest_worker import propose_from_nameplate
+
+    out = propose_from_nameplate(
+        tenant_id="",
+        fields={"manufacturer": "X", "model": "Y"},
+    )
+    assert out == {}, f"expected empty result, got {out!r}"

--- a/tests/integration/test_phase0_schema.py
+++ b/tests/integration/test_phase0_schema.py
@@ -365,6 +365,102 @@ def test_propose_from_nameplate_writes_suggestion(conn):
                     )
 
 
+def test_propose_from_nameplate_template_match_writes_instance(conn):
+    """Template-match branch: nameplate matches an existing component_templates
+    row → worker writes BOTH an installed_component_instances row AND an
+    ai_suggestions row (suggestion_type='kg_entity').
+
+    This exercises the code path that the prior test deliberately avoids
+    (it uses a unique model so no template matches). Without this, a typo
+    on the installed_component_instances INSERT would never trip in CI.
+    """
+    from shared.workers.photo_ingest_worker import propose_from_nameplate
+
+    template_id = str(uuid.uuid4())
+    template_mfr = "PhaseZeroVendor"
+    template_model = f"TPL-{uuid.uuid4().hex[:8]}"
+
+    suggestion_id: str | None = None
+    instance_id: str | None = None
+
+    try:
+        # Seed a component_templates row so the worker's _find_template
+        # branch returns a match. component_templates is global (no
+        # tenant_id) — _find_template selects by (manufacturer, model)
+        # case-insensitive. Most NOT NULL JSONB fields have '{}' / '[]'
+        # defaults; component_category + component_type do not.
+        with conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO component_templates
+                          (id, manufacturer, model,
+                           component_category, component_type)
+                       VALUES (%s, %s, %s, %s, %s)""",
+                    (
+                        template_id,
+                        template_mfr, template_model,
+                        "drive", "vfd",
+                    ),
+                )
+
+        result = propose_from_nameplate(
+            tenant_id=STAGING_TENANT,
+            fields={
+                "manufacturer": template_mfr,
+                "model": template_model,
+                "serial": "TPL-SN-1",
+                "voltage": "480V",
+                "fla": "3.5A",
+                "hp": "2",
+                "frequency": "60Hz",
+                "rpm": "1750",
+            },
+            chat_id="phase0-tplmatch",
+        )
+        assert result, "worker refused to write for template-match nameplate"
+        suggestion_id = result["suggestion_id"]
+        instance_id = result.get("instance_id")
+        assert result["suggestion_type"] == "kg_entity", (
+            f"expected kg_entity (template matched), got {result['suggestion_type']}"
+        )
+        assert instance_id, "kg_entity branch must produce an installed_component_instance"
+
+        # Confirm the installed_component_instances row exists with the
+        # template binding the worker claims it wrote.
+        with conn:
+            with conn.cursor() as cur:
+                _with_tenant(cur, STAGING_TENANT)
+                cur.execute(
+                    "SELECT template_id, human_confirmed, component_name "
+                    "FROM installed_component_instances WHERE id = %s",
+                    (instance_id,),
+                )
+                row = cur.fetchone()
+                assert row is not None, "instance row missing"
+                tid, confirmed, cname = row
+                assert str(tid) == template_id
+                assert confirmed is False, \
+                    "proposed-from-photo instance must not be auto-confirmed"
+                assert template_model in cname
+    finally:
+        with conn:
+            with conn.cursor() as cur:
+                if suggestion_id:
+                    cur.execute(
+                        "DELETE FROM ai_suggestions WHERE id = %s",
+                        (suggestion_id,),
+                    )
+                if instance_id:
+                    cur.execute(
+                        "DELETE FROM installed_component_instances WHERE id = %s",
+                        (instance_id,),
+                    )
+                cur.execute(
+                    "DELETE FROM component_templates WHERE id = %s",
+                    (template_id,),
+                )
+
+
 def test_propose_from_nameplate_empty_tenant_no_write():
     """Early exit: empty tenant → no NeonDB call at all."""
     from shared.workers.photo_ingest_worker import propose_from_nameplate

--- a/tests/test_photo_ingest_worker.py
+++ b/tests/test_photo_ingest_worker.py
@@ -1,0 +1,105 @@
+"""Offline tests for `mira-bots/shared/workers/photo_ingest_worker.py`.
+
+These cover the pure-Python guard rails: confidence scoring + the four
+early-exit paths (no tenant, parse error, missing manufacturer, missing
+model). The NeonDB write path is exercised by the Staging Gate workflow
+against the staging Neon branch.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make mira-bots importable from the repo root.
+REPO_ROOT = Path(__file__).parent.parent
+MIRA_BOTS = REPO_ROOT / "mira-bots"
+if str(MIRA_BOTS) not in sys.path:
+    sys.path.insert(0, str(MIRA_BOTS))
+
+# psycopg2 is a transitive import; on dev workstations without it installed
+# we can still import the module and call the pure functions, because the
+# import lives at module top-level and never runs against a real connection
+# in these tests. If psycopg2 isn't available, skip the file — CI installs
+# the bot requirements (which include psycopg2-binary) and runs everything.
+pytest.importorskip("psycopg2", reason="psycopg2-binary required for this module's import")
+
+from shared.workers.photo_ingest_worker import (  # noqa: E402
+    _MIN_PROPOSAL_CONFIDENCE,
+    _score,
+    propose_from_nameplate,
+)
+
+# ── _score ────────────────────────────────────────────────────────────────
+
+
+class TestScore:
+    def test_empty_fields_scores_zero(self):
+        assert _score({}) == 0.0
+
+    def test_all_eight_fields_populated_caps_at_ceiling(self):
+        full = {
+            "manufacturer": "AutomationDirect",
+            "model": "GS10",
+            "serial": "AD24-1",
+            "voltage": "230V",
+            "fla": "5A",
+            "hp": "1",
+            "frequency": "60Hz",
+            "rpm": "1750",
+        }
+        # 8/8 populated = 1.0, capped at 0.95.
+        assert _score(full) == 0.95
+
+    def test_unknown_sentinel_penalises(self):
+        # Same 2/8 coverage as `partial` below; "Unknown" should drop it lower.
+        partial = {"manufacturer": "AB", "model": "PF525"}
+        with_unknown = {"manufacturer": "Unknown", "model": "PF525"}
+        assert _score(with_unknown) < _score(partial)
+
+    def test_score_never_exceeds_one(self):
+        many = {k: "x" for k in (
+            "manufacturer", "model", "serial", "voltage",
+            "fla", "hp", "frequency", "rpm",
+        )}
+        assert _score(many) <= 1.0
+
+
+# ── propose_from_nameplate early exits ────────────────────────────────────
+
+
+class TestEarlyExits:
+    """All four early-exit paths return {} without touching NeonDB."""
+
+    def test_no_tenant_id_returns_empty(self):
+        assert propose_from_nameplate("", {"manufacturer": "AB", "model": "PF525"}) == {}
+
+    def test_parse_error_returns_empty(self):
+        assert propose_from_nameplate(
+            "78917b56-f85f-43bb-9a08-1bb98a6cd6c3",
+            {"parse_error": "unparseable response"},
+        ) == {}
+
+    def test_missing_manufacturer_returns_empty(self):
+        assert propose_from_nameplate(
+            "78917b56-f85f-43bb-9a08-1bb98a6cd6c3",
+            {"manufacturer": "", "model": "PF525"},
+        ) == {}
+
+    def test_missing_model_returns_empty(self):
+        assert propose_from_nameplate(
+            "78917b56-f85f-43bb-9a08-1bb98a6cd6c3",
+            {"manufacturer": "AB", "model": ""},
+        ) == {}
+
+
+# ── _MIN_PROPOSAL_CONFIDENCE sanity ───────────────────────────────────────
+
+
+def test_min_confidence_is_in_band():
+    # If this drifts above 0.5 the Hub UI sort by-confidence stops working;
+    # if it drifts to 0 we flood /proposals with noise. Floor must stay
+    # below the "medium" cutoff and above the noise floor.
+    assert 0.1 < _MIN_PROPOSAL_CONFIDENCE < 0.5

--- a/tools/verify_phase0_deploy.py
+++ b/tools/verify_phase0_deploy.py
@@ -1,0 +1,296 @@
+"""Post-deploy schema verification for Phase 0 (migrations 025/026/027).
+
+Checks that the three Phase 0 tables, their indexes, RLS policies, CHECK
+constraints, and factorylm_app grants exist as declared in
+`mira-hub/db/migrations/02{5,6,7}_*.sql`. Connects via NEON_DATABASE_URL
+(typically supplied by Doppler: `factorylm/dev`, `/stg`, or `/prd`).
+
+Usage
+-----
+    NEON_DATABASE_URL=... python tools/verify_phase0_deploy.py
+    doppler run --project factorylm --config stg -- python tools/verify_phase0_deploy.py
+
+Exit codes
+----------
+    0 — every check passed
+    1 — one or more checks failed (see the table on stdout)
+    2 — could not connect to the database / NEON_DATABASE_URL unset
+
+Output is a single PASS/FAIL banner plus a checklist table. Designed to
+be run as a step in a GitHub Actions workflow with `set -e` so the job
+fails on any drift.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass
+
+import psycopg2
+
+
+# Expected schema. Mirrors `mira-hub/db/migrations/025-027*.sql`.
+#
+# Keeping this hand-written rather than introspected lets the script catch
+# accidental schema drift (column removed, RLS policy dropped, grant
+# stripped) — exactly what a re-apply against a half-migrated branch could
+# silently cause if the source SQL was edited without bumping the migration.
+
+EXPECTED_TABLES = ("tag_entities", "wiring_connections", "ai_suggestions")
+
+EXPECTED_COLUMNS: dict[str, set[str]] = {
+    "tag_entities": {
+        "id", "tenant_id", "uns_path", "sparkplug_topic", "opcua_node_id",
+        "symbolic_name", "data_type", "units", "scaling", "source_kind",
+        "source_address", "component_instance_id", "expected_envelope",
+        "approval_state", "proposed_by", "evidence_summary",
+        "created_at", "updated_at",
+    },
+    "wiring_connections": {
+        "id", "tenant_id", "source_entity_id", "source_terminal",
+        "dest_entity_id", "dest_terminal", "wire_number", "cable_id",
+        "gauge_awg", "color", "function_class", "drawing_reference",
+        "approval_state", "proposed_by", "evidence_summary",
+        "created_at", "updated_at",
+    },
+    "ai_suggestions": {
+        "id", "tenant_id", "suggestion_type", "source_kind",
+        "source_document_id", "source_page", "source_id",
+        "extracted_data", "confidence", "status", "risk_level",
+        "proposed_by", "reviewed_by", "reviewed_at", "review_note",
+        "title", "body", "created_at", "updated_at",
+    },
+}
+
+EXPECTED_INDEXES = (
+    # tag_entities (025)
+    "idx_tag_entities_uns_path_gist",
+    "idx_tag_entities_source_address",
+    "idx_tag_entities_sparkplug_topic",
+    "idx_tag_entities_component",
+    "idx_tag_entities_pending",
+    # wiring_connections (026)
+    "idx_wiring_connections_source",
+    "idx_wiring_connections_dest",
+    "idx_wiring_connections_wire_number",
+    "idx_wiring_connections_cable",
+    "idx_wiring_connections_pending",
+    # ai_suggestions (027)
+    "idx_ai_suggestions_pending",
+    "idx_ai_suggestions_risk",
+    "idx_ai_suggestions_source_doc",
+    "idx_ai_suggestions_reviewer",
+)
+
+EXPECTED_POLICIES = {
+    "tag_entities": "tag_entities_tenant",
+    "wiring_connections": "wiring_connections_tenant",
+    "ai_suggestions": "ai_suggestions_tenant",
+}
+
+EXPECTED_GRANTS = {
+    "tag_entities": {"SELECT", "INSERT", "UPDATE"},
+    "wiring_connections": {"SELECT", "INSERT", "UPDATE"},
+    "ai_suggestions": {"SELECT", "INSERT", "UPDATE"},
+}
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+def _check_tables(cur) -> list[CheckResult]:
+    out: list[CheckResult] = []
+    for tbl in EXPECTED_TABLES:
+        cur.execute("SELECT to_regclass(%s)", (f"public.{tbl}",))
+        exists = cur.fetchone()[0] is not None
+        out.append(CheckResult(
+            f"table {tbl}",
+            exists,
+            "exists" if exists else "MISSING",
+        ))
+    return out
+
+
+def _check_columns(cur) -> list[CheckResult]:
+    out: list[CheckResult] = []
+    for tbl, expected in EXPECTED_COLUMNS.items():
+        cur.execute(
+            "SELECT column_name FROM information_schema.columns "
+            "WHERE table_schema='public' AND table_name=%s",
+            (tbl,),
+        )
+        present = {r[0] for r in cur.fetchall()}
+        missing = expected - present
+        out.append(CheckResult(
+            f"columns {tbl}",
+            not missing,
+            "all present" if not missing else f"MISSING: {sorted(missing)}",
+        ))
+    return out
+
+
+def _check_indexes(cur) -> list[CheckResult]:
+    out: list[CheckResult] = []
+    for idx in EXPECTED_INDEXES:
+        cur.execute("SELECT to_regclass(%s)", (f"public.{idx}",))
+        exists = cur.fetchone()[0] is not None
+        out.append(CheckResult(
+            f"index {idx}",
+            exists,
+            "exists" if exists else "MISSING",
+        ))
+    return out
+
+
+def _check_rls(cur) -> list[CheckResult]:
+    out: list[CheckResult] = []
+    for tbl in EXPECTED_TABLES:
+        # Look up by name rather than ::regclass cast — the cast raises if
+        # the table is absent, which would crash this script before it
+        # could report the failure cleanly.
+        cur.execute(
+            "SELECT c.relrowsecurity FROM pg_class c "
+            "JOIN pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE n.nspname = 'public' AND c.relname = %s",
+            (tbl,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            out.append(CheckResult(f"RLS enabled {tbl}", False, "TABLE MISSING"))
+            continue
+        enabled = bool(row[0])
+        out.append(CheckResult(
+            f"RLS enabled {tbl}",
+            enabled,
+            "enabled" if enabled else "DISABLED",
+        ))
+    for tbl, pol in EXPECTED_POLICIES.items():
+        cur.execute(
+            "SELECT 1 FROM pg_policies WHERE schemaname='public' "
+            "AND tablename=%s AND policyname=%s",
+            (tbl, pol),
+        )
+        exists = cur.fetchone() is not None
+        out.append(CheckResult(
+            f"policy {pol}",
+            exists,
+            "present" if exists else "MISSING",
+        ))
+    return out
+
+
+def _check_grants(cur) -> list[CheckResult]:
+    out: list[CheckResult] = []
+    for tbl, expected in EXPECTED_GRANTS.items():
+        cur.execute(
+            "SELECT privilege_type FROM information_schema.role_table_grants "
+            "WHERE grantee='factorylm_app' AND table_schema='public' "
+            "AND table_name=%s",
+            (tbl,),
+        )
+        granted = {r[0] for r in cur.fetchall()}
+        missing = expected - granted
+        out.append(CheckResult(
+            f"grants {tbl} factorylm_app",
+            not missing,
+            f"{sorted(expected)}" if not missing else f"MISSING: {sorted(missing)}",
+        ))
+    return out
+
+
+def _check_check_constraints(cur) -> list[CheckResult]:
+    """Spot-check the CHECK constraints that gate writer typos at INSERT time."""
+    out: list[CheckResult] = []
+    checks = [
+        ("tag_entities",      "data_type",       {"BOOL", "REAL", "INT16", "STRING"}),
+        ("tag_entities",      "source_kind",     {"plc_address", "modbus_register", "sparkplug_metric"}),
+        ("tag_entities",      "approval_state",  {"proposed", "verified", "rejected", "needs_review"}),
+        ("ai_suggestions",    "suggestion_type", {"kg_edge", "kg_entity", "tag_mapping",
+                                                  "component_profile", "uns_confirmation",
+                                                  "namespace_move"}),
+        ("ai_suggestions",    "status",          {"pending", "accepted", "rejected", "deferred",
+                                                  "superseded"}),
+        ("ai_suggestions",    "risk_level",      {"low", "medium", "high", "safety_critical"}),
+    ]
+    for tbl, col, must_include in checks:
+        cur.execute(
+            """SELECT pg_get_constraintdef(con.oid)
+                 FROM pg_constraint con
+                 JOIN pg_class cls ON cls.oid = con.conrelid
+                WHERE cls.relname = %s
+                  AND con.contype = 'c'
+                  AND pg_get_constraintdef(con.oid) ILIKE %s""",
+            (tbl, f"%{col}%"),
+        )
+        defs = [r[0] for r in cur.fetchall()]
+        joined = " | ".join(defs)
+        missing_values = [v for v in must_include if v not in joined]
+        out.append(CheckResult(
+            f"CHECK {tbl}.{col}",
+            not missing_values and bool(defs),
+            "ok" if not missing_values and defs else (
+                f"NO CHECK FOUND" if not defs else f"MISSING values: {missing_values}"
+            ),
+        ))
+    return out
+
+
+def _print_table(results: list[CheckResult]) -> None:
+    width_name = max(len(r.name) for r in results)
+    print(f"{'CHECK'.ljust(width_name)}  STATUS  DETAIL")
+    print(f"{'-' * width_name}  ------  ------")
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        print(f"{r.name.ljust(width_name)}  {status:<6}  {r.detail}")
+
+
+def main() -> int:
+    url = os.environ.get("NEON_DATABASE_URL", "")
+    if not url:
+        print("ERROR: NEON_DATABASE_URL not set", file=sys.stderr)
+        return 2
+
+    try:
+        conn = psycopg2.connect(url)
+    except Exception as e:
+        print(f"ERROR: connect failed: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        with conn:
+            with conn.cursor() as cur:
+                # Print which DB host we're against — useful for log triage.
+                cur.execute("SELECT current_database(), inet_server_addr()")
+                row = cur.fetchone() or ("?", None)
+                db, host = row[0], row[1]
+                print(f"Verifying Phase 0 schema against db={db} host={host or 'pooler'}")
+                print()
+
+                results: list[CheckResult] = []
+                results.extend(_check_tables(cur))
+                results.extend(_check_columns(cur))
+                results.extend(_check_indexes(cur))
+                results.extend(_check_rls(cur))
+                results.extend(_check_grants(cur))
+                results.extend(_check_check_constraints(cur))
+    finally:
+        conn.close()
+
+    _print_table(results)
+
+    failed = [r for r in results if not r.passed]
+    print()
+    if failed:
+        print(f"RESULT: FAIL  ({len(failed)}/{len(results)} checks failed)")
+        return 1
+    print(f"RESULT: PASS  ({len(results)} checks passed)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase 0 of the ground-truth architecture investigation ([PR #1417](https://github.com/Mikecranesync/MIRA/pull/1417), `docs/specs/mira-ground-truth-architecture-investigation.md`). Ships the three new Hub tables + closes the photo → KG demo loop.

- **3 new Hub migrations:** `025_tag_entities`, `026_wiring_connections`, `027_ai_suggestions`. All tenant-scoped UUID + RLS + GRANT to `factorylm_app`, matching Hub 018/021/023 convention. Idempotent (`CREATE TABLE IF NOT EXISTS`) with inline rollback comments.
- **ADR-0014 supersedes ADR-0013 §Decision item 1.** ADR-0013 (2026-05-16) rejected `ai_suggestions` on the assumption it duplicated `relationship_proposals`. The investigation showed `relationship_proposals` is **edge-only** — it cannot represent `kg_entity`, `tag_mapping`, `component_profile`, `uns_confirmation`, or `namespace_move` suggestions. ADR-0014 reinstates `ai_suggestions` as a thin work-queue header that points at `relationship_proposals.id` for `kg_edge` rows and is the canonical store for the other five. No duplicate workflow for edges.
- **Photo → KG demo loop** (`docs/specs/mira-ground-truth-architecture-investigation.md` §3.1 #1, §6.1):
  - New `mira-bots/shared/workers/photo_ingest_worker.py` — module-level `propose_from_nameplate()`. Template-match → propose an `installed_component_instances` row + `ai_suggestions` of type `kg_entity`. No template → propose a `component_profile` suggestion.
  - Wired into `Supervisor._handle_nameplate` between the mira-web seed and session-state-update steps via `asyncio.to_thread` (psycopg2 is sync). Best-effort — never breaks the technician's reply path.
  - `mira-core/mira-ingest/db/neon.py`: new `insert_photo_ai_suggestion()` using the existing SQLAlchemy engine (architecture wall forbids mira-ingest from importing mira-bots).
  - `/ingest/photo` returns `ai_suggestion_id` in the response.

## Deploy ordering (important)

Migrations 025/026/027 must be applied via `apply-migrations.yml` **before** `deploy-vps.yml` lands the code. The code is best-effort (psycopg2 errors swallowed → `{}` return) so a wrong-order deploy doesn't crash, but every photo path will log `UndefinedTable` warnings until the migrations land. Standard dev → staging → prod sequence per `docs/environments.md` §"Hard rules" #5.

## What I did NOT touch

- **`relationship_proposals`** stays as authored — it remains the edge-specific catalog with `relationship_evidence` chain. `ai_suggestions` is layered on top, not a replacement.
- **Dual `kg_entities` schema** (Hub UUID vs engine TEXT) — flagged as structural risk in investigation §3.2 #7 / #12; out of scope.
- **UNS resolver Stage-3 no-op-in-asyncio bug** (investigation §3.1 #6) — also out of scope.

## Verification

- **9 new offline tests** (`tests/test_photo_ingest_worker.py`) — score function + 4 early-exit paths. All passing.
- **16/18 pre-existing nameplate tests pass** on this branch. The 2 failures (`test_nameplate_flow_calls_mcp_and_web`, `test_nameplate_flow_graceful_on_mcp_failure`) **also fail on origin/main** at HEAD — pre-existing regression in the \"Asset registered\" reply text, unrelated to this PR. Verified via `git stash` + retest.
- **Staging-branch end-to-end run** (`docs/verification/2026-05-18-bm25-or-fix-staging-run.md`): 10/10 questions executed against `factorylm/stg` Neon branch, mean rubric 4.48, 9/10 passed. The one hard fail is a known `MIRA_TENANT_ID=\"staging\"` config gotcha already documented in `.github/workflows/staging-gate.yml` (CI pins it to a real UUID; local `doppler run -c stg` doesn't).
- **Ruff:** all new files clean.
- **Bytecompile:** all changed Python files clean.

## Why migrations weren't applied locally

`Doppler factorylm/dev` and `factorylm/prd` both point at the same NeonDB endpoint (`ep-purple-hall-...`) — Gap-2 in `docs/environments.md`. Per hard rule #1, I do not run `psql` against prod from a Claude Code session. Migration verification will happen via `apply-migrations.yml` in dry-run mode before apply. The staging Neon branch (`ep-polished-hall-...`) has its own URL but is not currently a migration target.

## Follow-ups (NOT in this PR)

- Pin `MIRA_TENANT_ID` to a real UUID on Doppler `factorylm/stg` so local staging matches CI's staging-gate behavior.
- Apply migrations 025/026/027 to the staging Neon branch via a staging-migrations workflow before merging.
- Hub `/proposals` UI work to render the new `ai_suggestions` types — not in scope, table ships so the UI work isn't schema-blocked.

## Test plan

- [ ] CI: `Code Review`, `enforcement-audit`, `Smoke Test`, `Staging Gate` all green
- [ ] Repo admin runs `apply-migrations.yml` in `dry-run` mode for 025,026,027 against prod NeonDB — verify the plan only includes the three new files and reports zero existing-table conflicts
- [ ] Repo admin re-runs in `apply` mode after sign-off
- [ ] Post-merge: send a Telegram nameplate photo and confirm a new row in `ai_suggestions` (`SELECT id, suggestion_type, title, created_at FROM ai_suggestions ORDER BY created_at DESC LIMIT 5;` via db-inspect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)