### PR TITLE
chore(promo-director): COMPETITOR_ANALYSIS.md refresh 2026-05-21

### DIFF
--- a/.claude/skills/promo-director/references/COMPETITOR_ANALYSIS.md
+++ b/.claude/skills/promo-director/references/COMPETITOR_ANALYSIS.md
@@ -1,8 +1,29 @@
 # Competitor Video Analysis — MIRA Promo Director
 
-**Last refresh:** 2026-05-03
+**Last refresh:** 2026-05-21
 **Scope:** Promo, launch, explainer, and product-demo videos. YouTube-primary; official channels and partner placements included.
 **Note:** YouTube direct-fetch is blocked (403). All entries are search-derived. Hook text extracted from press releases, descriptions, and search snippets. Mark `[transcript not verified]` where opening details are inferred.
+
+---
+
+## Refresh delta — 2026-05-21
+
+*Scan window: 2026-05-04 → 2026-05-21. 4 vendors with new signal.*
+
+### Most actionable change for the playbook
+Notion 3.5 (May 13) shifted from "agents inside Notion" to "Notion orchestrates agents from everywhere" (Claude Code, Cursor, Codex, Decagon all work in-box via external agents API). The "orchestration hub" frame is spreading across B2B SaaS. MIRA's counter-positioning: not another agent to coordinate — the factory-specific intelligence layer that makes any agent grounded. UNS + KG is the moat; put it front-and-center before a CMMS vendor claims the "hub" frame for maintenance.
+
+### New findings
+
+**CMMS / EAM**
+- **MaintainX** — "What's New: May 2026" (blog-only, no video): https://www.getmaintainx.com/blog/whats-new-at-maintainx-may-2026 — AI Procedure Recommendations attaches the right procedure at work order creation time (from title+description); pattern deepening toward MIRA's diagnostic territory
+
+**Predictive maintenance**
+- **Tractian** — AI Transcription for Voice Notes (late Apr 2026, no video): https://tractian.com/en/blog/ai-transcription-for-voice-notes-release — voice notes → AI transcription → structured text in work orders and inspections; field-first UX direction
+
+**B2B SaaS / dev-tools**
+- **Notion** — 3.5: Developer Platform (May 13): https://www.youtube.com/watch?v=zCFlM2XhJJE — CEO Ivan Zhao livestreamed; orchestration hub framing, external agents API (Claude Code, Cursor, Codex, Decagon out of the box), Workers (hosted code runtime), Database Sync; 1M+ custom agents created since Feb 2026
+- **Anthropic** — Code with Claude 2026 conference: SF keynote https://www.youtube.com/watch?v=wjvESxKgqaQ (May 6), London https://www.youtube.com/watch?v=6amLO7I9xdg (May 20-21) — first developer-conference format; announced Managed Agents, Proactive Workflows, Capability Curve; all keynotes livestreamed to YouTube; new launch vehicle pattern for Anthropic
 
 ---
 
@@ -86,6 +107,13 @@ UpKeep Nova's "acts on it" framing directly maps to MIRA's core value prop. Comp
 - "Digitize Fast with MaintainX and AI": https://www.youtube.com/watch?v=X8cY-d-_KZM
 - "Streamline workflows with MaintainX and AI": https://www.youtube.com/watch?v=z9mOVm-PtyY
 
+**May 2026 update (blog-only, no video)**
+- URL: https://www.getmaintainx.com/blog/whats-new-at-maintainx-may-2026
+- AI Procedure Recommendations: attaches the right procedure at work order creation time, generated from title + description; reduces procedure-from-scratch time
+- Sub Work Orders: break complex jobs into tracked sub-WOs, each assignable to different teams/assets
+- Scalable Automations improvements
+- Pattern note: MaintainX is closing the gap toward MIRA's diagnostic territory — "know the right procedure before the tech starts" is one step from "diagnose the fault before the tech arrives"
+
 **Market position:** 13,000+ companies; Deloitte Technology Fast 500 2025 winner.
 
 ---
