### PR TITLE
fix(whatsapp): add missing shared/ deps (yaml + langfuse + sqlalchemy + psycopg2)

### DIFF
--- a/mira-bots/whatsapp/requirements.txt
+++ b/mira-bots/whatsapp/requirements.txt
@@ -4,3 +4,7 @@ uvicorn==0.42.0
 httpx==0.27.*
 Pillow>=12.0
 python-multipart==0.0.22
+PyYAML==6.0.3
+langfuse>=2.50.0,<3.0.0
+sqlalchemy>=2.0
+psycopg2-binary>=2.9


### PR DESCRIPTION
## Summary
- Adds `PyYAML`, `langfuse`, `sqlalchemy`, `psycopg2-binary` to `mira-bots/whatsapp/requirements.txt`
- Aligns whatsapp bot deps with the slack bot (same `shared/` modules, slack is healthy on Charlie)
- Resolves crash-loop on Charlie: `ModuleNotFoundError: No module named 'yaml'` from `shared/inference/router.py:22`

Fixes #1285.

## Why these specific deps
The Dockerfile copies `shared/` into the image. That tree includes:
- `shared/inference/router.py` → imports `yaml`
- `shared/engine.py` → transitively imports langfuse, sqlalchemy, psycopg2 via the NeonDB recall + RAG worker path

The slack bot has had these pinned for months — whatsapp was the odd one out.

## Verification
```
$ docker build -f whatsapp/Dockerfile -t mira-whatsapp-test .
[+] Building ... DONE

$ docker run --rm mira-whatsapp-test python -c \
    "import yaml, langfuse, sqlalchemy, psycopg2; from shared.inference import router; print('all imports OK')"
all imports OK

$ docker run --rm -e MIRA_DB_PATH=/tmp/test.db mira-whatsapp-test python -c \
    "import bot; print('bot module imported OK, FastAPI app:', type(bot.app).__name__)"
... InferenceRouter disabled — INFERENCE_BACKEND=local (expected at build-test time)
bot module imported OK, FastAPI app: FastAPI
```

## Test plan
- [ ] CI builds the new image
- [ ] After merge → rebuild + redeploy on Charlie (`docker compose up -d --build mira-bot-whatsapp`)
- [ ] Verify container stays up: `docker ps --filter name=mira-bot-whatsapp` → `Up` not `Restarting`
- [ ] Hit `/webhook` health (or send Twilio sandbox test message)

🤖 Generated with [Claude Code](https://claude.com/claude-code)