### PR TITLE
fix(quickstart): wire QUICKSTART_TENANT_ID + audit middleware exclusion

### DIFF
--- a/docker-compose.staging-vps.yml
+++ b/docker-compose.staging-vps.yml
@@ -232,6 +232,11 @@ services:
       - HUB_AUTH_GOOGLE_CLIENT_ID=${HUB_AUTH_GOOGLE_CLIENT_ID:-}
       - HUB_AUTH_GOOGLE_CLIENT_SECRET=${HUB_AUTH_GOOGLE_CLIENT_SECRET:-}
       - HUB_TENANT_ID=${HUB_TENANT_ID:-mike}
+      # Public /quickstart landing — tenant whose KB corpus the anonymous
+      # ask endpoint queries (ADR-0014, Twilio moment). Doppler-injected in
+      # staging/prod; fallback below is the founder's tenant where the
+      # seeded OEM corpus currently lives.
+      - QUICKSTART_TENANT_ID=${QUICKSTART_TENANT_ID:-78917b56-f85f-43bb-9a08-1bb98a6cd6c3}
       - NEXT_PUBLIC_PIPELINE_API_URL=${NEXT_PUBLIC_PIPELINE_API_URL:-http://165.245.138.91:4099}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}

--- a/mira-hub/src/app/api/quickstart/ask/route.ts
+++ b/mira-hub/src/app/api/quickstart/ask/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { withTenantContext } from "@/lib/tenant-context";
-import { DEMO_TENANT_ID } from "@/lib/demo-auth";
 import { cascadeComplete, type CascadeMessage } from "@/lib/llm/cascade";
 import {
   retrieveManualChunks,
@@ -12,10 +11,12 @@ import {
 export const dynamic = "force-dynamic";
 
 // See /api/quickstart/manufacturers/route.ts for the rationale on
-// QUICKSTART_TENANT_ID. Defaults to the demo tenant in dev; in prod set the
-// env var to the dedicated public-knowledge tenant.
+// QUICKSTART_TENANT_ID. Production sets it via Doppler / docker-compose;
+// fallback is the founder's tenant where the seeded OEM corpus lives.
+const QUICKSTART_FALLBACK_TENANT_ID = "78917b56-f85f-43bb-9a08-1bb98a6cd6c3";
+
 function quickstartTenantId(): string {
-  return process.env.QUICKSTART_TENANT_ID?.trim() || DEMO_TENANT_ID;
+  return process.env.QUICKSTART_TENANT_ID?.trim() || QUICKSTART_FALLBACK_TENANT_ID;
 }
 
 interface AskPayload {

--- a/mira-hub/src/app/api/quickstart/manufacturers/route.ts
+++ b/mira-hub/src/app/api/quickstart/manufacturers/route.ts
@@ -1,15 +1,16 @@
 import { NextResponse } from "next/server";
 import { withTenantContext } from "@/lib/tenant-context";
-import { DEMO_TENANT_ID } from "@/lib/demo-auth";
 
 export const dynamic = "force-dynamic";
 
 // /quickstart is a public no-auth page (ADR-0014, the "Twilio moment").
-// We query KB chunks scoped to a designated public tenant. By default this
-// is the demo tenant; production sets QUICKSTART_TENANT_ID to a dedicated
-// "shared knowledge" tenant once the 83K-chunk corpus is mounted there.
+// We query KB chunks scoped to a designated public tenant. Production sets
+// QUICKSTART_TENANT_ID via Doppler / docker-compose; if unset we fall back
+// to the founder's tenant, which is where the seeded OEM corpus lives today.
+const QUICKSTART_FALLBACK_TENANT_ID = "78917b56-f85f-43bb-9a08-1bb98a6cd6c3";
+
 function quickstartTenantId(): string {
-  return process.env.QUICKSTART_TENANT_ID?.trim() || DEMO_TENANT_ID;
+  return process.env.QUICKSTART_TENANT_ID?.trim() || QUICKSTART_FALLBACK_TENANT_ID;
 }
 
 /**


### PR DESCRIPTION
## Summary

The /quickstart landing page (ADR-0014, the Twilio moment) was reported as
broken in two ways:

1. /api/quickstart/* gated by NextAuth middleware → redirect to /login
2. QUICKSTART_TENANT_ID set in Doppler but not consumed by any code

### What I found vs. what I changed

**Bug 1 (middleware): already fixed in main**, no change in this PR.
Commit 8a158425 added both \`quickstart\` and \`api/quickstart\` to the
middleware matcher's negative-lookahead exclusion list
(\`mira-hub/src/middleware.ts:165\`), alongside \`api/auth\`, \`api/public\`,
\`api/health\`, etc. The matcher pattern stops middleware from running on
those paths entirely — they are public.

If \`/api/quickstart/manufacturers/\` is still 302-ing to \`/login\` on the
deployed stg-mira-hub, the running container is stale relative to main —
rebuild stg-mira-hub and the redirect goes away. Verification curl
commands in the testing section below.

**Bug 2 (env var not consumed): partial fix existed, completed here.**
Both route handlers (\`/api/quickstart/manufacturers/route.ts\` and
\`/api/quickstart/ask/route.ts\`) already read
\`process.env.QUICKSTART_TENANT_ID\`, but fell back to
\`DEMO_TENANT_ID = "00000000-0000-0000-0000-0000000000d1"\` — a tenant with
no KB rows. This PR:

- Replaces the fallback with the founder's tenant
  \`78917b56-f85f-43bb-9a08-1bb98a6cd6c3\` where the seeded OEM corpus
  actually lives, so a misconfigured deploy still returns real chunks.
- Adds \`QUICKSTART_TENANT_ID=\${QUICKSTART_TENANT_ID:-78917b56-...}\` to
  the mira-hub environment block in \`docker-compose.staging-vps.yml\`,
  matching the convention of the other Doppler-injected vars in that
  block (\`HUB_TENANT_ID\`, \`AUTH_SECRET\`, etc.).

### Out of scope (intentionally)

- \`docker-compose.saas.yml\` — prod compose. Same change is needed there
  before this lands in prod; deliberately deferred to its own PR so it
  can be reviewed alongside the prod corpus-tenant decision (is the
  founder tenant really the right public source, or should we mount a
  dedicated read-only "public-knowledge" tenant?).
- \`docker-compose.hub.yml\` / \`docker-compose.yml\` — local dev. Falls
  back to the inlined founder tenant; no compose change required.

## Test plan

- [ ] CI: \`mira-hub\` build + Playwright suite green (no surface area
      change outside the two route handlers and one compose key).
- [ ] On the VPS: \`docker compose -f docker-compose.staging-vps.yml up -d --build mira-hub\`
- [ ] \`curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4101/api/quickstart/manufacturers/\` → \`200\` (not \`307\` or \`302\` to /login)
- [ ] \`curl -s http://127.0.0.1:4101/api/quickstart/manufacturers/ | jq '.manufacturers | length'\` → non-zero (proves the founder-tenant corpus is reachable)
- [ ] \`curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4101/quickstart/\` → \`200\` (page renders without auth)
- [ ] \`curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4101/feed\` → \`307\` to /login (other routes still gated — regression check)
- [ ] \`curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:4101/namespace\` → \`307\` to /login (other routes still gated — regression check)

> Note from author: I do not have SSH to the staging VPS from CHARLIE in
> this session — the build/restart + curl verification is a manual step
> for whoever lands this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)