### PR TITLE
feat(hub): migration 026 — dedupe kg_entities + reapply 025's natural-key reconcile

### DIFF
--- a/mira-hub/db/migrations/026_kg_entities_dedupe_and_constraint.sql
+++ b/mira-hub/db/migrations/026_kg_entities_dedupe_and_constraint.sql
@@ -1,0 +1,100 @@
+BEGIN;
+
+-- Migration 026: dedupe kg_entities, then apply the natural-key reconcile
+-- that migration 025 attempted but rolled back.
+--
+-- Background:
+--   025 tried ALTER COLUMN DROP NOT NULL + DROP old UNIQUE + CREATE UNIQUE
+--   INDEX (tenant_id, entity_type, name). The CREATE UNIQUE INDEX failed
+--   because prod kg_entities has duplicate rows on that key (workflow run
+--   26103240406 — at least one work_order row was duplicated). --single-transaction
+--   rolled back everything; prod schema is unchanged after 025 ran.
+--
+--   The duplicates arose because kg_writer.upsert_entity has been failing
+--   its ON CONFLICT clause for as long as the prod schema mismatched
+--   (the constraint it referenced never existed). Inserts went through but
+--   ON CONFLICT had nothing to bite, leaving duplicates from repeated
+--   demo-seed and ingest runs.
+--
+-- This migration:
+--   1. Builds a dedup map (one survivor per natural key — earliest by
+--      created_at, tiebreak by id ASC).
+--   2. Deletes proposals + namespace_versions rows pointing at duplicates
+--      (no FK, manual cleanup).
+--   3. Deletes the duplicate kg_entities rows. kg_relationships cascades
+--      via the ON DELETE CASCADE FK in migration 001 — relationships that
+--      pointed at duplicates are dropped. This is intentional: the duplicates
+--      shouldn't have existed, so neither should their attached edges.
+--      Kept-row relationships from earlier writes are preserved.
+--   4. Re-runs the 025 schema changes (idempotent so safe even if 025 had
+--      partially applied).
+--
+-- Idempotent: re-running after success is a no-op (dedup map is empty,
+-- DROP NOT NULL / DROP CONSTRAINT IF EXISTS / CREATE UNIQUE INDEX IF NOT
+-- EXISTS all skip on second pass).
+
+-- 1. Identify duplicates: rows that are not the earliest in their natural-key group.
+CREATE TEMP TABLE _kg_dedupe_map ON COMMIT DROP AS
+WITH ranked AS (
+    SELECT id, tenant_id, entity_type, name, created_at,
+           row_number() OVER (
+               PARTITION BY tenant_id, entity_type, name
+               ORDER BY created_at ASC, id ASC
+           ) AS rn
+    FROM kg_entities
+)
+SELECT id AS dup_id FROM ranked WHERE rn > 1;
+
+DO $$
+DECLARE
+    n bigint;
+BEGIN
+    SELECT count(*) INTO n FROM _kg_dedupe_map;
+    RAISE NOTICE 'kg_entities dedupe: % duplicate rows will be removed', n;
+END$$;
+
+-- 2. Clean up rows in tables that reference kg_entities.id but have no FK
+--    (so no cascade). Tables are migrated separately; guard with IF EXISTS.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'relationship_proposals'
+    ) THEN
+        EXECUTE 'DELETE FROM relationship_proposals
+                 WHERE source_entity_id IN (SELECT dup_id FROM _kg_dedupe_map)
+                    OR target_entity_id IN (SELECT dup_id FROM _kg_dedupe_map)';
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM information_schema.tables
+        WHERE table_schema = 'public' AND table_name = 'namespace_versions'
+    ) THEN
+        EXECUTE 'DELETE FROM namespace_versions
+                 WHERE entity_id IN (SELECT dup_id FROM _kg_dedupe_map)';
+    END IF;
+END$$;
+
+-- 3. Delete duplicate kg_entities. kg_relationships cascade-deletes via FK.
+DELETE FROM kg_entities
+WHERE id IN (SELECT dup_id FROM _kg_dedupe_map);
+
+-- 4. Apply the natural-key reconcile that 025 attempted.
+ALTER TABLE kg_entities ALTER COLUMN entity_id DROP NOT NULL;
+
+ALTER TABLE kg_entities
+    DROP CONSTRAINT IF EXISTS kg_entities_tenant_id_entity_type_entity_id_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS kg_entities_tenant_type_name_key
+    ON kg_entities (tenant_id, entity_type, name);
+
+COMMIT;
+
+-- ─── Rollback (manual, lossy) ────────────────────────────────────────
+-- DROP INDEX IF EXISTS kg_entities_tenant_type_name_key;
+-- ALTER TABLE kg_entities ADD UNIQUE (tenant_id, entity_type, entity_id);
+-- ALTER TABLE kg_entities ALTER COLUMN entity_id SET NOT NULL;
+--   -- ⚠ SET NOT NULL fails as soon as kg_writer runs against the migrated
+--   --   schema (it doesn't populate entity_id). Plan a backfill SET
+--   --   entity_id = gen_random_uuid()::text WHERE entity_id IS NULL first.
+-- -- The duplicate rows are gone forever; only a NeonDB point-in-time
+-- -- restore can recover them.


### PR DESCRIPTION
## Summary

Supersedes the failed apply of #1436 (migration 025). Adds the dedup step
that 025 was missing so the unique index can land.

## What 025 hit

[Workflow run 26103240406](https://github.com/Mikecranesync/MIRA/actions/runs/26103240406):

\`\`\`
ERROR: could not create unique index \"kg_entities_tenant_type_name_key\"
DETAIL: Key (tenant_id, entity_type, name)=(78917b56..., work_order,
        [MIRA] Pump-A1 — corrective action) is duplicated.
\`\`\`

\`--single-transaction\` rolled all of 025 back. Prod schema is unchanged after #1436 merged + ran.

## Why duplicates exist

\`kg_writer.upsert_entity\` has always specified \`ON CONFLICT (tenant_id, entity_type, name) DO UPDATE\`, but the actual UNIQUE in prod is \`(tenant_id, entity_type, entity_id)\`. The ON CONFLICT clause errors at write time → caller's try/except logs and moves on. But the upstream INSERT must've gone through some *other* path (demo seeds, an older direct-INSERT code, or manual fixtures) because rows accumulated. Repeated runs of the same path → multiple rows per natural key.

## What 026 does

1. Build a dedup map: keep earliest per \`(tenant_id, entity_type, name)\`, drop the rest.
2. Remove non-cascading references (\`relationship_proposals\`, \`namespace_versions\`).
3. DELETE duplicate kg_entities rows. \`kg_relationships\` cascades via FK (intentional: duplicates' edges shouldn't have existed either).
4. Run the 025 schema changes (DROP NOT NULL, DROP old UNIQUE, CREATE UNIQUE INDEX).

## Data-loss acknowledgement

- Relationships pointing at duplicate rows are dropped via cascade. Real production traffic likely didn't differentiate dup vs kept entities for relationship attachment (the writer's lookup-by-name returned the first row, which is the survivor here).
- \`relationship_proposals\` and \`namespace_versions\` entries pointing at duplicates are deleted.
- No NeonDB point-in-time-restore checkpoint is taken — Neon's PITR window covers this if rollback is needed.

## Why 025 stays in the tree

It captured an honest attempt and the \`migrations=025\` workflow input still resolves. 026 is what actually works against prod data. Run \`migrations=026\`.

## After this lands

\`\`\`bash
gh workflow run apply-migrations.yml -f mode=apply \\
    -f migrations=026 -f run_backfill=true
\`\`\`

Backfill should finally write rows: \`entities created: ~266\`, \`entries linked: ~10k+\`. The dedup count will print as a NOTICE in the apply log.

## Stack so far

- #1366 ✅ workflow \`--commit\`
- #1383 ✅ \`uns_backfill\` empty-comment crash
- #1384 ✅ \`:p::type\` → \`CAST(:p AS type)\`
- #1391 ✅ migration 024 — \`source_chunk_id\` column
- #1436 ✅ migration 025 — \`UNIQUE(tenant,type,name)\` (merged but apply rolled back)
- **#1437 (this PR)** — migration 026 — dedup-then-constrain

🤖 Generated with [Claude Code](https://claude.com/claude-code)