### PR TITLE
fix(staging): atlas-api host.docker.internal mapping for MinIO hairpin NAT

### DIFF
--- a/docker-compose.staging-vps.yml
+++ b/docker-compose.staging-vps.yml
@@ -77,6 +77,13 @@ services:
         condition: service_healthy
       atlas-minio:
         condition: service_started
+    extra_hosts:
+      # Linux Docker bridge has no hairpin NAT — atlas-api's MinioService.init()
+      # connects to PUBLIC_MINIO_ENDPOINT at startup and crash-loops when that URL
+      # points at the host's public IP. Mapping host.docker.internal to the host
+      # gateway lets factorylm/stg set ATLAS_PUBLIC_MINIO_URL=http://host.docker.internal:4900.
+      # Same pattern shipped for prod in PR #1439 (mira-cmms/docker-compose.yml).
+      - "host.docker.internal:host-gateway"
     environment:
       DB_URL: stg-atlas-db/atlas
       DB_USER: ${ATLAS_DB_USER:-atlas}
@@ -90,7 +97,7 @@ services:
       MINIO_ACCESS_KEY: ${ATLAS_MINIO_USER:-minioadmin}
       MINIO_SECRET_KEY: ${ATLAS_MINIO_PASSWORD}
       STORAGE_TYPE: minio
-      PUBLIC_MINIO_ENDPOINT: ${ATLAS_PUBLIC_MINIO_URL:-http://165.245.138.91:4900}
+      PUBLIC_MINIO_ENDPOINT: ${ATLAS_PUBLIC_MINIO_URL:-http://host.docker.internal:4900}
       INVITATION_VIA_EMAIL: "false"
       ENABLE_EMAIL_NOTIFICATIONS: "false"
       ENABLE_SSO: "false"


### PR DESCRIPTION
## Summary
- Mirror PR #1439's fix to `docker-compose.staging-vps.yml` (prod compose untouched there)
- `stg-atlas-api` is currently restart-looping in staging with `Failed to connect to /165.245.138.91:4900` — Linux Docker bridge lacks hairpin NAT
- Adds `extra_hosts: host.docker.internal:host-gateway` + changes `PUBLIC_MINIO_ENDPOINT` default to `host.docker.internal:4900`

## Test plan
- [ ] Merge → `gh workflow run deploy-staging.yml -f services="atlas-api"` (once the workflow Doppler-token issue is sorted; until then, manual recreate on VPS)
- [ ] `curl http://165.245.138.91:4088/` returns 200 (currently times out)
- [ ] `docker logs stg-atlas-api` no longer shows MinIO connect errors
- [ ] Prod atlas-api unaffected (saas.yml not touched here)

Closes the atlas-api leg of the staging environment work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)