### PR TITLE
fix(hub): synthesize missing parent nodes in namespace tree (#1344)

### DIFF
--- a/mira-hub/src/app/(hub)/namespace/page.tsx
+++ b/mira-hub/src/app/(hub)/namespace/page.tsx
@@ -42,6 +42,8 @@ const KIND_ICON: Record<string, React.ElementType> = {
   component: Cog,
   component_template: Cog,
   document: FileText,
+  // Synthesized parent (no kg_entities row) — see #1344. Renders as a folder.
+  namespace: Layers,
 };
 
 // Next.js `<Link>` auto-prepends the configured basePath ('/hub' in this

--- a/mira-hub/src/app/api/namespace/tree/route.test.ts
+++ b/mira-hub/src/app/api/namespace/tree/route.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { buildTree, type NamespaceNode } from "./route";
+
+interface EntityFixture {
+  id: string;
+  entity_type: string;
+  entity_id: string;
+  name: string;
+  uns_path: string | null;
+  created_at: string;
+}
+
+function entity(p: Partial<EntityFixture> & { id: string }): EntityFixture {
+  return {
+    entity_type: "equipment",
+    entity_id: p.id,
+    name: p.name ?? p.id,
+    uns_path: null,
+    created_at: "2026-05-19T00:00:00Z",
+    ...p,
+  };
+}
+
+function findByPath(nodes: NamespaceNode[], path: string): NamespaceNode | null {
+  for (const n of nodes) {
+    if (n.unsPath === path) return n;
+    const inChild = findByPath(n.children, path);
+    if (inChild) return inChild;
+  }
+  return null;
+}
+
+describe("buildTree — namespace tree", () => {
+  it("nests entities under existing parent entities (wizard path)", () => {
+    const entities = [
+      entity({ id: "site-1", entity_type: "site", name: "Lake Wales", uns_path: "enterprise.lake_wales" }),
+      entity({ id: "line-1", entity_type: "line", name: "Line A", uns_path: "enterprise.lake_wales.line_a" }),
+      entity({ id: "eq-1", entity_type: "equipment", name: "Pump-01", uns_path: "enterprise.lake_wales.line_a.pump_01" }),
+    ];
+    const roots = buildTree(entities, []);
+    expect(roots).toHaveLength(1);
+    const site = findByPath(roots, "enterprise.lake_wales");
+    expect(site?.kind).toBe("site");
+    expect(site?.children).toHaveLength(1);
+    expect(site?.children[0].unsPath).toBe("enterprise.lake_wales.line_a");
+    expect(site?.children[0].children[0].unsPath).toBe("enterprise.lake_wales.line_a.pump_01");
+  });
+
+  it("synthesizes missing ancestor nodes so orphan leaves nest correctly (#1344)", () => {
+    // Real bug shape: a manual row with a deep path but no intermediate parent rows.
+    const entities = [
+      entity({
+        id: "manual-siemens-sinamics",
+        entity_type: "manual",
+        name: "Siemens SINAMICS Manual",
+        uns_path: "enterprise.knowledge_base.siemens.sinamics.manuals",
+      }),
+    ];
+    const roots = buildTree(entities, []);
+
+    // Only one root: the synthesized 'enterprise' namespace.
+    expect(roots).toHaveLength(1);
+    expect(roots[0].unsPath).toBe("enterprise");
+    expect(roots[0].kind).toBe("namespace");
+    expect(roots[0].id).toBe("synthetic:enterprise");
+
+    // The full path is reachable through synthesized parents.
+    expect(findByPath(roots, "enterprise.knowledge_base")?.kind).toBe("namespace");
+    expect(findByPath(roots, "enterprise.knowledge_base.siemens")?.name).toBe("Siemens");
+    expect(findByPath(roots, "enterprise.knowledge_base.siemens.sinamics")?.name).toBe("Sinamics");
+
+    const manualNode = findByPath(roots, "enterprise.knowledge_base.siemens.sinamics.manuals");
+    expect(manualNode?.kind).toBe("manual");
+    expect(manualNode?.id).toBe("manual-siemens-sinamics");
+  });
+
+  it("merges multiple orphans under a single synthesized ancestor", () => {
+    const entities = [
+      entity({
+        id: "m1",
+        entity_type: "manual",
+        name: "Siemens Manual",
+        uns_path: "enterprise.knowledge_base.siemens.sinamics.manuals",
+      }),
+      entity({
+        id: "m2",
+        entity_type: "manual",
+        name: "Allen Manual",
+        uns_path: "enterprise.knowledge_base.allen_bradley.powerflex_525.manuals",
+      }),
+    ];
+    const roots = buildTree(entities, []);
+    expect(roots).toHaveLength(1);
+    const kb = findByPath(roots, "enterprise.knowledge_base");
+    expect(kb?.children).toHaveLength(2);
+    // Display name title-cases segments split by underscore.
+    expect(findByPath(roots, "enterprise.knowledge_base.allen_bradley")?.name).toBe("Allen Bradley");
+  });
+
+  it("synthesized parents have zero proposal counts and synthetic id prefix", () => {
+    const roots = buildTree(
+      [entity({ id: "m1", entity_type: "manual", uns_path: "enterprise.knowledge_base.siemens" })],
+      [{ uns_path: "enterprise.knowledge_base", status: "proposed", cnt: "5" }],
+    );
+    const kb = findByPath(roots, "enterprise.knowledge_base");
+    expect(kb?.id).toBe("synthetic:enterprise.knowledge_base");
+    // Proposals attach to real entity rows only — synthetic parents stay at zero.
+    expect(kb?.counts.proposalsPending).toBe(0);
+  });
+
+  it("does not synthesize when all parents already have real rows", () => {
+    const entities = [
+      entity({ id: "ent", entity_type: "namespace_root", uns_path: "enterprise", name: "Enterprise" }),
+      entity({ id: "site", entity_type: "site", uns_path: "enterprise.lake_wales", name: "Lake Wales" }),
+      entity({ id: "eq", entity_type: "equipment", uns_path: "enterprise.lake_wales.pump", name: "Pump" }),
+    ];
+    const roots = buildTree(entities, []);
+    expect(roots).toHaveLength(1);
+    expect(roots[0].id).toBe("ent");
+    expect(roots[0].kind).toBe("namespace_root");
+  });
+
+  it("entities with null uns_path remain top-level roots", () => {
+    const entities = [
+      entity({ id: "orphan-1", entity_type: "tag", name: "Loose Tag", uns_path: null }),
+      entity({ id: "eq-1", entity_type: "equipment", uns_path: "enterprise.site.eq", name: "EQ" }),
+    ];
+    const roots = buildTree(entities, []);
+    // Loose tag stays as a root; the equipment forms its own synthesized tree.
+    expect(roots.length).toBeGreaterThanOrEqual(2);
+    expect(roots.some((r) => r.id === "orphan-1")).toBe(true);
+  });
+});

--- a/mira-hub/src/app/api/namespace/tree/route.ts
+++ b/mira-hub/src/app/api/namespace/tree/route.ts
@@ -38,6 +38,7 @@ export interface NamespaceNode {
   id: string;
   name: string;
   kind: string; // entity_type — 'site', 'area', 'line', 'asset', 'component', 'document', ...
+                // or 'namespace' for a synthesized path segment that has no kg_entities row.
   unsPath: string | null;
   counts: {
     children: number;
@@ -87,7 +88,7 @@ export async function GET() {
   }
 }
 
-function buildTree(
+export function buildTree(
   entities: KgEntityRow[],
   proposalCounts: ProposalCountRow[],
 ): NamespaceNode[] {
@@ -123,6 +124,21 @@ function buildTree(
     nodesByPath.set(e.uns_path ?? `__orphan__:${e.id}`, node);
   }
 
+  // Synthesize parent nodes for any ancestor path that lacks a kg_entities row.
+  // Without this, a manual at `enterprise.knowledge_base.siemens.sinamics.manuals`
+  // with no row at `enterprise.knowledge_base.siemens` would render as a top-level
+  // root instead of nesting under "Siemens". See #1344.
+  for (const e of entities) {
+    if (!e.uns_path) continue;
+    let cursor = parentOf(e.uns_path);
+    while (cursor) {
+      if (!nodesByPath.has(cursor)) {
+        nodesByPath.set(cursor, synthesizeParent(cursor));
+      }
+      cursor = parentOf(cursor);
+    }
+  }
+
   for (const node of nodesByPath.values()) {
     if (!node.unsPath || node.unsPath.length === 0) {
       roots.push(node);
@@ -145,4 +161,22 @@ function parentOf(path: string): string | null {
   const i = path.lastIndexOf(".");
   if (i < 0) return null;
   return path.slice(0, i);
+}
+
+function synthesizeParent(path: string): NamespaceNode {
+  const lastSegment = path.slice(path.lastIndexOf(".") + 1);
+  // Display: replace underscores with spaces, title-case each word.
+  const display = lastSegment
+    .split("_")
+    .filter((s) => s.length > 0)
+    .map((s) => s.charAt(0).toUpperCase() + s.slice(1))
+    .join(" ");
+  return {
+    id: `synthetic:${path}`,
+    name: display || lastSegment,
+    kind: "namespace",
+    unsPath: path,
+    counts: { children: 0, proposalsPending: 0, proposalsVerified: 0 },
+    children: [],
+  };
 }


### PR DESCRIPTION
Closes #1344.

## Summary
- Manuals/equipment with deep `uns_path`s were rendering as top-level roots in `/namespace` because no intermediate `kg_entities` rows existed for ancestor paths like `enterprise` or `enterprise.knowledge_base.<mfr>`.
- `buildTree` now walks each entity's parent chain and synthesizes `kind: "namespace"` nodes for any missing ancestor, so the existing 269 `manual` rows and 552 `enterprise.*` paths nest correctly without a backfill or hourly Routine.

## Empirical baseline (prod NeonDB, 2026-05-19, read-only)
```
entity_type | total | with_uns_path
manual      |   281 |           269
equipment   |   276 |           276   ← #1343 already fixed in 739478d8

rows at uns_path 'enterprise' or 'enterprise.knowledge_base' : 0
rows with entity_type IN ('manufacturer','model')            : 0
```

Without synthesis, every one of those 269 manuals is its own root.

## Approach vs. the original spec
The issue proposed mirroring `knowledge_entries` into `kg_entities` as new `manufacturer` / `model` rows plus an hourly Routine. I went with the smaller fix:
- Tree builder synthesizes parents on read → ~30 lines, no new tables, no new worker, no new ON CONFLICT semantics to maintain.
- Handles **all** orphan entity types (manuals today, parts/fault_codes/plc_tags tomorrow) without per-type code.
- Synthesized nodes have `id: "synthetic:<path>"` so the frontend can distinguish them; proposals attach to real entity rows only, so synthesized parents stay at zero counts (correct behavior).
- If a real row later lands at a synthesized path, the real row wins on read (we check `nodesByPath.has(cursor)` before synthesizing).

## Test plan
- [x] `bun run test src/app/api/namespace/tree/route.test.ts` → 6/6 pass
  - Wizard-path nesting (real parents, no synthesis)
  - Knowledge_base orphan synthesis (the actual bug shape)
  - Multi-orphan merge under a shared synthesized ancestor
  - Zero proposal counts on synthesized nodes
  - No synthesis when all parents have real rows
  - `uns_path = null` entities remain top-level roots
- [x] `bun run test src/lib/knowledge-graph/__tests__/cmms-sync.test.ts` → 12/12 (no regression in adjacent code)
- [x] `bun run lint` on changed files → clean
- [x] `npx tsc --noEmit` → only pre-existing unrelated error in `rls-deny.integration.test.ts`

## Manual verification on staging
After deploy, hit `/api/namespace/tree` with a tenant that has knowledge_entries data and verify the response collapses into a single `enterprise` root with `enterprise.knowledge_base.<mfr>.<model>` substructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)