### PR TITLE
fix(hub): validate session tenantId as UUID; staging remap for legacy 'mike'

### DIFF
--- a/mira-hub/db/staging-fixes/2026-05-19_mike_tenant_remap.sql
+++ b/mira-hub/db/staging-fixes/2026-05-19_mike_tenant_remap.sql
@@ -1,0 +1,47 @@
+-- Staging-only minimal fix: remap hub_users.tenant_id='mike' (legacy string) to a real UUID.
+-- Root cause: hub_tenants.id is TEXT but kg_entities and namespace tables are UUID. A
+-- legacy seed used the slug 'mike' as a tenant id; the value works for TEXT-typed tables
+-- but the API casts $1::uuid in `kg_entities` queries and blows up with
+-- `invalid input syntax for type uuid: "mike"`.
+-- Affected endpoints: /api/namespace/tree, /api/readiness, /api/wizard/[step],
+-- /api/proposals, /api/usage. See issues #1421, #1422, #1423, #1426, #1431.
+--
+-- This script ONLY touches hub_users and hub_tenants. It does NOT migrate orphaned data in
+-- TEXT-typed tables (hub_uploads, kb_chunks, cmms_equipment, work_orders, etc.). Those rows
+-- stay where they are and become invisible until a follow-up data migration moves them. The
+-- trade-off is intentional: a narrow fix that unblocks the API without destroying anything
+-- via conflict-resolution shortcuts.
+--
+-- Safe to run multiple times — gated on tenant_id='mike'.
+
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- Idempotent: create a fresh, dedicated staging tenant if it doesn't already exist.
+INSERT INTO hub_tenants (name, slug)
+SELECT 'Mike (Staging)', 'mike-staging'
+WHERE NOT EXISTS (SELECT 1 FROM hub_tenants WHERE slug = 'mike-staging');
+
+DO $$
+DECLARE
+    target_uuid TEXT;
+    n INT;
+BEGIN
+    SELECT id INTO target_uuid FROM hub_tenants WHERE slug = 'mike-staging';
+    IF target_uuid IS NULL THEN
+        RAISE EXCEPTION 'failed to resolve mike-staging tenant id';
+    END IF;
+    -- Sanity: the resolved id must be a valid UUID, otherwise we'd just shift the problem.
+    PERFORM target_uuid::uuid;
+
+    UPDATE hub_users SET tenant_id = target_uuid WHERE tenant_id = 'mike';
+    GET DIAGNOSTICS n = ROW_COUNT;
+    RAISE NOTICE 'hub_users remapped: % rows (mike → %)', n, target_uuid;
+
+    PERFORM 1 FROM hub_users WHERE tenant_id = 'mike';
+    IF FOUND THEN
+        RAISE EXCEPTION 'hub_users still has tenant_id=''mike'' after remap';
+    END IF;
+END $$;
+
+COMMIT;

--- a/mira-hub/src/lib/session.ts
+++ b/mira-hub/src/lib/session.ts
@@ -53,14 +53,26 @@ export async function requireSession(): Promise<SessionContext> {
     throw new UnauthorizedError();
   }
 
+  // hub_tenants.id is TEXT, but most data tables (kg_entities, relationship_proposals,
+  // wizard_progress, namespace_versions, etc.) declare tenant_id UUID. A legacy seed
+  // ('mike' as a tenant slug) blew up every UUID-cast query with HTTP 500. Treat any
+  // non-UUID session tenant as unauthenticated so the user gets a clean 401/redirect
+  // instead of a 500 on every API call.
+  const tid = token.tid as string;
+  if (!UUID_RE.test(tid)) {
+    throw new UnauthorizedError();
+  }
+
   return {
     userId: token.uid as string,
-    tenantId: token.tid as string,
+    tenantId: tid,
     email: (token.email as string) ?? "",
     status: (token.status as string) ?? "trial",
     trialExpiresAt: (token.trialExpiresAt as string) ?? null,
   };
 }
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Resolve the session or return a 401 NextResponse. Use at the top of


### PR DESCRIPTION
## Summary
- Root-cause fix for staging P0 audit findings #1421, #1422, #1423 + related #1426, #1431
- Defensive code change so any future malformed session returns 401 instead of 500
- Documented + checked-in staging-only SQL remap (already applied to staging Neon)

## Root cause
\`hub_tenants.id\` is TEXT but every namespace/KG table (kg_entities, relationship_proposals, wizard_progress, namespace_versions, health_scores) declares \`tenant_id UUID\`. A legacy seed used the slug \`'mike'\` as a \`hub_users.tenant_id\`. This works fine for TEXT-typed tables but blows up the moment any API route does \`WHERE tenant_id = \$1::uuid\` — Postgres throws \`invalid input syntax for type uuid: "mike"\`, the catch-block in the route returns 500.

Surfaced as HTTP 500 on:
- \`/api/namespace/tree/\` (#1421, P0)
- \`/api/readiness/\` (#1422, P0)
- \`/api/wizard/[step]\` (#1423, P0)
- \`/api/proposals/\` (#1426, P1)
- \`/api/usage/\` (#1431, P2)

All same root cause: 14 staging \`hub_users\` rows had \`tenant_id='mike'\`.

## Changes
1. \`mira-hub/src/lib/session.ts\` — \`requireSession\` now validates the JWT \`tid\` claim is UUID-shaped and throws \`UnauthorizedError\` otherwise. A misconfigured tenant can no longer silently propagate into downstream queries; user gets a 401 and a login redirect, ops gets a single recognizable failure point.
2. \`mira-hub/db/staging-fixes/2026-05-19_mike_tenant_remap.sql\` — applied to staging Neon (Doppler \`factorylm/stg\`). Creates a dedicated \`'Mike (Staging)'\` hub_tenants row and remaps the 14 affected \`hub_users\` from \`'mike'\` to its UUID. Idempotent, transactional, touches only hub_users + hub_tenants.

## Trade-off acknowledged
The remap does NOT migrate orphaned data in TEXT-typed tables (\`hub_uploads\`, \`kb_chunks\`, \`cmms_equipment\`, \`work_orders\` — 248 rows total). Those rows still have \`tenant_id='mike'\` and become invisible until a follow-up migration moves them. This was intentional: a narrow fix that unblocks the API without destructive conflict-resolution shortcuts.

Follow-up issue worth filing (after this lands): tighten \`hub_tenants.id\` to UUID type to prevent the whole class of bugs.

## Production impact
None. Production \`hub_users\` were created via Google sign-in and got auto-generated UUIDs from \`gen_random_uuid()::text\`. Only the explicitly seeded staging records used the \`'mike'\` slug.

## Test plan
- [x] Apply remap SQL to staging Neon → 14 rows remapped, post-condition assertions pass
- [x] Verify \`/api/namespace/tree/\`, \`/api/readiness/\`, \`/api/wizard/company/\`, \`/api/proposals/\` return 307→login (was 500) when unauth on staging
- [x] Tail \`stg-mira-hub\` logs — no fresh \`invalid input syntax for type uuid\` errors
- [ ] Re-run \`audit-staging-2026-05-19.spec.ts\` Playwright with playwright@factorylm.com login — expect feed/namespace/onboarding/proposals/usage \`failedRequests: []\`
- [ ] CI: type-check + ruff + ast-grep gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)