### PR TITLE
fix(hub): hide + on synthetic namespace rows — fix "parentId required (uuid)" dead-end

### DIFF
--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## [1.9.1] - 2026-05-22
+### Fixed
+- `/hub/namespace` — clicking `+` on a synthesized parent row (kind=`namespace`, id prefixed `synthetic:`) returned `400 parentId required (uuid)` with no way to recover, because POST `/api/namespace/node` requires a UUID and synthesized nodes have no kg_entities row. Hide the `+` button on synthesized rows and show a short hint ("run onboarding to add") so the user is steered to the wizard that materializes a real parent. Inline-create remains available on every real (UUID-id) row.
+
 ## [1.9.0] - 2026-05-21
 ### Added
 - `/hub/namespace` — inline child creation on every tree row. A `+` button (always visible, ≥44×44 tap target) expands a card under the parent with a kind dropdown (site/area/line/equipment/component/namespace/custom), name input, live read-only path preview (`parent.uns_path.<slug>`), and 3-source file attach (Google Drive, Dropbox, Upload-from-device). Save creates the kg_entities row + writes a `namespace_versions` audit row (operation=create) + binds any attached file's `hub_uploads.uns_path` to the new node. Mobile-first; Playwright suite covers 9 acceptance scenarios incl. iPhone viewport tap-target check.

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/app/(hub)/namespace/page.tsx
+++ b/mira-hub/src/app/(hub)/namespace/page.tsx
@@ -268,6 +268,9 @@ function TreeNode({
   const isSelected = node.id === selectedId;
   const isDragging = draggingId === node.id;
   const isDropTarget = dropTargetId === node.id && draggingId !== node.id;
+  // Synthesized parents (#1344) have no kg_entities row — POST /api/namespace/node
+  // rejects their id as non-UUID. Hide create affordance there; show a hint instead.
+  const isSynthetic = node.id.startsWith("synthetic:");
 
   return (
     <div>
@@ -326,22 +329,33 @@ function TreeNode({
             </span>
           )}
         </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onStartCreate(node.id);
-          }}
-          className="ml-2 flex shrink-0 items-center justify-center rounded-md text-slate-500 hover:bg-blue-50 hover:text-blue-700"
-          aria-label={`Add child of ${node.name}`}
-          data-testid="namespace-add-child"
-          data-add-child-of={node.id}
-          style={{ minWidth: "44px", minHeight: "44px" }}
-        >
-          <Plus className="h-5 w-5" />
-        </button>
+        {isSynthetic ? (
+          <span
+            className="ml-2 hidden shrink-0 items-center px-2 text-[11px] text-slate-400 sm:flex"
+            data-testid="namespace-add-child-disabled"
+            data-add-child-of={node.id}
+            title="This row is a placeholder for a missing ancestor. Run the onboarding wizard to add a real parent before creating children here."
+          >
+            run onboarding to add
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onStartCreate(node.id);
+            }}
+            className="ml-2 flex shrink-0 items-center justify-center rounded-md text-slate-500 hover:bg-blue-50 hover:text-blue-700"
+            aria-label={`Add child of ${node.name}`}
+            data-testid="namespace-add-child"
+            data-add-child-of={node.id}
+            style={{ minWidth: "44px", minHeight: "44px" }}
+          >
+            <Plus className="h-5 w-5" />
+          </button>
+        )}
       </div>