@@ -119,6 +147,12 @@ No video content surfaced for 2025–2026. Both mid-market; no AI agent pivot ob
 - $120M Series C (Dec 2024, Sapphire + General Catalyst)
 - Oracle Cloud Infrastructure partnership (Mar 2025): adopted OCI to support Copilot scale
 - Competitive note: hardware-first (IoT sensors + software); MIRA's counterplay is sensor-agnostic + OEM-manual-native
+
+**AI Transcription for Voice Notes (late Apr 2026, no video)**
+- URL: https://tractian.com/en/blog/ai-transcription-for-voice-notes-release
+- Voice notes in work orders, inspections, and other modules → instant AI transcription → structured text
+- Designed for field use: reduces friction for technicians who won't type, will speak
+- Pattern note: Tractian is going voice-first for field UX. MIRA's Slack-first approach is messaging-first — watching whether voice becomes the field standard is worth tracking.
 
 ---
 
@@ -304,6 +338,15 @@ No promo video surfaced. Apr 2026: Linear Agent + MCP support. Channel: https://
 - 30+ product releases in recent months per search results
 - No standalone promo video; analyst/conference appearances as primary video channel
 
+**Code with Claude 2026 conference (May 6 SF, May 20-21 London)**
+- SF keynote: https://www.youtube.com/watch?v=wjvESxKgqaQ
+- London keynote: https://www.youtube.com/watch?v=6amLO7I9xdg
+- Format: multi-city developer conference, all keynotes livestreamed to YouTube; first time Anthropic has run a developer conference as their primary launch vehicle
+- Announced: Managed Agents, Proactive Workflows, Capability Curve
+- Speaker roster: CPO Ami Vora, Head of Claude Code Cat Wu, Boris Cherny; partner demos from GitHub, Vercel, Datadog, Bun
+- Pattern: conference-as-launch-vehicle (same as Figma Config, Stripe Sessions, Inductive Automation ICC) — now standard for developer-platform companies
+- Transfer to MIRA: "factory maintenance summit" or "plant intelligence day" could be a future launch vehicle for enterprise customer acquisition
+
 ---
 
 ### Cursor
@@ -339,6 +382,17 @@ No promo video surfaced. Apr 2026: Linear Agent + MCP support. Channel: https://
 - Music: likely ambient [not verified]
 - CTA: soft — "available now in Notion AI"
 - Pattern note: "busywork → life's work" contrast is the tightest agent-value compression found across all vendors; adapt for MIRA as "fault-chasing → running the line"
+
+**3.5: Developer Platform (May 13, 2026)**
+- URL: https://www.youtube.com/watch?v=zCFlM2XhJJE ("Notion Just Announced A Massive Shift (Big Update)")
+- Release notes: https://www.notion.com/releases/2026-05-13
+- Presenter: CEO Ivan Zhao (livestreamed "Make with Notion: Developer Platform" event)
+- Key shift: Notion as orchestration hub for external agents — Claude Code, Cursor, Codex, Decagon work in-box via External Agents API
+- Components: Notion Workers (hosted code runtime, no own servers), Database Sync (pull from Salesforce, Zendesk, Postgres, etc.), External Agents API, CLI
+- Scale: 1M+ custom agents created by users since Custom Agents launched Feb 2026
+- Pricing: free through Aug 11, 2026 (developer adoption play)
+- Strategic frame: moved from "Notion has agents" → "Notion coordinates all agents" — orchestration layer positioning
+- Transfer to MIRA: the competing frame is "every tool your agents need in one hub"; MIRA's counter must be "factory-grounded intelligence, not another orchestration layer"
 
 ---
 
@@ -398,3 +452,7 @@ No video content surfaced for 2025–2026.
 - **MaintainX**: added knowledge-base framing (OEM manual ingestion) in Feb 2025; previously pure workflow CMMS. Now directly adjacent to MIRA's diagnostic KB approach.
 - **Inductive Automation**: doubled down on educational content (SCADA 101) over product feature content in 2025 — treating top-of-funnel education as the acquisition channel.
 - **Augury**: moved from B2B-tech-style VO demos to third-party credibility (Bloomberg) for enterprise deals, while maintaining technical deep-dives for practitioner audience.
