### PR TITLE
fix(hub): align /upgrade pricing with /pricing source-of-truth (#1461)

### DIFF
--- a/mira-hub/src/app/(hub)/upgrade/page.tsx
+++ b/mira-hub/src/app/(hub)/upgrade/page.tsx
@@ -1,63 +1,91 @@
 "use client";
 
-import { Factory, Zap, Users, Check, LogOut } from "lucide-react";
+// Tier names + prices MUST match the canonical pricing surface at
+// https://factorylm.com/pricing (served from `mira-web/public/pricing.html`).
+// `/pricing` is the source of truth — when these diverge, edit this file.
+// Issue #1461 fixed the divergence on 2026-05-20.
+//
+// Known gap (separate followup): the Operating Layer card here says $499/mo
+// per plant, but the only Stripe `STRIPE_PRICE_ID` configured today is the
+// $97/mo beta plan. `/buy` will charge the $97 amount until Stripe products
+// for Assessment / Operating Layer are wired up. Track in #1461 followup.
+
+import { Factory, ClipboardCheck, FlaskConical, Workflow, Check, LogOut } from "lucide-react";
 import { signOut } from "next-auth/react";
 
 const PLANS = [
   {
-    id: "individual",
-    name: "Individual",
-    price: "$20",
-    period: "/month",
-    description: "Perfect for solo maintenance techs and plant engineers",
-    highlight: "Most popular",
+    id: "assessment",
+    tier: "1. Assessment",
+    name: "Assessment",
+    price: "$500",
+    period: "one-time",
+    description: "We walk your floor. Score your Maintenance AI Readiness. Deliver a written gap report + namespace blueprint.",
+    highlight: "Start here",
     color: "#2563EB",
+    cta: "Book your assessment",
+    ctaHref: "https://factorylm.com/buy?from=hub-upgrade&plan=assessment",
+    icon: ClipboardCheck,
     features: [
-      "AI diagnostic assistant",
-      "Work order & PM scheduling",
-      "Asset & parts management",
-      "1 user seat",
-      "All integrations (Telegram, Slack)",
-      "7-day free trial",
+      "Onsite or remote (1 day)",
+      "Asset inventory walkthrough",
+      "Document & manual audit",
+      "PLC tag & CMMS hygiene review",
+      "Written report with prioritized roadmap",
+      "No software demo, no upsell",
     ],
   },
   {
-    id: "facility",
-    name: "Facility",
-    price: "$499",
-    period: "/month",
-    description: "For maintenance teams and full plant operations",
+    id: "pilot",
+    tier: "2. Pilot",
+    name: "Pilot",
+    price: "$2–5K",
+    period: "/mo · 3-mo min",
+    description: "We structure one line: nameplates, manuals, PLC tags, PMs, fault history. MIRA goes live on that scope.",
     highlight: null,
     color: "#0891B2",
+    cta: "Talk to Mike",
+    ctaHref: "mailto:mike@factorylm.com?subject=FactoryLM%20Pilot%20inquiry%20(from%20hub%20upgrade)",
+    icon: FlaskConical,
     features: [
-      "Everything in Individual",
-      "Unlimited user seats",
-      "Multi-site support",
-      "Custom KB ingestion",
-      "SLA support",
-      "Dedicated onboarding",
+      "Hands-on namespace structuring",
+      "OEM manual indexing",
+      "PLC tag ↔ asset reconciliation",
+      "MIRA deployed on the pilot line",
+      "Before/after namespace report",
+      "Direct line to Mike + the team",
+    ],
+  },
+  {
+    id: "operating",
+    tier: "3. Operating Layer",
+    name: "Operating Layer",
+    price: "$499",
+    period: "/mo per plant",
+    description: "MIRA in production on a structured namespace. Telegram + web + CMMS write-back. Quarterly namespace audits.",
+    highlight: null,
+    color: "#7C3AED",
+    cta: "Subscribe",
+    ctaHref: "https://factorylm.com/buy?from=hub-upgrade&plan=operating",
+    icon: Workflow,
+    features: [
+      "Unlimited MIRA queries, whole team",
+      "Cited OEM answers + fault history",
+      "CMMS write-back (MaintainX, Limble, UpKeep, Atlas)",
+      "Continuous structuring as assets come online",
+      "Quarterly namespace quality audit",
+      "14-day money-back guarantee",
     ],
   },
 ];
 
 export default function UpgradePage() {
-  function handleUpgrade(planId: string) {
-    // mira-web owns the Stripe billing surface (see deployment/nginx-phase2-live.conf
-    // — `/pricing` and `/api/checkout/*` both proxy to mira-web :3200). Sending the
-    // user to /pricing lets them pick a plan that matches the live Stripe price IDs;
-    // sending them to /api/checkout/session bypasses pricing and opens Stripe directly.
-    // We use /pricing because the hub plan list ($20 / $499) doesn't yet match the
-    // canonical mira-web tiers ($97 / $297) — defer the tier reconciliation to a
-    // follow-up. `planId` is logged via the query string so we can analyze drop-off.
-    window.location.href = `/pricing?from=hub-upgrade&plan=${encodeURIComponent(planId)}`;
-  }
-
   return (
     <div
       className="min-h-screen flex flex-col items-center justify-center px-4 py-12"
       style={{ background: "linear-gradient(135deg, #0F172A 0%, #1E293B 50%, #0F172A 100%)" }}
     >
-      <div className="w-full max-w-3xl">
+      <div className="w-full max-w-6xl">
         <div className="text-center mb-10">
           <div
             className="w-16 h-16 rounded-2xl flex items-center justify-center mx-auto mb-6"
@@ -66,66 +94,70 @@ export default function UpgradePage() {
             <Factory className="w-8 h-8 text-white" />
           </div>
           <h1 className="text-3xl font-bold text-white mb-3">Your trial has ended</h1>
-          <p className="text-slate-400 text-base max-w-md mx-auto">
-            Upgrade to continue using FactoryLM. We beat Factory AI at half the price.
+          <p className="text-slate-400 text-base max-w-xl mx-auto">
+            Three ways to work with us. Most plants start with the $500 Assessment — it's the easiest yes you'll make this quarter.
           </p>
         </div>
 
-        <div className="grid md:grid-cols-2 gap-6 mb-8">
-          {PLANS.map(plan => (
-            <div
-              key={plan.id}
-              className="rounded-2xl border p-6 flex flex-col"
-              style={{
-                background: "rgba(26,29,35,0.95)",
-                borderColor: plan.highlight ? "#2563EB" : "rgba(148,163,184,0.15)",
-                boxShadow: plan.highlight ? "0 0 32px rgba(37,99,235,0.2)" : "none",
-              }}
-            >
-              {plan.highlight && (
-                <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold mb-4 self-start"
-                  style={{ backgroundColor: "rgba(37,99,235,0.15)", color: "#60A5FA" }}>
-                  <Zap className="w-3 h-3" /> {plan.highlight}
-                </div>
-              )}
-
-              <div className="flex items-center gap-2 mb-2">
-                {plan.id === "facility" ? (
-                  <Users className="w-5 h-5" style={{ color: plan.color }} />
-                ) : (
-                  <Zap className="w-5 h-5" style={{ color: plan.color }} />
-                )}
-                <span className="text-white font-semibold text-lg">{plan.name}</span>
-              </div>
-
-              <div className="flex items-baseline gap-1 mb-2">
-                <span className="text-4xl font-bold text-white">{plan.price}</span>
-                <span className="text-slate-400 text-sm">{plan.period}</span>
-              </div>
-              <p className="text-slate-400 text-sm mb-5">{plan.description}</p>
-
-              <ul className="space-y-2.5 mb-6 flex-1">
-                {plan.features.map(f => (
-                  <li key={f} className="flex items-start gap-2">
-                    <Check className="w-4 h-4 flex-shrink-0 mt-0.5" style={{ color: plan.color }} />
-                    <span className="text-sm text-slate-300">{f}</span>
-                  </li>
-                ))}
-              </ul>
-
-              <button
-                onClick={() => handleUpgrade(plan.id)}
-                className="w-full h-11 rounded-lg font-semibold text-white transition-opacity hover:opacity-90"
-                style={{ background: `linear-gradient(135deg, ${plan.color}, ${plan.id === "individual" ? "#0891B2" : "#7C3AED"})` }}
+        <div className="grid md:grid-cols-3 gap-6 mb-8">
+          {PLANS.map(plan => {
+            const Icon = plan.icon;
+            return (
+              <div
+                key={plan.id}
+                className="rounded-2xl border p-6 flex flex-col"
+                style={{
+                  background: "rgba(26,29,35,0.95)",
+                  borderColor: plan.highlight ? "#2563EB" : "rgba(148,163,184,0.15)",
+                  boxShadow: plan.highlight ? "0 0 32px rgba(37,99,235,0.2)" : "none",
+                }}
               >
-                Start {plan.name} Plan
-              </button>
-            </div>
-          ))}
+                {plan.highlight && (
+                  <div className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold mb-4 self-start"
+                    style={{ backgroundColor: "rgba(37,99,235,0.15)", color: "#60A5FA" }}>
+                    {plan.highlight}
+                  </div>
+                )}
+
+                <div className="flex items-center gap-2 mb-2">
+                  <Icon className="w-5 h-5" style={{ color: plan.color }} />
+                  <span className="text-slate-400 text-xs uppercase tracking-wider">{plan.tier}</span>
+                </div>
+
+                <div className="flex items-baseline gap-1 mb-2">
+                  <span className="text-4xl font-bold text-white">{plan.price}</span>
+                  <span className="text-slate-400 text-sm">{plan.period}</span>
+                </div>
+                <p className="text-slate-400 text-sm mb-5">{plan.description}</p>
+
+                <ul className="space-y-2.5 mb-6 flex-1">
+                  {plan.features.map(f => (
+                    <li key={f} className="flex items-start gap-2">
+                      <Check className="w-4 h-4 flex-shrink-0 mt-0.5" style={{ color: plan.color }} />
+                      <span className="text-sm text-slate-300">{f}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <a
+                  href={plan.ctaHref}
+                  className="w-full h-11 rounded-lg font-semibold text-white transition-opacity hover:opacity-90 flex items-center justify-center"
+                  style={{ background: `linear-gradient(135deg, ${plan.color}, ${plan.color === "#2563EB" ? "#0891B2" : "#2563EB"})` }}
+                  data-cta={`hub-upgrade-${plan.id}`}
+                >
+                  {plan.cta} →
+                </a>
+              </div>
+            );
+          })}
         </div>
 
         <div className="text-center">
-          <p className="text-slate-500 text-sm mb-3">Questions? <a href="mailto:mike@factorylm.com" className="text-blue-400 hover:text-blue-300">Contact us</a></p>
+          <p className="text-slate-500 text-sm mb-3">
+            Questions? <a href="mailto:mike@factorylm.com" className="text-blue-400 hover:text-blue-300">Contact us</a>
+            {" · "}
+            <a href="https://factorylm.com/pricing" className="text-blue-400 hover:text-blue-300">See full pricing</a>
+          </p>
           <button
             onClick={() => signOut({ callbackUrl: "/login" })}
             className="inline-flex items-center gap-1.5 text-sm text-slate-500 hover:text-slate-300 transition-colors"


### PR DESCRIPTION
## Summary

- /upgrade was showing **\$20 / \$499** (SaaS framing) while /pricing shows **\$500 / \$2–5K / \$499** (consultancy framing). The redirect from /upgrade → /pricing landed the user on a page that contradicted what they had just seen.
- Replaced the two-card SaaS tier list with the same three cards from \`mira-web/public/pricing.html\`: Assessment, Pilot, Operating Layer.
- Source-of-truth comment at the top of \`page.tsx\` so future edits don't drift again.

## Known gap (separate follow-up)

Stripe \`STRIPE_PRICE_ID\` is wired to the legacy \$97/mo beta plan. /buy → checkout will still charge \$97 regardless of plan picked. Per-plan Stripe products belong in a separate PR — flagged in the file comment.

## Test plan

- [ ] Open /upgrade (hub) — three tier cards: Assessment / Pilot / Operating Layer with matching copy.
- [ ] Open /pricing (marketing) — same three offers, same prices, same order.
- [ ] CTA links: Assessment → \`factorylm.com/buy?from=hub-upgrade\&plan=assessment\`, Pilot → \`mailto:mike@factorylm.com\`, Operating → \`/buy?plan=operating\`.
- [ ] Sign-out button still works.

Closes #1461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)