### PR TITLE
feat(staging): wire stg-mira-mcp to Atlas + add mira-cmms-sync worker

### DIFF
--- a/docker-compose.staging-vps.yml
+++ b/docker-compose.staging-vps.yml
@@ -138,6 +138,10 @@ services:
       - MIRA_HUB_URL=http://stg-mira-hub:3000
       - INTERNAL_KG_API_KEY=${INTERNAL_KG_API_KEY:-}
       - NEON_DATABASE_URL=${NEON_DATABASE_URL}
+      # Atlas CMMS — mira-mcp work-order tools call into stg-atlas-api.
+      - HUB_CMMS_API_URL=http://stg-atlas-api:8080
+      - ATLAS_API_USER=${ATLAS_API_USER:-}
+      - ATLAS_API_PASSWORD=${ATLAS_API_PASSWORD:-}
     volumes:
       - /opt/mira-staging/data:/mira-db
     networks:
@@ -370,6 +374,35 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+
+  # ─── mira-cmms-sync — NeonDB ↔ Atlas sync worker (staging) ────────────────
+  # Mirrors saas.yml's mira-cmms-sync block but talks to stg-atlas-api inside
+  # staging-net. Default off (CMMS_SYNC_ENABLED=false) — staging is a clean
+  # sandbox; flip true in Doppler factorylm/stg when ready to test the loop
+  # end-to-end. Required for Hub Feed/Schedule pages to surface real Atlas
+  # work-order data instead of mock fixtures.
+  mira-cmms-sync:
+    build:
+      context: ./mira-hub
+      dockerfile: Dockerfile.sync-worker
+    container_name: stg-mira-cmms-sync
+    environment:
+      - NEON_DATABASE_URL=${NEON_DATABASE_URL:-}
+      - HUB_CMMS_API_URL=${HUB_CMMS_API_URL:-http://stg-atlas-api:8080}
+      - ATLAS_API_USER=${ATLAS_API_USER:-}
+      - ATLAS_API_PASSWORD=${ATLAS_API_PASSWORD:-}
+      - CMMS_SYNC_ENABLED=${CMMS_SYNC_ENABLED:-false}
+      - CMMS_SYNC_INTERVAL_MS=${CMMS_SYNC_INTERVAL_MS:-60000}
+    command: ["bun", "run", "scripts/cmms-sync-worker.ts", "--interval-ms", "${CMMS_SYNC_INTERVAL_MS:-60000}"]
+    networks:
+      - staging-net
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+    depends_on:
+      - mira-hub
 
 networks:
   staging-net:


### PR DESCRIPTION
## Summary
Layer 5/6 of the staging Atlas build-out chain:
- Layer 1 (Spring boot): #1447 merged ✅
- Layer 2 (atlas-api Spring @Value): #1466 (pending merge)
- Layer 3 (atlas-frontend): #1468 (pending merge)
- Layer 4 (PM seed): PR C (pending)
- Layer 5 (mira-mcp→Atlas creds): **this PR**
- Layer 6 (cmms-sync worker): **this PR**

Two changes to `docker-compose.staging-vps.yml`:

**1. stg-mira-mcp gets Atlas creds**
Forwards `HUB_CMMS_API_URL` (internal `http://stg-atlas-api:8080`) + `ATLAS_API_USER` + `ATLAS_API_PASSWORD`. Required for mira-mcp's work-order tools to hit stg-atlas-api.

**2. Adds stg-mira-cmms-sync**
Mirrors `saas.yml`'s block. Default **off** (`CMMS_SYNC_ENABLED=false`) — staging is a clean sandbox. Flip to `true` in Doppler `factorylm/stg` when ready to drive Hub Feed/Schedule pages with real Atlas WO/PM data.

## Test plan
- [ ] Merge → manual recreate on VPS: `ssh root@165.245.138.91 'cd /opt/mira-staging && git pull && doppler run --project factorylm --config stg -- docker compose -f docker-compose.staging-vps.yml up -d --no-deps --build mira-mcp mira-cmms-sync'`
- [ ] `docker exec stg-mira-mcp env | grep ATLAS_API_USER` shows the Doppler value
- [ ] `docker logs stg-mira-cmms-sync` shows the "Atlas client unconfigured" warn until `CMMS_SYNC_ENABLED=true`
- [ ] Prod `mira-cmms-sync` unaffected

## Order
Merges cleanly on its own; runtime only helpful after #1466 + #1468 are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)