### PR TITLE
fix(hub-e2e): API-based NextAuth signin instead of brittle login UI

### DIFF
--- a/mira-hub/tests/e2e/namespace-inline-create.spec.ts
+++ b/mira-hub/tests/e2e/namespace-inline-create.spec.ts
@@ -41,12 +41,61 @@ async function register({ request }: { request: import("@playwright/test").APIRe
   expect([201, 409]).toContain(res.status());
 }
 
+/**
+ * NextAuth credentials sign-in via API instead of the login UI.
+ *
+ * The login UI is fully client-rendered and password input visibility timing
+ * is unreliable from a CI runner. The credentials provider sits behind the
+ * standard NextAuth signin flow which we can drive headlessly:
+ *   1. GET /api/auth/csrf → csrfToken
+ *   2. POST /api/auth/callback/credentials/ with cookie + form fields
+ *   3. Response sets the session cookie which we transfer into the browser ctx.
+ */
+type PWCookie = Awaited<
+  ReturnType<import("@playwright/test").APIRequestContext["storageState"]>
+> extends { cookies: infer C }
+  ? C
+  : never;
+
+async function apiSignIn(
+  request: import("@playwright/test").APIRequestContext,
+): Promise<PWCookie> {
+  // 1. csrf
+  const csrfRes = await request.get(`${HUB}/api/auth/csrf`);
+  expect(csrfRes.status()).toBe(200);
+  const { csrfToken } = (await csrfRes.json()) as { csrfToken: string };
+
+  // 2. credentials callback (NextAuth expects form-urlencoded, not JSON)
+  const form = new URLSearchParams();
+  form.set("email", CREDS.email);
+  form.set("password", CREDS.password);
+  form.set("csrfToken", csrfToken);
+  form.set("redirect", "false");
+  form.set("json", "true");
+  form.set("callbackUrl", HUB);
+
+  const signInRes = await request.post(`${HUB}/api/auth/callback/credentials/`, {
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    data: form.toString(),
+    maxRedirects: 0,
+  });
+  // 200 OK on success (json:true) — 302 with the error param query on bad creds.
+  expect([200, 302]).toContain(signInRes.status());
+
+  // 3. extract session cookie from request storage
+  const state = await request.storageState();
+  const sessionCookie = state.cookies.find(
+    (c) =>
+      c.name === "next-auth.session-token" ||
+      c.name === "__Secure-next-auth.session-token",
+  );
+  expect(sessionCookie, "no session cookie returned from credentials signin").toBeTruthy();
+  return state.cookies;
+}
+
 async function login(page: import("@playwright/test").Page) {
-  await page.goto(`${HUB}/login`, { waitUntil: "networkidle" });
-  await page.locator('input[type="email"]').first().fill(CREDS.email);
-  await page.locator('input[type="password"]').first().fill(CREDS.password);
-  await page.locator('button[type="submit"]').first().click();
-  await page.waitForURL(/\/(feed|hub|namespace)/i, { timeout: 15_000 });
+  const cookies = await apiSignIn(page.request);
+  await page.context().addCookies(cookies);
 }
 
 async function findRowByName(


### PR DESCRIPTION
## Summary
Drives the credentials provider headlessly so the e2e suite stops timing out on `input[type=password]` (login page is fully client-rendered, password input not interactable within 30s from CI runner).

## What changed
- `apiSignIn` helper: GET /api/auth/csrf → POST /api/auth/callback/credentials/ → grab session cookie from APIRequestContext storage
- `login()` transfers the cookie to the BrowserContext via `addCookies()`
- Decouples the test from login-UI markup churn

## Why
Previous run failures:
- 5 scenarios → `locator.fill` timeout on `input[type="password"]`
- 1 scenario → `register` got 405 (nginx /hub strip → POST follows redirect as GET)
- The URL-bare-host fix in #1488 resolved #1; this PR resolves the timeout.

## Test plan
- [ ] CI green
- [ ] After merge, dispatch `Namespace inline-create E2E (post-deploy)` workflow with default URL → all 9 scenarios pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)