### PR TITLE
feat(hub): wizard step 5 + 3 P2 investigation docs (#1459, #1463-1465)

### DIFF
--- a/docs/adr/0015-mira-core-sunset.md
+++ b/docs/adr/0015-mira-core-sunset.md
@@ -1,0 +1,172 @@
+# ADR-0015: Sunset mira-core (Open WebUI) — investigation draft
+
+## Status
+**Draft / investigation** — 2026-05-20
+
+**Tracks issue:** #1463
+**Related:** ADR-0008 (sidecar deprecation), ADR-0014 (product-led wedge)
+
+> This ADR is *research only*. No code changes accompany this commit.
+> Decision is deferred until the migration plan in §6 is reviewed.
+
+---
+
+## Context
+
+`mira-core` is the SaaS bundle's Open WebUI deployment (`ghcr.io/open-webui/open-webui:v0.8.10`), wired in via `docker-compose.saas.yml` as the container `mira-core-saas`. It originally served three roles in the v0.x MIRA architecture:
+
+1. **Chat UI** — the customer-facing chat surface and conversation history.
+2. **Auth** — Open WebUI's account system + JWT.
+3. **KB browse / upload** — Open WebUI's RAG document library + embedding store.
+
+It also hosts `mira-ingest` (the photo / asset-tag ingestion service) at `mira-core/mira-ingest/`, which is a separate FastAPI service that *talks to* Open WebUI for embedding storage but is logically distinct from the Open WebUI process itself.
+
+The MIRA architecture has evolved past most of those roles:
+
+- **Chat path moved to `mira-pipeline`** (ADR-0008): the OpenAI-compat shim wrapping `Supervisor` (`mira-bots/shared/engine.py`) is now the production chat path on the VPS.
+- **Hub auth (NextAuth)** is the canonical multi-tenant auth surface (ADR-0014).
+- **Hub `/knowledge` and `/documents`** routes already surface KB content from `kg_entities` / `knowledge_entries` via NeonDB.
+- **`/quickstart`** (ADR-0014) is the public, no-auth grounded-answer surface — already shipped, owned by `mira-pipeline`, indexed by NeonDB.
+
+The `docs/THEORY_OF_OPERATIONS.md` layer map does **not** list `mira-core` as a canonical layer. It is, today, infrastructure with diminishing product purpose.
+
+---
+
+## 1. What mira-core currently provides
+
+Mapped from the live `docker-compose.saas.yml` and code grep (`OPENWEBUI_BASE_URL`, `mira-core` references):
+
+| Capability | Provided by mira-core | Live consumer |
+|------------|-----------------------|---------------|
+| Web chat UI at `:8080` | ✅ Open WebUI front-end | Some internal flows; not the customer surface |
+| User accounts + JWT | ✅ Open WebUI auth | mira-ingest → `OPENWEBUI_API_KEY` |
+| KB document library | ✅ Open WebUI RAG store | `mira-bots/shared/workers/rag_worker.py` `_call_openwebui()` fallback path |
+| Embedding store (Open WebUI's internal vector DB) | ✅ | mira-crawler embedder fallback |
+| `/api/chat/completions` Ollama proxy | ✅ Open WebUI passthrough | `mira-bots/shared/workers/{rag,nameplate,print}_worker.py` fallback layer |
+| Branding / custom logo | ✅ via `entrypoint-mira.sh` + `/branding` volume mount | n/a (customer-invisible) |
+| MCPO proxy (`mira-mcp` over OpenAPI) | ✅ via `Dockerfile.mcpo` | dev path; redundant with FastMCP REST |
+
+**Other consumers in repo grep (`grep -rE 'OPENWEBUI|mira-core'`):**
+- `mira-web/src/server.ts`, `mira-web/src/routes/inbox.ts` — marketing site uses Open WebUI as an inbox backend
+- `mira-web/src/lib/account-deletion.ts` — account-deletion handler cascades through Open WebUI
+- `tools/migrate_sidecar_oem_to_owui.py` — one-shot migration script (#195 follow-up)
+- `tools/owui_tools/setup_owui_models.py` — model registration helper
+- `mira-bots/setup_v2.py` — installer mentions OPENWEBUI envs
+- `evals/query_stub.py`, `tools/staging_test.py` — eval/test harnesses
+
+---
+
+## 2. What the Hub already covers (today)
+
+- ✅ **Auth** — NextAuth on `mira-hub/src/app/api/auth/`. Multi-tenant by design, Doppler-managed secrets, SAML on the way (`@node-saml/node-saml` already in deps).
+- ✅ **Chat surface (cited)** — `/quickstart` (public no-auth) + the planned authenticated `/ask` surface, both routed through `mira-pipeline`.
+- ✅ **KB browse** — `/knowledge`, `/documents`, `/library` routes; render from NeonDB.
+- ✅ **Conversation history** — Hub's `conversations` route (still partly mocked at the time of writing; tracked separately).
+- ✅ **Per-tenant settings, billing, team** — pure Hub responsibility.
+
+---
+
+## 3. What Hub does NOT cover (the gaps to close before sunset)
+
+| Gap | Severity | Owned by | Notes |
+|-----|----------|----------|-------|
+| RAG fallback path in `rag_worker._call_openwebui()` | **High** | Engine | This is the catch-all if Groq/Cerebras/Gemini all fail. Need an equivalent fallback that does NOT route through Open WebUI. Options: (a) accept the cascade-failure error and return the structured "no grounded answer" payload, (b) replace the OWUI passthrough with a direct Ollama call on the same VPS, (c) drop the fallback (cascade already has 3 providers). |
+| Nameplate worker OWUI fallback (`nameplate_worker._call_openwebui`) | **Medium** | Engine | Same calculus as above. Vision uses `qwen2.5vl:7b` via OWUI; can call Ollama directly. |
+| Print worker OWUI passthrough | **Medium** | Engine | Same as above. |
+| `mira-ingest`'s OWUI dependency for OEM document RAG indexing | **High** | Crawler / ingest | mira-ingest writes to OWUI's Knowledge collections (`OPENWEBUI_KB_*`). Need to confirm whether the new NeonDB-backed `knowledge_entries` path covers all the indexing flows. If yes, mira-ingest's OWUI dependency is gone. |
+| Eval harness (`evals/query_stub.py`, `tools/staging_test.py`) targeting OWUI | **Low** | Tools | Rewrite eval target to mira-pipeline. One-day task. |
+| mira-web inbox backend dependency (`mira-web/src/routes/inbox.ts`) | **Medium** | Web | The marketing site's inbox today routes via OWUI. Replace with Hub `/conversations` API or split inbox to a Hub-owned route. |
+| MCPO proxy (Dockerfile.mcpo) | **Low** | Dev | Used in dev for MCP-over-OpenAPI prototyping. Not needed in prod sunset path. |
+| `mira-core/branding/` custom logo + entrypoint | **Cosmetic** | Ops | Customer never sees OWUI today (mira-pipeline is the chat path). Cosmetic; dropped on sunset. |
+| `mira-core/data/` volume — Open WebUI's SQLite (`webui.db`) | **Data** | Ops | Per-tenant chat history. Need to migrate to Hub conversations or accept loss with notice. |
+
+---
+
+## 4. Risk assessment
+
+**HIGH risk:**
+- The RAG-cascade fallback to OWUI is load-bearing during cloud-provider outages. Removing it without a replacement reduces reliability during Groq/Cerebras/Gemini incidents.
+- mira-ingest's KB upload pipeline writes to OWUI Knowledge collections; sunset before NeonDB-backed indexing is at 100% parity loses upload functionality.
+- mira-web's inbox is wired to OWUI. Cutting the cord with no replacement breaks the marketing-site inbox.
+
+**MEDIUM risk:**
+- OWUI also hosts the eval target for `evals/query_stub.py` and `tools/staging_test.py`. Sunset would invalidate the current staging-eval harness until eval targets are migrated.
+- Account-deletion in `mira-web/src/lib/account-deletion.ts` calls OWUI; cleanup paths need an OWUI-free replacement.
+
+**LOW risk:**
+- The chat-UI surface of OWUI is not customer-visible (mira-pipeline owns chat today). Customers will not notice the sunset.
+- Branding / theming files are inert without OWUI.
+- MCPO proxy is dev-only; trivial to remove.
+
+---
+
+## 5. Hard prerequisites (must hold before sunset)
+
+1. **OWUI fallback is no longer load-bearing.** Either accept cascade-only (no fallback), or replace OWUI passthrough with direct Ollama calls in `rag_worker`, `nameplate_worker`, `print_worker`. Decision pending; recommendation in §6.
+2. **mira-ingest indexes to NeonDB only.** Confirm `knowledge_entries` round-trip parity with OWUI Knowledge collections for OEM corpus (Rockwell, ABB, Siemens, Schneider, GS10, PowerFlex, Micro820). Track via `tools/migrate_sidecar_oem_to_owui.py` follow-up (#195).
+3. **mira-web inbox migrated.** Route to Hub `/conversations` API or split out a Hub-owned inbox.
+4. **Eval target migrated.** Rewrite `evals/query_stub.py` + `tools/staging_test.py` to hit mira-pipeline. Confirm staging-gate / `tests/eval/` suites still pass.
+5. **Account-deletion cascade rewritten.** Drop OWUI step from `mira-web/src/lib/account-deletion.ts`.
+6. **Per-tenant chat history migration plan.** Either (a) export OWUI `webui.db` → Hub `conversations` on cutover, or (b) freeze legacy history at a public URL + retire.
+
+---
+
+## 6. Migration plan (proposed)
+
+**Phase 1 — Decouple (2 weeks)**
+
+- Audit OWUI fallback usage in `rag_worker`, `nameplate_worker`, `print_worker`. Confirm cascade reliability data (provider success rates from existing telemetry). Decision: drop fallback (cleanest) vs replace with direct Ollama (more reliable but more infra).
+- Replace `mira-web/src/routes/inbox.ts` OWUI dependency with Hub-owned route. PR.
+- Rewrite `mira-web/src/lib/account-deletion.ts` to skip OWUI step. PR.
+- Confirm `mira-ingest` writes to `knowledge_entries` (NeonDB) as the primary path; OWUI write becomes opt-in.
+
+**Phase 2 — Migrate (2 weeks)**
+
+- Export per-tenant OWUI conversation history from `mira-core/data/webui.db` to Hub `conversations` table. Migration script + dry-run.
+- Migrate eval targets in `evals/query_stub.py` and `tools/staging_test.py` to mira-pipeline.
+- Remove `OPENWEBUI_BASE_URL` requirement from `mira-bots/setup_v2.py` installer.
+
+**Phase 3 — Sunset (1 week)**
+
+- Remove `mira-core` from `docker-compose.saas.yml`. Keep the directory in repo for one release as a fallback.
+- Remove `OPENWEBUI_*` env vars from Doppler `factorylm/prd`.
+- Drop `mira-core/branding`, `entrypoint-mira.sh`, `Dockerfile.mcpo`, `mcpo-config.json`.
+- Tag `mira-core-sunset` release.
+
+**Phase 4 — Cleanup (lazy)**
+
+- Delete `mira-core/` directory in a follow-up commit after one release of soak time.
+- Archive `mira-core/data/` snapshot for compliance / audit.
+
+---
+
+## 7. Open questions (for the deciding review)
+
+1. **OWUI fallback: drop or replace?** What is the provider-cascade success rate over the last 90 days? Is the fallback ever triggered?
+2. **Per-tenant conversation history migration: live cutover or accept loss?** Customers on `app.factorylm.com` may have OWUI history. Importance?
+3. **mira-ingest indexing parity with NeonDB:** is `knowledge_entries` at 100% feature-parity for the existing OEM corpus and ingest flows?
+4. **Branding / UI:** does any customer-facing flow today still link to the OWUI front-end at `app.factorylm.com:8080`? Best as of grep, no — but worth confirming on prod nginx.
+5. **MCPO replacement:** the dev MCPO proxy exposes `mira-mcp` over OpenAPI. Do we need an equivalent in the post-sunset world, or is the FastMCP REST shim sufficient?
+
+---
+
+## 8. Recommendation (preliminary — pending §7 answers)
+
+**Migrate, do not preserve.** mira-core has been infrastructure-debt since ADR-0014's product-led wedge decision. The sunset path is well-defined; the migration is bounded (~5 weeks of phased work); the value of keeping OWUI in-bundle is diminishing.
+
+The conservative variant: replace the OWUI fallback in worker call-paths with a direct Ollama call on the VPS, rather than dropping the fallback entirely. That keeps the resilience story intact while removing the OWUI process.
+
+**Next step:** answer §7 questions, accept this ADR, and open the Phase 1 PRs.
+
+---
+
+## References
+
+- ADR-0008 — sidecar deprecation (the earlier "move chat off services-installed RAG" decision)
+- ADR-0014 — product-led wedge (the strategic context that demoted mira-core)
+- `docs/THEORY_OF_OPERATIONS.md` — canonical layer map (note: mira-core not listed)
+- `docker-compose.saas.yml` — current mira-core bundle
+- `mira-core/CLAUDE.md` (and submodule CLAUDE.md files) — local-deep context
+- `mira-bots/shared/workers/{rag,nameplate,print}_worker.py` — OWUI fallback consumers
+- Issue #1463 — original investigation request
+- Issue #195 — OEM migration tracker (precondition)

--- a/docs/adr/0016-mira-bridge-flowfuse.md
+++ b/docs/adr/0016-mira-bridge-flowfuse.md
@@ -1,0 +1,175 @@
+# ADR-0016: Evaluate replacing mira-bridge with FlowFuse — investigation draft
+
+## Status
+**Draft / investigation** — 2026-05-20
+
+**Tracks issue:** #1465
+**Related:** ADR-0014 (product-led wedge)
+
+> Research only. No code changes accompany this commit.
+
+---
+
+## 1. Context
+
+`mira-bridge` is a self-hosted Node-RED 4.x deployment (`nodered/node-red:4.1.7-22`) wrapped in a custom Dockerfile + a shared SQLite WAL coordination layer. Today it does three things:
+
+1. **Message routing.** Inbound Telegram webhooks → MIRA core services. REST triggers (`/uns-confirmed`, `/scrape-complete`, etc.) → `mira-mcp` and `mira-bots`.
+2. **Shared SQLite write authority.** `mira-bridge` holds the write lock on `mira.db` (WAL mode). `mira-mcp` and `mira-ingest` read/write the same file via a Docker volume.
+3. **Scheduled tasks.** `mira-scheduled-tasks.json` runs periodic Node-RED-driven jobs.
+
+The three current flows total 858 lines of JSON across `mira-dashboard-conveyor.json`, `mira-scheduled-tasks.json`, `mira-setup-wizard.json`. Flow edits are made in the Node-RED UI, exported, and committed manually — a workflow that has drifted (commits frequently lag the deployed flow state).
+
+**FlowFuse** is a managed Node-RED platform (commercial + open-source self-host) that adds:
+- Multi-tenant project isolation (each team gets its own Node-RED instance).
+- Centralized secrets, env vars, deploy snapshots, audit log.
+- A blueprint / template system (publish a flow, deploy to N tenants).
+- Role-based access (admin / editor / viewer).
+- Hosted plan that maps to MIRA's expected SaaS tier model.
+
+The question is whether the operational debt of self-hosted Node-RED + custom WAL coordination is greater than the lift + ongoing cost of FlowFuse.
+
+---
+
+## 2. What mira-bridge does today (feature inventory)
+
+| Capability | Implementation | Risk if changed |
+|------------|----------------|-----------------|
+| Inbound webhook routing (Telegram, REST) | Node-RED HTTP-in nodes | High — production chat path goes through this |
+| SQLite write lock on `mira.db` | mira-bridge holds write authority; others use WAL reads | Medium — relocating the write authority is a coordinated migration |
+| Scheduled jobs (`mira-scheduled-tasks.json`) | Node-RED scheduler | Low — replaceable with Celery beat or `mcp__scheduled-tasks__` |
+| Setup wizard flow (`mira-setup-wizard.json`) | Node-RED UI flow | Medium — embedded into early-customer onboarding |
+| Dashboard / conveyor flow (`mira-dashboard-conveyor.json`) | Node-RED UI flow | Low — demo/visualization layer, not production-critical |
+| Volume coordination with mira-mcp + mira-ingest | Docker volume mount of `/data` | High — shared SQLite is the database for these three services |
+
+**Customer-visible surface:** none. mira-bridge runs at `:1880` internally; not exposed to the public.
+
+**Test surface:** `tests/regime3_bridge/` (Node-RED-specific) + integration tests under `tests/regime4_*` that depend on the shared `mira.db`.
+
+---
+
+## 3. FlowFuse feature-parity assessment
+
+| Capability we need | FlowFuse equivalent | Parity |
+|--------------------|---------------------|--------|
+| Node-RED 4.x flow engine | ✅ Native | Full |
+| HTTP-in inbound routing | ✅ Native | Full |
+| Shared SQLite WAL across containers | ❌ FlowFuse isolates per-project storage | **No parity** — would have to move shared state out of mira-bridge entirely (e.g. all writes through NeonDB or a managed Postgres) |
+| Docker-volume bind mounts | ❌ Hosted FlowFuse uses internal storage; self-hosted FlowFuse supports volumes but loses the tenancy benefit | Partial |
+| Manual JSON commits of flow edits | ✅ Replaced by FlowFuse snapshots + Git sync | **Improves on current** — Git sync is built-in |
+| Per-tenant isolation | ✅ Native (FlowFuse Teams) | **Improves on current** — today mira-bridge is single-tenant |
+| Secrets management | ✅ FlowFuse env vars + secrets | Equivalent (we already use Doppler; either works) |
+| Audit log of flow changes | ✅ Native | **Improves on current** — today flow changes only show up as JSON diffs at commit time, if at all |
+| Scheduled tasks | ✅ Node-RED scheduler nodes still work | Full |
+
+**The blocker:** FlowFuse's tenancy model assumes per-project storage. The current `mira-bridge` SQLite WAL pattern (mira-mcp + mira-ingest share the file via volume) is incompatible with multi-tenant FlowFuse. To use FlowFuse multi-tenancy we must first move the shared state out of SQLite-on-volume.
+
+---
+
+## 4. Multi-tenant story
+
+**Current state:** mira-bridge is single-tenant. All factory data is co-mingled in one `mira.db` SQLite file. Tenancy is enforced upstream in `mira-bots/shared/chat_tenant.py` and `mira-pipeline`, not in Node-RED. This works for now because:
+- The bridge mostly does stateless message routing; the tenancy filter happens before/after the bridge.
+- The shared SQLite is essentially a queue + state cache, not a primary record.
+
+**FlowFuse multi-tenant variants:**
+
+- **(a) Self-hosted FlowFuse, single team.** Same tenancy posture as today, but with FlowFuse's improved flow management + Git sync + audit log. No tenancy improvement. Cost: open-source self-host (free), single VPS.
+- **(b) Self-hosted FlowFuse, multiple teams.** Each MIRA customer gets a separate Node-RED instance. Requires moving shared SQLite state to NeonDB (or a managed Postgres) first.
+- **(c) FlowFuse Cloud (managed).** Same as (b) but FlowFuse runs the infrastructure. Removes the operational tax of patching Node-RED + the FlowFuse control plane.
+
+**The product-led wedge implication (per ADR-0014):** self-serve onboarding implies many small tenants. If each tenant gets a Node-RED instance, the per-tenant cost has to be near zero. Variants (b) and (c) only make sense at scale; variant (a) is the conservative path.
+
+---
+
+## 5. Cost projection at MIRA's SaaS scale
+
+Working assumptions: $97 tier customer, ~150 paying tenants by Q4 2026, ~1,000 by 2027 EOY.
+
+| Variant | Per-tenant cost | At 150 tenants | At 1,000 tenants | Notes |
+|---------|-----------------|----------------|-------------------|-------|
+| (a) Self-hosted FlowFuse, single team | $0 / tenant | $0/mo + 1 VPS ($30/mo) | Same | No tenancy improvement, but better flow ops |
+| (b) Self-hosted FlowFuse, multi-team | Compute per instance — assume 256MB RAM, $0.01/hr per Node-RED process = ~$7/mo at idle | ~$1k/mo | ~$7k/mo | Plus the lift to move shared SQLite to NeonDB |
+| (c) FlowFuse Cloud (Team plan, $30 / team / mo per published pricing snapshot 2026-Q2) | ~$30 / tenant | $4.5k/mo | $30k/mo | Margin death at $97 ARPU |
+
+**Numbers are illustrative — FlowFuse Cloud pricing must be re-checked against the live page before any commit.**
+
+Conclusion: variant (c) is incompatible with the $97 / $297 tier ARPU. Variant (b) is plausible at small scale but loses margin past ~500 tenants. Variant (a) is cost-neutral and gives flow-ops upside.
+
+---
+
+## 6. Migration plan / risk
+
+### If we choose variant (a) — self-hosted FlowFuse, single team
+
+**Lift:** ~1 week
+
+1. Stand up FlowFuse OSS on the staging VPS. Confirm Node-RED 4.x project boots with the existing flow JSON.
+2. Import current flows (`mira-dashboard-conveyor.json`, `mira-scheduled-tasks.json`, `mira-setup-wizard.json`) into a FlowFuse project.
+3. Wire FlowFuse's Git sync to a `mira-bridge-flows/` repo (or stay in the monorepo at `mira-bridge/flows/`).
+4. Hand-test on staging: webhook routing, scheduled jobs, setup wizard.
+5. Cut over prod: replace `mira-bridge` container with FlowFuse-managed Node-RED.
+
+**Risks:** low. FlowFuse OSS is well-supported; the migration is "lift and shift" a Node-RED runtime.
+
+**Wins:** Git sync, audit log, snapshot rollback, better UI.
+
+### If we choose variant (b) — self-hosted FlowFuse, multi-team
+
+**Lift:** ~6–8 weeks
+
+1. Move shared SQLite state to NeonDB. Refactor mira-mcp + mira-ingest to talk to NeonDB instead of `/data/mira.db`. This is the biggest piece. Tracked by ADR-0013 (UNS namespace builder schema canonicalization) — likely overlaps.
+2. Stand up FlowFuse OSS in multi-team mode. Build a tenant-onboarding hook that provisions a new team on signup.
+3. Repackage the current flows as a FlowFuse blueprint. Each new tenant gets the blueprint deployed.
+4. Per-tenant secrets injection from Doppler.
+5. Migration of existing tenants — coordinated downtime or live cutover.
+
+**Risks:** high. Touches the entire mira-mcp + mira-ingest data layer. The shared-SQLite-via-volume pattern is load-bearing today.
+
+**Wins:** true per-tenant isolation at the orchestration layer; aligns with ADR-0014 product-led wedge.
+
+### If we choose variant (c) — FlowFuse Cloud
+
+Same lift as (b) plus a hosted-vendor dependency. Cost-prohibitive at MIRA's price point per §5. Not recommended.
+
+---
+
+## 7. Recommendation (preliminary — pending review)
+
+**Defer. Stay on stock Node-RED for the MVP window. Revisit at 500 paying tenants.**
+
+Rationale:
+- The current pain (manual flow JSON commits, no audit log) is real but minor. Workarounds exist (e.g., a pre-commit hook that exports flows from the running container).
+- The multi-tenant story (variant b/c) is a large, risky refactor that the 90-day MVP plan (`docs/plans/2026-04-19-mira-90-day-mvp.md`) does not have room for.
+- Variant (a) is mostly upside but does not move the needle on the constraints we actually care about (multi-tenancy, cost-per-tenant). Net-net it's nice-to-have, not load-bearing.
+- mira-bridge's role is already shrinking — ADR-0014 moved the chat path to mira-pipeline, and most scheduled tasks are migrating to MIRA Routines (`wiki/references/routines.md`). The amortized importance of mira-bridge is declining.
+
+**Conditional acceptance triggers:**
+
+- If we hit a multi-tenant deal that requires per-customer Node-RED isolation → fast-track variant (b).
+- If Node-RED 4.x EOL is announced or a CVE forces a major patch → use that window to evaluate FlowFuse Cloud as a managed alternative.
+- If the manual JSON-flow workflow causes a production incident (e.g., undeployed flow drift) → minimal variant (a) becomes the immediate fix.
+
+---
+
+## 8. Open questions (for the deciding review)
+
+1. **Verify FlowFuse Cloud pricing for 2026-Q2.** Numbers in §5 are illustrative.
+2. **Confirm Node-RED 4.x LTS window.** If EOL is < 12 months out, the urgency increases.
+3. **Audit: how often are flows changed in prod without a commit?** If "frequently," the audit-log upside of variant (a) gets more weight.
+4. **Quantify shared-SQLite usage.** How many writes/sec hit `mira.db` from mira-bridge vs mira-mcp vs mira-ingest? If most writes are bridge-only, variant (b) becomes cheaper than this draft assumes.
+5. **Tenant-isolation requirement timing.** Do we actually need orchestration-layer tenancy, or is the upstream filter (`chat_tenant.py` + `mira-pipeline`) sufficient indefinitely?
+
+---
+
+## 9. References
+
+- Issue #1465 — original investigation request
+- `mira-bridge/CLAUDE.md` — current bridge context
+- `mira-bridge/docker-compose.yml` — current deployment
+- `mira-bridge/flows/*.json` — current flow definitions (858 lines total)
+- ADR-0014 — product-led wedge (the strategic context that demoted bridge importance)
+- ADR-0013 — UNS namespace builder schema canonicalization (the multi-tenant data layer)
+- `wiki/references/routines.md` — MIRA Routines (the scheduled-task replacement path)
+- FlowFuse OSS — https://github.com/FlowFuse/flowfuse (verify before citing in final version)
+- FlowFuse Cloud pricing — verify against current page before final version

--- a/docs/plans/2026-05-20-engine-split.md
+++ b/docs/plans/2026-05-20-engine-split.md
@@ -1,0 +1,297 @@
+# Plan: Split `mira-bots/shared/engine.py` god-class
+
+**Status:** Draft (planning only — no code changes in this PR)
+**Created:** 2026-05-20
+**Tracks:** #1464
+**Owner:** TBD
+**Effort:** ~1 week (5 working days, single contributor)
+
+---
+
+## 1. Why now
+
+`mira-bots/shared/engine.py` is 4,626 lines, ~62 methods, all rooted in one `Supervisor` class. It is the load-bearing surface for:
+
+- Telegram + Slack adapter entry points (via `Supervisor.process()` / `process_full()` / `process_multi_photo()`)
+- mira-pipeline's OpenAI-compat shim (the production VPS chat path)
+- The 5-regime test suite + golden cases (`tests/golden_*.csv`)
+- The GS11 grounding regression suite (post-2026-05-18 embed-sidecar incident)
+
+Symptoms that this matters now:
+
+- **Onboarding cost.** New contributors take days to map the file; `mira-trace-technician-flow` exists primarily because engine.py is too dense to read straight.
+- **Test surface drift.** Coverage focuses on `process()` outcomes; internal-method tests are rare because the surface is too tangled to mock cleanly.
+- **Merge friction.** PRs touching engine.py routinely collide. The 2026-04-25 overnight run produced 14 branches; many were engine.py-adjacent.
+- **State-transition reasoning is hard.** The FSM is `fsm.py` but the *transitions* are scattered across `_handle_*` methods. Reviewers can't see the flow without a debugger.
+
+This is tech debt. No new feature unlocks the split — but every future engine PR pays the tax.
+
+---
+
+## 2. Constraints (non-negotiable)
+
+1. **5-regime test suite stays green.** `pytest tests/ -q` at the head of each commit.
+2. **Golden cases pass.** `tests/golden_factorylm.csv`, `tests/golden_hybrid.csv` — diagnostic engine truth set.
+3. **GS11 grounding regression net passes.** Per `.claude/skills/bot-grounding-tests/` — mandatory pre-push for retrieval-layer edits.
+4. **No behavior change.** This is a refactor, not a feature. Each commit must be byte-for-byte identical on response output for the existing golden corpus.
+5. **One file move per commit.** Re-exports preserve import paths during the transition.
+6. **The public Supervisor API (`process`, `process_full`, `process_multi_photo`, `reset`, `log_feedback`) keeps its name and signature.** Adapters in `mira-bots/{telegram,slack,email}/` and `mira-pipeline/main.py` must not need changes.
+
+---
+
+## 3. Target structure
+
+```
+mira-bots/shared/engine/
+├── __init__.py          # re-exports Supervisor (preserves `from shared.engine import Supervisor`)
+├── core.py              # Supervisor class skeleton, __init__, process(), process_full(),
+│                        # process_multi_photo(), reset(), log_feedback() — the run-loop + lifecycle
+├── fsm_handlers.py      # FSM transition handlers (_handle_cmms_pending, _handle_pm_suggestion_pending,
+│                        # _handle_nameplate, _handle_session_followup, _handle_manual_lookup_*)
+├── grounding.py         # _is_grounded(), _apply_quality_gate(), _self_critique_diagnosis(),
+│                        # _call_with_correction(), groundedness scoring helpers
+├── recall.py            # KB recall path — coordinates with neon_recall.py and rag_worker
+├── cmms.py              # Work-order / CMMS bridge — _build_wo_draft(), _post_cmms_work_order(),
+│                        # _handle_wo_request(), _handle_cmms_pending(), _handle_check_equipment_history()
+├── uns_gate.py          # UNS namespace-confirmation gate — _should_fire_uns_gate(),
+│                        # the confirmation message builder, the wait-for-confirmation handler
+├── photos.py            # Photo / vision / schematic handling — _save_session_photo(),
+│                        # _load_session_photo(), _extract_schematic(), _summarize_schematic(),
+│                        # _build_print_reply()
+├── replies.py           # Reply formatting — _format_simple_response(), _greeting_response(),
+│                        # _format_reply(), _make_result(), _parse_response()
+├── routing.py           # Intent routing — _handle_general_question(), _handle_multi_vendor_question(),
+│                        # _handle_asset_switch(), _handle_documentation_intent(), etc.
+├── persistence.py       # State persistence — _ensure_table(), _load_state(), _save_state(),
+│                        # _record_exchange(), _log_interaction()
+└── helpers.py           # Module-level helpers — _is_fresh_question_during_wo(),
+                         # _clean_option_list(), _clean_asset_name(), _strip_memory_block(),
+                         # _infer_confidence(), _is_doc_specific(), _message_is_specific_question()
+```
+
+`engine.py` itself becomes a 1-line shim:
+
+```python
+# mira-bots/shared/engine.py
+from .engine import Supervisor  # noqa: F401  re-export for backwards-compat
+```
+
+Or, equivalently, delete `engine.py` and rely on `engine/__init__.py`. The shim variant minimizes import-path churn during the rollout; the `__init__.py`-only variant is the post-rollout end state.
+
+---
+
+## 4. Method-to-file mapping (from current engine.py)
+
+Line numbers refer to `engine.py` at commit `6802b9d8` (this branch's HEAD).
+
+### → `core.py` (Supervisor lifecycle + public API)
+
+| Line | Method |
+|------|--------|
+| 465 | `class Supervisor` |
+| 468 | `__init__` |
+| 538 | `_background_state_for` (used by `process` to suppress diagnostic carryover) |
+| 542 | `_clear_diagnostic_carryover` |
+| 582 | `_load_recent_session_photo` |
+| 708 | `_make_result` |
+| 734 | `process` |
+| 855 | `process_multi_photo` |
+| 999 | `process_full` |
+| 2222 | `reset` |
+| 2250 | `log_feedback` |
+
+### → `fsm_handlers.py`
+
+| Line | Method |
+|------|--------|
+| 2049 | `_handle_cmms_pending` |
+| 2180 | `_handle_pm_suggestion_pending` |
+| 2270 | `_handle_nameplate` |
+| 2523 | `_handle_session_followup` |
+| 2649 | `_enter_manual_lookup_gathering` |
+| 2722 | `_handle_manual_lookup_gathering` |
+| 3418 | `_handle_dont_know_followup` |
+| 3467 | `_maybe_dispatch_via_dst` |
+
+### → `grounding.py`
+
+| Line | Method |
+|------|--------|
+| 799 | `_apply_quality_gate` |
+| 2429 | `_self_critique_diagnosis` |
+| 2475 | `_call_with_correction` |
+| 4285 | `_is_grounded` |
+
+### → `recall.py`
+
+| Line | Method |
+|------|--------|
+| 3922 | `_do_documentation_lookup` |
+| 4059 | `_check_pending_doc_job` |
+| 4140 | `_fire_scrape_trigger` |
+
+(Note: pure recall is already in `neon_recall.py` + `workers/rag_worker.py`; `engine/recall.py` is the *coordinator* layer.)
+
+### → `cmms.py`
+
+| Line | Method |
+|------|--------|
+| 1973 | `_build_wo_draft` |
+| 2005 | `_post_cmms_work_order` |
+| 3382 | `_handle_wo_request` |
+| 3622 | `_handle_check_equipment_history` |
+
+(Plus the relevant parts of `_handle_cmms_pending` — judgement call whether that lives in `fsm_handlers.py` or `cmms.py`. Recommended: `fsm_handlers.py` since the dominant axis is FSM transition.)
+
+### → `uns_gate.py`
+
+| Line | Method |
+|------|--------|
+| 4400 | `_should_fire_uns_gate` |
+
+(Plus the inline confirmation-message logic in `process_full()` — needs extraction into a `build_confirmation_message()` function.)
+
+### → `photos.py`
+
+| Line | Method |
+|------|--------|
+| 525 | `_save_session_photo` |
+| 529 | `_load_session_photo` |
+| 533 | `_clear_session_photo` |
+| 606 | `_build_print_reply` |
+| 609 | `_extract_schematic` |
+| 649 | `_summarize_schematic` |
+
+### → `replies.py`
+
+| Line | Method |
+|------|--------|
+| 689 | `_infer_confidence` |
+| 2933 | `_format_simple_response` |
+| 2940 | `_greeting_response` |
+| 4372 | `_parse_response` |
+| 4386 | `_format_reply` |
+
+### → `routing.py`
+
+| Line | Method |
+|------|--------|
+| 3029 | `_handle_general_question` |
+| 3214 | `_handle_multi_vendor_question` |
+| 3302 | `_handle_asset_switch` |
+| 3691 | `_handle_store_documentation` |
+| 3816 | `_handle_documentation_intent` |
+| 3846 | `_handle_instructional_question` |
+| 3894 | `_call_llm_direct` |
+
+### → `persistence.py`
+
+| Line | Method |
+|------|--------|
+| 4311 | `_ensure_table` |
+| 4315 | `_load_state` |
+| 4319 | `_save_state` |
+| 4335 | `_record_exchange` |
+| 4339 | `_log_interaction` |
+| 4382 | `_advance_state` |
+
+### → `helpers.py` (module-level)
+
+| Line | Method |
+|------|--------|
+| (top) | `_is_fresh_question_during_wo` |
+| (top) | `_clean_option_list` |
+| (top) | `_clean_asset_name` |
+| 677 | `_is_doc_specific` |
+| 3014 | `_message_is_specific_question` |
+| 3354 | `_parse_asset_fault_from_message` |
+| 4324 | `_strip_memory_block` |
+
+---
+
+## 5. Sequencing (5-day plan)
+
+Each day ends with green CI on the worktree branch. No file move ships without the tests passing.
+
+### Day 1 — Mechanical extraction (zero behavior change)
+
+Order matters: smallest-blast-radius modules first, so failure modes show up in cheap commits.
+
+1. **`helpers.py`** — module-level pure functions. No `self` references. Lowest blast radius. Commit, push, verify CI.
+2. **`persistence.py`** — `_ensure_table`, `_load_state`, `_save_state`, `_record_exchange`, `_log_interaction`. All self-contained sqlite work. Commit, push, verify.
+3. **`replies.py`** — formatting helpers. No external I/O. Commit, push, verify.
+4. **`photos.py`** — session-photo helpers, schematic extraction. Some external I/O (`workers/vision_worker.py`). Commit, push, verify.
+
+### Day 2 — Mid-blast-radius extractions
+
+5. **`grounding.py`** — quality-gate + self-critique. Calls into `citation_compliance.py`. Run GS11 regression suite after this commit. Commit, verify.
+6. **`uns_gate.py`** — the namespace-confirmation gate. Pulls from `uns_resolver.py`. **Hand-test the gate flow on staging Telegram** before committing — UNS gate failure is a production bug per `.claude/CLAUDE.md`. Commit, verify.
+
+### Day 3 — High-blast-radius extractions
+
+7. **`cmms.py`** — work-order flow. Touches `integrations/atlas_cmms.py`, `integrations/hub_neon.py`, `integrations/pm_suggestions.py`. Run a CMMS smoke pass (`tests/regime5_*` if present). Commit, verify.
+8. **`routing.py`** — general/multi-vendor/asset-switch/documentation handlers. Touches `conversation_router.py`. Run the golden cases here. Commit, verify.
+
+### Day 4 — FSM extraction
+
+9. **`fsm_handlers.py`** — all `_handle_*` methods for pending states. Touches `dialogue_state.py`, `dialogue_tracker.py`, `fsm.py`. This is the highest-blast-radius commit. Run the full 5-regime suite + GS11 + golden cases before push. Commit, verify.
+10. **`recall.py`** — recall-coordinator layer. Touches `neon_recall.py`, `workers/rag_worker.py`. Run GS11 again. Commit, verify.
+
+### Day 5 — Wrap-up
+
+11. **`core.py`** — what's left becomes `Supervisor`'s skeleton. Move `__init__`, public-API methods, and the run-loop here. Update `engine.py` to be a 1-line re-export shim.
+12. **Sweep:** `ruff check mira-bots/shared/engine/` + `ruff format`. Verify import graph is clean (no cycles).
+13. **Smoke:** staging deploy + full pre-merge gate (`smoke-test.yml`, `staging-gate`, GS11, golden cases). PR review + merge.
+
+---
+
+## 6. Verification gates (per-commit)
+
+Every commit between Day 1 and Day 5 must satisfy:
+
+1. `ruff check mira-bots/` exits 0.
+2. `pytest tests/ -q -m 'not slow'` exits 0.
+3. `pytest tests/golden_factorylm.csv tests/golden_hybrid.csv -q` no regressions vs baseline.
+4. The bot-grounding-tests skill suite passes (GS11 regression net).
+5. `grep -rn 'from .engine import' mira-bots/` — no caller has changed (refactor is internal).
+
+Day 5 adds:
+
+6. Staging deploy succeeds.
+7. `bash install/smoke_test.sh` against staging-VPS — green.
+8. Telegram + Slack smoke pass on staging bot accounts.
+
+---
+
+## 7. Rollback strategy
+
+- Each commit is a single file move with re-exports. Reverting any one commit returns to the prior working state without cascading.
+- If Day 4 (FSM handlers) regresses GS11 or the UNS gate, revert that commit and re-plan the split (the FSM is the highest-risk axis).
+- If the full Day-5 PR is reverted, the engine continues to work from the old `engine.py` location (the per-commit re-exports keep all import paths alive throughout the migration).
+
+---
+
+## 8. Out of scope
+
+This plan is **refactor only**. It explicitly does NOT include:
+
+- Behavior changes — no new groundedness scoring, no new FSM states, no new handlers.
+- Test additions or coverage improvements (those are follow-up; they're easier *after* the split).
+- Performance changes — async loop, retries, timeouts all stay as-is.
+- New abstractions — no plugin systems, no dependency injection, no service locators. Just file moves.
+- `mira-bots/shared/workers/` reshuffling — workers are already separated; not touching them.
+
+If reviewers want any of the above, file separate issues. The whole point of this refactor is *reducing* the variables in flight; piling on dilutes that.
+
+---
+
+## 9. References
+
+- Issue #1464 — original tech-debt ticket
+- `mira-bots/shared/engine.py` — current source (4,626 lines)
+- `mira-bots/shared/CLAUDE.md` — local context
+- `mira-bots/shared/fsm.py`, `dialogue_state.py`, `dialogue_tracker.py` — existing FSM modules (already split out)
+- `mira-bots/shared/workers/` — worker layer (already split out)
+- `.claude/skills/bot-grounding-tests/SKILL.md` — GS11 regression contract
+- `tests/golden_factorylm.csv`, `tests/golden_hybrid.csv` — golden corpus
+- ADR-0014 — product-led wedge (the strategic context that makes this debt worth paying down now)

--- a/mira-hub/src/app/(hub)/onboarding/page.tsx
+++ b/mira-hub/src/app/(hub)/onboarding/page.tsx
@@ -18,10 +18,10 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { ArrowLeft, ArrowRight, Building2, Factory, Loader2, MapPin, Sparkles } from "lucide-react";
+import { ArrowLeft, ArrowRight, Building2, Factory, Loader2, MapPin, MessageSquare, Sparkles } from "lucide-react";
 import { API_BASE } from "@/lib/config";
 
-type StepId = "company" | "site" | "line" | "review";
+type StepId = "company" | "site" | "line" | "review" | "try";
 
 interface CompanyPayload { name: string }
 interface SitePayload    { name: string; location?: string }
@@ -37,6 +37,7 @@ const STEPS: { id: StepId; label: string; icon: React.ElementType }[] = [
   { id: "site",    label: "First site",     icon: MapPin },
   { id: "line",    label: "First line",     icon: Factory },
   { id: "review",  label: "Review & finish", icon: Sparkles },
+  { id: "try",     label: "Try MIRA",        icon: MessageSquare },
 ];
 
 export default function OnboardingPage() {
@@ -111,7 +112,7 @@ export default function OnboardingPage() {
       });
       const data = (await res.json().catch(() => ({}))) as { error?: string; sitePath?: string };
       if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
-      router.replace("/namespace");
+      advance("try");
     } catch (e) {
       setError((e as Error).message);
     } finally {
@@ -191,6 +192,13 @@ export default function OnboardingPage() {
             finishing={finishing}
             onBack={() => advance("line")}
             onFinish={finish}
+          />
+        )}
+        {activeStep === "try" && (
+          <TryStep
+            payloads={payloads}
+            onTry={() => router.push("/quickstart")}
+            onSkip={() => router.replace("/namespace")}
           />
         )}
       </div>
@@ -437,6 +445,61 @@ function ReviewStep({
         rightTestId="onboarding-finish"
         onRight={onFinish}
       />
+    </div>
+  );
+}
+
+function TryStep({
+  payloads,
+  onTry,
+  onSkip,
+}: {
+  payloads: AllPayloads;
+  onTry: () => void;
+  onSkip: () => void;
+}) {
+  const lineName = payloads.line?.name ?? "your line";
+  return (
+    <div className="space-y-5" data-testid="step-try">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-emerald-50 text-emerald-600">
+          <Sparkles className="h-5 w-5" />
+        </div>
+        <div>
+          <h2 className="text-lg font-semibold text-slate-900">Namespace ready.</h2>
+          <p className="mt-1 text-sm text-slate-600">
+            MIRA now knows about <span className="font-medium text-slate-900">{lineName}</span>.
+            Ask a real maintenance question and get a cited answer from the OEM corpus —
+            fault codes, troubleshooting steps, part references.
+          </p>
+        </div>
+      </div>
+      <div className="rounded-md border border-blue-100 bg-blue-50 p-3 text-xs text-blue-900">
+        <strong>Example asks:</strong>
+        <ul className="mt-1 list-disc space-y-0.5 pl-5">
+          <li>What does fault F0004 mean on a PowerFlex 525?</li>
+          <li>How do I reset an Allen-Bradley 1756-EN2T module?</li>
+          <li>Common causes of overheating on a SEW-Eurodrive gearmotor?</li>
+        </ul>
+      </div>
+      <div className="flex flex-col-reverse gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <button
+          type="button"
+          onClick={onSkip}
+          className="inline-flex items-center gap-1 text-sm font-medium text-slate-600 hover:text-slate-900"
+          data-testid="onboarding-skip-try"
+        >
+          Skip to namespace
+        </button>
+        <button
+          type="button"
+          onClick={onTry}
+          className="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700"
+          data-testid="onboarding-try-mira"
+        >
+          <MessageSquare className="h-4 w-4" /> Try MIRA now <ArrowRight className="h-4 w-4" />
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Bundles one P1 code change with three P2 investigation docs — all from the hub-overhaul P1 list. Closes #1459, #1463 (investigation), #1464 (investigation), #1465 (investigation).

### Commit 1 — `feat(hub)` #1459: onboarding wizard step 5

- Adds a fifth step ("Try MIRA") to the namespace onboarding wizard, surfacing immediately after the user clicks "Create namespace"
- Primary CTA routes to `/quickstart` (public, no-auth grounded-answer surface — ADR-0014)
- Secondary CTA falls back to `/namespace` (prior endpoint of the wizard)
- In-session only: reloading `/onboarding` after `status=completed` still redirects to `/namespace`, so the wizard `finish` API contract is unchanged

data-testid contract: `step-try`, `onboarding-try-mira`, `onboarding-skip-try`.

### Commit 2 — `docs(adr,plans)` #1463/#1464/#1465: three P2 investigations

- `docs/adr/0015-mira-core-sunset.md` — draft ADR. Inventories what mira-core (Open WebUI) provides, what the Hub already covers, the gaps, 4-phase migration plan. Recommendation: migrate, not preserve.
- `docs/plans/2026-05-20-engine-split.md` — refactor plan for the 4,626-line `Supervisor` in `mira-bots/shared/engine.py`. Maps all 62 methods to 11 target files. 5-day sequencing, per-commit gates, rollback strategy. Behavior-preserving only.
- `docs/adr/0016-mira-bridge-flowfuse.md` — draft ADR for FlowFuse evaluation. Feature-parity matrix, 3 multi-tenant variants, cost projection at $97/$297 ARPU. Recommendation: defer; revisit at 500 tenants or Node-RED EOL.

No production-code changes from commit 2.

## Test plan
- [ ] (manual) Complete wizard on staging → land on `step-try` → click `onboarding-try-mira` → arrive at `/quickstart`
- [ ] (manual) Complete wizard → click `onboarding-skip-try` → arrive at `/namespace`
- [ ] Reload `/onboarding` after `status=completed` → redirects to `/namespace` (prior behavior preserved)
- [ ] Read the three docs and either accept or comment with answers to the open questions in each

🤖 Generated with [Claude Code](https://claude.com/claude-code)