### PR TITLE
fix(infra): cap mem_limit on remaining 47 services (completes #1516)

### DIFF
--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -1,5 +1,7 @@
 services:
   mira-hub:
+    mem_limit: 1g
+    memswap_limit: 1g
     build:
       context: ./mira-hub
       dockerfile: Dockerfile

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -11,6 +11,8 @@ services:
 
   # ── Flower — Celery task monitor ─────────────────────────────────────────
   flower:
+    mem_limit: 256m
+    memswap_limit: 256m
     image: mher/flower:2.0
     container_name: mira-flower
     restart: unless-stopped
@@ -31,6 +33,8 @@ services:
 
   # ── RedisInsight — Redis browser UI ──────────────────────────────────────
   redisinsight:
+    mem_limit: 256m
+    memswap_limit: 256m
     image: redis/redisinsight:2.58
     container_name: mira-redisinsight
     restart: unless-stopped
@@ -58,10 +62,8 @@ services:
       - '--storage.tsdb.retention.time=15d'
     networks:
       - core-net
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+    mem_limit: 512m
+    memswap_limit: 512m
 
   # ── Grafana — dashboards ──────────────────────────────────────────────────
   grafana:
@@ -82,10 +84,8 @@ services:
       - prometheus
     networks:
       - core-net
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+    mem_limit: 512m
+    memswap_limit: 512m
 
 networks:
   core-net:

--- a/docker-compose.pathb.yml
+++ b/docker-compose.pathb.yml
@@ -11,6 +11,8 @@
 
 services:
   mira-sidecar:
+    mem_limit: 1g
+    memswap_limit: 1g
     build:
       context: .
       dockerfile: mira-sidecar/Dockerfile

--- a/docker-compose.staging-vps.yml
+++ b/docker-compose.staging-vps.yml
@@ -31,6 +31,8 @@
 services:
   # ─── Atlas CMMS — staging DB + storage ─────────────────────────────────────
   atlas-db:
+    mem_limit: 1g
+    memswap_limit: 1g
     image: postgres:16-alpine
     container_name: stg-atlas-db
     restart: unless-stopped
@@ -51,6 +53,8 @@ services:
       retries: 5
 
   atlas-minio:
+    mem_limit: 512m
+    memswap_limit: 512m
     image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: stg-atlas-minio
     restart: unless-stopped
@@ -117,10 +121,8 @@ services:
       - "0.0.0.0:4088:8080"
     networks:
       - staging-net
-    deploy:
-      resources:
-        limits:
-          memory: 1G
+    mem_limit: 1g
+    memswap_limit: 1g
     healthcheck:
       test: ["CMD-SHELL", "wget -qS -O /dev/null http://localhost:8080/ 2>&1 | grep -q 'HTTP/'"]
       interval: 15s
@@ -159,10 +161,8 @@ services:
       - "0.0.0.0:4100:3000"
     networks:
       - staging-net
-    deploy:
-      resources:
-        limits:
-          memory: 256M
+    mem_limit: 256m
+    memswap_limit: 256m
     healthcheck:
       test: ["CMD-SHELL", "wget -qS -O /dev/null http://127.0.0.1:3000/ 2>&1 | grep -q 'HTTP/'"]
       interval: 15s
@@ -198,10 +198,8 @@ services:
     networks:
       - staging-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+    mem_limit: 512m
+    memswap_limit: 512m
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')"]
       interval: 30s
@@ -253,10 +251,8 @@ services:
     networks:
       - staging-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 1G
+    mem_limit: 1g
+    memswap_limit: 1g
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9099/health"]
       interval: 30s
@@ -336,10 +332,8 @@ services:
       - ./docs/promo-screenshots:/app/docs/promo-screenshots:rw
       - ./tools/web-review-runs:/app/tools/web-review-runs:ro
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 1G
+    mem_limit: 1g
+    memswap_limit: 1g
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://127.0.0.1:3000/api/health/"]
       interval: 30s
@@ -375,10 +369,8 @@ services:
     networks:
       - staging-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+    mem_limit: 512m
+    memswap_limit: 512m
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3000/api/health"]
       interval: 30s
@@ -429,10 +421,8 @@ services:
     networks:
       - staging-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+    mem_limit: 512m
+    memswap_limit: 512m
     healthcheck:
       test: ["CMD", "sh", "-c", "cat /proc/1/cmdline | tr '\\0' ' ' | grep -q 'bot.py'"]
       interval: 30s
@@ -462,10 +452,8 @@ services:
     networks:
       - staging-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 256M
+    mem_limit: 256m
+    memswap_limit: 256m
     depends_on:
       - mira-hub
 

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -62,10 +62,8 @@ services:
     networks:
       - staging-net
     restart: "no"
-    deploy:
-      resources:
-        limits:
-          memory: 1G
+    mem_limit: 1g
+    memswap_limit: 1g
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:9099/health"]
       interval: 30s
@@ -91,10 +89,8 @@ services:
     networks:
       - staging-net
     restart: "no"
-    deploy:
-      resources:
-        limits:
-          memory: 256M
+    mem_limit: 256m
+    memswap_limit: 256m
     healthcheck:
       test: ["CMD", "sh", "-c", "cat /proc/1/cmdline | tr '\\0' ' ' | grep -q 'bot.py'"]
       interval: 30s

--- a/docker-compose.sync.yml
+++ b/docker-compose.sync.yml
@@ -1,5 +1,7 @@
 services:
   mira-atlas-hub-sync:
+    mem_limit: 256m
+    memswap_limit: 256m
     image: python:3.12-slim
     container_name: mira-atlas-hub-sync
     restart: unless-stopped

--- a/mira-bots/docker-compose.yml
+++ b/mira-bots/docker-compose.yml
@@ -49,10 +49,8 @@ services:
       - bot-net
       - core-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+    mem_limit: 512m
+    memswap_limit: 512m
     healthcheck:
       test: ["CMD", "sh", "-c", "cat /proc/1/cmdline | tr '\\0' ' ' | grep -q 'bot.py'"]
       interval: 30s
@@ -74,10 +72,8 @@ services:
       - bot-net
       - core-net
     restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 512M
+    mem_limit: 512m
+    memswap_limit: 512m
     healthcheck:
       test: ["CMD", "sh", "-c", "cat /proc/1/cmdline | tr '\\0' ' ' | grep -q 'bot.py'"]
       interval: 30s
@@ -85,6 +81,8 @@ services:
       retries: 3
 
   teams-bot:
+    mem_limit: 512m
+    memswap_limit: 512m
     profiles: ["dormant"]
     build:
       context: .
@@ -110,6 +108,8 @@ services:
       retries: 3
 
   whatsapp-bot:
+    mem_limit: 512m
+    memswap_limit: 512m
     profiles: ["dormant"]
     build:
       context: .
@@ -135,6 +135,8 @@ services:
       retries: 3
 
   reddit-bot:
+    mem_limit: 512m
+    memswap_limit: 512m
     profiles: ["dormant"]
     build:
       context: .
@@ -165,6 +167,8 @@ services:
       retries: 3
 
   telegram-test-runner:
+    mem_limit: 512m
+    memswap_limit: 512m
     build:
       context: .
       dockerfile: telegram_test_runner/Dockerfile

--- a/mira-bridge/docker-compose.yml
+++ b/mira-bridge/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   node-red:
+    mem_limit: 512m
+    memswap_limit: 512m
     image: nodered/node-red:4.1.7-22
     container_name: mira-bridge
     ports:

--- a/mira-cmms/docker-compose.yml
+++ b/mira-cmms/docker-compose.yml
@@ -4,6 +4,8 @@
 
 services:
   atlas-db:
+    mem_limit: 1g
+    memswap_limit: 1g
     image: postgres:16-alpine
     container_name: atlas-db
     restart: unless-stopped
@@ -24,6 +26,8 @@ services:
       retries: 5
 
   atlas-minio:
+    mem_limit: 512m
+    memswap_limit: 512m
     image: minio/minio:RELEASE.2025-04-22T22-12-26Z
     container_name: atlas-minio
     restart: unless-stopped
@@ -45,6 +49,8 @@ services:
       retries: 5
 
   atlas-api:
+    mem_limit: 512m
+    memswap_limit: 512m
     image: intelloop/atlas-cmms-backend@sha256:21c42377dd758dbc4a9aa1676e62b01a13cf8822b0ecd3019b274b53c2369b1e
     container_name: atlas-api
     restart: unless-stopped
@@ -96,6 +102,8 @@ services:
       start_period: 30s
 
   atlas-frontend:
+    mem_limit: 512m
+    memswap_limit: 512m
     build:
       context: /Users/bravonode/factorylm/apps/cmms/frontend
       dockerfile: Dockerfile

--- a/mira-core/docker-compose.oracle.yml
+++ b/mira-core/docker-compose.oracle.yml
@@ -3,18 +3,24 @@
 # Requires: BRAVO_HOST (Tailscale IP or hostname of the Bravo compute node)
 services:
   open-webui:
+    mem_limit: 512m
+    memswap_limit: 512m
     environment:
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
     extra_hosts:
       - "host.docker.internal:${BRAVO_HOST}"
 
   mira-mcpo:
+    mem_limit: 512m
+    memswap_limit: 512m
     image: mira-core-mira-mcpo:${MIRA_MCPO_VERSION:-3.4}
     build:
       context: .
       dockerfile: Dockerfile.mcpo
 
   mira-ingest:
+    mem_limit: 512m
+    memswap_limit: 512m
     environment:
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
     ports:
@@ -23,6 +29,8 @@ services:
       - "host.docker.internal:${BRAVO_HOST}"
 
   mira-pipeline:
+    mem_limit: 512m
+    memswap_limit: 512m
     environment:
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
     extra_hosts:

--- a/mira-core/docker-compose.yml
+++ b/mira-core/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   open-webui:
+    mem_limit: 512m
+    memswap_limit: 512m
     image: ghcr.io/open-webui/open-webui:v0.8.10
     container_name: mira-core
     ports:
@@ -62,6 +64,8 @@ services:
       - "host.docker.internal:host-gateway"
 
   mira-mcpo:
+    mem_limit: 512m
+    memswap_limit: 512m
     image: mira-core-mira-mcpo:${MIRA_MCPO_VERSION:-3.4}
     container_name: mira-mcpo
     command: --port 8000 --api-key ${MCPO_API_KEY} --config /mcp/config.json
@@ -86,6 +90,8 @@ services:
       - "host.docker.internal:host-gateway"
 
   mira-ingest:
+    mem_limit: 512m
+    memswap_limit: 512m
     build:
       context: ./mira-ingest
     container_name: mira-ingest
@@ -122,6 +128,8 @@ services:
       - "host.docker.internal:host-gateway"
 
   mira-tika:
+    mem_limit: 512m
+    memswap_limit: 512m
     image: apache/tika:3.1.0.0
     container_name: mira-tika
     ports:
@@ -137,6 +145,8 @@ services:
       start_period: 15s
 
   mira-pipeline:
+    mem_limit: 512m
+    memswap_limit: 512m
     build:
       context: ..
       dockerfile: mira-pipeline/Dockerfile
@@ -186,6 +196,10 @@ services:
       - "host.docker.internal:host-gateway"
 
   mira-docling:
+    # Match saas.yml — docling is the known OOM victim (PR #1336). 512m WILL
+    # trip on a real PDF.
+    mem_limit: 3g
+    memswap_limit: 3g
     image: quay.io/docling-project/docling-serve:v1.16.1
     container_name: mira-docling
     ports:

--- a/mira-crawler/docker-compose.yml
+++ b/mira-crawler/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   mira-redis:
+    mem_limit: 512m
+    memswap_limit: 512m
     image: redis:7.4.2-alpine
     container_name: mira-redis
     restart: unless-stopped
@@ -23,10 +25,8 @@ services:
     depends_on:
       mira-redis:
         condition: service_healthy
-    deploy:
-      resources:
-        limits:
-          memory: 1G
+    mem_limit: 1g
+    memswap_limit: 1g
     environment:
       - CELERY_BROKER_URL=redis://mira-redis:6379/0
       - CELERY_RESULT_BACKEND=redis://mira-redis:6379/1
@@ -47,6 +47,8 @@ services:
       retries: 3
 
   mira-task-bridge:
+    mem_limit: 512m
+    memswap_limit: 512m
     build:
       context: ..
       dockerfile: mira-crawler/Dockerfile.bridge

--- a/mira-mcp/docker-compose.yml
+++ b/mira-mcp/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   mira-mcp:
+    mem_limit: 512m
+    memswap_limit: 512m
     build: .
     container_name: mira-mcp
     ports:

--- a/mira-scan-monday/docker-compose.yml
+++ b/mira-scan-monday/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   backend:
+    mem_limit: 512m
+    memswap_limit: 512m
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -46,6 +48,8 @@ services:
       start_period: 10s
 
   frontend:
+    mem_limit: 512m
+    memswap_limit: 512m
     build:
       context: ./frontend
       dockerfile: Dockerfile

--- a/mira-web/docker-compose.yml
+++ b/mira-web/docker-compose.yml
@@ -3,6 +3,8 @@
 
 services:
   mira-web:
+    mem_limit: 512m
+    memswap_limit: 512m
     build: .
     container_name: mira-web
     restart: unless-stopped


### PR DESCRIPTION
Completes the fix started in PR #1517 (\`saas.yml\` — 13 services). The lint added in PR #1515 found **47 more services** without \`mem_limit\` across 15 other compose files. Same risk shape: any unbounded container can replay the 2026-05-16 docling OOM-deadlock that took the VPS offline for 8.7 hours.

## Numbers

| Source | swarm→v2 | no-cap → default | Total capped |
|---|---|---|---|
| PR #1517 (\`saas.yml\`) | 12 | 0 (docling kept at 3g) | 13 |
| **This PR** (15 files) | **15** | **32** | **47** |
| **Combined** | **27** | **32** | **60** |

After both PRs merge: **60 services properly capped**, was just 1 (docling, from #1336).

## Notable values

- **\`mira-docling\` in \`mira-core/docker-compose.yml\` bumped to 3g** — the default 512m would have OOM'd on a real PDF during local dev, replicating the prod failure at small scale.
- **\`atlas-db\` 1g, \`atlas-minio\` 512m** for the Atlas CMMS stack (staging + cmms compose files).
- **\`mira-relay\` 256m, \`mira-cmms-sync\` 256m** for the lightweight services.

## What this fixes

Before: a memory leak in any of the 47 unbounded containers could starve the host. PR #1336 caught one (docling); these are the other 47.

After (combined with #1517): the OOM killer fires on the one container, the container restarts (or doesn't, per its \`restart\` policy), and nginx + tailscaled keep running. No more 8.7-hour hangs from a single bad container.

## What I'm NOT doing in this PR

- Tuning the values — using existing Swarm values where present, sensible defaults elsewhere. If your operational experience says one is wrong (e.g. \`mira-hub\` needs 2g), bump in a follow-up.
- Flipping the lint to required — that's a one-line follow-up after this + #1517 merge.

## Verified

- [x] All 15 changed files parse as valid YAML
- [x] Lint passes 47/47 ok, 0 warnings, 0 failures
- [x] \`docker compose -f <file> config --quiet\` exits 0 where it can (a few files have unrelated pre-existing env-required errors — not caused by these changes)

## Stack

#1336 (docling) → #1517 (saas.yml 13 services) → **this PR (47 more services)** → flip lint to required

Closes nothing on its own; together with #1517, fully closes #1516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)