### PR TITLE
fix(ingest): extract PDF tables as markdown chunks + surface page in citations

### DIFF
--- a/mira-bots/shared/response_formatter.py
+++ b/mira-bots/shared/response_formatter.py
@@ -291,12 +291,19 @@ def _format_citation_label(c: dict) -> str:
     3. If only source_url is set, parse the URL stem with the same pattern, and
        infer manufacturer from the hostname when possible.
     4. Otherwise, fall back to whatever non-empty pieces we have.
-    Always optionally append the section if present.
+    Always optionally append the section, then the page number (when present).
     """
     mfr = (c.get("manufacturer") or "").strip()
     mdl = (c.get("model_number") or "").strip()
     section = (c.get("section") or "").strip()
     src_url = (c.get("source_url") or "").strip()
+    # Pull page_num from the top-level field (set by rag_worker._build_kb_status)
+    # and fall back to metadata for callers that haven't flattened it yet.
+    page_num = c.get("page_num")
+    if page_num is None:
+        meta = c.get("metadata")
+        if isinstance(meta, dict):
+            page_num = meta.get("page_num")
 
     label = ""
     if mdl:
@@ -325,6 +332,8 @@ def _format_citation_label(c: dict) -> str:
 
     if section:
         label = f"{label} — {section}"
+    if isinstance(page_num, int) and page_num > 0:
+        label = f"{label}, p. {page_num}"
     return label
 
 

--- a/mira-bots/tests/test_citation_format.py
+++ b/mira-bots/tests/test_citation_format.py
@@ -65,6 +65,41 @@ class TestCitationLabel:
         )
         assert label.endswith("Fault F0005")
 
+    def test_page_num_appended_when_present(self):
+        label = _format_citation_label(
+            {
+                "manufacturer": "Allen-Bradley",
+                "model_number": "PowerFlex 525",
+                "section": "Fault F004",
+                "page_num": 12,
+            }
+        )
+        assert label.endswith("p. 12")
+        assert "Fault F004" in label
+
+    def test_page_num_falls_back_to_metadata(self):
+        # Some callers pass the chunk dict before flattening; _format should
+        # still recover page_num from the metadata sub-dict.
+        label = _format_citation_label(
+            {
+                "manufacturer": "Allen-Bradley",
+                "model_number": "PowerFlex 525",
+                "metadata": {"page_num": 47, "section": ""},
+            }
+        )
+        assert label.endswith("p. 47")
+
+    def test_page_num_zero_or_none_omitted(self):
+        for bad in (None, 0, -1, "12", 12.5):
+            label = _format_citation_label(
+                {
+                    "manufacturer": "Allen-Bradley",
+                    "model_number": "PowerFlex 525",
+                    "page_num": bad,
+                }
+            )
+            assert "p." not in label
+
     def test_no_double_manufacturer(self):
         # If model already includes the manufacturer name, don't repeat it.
         label = _format_citation_label(

--- a/mira-crawler/ingest/converter.py
+++ b/mira-crawler/ingest/converter.py
@@ -4,7 +4,11 @@ Supports two backends:
 - pdfplumber (default, fast, text-layer PDFs only)
 - Docling (opt-in via USE_DOCLING=true, ML-powered, handles scanned PDFs)
 
-Returns list[dict] with keys {text, page_num, section}.
+Returns list[dict] with keys {text, page_num, section, chunk_type?}.
+Tables in PDFs are emitted as separate chunks with chunk_type="table" and
+markdown-formatted text; pdfplumber's extract_text() alone would flatten
+table structure into whitespace and lose rows/columns.
+
 All exceptions caught — never crashes on bad input.
 """
 
@@ -13,6 +17,7 @@ from __future__ import annotations
 import io
 import logging
 import re
+from typing import Sequence
 
 logger = logging.getLogger("mira-crawler.converter")
 
@@ -66,12 +71,46 @@ def _detect_sections(page_text: str) -> list[tuple[str, str]]:
     return sections
 
 
