### PR TITLE
docs(agent-skills): wire Matt Pocock skills config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,3 +230,19 @@ This file targets **~120 lines** (map, not encyclopedia). Agent compliance drops
 - Delete rules Claude follows naturally. Audit monthly.
 - Deep content lives in: `docs/`, `wiki/references/`, `tests/eval/`.
 - Line count as of last audit: see `wc -l CLAUDE.md`
+
+---
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues at `Mikecranesync/MIRA` via `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Pocock canonical names: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Multi-context. Root `CONTEXT-MAP.md` lists per-module contexts. Primary doctrine: `docs/THEORY_OF_OPERATIONS.md`. See `docs/agents/domain.md`.

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,23 @@
+# CONTEXT-MAP
+
+MIRA is a multi-context monorepo. This file points engineering skills at the per-module contexts.
+
+| Context | Module | Seed doc (until CONTEXT.md grows lazily) | Role |
+|---|---|---|---|
+| slack-bot-engine | `mira-bots/` | `mira-bots/shared/CLAUDE.md` | Slack/Telegram adapters + GSD engine + UNS gate |
+| ingest-rag | `mira-core/mira-ingest/` | `mira-core/mira-ingest/CLAUDE.md` | Photo + PDF ingest, NeonDB writes |
+| chat-pipeline | `mira-pipeline/` | `mira-pipeline/CLAUDE.md` | OpenAI-compat wrapper around Supervisor |
+| mcp-server | `mira-mcp/` | `mira-mcp/CLAUDE.md` | FastMCP server, CMMS tools |
+| atlas-cmms | `mira-cmms/` | `mira-cmms/CLAUDE.md` | Work orders, PM scheduling, asset registry |
+| marketing-funnel | `mira-web/` | `mira-web/CLAUDE.md` | PLG funnel, Stripe, /cmms landing |
+| sidecar-legacy | `mira-sidecar/` | `mira-sidecar/CLAUDE.md` | Deprecated ChromaDB (sunset pending — see ADR-0008) |
+| bridge-orchestration | `mira-bridge/` | `mira-bridge/CLAUDE.md` | Node-RED orchestration, SQLite WAL |
+| hub | `mira-hub/` | `mira-hub/CLAUDE.md` + `mira-hub/AGENTS.md` | Auth + tenant + Next.js app shell |
+| knowledge-ingest | `mira-crawler/` | (no module CLAUDE.md — use `.claude/skills/knowledge-ingest.md`) | OEM discovery + chunker |
+
+System-wide ADRs: `docs/adr/` (0001–0016).
+System-wide specs: `docs/specs/`.
+System-wide plans: `docs/plans/`.
+Primary doctrine: `docs/THEORY_OF_OPERATIONS.md`.
+
+Per-context ADRs may grow under `<module>/docs/adr/` later; none today.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,67 @@
+# Domain Docs
+
+How the engineering skills should consume MIRA's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`docs/THEORY_OF_OPERATIONS.md`** — MIRA's primary doctrine (what it is, how it works, why). This is the project glossary equivalent until a real `CONTEXT.md` is grown lazily.
+- **`CONTEXT-MAP.md`** at the repo root — points at MIRA's per-module contexts (mira-bots, mira-core, mira-hub, etc.).
+- **`docs/adr/`** — 16 system-wide ADRs (0001–0016). Read ones that touch the area you're about to work in.
+- **Per-module `CLAUDE.md`** — each module dir (`mira-bots/`, `mira-core/`, `mira-hub/`, `mira-cmms/`, `mira-mcp/`, `mira-pipeline/`, `mira-web/`, `mira-sidecar/`, `mira-bridge/`) carries its own deep context. These are the seed "CONTEXT.md per context" until lazy per-module CONTEXT.md files emerge via `/grill-with-docs`.
+- **Specs:** `docs/specs/` — product surface contracts (UNS gate, namespace builder, DST FSM).
+- **Plans:** `docs/plans/` — phased execution. Active: 90-day MVP plan + namespace-builder plan.
+
+If any per-module `CONTEXT.md` doesn't exist yet, proceed silently — `/grill-with-docs` creates them lazily when terms or decisions actually get resolved.
+
+## File structure (multi-context)
+
+```
+/
+├── CONTEXT-MAP.md                       ← lists per-module contexts
+├── CLAUDE.md                            ← root build-state + repo map
+├── docs/
+│   ├── THEORY_OF_OPERATIONS.md          ← primary doctrine (glossary seed)
+│   ├── adr/                             ← 16 system-wide decisions
+│   ├── specs/                           ← product-surface contracts
+│   └── plans/                           ← phased execution
+├── mira-bots/      CLAUDE.md            ← Slack/Telegram adapters + engine
+├── mira-core/      CLAUDE.md            ← Open WebUI + ingest
+├── mira-hub/       CLAUDE.md + AGENTS.md
+├── mira-cmms/      CLAUDE.md            ← Atlas CMMS
+├── mira-mcp/       CLAUDE.md            ← FastMCP server
+├── mira-pipeline/  CLAUDE.md            ← OpenAI-compat wrapper
+├── mira-web/       CLAUDE.md            ← PLG funnel
+├── mira-sidecar/   CLAUDE.md            ← legacy ChromaDB
+├── mira-bridge/    CLAUDE.md            ← Node-RED orchestration
+└── ...
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (issue title, refactor proposal, hypothesis, test name), use MIRA terminology as defined in `THEORY_OF_OPERATIONS.md` and `.claude/rules/uns-compliance.md` + `.claude/rules/security-boundaries.md`.
+
+Examples of correct MIRA vocabulary:
+- "UNS path" not "namespace string"
+- "fault code" not "error code"
+- "asset" / "component" / "instance" — distinct concepts; don't conflate
+- "proposed relationship" vs "verified relationship" — never collapse the distinction
+- "UNS location confirmation gate" — the non-negotiable pre-troubleshooting checkpoint
+- "Slack-first" — the product surface, not "chatbot"
+
+If the concept you need isn't in `THEORY_OF_OPERATIONS.md` yet, that's a signal — either you're inventing language MIRA doesn't use (reconsider), or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0002 (bot adapter pattern) — but worth reopening because…_
+
+Especially watch for conflicts with:
+- ADR-0008 (sidecar deprecation) — don't propose new sidecar work
+- ADR-0011 (no LangGraph migration) — don't propose LangChain/LangGraph adoption
+- ADR-0013 (UNS namespace builder schema canonicalization)
+- ADR-0016 (mira-bridge → FlowFuse)
+
+## Marketplace objective lock
+
+Per `~/.claude/CLAUDE.md` (global) and root `CLAUDE.md`: MIRA is locked on the monday.com marketplace objective through 2026-07-19. Engineering skills that propose architectural changes, refactors, or new features must check whether the work falls inside Phase 1/Phase 2 of `~/.claude/plans/dev-api-key-for-optimized-badger.md` or is captured in `docs/ideation/` for later. This is enforced by `mira-saas-scope-guard` skill — invoke it when a Pocock skill output proposes scope expansion.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

- Append `## Agent skills` block to root `CLAUDE.md` (+14 lines).
- Add `docs/agents/{issue-tracker,triage-labels,domain}.md` so Pocock engineering skills (`to-issues`, `to-prd`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, `zoom-out`) read MIRA-specific config.
- Add `CONTEXT-MAP.md` at root listing the 10 module contexts.

Pocock skills themselves live in `~/.claude/skills/` (global install). No code changes.

## Test plan

- [ ] In a Claude Code session in this repo, invoke `Skill: zoom-out` — should read `docs/THEORY_OF_OPERATIONS.md` per `docs/agents/domain.md`.
- [ ] Confirm 5 GitHub labels exist on `Mikecranesync/MIRA`: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix` (already created out-of-band).
- [ ] Sanity check: `git diff main..docs/pocock-skills-setup --stat` shows 5 files, +143 lines, no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)