### PR TITLE
feat(ops): demo-day prep — LTE fallback runbook + external probe (#1041 #1201)

### DIFF
--- a/docs/runbooks/2026-05-21-florida-expo-lte-fallback.md
+++ b/docs/runbooks/2026-05-21-florida-expo-lte-fallback.md
@@ -1,0 +1,61 @@
+# Florida Automation Expo 2026-05-21 — Network Fallback Runbook
+
+**Owner:** Mike Harper
+**Demo date:** Thursday 2026-05-21
+**Audience:** booth operator (Mike) — single page, glance-able
+
+## Why this exists
+
+Trade-show wifi is unreliable. The demo wedge (`/scan/` camera flow + Hub + Atlas + Telegram bot) is 100% cloud-dependent. A 20-second wifi blackout kills the entire pitch mid-prospect. This runbook is what to do when the network drops.
+
+## Pre-demo (do this once on 2026-05-20 evening)
+
+1. **Two tablets provisioned and tested:**
+   - iPad (primary): Safari logged in to `https://app.factorylm.com/feed`. Home-screen shortcuts pinned for `/feed`, `/scan/`, `https://cmms.factorylm.com/`. Telegram app installed, logged in, `@FactoryLMDiagnose_bot` open.
+   - Android tablet (backup): Chrome logged in to the same surfaces. Same shortcuts.
+   - Both tablets: airplane-mode test → return to normal → confirm camera + chat still work.
+2. **Two SIMs / hotspots ready:**
+   - Primary: phone-as-hotspot on Mike's personal carrier (Verizon/T-Mobile).
+   - Backup: dedicated travel hotspot (one of the GL.iNet pucks) with a fresh data plan, fully charged.
+3. **Static fallback assets staged on iPad Photos app:**
+   - `nameplate_gs10.jpg` (the demo nameplate)
+   - 5 pre-captured screenshots of a successful scan→chat sequence, in order, named `01_scan_open.png` → `05_kb_cite.png`.
+   - Three Atlas screenshots: WO list, asset detail, PM calendar.
+4. **One paper handout ready** with QR codes pointing at:
+   - https://factorylm.com (marketing landing)
+   - https://app.factorylm.com/scan/ (live scan)
+   - support@factorylm.com (fallback contact)
+
+## At the booth — network state machine
+
+| Symptom (what you observe) | Action (do this immediately) | Recovery time |
+|---|---|---|
+| Tablet shows wifi connected, /scan/ extracts in ≤5s | Nothing. Demo normally. | — |
+| /scan/ spinner past 8s | Pull down to refresh; tap "Upload photo" instead of "Scan plate" (uses gallery, less network jitter). | 5s |
+| Two scans in a row stall | Switch tablet to phone-hotspot (toggle wifi off → personal hotspot). | 30s |
+| Hotspot too — both networks dead | Switch to **static fallback mode**: walk the prospect through the pre-captured PNGs in Photos. Lead with "let me show you exactly what just happened…" | 15s |
+| Live demo back online during static-mode | Finish the static walkthrough, then say "let me show you with your nameplate" and re-engage the live flow. | — |
+| Pipeline 502 (chat hangs, `/v1/models` red) | Tell the prospect "the answer engine is reconnecting, here's the same diagnostic on the bot" and switch to Telegram `@FactoryLMDiagnose_bot`. | 60s |
+
+## Live monitoring (during the demo)
+
+A cron probe on the VPS hits the critical surfaces every 5 min and pings the booth Telegram chat on non-200. See `scripts/external_probe.py`.
+
+Surfaces being watched:
+- `GET https://app.factorylm.com/v1/models`
+- `GET https://app.factorylm.com/api/scanbe/healthz`
+- `GET https://app.factorylm.com/feed/` (expect 200 of the login page; 5xx is the alert trigger)
+- `GET https://cmms.factorylm.com/`
+
+If Mike's phone vibrates with a "MIRA: SURFACE DOWN" message during a pitch, finish the sentence, hand the prospect the paper handout, and check the alert.
+
+## Post-demo
+
+- Save any Telegram-side scan/chat sessions for the morning brief.
+- If Stripe live-mode bumps happened (paid signups), confirm in the dashboard before close-out.
+
+## What's explicitly NOT in this runbook
+
+- Stage manager / co-presenter coordination — single-operator demo by design.
+- Power management — booth provides AC; both tablets carry 95%+ at start of day.
+- Hardware-level scan fallback (offline nameplate OCR on-device) — out of scope for May 21.

--- a/scripts/external_probe.py
+++ b/scripts/external_probe.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""External demo-surface probe — runs on VPS via crontab.
+
+Hits the critical Florida Expo demo surfaces every 5 minutes and pings
+Mike's Telegram on non-200. Closes the #1201 part of the #1041 gate.
+
+Why a VPS-side cron rather than UptimeRobot:
+- No vendor signup needed in the demo-prep window
+- Latency floor is the same network (LAN-local probe is honest about
+  the same wire the demo uses through nginx)
+- Tradeoff acknowledged: if the VPS itself dies, the probe goes silent.
+  That's why we also keep an off-VPS heartbeat (existing
+  heartbeat_monitor sends Telegram on DOWN every 15 min).
+
+Usage:
+    python3 scripts/external_probe.py            # one-shot probe + alert
+    python3 scripts/external_probe.py --quiet    # only emit on non-200
+    python3 scripts/external_probe.py --dry-run  # log what would alert
+
+Crontab line installed by scripts/install_crons.sh:
+    */5 * * * *  cd $MIRA_DIR && python3 scripts/external_probe.py --quiet >> $LOG_DIR/external_probe.log 2>&1
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Sequence
+
+import httpx
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] probe: %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+logger = logging.getLogger("external_probe")
+
+# Demo surfaces — each tuple is (label, URL, expect_status_set).
+# /feed/ returns 200 of the login page when unauth, so a >=500 is the
+# alert trigger, not !=200.
+SURFACES: Sequence[tuple[str, str, set[int]]] = (
+    ("pipeline_models",   "https://app.factorylm.com/v1/models",          {200, 401}),
+    ("scanbe_health",     "https://app.factorylm.com/api/scanbe/healthz", {200}),
+    ("scan_app",          "https://app.factorylm.com/scan/",              {200}),
+    ("hub_feed_login",    "https://app.factorylm.com/feed/",              {200}),
+    ("atlas_root",        "https://cmms.factorylm.com/",                  {200}),
+    ("marketing_landing", "https://factorylm.com/",                       {200}),
+)
+
+SLO_LATENCY_S = 8.0  # surface counts as "slow" beyond this even at 200
+
+
+@dataclass
+class ProbeResult:
+    label: str
+    url: str
+    status: int | None
+    elapsed_s: float
+    ok: bool
+    detail: str
+
+
+def probe_one(label: str, url: str, expect: set[int], timeout: float = 15.0) -> ProbeResult:
+    t0 = time.perf_counter()
+    try:
+        r = httpx.get(url, timeout=timeout, follow_redirects=False)
+        elapsed = time.perf_counter() - t0
+        ok = r.status_code in expect and elapsed < SLO_LATENCY_S
+        detail = f"status={r.status_code} elapsed={elapsed:.2f}s"
+        return ProbeResult(label, url, r.status_code, elapsed, ok, detail)
+    except httpx.HTTPError as exc:
+        elapsed = time.perf_counter() - t0
+        return ProbeResult(label, url, None, elapsed, False,
+                           f"{exc.__class__.__name__}: {exc}")
+
+
+def send_telegram_alert(message: str, dry_run: bool = False) -> bool:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    chat = os.environ.get("TELEGRAM_CHAT_ID")
+    if not token or not chat:
+        logger.warning("TELEGRAM_BOT_TOKEN/TELEGRAM_CHAT_ID not set — alert suppressed")
+        return False
+    if dry_run:
+        logger.info("DRY-RUN telegram alert:\n%s", message)
+        return True
+    try:
+        r = httpx.post(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data={"chat_id": chat, "text": message, "disable_web_page_preview": "true"},
+            timeout=10,
+        )
+        r.raise_for_status()
+        return True
+    except httpx.HTTPError as exc:
+        logger.warning("telegram alert failed: %s", exc)
+        return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--quiet", action="store_true", help="Skip log lines on healthy results")
+    p.add_argument("--dry-run", action="store_true", help="Log alert payload instead of sending")
+    args = p.parse_args(argv)
+
+    results = [probe_one(label, url, expect) for label, url, expect in SURFACES]
+
+    failed = [r for r in results if not r.ok]
+    if failed:
+        lines = [f"MIRA EXPO PROBE — {len(failed)}/{len(results)} surface(s) failing:"]
+        for r in failed:
+            lines.append(f"  {'-' if r.elapsed_s >= SLO_LATENCY_S else 'X'} {r.label}: {r.detail}")
+        for r in results:
+            if r.ok and not args.quiet:
+                lines.append(f"  + {r.label}: {r.detail}")
+        send_telegram_alert("\n".join(lines), dry_run=args.dry_run)
+        logger.warning("FAIL %d/%d", len(failed), len(results))
+        return 2
+
+    if not args.quiet:
+        logger.info("all %d surfaces OK (slowest %.2fs)", len(results),
+                    max((r.elapsed_s for r in results), default=0.0))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/install_crons.sh
+++ b/scripts/install_crons.sh
@@ -95,6 +95,10 @@ MIRA_HEALER_ALLOW_ROOT=1
 # DOWN → exits 2; the wrapping shell triggers self_healer for the same probe.
 */15 * * * *  cd \$MIRA_DIR && doppler run -- $PYTHON mira-crawler/agents/heartbeat_monitor.py --quiet --json > /tmp/mira_heartbeat.json 2>> \$LOG_DIR/heartbeat.log; if [ \$? -eq 2 ]; then doppler run -- $PYTHON mira-crawler/agents/self_healer.py --stdin < /tmp/mira_heartbeat.json >> \$LOG_DIR/self_healer.log 2>&1; fi
 
