### PR TITLE
feat(hub): migration 025 — reconcile kg_entities natural key with kg_writer

### DIFF
--- a/mira-hub/db/migrations/025_kg_entities_natural_key.sql
+++ b/mira-hub/db/migrations/025_kg_entities_natural_key.sql
@@ -1,0 +1,50 @@
+BEGIN;
+
+-- Migration 025: reconcile kg_entities natural key with kg_writer.upsert_entity.
+--
+-- mira-crawler/ingest/kg_writer.py:upsert_entity uses
+--   ON CONFLICT (tenant_id, entity_type, name) DO UPDATE
+-- and its docstring documents the natural key as (tenant_id, entity_type, name).
+--
+-- Prod's original constraint from migrations/001_knowledge_graph.sql was
+--   UNIQUE(tenant_id, entity_type, entity_id)
+-- with entity_id TEXT NOT NULL. kg_writer never populates entity_id, so
+-- every INSERT failed twice:
+--   * NOT NULL on entity_id (default NULL because column omitted from INSERT)
+--   * "no unique or exclusion constraint matching the ON CONFLICT specification"
+--
+-- Workflow run 26064409010 surfaced the second error after #1391 added the
+-- source_chunk_id column. Per ADR-0013 the hub-side schema is authoritative,
+-- so we adjust the schema to match the writer + docstring.
+--
+-- entity_id is preserved as a nullable auxiliary (no current code reads it
+-- across mira-hub/src, mira-crawler, mira-bots, mira-mcp, tools — verified
+-- with grep). Drop the column in a follow-up if it stays unused.
+--
+-- Idempotent: ALTER COLUMN DROP NOT NULL is a no-op when already nullable;
+-- DROP CONSTRAINT IF EXISTS and CREATE UNIQUE INDEX IF NOT EXISTS handle
+-- re-runs cleanly.
+
+-- 1. Allow NULL on entity_id. kg_writer's INSERT omits the column entirely,
+--    so the default-NULL needs to be permitted.
+ALTER TABLE kg_entities ALTER COLUMN entity_id DROP NOT NULL;
+
+-- 2. Drop the legacy unique on (tenant_id, entity_type, entity_id).
+--    Auto-named by PostgreSQL from the inline UNIQUE() in migration 001:
+--    {table}_{col1}_{col2}_{col3}_key.
+ALTER TABLE kg_entities
+    DROP CONSTRAINT IF EXISTS kg_entities_tenant_id_entity_type_entity_id_key;
+
+-- 3. Create the unique kg_writer's ON CONFLICT clause expects.
+CREATE UNIQUE INDEX IF NOT EXISTS kg_entities_tenant_type_name_key
+    ON kg_entities (tenant_id, entity_type, name);
+
+COMMIT;
+
+-- ─── Rollback (manual, requires data inspection) ──────────────────────
+-- DROP INDEX IF EXISTS kg_entities_tenant_type_name_key;
+-- ALTER TABLE kg_entities ADD UNIQUE (tenant_id, entity_type, entity_id);
+-- ALTER TABLE kg_entities ALTER COLUMN entity_id SET NOT NULL;
+--   -- ⚠ SET NOT NULL fails if any rows have NULL entity_id (which they will
+--   --   the moment kg_writer runs against this migrated schema). Plan a
+--   --   backfill query before reverting.


### PR DESCRIPTION
## Summary

Aligns prod \`kg_entities\` schema with what \`kg_writer.upsert_entity\` (and its own docstring) has always expected: \`UNIQUE(tenant_id, entity_type, name)\` instead of \`UNIQUE(tenant_id, entity_type, entity_id)\`.

## Why

After PR #1391 added the missing \`source_chunk_id\` column, workflow run [#26064409010](https://github.com/Mikecranesync/MIRA/actions/runs/26064409010) reached the next layer of schema/code drift:

\`\`\`
psycopg2.errors.InvalidColumnReference: there is no unique or exclusion
constraint matching the ON CONFLICT specification
\`\`\`

\`kg_writer.upsert_entity\` does:

\`\`\`sql
INSERT INTO kg_entities (tenant_id, entity_type, name, properties,
                         source_chunk_id, uns_path)
VALUES (...)
ON CONFLICT (tenant_id, entity_type, name) DO UPDATE ...
\`\`\`

- \`entity_id\` is NOT in the column list — \`NOT NULL\` default-NULL would fail
- ON CONFLICT spec doesn't match the prod constraint

kg_writer.py's own header comment (line 6) declares the natural key as \`(tenant_id, entity_type, name)\`. The migration is the drift, not the code.

## Verified — entity_id is unused

grep across \`mira-hub/src/\`, \`mira-crawler/\`, \`mira-bots/\`, \`mira-mcp/\`, and \`tools/\`: zero callers read \`kg_entities.entity_id\`. Safe to make nullable. Drop the column entirely in a follow-up if it stays unused.

## What this migration does

\`\`\`sql
ALTER TABLE kg_entities ALTER COLUMN entity_id DROP NOT NULL;

ALTER TABLE kg_entities
    DROP CONSTRAINT IF EXISTS kg_entities_tenant_id_entity_type_entity_id_key;

CREATE UNIQUE INDEX IF NOT EXISTS kg_entities_tenant_type_name_key
    ON kg_entities (tenant_id, entity_type, name);
\`\`\`

Three idempotent statements. Re-running is safe.

## Staging path

PR #1386 + #1420 just shipped the NeonDB-branch staging gate. This PR should be the first real schema-drift test of that gate — the gate runs migrations against a branched NeonDB before merge.

## After this lands

\`\`\`bash
gh workflow run apply-migrations.yml -f mode=apply \\
    -f migrations=025 -f run_backfill=true
\`\`\`

Expected backfill result: \`entities created: ~266\`, \`entries linked: ~10k+\`. Was 0/0 in the prior three runs.

## Stack so far

- #1366 ✅ workflow \`--commit\` flag (the original bug)
- #1383 ✅ \`uns_backfill.py\` empty-comment crash
- #1384 ✅ \`:p::type\` → \`CAST(:p AS type)\`
- #1391 ✅ migration 024 — \`source_chunk_id\` column
- **#1422 (this PR)** — migration 025 — natural key reconcile

After #1422 the kg_entities backfill should write rows for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)