-      {creatingUnderId === node.id && (
+      {creatingUnderId === node.id && !isSynthetic && (
         <CreateChildCard
           parentId={node.id}
           parentName={node.name}

--- a/mira-hub/tests/e2e/namespace-inline-create.spec.ts
+++ b/mira-hub/tests/e2e/namespace-inline-create.spec.ts
@@ -526,6 +526,69 @@ test.describe("Namespace inline create + doc attach", () => {
     }
   });
 
+  test("Scenario 10 — synthetic parent rows show disabled hint, not + button", async ({
+    page,
+  }) => {
+    // Synthesized parents (#1344) are rendered when kg_entities references an
+    // ancestor uns_path that has no row. Their id is `synthetic:<path>` and
+    // POST /api/namespace/node rejects non-UUID parentIds with 400.
+    // The fix in mira-hub v1.9.1 swaps the + button for a hint span on these
+    // rows, so the user never reaches the broken POST.
+    //
+    // We can't reliably seed a synthetic parent through the public wizard
+    // (it always creates a fully-rooted chain). If the seeded tenant happens
+    // to expose one (manual ingest history, prior test runs), assert the new
+    // affordance; otherwise skip cleanly. The API-level guarantee in
+    // Scenario 11 still holds.
+    const tree = page.locator('[data-testid="namespace-tree"]');
+    if (!(await tree.isVisible().catch(() => false))) {
+      test.skip(true, "Empty tree — no rows to inspect");
+    }
+    // The disabled hint is rendered with data-testid="namespace-add-child-disabled".
+    const disabledHint = page.locator('[data-testid="namespace-add-child-disabled"]');
+    const count = await disabledHint.count();
+    if (count === 0) {
+      test.skip(true, "No synthetic parents in this tenant — covered by Scenario 11 API check");
+    }
+    // For every disabled hint, the same row must NOT also have an + button.
+    for (let i = 0; i < count; i++) {
+      const hint = disabledHint.nth(i);
+      const row = hint.locator('xpath=ancestor::*[@data-testid="namespace-node"][1]');
+      const plusInRow = row.locator('[data-testid="namespace-add-child"]');
+      await expect(plusInRow).toHaveCount(0);
+      // The hint row should carry a parent id with the synthetic: prefix.
+      const dataId = await hint.getAttribute("data-add-child-of");
+      expect(dataId, "synthetic hint row missing data-add-child-of").toBeTruthy();
+      expect(dataId!.startsWith("synthetic:")).toBeTruthy();
+    }
+  });
+
+  test("Scenario 11 — POST /api/namespace/node rejects synthetic: parentId with 400 (no 5xx)", async ({
+    page,
+  }) => {
+    // Server contract test. The UI fix hides the + button on synthetic rows,
+    // but the server still has to refuse non-UUID parentIds cleanly. A 5xx
+    // here would mean a regression in the regex guard at
+    // mira-hub/src/app/api/namespace/node/route.ts.
+    const res = await page.request.post(`${HUB}/api/namespace/node`, {
+      headers: { "content-type": "application/json" },
+      data: {
+        parentId: "synthetic:enterprise.knowledge_base",
+        kind: "site",
+        name: "should be rejected",
+      },
+    });
+    // Expect 400 (bad parentId) — accept 401/403 if session expired between
+    // beforeAll and this test. NOT 500, NOT 201.
+    expect([400, 401, 403]).toContain(res.status());
+    expect(res.status()).not.toBe(201);
+    expect(res.status()).not.toBe(500);
+    if (res.status() === 400) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      expect(body.error ?? "").toMatch(/parentId|uuid/i);
+    }
+  });
+
   test("Scenario 9 — regression: existing tree features still work", async ({ page }) => {
     // Drag-drop is exposed via draggable attribute.
     const firstRow = page.locator('[data-testid="namespace-node"]').first();


### PR DESCRIPTION
## Summary

- Hide the `+` button on synthesized namespace tree rows (`id` prefixed `synthetic:`, kind `namespace`) and show a small **"run onboarding to add"** hint instead. Real (UUID-id) rows still show `+` and the inline-create card works as shipped in #1486.
- Adds 2 Playwright scenarios to guard the fix: UI hint presence (Scenario 10) and server-side `400` on `synthetic:` parentId (Scenario 11).
- Bumps `mira-hub` → **1.9.1**, CHANGELOG appended.

## Bug repro (user-reported)

> "the namespace hierarchy says I need a uuid when trying to create a new site but doesn't have a place to type it in"

Steps:
1. Open `/hub/namespace` on a tenant whose tree contains a synthesized parent row (any tenant where a `kg_entities` row references an `uns_path` whose ancestor segments lack their own rows — created by #1344 to keep the tree from breaking apart).
2. Tap `+` on the synthesized row.
3. Fill in a Name and tap Save.
4. **Before:** red error `parentId required (uuid)`. No input field for a UUID exists. Dead-end.
5. **After:** `+` button is replaced with a hint; user is steered to onboarding, which creates a real parent.

## Root cause

| File | Line | Role |
|------|------|------|
| `mira-hub/src/app/api/namespace/tree/route.ts` | 166–182 | `synthesizeParent()` assigns `id: \`synthetic:${path}\`` to ancestors with no `kg_entities` row. |
| `mira-hub/src/app/api/namespace/node/route.ts` | 69 | POST handler validates `parentId` with `/^[0-9a-f-]{36}$/i` → 400 on any `synthetic:` id. |
| `mira-hub/src/components/namespace/CreateChildCard.tsx` | 282–285 | Surfaces the 400 error string as `errors.submit` — no recovery affordance because the parent isn't a real DB row. |

Until #1486, this was harmless: synthesized rows were drag/click targets but not create targets. The new `+` button exposed every row including synthetic ones.

## Why hide instead of materialize on save (Option A vs B)

Considered: on `synthetic:` parentId, materialize the missing ancestor chain as real `kg_entities` rows before inserting the child. **Rejected** — spec hard constraint #7 (`docs/superpowers/specs/2026-05-21-namespace-tree-inline-create-goal-prompt.md`) forbids auto-promotion. Silently inserting `verified` kg_entities for ancestors during a child save is exactly that. Either we'd prompt for each ancestor name (UX cliff) or mark them `proposed`, which contradicts the spec's human-created→verified rule.

Option A (hide + hint) preserves the invariant. The onboarding wizard remains the single entry point for materializing root-level real rows.

## Test plan

- [x] Scenario 10 — `data-testid="namespace-add-child-disabled"` rendered on synthetic rows, `data-testid="namespace-add-child"` is **not** present on the same row, and `data-add-child-of` starts with `synthetic:`. Skips cleanly when no synthetic exists in the seeded tenant (Scenario 11 still covers the server contract).
- [x] Scenario 11 — `POST /api/namespace/node` with `parentId: "synthetic:enterprise.knowledge_base"` returns **400** (not 5xx, not 201). Body contains `parentId|uuid`.
- [ ] Manual phone-probe at `http://165.245.138.91:4101/hub/namespace/` after staging deploy.

Existing scenarios 1–9 unchanged; no regression to the happy path.

## Verification before merge

1. CI green (lint, vitest, build, namespace e2e).
2. After deploy to staging, manual phone-probe at `http://165.245.138.91:4101/hub/namespace/`:
   - Confirm `+` still works on real (UUID-id) rows (e.g., the seeded `Enterprise` / `Plant Seed` / `Line Seed`).
   - Confirm hint appears on any synthetic row (or note none exist in current seed).
3. Tag `mira-hub/v1.9.1` at merge commit; push tag; trigger prod deploy.

## Follow-up testing issues (filed)

- #1501 — Seed a synthetic-parent fixture so Scenario 10 stops skipping in CI.
- #1502 — Audit ALL tree affordances (drag-drop, detail pane, search, future rename/delete) for synthetic-row safety. Depends on #1501.
- #1503 — Server-side fuzz of `POST /api/namespace/node` parentId validation (catches 5xx-instead-of-400 cases the current regex misses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)