### PR TITLE
fix(web): pricing CTA reconcile + gitignore scratchpad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ mira_copy/outputs/*
 .tmp_*
 .claude/worktrees/
 .worktrees/
+.claude/scratchpad/
 
 # Skill eval workspaces (skill-creator iteration runs; rebuilt locally per session)
 .claude/skills/*-workspace/

--- a/mira-web/CHANGELOG.md
+++ b/mira-web/CHANGELOG.md
@@ -7,6 +7,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) with
 to the component (`mira-web/vX.Y.Z`) so they don't collide with the MIRA
 monorepo's top-level tag progression.
 
+## [0.7.1] — 2026-05-23
+
+### Fixed
+- **Pricing CTA reconcile.** `buy.html` Operating Layer card had a
+  `Subscribe — $499/mo →` button pointing at
+  `/api/checkout/session?plan=operating`. The route ignores `plan=` and
+  always uses the single `STRIPE_PRICE_ID` ($97/mo), so users clicking
+  the $499 button were charged $97. The Operating Layer is invoice-quoted
+  (services-led), not Stripe self-serve. CTA now opens a Talk-to-Mike
+  mailto, matching the Pilot tier pattern.
+- **`llms-full.txt` pricing drift.** Removed the stale `MIRA Integrated —
+  $297/month` tier (does not exist in Stripe, on `pricing.html`, or
+  anywhere else). Added the $499/mo Operating Layer entry plus the
+  services entry points so LLM crawlers see the same offer surface as
+  the public site.
+
 ## [0.6.0] — 2026-05-03
 
 ### Changed

--- a/mira-web/package.json
+++ b/mira-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-web",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "FactoryLM PLG funnel — CMMS acquisition & onboarding flow",
   "type": "module",
   "scripts": {

--- a/mira-web/public/buy.html
+++ b/mira-web/public/buy.html
@@ -263,10 +263,10 @@
             <li>Continuous structuring as assets come online</li>
             <li>Quarterly namespace quality audit</li>
           </ul>
-          <a href="/api/checkout/session?plan=operating&amp;src=buy"
+          <a href="mailto:mike@factorylm.com?subject=FactoryLM%20Operating%20Layer%20inquiry"
              class="cta cta-secondary"
              data-cta="buy-operating">
-            Subscribe — $499/mo →
+            Talk to Mike about Operating Layer →
           </a>
         </article>
 

--- a/mira-web/public/llms-full.txt
+++ b/mira-web/public/llms-full.txt
@@ -38,21 +38,28 @@ the plant's own work order history, not industry averages.
 
 ---
 
-## Pricing (as of 2026-04)
+## Pricing (as of 2026-05)
 
-- **MIRA Troubleshooter** — $97/month per plant
+Two motions: self-serve SaaS ($97/mo, Stripe Checkout) and services-led
+Operating Layer ($499/mo, invoiced per plant).
+
+- **MIRA Troubleshooter** — $97/month per plant (Stripe Checkout)
   - Unlimited AI chat with cited answers
   - One workspace per plant
   - OEM manual upload + OCR indexing
   - Work order templates
   - No per-seat fees
 
-- **MIRA Integrated** — $297/month per plant
+- **Operating Layer** — $499/month per plant (invoiced; contact sales)
   - Everything in Troubleshooter
+  - Structured UNS namespace + quarterly audits
+  - CMMS write-back (Atlas, or your existing CMMS)
   - Auto-generated work orders from MIRA recommendations
-  - Atlas CMMS full access
   - PM schedule automation
   - Shift handoff reports
+
+Engagement entry points (services side): $500 Assessment, $2–5K/mo Pilot
+(3-month minimum) — see https://factorylm.com/pricing.
 
 Enterprise (multi-plant, SOC 2, SSO): contact mike@factorylm.com
 


### PR DESCRIPTION
## Summary
Backlog sweep items B + D (part) from session goal.

- **B (pricing reconcile):** Stripe API audit found only ONE live recurring price — `price_1TKfszKEiEMIMSf1rzmfTFwf` at **$97/mo**. The `$499/mo` Operating Layer and `$297/mo` MIRA Integrated tiers cited in site copy are **not** in Stripe. Operating Layer is services-led / invoiced; MIRA Integrated never existed (stale copy in `llms-full.txt`).
  - `buy.html`: Operating Layer card was rendering `Subscribe — $499/mo →` pointing at `/api/checkout/session?plan=operating`. `createDirectCheckoutSession()` in `mira-web/src/lib/stripe.ts:91` ignores `plan=` and always uses `STRIPE_PRICE_ID` ($97). So the $499 button was charging $97 — silent customer-facing bug. CTA now opens a Talk-to-Mike mailto, matching the Pilot tier.
  - `llms-full.txt`: Removed phantom $297 tier; added the $499 Operating Layer + Assessment/Pilot entry points so the LLM-crawler doc matches `pricing.html`.
- **D (partial):** `.gitignore` adds `.claude/scratchpad/` — session ephemera that should not show up as untracked.

**D blocker surfaced** (not in this PR): two untracked paths need deletion that the local rm-deny rule prohibits — `mira-hud/` (6.7M archived module leftover; lives on `archive/mira-hud-2026-04`) and `UsershharpAppDataLocalTempmodels.json` (502 HTML garbage). Mike to delete manually or relax the deny rule.

Companion sweep items in same session:
- A: 024/025/026 backfilled to staging (PR-less ops; verified via db-inspect.yml).
- C: `DOPPLER_TOKEN` provisioned on GH `staging` environment scoped to `factorylm/stg`.
- E: hook audit — no auto-commit/branch-switch hooks present; the "surprises" were `gh pr merge --delete-branch` doing the work atomically.

## Test plan
- [ ] `bun test` in mira-web/
- [ ] Visit `app.factorylm.com/buy` — Operating Layer CTA opens mailto, not broken checkout
- [ ] `curl -I https://factorylm.com/llms-full.txt` — 200, served fresh
- [ ] No new Stripe-side changes needed; STRIPE_PRICE_ID still authoritative

🤖 Generated with [Claude Code](https://claude.com/claude-code)