+- **MaintainX** (May 2026): deepened knowledge-at-the-moment-of-need from CoPilot (manual lookup) to AI Procedure Recommendations (auto-attach at WO creation). No video — updates are blog/changelog-only now. Converging on MIRA's diagnostic territory from the workflow side.
+- **Tractian** (Apr 2026): added voice-first field UX (AI transcription of voice notes). Direction is reducing text-entry friction for technicians in the field. No video announced.
+- **Notion** (May 2026): pivoted from "product with agents" to "platform that orchestrates all agents". "Orchestration hub" framing is the new battleground in B2B SaaS — multiple vendors will attempt this in the industrial maintenance space.
+- **Anthropic** (May 2026): adopted developer conference as primary product launch vehicle (Code with Claude 2026, multi-city, keynotes on YouTube). Previously analyst/media appearances only.

--- a/mira-crawler/tests/test_converter_tables.py
+++ b/mira-crawler/tests/test_converter_tables.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from ingest.converter import _format_table_markdown, extract_from_pdf
 
 

--- a/tools/verify_phase0_deploy.py
+++ b/tools/verify_phase0_deploy.py
@@ -29,7 +29,6 @@ from dataclasses import dataclass
 
 import psycopg2
 
-
 # Expected schema. Mirrors `mira-hub/db/migrations/025-027*.sql`.
 #
 # Keeping this hand-written rather than introspected lets the script catch
@@ -41,25 +40,64 @@ EXPECTED_TABLES = ("tag_entities", "wiring_connections", "ai_suggestions")
 
 EXPECTED_COLUMNS: dict[str, set[str]] = {
     "tag_entities": {
-        "id", "tenant_id", "uns_path", "sparkplug_topic", "opcua_node_id",
-        "symbolic_name", "data_type", "units", "scaling", "source_kind",
-        "source_address", "component_instance_id", "expected_envelope",
-        "approval_state", "proposed_by", "evidence_summary",
-        "created_at", "updated_at",
+        "id",
+        "tenant_id",
+        "uns_path",
+        "sparkplug_topic",
+        "opcua_node_id",
+        "symbolic_name",
+        "data_type",
+        "units",
+        "scaling",
+        "source_kind",
+        "source_address",
+        "component_instance_id",
+        "expected_envelope",
+        "approval_state",
+        "proposed_by",
+        "evidence_summary",
+        "created_at",
+        "updated_at",
     },
     "wiring_connections": {
-        "id", "tenant_id", "source_entity_id", "source_terminal",
-        "dest_entity_id", "dest_terminal", "wire_number", "cable_id",
-        "gauge_awg", "color", "function_class", "drawing_reference",
-        "approval_state", "proposed_by", "evidence_summary",
-        "created_at", "updated_at",
+        "id",
+        "tenant_id",
+        "source_entity_id",
+        "source_terminal",
+        "dest_entity_id",
+        "dest_terminal",
+        "wire_number",
+        "cable_id",
+        "gauge_awg",
+        "color",
+        "function_class",
+        "drawing_reference",
+        "approval_state",
+        "proposed_by",
+        "evidence_summary",
+        "created_at",
+        "updated_at",
     },
     "ai_suggestions": {
-        "id", "tenant_id", "suggestion_type", "source_kind",
-        "source_document_id", "source_page", "source_id",
-        "extracted_data", "confidence", "status", "risk_level",
-        "proposed_by", "reviewed_by", "reviewed_at", "review_note",
-        "title", "body", "created_at", "updated_at",
+        "id",
+        "tenant_id",
+        "suggestion_type",
+        "source_kind",
+        "source_document_id",
+        "source_page",
+        "source_id",
+        "extracted_data",
+        "confidence",
+        "status",
+        "risk_level",
+        "proposed_by",
+        "reviewed_by",
+        "reviewed_at",
+        "review_note",
+        "title",
+        "body",
+        "created_at",
+        "updated_at",
     },
 }
 
@@ -108,11 +146,13 @@ def _check_tables(cur) -> list[CheckResult]:
     for tbl in EXPECTED_TABLES:
         cur.execute("SELECT to_regclass(%s)", (f"public.{tbl}",))
         exists = cur.fetchone()[0] is not None
