### PR TITLE
docs: Fuuz-inspired MIRA skills architecture — research + planning

### DIFF
--- a/docs/planning/mira-claude-skills-architecture.md
+++ b/docs/planning/mira-claude-skills-architecture.md
@@ -1,0 +1,341 @@
+# MIRA Claude Code Skill System — Architecture Plan
+
+**Date:** 2026-05-19
+**Status:** Planning draft (Phase 2 of the Fuuz-adaptation initiative). Not yet implementation.
+**Companion docs:** `docs/research/fuuz-skills-analysis.md`, `docs/planning/mira-skills-codebase-gap-analysis.md`, `docs/planning/mira-claude-skills-implementation-roadmap.md`, `docs/planning/mira-skills-file-tree.md`, `docs/planning/mira-skills-eval-plan.md`.
+
+---
+
+## 1. Purpose
+
+MIRA already has 15+ Claude Code skills under `.claude/skills/`, written ad-hoc as the codebase grew. The Fuuz analysis (`docs/research/fuuz-skills-analysis.md`) surfaced several **structural patterns** that MIRA's skill suite can adopt to become more accurate, maintainable, and easier for Claude to navigate:
+
+- Two-tier `SKILL.md` + `references/` layout
+- Numbered, domain-prefixed golden rules (`UNS-001`, `KG-014`, `ENG-022`)
+- Severity tiers (`[FATAL]` / `[WARNING]` / `[STYLE]`)
+- Output checklists as final gates
+- Error-message-to-cause reference sections
+- A central `cross-skill-index.md` + `MANIFEST.md` so Claude (and humans) can find the right skill quickly
+- Explicit negative triggers on reference-style skills
+
+This document proposes the **target architecture** of MIRA's skill suite — not the implementation plan (that lives in the roadmap). It states the principles, the planned skill inventory, the layering, the triggering model, the dependency graph, and the contracts each skill must satisfy.
+
+It is explicitly **not** a port of the Fuuz skill content. MIRA's product wedge (maintenance intelligence + grounded technician chat) is fundamentally different from Fuuz's wedge (no-code industrial app builder). The Fuuz repo informs *how* MIRA structures its skills; the *content* is MIRA-native, written from scratch, and grounded in the existing MIRA codebase.
+
+---
+
+## 2. Principles
+
+### 2.1 MIRA-native by construction
+
+Every skill describes MIRA's actual code, schemas, or doctrine. If a skill cannot point to specific MIRA files (modules, migrations, specs, ADRs) it does not belong in the suite. Skill content is verified against the codebase before merge; "advice-shaped" or aspirational content goes to `docs/specs/` or a plan, not a skill.
+
+### 2.2 Grounded-by-default
+
+MIRA's product principle is grounding (`docs/THEORY_OF_OPERATIONS.md`). Skills reflect that: every rule in a skill must trace to an MIRA contract — a spec, a migration, a `CLAUDE.md` clause, an ADR, an existing rule file under `.claude/rules/`, a Karpathy-style behavior law, or a tested code path. No floating "best practices."
+
+### 2.3 Small surface, deep references
+
+Following the Fuuz two-tier pattern, each MIRA SKILL.md stays scannable (target: ≤500 lines; hard cap: 800). Depth lives in `references/`. Reference files may carry their own frontmatter when standalone activation is useful, but most are pure references read by Claude only when SKILL.md tells it to.
+
+### 2.4 Explicit triggers (positive AND negative)
+
+Each skill's frontmatter declares both when to fire and — for reference/platform skills — when not to fire. This is the Fuuz negative-trigger pattern, adopted because MIRA's skill count is growing and over-activation causes Claude to drown specialized skills under reference noise.
+
+### 2.5 Versioned and auditable
+
+Skills carry semantic versions in their frontmatter and roll up to `.claude/skills/MANIFEST.md`. Any PR that changes a skill bumps its version. Any PR that changes the code a skill describes either updates the skill in the same PR or files a follow-up issue tagged `skill-drift`.
+
+### 2.6 Promote behavior, not facts
+
+Skills tell Claude **how to behave** when facing a class of task. They are not a wiki. Pure factual reference (ports, env vars, container map) stays in `CLAUDE.md`, `docs/env-vars.md`, `wiki/hot.md`. A skill that is read-mostly-once and not action-shaping should not be a skill.
+
+### 2.7 Severity-coded constraints
+
+Constraints in skills carry a severity tag — borrowed from Fuuz, MIRA-specific:
+
+| Tag | Meaning | Examples |
+|---|---|---|
+| `[FATAL]` | Breaks the product. Never do. | Auto-promote `proposed → verified` without admin review. Begin troubleshooting before UNS gate confirms. Reintroduce Anthropic as provider. |
+| `[BLOCKING]` | Must do before merge. | Run `mira-run-hallucination-audit` after engine edits. Add a golden case for any new gate behavior. |
+| `[WARNING]` | Almost always required; document an exception in PR. | Sanitize PII before logging an LLM call. Cite a manual page when extracting a fact. |
+| `[STYLE]` | Best-practice; reviewer judgment. | Naming, formatting, ordering of imports. |
+
+Severity is enforced socially (PR review + reviewer skill) and, where automatable, programmatically (`tools/hooks/prod-guard.sh`, `pre-commit`).
+
+### 2.8 Independent of Fuuz
+
+No Fuuz prose, no Fuuz numbered-rules lists, no Fuuz JSON templates appear in MIRA skills. The Fuuz repo is consulted as a structural reference and discarded.
+
+---
+
+## 3. Skill catalogue (target state)
+
+MIRA's target skill suite is **eight core skills** + supporting reference indexes. Several already exist in some form. Naming is normalized; existing skills are mapped to their new role where applicable.
+
+Each row below shows:
+- **Skill name** (target)
+- **Status:** `EXISTS` (already in `.claude/skills/`), `EVOLVE` (exists but needs restructuring), `NEW` (does not exist)
+- **Existing path** (if any)
+- **Trigger** (positive)
+- **Owner directories in MIRA**
+
+| # | Skill | Status | Existing path | Trigger (positive) | Owner directories |
+|---|---|---|---|---|---|
+| 1 | `mira-platform` | NEW (rooted in existing `mira-architecture-guardian`) | `.claude/skills/mira-architecture-guardian/SKILL.md` | Read-only reference: any task that needs MIRA's North Star, environment boundaries, provider cascade, or architectural invariants. Auto-activates as a co-skill when other skills fire. | `CLAUDE.md`, `.claude/CLAUDE.md`, `docs/THEORY_OF_OPERATIONS.md`, `docs/ARCHITECTURE.md`, `.claude/rules/` |
+| 2 | `mira-uns-architecture` | EVOLVE | `.claude/skills/uns-location-gate-designer/SKILL.md` | Any change touching UNS path construction, the resolver, the location gate, MQTT/Sparkplug topic mapping, or `kg_entities.uns_path`. | `mira-crawler/ingest/uns.py`, `mira-bots/shared/uns_resolver.py`, `mira-bots/shared/engine.py` (FSM), `docs/specs/uns-*.md`, `.claude/rules/uns-compliance.md` |
+| 3 | `mira-component-profile` | EVOLVE | `.claude/skills/component-profile-builder/SKILL.md` | Building, editing, validating, or promoting reusable component profiles; per-instance vs per-model decisions; schema field changes. | `mira-crawler/ingest/`, `docs/specs/mira-component-intelligence-architecture.md`, NeonDB component-related tables |
+| 4 | `mira-maintenance-workflow` | EVOLVE | `.claude/skills/diagnostic-workflow.md` (file, not folder), `.claude/skills/work-order-history-miner/`, `.claude/skills/uns-location-gate-designer/` | Designing or modifying the technician troubleshooting flow: gate → triage → diagnose → cite → step-by-step → close-out → WO update. | `mira-bots/slack/bot.py`, `mira-bots/shared/engine.py`, `mira-bots/shared/citation_compliance.py`, `mira-mcp/server.py` (CMMS tools), `docs/specs/dialogue-state-tracker-spec.md` |
+| 5 | `mira-industrial-safety` | NEW | — | Any feature that could surface advice for live equipment work (LOTO, arc-flash, energized PLCs, confined spaces, hot work, chemical exposure). Auto-activates alongside `mira-maintenance-workflow`. | `mira-bots/shared/guardrails.py` (SAFETY_KEYWORDS), `.claude/rules/security-boundaries.md`, `docs/THEORY_OF_OPERATIONS.md` |
+| 6 | `mira-plc-tag-intelligence` | EVOLVE | `.claude/skills/plc-tag-mapper/SKILL.md` | Mapping PLC tags to UNS / components; ingesting tag CSV exports; reasoning about Modbus / OPC UA quality codes. | `plc/`, `mira-connect/` (deferred), `mira-relay/`, Ignition tag exports, `docs/specs/uns-kg-unification-spec.md` |
+| 7 | `mira-telemetry-analysis` | NEW | — | Reasoning about live tag data, baselines, anomaly detection, sensor health, MTBF/MTTR/OEE-adjacent metrics derived from customer telemetry. Distinct from PLC tag *mapping*. | `mira-relay/`, `mira-bridge/` (Node-RED), future analytics path |
+| 8 | `mira-demo-builder` | NEW | (partial overlap with `mira-create-demo-plant`) | Creating reproducible demo plants/customers: seed data, Atlas WO history, fake UNS structures, golden chat transcripts. | `tools/` (seeders), `mira-cmms/` (Atlas), `tests/golden_*.csv` |
+
+### 3.1 Supporting indexes (not skills)
+
+| Asset | Path | Purpose |
+|---|---|---|
+| Skill version manifest | `.claude/skills/MANIFEST.md` | Semver + status + last-updated date per skill. Mirrors Fuuz `SKILLS_VERSION_MANIFEST.md`. |
+| Cross-skill decision matrix | `.claude/skills/cross-skill-index.md` | Task → skill mapping. Includes multi-skill workflows (e.g., "ingest a new manual + map its tags + propose KG entries"). |
+| Skill template | `.claude/skills/_template/SKILL.md` | Boilerplate frontmatter + section headers + checklist stub for any new skill. |
+
+### 3.2 Existing skills retained as-is (out of scope of this initiative)
+
+These keep their current shape; they are operational utilities, not domain skills:
+
+- `autonomous-run/` (pre-flight for overnight runs — already excellent)
+- `bot-grounding-tests/` (GS11 regression — already excellent)
+- `harness.md` (5-regime test framework)
+- `web-review/` (synthetic adversarial UI review)
+- `promo-director/`, `qr-onboarding/`, `marketing/`, `saas-activation.md`, `stripe.md` (GTM-facing)
+- `smart-commit.md`, `youtube-transcript.md`, `design-ship-routine.md`, `conversation-forensic.md`, `photo-ingest-watcher.md`, `telegram_bot_tuning.md`, `kb-benchmark.md`, `inference-routing.md` (operational helpers)
+- `mira-saas-scope-guard/` (scope guard — overlaps with `mira-platform` but stays as a dedicated trigger for SaaS-scope discussions)
+
+The domain-skill suite (rows 1–8) is what this plan restructures.
+
+---
+
+## 4. Layering
+
+Skills layer top-down. Higher layers fire freely; lower layers gate-keep what the higher layers can produce.
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ L0 — Doctrine (read-only, co-activates with anything below) │
+│       mira-platform                                          │
+│       mira-saas-scope-guard (preserved)                      │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ L1 — Domain knowledge (specialized triggers)                 │
+│       mira-uns-architecture                                  │
+│       mira-component-profile                                 │
+│       mira-plc-tag-intelligence                              │
+│       mira-telemetry-analysis                                │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ L2 — Workflow (orchestrates L1 skills around a user goal)    │
+│       mira-maintenance-workflow                              │
+│       mira-demo-builder                                      │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ L3 — Safety (cross-cuts everything; never auto-deactivates)  │
+│       mira-industrial-safety                                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Cross-cutting from below: `mira-industrial-safety` is a floor. Any L1/L2 output that touches energized equipment, lockout, or confined-space work must pass through it; the skill carries `[FATAL]`-tagged rules that supersede contrary suggestions from other skills.
+
+Cross-cutting from above: `mira-platform` is the ceiling — it states the doctrine ("Slack is the front door", "Anthropic must never be reintroduced", "every reply is grounded") and an L1/L2 skill cannot override its `[FATAL]` rules.
+
+---
+
+## 5. SKILL.md contract (every domain skill must satisfy this)
+
+Frontmatter:
+
+```yaml
+---
+name: <kebab-case-skill-name>
+description: <when-to-trigger sentence(s); for reference skills include "Do NOT trigger for...">
+version: <semver, starts at 0.1.0>
+status: draft | review | ready | deployed | deprecated
+last-updated: YYYY-MM-DD
+owner-paths:
+  - <repo path the skill is authoritative for>
+related-skills:
+  - <other skill name>
+---
+```
+
+Body (recommended H2 order; deviations require justification):
+
+1. **When to invoke** — positive triggers. Optional "Do NOT trigger for..." for reference skills.
+2. **What this skill grounds in** — list of authoritative MIRA files (specs, ADRs, migrations, rules). This is the audit trail.
+3. **Constraints** — numbered, severity-tagged rules. Domain prefix codes:
+   - `UNS-NNN` (UNS architecture)
+   - `KG-NNN` (knowledge graph)
+   - `ING-NNN` (ingestion)
+   - `ENG-NNN` (engine / FSM)
+   - `SLK-NNN` (Slack UX)
+   - `SAFE-NNN` (safety)
+   - `PLC-NNN` (PLC / OPC UA)
+   - `TLM-NNN` (telemetry / analytics)
+   - `COMP-NNN` (component profiles)
+   - `WO-NNN` (work-order / CMMS)
+4. **Workflows** — step-by-step procedures. Each step explicit; checkpoints between steps where Claude should pause and verify.
+5. **Common errors** — error-message-to-cause table (Fuuz pattern).
+6. **Output checklist** — checkbox list Claude runs through before declaring done. The checklist is the final gate.
+7. **References** — list of files under `references/` and what each covers.
+
+Length target: ≤500 lines. Reference files absorb depth.
+
+---
+
+## 6. references/ contract
+
+Reference files are read on-demand by Claude when SKILL.md instructs it to. They do not have to follow the SKILL.md structure but should:
+
+- Start with a one-paragraph purpose statement.
+- Cite the MIRA file(s) they describe.
+- Be self-contained enough to be read without the parent SKILL.md.
+- Avoid duplicating SKILL.md content; SKILL.md is rules, references/ is depth.
+
+Optional standalone frontmatter (for references useful on their own):
+
+```yaml
+---
+name: <skill-name>:<reference-name>
+description: <when Claude should jump straight to this reference>
+parent-skill: <skill-name>
+---
+```
+
+---
+
+## 7. Triggering and co-activation
+
+### 7.1 Independent activation
+
+Domain skills fire on their natural keyword surface:
+- `mira-uns-architecture` — "UNS path", "resolve to", "ltree", changes under `uns.py` or `uns_resolver.py`.
+- `mira-component-profile` — "component profile", "per-instance vs per-model", changes under `component_*` modules.
+- `mira-plc-tag-intelligence` — "PLC tag", "Modbus", "Sparkplug B", "OPC UA quality", PLC tag CSVs.
+- etc.
+
+### 7.2 Mandatory co-activation
+
+When any domain skill fires that could surface technician-facing or energized-equipment guidance, `mira-industrial-safety` **must** co-activate. This is enforced via:
+- A clause in each domain skill's "When to invoke" section ("Co-activate `mira-industrial-safety` for any output that reaches a technician.")
+- A pre-output check in the workflow skill that aborts if `mira-industrial-safety` has not been consulted on safety-keyword-bearing content.
+
+### 7.3 Doctrine co-activation
+
+`mira-platform` is the default ceiling skill. Any time a domain or workflow skill fires, `mira-platform` is consulted for cross-cutting constraints (provider cascade, environment boundaries, North Star). It is the equivalent of Fuuz's `fuuz-platform` skill with the explicit negative trigger.
+
+### 7.4 Negative triggers
+
+- `mira-platform` does NOT trigger as the *primary* skill for UNS resolution, KG proposals, ingestion, or workflow design — those have dedicated skills. It triggers as a *co-activated* reference.
+- `mira-saas-scope-guard` does NOT trigger for already-in-scope feature work — only for scope/expansion discussions.
+
+---
+
+## 8. Dependency graph (skill → MIRA artifacts)
+
+For each domain skill, the planning doc commits to an explicit ownership map. This is what the gap analysis will check against the current codebase.
+
+```
+mira-platform
+  ↳ CLAUDE.md, .claude/CLAUDE.md, docs/THEORY_OF_OPERATIONS.md,
+    docs/ARCHITECTURE.md, .claude/rules/*, docs/environments.md, NORTH_STAR.md
+
+mira-uns-architecture
+  ↳ mira-crawler/ingest/uns.py, mira-bots/shared/uns_resolver.py,
+    docs/specs/uns-kg-unification-spec.md, docs/specs/uns-message-resolver-spec.md,
+    docs/migrations/004_kg_entities.sql, .claude/rules/uns-compliance.md
+
+mira-component-profile
+  ↳ mira-crawler/ingest/, docs/specs/mira-component-intelligence-architecture.md,
+    mira-hub/db/migrations/, NeonDB component-related tables
+
+mira-maintenance-workflow
+  ↳ mira-bots/slack/bot.py, mira-bots/shared/engine.py,
+    mira-bots/shared/citation_compliance.py, mira-mcp/server.py,
+    docs/specs/dialogue-state-tracker-spec.md, tests/golden_*.csv
+
+mira-industrial-safety
+  ↳ mira-bots/shared/guardrails.py (SAFETY_KEYWORDS),
+    .claude/rules/security-boundaries.md, docs/THEORY_OF_OPERATIONS.md
+
+mira-plc-tag-intelligence
+  ↳ plc/, mira-connect/, mira-relay/, ignition/ (when present),
+    docs/specs/uns-kg-unification-spec.md
+
+mira-telemetry-analysis
+  ↳ mira-relay/, mira-bridge/, future telemetry path (TBD)
+
+mira-demo-builder
+  ↳ tools/, mira-cmms/ (Atlas), tests/golden_*.csv,
+    docs/plans/*-demo-*.md
+```
+
+The gap analysis (`mira-skills-codebase-gap-analysis.md`) checks each of these paths exists and is current.
+
+---
+
+## 9. Evaluation contract
+
+Skills must be testable. Two evaluation layers:
+
+**Layer A — Structural lint.** A static checker (`tools/skills_lint.py`, to be built) validates:
+- Frontmatter completeness (name, description, version, status, last-updated, owner-paths).
+- SKILL.md size cap (≤800 lines, target ≤500).
+- All `owner-paths` exist in the repo.
+- All `related-skills` exist.
+- Severity tags present where claimed.
+- `MANIFEST.md` row exists and matches frontmatter.
+
+**Layer B — Behavioral eval.** Per-skill prompt eval pairs (`tests/skills/eval/<skill-name>.yaml`) that exercise:
+- Positive trigger: a prompt that should activate the skill; assert Claude references it.
+- Negative trigger: a prompt that should *not* activate the skill; assert Claude does not pull it in.
+- Constraint enforcement: a prompt that tempts Claude to break a `[FATAL]` rule; assert Claude refuses or reroutes.
+- Output-checklist pass: a successful run; assert Claude's response references the checklist.
+
+The full eval plan lives in `docs/planning/mira-skills-eval-plan.md`.
+
+---
+
+## 10. Non-goals
+
+To prevent scope creep — this initiative does **not**:
+
+- Copy or paraphrase Fuuz content.
+- Touch production code (`mira-bots/`, `mira-pipeline/`, `mira-mcp/`, etc.) during the planning + Phase A drafting phases.
+- Replace `CLAUDE.md` or `.claude/rules/`. Skills are complementary; they are read by Claude on a trigger, not loaded into every context.
+- Build new MIRA functionality. Skills describe what exists.
+- Introduce a new artifact format (no `.skill` ZIP archives). MIRA uses raw markdown under `.claude/skills/` per Anthropic's current convention.
+- Lock anyone into the proposed skill names — names are reviewed in Phase A.
+
+---
+
+## 11. Open questions (resolve in roadmap Phase A)
+
+1. **Skill folder vs file convention.** Many existing MIRA skills are loose `.md` files (`bot-adapters.md`, `diagnostic-workflow.md`). The Fuuz pattern (and the deeper MIRA skills) use folders. Standardize on folders for any skill with a `references/` subdirectory; keep loose `.md` for trivial skills.
+2. **Where to live: `.claude/skills/` vs `wiki/`?** Skills stay under `.claude/skills/`. The `wiki/` keeps its ops-wiki role. Cross-references between the two are explicit.
+3. **`mira-demo-builder` overlap with `mira-create-demo-plant`.** Likely the existing command becomes a workflow inside the new skill. Confirm in Phase A.
+4. **Telemetry skill scope.** The line between `mira-plc-tag-intelligence` (mapping) and `mira-telemetry-analysis` (analytics) needs a crisp boundary; default proposal: mapping = static (tag → UNS path → component), analytics = dynamic (tag values over time → anomaly / baseline / signal). Confirm in Phase A.
+5. **MCP/skill duplication.** Some skills currently describe behavior also enforced by MCP tools (`mira-mcp/server.py`). Avoid duplicating tool docs in skills; skills cite the MCP server, MCP server documents its own surface.
+
+---
+
+## 12. Cross-references
+
+- `docs/research/fuuz-skills-analysis.md` — Fuuz research, adaptation map.
+- `docs/planning/mira-skills-codebase-gap-analysis.md` — what exists vs what this plan requires.
+- `docs/planning/mira-claude-skills-implementation-roadmap.md` — Phases A–G.
+- `docs/planning/mira-skills-file-tree.md` — target file tree.
+- `docs/planning/mira-skills-eval-plan.md` — evaluation strategy.
+- `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules/` — current doctrine.
+- `docs/THEORY_OF_OPERATIONS.md` — primary product doctrine.

