### PR TITLE
fix(cmms): atlas-api host.docker.internal mapping for MinIO hairpin NAT

### DIFF
--- a/mira-cmms/docker-compose.yml
+++ b/mira-cmms/docker-compose.yml
@@ -48,6 +48,13 @@ services:
     image: intelloop/atlas-cmms-backend@sha256:21c42377dd758dbc4a9aa1676e62b01a13cf8822b0ecd3019b274b53c2369b1e
     container_name: atlas-api
     restart: unless-stopped
+    # atlas-api's bean init connects to PUBLIC_MINIO_ENDPOINT at startup; Linux Docker
+    # bridge has no hairpin NAT, so a host-public-IP value crash-loops the container.
+    # Deploys that need to point the public URL at the host gateway can set
+    # ATLAS_PUBLIC_MINIO_URL=http://host.docker.internal:<port>. Mac/Windows already
+    # have host.docker.internal; Linux needs the explicit mapping.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     depends_on:
       atlas-db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
Single-line compose change so the atlas-api container can resolve `host.docker.internal` on Linux hosts. Unblocks the staging `/cmms` 503 (#1425).

## Root cause (from #1425 comments)
atlas-api's Spring bean init connects to `PUBLIC_MINIO_ENDPOINT` at startup to verify MinIO reachability. On staging the public URL is `http://165.245.138.91:4900`, and the Linux Docker bridge has no hairpin NAT — a container can't reach its own host's public IP. The container crash-loops on `Failed to connect to /165.245.138.91:4900`.

Verified from inside `stg-atlas-api`:
- `wget stg-atlas-minio:9000` → 403 (reachable)
- `wget 165.245.138.91:4900` → timeout (unreachable)

## Change

`mira-cmms/docker-compose.yml` — add `extra_hosts: ["host.docker.internal:host-gateway"]` to the `atlas-api` service.

## Deploy steps (staging only)

1. Pull this PR onto VPS `/opt/mira/`.
2. In Doppler `factorylm/stg`, set `ATLAS_PUBLIC_MINIO_URL=http://host.docker.internal:4900` (replaces the previous public-IP value).
3. `doppler run -p factorylm -c stg -- docker compose up -d --force-recreate atlas-api`.
4. Verify: `docker exec stg-atlas-api wget -qO- http://host.docker.internal:4900/minio/health/live` returns OK.
5. Verify: `curl -sS http://127.0.0.1:4101/api/cmms/stats/` returns 200 (was 503).

## Production impact

None. The `extra_hosts` entry is harmless when unused — `host.docker.internal` resolves to the host gateway only if something references it. Prod's `ATLAS_PUBLIC_MINIO_URL` (the public DNS name) is unchanged and continues working.

## Trade-off acknowledged

If `ATLAS_PUBLIC_MINIO_URL` points at `host.docker.internal`, the same value flows into signed URLs handed to browsers — meaning **staging browser downloads of CMMS file attachments won't resolve** (the hostname is container-internal). This is acceptable for the audit checklist (file downloads aren't tested), but the right long-term fix is a code patch in atlas-api so the bean init uses internal `MINIO_ENDPOINT` while reserving `PUBLIC_MINIO_ENDPOINT` strictly for signed-URL generation. Tracked as a follow-up.

## Test plan

- [ ] CI: ruff + lint pass
- [ ] Apply on staging VPS per deploy steps above
- [ ] `docker logs stg-atlas-api` shows no `Failed to connect to /` errors
- [ ] `curl http://127.0.0.1:4101/api/cmms/stats/` returns 200
- [ ] Hub `/cmms` page no longer 503s
- [ ] No production touched

Closes #1425

🤖 Generated with [Claude Code](https://claude.com/claude-code)