### PR TITLE
feat(skills): draft mira-platform, mira-uns-architecture, mira-industrial-safety skills

### DIFF
--- a/.claude/skills/mira-industrial-safety/SKILL.md
+++ b/.claude/skills/mira-industrial-safety/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: mira-industrial-safety
+description: |
+  L3 cross-cutting safety skill for MIRA. Auto-co-activates with any user-facing workflow whose output could surface advice on energized equipment, lockout/tagout (LOTO), arc flash, confined space, hot work, pressurized systems, chemical exposure, or fall hazards. Owns the SAFETY_KEYWORDS list in mira-bots/shared/guardrails.py and the STOP+escalate behavior. Triggers on any edit to guardrails.py, on any feature that could touch live equipment guidance, on any prompt mentioning a safety-keyword phrase, and on PRs that change how the engine handles SAFETY_ALERT messages. Supersedes generic troubleshooting flow when safety keywords match — even when mira-uns-architecture and mira-maintenance-workflow would otherwise own the response.
+version: 0.1.0
+status: draft
+last-updated: 2026-05-19
+owner-paths:
+  - mira-bots/shared/guardrails.py
+  - .claude/rules/security-boundaries.md
+  - docs/THEORY_OF_OPERATIONS.md
+related-skills:
+  - mira-platform
+  - mira-uns-architecture
+  - mira-maintenance-workflow
+  - slack-technician-ux-writer
+---
+
+# mira-industrial-safety
+
+> **Status:** Draft (Phase 6 of the Fuuz-adaptation initiative). New skill. The mechanism it documents (the SAFETY_KEYWORDS list in `mira-bots/shared/guardrails.py`) already exists; this skill centralizes the behavior contract Claude must follow when reasoning about features that could touch live equipment guidance.
+
+## 1. When to invoke
+
+Invoke as a **co-skill** with any of:
+
+- `mira-maintenance-workflow` — for any technician-facing response.
+- `mira-uns-architecture` — when the gate identifies an asset whose work would involve energy isolation.
+- `mira-platform` — when reviewing a feature that could surface live-equipment guidance.
+
+Direct triggers (always activate this skill):
+
+- Edits to `mira-bots/shared/guardrails.py` (especially `SAFETY_KEYWORDS`, `SAFETY_KEYWORDS_IMMEDIATE`, or the `classify_intent()` safety branch).
+- Edits to the engine's SAFETY_ALERT handling path.
+- Any inbound message containing one of the SAFETY_KEYWORDS phrases.
+- Any new feature, ingestion source, or output channel that could surface PPE, LOTO, arc-flash, confined-space, or chemical-exposure guidance.
+- PR review on any change that *removes* a safety keyword or *narrows* the safety branch.
+
+### Do NOT trigger as the primary skill for
+
+- Generic UNS path work that doesn't involve a safety-keyword surface → `mira-uns-architecture`.
+- General Slack message styling outside the STOP+escalate template → `slack-technician-ux-writer`.
+- Component-profile field design → `mira-component-profile`.
+
+## 2. What this skill grounds in
+
+| File | What it covers |
+|---|---|
+| `mira-bots/shared/guardrails.py` | `SAFETY_KEYWORDS` (full phrase list), `SAFETY_KEYWORDS_IMMEDIATE` (immediate-stop subset), `classify_intent()` safety branch, query-expansion rules around safety phrases. |
+| `.claude/rules/security-boundaries.md` | "Safety Keywords" section (21 phrase-level triggers), match logic, immediate STOP escalation, false-positive handling for questions like "what is arc flash". |
+| `docs/THEORY_OF_OPERATIONS.md` | Grounded troubleshooting contract — MIRA never advises on live work without verified isolation evidence. |
+
+Primary regulatory references (citable independently, not from any third-party skill content):
+
+- **OSHA 29 CFR 1910.147** — Control of Hazardous Energy (Lockout/Tagout).
+- **NFPA 70E** — Standard for Electrical Safety in the Workplace (arc flash, PPE categories, approach boundaries).
+- **OSHA 29 CFR 1910.146** — Permit-Required Confined Spaces.
+- **OSHA 29 CFR 1910.252** — Welding, Cutting, and Brazing (hot work).
+- **OSHA 29 CFR 1910.119** — Process Safety Management of Highly Hazardous Chemicals.
+
+These regulations are public-domain US federal standards; MIRA references them by section, not by paraphrasing third-party explanations.
+
+## 3. The non-negotiable rule
+
+**MIRA never advises an action on energized, pressurized, or hazardous-state equipment without a verified isolation step. When a safety keyword fires, the response is STOP + escalate — not troubleshooting.**
+
+## 4. Constraints
+
+### 4.1 Detection
+
+- **SAFE-001** `[FATAL]` Keep `SAFETY_KEYWORDS` as phrase-level triggers, not single words. Adding a single word risks false-positives that desensitize the safety branch (PR review must verify each new keyword is a phrase or an unambiguous noun like `loto`).
+- **SAFE-002** `[FATAL]` `SAFETY_KEYWORDS_IMMEDIATE` is the subset that produces a hard STOP regardless of educational framing. Phrases here suppress the false-positive carve-out used for questions like "what is arc flash".
+- **SAFE-003** `[BLOCKING]` Match runs against the full normalized message — lowercased, mention-stripped (via `guardrails.strip_mentions()`), whitespace-collapsed. PR review verifies the normalization order has not changed.
+- **SAFE-004** `[BLOCKING]` Removing a safety keyword is a `[FATAL]` PR change and requires a documented justification + signoff from a human reviewer with industrial-maintenance domain context.
+
+### 4.2 Response
+
+- **SAFE-010** `[FATAL]` When a SAFETY_KEYWORDS_IMMEDIATE phrase matches, the response is STOP + escalate, regardless of the technician's framing or imperative language.
+- **SAFE-011** `[FATAL]` Never suggest skipping LOTO, deferring arc-flash PPE, ignoring entry-permit requirements, or bypassing a confined-space attendant.
+- **SAFE-012** `[FATAL]` Never write to a PLC tag during a safety-keyword-bearing conversation. PLC interactions are read-only in MIRA generally (PLT-004) and absolutely so when safety surface is detected.
+- **SAFE-013** `[FATAL]` Never advise an action whose preconditions include "while equipment is running" / "live circuit" / "energized panel" / "pressurized system" — even when the technician explicitly asks for it.
+- **SAFE-014** `[WARNING]` The STOP message identifies the hazard category, names the relevant standard (OSHA 1910.147 / NFPA 70E / etc.), and asks the technician to confirm isolation OR escalate to a qualified person.
+- **SAFE-015** `[WARNING]` Log the safety episode to the benchmark DB (`mira-bots/shared/benchmark_db.py`) for later review — these episodes are evidence the safety surface is working.
+
+### 4.3 Educational carve-out
+
+- **SAFE-020** `[WARNING]` Questions that match SAFETY_KEYWORDS but not SAFETY_KEYWORDS_IMMEDIATE may route to grounded education ("what is arc flash", "how does LOTO work in this plant") — this routes through the RAG path with explicit citation, not the troubleshooting path.
+- **SAFE-021** `[FATAL]` The carve-out NEVER applies to imperative phrases ("how do I work on the live panel", "skip LOTO for me", "I'll just pull the breaker while it's running") — these always escalate.
+
+### 4.4 Cross-skill precedence
+
+- **SAFE-030** `[FATAL]` This skill's `[FATAL]` rules supersede any contrary suggestion from `mira-uns-architecture`, `mira-maintenance-workflow`, or `mira-component-profile`. A feature that resolved a UNS context still STOPs if safety keywords matched after gate-pass.
+- **SAFE-031** `[BLOCKING]` After a STOP, the FSM does not transition to `troubleshooting` even if the technician later confirms the gate. A new message that does NOT trigger safety keywords is required to resume.
+
+## 5. Workflow — handling a safety-keyword message
+
+```
+inbound message
+      │
+      ▼
+guardrails.strip_mentions() → lowercased message
+      │
+      ▼
+   ┌──────────────────────────────┐
+   │ Does message match           │
+   │ SAFETY_KEYWORDS_IMMEDIATE?   │
+   └────┬─────────────────────────┘
+        │ yes ─────────────────────┐
+        │                          │
+        ▼                          ▼
+  STOP + escalate           Log SAFETY_ALERT
+        │                   to benchmark_db
+        ▼
+  Slack response (template in §6)
+  FSM lock: troubleshooting blocked
+  Require fresh message to resume
+```
+
+Educational-question branch:
+
+```
+   message matches SAFETY_KEYWORDS but NOT SAFETY_KEYWORDS_IMMEDIATE
+   AND message is interrogative (what is / how does / explain)
+   AND message contains no imperative ("just", "skip", "while running")
+        │
+        ▼
+   Route to RAG with citation
+   Reply must cite a manual page or a public standard
+```
+
+## 6. STOP message template
+
+```
+⚠️ I'm pausing before we go further.
+
+Your message mentions: <keyword phrase>
+That's a hazard category covered by <OSHA 1910.147 / NFPA 70E / OSHA 1910.146>.
+
+Before I help with this, please confirm one of:
+
+✅ The equipment is fully de-energized and locked out (or otherwise isolated)
+✅ A qualified person has cleared the work
+❌ I'd rather escalate this to a supervisor / EHS — please do.
+
+I can't recommend steps that would touch live / pressurized / confined-space conditions.
+```
+
+The exact phrasing lives in `references/escalation-templates.md`; Slack rendering is block-kit, see `mira-maintenance-workflow/references/slack-message-templates.md`.
+
+## 7. Anti-patterns (these are bugs)
+
+- A reply that begins with troubleshooting steps while the message contained `"arc flash"`, `"loto"`, `"de-energize"`, `"live panel"`, `"pressurized"`, `"confined space"`, `"gas leak"`, etc. (SAFE-010).
+- A code path that strips a safety keyword from a normalized message to "improve recall" (SAFE-003).
+- A test case that asserts "what is arc flash" returns troubleshooting steps (SAFE-020 — that's the carve-out, but it returns RAG-cited education, not steps).
+- Removing a SAFETY_KEYWORDS phrase to fix a false positive without finding an alternative way to disambiguate (SAFE-004).
+- The FSM resuming `troubleshooting` after a STOP without a fresh non-safety message (SAFE-031).
+
+## 8. Common errors (error → cause → fix)
+
+| Error / symptom | Likely cause | Fix |
+|---|---|---|
+| Replies include troubleshooting steps for "arc flash on conveyor B16" | Safety branch not consulted before troubleshooting branch | Move SAFETY_KEYWORDS_IMMEDIATE check to the front of `classify_intent()` (SAFE-010) |
+| "What is LOTO?" returns a STOP message instead of education | Carve-out not implemented or too narrow | Verify the interrogative-question path (SAFE-020); add a golden case |
+| "How do I pull the breaker while running" returns RAG education | Imperative not detected; carve-out leaked | Tighten imperative detection — "while running" is always SAFE-021 |
+| Safety episode not logged | `benchmark_db.evidence_packet` not invoked on SAFETY_ALERT | Wire the log call into the safety branch (SAFE-015) |
+| FSM resumes troubleshooting after a STOP without fresh message | `troubleshooting_unlock` triggered on next reply regardless of safety state | Require a non-safety message after STOP (SAFE-031) |
+
+## 9. Output checklist
+
+Before declaring a safety-surface-touching change complete:
+
+- [ ] `SAFETY_KEYWORDS` and `SAFETY_KEYWORDS_IMMEDIATE` lists reviewed; no single-word triggers added.
+- [ ] Normalization order (mention-strip → lowercase) preserved.
+- [ ] Match check runs BEFORE intent classification (front of `classify_intent()`).
+- [ ] Imperative phrases ("just", "skip", "while running", "live", "energized") always escalate.
+- [ ] STOP message contains hazard category + standard reference + confirmation options.
+- [ ] Safety episode logged to benchmark DB.
+- [ ] FSM does not transition to `troubleshooting` after STOP without a fresh non-safety message.
+- [ ] PLC writes blocked on safety-surface conversations.
+- [ ] Golden cases added/updated covering: imperative-live-work refusal, educational-question carve-out, mixed-message handling, post-STOP resume blocking.
+- [ ] `/mira-run-hallucination-audit` run; safety-branch findings reviewed.
+
+## 10. References
+
+See `references/` for depth:
+
+- `references/safety-keywords.md` — the canonical phrase list with rationale per phrase, including SAFETY_KEYWORDS_IMMEDIATE subset and the v2.4.1 electrical-isolation additions.
+- `references/escalation-templates.md` — STOP message variants (electrical, mechanical, confined space, chemical, hot work) and block-kit JSON.
+- `references/regulatory-frame.md` — OSHA / NFPA standard citations (section + scope) for STOP messages and PR justifications. Independently citable from primary sources.
+
+## 11. Cross-references
+
+- `mira-platform/SKILL.md` — PLT-004 (no arbitrary PLC writes), PLT-070 (no LLM-call abstractions).
+- `mira-uns-architecture/SKILL.md` — the gate runs first, but this skill's `[FATAL]` rules supersede any post-gate troubleshooting (SAFE-030).
+- `mira-maintenance-workflow/SKILL.md` — workflow consults this skill in every stage; STOP at any stage is final.
+- `slack-technician-ux-writer/SKILL.md` — STOP message styling.

--- a/.claude/skills/mira-platform/SKILL.md
+++ b/.claude/skills/mira-platform/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: mira-platform
+description: |
+  Read-only doctrine and architecture reference for MIRA. Co-activates with any other MIRA domain or workflow skill to provide cross-cutting constraints — North Star, environment boundaries, provider cascade, hard constraints (PRD §4), and screenshot/commit conventions. Use when reviewing a feature proposal, refactor, or PR for alignment with the product wedge. Do NOT trigger as the *primary* skill for UNS resolution (mira-uns-architecture), component profile work (mira-component-profile), maintenance workflow design (mira-maintenance-workflow), or safety-keyword handling (mira-industrial-safety) — those have dedicated specialized skills; this one provides the ceiling, not the answer.
+version: 0.1.0
+status: draft
+last-updated: 2026-05-19
+owner-paths:
+  - CLAUDE.md
+  - .claude/CLAUDE.md
+  - docs/THEORY_OF_OPERATIONS.md
+  - docs/ARCHITECTURE.md
+  - docs/environments.md
+  - NORTH_STAR.md
+  - .claude/rules/uns-compliance.md
+  - .claude/rules/security-boundaries.md
+  - .claude/rules/python-standards.md
+  - .claude/rules/karpathy-principles.md
+related-skills:
+  - mira-uns-architecture
+  - mira-industrial-safety
+  - mira-component-profile
+  - mira-maintenance-workflow
+  - mira-saas-scope-guard
+---
+
+# mira-platform
+
+> **Status:** Draft (Phase 6 of the Fuuz-adaptation initiative). Replaces the role of `mira-architecture-guardian/` once Phase A of the implementation roadmap completes. Until then, both can coexist; this skill is the more comprehensive target shape.
+
+## 1. When to invoke
+
+Invoke as a **co-skill** whenever any of the following hold:
+
+- A feature request, PR, or refactor could expand MIRA's surface area beyond the maintenance-intelligence wedge.
+- A PR touches `mira-bots/`, `mira-pipeline/`, `mira-mcp/`, `mira-crawler/`, `mira-cmms/`, `mira-web/`, `mira-bridge/`, `mira-relay/`, or `mira-hub/`.
+- Any task involves provider selection, secrets, environment boundaries, the screenshot rule, or the commit convention.
+- A reply needs to be checked against MIRA's North Star ("Slack = front door, UNS/MQTT = nervous system, KG + component templates = memory, customer docs + work orders = evidence").
+
+### Do NOT trigger as the primary skill for
+
+- UNS path construction or resolution → use `mira-uns-architecture`.
+- Component-profile design → use `mira-component-profile`.
+- Technician dialogue or troubleshooting flow → use `mira-maintenance-workflow`.
+- Safety keyword handling → use `mira-industrial-safety`.
+- SaaS scope classification of an inbound request → use `mira-saas-scope-guard`.
+
+This is the **ceiling** skill, not the answer skill.
+
+## 2. What this skill grounds in
+
+Authoritative MIRA files. Every constraint below traces to one of these:
+
+| File | What it covers |
+|---|---|
+| `CLAUDE.md` | Build state, env vars, container map, hard constraints |
+| `.claude/CLAUDE.md` | Product rules, North Star, UNS gate, grounded troubleshooting |
+| `docs/THEORY_OF_OPERATIONS.md` | Primary doctrine — what MIRA is and is not |
+| `docs/ARCHITECTURE.md` | Layer map + dependency rules |
+| `docs/environments.md` | Dev / Staging / Prod doctrine |
+| `NORTH_STAR.md` | Commercial flywheel |
+| `.claude/rules/uns-compliance.md` | UNS data-shape enforcement |
+| `.claude/rules/security-boundaries.md` | Secrets, PII, safety keywords, Docker |
+| `.claude/rules/python-standards.md` | ruff, httpx, NeonDB, async |
+| `.claude/rules/karpathy-principles.md` | Behavior laws |
+
+If a constraint here doesn't trace to one of these files, that's a bug in this skill — file an issue.
+
+## 3. Architecture invariants
+
+```
+        ┌─────────────────────────────────────────┐
+        │ Slack technician (front door)            │
+        │ (Telegram / Teams optional, same engine) │
+        └────────────────┬─────────────────────────┘
+                         │
+        ┌────────────────▼─────────────────────────┐
+        │ Engine — mira-bots/shared/engine.py      │
+        │  • Intent classifier                     │
+        │  • UNS resolver (uns_resolver.py)        │
+        │  • Confirmation gate                     │
+        │  • Grounding + citation compliance       │
+        │  • Inference cascade (Groq→Cerebras→Gem) │
+        └────────────────┬─────────────────────────┘
+                         │
+   ┌─────────────────────┼──────────────────────────┐
+   ▼                     ▼                          ▼
+UNS / MQTT          KG + component        Customer docs +
+(live nervous       templates             work-order history
+ system)            (memory)              (evidence)
+```
+
+Lines that cross these layers do so through the engine. New front doors must connect to the engine; new context sources must register through the UNS layer; new evidence sources must be cited through the citation-compliance pipeline.
+
+## 4. Constraints
+
+### 4.1 Product wedge
+
+- **PLT-001** `[FATAL]` MIRA is not a generic chatbot. Replies that are not grounded in plant context, manuals, work orders, or component templates must be rerouted to "I don't have evidence for that yet."
+- **PLT-002** `[FATAL]` Slack is the front door. Adding a new front door (web chat, voice, email, etc.) must preserve the Slack contract: same engine, same gate, same grounding. See `.claude/CLAUDE.md` "North Star architecture".
+- **PLT-003** `[FATAL]` Never replace SCADA or CMMS. MIRA augments them; it never becomes them. Cross-check with `mira-saas-scope-guard` before approving any feature that looks SCADA-adjacent.
+- **PLT-004** `[FATAL]` Never expose arbitrary PLC writes through MIRA. PLC reads via `mira-relay`/`mira-connect` (when shipped) are read-only by default; write paths require a separate, audited interface and explicit human approval.
+
+### 4.2 Inference + provider cascade
+
+- **PLT-010** `[FATAL]` Never reintroduce Anthropic as an LLM provider. Removed PR #610 (verified by memory). Provider cascade is **Groq → Cerebras → Gemini**.
+- **PLT-011** `[WARNING]` Always go through `InferenceRouter.complete()` (`mira-bots/shared/inference/router.py`). Default behavior includes PII sanitization (IP/MAC/SN). Setting `sanitize=False` requires a justified comment in the PR.
+- **PLT-012** `[STYLE]` Single-provider direct calls are a code smell. If you find one in the codebase, file an issue or fix it in the same PR.
+
+### 4.3 Environment boundaries
+
+See `references/environment-doctrine.md` for the full table.
+
+- **PLT-020** `[FATAL]` Never run `psql` or raw SQL against prod NeonDB from a code session. Use staging, dev, or `db-inspect.yml`. Enforced by `tools/hooks/prod-guard.sh`.
+- **PLT-021** `[FATAL]` Never restart, rebuild, or `docker compose` a VPS container directly. Use `deploy-vps.yml`.
+- **PLT-022** `[FATAL]` Never point a feature-branch build at `@FactoryLM_Diagnose` (production Telegram bot). Use a dev/staging adapter.
+- **PLT-023** `[BLOCKING]` Engine / RAG / retrieval / classifier changes must pass the staging gate (`smoke-test.yml` + `tests/eval/`) before deploy.
+- **PLT-024** `[BLOCKING]` Migrations follow dev → staging → prod via `apply-migrations.yml` (`dry-run` then `apply`). Never hand-edit prod schema.
+- **PLT-025** `[BLOCKING]` KB seeds: staging first, verify BM25 retrieval, then prod. (Lesson: PR #1385 — embedding-gate killed BM25 in May 2026.)
+
+### 4.4 Secrets
+
+- **PLT-030** `[FATAL]` All secrets via Doppler (`factorylm/dev`, `factorylm/stg`, `factorylm/prd`). Never `.env` files in git.
+- **PLT-031** `[FATAL]` Never copy prod secrets into a dev shell. Set them in `factorylm/dev`.
+- **PLT-032** `[BLOCKING]` Before commit: `git remote -v` (right repo?) + `git diff --cached` (no secrets?).
+
+### 4.5 UNS compliance (summary; full rules in `mira-uns-architecture`)
+
+- **PLT-040** `[FATAL]` Every asset row has `uns_path` or `equipment_entity_id` FK. No free-form manufacturer/model string pairs.
+- **PLT-041** `[FATAL]` UNS paths built ONLY by functions in `mira-crawler/ingest/uns.py` (`manufacturer_path`, `model_path`, `fault_code_path`, etc.). No hand-formatted `f"enterprise.knowledge_base.{mfr}.{model}"`.
+
+### 4.6 Grounding contract
+
+- **PLT-050** `[FATAL]` MIRA must not begin troubleshooting before the UNS gate confirms. See `mira-uns-architecture` and `.claude/CLAUDE.md` "non-negotiable UNS location-confirmation gate".
+- **PLT-051** `[WARNING]` Every claim cites at least one of: UNS / asset namespace, MQTT / live tag data, PLC tag map, customer manuals, wiring diagrams, work-order history, verified KG relationships, technician confirmation, admin-approved component profile.
+- **PLT-052** `[WARNING]` Feature changes that can lower groundedness scores must call that out in the PR. See `mira-bots/shared/citation_compliance.py` and `mira-bots/shared/benchmark_db.py`.
+
+### 4.7 Knowledge graph
+
+- **PLT-060** `[FATAL]` Never auto-promote `proposed → verified` in `kg_relationships`. Promotion is an admin action.
+- **PLT-061** `[FATAL]` Every `kg_relationships` row carries evidence (source doc + page, or work-order id, or technician confirmation id) and a confidence value.
+
+### 4.8 Frameworks + abstractions
+
+- **PLT-070** `[FATAL]` No LangChain, no TensorFlow, no n8n, no framework that abstracts the LLM call. PRD §4.
+- **PLT-071** `[STYLE]` Engine layer, bot adapters, and ingest pipelines read top-to-bottom — not chained through indirections.
+
+### 4.9 Python standards
+
+- **PLT-080** `[STYLE]` Python 3.12; modern type hints (`list[str]`, `str | None`); `uv` for package management; `ruff` for lint/format. See `references/hard-constraints.md` and `.claude/rules/python-standards.md`.
+- **PLT-081** `[WARNING]` `httpx` for HTTP, not `requests`. `yaml.safe_load`, never `yaml.load`. NeonDB with `NullPool`. SQLite with `PRAGMA journal_mode=WAL`.
+
+### 4.10 Commits
+
+- **PLT-090** `[WARNING]` Conventional Commits: `feat/fix/security/docs/refactor/test/chore/BREAKING`. Scope hint: module name (`feat(slack):`, `fix(engine):`).
+
+### 4.11 Screenshot rule
+
+- **PLT-100** `[BLOCKING]` For visible `mira-web` UI changes, save before/after Playwright proofs to `docs/promo-screenshots/` with format `YYYY-MM-DD_feature_viewport.png`. See `references/screenshot-rule.md`.
+
+## 5. Workflow — reviewing a feature proposal
+
+1. **Locate the wedge.** Does this request align with the maintenance-intelligence wedge? If unclear → activate `mira-saas-scope-guard` and reroute.
+2. **Locate the front door.** Does this preserve Slack as the front door? If a new front door is proposed, does it route through `mira-bots/shared/engine.py`?
+3. **Locate the evidence.** Does this surface grounded answers (UNS, KG, manuals, WO history) or does it produce un-grounded chat? If un-grounded, refuse.
+4. **Locate the safety surface.** Could this surface advice on energized equipment, LOTO, confined spaces? If yes → activate `mira-industrial-safety`.
+5. **Locate the environment.** Does this touch prod NeonDB, the VPS, the production bot, or the KG `verified` set without staging gate? If yes → refuse or require explicit human override.
+6. **Locate the abstractions.** Does this add LangChain/TensorFlow/n8n or a wrapper over the LLM call? If yes → refuse.
+7. **Run the output checklist below.**
+
+## 6. Common errors (error message → cause → fix)
+
+| Error / symptom | Likely cause | Fix |
+|---|---|---|
+| "Anthropic key not set" appears in logs | Someone reintroduced an Anthropic provider | Remove the provider; restore Groq → Cerebras → Gemini cascade (PLT-010) |
+| Prod NeonDB write from a feature branch | `prod-guard.sh` bypassed via `MIRA_ALLOW_PROD=1` | Revert the write; rerun against staging |
+| Engine PR merged without smoke test | `smoke-test.yml` skipped | Run smoke against `factorylm.com` + `app.factorylm.com`; rollback if fails |
+| Grounding score drop after merge | A change weakened evidence requirements | Surface in PR, revert if not justified by a feature change |
+| Slack reply on prod from a feature branch | Feature branch pointed at `@FactoryLM_Diagnose` | Switch to dev/staging Telegram bot; verify with `tests/eval/` |
+| `kg_relationships` row promoted without admin sign-off | Auto-verification path slipped in | Revert; add a `[FATAL]` PR comment referencing PLT-060 |
+
+## 7. Output checklist
+
+Before declaring a feature proposal aligned with `mira-platform`, confirm all of:
+
+- [ ] Aligned with the maintenance-intelligence wedge (or explicitly out-of-scope and routed to `mira-saas-scope-guard`).
+- [ ] Slack front door preserved (or new adapter routes through `shared/engine.py`).
+- [ ] Provider cascade preserved (Groq → Cerebras → Gemini; no Anthropic).
+- [ ] Environment boundaries respected (no prod psql, no direct VPS docker compose, no feature-branch traffic to `@FactoryLM_Diagnose`).
+- [ ] Secrets via Doppler.
+- [ ] UNS gate preserved (or explicitly evolved through `mira-uns-architecture`).
+- [ ] Safety keywords still trigger STOP+escalate (`mira-industrial-safety` consulted if applicable).
+- [ ] KG `verified` state still requires admin promotion.
+- [ ] No LangChain / TensorFlow / n8n / generic LLM-abstraction framework introduced.
+- [ ] Conventional Commit message used.
+- [ ] Screenshot rule honored for visible `mira-web` UI changes.
+
+## 8. References
+
+See `references/` for depth:
+
+- `references/provider-cascade.md` — cascade order, fallback semantics, error handling.
+- `references/environment-doctrine.md` — full dev/staging/prod table, promotion workflow, hotfix bypass.
+- `references/screenshot-rule.md` — Playwright proof format, viewport rules, archive location.
+- `references/hard-constraints.md` — PRD §4 hard constraints in canonical form.
+
+## 9. Cross-references
+
+- `mira-uns-architecture/SKILL.md` — UNS path construction, resolver, location gate.
+- `mira-industrial-safety/SKILL.md` — safety keyword handling, escalation.
+- `mira-component-profile/SKILL.md` — reusable component memory.
+- `mira-maintenance-workflow/SKILL.md` — technician dialogue + troubleshooting flow.
+- `mira-saas-scope-guard/SKILL.md` — scope classification of inbound requests.

--- a/.claude/skills/mira-uns-architecture/SKILL.md
+++ b/.claude/skills/mira-uns-architecture/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: mira-uns-architecture
+description: |
+  L1 domain skill for everything UNS in MIRA — path construction via mira-crawler/ingest/uns.py, message resolution via mira-bots/shared/uns_resolver.py, the non-negotiable location-confirmation gate in mira-bots/shared/engine.py, kg_entities.uns_path, and MQTT/Sparkplug B topic mapping. Triggers on any task touching a UNS path string, the resolver, the gate, ltree storage, or the namespace structure. Subsumes and extends the older uns-location-gate-designer skill — this one owns the architecture, not just the gate.
+version: 0.1.0
+status: draft
+last-updated: 2026-05-19
+owner-paths:
+  - mira-crawler/ingest/uns.py
+  - mira-bots/shared/uns_resolver.py
+  - mira-bots/shared/engine.py
+  - .claude/rules/uns-compliance.md
+  - docs/specs/uns-kg-unification-spec.md
+  - docs/specs/uns-message-resolver-spec.md
+  - docs/specs/maintenance-namespace-builder-spec.md
+  - docs/migrations/004_kg_entities.sql
+related-skills:
+  - mira-platform
+  - mira-industrial-safety
+  - mira-component-profile
+  - mira-maintenance-workflow
+  - knowledge-graph-proposer
+---
+
+# mira-uns-architecture
+
+> **Status:** Draft (Phase 6 of the Fuuz-adaptation initiative). Subsumes the role of `uns-location-gate-designer/`. Until the alias is wired (Phase B of the roadmap), both may coexist; this one is the broader target.
+
+## 1. When to invoke
+
+Invoke for any task that:
+
+- Changes a UNS path string in code, tests, or docs.
+- Touches `mira-crawler/ingest/uns.py` (the path builders).
+- Touches `mira-bots/shared/uns_resolver.py` (message → UNS resolution).
+- Touches `mira-bots/shared/engine.py` in the location-gate region (FSM state `awaiting_context`).
+- Reasons about `kg_entities.uns_path` storage, ltree queries, or namespace migrations.
+- Designs or modifies the technician confirmation message that follows resolution.
+- Maps MQTT topics or Sparkplug B namespaces into MIRA's UNS.
+- Adds a new front door that needs to invoke the gate.
+
+### Do NOT trigger as the primary skill for
+
+- Pure component-template design (per-instance/per-model, profile schema) → use `mira-component-profile`. (UNS is the address; the profile is the contents.)
+- KG relationship rules (proposed/verified, evidence/confidence) → use `knowledge-graph-proposer`.
+- Slack message styling apart from the gate confirmation message → use `slack-technician-ux-writer`.
+
+## 2. What this skill grounds in
+
+| File | What it covers |
+|---|---|
+| `mira-crawler/ingest/uns.py` | Path builders: `slug()`, `manufacturer_path()`, `family_path()`, `model_path()`, `manual_path()`, `fault_code_path()`, `pm_schedule_path()`, `parts_list_path()`, `community_class_path()`, `site_path()`. `RESERVED_LABELS` set. `is_valid_path()`, `is_valid_label()`. |
+| `mira-bots/shared/uns_resolver.py` | `UNSContext` + `UNSResolution` dataclasses. `resolve_uns_path()`, `resolve_uns_path_multi()`. Extractors: `_extract_fault_codes()`, `_match_vendor()`, `_is_model_candidate()`, `_find_model_near_vendor()`. Confidence assignment via `_confidence()`. DB enrichment via `_enrich_from_db()`. |
+| `mira-bots/shared/engine.py` (gate region) | FSM state `awaiting_context` → `troubleshooting`. Confirmation payload construction. `_clear_diagnostic_carryover` on asset change. |
+| `.claude/rules/uns-compliance.md` | 9 numbered rules: never reinvent builders, one extraction point per turn, slugs from `uns.slug()`, fault-codes-before-model, pure-digit models valid, reserved labels off-limits, lowercase only, offline mode is the floor, confidence is a band. |
+| `docs/specs/uns-kg-unification-spec.md` | UNS schema authority. |
+| `docs/specs/uns-message-resolver-spec.md` | Resolver Stage-1 spec (shipped). Confidence bands defined in §2.4. |
+| `docs/specs/maintenance-namespace-builder-spec.md` | The product surface — UNS gate, AI proposals, readiness levels. |
+| `docs/migrations/004_kg_entities.sql` | `kg_entities.uns_path` column shape. |
+
+## 3. The non-negotiable rule
+
+**MIRA must not begin troubleshooting until it has resolved the technician's work context inside the UNS AND the technician has confirmed.**
+
+A code path that emits troubleshooting advice before the gate is a **bug**. `/mira-run-hallucination-audit` exists to find these.
+
+## 4. Constraints
+
+### 4.1 Path construction
+
+- **UNS-001** `[FATAL]` Paths under `enterprise.*` are built ONLY by the functions in `mira-crawler/ingest/uns.py`. Never hand-format `f"enterprise.knowledge_base.{mfr}.{model}"` anywhere in the codebase.
+- **UNS-002** `[FATAL]` Slugs are produced by `uns.slug()` — lowercase, runs of non-alphanumeric collapsed to `_`. Never `.lower().replace(" ", "_")` ad-hoc.
+- **UNS-003** `[FATAL]` UNS paths are lowercase. Display names (e.g., `"Rockwell Automation"`) live on `UNSContext.manufacturer`; the path segment is `uns.slug("Rockwell Automation")` → `rockwell_automation`.
+- **UNS-004** `[FATAL]` Reserved labels in `uns.RESERVED_LABELS` (e.g., `site`, `area`, `equipment`, `fault_codes`) must never be used as manufacturer / model / instance slugs.
+- **UNS-005** `[WARNING]` Pure-digit models are valid when adjacent to a known vendor/family. `"PowerFlex 525"` → `model="525"`. The old "must contain a letter" rule in `_looks_like_model_number` is wrong for this case — do not reintroduce.
+
+### 4.2 Message resolution
+
+- **UNS-010** `[FATAL]` One extraction point per turn. Vendor, model, fault code, and category are resolved in `mira-bots/shared/uns_resolver.py` and stored on `state["uns_context"]`. Never call `vendor_name_from_text()` or `_looks_like_model_number()` directly in engine, workers, or DST code — they are private to the resolver.
+- **UNS-011** `[FATAL]` Fault codes are extracted BEFORE model candidates. Fault patterns (`F0004`, `E001`, `oC`, `A002`) must be stripped from the model-candidate token list before the model heuristic runs. Otherwise `"powerflex 525 f0004"` mis-resolves to `model="f0004"` (the historical bug).
+- **UNS-012** `[WARNING]` Confidence is a band (`high` / `medium` / `low`), not a freeform numeric score. Use the bands defined in `docs/specs/uns-message-resolver-spec.md` §2.4. Don't invent a new scheme per call site.
+- **UNS-013** `[WARNING]` Offline mode is the floor. The resolver must produce a useful result without NeonDB. DB enrichment via `_enrich_from_db()` is additive; any DB error falls back to the alias-table-only result.
+
+### 4.3 The location gate
+
+- **UNS-020** `[FATAL]` The FSM cannot reach the `troubleshooting` state without passing through the gate. New front doors (Teams, email, voice, web chat) must invoke the gate; they cannot bypass to direct LLM completion.
+- **UNS-021** `[FATAL]` Never auto-confirm context based on a thumbs-up emoji reaction or a single-character reply. Require text confirmation or an explicit button click.
+- **UNS-022** `[FATAL]` Never default to "common asset", "Line 1", or any other guess. When no UNS match exists, ask for context; do not fabricate.
+- **UNS-023** `[WARNING]` When confidence is `low` (only message-text hint, no UNS match), ask the technician for context rather than presenting a candidate.
+- **UNS-024** `[WARNING]` Confidence `high` requires a UNS match plus at least one corroborating evidence source (work-order history, PLC tag match, prior session, technician hint).
+- **UNS-025** `[WARNING]` When the technician changes asset mid-thread, reset the gate via `_clear_diagnostic_carryover` — do not carry context across asset changes.
+
+### 4.4 KG / persistence
+
+- **UNS-030** `[FATAL]` Every asset row in `kg_entities` has `uns_path` set, or an `equipment_entity_id` FK. No free-form manufacturer/model string pairs.
+- **UNS-031** `[BLOCKING]` UNS-related migrations go through `apply-migrations.yml` (`dry-run` then `apply`) in the dev → staging → prod order. Hub `mira-hub/db/migrations/` is authoritative for proposals/wizard/readiness columns; engine `docs/migrations/` keeps `kg_entities`/`kg_relationships` only (ADR-0013).
+
+### 4.5 MQTT / Sparkplug B
+
+- **UNS-040** `[WARNING]` MQTT topic mapping to MIRA's UNS must respect ISA-95 hierarchy and translate via `mira-relay` / `mira-crawler/ingest/uns.py` builders — not via free-form `topic.replace("/", ".")` shortcuts.
+- **UNS-041** `[STYLE]` Sparkplug B `spBv1.0/group_id/MESSAGE_TYPE/edge_node_id/device_id` topic segments translate to ISA-95 levels by convention; document the mapping in code comments at each translation site.
+
+## 5. Workflow — the gate, in detail
+
+When implementing or reviewing the gate, walk these steps in order:
+
+1. **Receive technician message** at the front-door adapter (Slack: `mira-bots/slack/bot.py`).
+2. **Extract candidates** — asset, line, area, machine, component, symptom, fault_code — from message text + thread context + user profile. All extraction lives in `uns_resolver.py`; do not duplicate.
+3. **Search the UNS** via `uns_resolver.resolve_uns_path()`. For multi-candidate use `resolve_uns_path_multi()`.
+4. **Identify candidates** — top K (default 3) `(site, area, line, asset, component, fault, evidence)` tuples.
+5. **Gather evidence** for the top candidate: message hint, work-order history hit, PLC tag match, manual reference, prior session context, technician profile hint.
+6. **Send the confirmation message** to Slack. The structured payload contains site / area / line / machine / asset / component / fault / evidence list / confidence band / confirm-buttons.
+7. **Wait** for confirmation, correction, or "different asset". Implement timeout + re-prompt cycle.
+8. **Only after confirmation, transition** FSM `awaiting_context` → `troubleshooting`.
+
+### Confirmation message shape
+
+```
+I think you are working on:
+
+Site:       <site>
+Area:       <area>
+Line:       <line>
+Asset:      <asset>
+Component:  <component>
+Fault/Symptom: <fault or symptom>
+
+Evidence:
+• <hint 1>
+• <hint 2>
+• <hint 3>
+
+Confidence: <high|medium|low>
+
+Confirm before I troubleshoot.
+[ ✅ Yes ]   [ ✏️ Different asset ]   [ ❌ Wrong, let me clarify ]
+```
+
+Slack rendering uses block-kit; the engine returns a structured payload that the adapter renders. See `mira-maintenance-workflow/references/slack-message-templates.md` for the canonical block-kit JSON.
+
+## 6. Edge cases
+
+- **No UNS match at all** → don't fabricate. Ask for asset/line/component (UNS-022, UNS-023).
+- **Multiple equally-likely candidates** → present top 2 side-by-side and ask the technician to pick.
+- **Technician corrects the candidate** → record the correction as evidence for future inference; transition to `troubleshooting` with the corrected context.
+- **Technician changes asset mid-thread** → reset the gate (UNS-025).
+- **Quick repeat fault on same asset** → prior-session context is evidence, but still confirm.
+- **Imperative language ("just tell me how to fix the conveyor")** → still gate. The gate is cheap; the bug is expensive.
+
+## 7. Anti-patterns (these are bugs)
+
+- Returning troubleshooting advice on the first message without confirmation (UNS-020).
+- Defaulting to a guess (UNS-022).
+- Marking confidence `high` without a UNS match (UNS-024).
+- Skipping the gate when the technician uses imperative language.
+- Auto-verifying the candidate after a thumbs-up reaction (UNS-021).
+- Hand-formatting `f"enterprise.knowledge_base.{mfr}.{model}"` (UNS-001).
+- Lowercase ad-hoc via `.lower().replace(" ", "_")` (UNS-002).
+
+## 8. Common errors (error message → cause → fix)
+
+| Error / symptom | Likely cause | Fix |
+|---|---|---|
+| Resolver returns `model="f0004"` for "powerflex 525 f0004" | Fault code not stripped from model candidates | Verify `_extract_fault_codes()` runs before `_find_model_near_vendor()` (UNS-011) |
+| UNS path has mixed case | Slug not via `uns.slug()` | Replace ad-hoc lowercasing with `uns.slug()` (UNS-002, UNS-003) |
+| Engine begins troubleshooting on first message | FSM transition allowed pre-gate | Audit `mira-bots/shared/engine.py`; restore the `awaiting_context → troubleshooting` transition guard (UNS-020) |
+| `kg_entities` rows missing `uns_path` | New writer skipped the resolver | Add `uns_path` population at the writer or migrate with backfill (UNS-030) |
+| MQTT topic ingestion produces invalid ltree | Free-form replace shortcut | Route through `uns.py` builders (UNS-040) |
+| Context persists after technician switches asset | `_clear_diagnostic_carryover` not called | Wire it on asset-change detection (UNS-025) |
+
+## 9. Output checklist
+
+Before declaring a UNS-touching change complete, verify all of:
+
+- [ ] All UNS paths built via `mira-crawler/ingest/uns.py` functions.
+- [ ] All slugs via `uns.slug()`.
+- [ ] All paths lowercase.
+- [ ] No reserved labels used as manufacturer/model/instance slugs.
+- [ ] Fault codes extracted before model candidates.
+- [ ] Resolver extraction happens once per turn; downstream consumers read `state["uns_context"]`.
+- [ ] Confidence reported in bands, not floats.
+- [ ] Offline mode produces a useful result (DB optional).
+- [ ] The FSM cannot reach `troubleshooting` without passing the gate.
+- [ ] The confirmation message contains site / area / line / machine / asset / component / fault + evidence + confidence + buttons.
+- [ ] Auto-confirmation on emoji reactions blocked.
+- [ ] `_clear_diagnostic_carryover` wired on asset-change.
+- [ ] Golden cases added/updated in `tests/golden_*.csv` for each edge case touched.
+- [ ] `/mira-run-hallucination-audit` run and passing.
+
+## 10. References
+
+See `references/` for depth:
+
+- `references/uns-path-grammar.md` — slug grammar, reserved labels, path templates, ltree storage shape.
+- `references/resolver-state-machine.md` — vendor/model/fault extraction order, confidence assignment, offline fallback path.
+- `references/gate-message-templates.md` — confirmation block-kit JSON, timeout behavior, correction handling.
+
+## 11. Cross-references
+
+- `mira-platform/SKILL.md` — doctrine, environment boundaries.
+- `mira-industrial-safety/SKILL.md` — safety reroute supersedes the gate for safety-keyword messages.
+- `mira-component-profile/SKILL.md` — what sits at a UNS address.
+- `knowledge-graph-proposer/SKILL.md` — KG relationships keyed off UNS paths.
+- `mira-maintenance-workflow/SKILL.md` — the gate is the first stage of the workflow.
+- `slack-technician-ux-writer/SKILL.md` — Slack message style outside the gate.


### PR DESCRIPTION
## Summary

First skill drafts from the Fuuz-adaptation initiative. Companion to the **planning bundle in #1450** (read that first for context — research, architecture, gap analysis, roadmap, file tree, eval plan).

All three new skills carry `status: draft` in frontmatter and **coexist** with their existing counterparts. No existing skill is replaced or modified in this PR.

| Skill | Layer | Lines | Status | Coexists with |
|---|---|---|---|---|
| `mira-platform` | L0 doctrine | 213 | draft | `mira-architecture-guardian/` (untouched) |
| `mira-uns-architecture` | L1 domain | 205 | draft | `uns-location-gate-designer/` (untouched) |
| `mira-industrial-safety` | L3 cross-cut | 196 | draft | (new — formalizes the in-code SAFETY_KEYWORDS contract) |

## Skill highlights

### `mira-platform` (L0 doctrine, read-only ceiling)
- Explicit **negative trigger** ("Do NOT trigger as the *primary* skill for...") to prevent over-activation against specialized skills.
- 30 numbered constraints with `PLT-NNN` prefix and `[FATAL]/[BLOCKING]/[WARNING]/[STYLE]` severity tags.
- Owner-paths cite `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules/*`, `docs/THEORY_OF_OPERATIONS.md`, `docs/ARCHITECTURE.md`, `docs/environments.md`, `NORTH_STAR.md`.
- Covers: product wedge, provider cascade (Groq→Cerebras→Gemini, **no Anthropic**), environment boundaries, secrets via Doppler, UNS compliance summary, grounding contract, KG promotion rules, framework bans (LangChain/TensorFlow/n8n), Python standards, commits, screenshot rule.

### `mira-uns-architecture` (L1 domain — subsumes the gate-designer role)
- 25 numbered constraints with `UNS-NNN` prefix.
- Owns the **non-negotiable location-confirmation gate** (UNS-020 `[FATAL]`: FSM cannot reach `troubleshooting` without passing the gate).
- Covers: path construction via `mira-crawler/ingest/uns.py` builders, message resolution via `mira-bots/shared/uns_resolver.py`, the gate FSM, `kg_entities.uns_path` persistence, MQTT/Sparkplug B topic mapping.
- Includes 8-step gate workflow, confirmation-message shape, error-message-to-cause table, 14-item output checklist.

### `mira-industrial-safety` (L3 cross-cut, NEW)
- Formalizes the safety contract previously living only in `mira-bots/shared/guardrails.py` (the `SAFETY_KEYWORDS` list).
- 11 `SAFE-NNN` constraints across detection, response, educational carve-out, cross-skill precedence.
- **`[FATAL]` rules supersede contrary suggestions** from `mira-uns-architecture` / `mira-maintenance-workflow`.
- Cites OSHA 1910.147 (LOTO), NFPA 70E (arc flash), OSHA 1910.146 (confined space), OSHA 1910.252 (hot work), OSHA 1910.119 (process safety) — **primary sources only**, no third-party paraphrase.

## Architecture contract (per #1450)

All three skills follow the contract from `docs/planning/mira-claude-skills-architecture.md` §5:
- YAML frontmatter: `name`, `description`, `version`, `status`, `last-updated`, `owner-paths`, `related-skills`.
- ≤ 500-line SKILL.md (cap is 800).
- Severity-tagged numbered constraints with domain prefix codes.
- Workflow section + common-errors table + output checklist.
- Empty `references/` folders created (content queued for Phase B per roadmap).

## Test plan

- [ ] **Read #1450 first** for the planning context.
- [ ] Read each SKILL.md top-to-bottom (~615 lines total).
- [ ] Spot-check `owner-paths` frontmatter — every path should resolve to an existing file/dir.
- [ ] Verify the negative trigger on `mira-platform` ("Do NOT trigger as the *primary* skill for UNS resolution / component profile / maintenance workflow / safety-keyword handling").
- [ ] Verify no Fuuz prose, numbered-rules text, JSON templates, or named checklists appear (`grep -r "Fuuz" .claude/skills/mira-{platform,uns-architecture,industrial-safety}/` returns nothing).
- [ ] Confirm reverting this PR cleanly removes the three new skill folders without affecting anything else (3 `create mode 100644` lines in the commit).
- [ ] Optionally test-fire each skill in a Claude Code session: paste a triggering prompt and verify the relevant skill activates.

## What this does NOT do

- Does not modify `mira-architecture-guardian/`, `uns-location-gate-designer/`, or any other existing skill.
- Does not modify `mira-bots/shared/guardrails.py` or any production code.
- Does not change `MANIFEST.md` (doesn't exist yet — Phase A artifact).
- Does not rename, deprecate, or alias any existing skill.

The rename/alias work is queued for **Phase A/B** of the roadmap (#1450, `docs/planning/mira-claude-skills-implementation-roadmap.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)