+def _format_table_markdown(table: "Sequence[Sequence[str | None]]") -> str:
+    """Convert a pdfplumber table (list of rows) into GitHub-flavored markdown.
+
+    Returns empty string if the table is too small to be meaningful
+    (<2 non-empty rows or <2 columns after normalization).
+    """
+    if not table:
+        return ""
+
+    rows = [
+        [(cell or "").replace("\n", " ").replace("|", "\\|").strip() for cell in row]
+        for row in table
+    ]
+    rows = [r for r in rows if any(c for c in r)]
+    if len(rows) < 2:
+        return ""
+
+    width = max(len(r) for r in rows)
+    if width < 2:
+        return ""
+    rows = [r + [""] * (width - len(r)) for r in rows]
+
+    header, body = rows[0], rows[1:]
+    lines = [
+        "| " + " | ".join(header) + " |",
+        "|" + "|".join(["---"] * width) + "|",
+    ]
+    lines.extend("| " + " | ".join(r) + " |" for r in body)
+    return "\n".join(lines)
+
+
 def extract_from_pdf(
     data: bytes, max_pages: int = 300, min_chars: int = 80
 ) -> list[dict]:
-    """Extract text blocks from PDF bytes using pdfplumber.
+    """Extract text + table blocks from PDF bytes using pdfplumber.
 
