### PR TITLE
feat(staging): wire @Mira_stagong_bot Telegram bot into staging stack

### DIFF
--- a/docker-compose.staging-vps.yml
+++ b/docker-compose.staging-vps.yml
@@ -8,9 +8,11 @@
 #   doppler run --project factorylm --config stg -- \
 #     docker compose -f docker-compose.staging.yml up -d
 #
-# Phase 1 services only — NO bots (shared Slack tokens would dual-poll prod),
-# NO docling (1.7GB RAM), NO mira-core/ingest/sidecar/relay/bridge. The goal
-# is "see Hub from phone against staging NeonDB branch" — not a full replica.
+# Phase 1 services + staging Telegram bot (@Mira_stagong_bot — separate token
+# from prod, safe to dual-deploy). Still NO Slack bot (shared token would
+# dual-poll prod), NO docling (1.7GB RAM), NO mira-core/ingest/sidecar/relay/
+# bridge. The goal is "test from phone against staging NeonDB branch" — not a
+# full replica.
 #
 # Production runs on docker-compose.saas.yml and is NEVER touched by this file.
 #
@@ -307,6 +309,60 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+
+  # ─── Staging Telegram bot ──────────────────────────────────────────────────
+  # Polls @Mira_stagong_bot. MUST use TELEGRAM_BOT_TOKEN_STG (separate token
+  # from prod). Runs the Supervisor engine in-process — does not call
+  # mira-pipeline over HTTP.
+  mira-bot-telegram:
+    build:
+      context: .
+      dockerfile: mira-bots/telegram/Dockerfile
+    container_name: stg-mira-bot-telegram
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN_STG}
+      - MIRA_DB_PATH=/mira-db/mira.db
+      - OPENWEBUI_BASE_URL=disabled://staging
+      - OPENWEBUI_API_KEY=
+      - KNOWLEDGE_COLLECTION_ID=
+      - NEON_DATABASE_URL=${NEON_DATABASE_URL:-}
+      - MIRA_TENANT_ID=${MIRA_TENANT_ID:-staging}
+      - ADMIN_TELEGRAM_IDS=${ADMIN_TELEGRAM_IDS:-}
+      - VISION_MODEL=qwen2.5vl:7b
+      - OLLAMA_BASE_URL=disabled://staging
+      - INFERENCE_BACKEND=cloud
+      - GROQ_API_KEY=${GROQ_API_KEY:-}
+      - GROQ_MODEL=llama-3.3-70b-versatile
+      - GROQ_VISION_MODEL=meta-llama/llama-4-scout-17b-16e-instruct
+      - CEREBRAS_API_KEY=${CEREBRAS_API_KEY:-}
+      - CEREBRAS_MODEL=llama3.1-8b
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
+      - GEMINI_MODEL=${GEMINI_MODEL:-gemini-2.5-flash}
+      - GEMINI_VISION_MODEL=${GEMINI_VISION_MODEL:-gemini-2.5-flash}
+      - MCP_REST_API_KEY=${MCP_REST_API_KEY:-}
+      - MCP_BASE_URL=http://stg-mira-mcp:8001
+      - INGEST_SERVICE_URL=disabled://staging
+      - SESSION_RECORDING_PATH=/data/sessions
+      - NTFY_URL=${NTFY_URL:-https://ntfy.sh}
+      - NTFY_TOPIC=${NTFY_TOPIC:-mira-staging-alerts}
+    volumes:
+      - /opt/mira-staging/data:/mira-db
+      - /opt/mira-staging/data/sessions:/data/sessions
+    networks:
+      - staging-net
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    healthcheck:
+      test: ["CMD", "sh", "-c", "cat /proc/1/cmdline | tr '\\0' ' ' | grep -q 'bot.py'"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
 
 networks:
   staging-net:


### PR DESCRIPTION
## Summary
- Adds `stg-mira-bot-telegram` service to `docker-compose.staging-vps.yml`
- Reads `TELEGRAM_BOT_TOKEN_STG` from Doppler `factorylm/stg` (separate token from prod `@FactoryLM_Diagnose`, set 2026-05-19)
- Polls `@Mira_stagong_bot` — Mike's new staging bot for phone testing

## Why
Phase 1 staging compose explicitly excluded bots because Slack tokens are shared between stg and prod (dual-poll risk). Telegram now has a dedicated staging token, so the dual-poll concern is gone for that adapter. Slack remains excluded.

## Config
- Runs Supervisor engine in-process (same pattern as prod bot — no HTTP to mira-pipeline)
- `MCP_BASE_URL=http://stg-mira-mcp:8001` (staging MCP, staging Neon branch)
- `NEON_DATABASE_URL=${NEON_DATABASE_URL}` (resolves to staging branch via `factorylm/stg`)
- `OPENWEBUI_BASE_URL`/`OLLAMA_BASE_URL`/`INGEST_SERVICE_URL` → `disabled://staging` (consistent with rest of stg stack)
- Volume `/opt/mira-staging/data:/mira-db` — isolated from prod SQLite

## Test plan
- [ ] `gh workflow run smoke-test.yml` passes (or pre-existing pre-existing fails parity-check vs main)
- [ ] Deploy: `ssh root@165.245.138.91 'cd /opt/mira-staging && git pull && doppler run --project factorylm --config stg -- docker compose -f docker-compose.staging-vps.yml up -d --build stg-mira-bot-telegram'`
- [ ] `docker ps --filter name=stg-mira-bot-telegram` shows running
- [ ] `docker logs stg-mira-bot-telegram --tail 20` — successful Telegram polling, no token errors
- [ ] Test message to `@Mira_stagong_bot` returns a grounded answer
- [ ] Prod bot `mira-bot-telegram-saas` still responding (token-isolation check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)