### PR TITLE
fix(staging): add atlas-api Spring @Value placeholders to match prod

### DIFF
--- a/docker-compose.staging-vps.yml
+++ b/docker-compose.staging-vps.yml
@@ -102,6 +102,15 @@ services:
       PUBLIC_MINIO_ENDPOINT: ${ATLAS_PUBLIC_MINIO_URL:-http://host.docker.internal:4900}
       INVITATION_VIA_EMAIL: "false"
       ENABLE_EMAIL_NOTIFICATIONS: "false"
+      # Spring @Value placeholders below are required even when email is disabled —
+      # bean wiring happens before the feature flag is read. Match prod's compose
+      # (mira-cmms/docker-compose.yml) so atlas-api boots cleanly in staging.
+      SMTP_HOST: ${ATLAS_SMTP_HOST:-}
+      SMTP_PORT: ${ATLAS_SMTP_PORT:-587}
+      SMTP_USER: ${ATLAS_SMTP_USER:-}
+      SMTP_PWD: ${ATLAS_SMTP_PWD:-}
+      MAIL_RECIPIENTS: ${ATLAS_MAIL_RECIPIENTS:-}
+      KEYGEN_PRODUCT_TOKEN: ${ATLAS_KEYGEN_TOKEN:-}
       ENABLE_SSO: "false"
     ports:
       - "0.0.0.0:4088:8080"


### PR DESCRIPTION
## Summary
Follow-up to #1447. `stg-atlas-api` kept crash-looping after the MinIO hairpin-NAT fix landed because Spring bean wiring fails on missing `${MAIL_RECIPIENTS}` (and 5 other SMTP/Keygen placeholders) even when email is disabled — bean init runs before the feature flag.

Staging compose was missing the env keys that prod's `mira-cmms/docker-compose.yml` already passes through. This adds the same six keys with empty defaults.

## Test plan
- [ ] Merge → manual recreate atlas-api on VPS: `ssh root@165.245.138.91 'cd /opt/mira-staging && git pull && doppler run --project factorylm --config stg -- docker compose -f docker-compose.staging-vps.yml up -d --no-deps --force-recreate atlas-api'`
- [ ] `curl http://165.245.138.91:4088/` returns 200 (no more 000 timeout)
- [ ] `docker logs stg-atlas-api` shows `Started ApiApplication` and no placeholder errors
- [ ] Prod atlas-api unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)