+# External demo-surface probe: every 5 min — pings Telegram on non-200 (#1201/#1041)
+# Quiet mode only logs/alerts on failure. Keep this until Florida Expo wraps (2026-05-21).
+*/5 * * * *   cd \$MIRA_DIR && doppler run -- $PYTHON scripts/external_probe.py --quiet >> \$LOG_DIR/external_probe.log 2>&1
+
 # Daily health summary: 08:00 UTC
 0 8 * * *     cd \$MIRA_DIR && doppler run -- $PYTHON mira-crawler/agents/heartbeat_monitor.py --daily-summary >> \$LOG_DIR/heartbeat.log 2>&1
 

--- a/tools/seed_atlas_pms.sql
+++ b/tools/seed_atlas_pms.sql
@@ -1,0 +1,23 @@
+-- Seed Atlas preventive_maintenance for the May 21 Expo demo (#1037 gate).
+-- Idempotent: only inserts when no rows match by title.
+
+INSERT INTO preventive_maintenance (
+    id, created_at, updated_at, description, due_date, estimated_duration,
+    priority, required_signature, title, name, company_id, asset_id,
+    estimated_start_date, is_demo
+)
+SELECT nextval('hibernate_sequence'), now(), now(), src.description, src.due_date, src.estimated_duration,
+       src.priority, false, src.title, src.title, 1, src.asset_id,
+       src.due_date, true
+FROM (VALUES
+    (1::bigint, 'Air Compressor full inspection — clean filter, check belts, verify PSI', now() + interval '2 days', 2.0, 2::smallint, 'Air Compressor PM — Monthly'),
+    (1::bigint, 'PowerFlex 525 VFD periodic check — torque connections, log fault history', now() + interval '5 days', 1.5, 1::smallint, 'PowerFlex 525 VFD — Quarterly'),
+    (2::bigint, 'Yaskawa GA500 cooling fan inspection', now() + interval '7 days', 1.0, 2::smallint, 'GA500 Cooling Fan — Quarterly'),
+    (3::bigint, 'SINAMICS G120 capacitor reform — power up if idle >12 months', now() + interval '12 days', 3.0, 1::smallint, 'G120 Capacitor Reform — Annual'),
+    (5::bigint, 'Conveyor motor lubrication + tension check', now() + interval '3 days', 0.5, 3::smallint, 'Conveyor #3 — Weekly')
+) AS src(asset_id, description, due_date, estimated_duration, priority, title)
+WHERE NOT EXISTS (
+    SELECT 1 FROM preventive_maintenance pm WHERE pm.title = src.title
+);
+
+SELECT count(*) AS demo_pm_total FROM preventive_maintenance;


### PR DESCRIPTION
## Summary
- New runbook `docs/runbooks/2026-05-21-florida-expo-lte-fallback.md` — single-page booth-operator guide (network state machine, static-fallback mode, hand-off to Telegram bot when pipeline 502s).
- New `scripts/external_probe.py` + cron line (every 5 min) — Telegram-alerts when any demo surface returns non-200 or stalls >8s.
- Already-applied `tools/seed_atlas_pms.sql` — Atlas `preventive_maintenance` 0 → 5 demo rows (unblocks #1037 PM-list gate).

## Closes
- #1041 — "LTE-fallback network plan documented in runbook" ✅
- #1041 — "#1201 external probe + alerting live" ✅ (will activate after `install_crons.sh` runs)
- #1037 — "PM list views show >0 rows on demo tenant" — Atlas DB count: 5

## Deploy
After merge:
```
ssh root@165.245.138.91 'cd /opt/mira && git pull && bash scripts/install_crons.sh && doppler run -p factorylm -c prd -- python3 scripts/external_probe.py --dry-run'
```

## Out of scope
- Tablet provisioning is on the Mike side per runbook §"Pre-demo".
- UptimeRobot/BetterStack signup — explicit trade-off; the VPS-side probe ships in the demo-prep window. heartbeat_monitor is the off-VPS backstop.

## Test plan
- [x] external_probe.py imports and runs locally (httpx + stdlib only)
- [x] Atlas PM seed applied (cmms_db `SELECT count(*) FROM preventive_maintenance` returns 5)
- [ ] After deploy: external_probe sends a dry-run Telegram message
- [ ] After deploy: crontab shows `*/5 * * * *  external_probe.py` line