-    Returns list of {text, page_num, section} dicts.
+    Returns list of {text, page_num, section, chunk_type?} dicts.
+    Tables are emitted as separate chunks with chunk_type="table" and
+    markdown-formatted text. Text and table chunks are both returned so
+    retrieval can rank them independently.
     """
     try:
         import pdfplumber
@@ -80,29 +119,50 @@ def extract_from_pdf(
         return []
 
     blocks: list[dict] = []
+    table_count = 0
     try:
         with pdfplumber.open(io.BytesIO(data)) as doc:
             pages_to_read = min(len(doc.pages), max_pages)
             for page_idx in range(pages_to_read):
-                raw = doc.pages[page_idx].extract_text()
-                if not raw or len(raw.strip()) < 50:
-                    continue
-                text = _clean_text(raw)
-                sections = _detect_sections(text)
-                if not sections:
-                    sections = [("", text)]
-                for heading, body in sections:
-                    if len(body) >= min_chars:
+                page = doc.pages[page_idx]
+                raw = page.extract_text()
+                sections: list[tuple[str, str]] = []
+                if raw and len(raw.strip()) >= 50:
+                    text = _clean_text(raw)
+                    sections = _detect_sections(text) or [("", text)]
+                    for heading, body in sections:
+                        if len(body) >= min_chars:
+                            blocks.append({
+                                "text": body,
+                                "page_num": page_idx + 1,
+                                "section": heading,
+                            })
+
+                try:
+                    tables = page.extract_tables() or []
+                except Exception as e:
+                    # pdfplumber raises on some malformed pages; skip tables on this page only
+                    logger.debug("table extraction failed on page %d: %s", page_idx + 1, e)
+                    tables = []
+                heading_for_tables = sections[-1][0] if sections else ""
+                for table in tables:
+                    md = _format_table_markdown(table)
+                    if len(md) >= min_chars:
                         blocks.append({
-                            "text": body,
+                            "text": md,
                             "page_num": page_idx + 1,
-                            "section": heading,
+                            "section": heading_for_tables,
+                            "chunk_type": "table",
                         })
+                        table_count += 1
     except Exception as e:
         logger.warning("PDF extraction failed: %s", e)
         return []
 
-    logger.info("Extracted %d blocks from PDF (%d pages read)", len(blocks), pages_to_read)
+    logger.info(
+        "Extracted %d blocks from PDF (%d pages read, %d table chunks)",
+        len(blocks), pages_to_read, table_count,
+    )
     return blocks
 
 

--- a/mira-crawler/tests/test_converter_tables.py
+++ b/mira-crawler/tests/test_converter_tables.py
@@ -1,0 +1,108 @@
+"""Tests for table extraction in mira-crawler/ingest/converter.py.
+
+Covers _format_table_markdown (pure helper) and extract_from_pdf table emission
+behavior (mocked pdfplumber page so no real PDF required).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ingest.converter import _format_table_markdown, extract_from_pdf
+
+
+class TestFormatTableMarkdown:
+    def test_basic_table_renders_github_markdown(self):
+        table = [
+            ["Param", "Value", "Units"],
+            ["Voltage", "480", "V"],
+            ["Current", "12.5", "A"],
+        ]
+        md = _format_table_markdown(table)
+        assert "| Param | Value | Units |" in md
+        assert "|---|---|---|" in md
+        assert "| Voltage | 480 | V |" in md
+        assert "| Current | 12.5 | A |" in md
+
+    def test_none_and_empty_cells_become_blank(self):
+        md = _format_table_markdown([["A", "B"], [None, ""], ["", "x"]])
+        assert "|  | x |" in md
+
+    def test_pipe_in_cell_escaped(self):
+        md = _format_table_markdown([["k", "v"], ["a", "x|y"]])
+        assert "x\\|y" in md
+
+    def test_newline_in_cell_collapsed(self):
+        md = _format_table_markdown([["k", "v"], ["a", "line1\nline2"]])
+        assert "line1 line2" in md
+
+    def test_rejects_table_smaller_than_two_rows(self):
+        assert _format_table_markdown([["solo"]]) == ""
+        assert _format_table_markdown([]) == ""
+
+    def test_rejects_single_column(self):
+        assert _format_table_markdown([["A"], ["B"]]) == ""
+
+    def test_pads_short_rows(self):
+        md = _format_table_markdown([["A", "B", "C"], ["x"]])
+        assert "| x |  |  |" in md
+
+
+def _mock_page(text: str = "", tables: list | None = None):
+    page = MagicMock()
+    page.extract_text.return_value = text
+    page.extract_tables.return_value = tables or []
+    return page
+
+
+def _mock_doc(*pages):
+    doc = MagicMock()
+    doc.pages = list(pages)
+    doc.__enter__.return_value = doc
+    doc.__exit__.return_value = False
+    return doc
+
+
+class TestExtractFromPdfTableChunks:
+    def test_table_chunk_emitted_with_chunk_type_table(self):
+        pdfplumber = pytest.importorskip("pdfplumber")
+        long_table = [
+            ["Parameter", "Range", "Default"],
+            ["acceleration time", "0.1-600 s " * 5, "10 s"],
+            ["deceleration time", "0.1-600 s " * 5, "10 s"],
+        ]
+        page = _mock_page(text="Some intro text. " * 20, tables=[long_table])
+        with patch.object(pdfplumber, "open", return_value=_mock_doc(page)):
+            blocks = extract_from_pdf(b"fake", max_pages=10, min_chars=20)
+
+        table_blocks = [b for b in blocks if b.get("chunk_type") == "table"]
+        assert len(table_blocks) == 1
+        assert table_blocks[0]["page_num"] == 1
+        assert "| Parameter | Range | Default |" in table_blocks[0]["text"]
+
+    def test_tables_below_min_chars_are_skipped(self):
+        pdfplumber = pytest.importorskip("pdfplumber")
+        page = _mock_page(text="A " * 60, tables=[[["a", "b"], ["c", "d"]]])
+        with patch.object(pdfplumber, "open", return_value=_mock_doc(page)):
+            blocks = extract_from_pdf(b"fake", max_pages=10, min_chars=200)
+
+        assert not any(b.get("chunk_type") == "table" for b in blocks)
+
+    def test_table_extraction_failure_isolated_to_page(self):
+        pdfplumber = pytest.importorskip("pdfplumber")
+        bad = MagicMock()
+        bad.extract_text.return_value = "Page 1 content. " * 20
+        bad.extract_tables.side_effect = RuntimeError("malformed")
+        good = _mock_page(
+            text="Page 2 content. " * 20,
+            tables=[[["Col1", "Col2"], ["a" * 100, "b" * 100]]],
+        )
+        with patch.object(pdfplumber, "open", return_value=_mock_doc(bad, good)):
+            blocks = extract_from_pdf(b"fake", max_pages=10, min_chars=20)
+
+        text_pages = sorted({b["page_num"] for b in blocks if b.get("chunk_type") != "table"})
+        table_pages = [b["page_num"] for b in blocks if b.get("chunk_type") == "table"]
+        assert text_pages == [1, 2]
+        assert table_pages == [2]


