### PR TITLE
fix(infra): cap mem_limit on all 13 saas.yml services (closes #1516)

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -42,10 +42,8 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 1.5G
+    mem_limit: 1.5g
+    memswap_limit: 1.5g
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s
@@ -87,10 +85,8 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 1G
+    mem_limit: 1g
+    memswap_limit: 1g
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')"]
       interval: 30s
@@ -121,10 +117,8 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 1G
+    mem_limit: 1g
+    memswap_limit: 1g
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')"]
       interval: 30s
@@ -162,10 +156,8 @@ services:
       - mira-net
       - cmms-ext
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+    mem_limit: 512m
+    memswap_limit: 512m
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
       interval: 30s
@@ -221,10 +213,8 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 2G
+    mem_limit: 2g
+    memswap_limit: 2g
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9099/health"]
       interval: 30s
@@ -270,10 +260,8 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+    mem_limit: 512m
+    memswap_limit: 512m
     healthcheck:
       test: ["CMD", "sh", "-c", "cat /proc/1/cmdline | tr '\\0' ' ' | grep -q 'bot.py'"]
       interval: 30s
@@ -319,10 +307,8 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+    mem_limit: 512m
+    memswap_limit: 512m
     healthcheck:
       test: ["CMD", "python", "-c", "import slack_bolt"]
       interval: 30s
@@ -364,10 +350,8 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 256M
+    mem_limit: 256m
+    memswap_limit: 256m
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8765/health')"]
       interval: 30s
@@ -390,10 +374,8 @@ services:
     networks:
       - mira-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+    mem_limit: 512m
+    memswap_limit: 512m
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U nango"]
       interval: 10s
@@ -435,10 +417,8 @@ services:
       nango-db:
         condition: service_healthy
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 1G
+    mem_limit: 1g
+    memswap_limit: 1g
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3003/health"]
       interval: 30s
@@ -554,10 +534,8 @@ services:
       # Web-review findings — read-only, the cron only deletes its own files.
       - ./tools/web-review-runs:/app/tools/web-review-runs:ro
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 1G
+    mem_limit: 1g
+    memswap_limit: 1g
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health/"]
       interval: 30s
@@ -589,10 +567,8 @@ services:
       - mira-net
       - cmms-ext
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 256M
+    mem_limit: 256m
+    memswap_limit: 256m
     depends_on:
       - mira-hub
 


### PR DESCRIPTION
## Why

PR #1336 fixed \`mira-docling\` after the 2026-05-16 outage. **It never propagated to the other 12 services.** The lint added in PR #1515 found that every other service in \`docker-compose.saas.yml\` was using \`deploy.resources.limits.memory\` — Docker Swarm syntax that \`docker compose up\` silently ignores (\`HostConfig.Memory=0\` on every running container). Any one of them could replay the same 8.7-hour hang.

This PR converts them to compose v2 \`mem_limit:\` + \`memswap_limit:\` using the values Mike already had in \`deploy.resources\` so the operational tuning carries over verbatim — no new tuning decisions, just "the cap now actually applies."

## What changed

| Service | mem_limit | memswap_limit |
|---|---|---|
| mira-core | 1.5g | 1.5g |
| mira-ingest | 1g | 1g |
| mira-mcp | 1g | 1g |
| mira-web | 512m | 512m |
| mira-pipeline | 2g | 2g |
| mira-bot-telegram | 512m | 512m |
| mira-bot-slack | 512m | 512m |
| mira-docling | 3g | 3g (already correct from #1336 — preserved) |
| mira-relay | 256m | 256m |
| nango-db | 512m | 512m |
| nango-server | 1g | 1g |
| mira-hub | 1g | 1g |
| mira-cmms-sync | 256m | 256m |

\`memswap_limit\` is set equal to \`mem_limit\` so the cap actually holds. Without it, a container can swap unbounded and stall the host (same outcome by a different route).

Total committed: ~10.5 GB across 13 services. The host is 7.8 GB — but not all containers hit max at once. If the OOM killer fires, it kills ONE container (which restarts), not the whole host.

## Verified

- [x] 13/13 services pass the lint from PR #1515 (\`python3 scripts/check_compose_mem_limits.py --files docker-compose.saas.yml\`)
- [x] \`docker compose -f docker-compose.saas.yml config --quiet\` exits 0 (schema valid)
- [x] Values mirror the existing Swarm block — no operational change beyond \"the cap now actually applies\"

## After this merges — verify on the VPS

\`\`\`bash
ssh factorylm-prod
for c in \$(docker ps --format '{{.Names}}' | grep -E 'mira|nango|atlas'); do
  printf '%-30s %s\n' "\$c" "\$(docker inspect \$c | jq '.[].HostConfig.Memory')"
done
\`\`\`

Anything > 0 means the cap stuck. 0 means the deploy didn't actually restart the container — use \`docker compose up -d --force-recreate <name>\` to apply.

## What this does NOT cover

The lint found **46 more services** missing mem_limit in other compose files (\`staging-vps.yml\`, \`staging.yml\`, \`observability.yml\`, \`hub.yml\`, \`pathb.yml\`, \`sync.yml\`, and 8 nested \`mira-*/docker-compose.yml\`). Those are lower-urgency (staging-only or non-prod) and can land in follow-up PRs. After they're all clean, flip \`.github/workflows/compose-mem-lint.yml\` from \`continue-on-error: true\` to required.

Closes #1516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)