### PR TITLE
ci+docs: dependabot-skip 3 workflows + sweep known-issues.md

### DIFF
--- a/.github/workflows/deepeval-ci.yml
+++ b/.github/workflows/deepeval-ci.yml
@@ -26,6 +26,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Dependabot PRs cannot read `secrets.GROQ_API_KEY` (security default —
+      # only `dependabot` secrets are exposed). The offline DeepEval suite
+      # uses Groq as the judge LLM and exits 1 with
+      # "GROQ_API_KEY is not set — required for judge LLM", which blocks
+      # every dependency-bump merge. Skip the judge-LLM steps for Dependabot;
+      # CI (lint + unit tests) and the GS11 grounding regression layer below
+      # still run and catch dependency regressions. Mirrors the same pattern
+      # already used in staging-gate.yml.
+      - name: Skip notice (Dependabot PR)
+        if: github.actor == 'dependabot[bot]'
+        run: |
+          echo "Dependabot PR detected (actor=${{ github.actor }})."
+          echo "DeepEval judge steps skipped — Dependabot cannot access"
+          echo "GROQ_API_KEY. GS11 grounding pytest layer still runs."
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -35,6 +50,7 @@ jobs:
           pip install httpx deepeval>=1.0.0
 
       - name: Run DeepEval suite (offline)
+        if: github.actor != 'dependabot[bot]'
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
         run: |
@@ -59,6 +75,7 @@ jobs:
         # See wiki/references/bot-grounding-tests.md for the full test surface.
 
       - name: RAGAS sanity on GS11 golden set (advisory)
+        if: github.actor != 'dependabot[bot]'
         env:
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
         run: |

--- a/.github/workflows/migration-verify.yml
+++ b/.github/workflows/migration-verify.yml
@@ -40,6 +40,11 @@ permissions:
 jobs:
   apply-and-verify:
     name: apply-and-verify
+    # Dependabot PRs cannot access GitHub environment secrets — the staging
+    # `NEON_STG_DATABASE_URL` is empty, psql fails, and the job goes red.
+    # CI lint/unit and the staging-gate dependabot-skip already gate the
+    # dependency-bump risk. Skip the job-level run so the merge can proceed.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Uses the same `staging` environment as staging-gate.yml so we can read

--- a/.github/workflows/photo-e2e-verify.yml
+++ b/.github/workflows/photo-e2e-verify.yml
@@ -42,6 +42,11 @@ permissions:
 jobs:
   photo-e2e:
     name: photo-e2e
+    # Dependabot PRs cannot access GitHub environment secrets — the staging
+    # `NEON_STG_DATABASE_URL` is empty, the writer crashes, and the job goes
+    # red. CI lint/unit and the staging-gate dependabot-skip already gate the
+    # dependency-bump risk. Skip the job-level run so the merge can proceed.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 8
     environment: staging

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,20 +1,20 @@
 # MIRA Known Issues, Deferred Features, and Abandoned Approaches
 
 Extracted from CLAUDE.md to keep the build-state file lean.
-Updated: 2026-04-17
+Updated: 2026-05-23
 
 ## Known Broken / Incomplete
 
-- **Gemini key blocked** — `GEMINI_API_KEY` in Doppler returns 403 "Your project has been denied access". Get fresh key from aistudio.google.com and update Doppler `factorylm/prd`. Cascade falls through to Groq/Claude in the meantime (smoke-tested OK).
-- **Teams + WhatsApp** — Code-complete, pending cloud setup (Azure Bot Service, WhatsApp Business API)
-- **PLC at 192.168.1.100** — Unreachable from PLC laptop; needs physical check (power/switch/cable)
-- **Charlie Doppler keychain** — Same SSH keychain lock as Bravo had; needs `doppler configure set token-storage file`
-- **Charlie HUD** — Needs local terminal session to start (keychain blocks SSH start of Doppler)
-- **Reddit benchmark** — 15/16 questions hit intent guard canned responses, not real inference
-- **No CD pipeline** — CI validates but deploy to Bravo is manual (docker cp or SSH)
-- **NVIDIA NIM / Nemotron** — API key in Doppler but Regime 5 eval tests blocked on it
-- **mira-sidecar OEM migration pending** — 398 OEM chunks in `shared_oem` ChromaDB must move to Open WebUI KB before sidecar can be stopped. Script: `tools/migrate_sidecar_oem_to_owui.py`. Runbook: `docs/runbooks/sidecar-oem-migration.md`.
-- **mira-web → mira-pipeline cutover pending** — `mira-web/src/lib/mira-chat.ts` calls sidecar `:5000/rag`; must be rewritten to call pipeline `:9099/v1/chat/completions` before mira-web is publicly routed.
+- **Gemini key blocked** — `GEMINI_API_KEY` in Doppler returns 403 "Your project has been denied access". Get fresh key from aistudio.google.com and update Doppler `factorylm/prd`. Cascade falls through to Groq/Cerebras in the meantime (smoke-tested OK).
+- **Teams + WhatsApp** — Code-complete, pending cloud setup (Azure Bot Service, WhatsApp Business API). WhatsApp adapter shared-deps fixed 2026-05-22 (#1482) but webhook wiring still TODO.
+- **PLC at 192.168.1.100** — Unreachable from PLC laptop; needs physical check (power/switch/cable).
+- **Charlie Doppler keychain** — Same SSH keychain lock as Bravo had; needs `doppler configure set token-storage file`.
+- **Charlie HUD** — Needs local terminal session to start (keychain blocks SSH start of Doppler).
+- **Reddit benchmark** — 15/16 questions hit intent guard canned responses, not real inference. No recent work on `mira-bots/reddit/`.
+- **NVIDIA NIM / Nemotron** — API key in Doppler but Regime 5 eval tests blocked on it.
+- **VPS deploy uses `main` HEAD, not version tags** — Customer-facing components are tagged (`mira-hub/v*`, etc.) but `deploy-vps.yml` checks out `main`, so the namespaced tags are documentation only — they don't enforce reproducible deploys or give us a real rollback target. See `feedback_versioning_discipline_global.md`.
+- **DOPPLER_TOKEN drift between Doppler config and saas compose** — Secrets set in Doppler `factorylm/prd` don't reach a container unless also listed in the `env:` block of `docker-compose.saas.yml`. Edit both in the same PR.
+- **Default `deploy-vps.yml` TARGETS excludes mira-web** — Marketing-site PRs do not auto-deploy. Manual: `gh workflow run deploy-vps.yml -f services=mira-web`.
 
 ## Deferred Features
 
@@ -35,4 +35,10 @@ Updated: 2026-04-17
 | Google Photos API direct | rclone + Ollama triage | OAuth consent screen "Testing" mode returned empty results |
 | GWS CLI for Gmail | IMAP with Doppler app passwords | Scope registration issues on Windows |
 | glm-ocr model (as primary) | qwen2.5vl handles vision | Consistent 400 errors — retained as optional fallback in vision_worker.py |
-| mira-sidecar (ChromaDB RAG backend) | mira-pipeline + Open WebUI KB | ADR-0008 (Apr 2026): pipeline wraps GSDEngine directly; Open WebUI native KB (Docling) replaces ChromaDB. Sidecar still running pending OEM doc migration (398 chunks). |
+| Anthropic / Claude as cloud LLM provider | Groq → Cerebras → Gemini cascade | Removed PR #610. Do not reintroduce. |
+
+## Resolved (kept for context)
+
+- **mira-sidecar (ChromaDB RAG backend)** — Removed from `docker-compose.saas.yml` 2026-05-20 per ADR-0014. Replaced by mira-pipeline + Open WebUI native KB. OEM chunks no longer block sunset.
+- **mira-web → mira-pipeline cutover** — Done. `mira-web/src/lib/mira-chat.ts` now calls mira-pipeline `:9099/v1/chat/completions` (ADR-0008).
+- **No CD pipeline** — Resolved. `deploy-vps.yml` gates on `smoke-test.yml` success and deploys to VPS automatically on push to `main`. Manual fallback: `gh workflow run deploy-vps.yml -f services=<svc>`.


### PR DESCRIPTION
## Summary

Three tech-debt sweeps in one PR — all sharing the same root cause for items #1 + #2:

### 1. CI: skip judge / DB-needing jobs for Dependabot (3 workflows)

GitHub's security default: Dependabot PRs cannot read regular repo secrets — only `dependabot` secrets are exposed. We have 4 workflows that need real secrets (Groq judge or staging NeonDB), and every Python dep bump goes red because of empty secrets — not because the bump is broken.

Patches (mirror the existing pattern in `staging-gate.yml`):
- `deepeval-ci.yml` — per-step `if:` guard on the two GROQ-needing steps. GS11 grounding pytest layer still runs and catches dep regressions. Unblocks #1395, #1399, #1401, #1405.
- `migration-verify.yml` — job-level `if:` skip (whole job needs `NEON_STG_DATABASE_URL`).
- `photo-e2e-verify.yml` — job-level `if:` skip (same reason).

Net: 9 dependabot PRs become mergeable once this lands (8 in current backlog + future bumps).

### 2. docs(known-issues): sweep against current reality

Last update was 2026-04-17. Sweep:
- Move resolved items (mira-sidecar removed 2026-05-20 per ADR-0014, mira-web → mira-pipeline cutover per ADR-0008, "No CD pipeline" — `deploy-vps.yml` exists) into a "Resolved (kept for context)" section so new contributors stop chasing closed work.
- Surface current-reality gotchas from feedback memories: VPS deploys use `main` HEAD not version tags, DOPPLER ↔ compose env-block plumbing, default `deploy-vps.yml` TARGETS excludes mira-web.
- Add Anthropic/Claude removal (PR #610) to abandoned approaches so future sessions don't reintroduce it.

## Test plan

- [ ] CI passes on this PR (non-dependabot actor → all steps run normally)
- [ ] After merge: rerun DeepEval on #1395, #1399, #1401, #1405 — judge steps skip, GS11 pytest runs, job exits success
- [ ] After merge: rebase #1396, #1398, #1400 (staging-gate skip already in main since `1579b19d`) + #1394 (photo-e2e + apply-and-verify now skip)
- [ ] Real PRs touching `mira-bots/**` still get the full DeepEval judge — verified by manually triggering DeepEval on a non-dependabot PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)