### PR DESCRIPTION
## Summary
Two complementary bugs in the document pipeline that the RAGFlow ingestion evaluation surfaced. Both are read-side / chunk-shape changes — no schema migration, no deploy gating.

## Bug 1: pdfplumber strips table structure

`pdfplumber.Page.extract_text()` flattens table cells to whitespace, so every chunk built from a page containing a table loses the rows/columns. The RAGFlow eval estimated ~323 tables lost across PowerFlex 525 + Micro820 manuals alone — every parameter range, fault-code table, and PM interval table became unsearchable.

**Fix:** add an `extract_tables()` pass per page in `mira-crawler/ingest/converter.py`. Each detected table is converted to GitHub-flavored markdown (pipes/dashes), emitted as a separate chunk with `chunk_type=\"table\"`, tagged with the most recent section heading on the page. Text chunks still emit as before, so retrieval can rank text vs. table chunks independently.

The downstream chain already supports the new field:
- `mira-core/scripts/ingest_manuals.py:382-398` reads `chunk.get(\"chunk_type\", \"text\")`
- `mira-core/mira-ingest/db/neon.py:insert_knowledge_entries_batch` propagates `chunk_type` into the `knowledge_entries.chunk_type` column

## Bug 2: page number never surfaces in citations

`_format_citation_label()` in `mira-bots/shared/response_formatter.py` read manufacturer/model/section/source_url but **never read `page_num`** — even though `rag_worker._build_kb_status` flattens it onto the citation dict at line 601. Symptom: replies show
> [1] Allen-Bradley PowerFlex 525 — Fault F004

when they could show
> [1] Allen-Bradley PowerFlex 525 — Fault F004, p. 12

This is also why \"Citations say 'from manual' but can't say 'page 12'\" in the eval — the metadata IS in NeonDB, the formatter just discarded it.

**Fix:** read `c.get(\"page_num\")` first, fall back to `c.get(\"metadata\", {}).get(\"page_num\")`, append `, p. {N}` only for strictly positive int values. Existing label semantics unchanged when `page_num` is absent.

## Files

| File | Change |
|------|--------|
| `mira-crawler/ingest/converter.py` | New `_format_table_markdown()` helper; `extract_from_pdf` adds per-page table extraction loop |
| `mira-bots/shared/response_formatter.py` | `_format_citation_label` reads page_num (top-level + metadata fallback), appends \"p. N\" |
| `mira-crawler/tests/test_converter_tables.py` | 10 new tests (helper edge cases + mocked extract_from_pdf integration) |
| `mira-bots/tests/test_citation_format.py` | 3 new tests (page appended, metadata fallback, type guard) |

## Production impact

None on first deploy. Existing chunks in NeonDB retain their current `chunk_type` (mostly null / \"text\") — they won't be re-ingested by this PR. Once mira-crawler is rebuilt and the next ingest run happens, new table chunks land in `knowledge_entries.chunk_type='table'`.

Citation rendering picks up `page_num` on next response from a rebuilt bot container — no DB migration needed.

## Test plan

- [x] `pytest mira-crawler/tests/test_converter_tables.py -v` → 10/10 pass
- [x] `pytest mira-bots/tests/test_citation_format.py -v` → 18/18 pass (3 new)
- [ ] CI: ruff + lint + offline eval gates
- [ ] Smoke a known-table PDF (e.g. PowerFlex 525 parameter table) through mira-crawler on staging; confirm new chunks have `chunk_type='table'` and markdown content
- [ ] Run a follow-up question against an indexed manual on staging Slack; confirm reply citation shows \"p. N\"

## Not in scope

- `mira-core/scripts/ingest_manuals.py:_extract_from_pdf` (script-local duplicate of the pdfplumber loop) and `tools/ingest_local_pdfs.py:_extract_from_pdf` (yet another duplicate) — same bug pattern. Out of scope for this PR; should call the canonical `converter.extract_from_pdf` instead. Tracked as follow-up tech debt.
- Docling adapter — handles tables natively via its own structure-aware extraction. No change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)