### PR TITLE
feat(staging): add stg-atlas-frontend on port 4100

### DIFF
--- a/docker-compose.staging-vps.yml
+++ b/docker-compose.staging-vps.yml
@@ -23,6 +23,7 @@
 #   4000 → mira-mcp MCP     (prod 8009)
 #   4001 → mira-mcp REST    (prod 8001)
 #   4088 → atlas-api        (prod 8088)
+#   4100 → atlas-frontend   (prod 3100)
 #   4433 → atlas-db         (prod 5433)
 #   4900 → atlas-minio API  (prod 9000)
 #   4901 → atlas-minio UI   (prod 9001)
@@ -117,6 +118,47 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+
+  atlas-frontend:
+    # Pre-built image from Docker Hub. Prod's mira-cmms/docker-compose.yml uses a
+    # local build context that only resolves on Bravo — won't build on the VPS.
+    # Using the published image avoids that.
+    image: intelloop/atlas-cmms-frontend@sha256:9393849caa8ff980b02cdc0836d3797da78a8a3a4672acff80206de4e11fa8de
+    container_name: stg-atlas-frontend
+    restart: unless-stopped
+    depends_on:
+      atlas-api:
+        condition: service_healthy
+    environment:
+      API_URL: ${ATLAS_PUBLIC_API_URL:-http://165.245.138.91:4088}
+      INVITATION_VIA_EMAIL: "false"
+      CLOUD_VERSION: "false"
+      NODE_ENV: production
+      ENABLE_SSO: "false"
+      GOOGLE_TRACKING_ID: "disabled"
+      GOOGLE_KEY: "disabled"
+      MUI_X_LICENSE: "disabled"
+      OAUTH2_PROVIDER: "none"
+      LOGO_PATHS: "null"
+      CUSTOM_COLORS: "null"
+      BRAND_CONFIG: "null"
+      DEMO_LINK: "none"
+      PADDLE_SECRET_TOKEN: "disabled"
+      PADDLE_ENVIRONMENT: production
+      RECAPTCHA_SITE_KEY: "disabled"
+    ports:
+      - "0.0.0.0:4100:3000"
+    networks:
+      - staging-net
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qS -O /dev/null http://127.0.0.1:3000/ 2>&1 | grep -q 'HTTP/'"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
 
   # ─── MIRA core services (staging subset) ───────────────────────────────────
   mira-mcp:


### PR DESCRIPTION
## Summary
Staging compose was missing `atlas-frontend` entirely — prod's `mira-cmms/docker-compose.yml` defines it with a Bravo-only build context (`/Users/bravonode/factorylm/apps/cmms/frontend`) that can't resolve on the VPS.

Adds `stg-atlas-frontend` pinned to the same Docker Hub image SHA prod currently runs. Bound to `0.0.0.0:4100` so the Atlas web UI is reachable from a phone over the public internet for HIL review.

Part of the staging Atlas build-out chain (Layer 3 of 6). Layer 1 (Spring boot) needs #1466 first.

## Test plan
- [ ] Merge → `ssh root@165.245.138.91 'cd /opt/mira-staging && git pull && doppler run --project factorylm --config stg -- docker compose -f docker-compose.staging-vps.yml up -d atlas-frontend'`
- [ ] `curl http://165.245.138.91:4100/` returns 200
- [ ] Phone-open `http://165.245.138.91:4100/` shows Atlas signup screen
- [ ] First signup attempts to POST to `http://165.245.138.91:4088` (atlas-api) — requires #1466 merged for atlas-api to be healthy
- [ ] Prod atlas-frontend unaffected (uses local build, not this image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)