### PR TITLE
fix(crawler): kg_writer columns + rewrite db-inspect to psql

### DIFF
--- a/.github/workflows/db-inspect.yml
+++ b/.github/workflows/db-inspect.yml
@@ -1,9 +1,11 @@
 name: NeonDB inspect (P0 #1305/#1343/#1344)
 
-# Ad-hoc DB inspection workflow. Runs SQL inside mira-mcp-saas container on the
-# VPS (which has working SSL to Neon — Windows hosts can't reach Neon directly
-# per the gotcha in CLAUDE.md). Read-only. Drop after #1305/#1343/#1344 close
-# and a permanent /api/admin/db-inventory endpoint is in place.
+# Ad-hoc DB inspection workflow. Uses psql against NeonDB directly via the
+# Doppler-managed NEON_DATABASE_URL (factorylm/prd). Read-only.
+#
+# Previous version (pre-2026-05-19) executed Python inside the mira-mcp-saas
+# container and broke when the container lost psycopg2 in a rebuild. Switched
+# to the same psql pattern apply-migrations.yml uses for resilience.
 
 on:
   workflow_dispatch:
@@ -19,77 +21,107 @@ jobs:
     timeout-minutes: 5
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - name: Set up SSH
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Install psql
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/vps_deploy_key
-          chmod 600 ~/.ssh/vps_deploy_key
-          ssh-keyscan -H 165.245.138.91 >> ~/.ssh/known_hosts 2>/dev/null
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq postgresql-client-16
+          psql --version
 
-      - name: Inspect NeonDB via mira-mcp-saas
+      - name: Authenticate Doppler + resolve DATABASE_URL
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
         run: |
-          ssh -i ~/.ssh/vps_deploy_key -o StrictHostKeyChecking=no \
-            root@165.245.138.91 "bash -s" << 'ENDSSH'
-
           set -euo pipefail
-          cd /opt/mira
+          if [ -z "${DOPPLER_TOKEN:-}" ]; then
+            echo "::error::DOPPLER_TOKEN secret not set."
+            exit 1
+          fi
+          DATABASE_URL="$(doppler secrets get NEON_DATABASE_URL --project factorylm --config prd --plain)"
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::NEON_DATABASE_URL empty after Doppler fetch"
+            exit 1
+          fi
+          echo "::add-mask::$DATABASE_URL"
+          echo "DATABASE_URL=$DATABASE_URL" >> "$GITHUB_ENV"
 
-          echo "=== container status ==="
-          docker ps --filter "name=mira-mcp-saas" --format "table {{.Names}}\t{{.Status}}"
+      - name: Inspect kg_entities + kg_relationships
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+        run: |
+          set -euo pipefail
+          psql "$DATABASE_URL" --no-psqlrc -v ON_ERROR_STOP=0 <<'SQL'
+          \echo === connection identity ===
+          SELECT current_user AS connected_as, session_user;
+          SELECT rolname, rolbypassrls FROM pg_roles WHERE rolname = current_user;
 
-          echo
-          echo "=== NeonDB inventory ==="
-          docker exec mira-mcp-saas python -c "
-          import os, psycopg2
-          url = os.environ.get('NEON_DATABASE_URL', '')
-          if not url:
-              print('NEON_DATABASE_URL not set in container env')
-              raise SystemExit(2)
-          conn = psycopg2.connect(url)
-          cur = conn.cursor()
+          \echo
+          \echo === table inventory ===
+          SELECT tablename FROM pg_tables
+          WHERE schemaname='public'
+            AND tablename IN ('knowledge_entries','fault_codes','kg_entities',
+                              'kg_relationships','kg_bridge','tenant_invites',
+                              'kg_approval_state','relationship_proposals',
+                              'relationship_evidence')
+          ORDER BY tablename;
 
-          cur.execute(\"SELECT tablename FROM pg_tables WHERE schemaname='public' ORDER BY tablename;\")
-          tables = [r[0] for r in cur.fetchall()]
-          print(f'TABLE_COUNT: {len(tables)}')
-          for t in tables:
-              print('  ' + t)
+          \echo
+          \echo === row counts ===
+          SELECT 'kg_entities' AS tbl, COUNT(*)::text AS n FROM kg_entities
+          UNION ALL SELECT 'kg_entities NULL uns_path', COUNT(*)::text FROM kg_entities WHERE uns_path IS NULL
+          UNION ALL SELECT 'kg_relationships', COUNT(*)::text FROM kg_relationships
+          UNION ALL SELECT 'knowledge_entries', COUNT(*)::text FROM knowledge_entries;
 
-          required = [
-              'knowledge_entries', 'fault_codes', 'kg_entities', 'kg_relationships',
-              'kg_bridge', 'tenant_invites', 'kg_approval_state',
-          ]
-          missing = [t for t in required if t not in tables]
-          print(f'MISSING_REQUIRED: {missing}')
+          \echo
+          \echo === kg_entities columns ===
+          SELECT column_name, data_type
+          FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='kg_entities'
+          ORDER BY ordinal_position;
 
-          for q in [
-              (\"kg_entities total\", \"SELECT COUNT(*) FROM kg_entities;\"),
-              (\"kg_entities NULL uns_path\", \"SELECT COUNT(*) FROM kg_entities WHERE uns_path IS NULL;\"),
-              (\"kg_entities source='cmms'\", \"SELECT COUNT(*) FROM kg_entities WHERE source='cmms';\"),
-              (\"kg_entities source='cmms' NULL uns_path\", \"SELECT COUNT(*) FROM kg_entities WHERE source='cmms' AND uns_path IS NULL;\"),
-              (\"knowledge_entries total\", \"SELECT COUNT(*) FROM knowledge_entries;\"),
-              (\"kg_entities kind='knowledge_entry'\", \"SELECT COUNT(*) FROM kg_entities WHERE kind='knowledge_entry';\"),
-              (\"kg_relationships total\", \"SELECT COUNT(*) FROM kg_relationships;\"),
-          ]:
-              label, sql = q
-              try:
-                  cur.execute(sql)
-                  print(f'{label}: {cur.fetchone()[0]}')
-              except Exception as e:
-                  print(f'{label}: ERR {e.__class__.__name__}: {str(e)[:120]}')
-                  conn.rollback()
+          \echo
+          \echo === kg_relationships columns ===
+          SELECT column_name, data_type
+          FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='kg_relationships'
+          ORDER BY ordinal_position;
 
-          cur.execute(\"\"\"
-              SELECT column_name, data_type
-              FROM information_schema.columns
-              WHERE table_schema='public' AND table_name='kg_entities'
-              ORDER BY ordinal_position;
-          \"\"\")
-          print('--- kg_entities columns ---')
-          for col, dtype in cur.fetchall():
-              print(f'  {col}: {dtype}')
+          \echo
+          \echo === kg_relationships indexes ===
+          SELECT indexname, indexdef
+          FROM pg_indexes
+          WHERE schemaname='public' AND tablename='kg_relationships'
+          ORDER BY indexname;
 
-          conn.close()
-          "
-          ENDSSH
+          \echo
+          \echo === RLS state ===
+          SELECT c.relname,
+                 c.relrowsecurity AS rls_enabled,
+                 c.relforcerowsecurity AS rls_forced
+          FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname='public'
+            AND c.relname IN ('kg_entities','kg_relationships');
+
+          \echo
+          \echo === RLS policies ===
+          SELECT tablename, policyname, cmd, qual::text
+          FROM pg_policies
+          WHERE schemaname='public'
+            AND tablename IN ('kg_entities','kg_relationships');
+
+          \echo
+          \echo === kg_relationships sample (10) ===
+          SELECT * FROM kg_relationships LIMIT 10;
+
+          \echo
+          \echo === kg_relationships by type ===
+          SELECT relationship_type, COUNT(*)
+          FROM kg_relationships
+          GROUP BY relationship_type
+          ORDER BY 2 DESC;
+          SQL

--- a/mira-crawler/ingest/kg_writer.py
+++ b/mira-crawler/ingest/kg_writer.py
@@ -5,8 +5,14 @@ admin tools) must go through these helpers so the spec's invariants hold:
 
 - `kg_entities` UNIQUE (tenant_id, entity_type, name) → ON CONFLICT DO NOTHING
   on insert, then SELECT to obtain the canonical id.
-- `kg_relationships` UNIQUE (tenant_id, source_entity, target_entity,
-  relation_type) → same pattern.
+- `kg_relationships` UNIQUE (tenant_id, source_id, target_id,
+  relationship_type) → same pattern. (Column names follow the prod schema
+  established by mira-hub/db/migrations/001_knowledge_graph.sql; the
+  `source_entity`/`target_entity`/`relation_type` names in
+  docs/migrations/006_kg_bridge.sql never landed in prod — see ADR-0013
+  follow-up.) The Python parameter names below keep the
+  `source_entity`/`target_entity` spelling for backwards compatibility
+  with existing callers.
 - Every entity carries a non-NULL `uns_path` (spec §3.1, Phase 3).
 - Path grammar is enforced both at the application layer (uns.is_valid_path)
   and at the database layer (CHECK constraint added in migration 008).
@@ -163,15 +169,15 @@ def upsert_relationship(
             row = c.execute(
                 text("""
                     INSERT INTO kg_relationships
-                        (tenant_id, source_entity, target_entity,
-                         relation_type, properties, confidence,
+                        (tenant_id, source_id, target_id,
+                         relationship_type, properties, confidence,
                          source_chunk_id)
                     VALUES
                         (:tenant_id, :source, :target, :rel,
                          cast(:properties AS jsonb), :confidence,
                          cast(:source_chunk_id AS uuid))
                     ON CONFLICT
-                        (tenant_id, source_entity, target_entity, relation_type)
+                        (tenant_id, source_id, target_id, relationship_type)
                     DO UPDATE SET
                         confidence = GREATEST(kg_relationships.confidence,
                                               EXCLUDED.confidence)


### PR DESCRIPTION
## Summary

Two related fixes from investigating PR #1438's backfill failures.

**1. `kg_writer.py` was writing to the wrong columns** — `source_entity` / `target_entity` / `relation_type`. Those names come from `docs/migrations/006_kg_bridge.sql` which never landed in prod. Prod uses the hub-001 schema: `source_id` / `target_id` / `relationship_type`. Every relationship insert from kg_writer.py has been silently 500-ing since the writer was introduced. Confirmed via db-inspect (see PR commit history): 30 rows in prod, all from the hub-TS writers and `full_ingest_pipeline.py`, zero from `kg_writer.py`.

**2. `db-inspect.yml` was broken** — executed Python inside `mira-mcp-saas`, which lost `psycopg2` in a past rebuild. Rewrote to use `psql` against NeonDB directly via `NEON_DATABASE_URL` (same pattern as `apply-migrations.yml`). Added the queries needed to diagnose schema drift: column shapes, indexes (for ON CONFLICT validation), RLS state + policies, connected-role BYPASSRLS flag.

## Why kg_writer.py never worked

`docs/migrations/006_kg_bridge.sql` and `mira-hub/db/migrations/001_knowledge_graph.sql` both use `CREATE TABLE IF NOT EXISTS kg_relationships (...)` but with **different column names**. Whichever ran first in prod won — hub-001 did. ADR-0013 declared `docs/migrations/` authoritative for `kg_relationships` aspirationally, but the actual hub TypeScript stack (`mira-hub/src/lib/knowledge-graph/queries.ts`, `traversal.ts`, `extractor.ts`) reads/writes the hub-shape and is what's been running productively. `full_ingest_pipeline.py` already matches hub-shape (lines 426-429, 459-463). `kg_writer.py` was the outlier.

This PR aligns the writer with reality. ADR-0013 cleanup is a separate follow-up.

## Verification

- ✅ db-inspect run on `ops/db-inspect-psql-rewrite`: <https://github.com/Mikecranesync/MIRA/actions/runs/26127569334> — proved column shape, surfaced 30 working rows, confirmed `idx_kg_rel_dedup UNIQUE (tenant_id, source_id, target_id, relationship_type)` so ON CONFLICT will fire, confirmed `neondb_owner` has `rolbypassrls=t` so RLS won't filter writes.
- After merge: re-run `apply-migrations.yml` to kick `uns_backfill.py --commit`. Expect `kg_relationships` to grow with `has_manual` + `has_fault` edges from the 269 (tenant, manufacturer, model) triples already enumerated.

## Test plan

- [ ] Merge.
- [ ] Trigger `apply-migrations.yml` (apply, migrations="") — backfill-only run.
- [ ] Trigger `db-inspect.yml` again. Compare `kg_relationships by type` counts before/after.
- [ ] If `has_manual` count is now >0: fix landed correctly.
- [ ] If counts unchanged or backfill still 500s: open a follow-up — likely RLS / session-var divergence between this DB role and what tooling actually connects as.

🤖 Generated with [Claude Code](https://claude.com/claude-code)