-        out.append(CheckResult(
-            f"table {tbl}",
-            exists,
-            "exists" if exists else "MISSING",
-        ))
+        out.append(
+            CheckResult(
+                f"table {tbl}",
+                exists,
+                "exists" if exists else "MISSING",
+            )
+        )
     return out
 
 
@@ -126,11 +166,13 @@ def _check_columns(cur) -> list[CheckResult]:
         )
         present = {r[0] for r in cur.fetchall()}
         missing = expected - present
-        out.append(CheckResult(
-            f"columns {tbl}",
-            not missing,
-            "all present" if not missing else f"MISSING: {sorted(missing)}",
-        ))
+        out.append(
+            CheckResult(
+                f"columns {tbl}",
+                not missing,
+                "all present" if not missing else f"MISSING: {sorted(missing)}",
+            )
+        )
     return out
 
 
@@ -139,11 +181,13 @@ def _check_indexes(cur) -> list[CheckResult]:
     for idx in EXPECTED_INDEXES:
         cur.execute("SELECT to_regclass(%s)", (f"public.{idx}",))
         exists = cur.fetchone()[0] is not None
-        out.append(CheckResult(
-            f"index {idx}",
-            exists,
-            "exists" if exists else "MISSING",
-        ))
+        out.append(
+            CheckResult(
+                f"index {idx}",
+                exists,
+                "exists" if exists else "MISSING",
+            )
+        )
     return out
 
 
@@ -164,11 +208,13 @@ def _check_rls(cur) -> list[CheckResult]:
             out.append(CheckResult(f"RLS enabled {tbl}", False, "TABLE MISSING"))
             continue
         enabled = bool(row[0])
-        out.append(CheckResult(
-            f"RLS enabled {tbl}",
-            enabled,
-            "enabled" if enabled else "DISABLED",
-        ))
+        out.append(
+            CheckResult(
+                f"RLS enabled {tbl}",
+                enabled,
+                "enabled" if enabled else "DISABLED",
+            )
+        )
     for tbl, pol in EXPECTED_POLICIES.items():
         cur.execute(
             "SELECT 1 FROM pg_policies WHERE schemaname='public' "
@@ -176,11 +222,13 @@ def _check_rls(cur) -> list[CheckResult]:
             (tbl, pol),
         )
         exists = cur.fetchone() is not None
-        out.append(CheckResult(
-            f"policy {pol}",
-            exists,
-            "present" if exists else "MISSING",
-        ))
+        out.append(
+            CheckResult(
+                f"policy {pol}",
+                exists,
+                "present" if exists else "MISSING",
+            )
+        )
     return out
 
 
@@ -195,11 +243,13 @@ def _check_grants(cur) -> list[CheckResult]:
         )
         granted = {r[0] for r in cur.fetchall()}
         missing = expected - granted
-        out.append(CheckResult(
-            f"grants {tbl} factorylm_app",
-            not missing,
-            f"{sorted(expected)}" if not missing else f"MISSING: {sorted(missing)}",
-        ))
+        out.append(
+            CheckResult(
+                f"grants {tbl} factorylm_app",
+                not missing,
+                f"{sorted(expected)}" if not missing else f"MISSING: {sorted(missing)}",
+            )
+        )
     return out
 
 