--- a/docs/planning/mira-claude-skills-implementation-roadmap.md
+++ b/docs/planning/mira-claude-skills-implementation-roadmap.md
@@ -1,0 +1,193 @@
+# MIRA Skill System — Implementation Roadmap
+
+**Date:** 2026-05-19
+**Status:** Planning draft (Phase 4). Sequences the gap-closure work from `mira-skills-codebase-gap-analysis.md` into seven phases, A–G.
+**Companion docs:** `docs/research/fuuz-skills-analysis.md`, `docs/planning/mira-claude-skills-architecture.md`, `docs/planning/mira-skills-codebase-gap-analysis.md`, `docs/planning/mira-skills-file-tree.md`, `docs/planning/mira-skills-eval-plan.md`.
+
+This is the **execution sequence**, not a calendar. Calendar dates are deliberately omitted; the roadmap composes with the 90-day MVP plan (`docs/plans/2026-04-19-mira-90-day-mvp.md`) and the namespace-builder plan (`docs/plans/2026-05-15-maintenance-namespace-builder.md`) — the maintainer slots each phase between other work.
+
+---
+
+## Guiding rules across all phases
+
+1. **No production code changes.** Each phase touches only `.claude/skills/`, `docs/planning/`, `docs/research/`, `tools/skills_*.py`, and `tests/skills/`. Engine, bot, crawler, MCP, pipeline, web, and CMMS code are untouched.
+2. **Each phase is atomic.** Phases land as one PR each (or one small series). No phase depends on a half-merged earlier phase.
+3. **Each phase ends with proof.** Either a passing lint, a passing eval, or — for phases without automated checks — a written diff summary and a `wc -l` of the new skill content.
+4. **Reversible.** Every phase can be reverted with `git revert` of its PR. No phase imposes a structural change that can't be undone.
+5. **Fuuz is not imported.** No phase clones, imports, or paraphrases Fuuz content. Phase A artifacts are MIRA-native.
+
+---
+
+## Phase A — Foundation (manifest, template, decision matrix)
+
+**Goal:** Set up the scaffolding that every subsequent phase depends on.
+
+**Artifacts:**
+- `.claude/skills/MANIFEST.md` — full skill inventory with semver, status, last-updated, owner-paths, short description. Includes ALL existing skills (domain + operational), not just the 8 target domain skills, so the index is complete.
+- `.claude/skills/cross-skill-index.md` — task → skill decision matrix. Includes multi-skill workflows (e.g., "onboard a new customer plant", "ingest a new manual", "debug a low-grounding episode").
+- `.claude/skills/_template/SKILL.md` — boilerplate with required frontmatter, recommended H2 order, severity-tag convention, output-checklist stub.
+- `.claude/skills/_template/references/_template-reference.md` — boilerplate for reference files.
+
+**Decisions to resolve during Phase A:**
+- Folder vs loose-file convention (default: folder when references exist).
+- Skill rename policy (do we rename `uns-location-gate-designer` → `mira-uns-architecture` immediately, or keep alias?).
+- Whether `mira-architecture-guardian` becomes `mira-platform` or stays under its current folder name with the new role.
+
+**Definition of done:**
+- All three files exist.
+- `MANIFEST.md` has a row for every skill currently under `.claude/skills/`.
+- `_template/SKILL.md` shows the convention from §5 of the architecture doc.
+- One PR; reviewed; merged.
+
+**Risks:** Bikeshedding on naming. Mitigation: pick names; document alternatives considered in a "Decisions" section of the architecture doc; move on.
+
+---
+
+## Phase B — Doctrine + safety skills (Phase 6 of this initiative)
+
+**Goal:** Ship the three skills that gate every future skill: `mira-platform`, `mira-uns-architecture`, `mira-industrial-safety`. These are the three explicitly requested in the user's task brief.
+
+**Artifacts:**
+- `.claude/skills/mira-architecture-guardian/SKILL.md` rewritten to the target contract (or renamed to `mira-platform/` — Phase A decision).
+- `.claude/skills/mira-architecture-guardian/references/` (4 files): provider-cascade, environment-doctrine, screenshot-rule, hard-constraints.
+- `.claude/skills/mira-uns-architecture/SKILL.md` (new folder, or evolution of `uns-location-gate-designer/`).
+- `.claude/skills/mira-uns-architecture/references/` (3 files): uns-path-grammar, resolver-state-machine, gate-message-templates.
+- `.claude/skills/mira-industrial-safety/SKILL.md` (new).
+- `.claude/skills/mira-industrial-safety/references/` (3 files): safety-keywords, escalation-templates, regulatory-frame.
+
+**Verification:**
+- Each SKILL.md ≤ target size (500 lines, hard cap 800).
+- Each owner-path in frontmatter actually exists in the repo (lint script not yet built; verify manually in PR review).
+- Severity tags present on every constraint.
+- `MANIFEST.md` updated.
+- Cross-references in `cross-skill-index.md` updated.
+
+**Definition of done:**
+- Three new/rewritten SKILL.md files merged.
+- Reference files merged.
+- `MANIFEST.md` reflects the changes.
+- One commit per skill (or one PR per skill, depending on review preference). The user brief asks the skill drafts to be committed *separately* from planning docs — honor that.
+
+**Risks:** Severity tagging on the safety skill could be over-cautious (every rule `[FATAL]`) or under-cautious. Mitigation: pair-review with someone who knows the codebase — currently Mike.
+
+---
+
+## Phase C — Workflow + component skills
+
+**Goal:** Reshape the next tier: `mira-maintenance-workflow`, `mira-component-profile`, `mira-plc-tag-intelligence`.
+
+**Artifacts (per skill):** SKILL.md + 3-4 references.
+
+**Order within Phase C:**
+1. `mira-component-profile` first — it's the most mechanically clear (existing skill is already the closest to the target contract).
+2. `mira-plc-tag-intelligence` second — bounded scope, similar shape.
+3. `mira-maintenance-workflow` last — depends on the others and on the consolidation decision (subsume `work-order-history-miner` and `slack-technician-ux-writer` vs keep as separate co-skills).
+
+**Definition of done:**
+- Each ships with its own PR.
+- Behavioral eval pairs land alongside the skill (see Phase F).
+- `MANIFEST.md` + `cross-skill-index.md` updated each time.
+
+**Risks:** Workflow-skill consolidation decision blocks Phase C. Mitigation: make the decision in Phase A; document it in the architecture doc.
+
+---
+
+## Phase D — Telemetry + demo skills
+
+**Goal:** Ship the two new L1/L2 skills that don't yet have any existing material: `mira-telemetry-analysis` and `mira-demo-builder`.
+
+**Special consideration:** `mira-telemetry-analysis` describes a system that is still partially built. The skill must explicitly mark intended-but-not-yet-shipped behavior with TODO callouts and a "Not yet operational" status banner. This prevents Claude from over-claiming capability.
+
+**Artifacts (per skill):** SKILL.md + 3 references.
+
+**Definition of done:**
+- Both skills merged, status: `draft` until the underlying paths are operational, then promote to `ready`.
+- TODO callouts explicit.
+- Linked from `mira-demo-builder` to the existing `mira-create-demo-plant` slash command.
+
+**Risks:** `mira-telemetry-analysis` could ship guidance that doesn't match production reality. Mitigation: keep status `draft`, gate on the actual telemetry path shipping.
+
+---
+
+## Phase E — Tooling (lint + drift signal)
+
+**Goal:** Replace manual review with automated checks where possible.
+
+**Artifacts:**
+- `tools/skills_lint.py` — validates frontmatter, file size, owner-paths existence, related-skills existence, MANIFEST.md consistency, severity-tag presence on numbered rules.
+- `.githooks/pre-commit` (extend, don't replace) — runs `skills_lint.py` against any staged change under `.claude/skills/`.
+- `.github/workflows/skills-lint.yml` — CI job for PRs touching `.claude/skills/`.
+- Optional: a "skill drift" detector — when a PR changes a file listed in any skill's `owner-paths`, comment with the relevant skills and ask the author to consider a version bump.
+
+**Definition of done:**
+- `python tools/skills_lint.py` exits 0 against the entire `.claude/skills/` tree.
+- CI job green on a PR that touches a skill.
+- CI job red on a synthetic PR with a malformed skill (proven by a test PR closed without merge).
+
+**Risks:** Lint becomes a chore-blocker. Mitigation: lint warns; only frontmatter+size violations fail CI. Owner-paths missing → warning. Severity-tag missing → warning. Author can override with a comment.
+
+---
+
+## Phase F — Behavioral evaluation (Layer B)
+
+**Goal:** Per-skill behavioral evals so we know each skill actually triggers correctly.
+
+**Artifacts:**
+- `tests/skills/eval/<skill>.yaml` — 5–10 cases per skill: positive triggers, negative triggers, constraint-tempting, output-checklist-following.
+- `tests/skills/runner.py` — runs evals via the existing inference cascade (`InferenceRouter`).
+- `tests/skills/README.md` — how to add a case.
+
+**Definition of done:**
+- Eval suite exists for every domain skill listed in `mira-claude-skills-architecture.md` §3.
+- Each suite passes against the latest skill content.
+- Runner produces a markdown summary similar to the existing `bot-grounding-tests` regime.
+
+**Risks:** Eval cost (LLM calls per case). Mitigation: run on PR-touching-skills only, not every CI build; use the cheapest cascade tier for routine runs.
+
+---
+
+## Phase G — Drift loop + governance
+
+**Goal:** Close the loop so skills stay in sync with the code they describe.
+
+**Artifacts:**
+- `wiki/references/skill-governance.md` — when to bump a skill version, when to mark `deprecated`, who owns each skill.
+- Update PR template to include a "Skills touched / bumped" checkbox.
+- Quarterly skill audit calendar entry: walk `MANIFEST.md`, run lint + evals, retire stale skills, promote `draft` skills that have proven out.
+- A `wiki/references/skill-index.md` rendered from `MANIFEST.md` for human consumption (optional, derived).
+
+**Definition of done:**
+- Governance doc merged.
+- PR template updated.
+- First quarterly audit completed and logged in `wiki/`.
+- One stale skill identified (or zero, if MANIFEST already reflects truth).
+
+**Risks:** Governance work is the easiest to skip. Mitigation: bind the quarterly audit to a recurring routine (`mira-routines/`) so it's not a manual reminder.
+
+---
+
+## Phase ordering rationale
+
+A precedes everything because the manifest + template + index are infrastructure that every other phase writes against.
+
+B is the user-requested deliverable (Phase 6 of this initiative). It ships value immediately: three skills that strengthen the most consequential parts of MIRA's behavior (doctrine, UNS architecture, safety).
+
+C extends the pattern to the next tier. By this point the convention is proven and the team is fast.
+
+D is the most speculative — the underlying systems are not all shipped. It runs after C so we already have the template down.
+
+E and F automate what was previously manual. They run after the skill content is stable enough to lint against.
+
+G is the steady-state governance pass; it institutionalizes maintenance.
+
+---
+
+## Cross-references
+
+- `docs/planning/mira-claude-skills-architecture.md`
+- `docs/planning/mira-skills-codebase-gap-analysis.md`
+- `docs/planning/mira-skills-file-tree.md`
+- `docs/planning/mira-skills-eval-plan.md`
+- `docs/research/fuuz-skills-analysis.md`
+- `docs/plans/2026-04-19-mira-90-day-mvp.md` — overall MVP plan (this initiative is complementary, not blocking).
+- `docs/plans/2026-05-15-maintenance-namespace-builder.md` — namespace-builder plan (the UNS skill phases are sequenced to land after the namespace-builder Phase 1 has stabilized).

--- a/docs/planning/mira-fuuz-adaptation-final-report.md
+++ b/docs/planning/mira-fuuz-adaptation-final-report.md
@@ -1,0 +1,239 @@
+# MIRA × Fuuz — Adaptation Final Report
+
+**Date:** 2026-05-19
+**Status:** Final report (Phase 8 of the Fuuz-adaptation initiative).
+**Companion docs:** see §6 below.
+
+This report closes the planning initiative the user requested on 2026-05-19: *"Study the Fuuz Industrial Intelligence public repositories and create a planning-first implementation strategy for applying the same general approach to MIRA."*
+
+It summarizes:
+
+1. What was studied.
+2. What was decided.
+3. What was produced.
+4. What was deliberately **not** produced.
+5. Risks and mitigations.
+6. Next actions.
+
+---
+
+## 1. What was studied
+
+Two Fuuz public repositories (cloned read-only to `/Users/charlienode/reference-repos/`):
+
+- **`Fuuz-Industrial-Intelligence/fuuz-skills`** — 7 Claude Code skills (~50,000 lines of markdown across SKILL.md + references), covering Fuuz's platform: packages, schema, screens, flows, platform fundamentals, industrial ops, ML/telemetry.
+- **`Fuuz-Industrial-Intelligence/proveit2026`** — 3 production `.fuuz` package archives (gzipped tarballs containing platform JSON for a Data Broker, an Enterprise WMS, and an Enterprise C MES).
+
+The Fuuz GitHub org has 5 public repos in total; the 3 units-of-measure packages were excluded as out of scope.
+
+**Critical license finding:** neither Fuuz repo has a LICENSE file. Under default US copyright, that means all rights reserved by Fuuz Industrial Intelligence. The full audit is in `docs/research/fuuz-skills-analysis.md` §2.
+
+---
+
+## 2. What was decided
+
+### 2.1 Reuse posture
+
+| Category | Decision |
+|---|---|
+| Structural patterns (skill layout, manifest, references/ pattern, severity tiers, checklists, error tables) | **Adopt** — these are ideas/formats, not copyrightable expression. |
+| Open industrial standards cited in Fuuz skills (ISA-95, ISO 22400, ISA-88, OPC UA, ISA-101, OSHA 1910.147, NFPA 70E) | **Cite from primary sources** — independently citable. |
+| Specific prose, numbered golden-rules lists, JSON templates, named checklists | **Do not copy verbatim.** Write MIRA content from scratch. |
+| Fuuz-specific abstractions (JSONata, Relay-style GraphQL, Relationship TRIPLET constraint, `.fuuz` package format, `usable`/`active` tiers, ES5 sandbox, craft.js component registry, vendor-prefixed UNS) | **Do not adapt.** No MIRA analog; importing them would introduce category errors. |
+
+### 2.2 Target architecture
+
+MIRA's target skill suite is **8 domain skills** layered as:
+
+```
+L0 Doctrine    : mira-platform, mira-saas-scope-guard
+L1 Domain      : mira-uns-architecture, mira-component-profile,
+                 mira-plc-tag-intelligence, mira-telemetry-analysis
+L2 Workflow    : mira-maintenance-workflow, mira-demo-builder
+L3 Safety      : mira-industrial-safety (cross-cuts everything)
+```
+
+Plus supporting infrastructure: `MANIFEST.md`, `cross-skill-index.md`, `_template/`, lint tool, eval suite.
+
+Full rationale + skill-by-skill contract in `docs/planning/mira-claude-skills-architecture.md`.
+
+### 2.3 Patterns adopted from Fuuz (independently re-expressed)
+
+1. Two-tier SKILL.md + `references/` layout.
+2. Numbered constraints with domain-prefix codes (e.g., `UNS-001`, `SAFE-010`, `PLT-020`).
+3. Severity tags: `[FATAL]` / `[BLOCKING]` / `[WARNING]` / `[STYLE]`.
+4. Explicit "Do NOT trigger for..." clauses on doctrine/reference skills.
+5. Error-message-to-cause reference tables.
+6. Output-checklist as the final gate before declaring a task done.
+7. Version manifest with status labels (`draft` / `review` / `ready` / `deployed` / `deprecated`).
+8. Cross-skill index document.
+9. Failure-mode teaching (anti-patterns) over example teaching.
+10. Runtime-limitation callouts elevated to H2 with severity tag.
+
+### 2.4 Patterns rejected
+
+1. `.skill` ZIP-archive packaging — MIRA uses raw markdown per Anthropic convention.
+2. The Fuuz UNS path prefix `fuuz/{site}/...` — MIRA's UNS is ltree without vendor prefix.
+3. Fuuz's Relationship TRIPLET constraint (FK + forward + inverse) — MIRA uses standard PostgreSQL FKs.
+4. ES5 JavaScript runtime constraints — irrelevant to MIRA's Python 3.12 stack.
+5. craft.js screen JSON conventions — MIRA's UI is Slack + Hono/Bun web.
+
+---
+
+## 3. What was produced
+
+### 3.1 Research artifact
+
+| File | Lines | Status |
+|---|---|---|
+| `docs/research/fuuz-skills-analysis.md` | 1027 | ✅ complete |
+
+### 3.2 Planning artifacts
+
+| File | Lines | Status |
+|---|---|---|
+| `docs/planning/mira-claude-skills-architecture.md` | 341 | ✅ complete |
+| `docs/planning/mira-skills-codebase-gap-analysis.md` | 408 | ✅ complete |
+| `docs/planning/mira-claude-skills-implementation-roadmap.md` | 193 | ✅ complete |
+| `docs/planning/mira-skills-file-tree.md` | 257 | ✅ complete |
+| `docs/planning/mira-skills-eval-plan.md` | 281 | ✅ complete |
+| `docs/planning/mira-fuuz-adaptation-final-report.md` | (this file) | ✅ complete |
+
+### 3.3 Initial skill drafts (Phase 6 deliverables)
+
+| Skill | File | Lines | Status |
+|---|---|---|---|
+| `mira-platform` | `.claude/skills/mira-platform/SKILL.md` | 213 | ✅ draft (status: `draft` in frontmatter) |
+| `mira-uns-architecture` | `.claude/skills/mira-uns-architecture/SKILL.md` | 205 | ✅ draft |
+| `mira-industrial-safety` | `.claude/skills/mira-industrial-safety/SKILL.md` | 196 | ✅ draft |
+
+Reference files under each skill's `references/` are **stubs** (folders created, content deferred to roadmap Phase B). The architecture doc and file-tree doc commit to producing them; Phase B PRs will add content.
+
+### 3.4 Reference clone (outside repo)
+
+| Path | Purpose |
+|---|---|
+| `/Users/charlienode/reference-repos/fuuz-skills/` | Read-only clone for analysis. Will be deleted after audit period; not referenced by any MIRA code. |
+| `/Users/charlienode/reference-repos/proveit2026/` | Same. |
+
+These directories are outside the MIRA working tree and outside any commit. They are reference material only.
+
+### 3.5 Total writing produced
+
+```
+Research      : 1,027 lines
+Planning      : 1,480 lines (across 5 docs)
+Final report  :   170 lines (this file, approx)
+Skill drafts  :   614 lines (3 SKILL.md files)
+              ─────────────
+Total          ~3,300 lines of markdown, in 8 commitable files.
+```
+
+No production code changed. The audit trail is auditable: every constraint in every skill draft cites a specific MIRA file path under the skill's `owner-paths` frontmatter.
+
+---
+
+## 4. What was deliberately not done
+
+Per the user's hard rules + Karpathy "surgical changes" + Cluster 7 Laws:
+
+1. **No production code changes.** `mira-bots/`, `mira-pipeline/`, `mira-mcp/`, `mira-crawler/`, `mira-cmms/`, `mira-web/`, `mira-bridge/`, `mira-relay/`, `mira-hub/`, `mira-core/`, `plc/` — all untouched.
+2. **No Fuuz content imported.** No prose, no numbered-rules lists, no JSON templates, no checklists copied. The clones are external reference material only.
+3. **No license-restricted content reused.** Quotation in the research doc is limited to YAML frontmatter (for technical analysis), file paths (factual), and section header lists (factual). No prose.
+4. **No `mira-architecture-guardian/` rewrite.** The existing skill keeps working. The new `mira-platform/` folder sits alongside it as a draft. The rename/alias work is queued for Phase A/B in the roadmap, not this initiative.
+5. **No `uns-location-gate-designer/` rewrite.** Same — both coexist; the alias work is in the roadmap.
+6. **No deletions.** No existing skill, doc, or rule file was removed.
+7. **No new GitHub Actions, hooks, or CI workflows.** The eval-plan describes them; their creation is queued for Phases E/F in the roadmap.
+8. **No new MCP servers, no schema changes, no migrations.** All planning, no shipping.
+9. **No commits made automatically.** The user explicitly asked for separation of planning docs from skill drafts. Commits are left for explicit user-driven approval.
+10. **No removal of any `mira-` slash command or skill that already triggers.** Drafts use `status: draft` to coexist.
+
+---
+
+## 5. Risks and mitigations
+
+| # | Risk | Severity | Mitigation |
+|---|---|---|---|
+| 1 | Copying Fuuz expression (no license) | **HIGH** | Audit trail: this report + research doc explicitly state the all-rights-reserved finding and the no-verbatim policy. Skill drafts written from scratch with MIRA citations. |
+| 2 | Skill bloat: 8 domain skills + references + indexes is more surface than MIRA had | **MEDIUM** | Architecture caps SKILL.md at 500 lines target / 800 hard. Lint tool enforces. References push depth out of SKILL.md. |
+| 3 | Skill rot: skills drift behind code | **MEDIUM** | `MANIFEST.md` + version bumps in PRs + drift-check tool + quarterly audit (roadmap Phase G). |
+| 4 | Over-activation of doctrine skills | **MEDIUM** | Explicit negative triggers on `mira-platform` ("Do NOT trigger as the primary skill for..."). Lint warns when missing. |
+| 5 | Cost of behavioral evals (LLM calls) | **LOW** | Cheap cascade tier (Groq), cached responses, ≤100 cases total. Runs on PR-touching-skills only, plus weekly cron. |
+| 6 | Eval non-determinism (LLM jitter) | **LOW** | Pass = 4/5 runs (or threshold TBD in Phase F). |
+| 7 | Naming churn (renaming existing skills) | **LOW** | Alias period of one release per the file-tree doc; pointers at old paths. |
+| 8 | Workflow-skill consolidation may dissolve smaller specialized skills | **LOW** | Default is *keep separate, cross-link*; only dissolve if Phase A decision-meeting agrees. |
+| 9 | `mira-telemetry-analysis` describes a system not fully shipped | **LOW** | Keep status `draft` until the analytics pipeline is operational; explicit TODO callouts. |
+| 10 | Doctrine duplication between `CLAUDE.md`, `.claude/rules/`, and `mira-platform/SKILL.md` | **LOW** | Skill *cites* the rule files via `owner-paths`; does not duplicate them. Cross-references are explicit. |
+
+---
+
+## 6. Next actions
+
+In recommended order. Each is a separate PR (or small series). None is automatic; the user approves each.
+
+| # | Action | Phase | Estimated diff |
+|---|---|---|---|
+| 1 | Review + commit the planning bundle (research + 5 planning docs + this report) as a single PR — **planning only, no skill content**. | Initiative wrap-up | 3,300 lines of new markdown under `docs/research/` + `docs/planning/`. |
+| 2 | Commit the three draft skills (mira-platform, mira-uns-architecture, mira-industrial-safety) as a second PR, status `draft`. | Phase 6 ship | 614 lines + 3 empty `references/` folders. |
+| 3 | Phase A — `MANIFEST.md` + `cross-skill-index.md` + `_template/`. | Phase A | ~400 lines. |
+| 4 | Phase B — Promote the three drafts from `draft` to `review` after PR feedback. Fill out the 10 reference files committed to in the file tree. | Phase B | ~2,000 lines across 10 references. |
+| 5 | Phase C — Evolve `mira-component-profile`, `mira-plc-tag-intelligence`, `mira-maintenance-workflow`. | Phase C | ~2,500 lines. |
+| 6 | Phase D — Ship `mira-telemetry-analysis` (draft), `mira-demo-builder`. | Phase D | ~1,500 lines. |
+| 7 | Phase E — `tools/skills_lint.py` + CI workflow + drift-check tool. | Phase E | ~400 lines of Python + YAML. |
+| 8 | Phase F — `tests/skills/runner.py` + eval YAMLs per skill. | Phase F | ~1,000 lines of Python + YAML. |
+| 9 | Phase G — Governance doc + quarterly audit calendar entry. | Phase G | ~200 lines. |
+
+Total queued: roughly 8,000 additional lines of markdown + ~1,500 lines of Python/YAML, spread across 7 phases.
+
+---
+
+## 7. Decisions deferred to phase A
+
+These remain open by design (the architecture doc explicitly leaves them open):
+
+1. **Naming.** Keep `mira-architecture-guardian/` folder name (with widened role to "mira-platform") vs rename to `mira-platform/`. Current state: both exist, drafts coexist, decision in Phase A.
+2. **Loose-file vs folder.** Confirm the convention: folder when references exist, loose `.md` otherwise.
+3. **Workflow-skill consolidation.** Subsume `work-order-history-miner` + `slack-technician-ux-writer` into `mira-maintenance-workflow`, or keep them as cross-linked co-skills? Default proposal: keep separate.
+4. **Telemetry boundary.** Where does `mira-plc-tag-intelligence` end and `mira-telemetry-analysis` begin? Proposal: mapping = identity (tag → UNS path → component), analytics = values over time. Confirm in Phase A.
+5. **MCP duplication.** Skills cite MCP tools, do not re-document them; `.claude/mcp/<name>-spec.md` stays authoritative for MCP surface. Confirm in Phase A.
+
+---
+
+## 8. Companion docs
+
+- `docs/research/fuuz-skills-analysis.md` — full Fuuz research, license posture, adaptation map.
+- `docs/planning/mira-claude-skills-architecture.md` — target architecture, principles, contracts.
+- `docs/planning/mira-skills-codebase-gap-analysis.md` — what exists vs what's needed.
+- `docs/planning/mira-claude-skills-implementation-roadmap.md` — Phases A–G.
+- `docs/planning/mira-skills-file-tree.md` — target file layout.
+- `docs/planning/mira-skills-eval-plan.md` — structural lint + behavioral eval design.
+- `.claude/skills/mira-platform/SKILL.md` — doctrine skill draft.
+- `.claude/skills/mira-uns-architecture/SKILL.md` — UNS architecture + gate draft.
+- `.claude/skills/mira-industrial-safety/SKILL.md` — safety cross-cut draft.
+
+---
+
+## 9. Summary of changed files (this initiative)
+
+```
+docs/research/
+  fuuz-skills-analysis.md                                    [new]   1027 lines
+docs/planning/
+  mira-claude-skills-architecture.md                         [new]    341 lines
+  mira-skills-codebase-gap-analysis.md                       [new]    408 lines
+  mira-claude-skills-implementation-roadmap.md               [new]    193 lines
+  mira-skills-file-tree.md                                   [new]    257 lines
+  mira-skills-eval-plan.md                                   [new]    281 lines
+  mira-fuuz-adaptation-final-report.md                       [new]   ~170 lines
+.claude/skills/
+  mira-platform/SKILL.md                                     [new]    213 lines
+  mira-platform/references/                                  [new dir, empty]
+  mira-uns-architecture/SKILL.md                             [new]    205 lines
+  mira-uns-architecture/references/                          [new dir, empty]
+  mira-industrial-safety/SKILL.md                            [new]    196 lines
+  mira-industrial-safety/references/                         [new dir, empty]
+```
+
+Files modified: **none**. Files deleted: **none**. Production code touched: **none**. Existing skills modified: **none**. Existing rules, specs, ADRs, migrations modified: **none**.
+
+The branch (`claude/vigilant-margulis-196164`) contains only additions. Reverting the entire initiative is a single revert of the resulting PR(s).

--- a/docs/planning/mira-skills-codebase-gap-analysis.md
+++ b/docs/planning/mira-skills-codebase-gap-analysis.md
@@ -1,0 +1,408 @@
+# MIRA Skill System — Codebase Gap Analysis
+
+**Date:** 2026-05-19
+**Status:** Planning draft (Phase 3). Compares the target architecture in `mira-claude-skills-architecture.md` against what exists today.
+**Source for "target":** `docs/planning/mira-claude-skills-architecture.md`
+**Source for "current":** `.claude/skills/`, `.claude/rules/`, `CLAUDE.md`, `.claude/CLAUDE.md`, `docs/specs/`, `docs/migrations/`
+
+This document is the **delta** between current state and the proposed architecture. It is the input to the implementation roadmap.
+
+---
+
+## 1. Method
+
+For each of the eight target domain skills, the analysis records:
+
+1. What exists today (file path, size, shape).
+2. Which architecture-doc principles the existing material already satisfies.
+3. Where the gap is (missing content, missing structure, missing severity tags, missing references, missing checklist, missing MIRA-file linkage).
+4. Whether the existing skill is `EXISTS`, `EVOLVE`, or effectively `NEW`.
+5. Concrete artifacts that must be produced.
+
+Underlying assumption: **no production code changes** during this gap closure. Skills describe code; they do not modify it.
+
+---
+
+## 2. Inventory of current `.claude/skills/`
+
+Existing skills, grouped by role:
+
+### 2.1 Domain skills (in scope of this initiative)
+
+| Path | Lines | Folder/File | Frontmatter | Has `references/` | Severity tags | Output checklist |
+|---|---|---|---|---|---|---|
+| `mira-architecture-guardian/SKILL.md` | 56 | folder | name+description | no | no | no |
+| `uns-location-gate-designer/SKILL.md` | 89 | folder | name+description | no | implicit only | partial |
+| `plc-tag-mapper/SKILL.md` | 103 | folder | name+description | no | no | no |
+| `component-profile-builder/SKILL.md` | 144 | folder | name+description | no | no | no |
+| `diagnostic-workflow.md` | 175 | **file (no folder)** | name+description | no | no | no |
+| `work-order-history-miner/SKILL.md` | 97 | folder | name+description | no | no | no |
+| `manual-ingestion-extractor/SKILL.md` | 88 | folder | name+description | no | no | no |
+| `knowledge-graph-proposer/SKILL.md` | 96 | folder | name+description | no | no | no |
+| `slack-technician-ux-writer/SKILL.md` | ? | folder | name+description | no | no | no |
+| `bot-grounding-tests/SKILL.md` | ? | folder | name+description | no | implicit | yes (GS11 cases) |
+| `mira-saas-scope-guard/SKILL.md` | ? | folder | name+description | no | no | yes (classify) |
+
+### 2.2 Operational utilities (out of scope; kept as-is)
+
+`autonomous-run/`, `harness.md`, `kb-benchmark.md`, `inference-routing.md`, `smart-commit.md`, `youtube-transcript.md`, `design-ship-routine.md`, `conversation-forensic.md`, `photo-ingest-watcher.md`, `telegram_bot_tuning.md`, `web-review/`, `qr-onboarding/`, `marketing/`, `promo-director/`, `saas-activation.md`, `stripe.md`, `bot-adapters.md`, `knowledge-ingest.md`, `ar-hud.md`.
+
+### 2.3 Indexes (do not exist yet)
+
+- `.claude/skills/MANIFEST.md` — **NEW**
+- `.claude/skills/cross-skill-index.md` — **NEW**
+- `.claude/skills/_template/SKILL.md` — **NEW**
+
+---
+
+## 3. Per-skill gap analysis
+
+### 3.1 `mira-platform` (rooted in existing `mira-architecture-guardian`)
+
+**Status:** EVOLVE.
+
+**What exists:** `.claude/skills/mira-architecture-guardian/SKILL.md` (56 lines). Covers North Star, architecture invariants, scope guard.
+
+**What the target architecture requires:**
+- Doctrine-layer skill, reference-style, co-activates with others.
+- Explicit negative trigger ("Do NOT trigger as the primary skill for...").
+- Constraint list with severity tags covering provider cascade, environment boundaries, secrets via Doppler, screenshot rule, conventional commits, no Anthropic, etc.
+- Owner-paths frontmatter listing `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules/*`, `docs/THEORY_OF_OPERATIONS.md`, `docs/ARCHITECTURE.md`, `docs/environments.md`, `NORTH_STAR.md`.
+- Cross-references to `mira-saas-scope-guard`, `mira-industrial-safety`, and every L1/L2 skill.
+- `references/` for deeper content: provider-cascade detail, environment doctrine, screenshot rule, commit conventions, hard constraints from PRD §4.
+
+**Gaps:**
+- No negative trigger.
+- No severity tags.
+- No owner-paths.
+- No references/ folder.
+- Name conflict: should the file rename to `mira-platform/` or stay `mira-architecture-guardian/`? Recommended: keep folder name (no churn for existing references) but add an alias entry in `MANIFEST.md` and treat `mira-architecture-guardian` as the *deployed* name.
+
+**Artifacts to produce:**
+1. Rewrite `mira-architecture-guardian/SKILL.md` to the target contract (Phase 6, this initiative).
+2. Add `references/provider-cascade.md`, `references/environment-doctrine.md`, `references/screenshot-rule.md`, `references/hard-constraints.md`.
+3. Add a `MANIFEST.md` row.
+
+---
+
+### 3.2 `mira-uns-architecture` (rooted in existing `uns-location-gate-designer`)
+
+**Status:** EVOLVE.
+
+**What exists:** `uns-location-gate-designer/SKILL.md` (89 lines). Covers the UNS confirmation gate.
+
+**What the target architecture requires:**
+- L1 domain skill, owns UNS path construction, resolver behavior, the location gate, MQTT/Sparkplug topic mapping, and `kg_entities.uns_path`.
+- Owner-paths: `mira-crawler/ingest/uns.py`, `mira-bots/shared/uns_resolver.py`, `mira-bots/shared/engine.py` (gate portion), `docs/specs/uns-*.md`, `.claude/rules/uns-compliance.md`, `docs/migrations/004_kg_entities.sql`.
+- Numbered rules with `UNS-NNN` prefix.
+- Severity tags. (Begin troubleshooting before gate = `[FATAL]`. Use raw f-strings instead of `uns.slug()` = `[WARNING]`.)
+- Workflows: (a) extracting candidate context from a message, (b) constructing a UNS path, (c) writing the confirmation message, (d) handling correction.
+- Common errors: fault-code-before-model bug, reserved label collision, model token mistakes.
+- Output checklist: every assertion grounded; confirmation message format; path lowercased; reserved labels avoided.
+- `references/uns-path-grammar.md` (drawing from the existing `.claude/rules/uns-compliance.md`).
+- `references/resolver-state-machine.md`.
+- `references/gate-message-templates.md`.
+
+**Gaps:**
+- Scope is narrow today (just the gate). The new skill subsumes UNS path construction + resolver behavior.
+- No numbered constraints.
+- No references/.
+- Naming: the existing skill is the *gate*; the broader skill is the *architecture*. Recommend: rename to `mira-uns-architecture/`, leave a deprecation note in the old path for one release, or alias.
+
+**Artifacts to produce:**
+1. New `mira-uns-architecture/SKILL.md` (Phase 6, this initiative).
+2. Three references (above).
+3. Deprecation pointer at old `uns-location-gate-designer/` path.
+
+---
+
+### 3.3 `mira-component-profile` (rooted in existing `component-profile-builder`)
+
+**Status:** EVOLVE (mostly rename + reshape).
+
+**What exists:** `component-profile-builder/SKILL.md` (144 lines). The most thorough existing domain skill.
+
+**What the target architecture requires:**
+- L1 domain skill. Owns the component-profile schema, per-instance vs per-model semantics, proposal/verification flow.
+- Numbered rules with `COMP-NNN` prefix.
+- Severity tags. (`[FATAL]` for missing evidence on a verified row; `[WARNING]` for ambiguous per-model vs per-instance attribution.)
+- Owner-paths: `mira-crawler/ingest/`, `docs/specs/mira-component-intelligence-architecture.md`, NeonDB component-related tables, `mira-hub/db/migrations/`.
+- Cross-link to `mira-uns-architecture` (every component sits on a UNS path or `equipment_entity_id` FK).
+- `references/component-schema.md` (field-level reference).
+- `references/per-instance-vs-per-model.md` (decision matrix).
+- `references/promotion-flow.md` (proposed → verified, admin sign-off).
+
+**Gaps:**
+- No references/.
+- No numbered rules.
+- Rename to `mira-component-profile/` (shorter, parallel to other skill names). Keep `component-profile-builder/` as alias.
+
+**Artifacts to produce:**
+1. Rewrite SKILL.md to target contract (later phase; not in initial Phase 6).
+2. References (as above).
+
+---
+
+### 3.4 `mira-maintenance-workflow` (consolidates several existing skills)
+
+**Status:** EVOLVE + consolidate.
+
+**What exists (related):**
+- `diagnostic-workflow.md` (175 lines, **loose file**) — engine FSM, workers, confidence scoring.
+- `work-order-history-miner/SKILL.md` (97 lines).
+- `uns-location-gate-designer/SKILL.md` (89 lines) — the gate sub-flow.
+- `slack-technician-ux-writer/SKILL.md` — Slack output format.
+
+**What the target architecture requires:**
+- L2 workflow skill. Orchestrates L1 skills around the technician troubleshooting flow.
+- Pipeline: receive message → extract context → call `mira-uns-architecture` for resolution → emit confirmation → wait for confirmation → consult `mira-component-profile` + `work-order` references → produce grounded steps → close out → update WO.
+- Owner-paths: `mira-bots/slack/bot.py`, `mira-bots/shared/engine.py`, `mira-bots/shared/citation_compliance.py`, `mira-mcp/server.py` (CMMS tools), `docs/specs/dialogue-state-tracker-spec.md`, `tests/golden_*.csv`.
+- Numbered rules with `ENG-NNN` and `WO-NNN` prefixes.
+- Workflow stages each with their own checklist.
+- `references/fsm-states.md`.
+- `references/citation-compliance.md`.
+- `references/close-out-and-wo-update.md`.
+- `references/slack-message-templates.md` (could absorb `slack-technician-ux-writer`).
+
+**Gaps:**
+- Major one: `diagnostic-workflow.md` is a *loose markdown file* not a folder. Convert to `mira-maintenance-workflow/SKILL.md`.
+- No explicit pipeline stages with checklists.
+- No reference files.
+- The existing `work-order-history-miner/` and `slack-technician-ux-writer/` likely become references inside this skill, OR remain separate but cross-linked (decision in Phase A of the roadmap).
+
+**Artifacts to produce (later phase, not Phase 6):**
+1. `mira-maintenance-workflow/SKILL.md`.
+2. References (as above).
+3. Decision: subsume vs cross-link the related skills.
+
+---
+
+### 3.5 `mira-industrial-safety`
+
+**Status:** NEW.
+
+**What exists:**
+- `mira-bots/shared/guardrails.py` contains `SAFETY_KEYWORDS` (21 phrase-level triggers per `.claude/rules/security-boundaries.md`).
+- `.claude/rules/security-boundaries.md` documents the safety keyword mechanism.
+- No skill currently centralizes the safety behavior contract.
+
+**What the target architecture requires:**
+- L3 cross-cutting skill. Auto-co-activates with any user-facing workflow.
+- Owner-paths: `mira-bots/shared/guardrails.py`, `.claude/rules/security-boundaries.md`, `docs/THEORY_OF_OPERATIONS.md`.
+- Numbered rules with `SAFE-NNN` prefix.
+- `[FATAL]`-tagged rules covering:
+  - Never advise an action on energized equipment without a verified isolation step.
+  - Never suggest skipping LOTO or arc-flash PPE.
+  - Never write to a PLC tag during troubleshooting (read-only).
+  - Always reroute confined-space, hot-work, or chemical-exposure topics to a STOP + escalate message.
+- Workflow: detect → reroute → emit STOP message → log episode → require human confirmation.
+- `references/safety-keywords.md` (the 21 phrases + future additions).
+- `references/escalation-templates.md` (STOP messages).
+- `references/regulatory-frame.md` (OSHA 1910.147 LOTO, NFPA 70E arc flash — *cited from primary sources*, not Fuuz).
+
+**Gaps:**
+- The skill does not exist.
+- The mechanism (SAFETY_KEYWORDS list) exists in code but is not in a skill Claude can read when reasoning about features that touch live equipment.
+
+**Artifacts to produce (Phase 6, this initiative):**
+1. New `mira-industrial-safety/SKILL.md`.
+2. The three reference files.
+3. Cross-link from `mira-maintenance-workflow` and `mira-platform`.
+
+---
+
+### 3.6 `mira-plc-tag-intelligence` (rooted in existing `plc-tag-mapper`)
+
+**Status:** EVOLVE.
+
+**What exists:** `plc-tag-mapper/SKILL.md` (103 lines).
+
+**What the target architecture requires:**
+- L1 domain skill, scope = mapping tags to components and UNS paths.
+- Owner-paths: `plc/`, `mira-connect/` (deferred), `mira-relay/`, future `ignition/` exports.
+- Numbered rules with `PLC-NNN` prefix.
+- Severity tags (e.g., `[FATAL]` for inferring meaning from a tag name without evidence).
+- `references/tag-name-conventions.md` (Rockwell, Siemens, Allen-Bradley, generic OPC UA).
+- `references/quality-codes.md` (OPC UA quality codes from IEC 62541 primary source).
+- `references/sparkplug-b-topic-map.md`.
+
+**Gaps:**
+- No numbered rules.
+- No references/.
+- No Sparkplug B coverage.
+
+**Artifacts to produce (later phase):**
+1. Reshape SKILL.md.
+2. Three references.
+
+---
+
+### 3.7 `mira-telemetry-analysis`
+
+**Status:** NEW.
+
+**What exists:** No skill. `mira-relay/`, `mira-bridge/` partially document telemetry stream architecture.
+
+**What the target architecture requires:**
+- L1 domain skill. Distinct from `mira-plc-tag-intelligence` — that maps static identity; this reasons about dynamic values.
+- Numbered rules with `TLM-NNN` prefix.
+- `[FATAL]` rules: never assert an anomaly without a baseline; never claim a setpoint deviation without a documented setpoint source.
+- `references/baseline-construction.md` (EWMA, moving average, Z-score, drawn from primary statistical sources).
+- `references/anomaly-evidence-thresholds.md`.
+- `references/sensor-health-vs-process-anomaly.md`.
+
+**Gaps:**
+- Skill does not exist.
+- Underlying telemetry analytics pipeline is also partially built — the skill describes the path as it is *intended*, with explicit "TODO" markers where MIRA hasn't shipped yet.
+
+**Artifacts to produce (later phase):**
+1. New skill SKILL.md.
+2. References. (Some content may temporarily live under `docs/specs/` until the analytics path is built.)
+
+---
+
+### 3.8 `mira-demo-builder`
+
+**Status:** NEW (partial overlap with existing command `mira-create-demo-plant`).
+
+**What exists:**
+- `.claude/commands/mira-create-demo-plant.md` (slash command).
+- Seed scripts under `tools/`.
+- `mira-cmms/` (Atlas) work-order fixtures.
+- `tests/golden_*.csv` truth sets.
+
+**What the target architecture requires:**
+- L2 workflow skill. Used when creating reproducible demo plants for sales / launch / regression-testing.
+- Owner-paths: `tools/`, `mira-cmms/`, `tests/golden_*.csv`, `docs/plans/*-demo-*.md`.
+- Workflow: define plant identity → seed UNS → seed assets/components → seed WO history → seed golden chat transcripts → verify end-to-end.
+- `references/seed-data-shapes.md`.
+- `references/golden-transcript-format.md`.
+- `references/atlas-wo-fixtures.md`.
+
+**Gaps:**
+- No skill exists; demo construction is currently a slash command + ad-hoc tools.
+
+**Artifacts to produce (later phase):**
+1. New skill SKILL.md.
+2. References.
+3. Decision: does the slash command stay (as a quick-fire shortcut) or get absorbed?
+
+---
+
+## 4. Cross-cutting infrastructure gaps
+
+### 4.1 No skill version manifest
+
+**Gap:** No `.claude/skills/MANIFEST.md`.
+
+**Impact:** Skills drift behind code; there is no audit trail. (Documented case: `diagnostic-workflow.md` predates PR #1266's RESOLVED-state rebuild fix per memory.)
+
+**Artifact:** create `MANIFEST.md` listing every skill with semver, status, last-updated date, owner-paths, and short description. (Phase A artifact in the roadmap.)
+
+### 4.2 No cross-skill decision matrix
+
+**Gap:** No `.claude/skills/cross-skill-index.md`.
+
+**Impact:** With 15+ skills (and 8 domain skills proposed), Claude cannot consistently pick the right skill for a task. A decision matrix mirrors Fuuz's `cross-skill-index.md`.
+
+**Artifact:** `cross-skill-index.md` with task → skill mapping and multi-skill workflow recipes.
+
+### 4.3 No skill template
+
+**Gap:** No `.claude/skills/_template/SKILL.md`.
+
+**Impact:** Each new skill is structured ad-hoc; the contract from §5 of the architecture doc isn't enforced.
+
+**Artifact:** `_template/SKILL.md` with the required frontmatter, section headers, and checklist stub.
+
+### 4.4 No structural lint
+
+**Gap:** Nothing checks that skill frontmatter is well-formed or that `owner-paths` exist.
+
+**Impact:** A skill can claim ownership of a deleted file and Claude will follow it.
+
+**Artifact:** `tools/skills_lint.py` (Phase E in the roadmap).
+
+### 4.5 No per-skill behavioral eval
+
+**Gap:** Skills are not tested. The 5-regime test framework covers code; it does not cover skill activation behavior.
+
+**Impact:** A skill that fails to trigger on its target keywords goes unnoticed.
+
+**Artifact:** `tests/skills/eval/<skill>.yaml` and a runner. Detailed in `mira-skills-eval-plan.md` (Phase 7).
+
+### 4.6 Loose-file vs folder inconsistency
+
+**Gap:** Mixed convention — some skills are folders (`uns-location-gate-designer/SKILL.md`) and some are loose files (`diagnostic-workflow.md`, `inference-routing.md`).
+
+**Recommendation:** Folder for any skill that owns `references/`. Loose file is OK for trivial utility skills with no references and no expected growth. The eight target domain skills become folders.
+
+### 4.7 No severity-tag convention
+
+**Gap:** Constraints in existing skills are stated as prose without explicit severity.
+
+**Impact:** Claude doesn't reliably distinguish a `[FATAL]` rule (must refuse) from a `[STYLE]` rule (reviewer discretion).
+
+**Artifact:** Apply the severity convention from §2.7 of the architecture doc to every constraint in every domain skill.
+
+### 4.8 No negative triggers
+
+**Gap:** No existing skill uses a negative trigger clause.
+
+**Impact:** `mira-architecture-guardian` (and any future doctrine skill) will tend to over-activate.
+
+**Artifact:** Add "Do NOT trigger for..." clauses to every doctrine/reference skill (Phase 6 starts this with `mira-platform`).
+
+### 4.9 Skill drift signal not surfaced
+
+**Gap:** No CI signal exists when a skill describes code that has since changed.
+
+**Impact:** Skill content silently goes stale.
+
+**Possible artifacts (Phase E):**
+- A pre-commit hook that warns when a file under `owner-paths` is changed without a matching skill version bump.
+- A GitHub action that fails PRs editing `owner-paths` without `last-updated` in the relevant skill being bumped.
+
+---
+
+## 5. Risks identified during the gap walk
+
+1. **Consolidation risk** (`mira-maintenance-workflow` swallowing several existing skills). If we collapse `work-order-history-miner` and `slack-technician-ux-writer` into a single workflow skill, we lose the precise triggers those skills have today. Mitigation: keep them as separate referenced skills, owned by the workflow but not dissolved into it.
+2. **Rename churn.** Renaming `uns-location-gate-designer` → `mira-uns-architecture` changes a name that may be referenced elsewhere. Mitigation: add an alias in `MANIFEST.md`, leave a one-line pointer at the old path for one release.
+3. **Skill bloat.** The target architecture adds three new skills (`mira-platform` proper, `mira-industrial-safety`, `mira-telemetry-analysis`, `mira-demo-builder`) and grows several others. Mitigation: enforce SKILL.md size cap (≤800), push depth to references/.
+4. **Eval cost.** Behavioral evals (Layer B) require Claude calls. Mitigation: small N (5–10 cases per skill), run on PR-touching-skills only, not every CI build.
+5. **Doctrine-vs-skill duplication.** `CLAUDE.md`, `.claude/rules/`, and the new `mira-platform/SKILL.md` will overlap. Mitigation: `mira-platform` *cites* `CLAUDE.md`/`.claude/rules/`, does not duplicate them. Frontmatter `owner-paths` makes the ownership visible.
+6. **MCP overlap.** Some skills describe behavior also implemented by MCP tools in `mira-mcp/server.py`. Mitigation: skill cites MCP tool, doesn't re-document it. `.claude/mcp/<name>-spec.md` remains authoritative for MCP surface.
+
+---
+
+## 6. Summary
+
+| Skill | Status | Lines to write/touch (rough) | Phase |
+|---|---|---|---|
+| `mira-platform` (from `mira-architecture-guardian`) | EVOLVE | 250 + 4 refs (≈600) | **Phase 6 (this initiative)** |
+| `mira-uns-architecture` (from `uns-location-gate-designer`) | EVOLVE | 400 + 3 refs (≈900) | **Phase 6 (this initiative)** |
+| `mira-industrial-safety` | NEW | 300 + 3 refs (≈700) | **Phase 6 (this initiative)** |
+| `mira-component-profile` (from `component-profile-builder`) | EVOLVE | 400 + 3 refs | Later (Phase B/C in roadmap) |
+| `mira-maintenance-workflow` (consolidates) | EVOLVE | 500 + 4 refs | Later |
+| `mira-plc-tag-intelligence` (from `plc-tag-mapper`) | EVOLVE | 350 + 3 refs | Later |
+| `mira-telemetry-analysis` | NEW | 350 + 3 refs | Later (gated on telemetry pipeline maturity) |
+| `mira-demo-builder` | NEW | 350 + 3 refs | Later |
+| `MANIFEST.md`, `cross-skill-index.md`, `_template/` | NEW | ≈400 total | Phase A in roadmap |
+| `tools/skills_lint.py` | NEW | ≈200 | Phase E |
+| `tests/skills/eval/` | NEW | ≈600 | Phase F |
+
+Total Phase-6 (this initiative) writing target: ≈2200 lines of skill markdown, no production code changes. Everything else is queued in the roadmap.
+
+---
+
+## 7. Cross-references
+
+- `docs/research/fuuz-skills-analysis.md`
+- `docs/planning/mira-claude-skills-architecture.md`
+- `docs/planning/mira-claude-skills-implementation-roadmap.md`
+- `docs/planning/mira-skills-file-tree.md`
+- `docs/planning/mira-skills-eval-plan.md`
+- `CLAUDE.md`, `.claude/CLAUDE.md`
+- `.claude/rules/uns-compliance.md`, `.claude/rules/security-boundaries.md`, `.claude/rules/python-standards.md`, `.claude/rules/karpathy-principles.md`
+- `docs/THEORY_OF_OPERATIONS.md`, `docs/ARCHITECTURE.md`, `docs/environments.md`

--- a/docs/planning/mira-skills-eval-plan.md
+++ b/docs/planning/mira-skills-eval-plan.md
@@ -1,0 +1,281 @@
+# MIRA Skill System — Evaluation Plan
+
+**Date:** 2026-05-19
+**Status:** Planning draft (Phase 7). Defines how MIRA verifies that each skill in the proposed suite actually works — both structurally (lint) and behaviorally (LLM-driven evals).
+**Companion docs:** `docs/research/fuuz-skills-analysis.md`, `docs/planning/mira-claude-skills-architecture.md`, `docs/planning/mira-skills-codebase-gap-analysis.md`, `docs/planning/mira-claude-skills-implementation-roadmap.md`, `docs/planning/mira-skills-file-tree.md`.
+
+---
+
+## 1. Why evaluate skills
+
+Skills are easy to write and easy to break. Without evaluation:
+
+- A skill's trigger description rots as the codebase moves — `owner-paths` end up pointing at deleted files; the skill keeps firing but the constraints it cites no longer match reality.
+- A new skill over-activates and drowns specialized skills.
+- A `[FATAL]` rule silently degrades to advisory because no test ever exercises it.
+- A skill becomes a place for "best practices" rather than enforced behavior.
+
+Fuuz's skills repo has no public evaluation pipeline (per the research doc); MIRA cannot use them as a template here. The plan below is MIRA-native, building on existing infrastructure:
+
+- 5-regime test framework under `tests/` (covers code, not skill behavior).
+- GS11 bot-grounding regression net (`mira-bots/benchmarks/deepeval_suite.py`).
+- `tests/golden_factorylm.csv` truth set.
+- Inference cascade (`mira-bots/shared/inference/router.py`) which the eval runner can call via the same path the bot uses.
+
+---
+
+## 2. Two evaluation layers
+
+| Layer | What it tests | Speed | Where it runs |
+|---|---|---|---|
+| **A. Structural lint** | Frontmatter validity, file size, `owner-paths` existence, severity-tag presence, MANIFEST consistency | Fast (seconds) | Pre-commit + CI |
+| **B. Behavioral eval** | Does the skill actually fire? Does it refuse a `[FATAL]` rule violation? Does it leave the output checklist visible? | Slow (LLM calls) | CI for PRs touching `.claude/skills/`; weekly full run |
+
+Layer A is mandatory on every PR. Layer B is mandatory on PRs that change a skill's SKILL.md or `references/`; weekly otherwise.
+
+---
+
+## 3. Layer A — Structural lint
+
+### 3.1 Tool
+
+`tools/skills_lint.py` (Phase E in roadmap). Pure Python, stdlib only, no LLM calls.
+
+### 3.2 Checks
+
+| Check | Severity | Description |
+|---|---|---|
+| `frontmatter-present` | ERROR | SKILL.md must have YAML frontmatter delimited by `---`. |
+| `frontmatter-required-fields` | ERROR | `name`, `description`, `version`, `status`, `last-updated`, `owner-paths` all present. |
+| `frontmatter-name-matches-folder` | ERROR | Frontmatter `name` matches folder name (or filename stem for loose-file skills). |
+| `frontmatter-version-semver` | ERROR | `version` parses as `MAJOR.MINOR.PATCH`. |
+| `frontmatter-status-valid` | ERROR | `status` ∈ {`draft`, `review`, `ready`, `deployed`, `deprecated`}. |
+| `frontmatter-date-iso` | ERROR | `last-updated` matches `YYYY-MM-DD`. |
+| `owner-paths-exist` | WARNING | Each `owner-paths` entry resolves to an existing file or directory in the repo. |
+| `related-skills-exist` | WARNING | Each `related-skills` entry resolves to another skill in `.claude/skills/`. |
+| `size-soft-cap` | WARNING | SKILL.md ≤ 500 lines (architecture target). |
+| `size-hard-cap` | ERROR | SKILL.md ≤ 800 lines (hard limit). |
+| `manifest-row-present` | ERROR | `.claude/skills/MANIFEST.md` has a row for this skill. |
+| `manifest-version-matches` | ERROR | `MANIFEST.md` version + last-updated match the skill frontmatter. |
+| `severity-tags-on-rules` | WARNING | Any numbered rule (regex `^- \*\*[A-Z]+-\d+\*\*`) includes a `[FATAL]` / `[BLOCKING]` / `[WARNING]` / `[STYLE]` tag. |
+| `negative-trigger-on-doctrine` | WARNING | Skills with `status: doctrine` (or names matching `mira-platform`, `mira-architecture-guardian`) include a "Do NOT trigger for..." clause in the description. |
+| `output-checklist-present` | WARNING | A `## Output checklist` (or similar) section exists. |
+| `references-folder-exists` | INFO | If the skill is a folder, a `references/` subdirectory exists (informational; not all skills need one). |
+
+ERROR fails CI; WARNING reports a comment on the PR but does not block; INFO is logged only.
+
+### 3.3 CLI surface
+
+```
+$ python tools/skills_lint.py
+.claude/skills/mira-platform/SKILL.md ........... OK
+.claude/skills/mira-uns-architecture/SKILL.md ... OK
+.claude/skills/mira-industrial-safety/SKILL.md .. OK
+.claude/skills/diagnostic-workflow.md ........... WARN size-soft-cap (175 ≤ 500)
+.claude/skills/some-broken-skill/SKILL.md ....... ERROR frontmatter-required-fields:owner-paths
+                                                  ERROR manifest-row-present
+1 ERROR(s), 1 WARN(ing) across 23 skills.
+```
+
+### 3.4 CI integration
+
+`.github/workflows/skills-lint.yml`:
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - '.claude/skills/**'
+      - 'tools/skills_lint.py'
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: python tools/skills_lint.py
+```
+
+---
+
+## 4. Layer B — Behavioral eval
+
+### 4.1 Tool
+
+`tests/skills/runner.py` (Phase F in roadmap). Runs eval cases against the MIRA inference cascade (`InferenceRouter`). Cases are YAML.
+
+### 4.2 Case shapes
+
+Four case types per skill:
+
+| Case type | What it tests | Pass condition |
+|---|---|---|
+| `positive-trigger` | A prompt that should activate the skill | Model response references the skill (by name or by citing one of its `owner-paths`). |
+| `negative-trigger` | A prompt that should NOT activate the skill | Model response does not cite the skill. (Especially important for doctrine skills with explicit "Do NOT trigger for...".) |
+| `constraint-refusal` | A prompt that tempts the model to violate a `[FATAL]` rule | Model refuses or reroutes, explicitly referencing the rule code (e.g., `UNS-011`, `SAFE-010`). |
+| `checklist-run` | A prompt that should culminate in an output-checklist | Model output contains the checklist items (verified textually or via a structured-output schema). |
+
+### 4.3 Case file format
+
+`tests/skills/eval/<skill>.yaml`:
+
+```yaml
+skill: mira-uns-architecture
+version: 0.1.0
+runner_version: 1
+cases:
+  - id: pos-001
+    type: positive-trigger
+    prompt: |
+      I'm editing `mira-bots/shared/uns_resolver.py` to add a new vendor alias.
+      What constraints apply?
+    expect:
+      cites_skill: true
+      cites_rules_any_of: [UNS-001, UNS-002, UNS-010]
+
+  - id: neg-001
+    type: negative-trigger
+    prompt: |
+      What's the difference between an EWMA and a moving average for sensor baselines?
+    expect:
+      cites_skill: false
+
+  - id: ref-001
+    type: constraint-refusal
+    prompt: |
+      Quick patch: in `kg_writer.py`, build the UNS path as
+      `f"enterprise.knowledge_base.{vendor}.{model}"` to skip the slug call.
+    expect:
+      cites_skill: true
+      cites_rule: UNS-001
+      response_classification: refuse-or-reroute
+
+  - id: chk-001
+    type: checklist-run
+    prompt: |
+      I added a `model_path()` call to a new ingest worker. Walk me through
+      the output checklist before I open the PR.
+    expect:
+      cites_skill: true
+      checklist_items_present_at_least: 6
+```
+
+### 4.4 Runner behavior
+
+1. Loads each YAML in `tests/skills/eval/`.
+2. For each case, sends the `prompt` through `InferenceRouter.complete()` with the standard MIRA system prompt + the current skill suite available.
+3. Parses the response. Applies the `expect` matchers:
+   - `cites_skill`: regex on skill name or any `owner-paths` entry.
+   - `cites_rule`: regex on the rule code (e.g., `UNS-001`).
+   - `response_classification`: a small judge prompt (using the cheapest cascade tier) to classify the response as `refuse-or-reroute`, `comply-and-warn`, or `comply-without-warn`.
+   - `checklist_items_present_at_least`: count of `- [ ]` lines.
+4. Tallies pass/fail per case; fails the eval if any case fails.
+
+### 4.5 Cost control
+
+- Cheapest cascade tier (Groq) for all eval calls.
+- Cache responses by `(skill, case_id, prompt_hash)`; only re-run when a skill SKILL.md or referenced rule changes.
+- Per-skill case budget: 8–12 cases (2-3 of each type).
+- Total suite target: ≤ 100 cases. At Groq pricing this is negligible.
+
+### 4.6 CI integration
+
+`.github/workflows/skills-eval.yml`:
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - '.claude/skills/**'
+      - 'tests/skills/**'
+  schedule:
+    - cron: '17 4 * * 1'  # weekly Monday 04:17 UTC
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install httpx pyyaml
+      - run: python tests/skills/runner.py --secrets-via-doppler
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_STG_TOKEN }}
+```
+
+The eval runs against staging-tier Doppler (`factorylm/stg`) so prod isn't touched.
+
+---
+
+## 5. Per-skill eval targets (initial)
+
+| Skill | Positive | Negative | Constraint refusal | Checklist | Total cases |
+|---|---|---|---|---|---|
+| `mira-platform` | 3 | 3 | 3 (cascade, env boundaries, abstractions) | 1 | 10 |
+| `mira-uns-architecture` | 3 | 2 | 4 (UNS-001, UNS-011, UNS-020, UNS-022) | 1 | 10 |
+| `mira-industrial-safety` | 3 | 2 | 5 (SAFE-001, SAFE-010, SAFE-013, SAFE-021, SAFE-031) | 1 | 11 |
+| `mira-component-profile` | 2 | 2 | 3 | 1 | 8 |
+| `mira-maintenance-workflow` | 3 | 2 | 3 | 2 | 10 |
+| `mira-plc-tag-intelligence` | 2 | 2 | 3 | 1 | 8 |
+| `mira-telemetry-analysis` | 2 | 2 | 2 | 1 | 7 |
+| `mira-demo-builder` | 2 | 2 | 2 | 1 | 7 |
+| **Total** | | | | | **71** |
+
+71 cases × 1 LLM call each = trivial cost. Add buffer (judge-prompt overhead) — still <1000 calls per full run.
+
+---
+
+## 6. Skill-drift evaluation (Layer A.5)
+
+Between A (pure lint) and B (full LLM eval), there is a useful intermediate check:
+
+**Skill drift** — when a PR changes a file under any skill's `owner-paths`, does that PR also update the relevant skill (or at least its `last-updated`)?
+
+`tools/skills_drift_check.py` (optional Phase E):
+- For each file in `git diff --name-only main...HEAD`, find skills whose `owner-paths` cover it.
+- For each such skill, check whether the same PR also modified the skill folder or bumped `last-updated`.
+- If not, post a PR comment listing the skills and suggesting a version bump.
+
+This is advisory, not blocking. The intent is to keep skill drift visible.
+
+---
+
+## 7. Maintenance cadence
+
+- **Every PR touching `.claude/skills/`** — Layer A (lint) + Layer B (full eval).
+- **Every PR touching `owner-paths`** — Layer A + drift check (Layer A.5) + Layer B for affected skills only.
+- **Weekly cron** — Layer A + full Layer B + a report committed to `wiki/references/skill-eval-history.md`.
+- **Quarterly audit** — manual walk of `MANIFEST.md`: confirm `status`, retire deprecated, promote drafts that have proven out. Logged in `wiki/`.
+
+---
+
+## 8. Definition of done for the eval system
+
+- `tools/skills_lint.py` exists, runs in under 1s on the whole tree, exits 0 against current state.
+- `tests/skills/runner.py` exists, can run a single case end-to-end against Groq.
+- `tests/skills/eval/<skill>.yaml` exists for the 8 domain skills.
+- CI workflows are green on a representative PR (touching a skill).
+- Synthetic broken-skill PR is correctly rejected (proven by a test PR that's then closed without merge).
+- `wiki/references/skill-eval-history.md` accumulates weekly summaries.
+
+---
+
+## 9. Open questions
+
+1. **Judge model.** The `response_classification` matcher uses a tiny judge prompt. Self-judging (the same skill being eval'd) is wrong. Pick: Groq with a system prompt that strips skill context. Confirm in Phase F.
+2. **Determinism.** LLM eval is non-deterministic. Acceptable failure rate? Proposal: a case is "pass" if it passes ≥4 of 5 runs (5×N → 5×71 = 355 calls per full eval; still cheap). Confirm in Phase F.
+3. **Skill registration in the eval session.** The runner calls `InferenceRouter` but skills are loaded by Claude Code, not the router. The eval may need a separate skill-loading harness (load SKILL.md contents into the system prompt) so the model sees the constraint set. Spec out in Phase F.
+4. **Reuse vs new.** The 5-regime framework + GS11 suite are mature; consider whether `tests/skills/runner.py` is a new harness or a regime8 extension of the existing one. Default proposal: new harness — different shape (per-skill cases vs full-message-truth-set).
+
+---
+
+## 10. Cross-references
+
+- `docs/research/fuuz-skills-analysis.md`
+- `docs/planning/mira-claude-skills-architecture.md`
+- `docs/planning/mira-skills-codebase-gap-analysis.md`
+- `docs/planning/mira-claude-skills-implementation-roadmap.md`
+- `docs/planning/mira-skills-file-tree.md`
+- `mira-bots/benchmarks/deepeval_suite.py` — existing GS11 evals
+- `tests/eval/README.md` — existing 5-regime framework

--- a/docs/planning/mira-skills-file-tree.md
+++ b/docs/planning/mira-skills-file-tree.md
@@ -1,0 +1,257 @@
+# MIRA Skill System — Proposed File Tree
+
+**Date:** 2026-05-19
+**Status:** Planning draft (Phase 5). Target file layout once Phases A–D of the roadmap are complete.
+**Companion docs:** `docs/research/fuuz-skills-analysis.md`, `docs/planning/mira-claude-skills-architecture.md`, `docs/planning/mira-skills-codebase-gap-analysis.md`, `docs/planning/mira-claude-skills-implementation-roadmap.md`, `docs/planning/mira-skills-eval-plan.md`.
+
+This document shows the file tree as it will look after Phases A–D land. Items marked `[new]` are added by this initiative; items marked `[changed]` are reshaped from existing files; items marked `[unchanged]` are kept as-is; items marked `[alias]` are kept-or-replaced-by-pointer for backward compatibility.
+
+---
+
+## 1. Proposed `.claude/skills/` tree (post-Phase-D)
+
+```
+.claude/skills/
+│
+├── MANIFEST.md                                     [new]   Phase A — full skill inventory, semver, status
+├── cross-skill-index.md                            [new]   Phase A — task→skill decision matrix + multi-skill workflows
+├── _template/                                      [new]   Phase A
+│   ├── SKILL.md                                    [new]   Boilerplate SKILL.md per §5 of architecture doc
+│   └── references/
+│       └── _template-reference.md                  [new]   Boilerplate reference
+│
+├── mira-architecture-guardian/                     [changed] Phase B — becomes the "mira-platform" doctrine skill (alias retained)
+│   ├── SKILL.md                                    [changed] Rewritten to target contract; ≤500 lines
+│   └── references/
+│       ├── provider-cascade.md                     [new]   Groq → Cerebras → Gemini; no Anthropic
+│       ├── environment-doctrine.md                 [new]   Dev / Staging / Prod boundaries
+│       ├── screenshot-rule.md                      [new]   Promotional pipeline contract
+│       └── hard-constraints.md                     [new]   PRD §4 hard constraints
+│
+├── mira-uns-architecture/                          [new]   Phase B — folder; subsumes the gate-designer role
+│   ├── SKILL.md                                    [new]
+│   └── references/
+│       ├── uns-path-grammar.md                     [new]
+│       ├── resolver-state-machine.md               [new]
+│       └── gate-message-templates.md               [new]
+│
+├── uns-location-gate-designer/                     [alias] Phase B — keep folder with a one-line pointer at SKILL.md for one release, then remove
+│   └── SKILL.md                                    [changed] One-liner: "Renamed to mira-uns-architecture"
+│
+├── mira-industrial-safety/                         [new]   Phase B
+│   ├── SKILL.md                                    [new]
+│   └── references/
+│       ├── safety-keywords.md                      [new]
+│       ├── escalation-templates.md                 [new]
+│       └── regulatory-frame.md                     [new]   OSHA 1910.147, NFPA 70E — primary sources only
+│
+├── mira-component-profile/                         [changed] Phase C — renamed from component-profile-builder/
+│   ├── SKILL.md                                    [changed]
+│   └── references/
+│       ├── component-schema.md                     [new]
+│       ├── per-instance-vs-per-model.md            [new]
+│       └── promotion-flow.md                       [new]
+│
+├── component-profile-builder/                      [alias] Phase C — one-line pointer for one release
+│   └── SKILL.md                                    [changed]
+│
+├── mira-maintenance-workflow/                      [new]   Phase C — folder; consolidates diagnostic-workflow.md (loose file)
+│   ├── SKILL.md                                    [new]
+│   └── references/
+│       ├── fsm-states.md                           [new]
+│       ├── citation-compliance.md                  [new]
+│       ├── close-out-and-wo-update.md              [new]
+│       └── slack-message-templates.md              [new]
+│
+├── diagnostic-workflow.md                          [alias] Phase C — replaced by mira-maintenance-workflow/; leave one-line pointer for one release
+│
+├── mira-plc-tag-intelligence/                      [changed] Phase C — renamed from plc-tag-mapper/
+│   ├── SKILL.md                                    [changed]
+│   └── references/
+│       ├── tag-name-conventions.md                 [new]
+│       ├── quality-codes.md                        [new]   OPC UA quality codes from IEC 62541 primary source
+│       └── sparkplug-b-topic-map.md                [new]
+│
+├── plc-tag-mapper/                                 [alias] Phase C — one-line pointer for one release
+│   └── SKILL.md                                    [changed]
+│
+├── mira-telemetry-analysis/                        [new]   Phase D — status: draft (gated on telemetry path)
+│   ├── SKILL.md                                    [new]
+│   └── references/
+│       ├── baseline-construction.md                [new]   EWMA, moving avg, Z-score from primary stats sources
+│       ├── anomaly-evidence-thresholds.md          [new]
+│       └── sensor-health-vs-process-anomaly.md     [new]
+│
+├── mira-demo-builder/                              [new]   Phase D
+│   ├── SKILL.md                                    [new]
+│   └── references/
+│       ├── seed-data-shapes.md                     [new]
+│       ├── golden-transcript-format.md             [new]
+│       └── atlas-wo-fixtures.md                    [new]
+│
+├── work-order-history-miner/                       [unchanged] Phase C — kept as separate co-skill, cross-linked from mira-maintenance-workflow
+│   └── SKILL.md
+│
+├── slack-technician-ux-writer/                     [unchanged] Phase C — kept; cross-linked from mira-maintenance-workflow
+│   └── SKILL.md
+│
+├── manual-ingestion-extractor/                     [unchanged]
+│   └── SKILL.md
+│
+├── knowledge-graph-proposer/                       [unchanged]
+│   └── SKILL.md
+│
+├── mira-saas-scope-guard/                          [unchanged]
+│   └── SKILL.md
+│
+├── bot-grounding-tests/                            [unchanged]
+│   └── SKILL.md
+│
+├── autonomous-run/                                 [unchanged]
+│   └── ... (existing structure)
+│
+├── web-review/                                     [unchanged]
+├── qr-onboarding/                                  [unchanged]
+├── marketing/                                      [unchanged]
+├── promo-director/                                 [unchanged]
+│
+└── (loose files — operational helpers, untouched)
+    ├── ar-hud.md                                   [unchanged]
+    ├── bot-adapters.md                             [unchanged]
+    ├── conversation-forensic.md                    [unchanged]
+    ├── design-ship-routine.md                      [unchanged]
+    ├── harness.md                                  [unchanged]
+    ├── inference-routing.md                        [unchanged]
+    ├── kb-benchmark.md                             [unchanged]
+    ├── knowledge-ingest.md                         [unchanged]
+    ├── photo-ingest-watcher.md                     [unchanged]
+    ├── saas-activation.md                          [unchanged]
+    ├── smart-commit.md                             [unchanged]
+    ├── stripe.md                                   [unchanged]
+    ├── telegram_bot_tuning.md                      [unchanged]
+    └── youtube-transcript.md                       [unchanged]
+```
+
+---
+
+## 2. Proposed `tools/skills_*.py` (Phase E)
+
+```
+tools/
+├── skills_lint.py                                  [new]   Phase E
+└── skills_drift_check.py                           [new]   Phase E (optional)
+```
+
+`skills_lint.py` responsibilities:
+- Walk `.claude/skills/`.
+- Validate frontmatter (`name`, `description`, `version`, `status`, `last-updated`, `owner-paths`, optional `related-skills`).
+- Validate SKILL.md size (warn > 500 lines, fail > 800).
+- Validate `owner-paths` exist relative to repo root (warn if missing).
+- Validate `MANIFEST.md` row exists per skill and matches frontmatter version + last-updated.
+- Validate severity tag convention: any numbered rule (`UNS-001`, `KG-014`, etc.) must include a `[FATAL]`/`[BLOCKING]`/`[WARNING]`/`[STYLE]` tag (warn if missing).
+
+`skills_drift_check.py` (optional Phase E):
+- Reads `git diff --name-only main...HEAD`.
+- For each changed file, finds skills whose `owner-paths` cover it.
+- Posts a PR comment listing those skills and asking the author to consider a version bump.
+
+---
+
+## 3. Proposed `tests/skills/` (Phase F)
+
+```
+tests/
+└── skills/
+    ├── README.md                                   [new]   Phase F — how to add a case
+    ├── runner.py                                   [new]   Phase F — runs evals via InferenceRouter
+    ├── eval/
+    │   ├── mira-architecture-guardian.yaml         [new]   Phase F
+    │   ├── mira-uns-architecture.yaml              [new]   Phase F
+    │   ├── mira-industrial-safety.yaml             [new]   Phase F
+    │   ├── mira-component-profile.yaml             [new]   Phase F
+    │   ├── mira-maintenance-workflow.yaml          [new]   Phase F
+    │   ├── mira-plc-tag-intelligence.yaml          [new]   Phase F
+    │   ├── mira-telemetry-analysis.yaml            [new]   Phase F
+    │   └── mira-demo-builder.yaml                  [new]   Phase F
+    └── fixtures/
+        └── (eval fixture files: sample technician messages, sample manuals, sample tag CSVs)
+```
+
+Format of a `.yaml` eval case:
+
+```yaml
+skill: mira-uns-architecture
+cases:
+  - name: positive-trigger-uns-keyword
+    prompt: "I need to add a new UNS path for line 3 at the Lake Wales site."
+    expect_skill_activation: yes
+    expect_constraint_citations: [UNS-001, UNS-007]
+  - name: negative-trigger-generic-chat
+    prompt: "Hey, what's the weather like in Florida?"
+    expect_skill_activation: no
+  - name: constraint-tempting-skip-slug
+    prompt: "Build the UNS path enterprise.knowledge_base.RockwellAutomation.PowerFlex525 — don't bother slugging."
+    expect_skill_activation: yes
+    expect_constraint_refusal: UNS-003
+```
+
+---
+
+## 4. Proposed `docs/` additions
+
+```
+docs/
+├── research/
+│   └── fuuz-skills-analysis.md                     [exists]  Phase 1 — done
+├── planning/
+│   ├── mira-claude-skills-architecture.md          [exists]  Phase 2 — done
+│   ├── mira-skills-codebase-gap-analysis.md        [exists]  Phase 3 — done
+│   ├── mira-claude-skills-implementation-roadmap.md[exists]  Phase 4 — done
+│   ├── mira-skills-file-tree.md                    [exists]  Phase 5 — this file
+│   ├── mira-skills-eval-plan.md                    [pending] Phase 7
+│   └── mira-fuuz-adaptation-final-report.md        [pending] Phase 8
+└── (no other docs/ changes)
+```
+
+---
+
+## 5. Proposed `wiki/` additions (Phase G only)
+
+```
+wiki/
+└── references/
+    ├── skill-governance.md                         [new]    Phase G — versioning/deprecation policy + audit cadence
+    └── skill-index.md                              [new]    Phase G — human-readable view of MANIFEST.md
+```
+
+---
+
+## 6. Files explicitly NOT created
+
+- No `.skill` archive files (Fuuz uses ZIP-archive packaging; MIRA uses raw markdown — Anthropic convention).
+- No new `docs/specs/` files (skill content is not a spec; specs that already exist are *cited by* skills).
+- No new files under `mira-bots/`, `mira-pipeline/`, `mira-mcp/`, `mira-crawler/`, `mira-cmms/`, `mira-web/`, `mira-bridge/`, `mira-relay/`, `mira-hub/`, `mira-core/`. The skill initiative is documentation-only.
+
+---
+
+## 7. Naming + alias policy summary
+
+| Old name (folder) | New name (folder) | Alias period |
+|---|---|---|
+| `mira-architecture-guardian/` | `mira-architecture-guardian/` (role evolves to `mira-platform`) | n/a — folder kept, role widened |
+| `uns-location-gate-designer/` | `mira-uns-architecture/` | one release with a one-line pointer SKILL.md at old path |
+| `component-profile-builder/` | `mira-component-profile/` | one release |
+| `plc-tag-mapper/` | `mira-plc-tag-intelligence/` | one release |
+| `diagnostic-workflow.md` (loose file) | `mira-maintenance-workflow/` (folder) | one release with pointer file |
+
+Aliases exist purely so existing references (in PRs, in commits, in wiki pages) don't break. They are removed in a follow-up cleanup PR after one release.
+
+---
+
+## 8. Cross-references
+
+- `docs/planning/mira-claude-skills-architecture.md`
+- `docs/planning/mira-skills-codebase-gap-analysis.md`
+- `docs/planning/mira-claude-skills-implementation-roadmap.md`
+- `docs/planning/mira-skills-eval-plan.md`
+- `docs/research/fuuz-skills-analysis.md`

--- a/docs/research/fuuz-skills-analysis.md
+++ b/docs/research/fuuz-skills-analysis.md
@@ -1,0 +1,1027 @@
+# Fuuz Skills Analysis — Research Reference for MIRA
+
+**Date:** 2026-05-19
+**Analyst:** Claude Code (claude-sonnet-4-6) on CHARLIE node
+**Source repos:** `/Users/charlienode/reference-repos/fuuz-skills` (read-only clone) and `/Users/charlienode/reference-repos/proveit2026` (read-only clone)
+**Target:** Extract structural and pedagogical patterns for MIRA skill design. NOT a copy exercise.
+**Status:** Research complete. Patterns identified. Adaptation map grounded in existing MIRA skills.
+
+---
+
+## 1. Executive Summary
+
+### What Fuuz Is
+
+Fuuz (fuuz.com) is a cloud-native **Industrial Operations Platform** — a no-code/low-code SaaS for manufacturers to build MES, WMS, and process automation applications without writing traditional software. The platform's core abstraction is a **Data Model → Data Flow → Screen** triad where every data model auto-generates a GraphQL API, data flows implement server-side logic via a visual node editor, and screens are JSON-encoded component trees rendered by a React/craft.js runtime. Fuuz targets OT (operations technology) teams who need factory-floor applications but lack software engineering resources.
+
+### What the fuuz-skills Repo Is
+
+The `fuuz-skills` repository is a suite of **seven Claude Code skills** that teach Claude how to generate valid Fuuz platform artifacts. Each skill is a structured Markdown document with a YAML frontmatter trigger block, numbered golden rules, reference-file inventories, and domain-specific checklists. The skills are packaged as `.skill` archives (ZIP files with `SKILL.md` as the root) deployed via the Claude Code admin console. They function as executable operating guides: when a developer asks Claude to "create a Fuuz data model for production tracking," the appropriate skill activates and constrains Claude's output to valid platform JSON.
+
+The `proveit2026` repository contains three production-grade `.fuuz` application packages (gzipped tarballs) demonstrating the package format at real scale: Enterprise C MES (28 models, 26 screens, 39 flows), Enterprise B WMS (38 models, 33 screens, 33 flows), and a Data Broker app (34 models, 14 screens, 22 flows).
+
+### One-Sentence Comparison to MIRA
+
+Where Fuuz teaches Claude to **generate** platform artifacts for a proprietary no-code builder (schemas, UI JSON, flow graphs), MIRA's skill system teaches Claude to **ground** maintenance intelligence answers in plant context — a fundamentally different purpose: evidence accumulation over artifact generation.
+
+---
+
+## 2. License and Reuse Posture
+
+### License Finding
+
+**CRITICAL: Neither repository contains a LICENSE file.**
+
+Checked via:
+```
+ls /Users/charlienode/reference-repos/fuuz-skills/LICENSE* 2>/dev/null  → (no output)
+ls /Users/charlienode/reference-repos/proveit2026/LICENSE* 2>/dev/null  → (no output)
+```
+
+Under default US copyright law (17 U.S.C. § 106), the absence of an explicit license means **all rights reserved** by the author/organization. Fuuz Industrial Intelligence retains exclusive copyright over all content in both repositories.
+
+### What This Means for MIRA
+
+| Category | Status | Notes |
+|---|---|---|
+| Structural patterns (numbered rules format, section hierarchy, frontmatter trigger shape) | **Independently implementable** | Ideas and formats are not copyrightable — only specific expression is |
+| Open industrial standards cited within (ISA-95, ISO 22400, OPC UA quality codes, ISA-88) | **Cite from primary sources** | Standards themselves are independently publishable; use their own documentation |
+| Prose passages, golden-rules lists, named checklists verbatim | **NOT copyable** | Specific expression is protected |
+| JSON schema shapes and JSONata snippets | **NOT copyable verbatim** | Likely constitutes copyrightable code/expression |
+| Concept descriptions (what OEE is, EWMA formula) | **OK to describe independently** | Mathematical formulas and domain facts are not copyrightable |
+| `.fuuz` package format details | **Describe structurally, not verbatim** | The format itself is a Fuuz platform specification — use for understanding, not replication |
+
+### Conservative Posture
+
+This document describes patterns and structural concepts only. It quotes frontmatter exactly where needed for technical analysis. No numbered golden-rules lists, prose checklists, or JSON templates are reproduced. MIRA skill content must be written independently from scratch using these patterns as inspiration.
+
+---
+
+## 3. Repository Inventory
+
+### fuuz-skills Repository
+
+**Root:** `/Users/charlienode/reference-repos/fuuz-skills/`
+
+```
+fuuz-skills/
+├── README.md                          # Skills overview + installation instructions
+├── SKILLS_VERSION_MANIFEST.md         # Central version tracking + deployment process
+├── fuuz-packages/
+│   ├── SKILL.md                       # 1803 lines — most comprehensive skill
+│   └── references/
+│       └── package-deployment-lifecycle.md
+├── fuuz schema/                       # NOTE: space in directory name
+│   ├── SKILL.md                       # 794 lines
+│   └── references/
+│       └── (reference files)
+├── fuuz screens/                      # NOTE: space in directory name
+│   ├── SKILL.md                       # 955 lines
+│   └── references/
+│       ├── screen-essentials.md
+│       └── (other reference files)
+├── fuuz flows/                        # NOTE: space in directory name
+│   ├── SKILL.md                       # 675 lines
+│   └── references/
+│       └── (reference files)
+├── fuuz-platform/
+│   ├── SKILL.md                       # 627 lines
+│   └── references/
+│       ├── cross-skill-index.md
+│       ├── platform-glossary.md
+│       └── system-seeded-values.md
+├── fuuz-industrial-ops/
+│   ├── SKILL.md                       # 475 lines
+│   └── references/
+│       └── uns-patterns.md
+└── fuuz-ml-telemetry/
+    ├── SKILL.md                       # 399 lines
+    └── references/
+        └── validation-checklist.md
+```
+
+**File counts:**
+- Total files: 81
+- SKILL.md files: 7 (one per skill)
+- Reference markdown files: ~20
+- Total markdown lines across all files: ~50,093
+
+**Three directories use spaces in their names** (`fuuz schema/`, `fuuz screens/`, `fuuz flows/`) — this caused `xargs wc -l` failures during analysis. Paths require quoting or `-exec` mode in shell commands.
+
+### SKILL.md vs Reference Markdown
+
+Each skill follows a two-tier content architecture:
+1. **SKILL.md** — The primary operating guide. YAML frontmatter + numbered rules + section headers. This is what Claude loads when the skill activates.
+2. **`references/` subdirectory** — Supplementary reference documents. Some have their own YAML frontmatter (suggesting they can also act as standalone skill triggers). Others are pure reference tables.
+
+The version manifest explicitly states: **"Skills CANNOT reference files outside the skills directory. All content must be baked in."** Reference files are included in the `.skill` ZIP archive.
+
+### proveit2026 Repository
+
+**Root:** `/Users/charlienode/reference-repos/proveit2026/`
+
+```
+proveit2026/
+├── README.md                          # App descriptions + integration architecture
+├── Enterprise C MES App@0.0.1.fuuz   # Production MES package (~15MB)
+├── Enterprise B WMS App@0.0.1.fuuz   # WMS package
+└── ProveIT Data Broker App@0.0.1.fuuz # Data broker package
+```
+
+4 files total. The `.fuuz` files are the production artifacts — the README describes what they contain.
+
+### Skills Version Manifest Summary
+
+`/Users/charlienode/reference-repos/fuuz-skills/SKILLS_VERSION_MANIFEST.md` tracks all 7 skills with:
+- Status labels: `draft` / `review` / `ready` / `deployed` / `deprecated` / `baked-in`
+- Semantic version numbers (e.g., `v1.2.0`)
+- Deployment targets (which Claude Code teams/instances each skill is deployed to)
+- Complete version history from 2026-02-17 to 2026-02-22
+- A `NewTrainingData/` workflow directory for skill updates
+
+All 7 skills were at `deployed` or `baked-in` status as of the last manifest update.
+
+---
+
+## 4. Skill-by-Skill Breakdown
+
+### 4.1 fuuz-packages
+
+**File:** `/Users/charlienode/reference-repos/fuuz-skills/fuuz-packages/SKILL.md`
+**Lines:** 1803 (longest skill)
+
+**YAML Frontmatter (exact quote):**
+```yaml
+---
+name: fuuz-packages
+description: >
+  Create, manage, deploy, and troubleshoot Fuuz packages (.fuuz files) for the Fuuz Industrial Operations Platform
+  (fuuz.com). Trigger this skill whenever the user mentions Fuuz packages, .fuuz files, package deployment,
+  Green/Blue deployments in Fuuz, package versioning, package linting, environment promotion (build to QA to
+  production), tenant deployment, package rollback, industry accelerators, application packaging, or any work
+  involving bundling and deploying Fuuz application components. Also trigger when the user discusses multi-tenant
+  enterprise architecture, data migration between environments, or creating distributable Fuuz application bundles.
+---
+```
+
+**H2 Section Headers (19 sections):**
+1. What Is a Fuuz Package?
+2. Package Creation
+3. Package Validation (Automatic Linting)
+4. Fuuz Enterprise Architecture
+5. Green/Blue Deployment Strategy
+6. Data Migration
+7. Industry Accelerators
+8. Package JSON Structure
+9. Common Package Anti-Patterns
+10. Deployment Checklist
+11. (package-deployment-lifecycle.md has its own YAML with: Purpose, Package Creation, Validation, Enterprise Architecture, Green/Blue, Data Migration, Industry Accelerators, Package JSON Structure, Anti-Patterns, Checklist)
+
+**Reference Files:**
+- `references/package-deployment-lifecycle.md` — Deployment lifecycle procedures, validation checks, Green/Blue process, industry accelerator types
+
+**Notable Patterns:**
+- **71 numbered golden rules** — the highest density of any skill. Format: bold prefix (`**GP-001**:`), one-sentence constraint.
+- Rules use severity codes and domain prefixes: `GP-` (general package), `DM-` (data model), `SC-` (screen), `DF-` (data flow), `IM-` (import).
+- **"FATAL" vs "WARNING" severity tiers** — not all violations are equal. FATAL rules (wrong key count, missing required structures) are distinguished from style warnings.
+- **Pre-Package Validation Checklist** — checkbox format, split across model/screen/flow domains.
+- **Seven-key contract for package-data.json** (`dataModels`, `screens`, `dataFlows`, `dataMappings`, `documentDesigns`, `savedTransforms`, `data`) — exactly seven, no more, no less. This is the canonical FATAL violation pattern.
+- **Import Error Reference section** — maps actual platform error strings to their root causes and fixes. Practical debugging guide embedded in the skill.
+
+**Industrial-Domain Content:**
+- Green/Blue deployment pattern adapted for manufacturing tenants (zero-downtime for 24/7 operations)
+- Industry Accelerator types: MES, WMS, CMMS, Quality, Integration Broker, Track & Trace
+- Platform version pinning (`platformVersion: "2026.2.1"`)
+
+---
+
+### 4.2 fuuz-schema
+
+**File:** `/Users/charlienode/reference-repos/fuuz-skills/fuuz schema/SKILL.md`
+**Lines:** 794
+
+**YAML Frontmatter (exact quote):**
+```yaml
+---
+name: fuuz-schema
+description: >
+  Design Fuuz data models, generate package JSON, define fields and relationships for the Fuuz Industrial
+  Operations Platform (fuuz.com). Trigger this skill whenever the user mentions Fuuz data models, Fuuz schema
+  design, GraphQL, Fuuz field types, package JSON generation, database schema, data modeling for Fuuz, Fuuz
+  API generation, or wants to build any data-storage entity in a Fuuz application. Use for all tasks involving
+  model design, field definitions, relationship mapping, or creating the data layer of a Fuuz app.
+---
+```
+
+**H2 Section Headers (20 sections):**
+1. What is a Fuuz Data Model?
+2. Critical Rules — 24 numbered rules
+3. Data Model JSON Structure
+4. Model Classification
+5. Field Definitions
+6. Field Types Reference
+7. Relationship Patterns
+8. The Relationship TRIPLET
+9. Index Definitions
+10. Sequence Configuration
+11. Custom Fields
+12. System Fields (Never Define)
+13. Data Retention
+14. Model Naming Conventions
+15. Lookup / Enum Models
+16. Model Triggers
+17. Module Assignment
+18. Common Mistakes
+19. Validation Checklist
+20. Reference Files
+
+**Reference Files:**
+- Field types reference (comprehensive table of all supported field types)
+- Relationship patterns guide
+
+**Notable Patterns:**
+- **Relationship TRIPLET constraint** — every relationship requires exactly three pieces: (1) FK scalar field, (2) forward named relation, (3) inverse list on the target model. Missing any one causes import failure. This is the single most common error pattern documented.
+- **`usable` vs `active` distinction** — `usable` applies ONLY to lookup/enum models; `active` applies to master and transactional models. Mixing them causes silent data corruption.
+- **System fields blacklist** — `createdAt`, `updatedAt`, `createdBy`, `updatedBy` are auto-generated. Defining them explicitly causes duplicate-field import errors.
+- **Data retention tiers by model classification:**
+  - Setup models: 120 days
+  - Transactional models: 3650 days (10 years)
+  - Master models: 5475 days (15 years)
+- **Naming conventions enforced as rules:** PascalCase singular model names (`WorkOrder` not `work_orders`), camelCase field names, `At` suffix for DateTime fields (`startedAt`), `is`/`has` prefix for boolean fields.
+- **Pure-digit model names are valid** when adjacent to a known vendor/family. This was documented as a historical bug correction in the UNS resolver (model=`"525"` for PowerFlex 525 is correct).
+
+**Industrial-Domain Content:**
+- Master model examples: `Asset`, `Workcenter`, `Product`
+- Transactional model examples: `ProductionLog`, `Telemetry`, `Alarm`
+- Setup model examples: `AlarmCategory`, `ShiftSchedule`, `DowntimeReason`
+
+---
+
+### 4.3 fuuz-screens
+
+**File:** `/Users/charlienode/reference-repos/fuuz-skills/fuuz screens/SKILL.md`
+**Lines:** 955
+
+**YAML Frontmatter (exact quote):**
+```yaml
+---
+name: fuuz-screens
+description: >
+  Create Fuuz application screens (UI), design user interfaces for the Fuuz Industrial Operations Platform
+  (fuuz.com), build tables, forms, dashboards, HMIs, and mobile apps using Fuuz screen designer JSON.
+  Trigger this skill whenever the user mentions Fuuz screens, Fuuz UI, Fuuz screen designer, Fuuz components,
+  Fuuz screen JSON, building a Fuuz interface, designing a Fuuz dashboard, creating HMI screens, or any
+  visual interface work within a Fuuz application. Also trigger for mobile app screen design, table screens,
+  form screens, and screen component configurations.
+---
+```
+
+**H2 Section Headers (17 sections):**
+1. What is a Fuuz Screen?
+2. Critical Design Principles
+3. Critical Required Properties
+4. Screen JSON Structure
+5. Component Registry — 59 element types
+6. State Management
+7. Data Binding Patterns
+8. Common Errors Quick Reference
+9. Setup Table CRUD Checklist
+10. HMI Design Guidelines (ISA-101 compliance)
+11. Mobile App Design Guidelines
+12. Dashboard Design Patterns
+13. Form Design Patterns
+14. Screen Type Decision Matrix
+15. Output Checklist
+16. Reference Files
+17. Cross-Skill References
+
+**Reference Files:**
+- `references/screen-essentials.md` (has its own YAML frontmatter: `name: fuuz-screen-design`)
+
+**Notable Patterns:**
+- **59 named component types** — the most complete component registry of any skill. Each component has required properties listed.
+- **Screen type decision matrix** — maps user intent ("user needs to see a list", "user needs to fill out a form", "user needs real-time data") to the correct screen architecture.
+- **ISA-101 HMI compliance** noted for industrial display screens — high-contrast, minimal animation, touch-target sizing for gloved hands.
+- **Mobile-first design guidelines** for screens deployed on tablets/phones in the field.
+- **JSONata expression binding** is the primary data connection mechanism — `$state.context.someField` binds live flow data into screen components.
+- Cross-skill reference path: `/mnt/skills/user/fuuz-flows/SKILL.md` — reveals the runtime deployment path structure on the Claude Code admin console.
+- **Output Checklist** — final gate before declaring a screen complete. Enumerates required properties that commonly get omitted.
+
+**Industrial-Domain Content:**
+- HMI screen patterns for machine status monitoring
+- Mobile app patterns for technician field data entry
+- Production dashboard layouts for OEE and shift performance displays
+- ISA-101 color convention references (gray for normal, yellow for warning, red for fault)
+
+---
+
+### 4.4 fuuz-flows
+
+**File:** `/Users/charlienode/reference-repos/fuuz-skills/fuuz flows/SKILL.md`
+**Lines:** 675
+
+**YAML Frontmatter (exact quote):**
+```yaml
+---
+name: fuuz-flows-v1
+description: >
+  Build Fuuz data flows (server-side logic, automation, integrations) for the Fuuz Industrial Operations
+  Platform (fuuz.com). Trigger this skill whenever the user mentions Fuuz data flows, Fuuz flow designer,
+  Fuuz automation, Fuuz scheduled flows, Fuuz web flows, Fuuz gateway flows, Fuuz integration flows,
+  Fuuz document flows, building backend logic in Fuuz, GraphQL mutations in Fuuz, or any logic/automation
+  layer in a Fuuz application. Also trigger for JSONata transformations, flow debugging, Fuuz node
+  configuration, or connecting Fuuz to external systems.
+---
+```
+
+Note: The `name` field is `fuuz-flows-v1` (with version suffix) while all other skills use bare names. This may indicate the flows skill went through a versioning migration that left the version in the name field rather than tracked separately.
+
+**H2 Section Headers (14 sections):**
+1. Flow Types — Backend, Web, Gateway
+2. Flow Design Standards
+3. Fuuz API Architecture
+4. JSONata vs JavaScript Decision
+5. Critical JSONata Context Behavior
+6. Flow Execution Context and Timeouts
+7. Naming Conventions and Documentation Requirements
+8. Flow Development Workflow
+9. Common Flow Patterns
+10. GraphQL API Usage
+11. Node Reference — 50+ node types
+12. JSONata Custom Bindings
+13. Best Practices
+14. Resources
+
+**Reference Files:**
+- Flow-specific reference files (GraphQL patterns, JSONata examples)
+
+**Notable Patterns:**
+- **JavaScript runtime is restricted ES5** — no `let`/`const`, no arrow functions, no template literals, no `.toFixed()`. Flows run in a sandboxed ES5 environment. This is the single most common developer mistake, documented prominently.
+- **JSONata is preferred over JavaScript** for most transformations — JSONata runs natively on the platform without the ES5 restriction and is more debuggable.
+- **Three execution environments** with different timeout constraints:
+  - Backend flows: 20 minutes
+  - Web (Screen) flows: 10 minutes
+  - Gateway flows: varies by device
+- **Flow naming convention** enforces descriptive names that embed the trigger context and action: `[TriggerType]_[Model]_[Action]` pattern.
+- **Relay-style GraphQL connections** — all list queries return `edges { node { ... } }` shape. Never flat arrays.
+- **50+ node types** documented individually — Query, Mutate, Transform (JS/JSONata), Broadcast, Filter, Loop, HTTP Request, Schedule, Subscribe, Aggregate, etc.
+
+**Industrial-Domain Content:**
+- Gateway flows for PLC/device communication
+- Integration flows for ERP sync (SAP, Plex patterns)
+- Scheduled flows for OEE aggregation (15-minute windows)
+- Document flows for generating PDF work orders and labels
+
+---
+
+### 4.5 fuuz-platform
+
+**File:** `/Users/charlienode/reference-repos/fuuz-skills/fuuz-platform/SKILL.md`
+**Lines:** 627
+
+**YAML Frontmatter (exact quote):**
+```yaml
+---
+name: fuuz-platform
+description: >
+  Provide platform-wide reference knowledge for Fuuz Industrial Operations Platform (fuuz.com). Trigger
+  this skill for questions about the Fuuz platform architecture, system models (users, roles, settings),
+  platform connectors and device drivers, unit types and measures, schedule groups, visualization library
+  (FusionCharts), Custom JSONata library, system seeded values, platform settings configuration,
+  enterprise/tenant/application hierarchy, or any cross-cutting platform concept. Also trigger when
+  the user needs to understand the platform's built-in capabilities before building custom components,
+  or when other Fuuz skills need platform context (connector configs, driver types, seeded values).
+  Do NOT trigger for data model design (fuuz-schema), flow building (fuuz-flows), or screen creation
+  (fuuz-screens) unless those skills are also active.
+---
+```
+
+Note: This frontmatter includes an **explicit negative trigger** (`Do NOT trigger for...`) — a pattern none of the other skills use. This prevents platform-level context from overriding the specialized output-generating skills.
+
+**H2 Section Headers (18 sections):**
+1. What This Skill Covers
+2. Platform Architecture Overview
+3. System vs Custom Schema
+4. Dual API Architecture — Application API + System API
+5. System Seeded Values
+6. Connectors — 44 Built-In
+7. Device Gateway
+8. Device Drivers — 19 Built-In
+9. Visualization Library — FusionCharts
+10. Platform Settings — 12 System Settings
+11. Custom JSONata Library Reference
+12. Unit Types and Measures
+13. Schedule Groups and Events
+14. Roles and Access Control
+15. Data Mappings
+16. AI Development Rules
+17. Resources
+18. Cross-Skill Index (with `references/cross-skill-index.md`)
+
+**Reference Files:**
+- `references/cross-skill-index.md` — Task→skill decision matrix, dependency graph, multi-skill workflows
+- `references/platform-glossary.md` — Definitions of all 40+ core platform concepts
+- `references/system-seeded-values.md` — Pre-populated lookup values for all system enum types
+
+**Notable Patterns:**
+- **Reference-only skill** — explicitly produces no artifacts. Its sole purpose is providing grounding context to other skills and answering platform architecture questions.
+- **Explicit negative trigger** in frontmatter prevents over-activation.
+- **44 built-in connectors** and **19 device drivers** documented — SAP, Salesforce, HTTP, FTP, Plex, Oracle, SQL Server, Ethernet/IP PLC, Modbus TCP, MQTT Client, OPC-UA, etc.
+- **AI Development Rules section** — the skill includes rules for Claude's own behavior (what to do when uncertain, how to validate outputs, when to ask clarifying questions). This is the meta-layer of the skill system.
+- **Custom JSONata library** — Fuuz extends the JSONata standard with platform-specific functions. These are documented here rather than in fuuz-flows because they're platform-wide.
+- **Cross-skill dependency graph** (ASCII art in cross-skill-index.md) shows `fuuz-platform → fuuz-schema → fuuz-flows → fuuz-screens` as a directed dependency chain.
+
+**Industrial-Domain Content:**
+- Device drivers for PLCs, Modbus, OPC UA, MQTT Sparkplug B, SAP RFC
+- Unit conversion framework (ISA-95 units of measure categories)
+- Shift scheduling model (Schedule Groups → Schedules → Schedule Events → RRule)
+
+---
+
+### 4.6 fuuz-industrial-ops
+
+**File:** `/Users/charlienode/reference-repos/fuuz-skills/fuuz-industrial-ops/SKILL.md`
+**Lines:** 475
+
+**YAML Frontmatter (exact quote):**
+```yaml
+---
+name: fuuz-industrial-ops
+description: >
+  Apply industrial operations domain knowledge within Fuuz applications. Trigger this skill for OEE
+  calculations, ISO 22400 time classification, ISA-95 equipment hierarchy design, UNS topic structure,
+  alarm management patterns, workcenter state modeling, ERP integration patterns, or any manufacturing
+  KPI implementation in Fuuz. Also trigger for shift scheduling, downtime tracking, production reporting,
+  or when industrial standards compliance is required in a Fuuz application.
+---
+```
+
+**H2 Section Headers (14 sections):**
+1. When to Use This Skill
+2. ISA-95 Asset Hierarchy
+3. Unified Namespace (UNS)
+4. Alarm Management
+5. OEE and ISO 22400 Time Classification
+6. OPC UA Quality Codes
+7. Ideal Cycle Time Fallback Pattern
+8. OEE Domain Formulas
+9. Workcenter State Management
+10. Equipment-Specific Downtime Notes
+11. GraphQL Syntax Reference
+12. ERP Integration Patterns
+13. Resources
+14. Version History
+
+**Reference Files:**
+- `references/uns-patterns.md` — UNS topic building with JSONata, conditional hierarchy levels
+
+**Notable Patterns:**
+- **UNS topic format:** `fuuz/{site}/{area}/{line}/{cell}/{equipment}/{datatype}` — the `fuuz/` vendor prefix is hardcoded into all UNS path builders. This is vendor-specific, not the MQTT standard pattern.
+- **OEE benchmark documentation:** world-class = 85%, typical manufacturing = 60%. Gives Claude grounding for "is this OEE good?" questions.
+- **ISO 22400 time classification** — Planned Production Time, Scheduled Downtime, Unplanned Downtime, Equipment Failures, Quality Losses. Not invented by Fuuz; independently citable from ISO 22400.
+- **OPC UA quality code map:** 192 = Good, 64 = Uncertain, 16 = Bad. Platform-independent standard.
+- **Ideal Cycle Time Fallback Pattern** — when cycle time is unknown, derive it from the best-performing 10% of production records. This is an industry-standard estimation technique.
+- **Workcenter State Machine** — `Running` / `Idle` / `Scheduled Downtime` / `Unplanned Downtime` / `Changeover` / `Maintenance` state transitions.
+- **ERP Integration Patterns** — push/pull reconciliation strategies for SAP and Plex connectors.
+
+**Industrial-Domain Content:**
+This skill is entirely industrial-domain content. ISA-95 hierarchy, OEE formulas, alarm management, shift scheduling, quality codes. The Fuuz-specific parts are the GraphQL syntax for querying these structures — the domain knowledge itself is standard.
+
+---
+
+### 4.7 fuuz-ml-telemetry
+
+**File:** `/Users/charlienode/reference-repos/fuuz-skills/fuuz-ml-telemetry/SKILL.md`
+**Lines:** 399
+
+**YAML Frontmatter (exact quote):**
+```yaml
+---
+name: fuuz-ml-telemetry
+description: >
+  Implement machine learning and telemetry analytics in Fuuz applications. Trigger this skill for anomaly
+  detection, predictive analytics, statistical process control, telemetry data processing, sensor data
+  analysis, EWMA baselines, Z-score calculations, Pearson correlation, or any ML/analytics pipeline
+  in Fuuz. Also trigger for high-frequency data ingestion patterns, TTL index configuration, telemetry
+  model design, or when building self-learning analytics that adapt to changing equipment behavior.
+---
+```
+
+**H2 Section Headers (13 sections):**
+1. When to Use This Skill
+2. JavaScript Runtime Limitations (CRITICAL — ES5 only, labeled at section level)
+3. ML Pipeline Architecture
+4. EWMA Baseline Algorithm
+5. Z-Score Anomaly Detection
+6. Pearson Correlation Analysis
+7. SPC — Statistical Process Control
+8. Telemetry Model Design
+9. TTL Index Configuration
+10. High-Volume Data Patterns
+11. Validation Checklist
+12. Common Pitfalls and Debugging
+13. Resources
+
+**Reference Files:**
+- `references/validation-checklist.md` — Three-domain checklist (Data Model / Flow / Screen) in checkbox format
+
+**Notable Patterns:**
+- **EWMA formula documented explicitly:** `newMean = alpha * newValue + (1 - alpha) * oldMean`. O(1) memory — only the running mean is stored, not the full history. Alpha typically 0.1–0.3 for industrial sensor smoothing.
+- **Guard node pattern** — prevents writing to the DB when no historical data exists yet: `$count($.modelName.edges.node) = 0`. This is the standard Fuuz pattern for "first run" protection.
+- **Parallel mutation path architecture** — one JS Transform node fans out via a Broadcast node to multiple parallel paths: Path A (guard → mutate statistics), Path B (mutate raw telemetry), Path C (mutate alerts). This is the canonical high-throughput pattern.
+- **TTL index configuration** — for high-volume telemetry, the `ttl` field on the data model controls automatic record expiration. Documents optimal retention windows by data type.
+- **JavaScript Runtime Limitations labeled at section title level** (CRITICAL) — not buried in content. Escalated to H2 heading with severity marker.
+- **Three-domain validation checklist** — Data Model checks / Flow checks / Screen checks. Each domain has its own checkbox list. Structure is reusable for any multi-domain implementation skill.
+
+**Industrial-Domain Content:**
+- Sensor data anomaly detection for predictive maintenance
+- Vibration/temperature/pressure telemetry patterns
+- Statistical process control (SPC) for quality monitoring
+- High-volume time-series data at industrial IoT scale (millions of records/day)
+
+---
+
+## 5. Cross-Cutting Patterns
+
+### 5.1 Skill Loading Model
+
+Fuuz skills are **`.skill` archives** — ZIP files where `SKILL.md` is the root document. They are deployed via the Claude Code admin console and appear at a runtime path: `/mnt/skills/user/<skill-name>/SKILL.md`. Skills activate based on YAML frontmatter trigger keywords matching user intent.
+
+Key constraints from the version manifest:
+- **Skills CANNOT reference files outside the skills directory.** All content must be self-contained in the ZIP archive.
+- A skill's `name` field in the frontmatter is the activation identifier. One skill per activation event.
+- Multiple skills can be co-active (the cross-skill-index explicitly models multi-skill workflows).
+- Skill version bumps go through a `NewTrainingData/` workflow for re-deployment.
+
+MIRA's skill system uses a different mechanism (`.claude/skills/<name>/SKILL.md` in the repo, loaded via Claude Code's built-in skill scanning) but the structural principles are identical: frontmatter trigger, self-contained content, named activation.
+
+### 5.2 YAML Frontmatter Trigger Shape
+
+All 7 Fuuz skills use the same frontmatter shape:
+
+```yaml
+---
+name: <skill-name>          # Activation identifier
+description: >              # Multi-line trigger description
+  <keyword-rich prose that tells Claude when to activate this skill>
+---
+```
+
+**Pattern observations:**
+- The description is deliberately keyword-dense rather than cleanly written — it lists every plausible trigger phrase a developer might use, separated by commas.
+- Most descriptions end with "Also trigger when..." to catch edge cases.
+- The fuuz-platform skill uniquely adds "Do NOT trigger for..." to prevent over-activation against more specific skills.
+- None use `version:` in the frontmatter — version is tracked separately in `SKILLS_VERSION_MANIFEST.md`.
+- The `fuuz-flows` skill uses `name: fuuz-flows-v1` (version in name field) — an artifact of an older versioning approach apparently not cleaned up.
+
+**For MIRA:** MIRA's existing skills (from system reminder) include: `ar-hud`, `bot-adapters`, `conversation-forensic`, `design-ship-routine`, `diagnostic-workflow`, `harness`, `inference-routing`, `kb-benchmark`, `knowledge-ingest`, `photo-ingest-watcher`, `saas-activation`, `smart-commit`, `stripe`, `telegram_bot_tuning`, `youtube-transcript`. The frontmatter trigger pattern is the same mechanism.
+
+### 5.3 Reference-File Pattern
+
+Every skill that goes beyond ~500 lines outsources depth to `references/` subdirectory files. The pattern:
+- **SKILL.md** = operating rules + section headers + quick-reference tables
+- **`references/<topic>.md`** = deep domain content (full formula tables, complete checklists, exhaustive connector lists)
+
+Some reference files have their own YAML frontmatter (e.g., `screen-essentials.md`, `package-deployment-lifecycle.md`), suggesting they can activate standalone. Others are pure reference documents with no frontmatter.
+
+This two-tier architecture keeps SKILL.md scannable (600–900 lines for most skills, not 2000+) while making deep reference available when needed.
+
+### 5.4 Golden Rules Format
+
+Every skill uses numbered, titled rules in a consistent format:
+
+```
+**XX-NNN**: One-sentence constraint, imperative mood, no hedging.
+```
+
+Where `XX` is a domain prefix (GP = general package, DM = data model, SC = screen, DF = data flow) and `NNN` is a zero-padded sequence number. Rules increase in number across skills (fuuz-packages has 71, fuuz-schema has 24, fuuz-screens has ~30).
+
+**Key properties of effective rules:**
+- Imperative mood ("Never define", "Always include", "Use only")
+- Specific violation consequence documented when relevant ("causes import failure", "results in duplicate field error")
+- Severity where applicable — FATAL vs WARNING vs STYLE
+- One constraint per rule — never compound rules
+
+### 5.5 Error Reference Pattern
+
+`fuuz-packages/SKILL.md` includes an **Import Error Reference section** that maps actual platform error strings (what the user sees when an import fails) to their root causes. This is a high-value pattern: error-message-to-cause mapping is one of the most practical things a skill can teach Claude.
+
+Format:
+```
+Error message: "<exact string from platform>"
+Cause: <diagnosis>
+Fix: <corrective action>
+```
+
+### 5.6 Output Checklist Pattern
+
+Multiple skills include a final output checklist that Claude must run before declaring the artifact complete. The checklist is domain-specific:
+- `fuuz-packages/SKILL.md` → Pre-Package Validation Checklist (model/screen/flow domains)
+- `fuuz-screens/SKILL.md` → Output Checklist (required properties that commonly get omitted)
+- `fuuz-ml-telemetry/references/validation-checklist.md` → Three-domain checklist (Data Model / Flow / Screen)
+
+All use checkbox format: `- [ ] <check description>`. The checklist is the last section before "Reference Files" in each skill.
+
+### 5.7 Cross-Skill Dependency Documentation
+
+`fuuz-platform/references/cross-skill-index.md` explicitly documents:
+1. **Task → skill decision matrix** — for any task, which skill is primary, which are supporting
+2. **Artifact dependency graph** (ASCII art) — shows data flow direction: schema feeds flows feeds screens
+3. **Multi-skill workflow recipes** — e.g., "Build a New Application from Scratch = fuuz-platform → fuuz-schema → fuuz-flows → fuuz-screens in sequence"
+4. **File-level cross-references** — which exact files in each skill point to which files in other skills
+
+MIRA has no equivalent cross-skill index. This is a structural gap.
+
+### 5.8 Versioning Convention
+
+Skills use semantic versioning: `v<major>.<minor>.<patch>`. The version manifest tracks:
+- Current version per skill
+- Deployment target (which Claude Code instance)
+- Version history (all past versions with dates and change descriptions)
+- Status per deployment target (some skills are deployed to one team but not another)
+
+The rule: "A skill version bump requires re-packaging the `.skill` archive and re-deploying via the admin console." — manual process, no CI/CD for skills.
+
+### 5.9 How These Skills Teach Claude About a Proprietary Platform
+
+The core teaching mechanism is **constraint enumeration via negative examples**. Rather than describing what valid output looks like (which Claude could infer from examples), Fuuz skills focus on documenting:
+
+1. **What looks right but is wrong** — `usable` vs `active`, system fields you shouldn't define, ES5-only JS, wrong GraphQL shape
+2. **Silent failures** — issues that pass import but corrupt data (wrong retention tier, missing inverse relation)
+3. **Platform-specific deviations from standards** — JSONata behavior inside Fuuz differs from standard JSONata in specific documented ways
+4. **Error messages → causes** — when something fails, what does it say and why
+
+This is fundamentally different from "here's an example and extend it." It teaches the *failure modes* first.
+
+### 5.10 Naming Conventions as Enforced Rules
+
+Every skill establishes naming conventions as numbered rules, not style guidelines:
+- PascalCase singular for model names
+- camelCase for fields
+- Specific suffixes (`At` for DateTime, `is`/`has` for booleans)
+- Flow naming pattern `[TriggerType]_[Model]_[Action]`
+- `v<major>.<minor>.<patch>` for package versions
+
+The framing matters: "Use PascalCase singular for model names because the import validator rejects plurals" is a rule with a consequence, not a preference.
+
+---
+
+## 6. proveit2026 Analysis
+
+### Repository Overview
+
+`/Users/charlienode/reference-repos/proveit2026/` contains three production `.fuuz` packages demonstrating the Fuuz package format at real enterprise scale. Per the README:
+
+**Enterprise C — MES App:**
+- 28 data models, 26 screens, 39 data flows
+- Production tracking, work orders, OEE, shift management, equipment downtime
+- CESMII i3X standard compliance noted
+
+**Enterprise B — WMS App:**
+- 38 models, 33 screens, 33 flows
+- Warehouse management, inventory, picking, shipping, GS1/SSCC handling unit tracking
+- Integration with Enterprise C for production-inventory sync
+
+**Data Broker App:**
+- 34 models, 14 screens, 22 flows
+- MQTT/OPC UA/REST integration hub between Enterprise C, Enterprise B, and external ERP
+- Tag normalization, data routing, transformation layer
+
+**Integration architecture** (from README): Three-app topology where the Data Broker mediates all cross-app communication. Enterprise C and Enterprise B never communicate directly — all data flows through the broker. This is the Fuuz recommended multi-app architecture pattern.
+
+### .fuuz Package Format
+
+Confirmed by extraction of `ProveIT Data Broker App@0.0.1.fuuz`:
+
+```bash
+tar -xzf "ProveIT Data Broker App@0.0.1.fuuz" -C /tmp/fuuz-extract/
+```
+
+Produces exactly 3 files:
+
+**manifest.json** — package metadata:
+```json
+{
+  "name": "ProveIT Data Broker App",
+  "version": "0.0.1",
+  "applicationPublisherId": null,
+  "enterpriseId": "proveit",
+  "environmentId": "build",
+  "dependencies": {},
+  "specVersion": "2.0.0",
+  "platformVersion": "2026.2.1"
+}
+```
+
+**definition.json** — component selection manifest:
+- Top-level keys: `packageDefinition`, `packageDefinitionVersion`, `packageDefinitionSelections`
+- `packageDefinitionSelections` contains arrays of 5 types: `DataFlow`, `DataModel`, `Screen`, `Module`, `ModuleGroup`
+- Each selection entry: `{ "type": "<ComponentType>", "id": "<uuid>", "name": "<display-name>" }`
+
+**package-data.json** — all component definitions:
+- Top-level keys (exactly 7): `dataModels`, `dataFlows`, `dataMappings`, `documentDesigns`, `screens`, `savedTransforms`, `data`
+- Data Broker contents: 34 dataModels, 22 dataFlows, 0 dataMappings, 0 documentDesigns, 14 screens, 0 savedTransforms, 2 data entries
+
+Model names visible in Data Broker: `Area`, `Asset`, `Enterprise`, `EnterpriseCValues`, `EntityAsset`, `IotTag`, `IotTagDataPoint`, `IotTagGroup`, `IotTagValue`, `LineAsset`, `PendingRecord`, `ProductionLineShift`, `Shift`, `ShiftResult`, `Site`, `Tag`, `TagGroup`, and more (34 total).
+
+The Data Broker's model names confirm the ISA-95 hierarchy physically modeled in the schema: `Enterprise → Site → Area → Asset → IotTag → IotTagDataPoint`.
+
+### What the Package Format Reveals
+
+1. **No executable code in packages** — pure JSON throughout. All logic is expressed as declarative node configurations in the `dataFlows` array.
+2. **Platform version pinned in manifest** — `"platformVersion": "2026.2.1"` ensures reproducible deployment.
+3. **`data` array contains seed records** — the 2 data entries in the Data Broker are likely lookup table seeds (status codes, tag types, etc.).
+4. **UUID-based identities** — all component references use GUIDs, not names, for FK relationships between package components.
+5. **The "exactly 7 keys" rule is verified** — package-data.json has exactly `dataModels`, `dataFlows`, `dataMappings`, `documentDesigns`, `screens`, `savedTransforms`, `data`. The FATAL rule in fuuz-packages is accurate.
+
+---
+
+## 7. What Is Genuinely Transferable to MIRA
+
+These are **structural and pedagogical patterns** that MIRA can implement independently with its own content. None of these involve copying Fuuz expression.
+
+### 7.1 Two-Tier Skill Architecture (SKILL.md + references/)
+
+**Pattern:** Main SKILL.md stays scannable (600–900 lines of rules and quick-reference), with deep domain content in a `references/` subdirectory. Reference files can optionally carry their own YAML frontmatter for standalone activation.
+
+**MIRA application:** MIRA's `diagnostic-workflow`, `knowledge-ingest`, and `component-profile-builder` skills are likely candidates to grow beyond 600 lines. Split depth to `references/` before that threshold, keeping SKILL.md as the rules layer.
+
+### 7.2 Numbered Golden Rules with Domain Prefixes
+
+**Pattern:** `**XX-NNN**: Imperative constraint with documented consequence.`
+
+**MIRA application:** MIRA skills currently use prose sections. Numbered rules with domain prefix codes (`UNS-`, `KG-`, `ENG-`, `ING-`) would make constraint enumeration clearer and easier to reference in PRs ("this violates KG-003").
+
+### 7.3 Explicit Negative Trigger in Platform/Reference Skills
+
+**Pattern:** The `fuuz-platform` skill's frontmatter ends with "Do NOT trigger for data model design (fuuz-schema), flow building (fuuz-flows), or screen creation (fuuz-screens) unless those skills are also active."
+
+**MIRA application:** A future `mira-platform` or architecture reference skill should include explicit "Do NOT trigger for..." clauses to prevent it from overriding specialized output-generating skills.
+
+### 7.4 Error-Message-to-Cause Reference Section
+
+**Pattern:** Map exact platform error strings → root cause → fix. Embedded in the skill where users will encounter it.
+
+**MIRA application:** The MIRA engine has documented error patterns (hallucination audit findings, UNS resolution failures, groundedness score drops). A `Common Errors Reference` section in `diagnostic-workflow/SKILL.md` mapping engine error patterns to their causes would be high-value for debugging sessions.
+
+### 7.5 Output Checklist as Final Gate
+
+**Pattern:** Checkbox checklist at the end of each skill's operating section. Claude runs through it before declaring output complete.
+
+**MIRA application:** `knowledge-ingest/SKILL.md` and `component-profile-builder/SKILL.md` would benefit from output checklists. Example items: "Does every extracted fact have a source page reference?", "Is the confidence field populated?", "Has dedup.py been invoked?", "Does every asset row have a UNS path or equipment_entity_id FK?"
+
+### 7.6 Severity Tiers for Rule Violations
+
+**Pattern:** FATAL (blocks deployment) vs WARNING (review recommended) vs STYLE (best practice). Documented at the rule level.
+
+**MIRA application:** The UNS compliance rules and KG proposal rules have an implicit severity hierarchy. Making it explicit — `[FATAL]` for auto-promoting proposed→verified without review, `[WARNING]` for low groundedness score, `[STYLE]` for naming conventions — would help Claude prioritize which issues to fix vs flag.
+
+### 7.7 Cross-Skill Index Document
+
+**Pattern:** A standalone `cross-skill-index.md` that documents the skill dependency graph, task→skill decision matrix, and multi-skill workflow recipes. No SKILL.md content is duplicated; it purely maps the territory.
+
+**MIRA application:** MIRA has 15+ skills and no documented decision matrix. Creating `.claude/skills/cross-skill-index.md` (or `wiki/references/skill-index.md`) that maps "what to activate for UNS resolution tasks", "what to activate for KB ingestion", "what to activate for engine debugging" would reduce skill selection ambiguity.
+
+### 7.8 Version Manifest for Skills
+
+**Pattern:** `SKILLS_VERSION_MANIFEST.md` with semantic versioning, deployment targets, status labels (`draft`/`review`/`ready`/`deployed`/`deprecated`/`baked-in`), and version history.
+
+**MIRA application:** MIRA's 15 skills have no version tracking. A version manifest at `.claude/skills/MANIFEST.md` would surface when skills are stale relative to the codebase they describe (e.g., `diagnostic-workflow` was written before the RESOLVED-state rebuild fix in PR #1266).
+
+### 7.9 Failure Mode Teaching over Example Teaching
+
+**Pattern:** Fuuz skills teach by documenting what looks right but is wrong, silent failures, platform deviations from standards, and error message meanings — not by providing examples and saying "extend this."
+
+**MIRA application:** MIRA's `uns-compliance.md` already does this for UNS (fault codes must be extracted before model candidates, pure-digit models are valid, reserved labels are off-limits). Extend this approach to `knowledge-ingest`, `component-profile-builder`, and `diagnostic-workflow`.
+
+### 7.10 Runtime Limitation Documentation at Section Level
+
+**Pattern:** `fuuz-ml-telemetry/SKILL.md` elevates "JavaScript Runtime Limitations (CRITICAL)" to an H2 heading with a severity label — not buried in a subsection. This ensures Claude encounters it early in any scan.
+
+**MIRA application:** MIRA's Python-standards.md already documents some runtime constraints, but the pattern could be used in SKILL.md files directly. For example, `inference-routing/SKILL.md` could lead with "**[CRITICAL]** Never reintroduce Anthropic as a provider" as an H2 before the operational content.
+
+---
+
+## 8. What Is NOT Transferable
+
+These patterns are Fuuz-specific with no MIRA analog. Attempting to adapt them to MIRA would introduce category errors.
+
+### 8.1 JSONata as Primary Expression Language
+
+Fuuz's entire data binding and transformation layer is built on JSONata — a query language designed for JSON with functional composition semantics. JSONata is native to the Fuuz platform; MIRA has no equivalent binding language. MIRA's Python codebase uses standard Python/asyncio throughout. There is nothing to adapt.
+
+### 8.2 Relay-Style GraphQL Connections
+
+Fuuz auto-generates a full GraphQL API for every data model with Relay-style `edges { node { ... } }` query shapes. MIRA uses PostgreSQL/NeonDB with raw SQL or SQLAlchemy ORM. The GraphQL patterns documented across all Fuuz skills are platform-specific with no MIRA analog.
+
+### 8.3 The Relationship TRIPLET Constraint
+
+Fuuz's import validator requires that every model relationship be defined in three places simultaneously (FK scalar + forward relation + inverse list). This is a Fuuz platform constraint with no equivalent in MIRA's NeonDB schema design. MIRA's foreign key relationships follow standard PostgreSQL FK constraints.
+
+### 8.4 `.fuuz` Package Deployment Model
+
+Fuuz applications are distributed and deployed as `.fuuz` ZIP+TAR archives imported via the platform UI. MIRA deployments use Docker Compose with GitHub Actions CI/CD. There is no package archive format, no import validator, no platform-version pinning in MIRA's deployment model.
+
+### 8.5 Data Model Classification Tiers (usable vs active)
+
+The `usable`/`active` distinction is a Fuuz platform concept controlling how records are treated in list queries. MIRA's NeonDB tables use standard `is_active` boolean columns without platform-enforced semantic tiers.
+
+### 8.6 ES5 JavaScript Restriction
+
+Fuuz flows run in a sandboxed ES5 environment. MIRA has no such constraint — Python 3.12 is the execution environment throughout.
+
+### 8.7 Craft.js Screen Component System
+
+Fuuz screens are JSON-encoded craft.js component trees with 59 named element types. MIRA's user interfaces are either Slack/Telegram messages (plain text with Markdown) or React/Hono pages in `mira-web`. There is no screen component registry concept in MIRA.
+
+### 8.8 ISA-101 HMI Screen Compliance
+
+ISA-101 HMI design standards apply to graphical operator interfaces on factory floors — color conventions, touch target sizing, animation constraints for industrial displays. MIRA's technician interface is Slack on a phone. The visual compliance requirements don't transfer, though the underlying principle (design for gloved hands in a noisy plant) is partially applicable to MIRA's Slack UX.
+
+### 8.9 Vendor-Prefixed UNS Topics
+
+Fuuz's UNS uses `fuuz/{site}/{area}/...` — the vendor prefix `fuuz/` is hardcoded. MIRA's UNS uses ISA-95 ltree path notation without vendor prefixes. The UNS namespace structures are architecturally related (both follow ISA-95 hierarchy) but incompatible at the path level.
+
+### 8.10 Platform-Level Connector/Driver Registry
+
+Fuuz documents 44 built-in connectors and 19 device drivers as platform capabilities. MIRA doesn't have a built-in connector registry — integrations are implemented as custom Python services. The connector configuration patterns documented in `fuuz-platform/SKILL.md` have no MIRA equivalent.
+
+---
+
+## 9. Risks If MIRA Copies Blindly
+
+### Risk 1: Importing Fuuz's Copyright Expression
+
+**Severity: HIGH**
+Neither repository has a license. Reproducing Fuuz's numbered golden-rules lists, JSON templates, or prose checklists verbatim constitutes copyright infringement. The risk is not theoretical — Fuuz Industrial Intelligence is an active commercial company and these materials are their intellectual property.
+
+**Mitigation:** Structural patterns are ideas (not copyrightable). Specific expression is protected. Always write MIRA skill content from scratch using Fuuz patterns as structural inspiration, not textual templates.
+
+### Risk 2: Importing Platform-Specific Constraints as Universal Rules
+
+**Severity: MEDIUM**
+Fuuz skills are full of rules that are correct for Fuuz but wrong for MIRA. Examples: "Never define createdAt/updatedAt" (Fuuz auto-generates these; MIRA uses them explicitly), "Use `usable` for enum models" (Fuuz-specific field), "GraphQL returns `edges { node { ... } }`" (Fuuz-specific query shape; MIRA uses plain SQL result sets). Importing these as MIRA rules would introduce actual bugs.
+
+**Mitigation:** Every rule adopted from Fuuz pattern inspection must be verified against MIRA's actual architecture before adoption. The fact that a rule makes sense for a no-code platform does not make it applicable to a Python microservice system.
+
+### Risk 3: Confusing Fuuz UNS with MIRA UNS
+
+**Severity: MEDIUM**
+Both systems use "UNS" and reference ISA-95 hierarchy, but the implementations are incompatible:
+- Fuuz UNS: `fuuz/{site}/{area}/{line}/{cell}/{equipment}/{datatype}` — MQTT topic namespace, vendor-prefixed
+- MIRA UNS: ISA-95 ltree paths in PostgreSQL, no vendor prefix, used for knowledge graph addressing
+
+Copying Fuuz UNS path patterns into MIRA would introduce wrong path formats that would break `uns_resolver.py` and contaminate the NeonDB knowledge graph.
+
+**Mitigation:** Treat Fuuz UNS and MIRA UNS as independently designed systems that both happen to reference ISA-95. The Fuuz UNS documents in `fuuz-industrial-ops/references/uns-patterns.md` are useful for understanding ISA-95 hierarchy concepts, but the JSONata path builders and `fuuz/` prefix must never appear in MIRA code.
+
+### Risk 4: Skill Bloat Without Clear Activation Boundaries
+
+**Severity: LOW-MEDIUM**
+Fuuz's `fuuz-platform` skill has an explicit negative trigger precisely because, without it, the platform reference skill would over-activate and pollute every response with platform context. MIRA skills don't currently use negative triggers. As MIRA adds more skills, lack of explicit non-activation conditions could cause the wrong skill to dominate responses.
+
+**Mitigation:** When adding new reference/platform skills to MIRA, add "Do NOT trigger for..." clauses to prevent over-activation against specialized output-generating skills.
+
+### Risk 5: Version Manifest Becoming Stale
+
+**Severity: LOW**
+If MIRA adopts a version manifest pattern for skills but doesn't maintain it, the manifest becomes an actively misleading document — claiming skills are "ready" when they've drifted behind codebase changes. This is worse than no manifest.
+
+**Mitigation:** If a skill version manifest is created, it must be updated as part of any PR that changes skill content or the code/architecture the skill describes. Make skill manifest updates part of the PR template checklist.
+
+---
+
+## 10. Adaptation Map
+
+This section maps each Fuuz skill to its closest MIRA-native counterpart. The goal is to identify which existing MIRA skills could be strengthened by applying the structural patterns from Section 7, and where genuine gaps exist.
+
+### Fuuz → MIRA Skill Mapping
+
+| Fuuz Skill | Lines | Purpose | Closest MIRA Skill | Relationship | Action |
+|---|---|---|---|---|---|
+| `fuuz-industrial-ops` | 475 | ISA-95 hierarchy, OEE, UNS, alarm management | `uns-location-gate-designer` + `plc-tag-mapper` | Partial overlap: ISA-95 hierarchy and UNS concepts appear in both; MIRA handles the resolution side, Fuuz handles the modeling side | Extract ISA-95 hierarchy documentation pattern; verify against `mira-crawler/ingest/uns.py` before applying |
+| `fuuz-schema` | 794 | Data model design, relationship TRIPLETS, field types | `knowledge-graph-proposer` + `component-profile-builder` | Conceptual parallel: both define entity schemas and relationship rules; Fuuz targets GraphQL/NoSQL, MIRA targets NeonDB/PostgreSQL | Apply numbered-rules format with KG prefix codes; adopt severity tiers (FATAL for auto-verify-without-review) |
+| `fuuz-ml-telemetry` | 399 | EWMA, anomaly detection, SPC, telemetry pipelines | `bot-grounding-tests` + `harness` | Distant overlap: EWMA/Z-score algorithms are independently applicable for sensor baselines; Fuuz's implementation is JS/JSONata, MIRA's would be Python | EWMA and Z-score algorithms are independently citable from ML literature; reference primary sources (Holt 1957 for EWMA), not Fuuz documentation |
+| `fuuz-screens` | 955 | Craft.js screen JSON, component registry, HMI design | `slack-technician-ux-writer` | Conceptual parallel: both define "what a valid output looks like" for a specific rendering target; Fuuz targets craft.js JSON, MIRA targets Slack Block Kit messages | Apply the decision matrix pattern (user intent → output structure) to Slack message design; apply ISA-101's "gloved-hands, noisy plant" usability principle to Slack message length/format rules |
+| `fuuz-platform` | 627 | Platform architecture reference, connectors, API shapes | (no direct counterpart — nearest is MIRA's `CLAUDE.md` and `.claude/rules/`) | Structural parallel: reference-only skill providing grounding context; explicit negative trigger to prevent over-activation | Create `.claude/skills/mira-architecture-guardian/SKILL.md` as a platform reference skill; include explicit "Do NOT trigger for..." clause to prevent it displacing specialized skills |
+| `fuuz-packages` | 1803 | `.fuuz` package generation, validation, deployment | `knowledge-ingest` + `manual-ingestion-extractor` | Loose parallel: both involve bundling structured data for import into a target system; Fuuz's target is the platform importer, MIRA's target is NeonDB + Open WebUI KB | Apply the "exactly N top-level keys" constraint pattern to KB ingestion schemas; apply error-message-to-cause reference pattern for common ingestion failures |
+| `fuuz-flows` | 675 | Server-side flow logic, node configurations, ES5 JS | (no direct counterpart — MIRA's logic layer is `shared/engine.py` + Python services) | No direct mapping: Fuuz flows are a visual no-code abstraction over backend logic; MIRA implements equivalent logic directly in Python | This gap suggests a potential new MIRA skill: `pipeline-orchestration` covering `mira-pipeline/` + `shared/engine.py` FSM patterns, but this is out of scope for this analysis |
+
+### Detailed Adaptation Notes
+
+#### fuuz-industrial-ops → uns-location-gate-designer + plc-tag-mapper
+
+The ISA-95 hierarchy documentation in `fuuz-industrial-ops/SKILL.md` is the most directly useful domain content in the Fuuz skills suite. However, MIRA's UNS implementation is already operational (shipped in PR #1330 per memory). What to take:
+
+- **Section structure pattern**: ISA-95 hierarchy → UNS path format → alarm management → state machine → integration patterns. This sequencing makes sense for MIRA's equivalent skill.
+- **State machine documentation**: Fuuz's workcenter states (Running/Idle/Scheduled Downtime/Unplanned Downtime/Changeover/Maintenance) are exactly the states MIRA's engine tracks via the DST (`docs/specs/dialogue-state-tracker-spec.md`). A state-transition table in the MIRA skill would be high-value.
+- **NOT to take**: The specific UNS path format `fuuz/{site}/...` and all JSONata path builder patterns.
+
+#### fuuz-schema → knowledge-graph-proposer + component-profile-builder
+
+The TRIPLET constraint pattern — three coordinated definitions that must all be present for a relationship to be valid — has a direct MIRA analog in the KG relationship rules (`status + evidence + confidence` all required together). Framing MIRA's KG constraint as a triplet would make it more memorable:
+
+```
+**KG-TRIPLET**: Every kg_relationships row must have: (1) relationship_type from the controlled vocabulary, 
+(2) evidence field with source citation, (3) confidence value. A relationship missing any of these 
+three is incomplete and MUST NOT be promoted from 'proposed'.
+```
+
+The `usable`/`active` distinction maps conceptually to MIRA's `proposed`/`verified`/`rejected`/`needs_review` promotion states — both are platform-enforced status semantics that Claude must never circumvent.
+
+#### fuuz-ml-telemetry → bot-grounding-tests + harness
+
+The EWMA algorithm documented in fuuz-ml-telemetry (`newMean = alpha * newValue + (1 - alpha) * oldMean`) is independently applicable to MIRA's groundedness scoring. If MIRA wanted to build self-adapting baselines for engine performance (e.g., moving-average groundedness score per asset category), this is the algorithm to use. But the implementation would be pure Python — the Fuuz skill's ES5 JS constraints and Broadcast node patterns are irrelevant.
+
+The **three-domain validation checklist** (Data Model / Flow / Screen in Fuuz) maps to MIRA's (Schema / Engine / Bot Adapter) domains. The checkbox format is directly applicable.
+
+#### fuuz-screens → slack-technician-ux-writer
+
+The ISA-101 principle that HMI screens must work for operators wearing gloves in a noisy environment is directly applicable to Slack messages sent to maintenance technicians. MIRA's `slack-technician-ux-writer/SKILL.md` should encode this as a first-class constraint:
+
+- Short paragraphs (gloved thumb scrolling, not desktop reading)
+- High-information-density lead line (site → asset → component → fault, in that order)
+- Maximum 3 bullet points of evidence before asking for confirmation
+- No corporate hedging language
+
+The decision-matrix pattern from fuuz-screens (user intent → output structure) maps well: "technician reports a fault" → structured context confirmation message; "technician confirms context" → troubleshooting step list; "technician reports equipment back online" → close-out and WO update prompt.
+
+#### fuuz-platform → mira-architecture-guardian (new skill recommended)
+
+MIRA currently has no skill dedicated to preventing architectural violations across multiple other skills. MIRA's equivalent of `fuuz-platform` would be a read-only architecture reference skill that:
+
+1. Documents the provider cascade (Groq → Cerebras → Gemini — never Anthropic)
+2. Documents the UNS gate as a non-negotiable
+3. Documents the environment boundaries (no prod psql, no direct VPS docker compose)
+4. Carries an explicit negative trigger to prevent it from overriding specialized skills
+
+This skill would surface the information currently scattered across `CLAUDE.md`, `.claude/rules/`, and `docs/ARCHITECTURE.md` in a Claude-activatable format.
+
+#### fuuz-packages → knowledge-ingest + manual-ingestion-extractor
+
+The fuuz-packages skill's most transferable pattern is the **error-message-to-cause reference**. MIRA's ingestion pipeline has documented failure modes (embedding gate killed BM25 in May 2026 per memory; OEM migration blockers; dedup failures). An `Ingestion Error Reference` section in `knowledge-ingest/SKILL.md` mapping actual error messages to root causes would reduce debugging time.
+
+The **pre-ingestion validation checklist** from fuuz-packages maps directly: before calling `mira-crawler/ingest/` functions, Claude should verify that the source document has been chunked, deduplicated, confidence-tagged, and UNS-path-tagged.
+
+#### fuuz-flows → (gap: no direct counterpart)
+
+Fuuz flows are the visual no-code abstraction over backend logic. MIRA implements equivalent logic directly in Python in `shared/engine.py`, `mira-pipeline/`, and the various bot adapters. There is no MIRA "flow builder" skill because flows are Python code, not visual node graphs.
+
+However, this analysis surfaces a genuine skill gap: MIRA has no skill that teaches Claude how the `shared/engine.py` FSM, the inference cascade, and the grounding pipeline work together as an orchestration layer. A `pipeline-orchestration` skill covering these three would improve Claude's accuracy when asked to modify engine behavior. This is a recommendation, not an immediate action item — it falls outside the current 90-day MVP plan scope.
+
+---
+
+## Appendix A: File Reference Index
+
+All source files consulted during this analysis:
+
+| File | Lines | Purpose |
+|---|---|---|
+| `/Users/charlienode/reference-repos/fuuz-skills/README.md` | ~150 | Skills overview, installation, repo structure |
+| `/Users/charlienode/reference-repos/fuuz-skills/SKILLS_VERSION_MANIFEST.md` | ~200 | Version tracking, deployment targets, status legend |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz-packages/SKILL.md` | 1803 | Packages skill — 71 golden rules, package format, deployment |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz-packages/references/package-deployment-lifecycle.md` | 270 | Deployment procedures, Green/Blue, accelerators |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz schema/SKILL.md` | 794 | Schema design, field types, relationship TRIPLET |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz screens/SKILL.md` | 955 | Screen JSON, 59 component types, HMI design |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz screens/references/screen-essentials.md` | ~400 | Screen JSON structure, MainFormContainer pattern |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz flows/SKILL.md` | 675 | Flow types, ES5 constraint, 50+ node types, JSONata |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz-platform/SKILL.md` | 627 | Platform reference, 44 connectors, 19 drivers |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz-platform/references/cross-skill-index.md` | 166 | Task→skill matrix, dependency graph |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz-platform/references/platform-glossary.md` | 166 | 40+ core concept definitions |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz-industrial-ops/SKILL.md` | 475 | ISA-95, OEE, UNS, alarm management, OPC UA |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz-industrial-ops/references/uns-patterns.md` | ~100 | UNS topic building, JSONata conditional hierarchy |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz-ml-telemetry/SKILL.md` | 399 | EWMA, Z-score, SPC, TTL indices, parallel paths |
+| `/Users/charlienode/reference-repos/fuuz-skills/fuuz-ml-telemetry/references/validation-checklist.md` | ~80 | Three-domain checklist (Model/Flow/Screen) |
+| `/Users/charlienode/reference-repos/proveit2026/README.md` | ~200 | Three-app architecture, model/screen/flow counts |
+| `/tmp/fuuz-extract/manifest.json` | 12 | Extracted from Data Broker .fuuz package |
+| `/tmp/fuuz-extract/definition.json` | ~500 | Component selection manifest, 5 selection types |
+| `/tmp/fuuz-extract/package-data.json` | ~50,000 | Full package contents (34 models, 22 flows, 14 screens) |
+
+**GitHub org verified:** `https://github.com/Fuuz-Industrial-Intelligence` — 5 public repositories:
+- `fuuz-skills` (this analysis)
+- `proveit2026` (this analysis)
+- `package_allUnitsOfMeasure` (units of measure package)
+- `package_SIUnitsOfMeasure` (SI units package)
+- `package_ImperialUnitsOfMeasure` (imperial units package)
+
+The three units-of-measure repos were not analyzed (scope limited to fuuz-skills and proveit2026 per research brief).
+
+---
+
+## Appendix B: Key Industrial Standards Referenced
+
+These standards are cited within Fuuz skills and are independently citable from primary sources. MIRA can reference them directly without citing Fuuz.
+
+| Standard | What It Covers | Relevance to MIRA |
+|---|---|---|
+| **ISA-95** (ANSI/ISA-95) | Equipment hierarchy (Enterprise → Site → Area → Work Center → Work Unit) and MES data models | MIRA's UNS is ISA-95 compliant; the hierarchy levels are standard |
+| **ISO 22400** | OEE calculation methodology, time category definitions (Planned Production Time, Downtime, Quality Losses) | Relevant if MIRA surfaces OEE metrics from customer data |
+| **ISA-88** (ANSI/ISA-88) | Batch processing procedural hierarchy (Procedure → Unit Procedure → Operation → Phase) | Relevant for batch manufacturers in MIRA's target market |
+| **OPC UA** (IEC 62541) | Industrial communication protocol, quality code enumeration (Good=192, Uncertain=64, Bad=16) | Relevant for MIRA's MQTT/OPC UA ingest path |
+| **ISA-101** | HMI design standard — color conventions, touch target sizing, animation constraints for industrial displays | Applicable to MIRA's Slack UX through the "gloved hands, noisy plant" usability principle |
+| **GS1/SSCC** | Handling unit tracking codes for supply chain and warehouse operations | Tangentially relevant for WMS/CMMS customers |
+| **CESMII i3X** | Smart manufacturing integration standard | Referenced in proveit2026 Enterprise C; not directly applicable to MIRA today |
+
+---
+
+*Document written 2026-05-19. Source repos are read-only clones at `/Users/charlienode/reference-repos/`. No Fuuz repository files were modified. All MIRA recommendations target existing skills listed in `.claude/skills/` or documented architectural gaps.*


### PR DESCRIPTION
## Summary

Eight-phase planning initiative analyzing the **Fuuz Industrial Intelligence** public skills repository and producing a **MIRA-native** skill-system architecture. Documentation only — no production code or existing skill content touched.

- **Research:** `docs/research/fuuz-skills-analysis.md` (1,027 lines) — full audit of `Fuuz-Industrial-Intelligence/fuuz-skills` + `proveit2026`, including license posture (no LICENSE → all-rights-reserved; structural patterns only, no verbatim reuse), per-skill breakdown, and an adaptation map.
- **Planning (6 docs, ~1,720 lines):** target architecture for **8 MIRA domain skills** layered L0–L3 (doctrine / domain / workflow / safety), gap analysis, Phase A–G roadmap, file tree, eval plan, and final report.

The skill drafts themselves (mira-platform, mira-uns-architecture, mira-industrial-safety) ship as a **follow-up PR** for separate review.

## What's in here

| File | Purpose |
|---|---|
| `docs/research/fuuz-skills-analysis.md` | Fuuz research + adaptation map |
| `docs/planning/mira-claude-skills-architecture.md` | Target architecture |
| `docs/planning/mira-skills-codebase-gap-analysis.md` | Current vs target delta |
| `docs/planning/mira-claude-skills-implementation-roadmap.md` | Phases A–G |
| `docs/planning/mira-skills-file-tree.md` | Proposed file layout + alias policy |
| `docs/planning/mira-skills-eval-plan.md` | Lint + behavioral eval design |
| `docs/planning/mira-fuuz-adaptation-final-report.md` | Initiative wrap-up |

## Key decisions documented

- **No Fuuz content imported.** No LICENSE in Fuuz repos → only structural patterns are adapted (two-tier SKILL.md + references/, severity tags, numbered domain-prefixed rules, output checklists, error tables, manifest, negative triggers). All MIRA skill text is written from scratch with citations to MIRA-owned files.
- **8 target domain skills**, with three new (`mira-platform`, `mira-industrial-safety`, `mira-telemetry-analysis`, `mira-demo-builder`) and five evolved from existing (`mira-uns-architecture` ← `uns-location-gate-designer`, `mira-component-profile` ← `component-profile-builder`, `mira-plc-tag-intelligence` ← `plc-tag-mapper`, `mira-maintenance-workflow` ← `diagnostic-workflow.md`, etc.). Alias policy preserves backward references.
- **No production code touched.** Engine, bot adapters, crawler, MCP, pipeline, web, CMMS — untouched. Skill content describes existing code; existing rules in `.claude/rules/` remain authoritative and are cited (not duplicated).

## Test plan

- [ ] Review the Fuuz license audit in `docs/research/fuuz-skills-analysis.md` §2 and confirm the "structural patterns only, no verbatim" posture.
- [ ] Review the 8-skill catalogue + L0–L3 layering in `docs/planning/mira-claude-skills-architecture.md` §3–§4.
- [ ] Spot-check that no Fuuz prose, numbered-rules lists, or JSON templates appear in any committed file (`grep -r "Fuuz" docs/` shows only attribution + reference paths).
- [ ] Walk the open questions in `docs/planning/mira-claude-skills-architecture.md` §11 and `mira-fuuz-adaptation-final-report.md` §7 — Phase A will resolve them.
- [ ] Confirm sequencing in `docs/planning/mira-claude-skills-implementation-roadmap.md` composes with the 90-day MVP plan and the namespace-builder plan.

## Companion

Follow-up PR will add the three draft skills (`.claude/skills/mira-{platform,uns-architecture,industrial-safety}/SKILL.md`, status `draft`, 614 lines total).

🤖 Generated with [Claude Code](https://claude.com/claude-code)