@@ -207,15 +257,23 @@ def _check_check_constraints(cur) -> list[CheckResult]:
     """Spot-check the CHECK constraints that gate writer typos at INSERT time."""
     out: list[CheckResult] = []
     checks = [
-        ("tag_entities",      "data_type",       {"BOOL", "REAL", "INT16", "STRING"}),
-        ("tag_entities",      "source_kind",     {"plc_address", "modbus_register", "sparkplug_metric"}),
-        ("tag_entities",      "approval_state",  {"proposed", "verified", "rejected", "needs_review"}),
-        ("ai_suggestions",    "suggestion_type", {"kg_edge", "kg_entity", "tag_mapping",
-                                                  "component_profile", "uns_confirmation",
-                                                  "namespace_move"}),
-        ("ai_suggestions",    "status",          {"pending", "accepted", "rejected", "deferred",
-                                                  "superseded"}),
-        ("ai_suggestions",    "risk_level",      {"low", "medium", "high", "safety_critical"}),
+        ("tag_entities", "data_type", {"BOOL", "REAL", "INT16", "STRING"}),
+        ("tag_entities", "source_kind", {"plc_address", "modbus_register", "sparkplug_metric"}),
+        ("tag_entities", "approval_state", {"proposed", "verified", "rejected", "needs_review"}),
+        (
+            "ai_suggestions",
+            "suggestion_type",
+            {
+                "kg_edge",
+                "kg_entity",
+                "tag_mapping",
+                "component_profile",
+                "uns_confirmation",
+                "namespace_move",
+            },
+        ),
+        ("ai_suggestions", "status", {"pending", "accepted", "rejected", "deferred", "superseded"}),
+        ("ai_suggestions", "risk_level", {"low", "medium", "high", "safety_critical"}),
     ]
     for tbl, col, must_include in checks:
         cur.execute(
@@ -230,13 +288,15 @@ def _check_check_constraints(cur) -> list[CheckResult]:
         defs = [r[0] for r in cur.fetchall()]
         joined = " | ".join(defs)
         missing_values = [v for v in must_include if v not in joined]
-        out.append(CheckResult(
-            f"CHECK {tbl}.{col}",
-            not missing_values and bool(defs),
-            "ok" if not missing_values and defs else (
-                f"NO CHECK FOUND" if not defs else f"MISSING values: {missing_values}"
-            ),
-        ))
+        out.append(
+            CheckResult(
+                f"CHECK {tbl}.{col}",
+                not missing_values and bool(defs),
+                "ok"
+                if not missing_values and defs
+                else ("NO CHECK FOUND" if not defs else f"MISSING values: {missing_values}"),
+            )
+        )
     return out
 
 


### PR DESCRIPTION
## Summary
- 4 vendors with new signal since last refresh (2026-05-03)
- Most actionable change for the playbook: Notion 3.5 "orchestration hub" framing is spreading across B2B SaaS — a CMMS vendor claiming this frame for maintenance would directly undercut MIRA's positioning; counter-narrative (UNS + KG = factory-grounded intelligence, not a generic agent coordinator) should be explicit in promo materials

## New videos (per vendor)

### MaintainX
- https://www.getmaintainx.com/blog/whats-new-at-maintainx-may-2026 — blog-only, no video — AI Procedure Recommendations (auto-attach procedure at work order creation from title+description); incremental drift toward MIRA's diagnostic territory from the workflow side

### Tractian
- https://tractian.com/en/blog/ai-transcription-for-voice-notes-release — blog-only, no video — AI transcription of voice notes in work orders and inspections; voice-first field UX direction to watch

### Notion
- https://www.youtube.com/watch?v=zCFlM2XhJJE — "Notion Just Announced A Massive Shift (Big Update)" — CEO Ivan Zhao livestreamed the 3.5 Developer Platform launch; shifts Notion from "has agents" to "orchestrates all agents" (Claude Code, Cursor, Codex, Decagon in-box via External Agents API); 1M+ custom agents created since Feb 2026

### Anthropic
- https://www.youtube.com/watch?v=wjvESxKgqaQ — Code with Claude 2026 SF keynote (May 6) — Managed Agents, Proactive Workflows, Capability Curve; first developer-conference-as-launch-vehicle format for Anthropic
- https://www.youtube.com/watch?v=6amLO7I9xdg — Code with Claude 2026 London keynote (May 20-21)

## Test plan
- [ ] Read the Refresh delta section and confirm the new patterns are real signal, not noise
- [ ] If the Notion "orchestration hub" finding suggests a PROMO_DIRECTOR_PLAYBOOK.md edit, open a separate PR for that — do NOT auto-edit the playbook from this refresh

https://claude.ai/code/session_0164AcmtoLt9BUkx5h5cXR66

---
_Generated by [Claude Code](https://claude.ai/code/session_0164AcmtoLt9BUkx5h5cXR66)_