### PR TITLE
fix(engine): snapshot kb_status before self-critique await (closes #1520)

### DIFF
--- a/docs/context/PROGRESS.md
+++ b/docs/context/PROGRESS.md
@@ -6945,4 +6945,57 @@ Source of truth: `docs/plans/2026-04-19-mira-90-day-mvp.md`. Read its "Currently
 - ?? docs/promo-screenshots/2026-05-19_assets_desktop.png
 - ?? docs/promo-screenshots/2026-05-19_assets_mobile.png
 **Next:** _set by next session_
+
+### 2026-05-24 10:10 UTC — `HEAD`
+**Last commit:** 0892fae chore(audits): nightly hub audit 2026-05-24
+**Changed (vs. fork point):**
+- .claude/rules/uns-confirmation-gate.md
+- .claude/skills/mira-industrial-safety/SKILL.md
+- .claude/skills/mira-platform/SKILL.md
+- .claude/skills/mira-uns-architecture/SKILL.md
+- .github/baselines/mira-bench.json
+- .github/workflows/apply-migrations.yml
+- .github/workflows/ci.yml
+- .github/workflows/code-review.yml
+- .github/workflows/compose-mem-lint.yml
+- .github/workflows/deepeval-ci.yml
+- .github/workflows/diag-bm25.yml
+- .github/workflows/enforcement-audit.yml
+- .github/workflows/migration-verify.yml
+- .github/workflows/mira-benchmark-weekly.yml
+- .github/workflows/oauth-redirect-canary.yml
+- .github/workflows/photo-e2e-verify.yml
+- .github/workflows/smoke-test.yml
+- .github/workflows/staging-gate.yml
+- .github/workflows/staging-namespace-create-e2e.yml
+- .github/workflows/web-review-canary.yml
+**Working tree:** clean
+**Next:** _set by next session_
+
+### 2026-05-24 11:21 UTC — `fix/engine-kb-status-race-1520`
+**Last commit:** b50bee5 fix(engine): snapshot kb_status before self-critique await to close #1520 race
+**Changed (vs. fork point):**
+- .claude/rules/uns-confirmation-gate.md
+- .claude/skills/mira-industrial-safety/SKILL.md
+- .claude/skills/mira-platform/SKILL.md
+- .claude/skills/mira-uns-architecture/SKILL.md
+- .github/baselines/mira-bench.json
+- .github/workflows/apply-migrations.yml
+- .github/workflows/ci.yml
+- .github/workflows/code-review.yml
+- .github/workflows/compose-mem-lint.yml
+- .github/workflows/deepeval-ci.yml
+- .github/workflows/diag-bm25.yml
+- .github/workflows/enforcement-audit.yml
+- .github/workflows/migration-verify.yml
+- .github/workflows/mira-benchmark-weekly.yml
+- .github/workflows/oauth-redirect-canary.yml
+- .github/workflows/photo-e2e-verify.yml
+- .github/workflows/smoke-test.yml
+- .github/workflows/staging-gate.yml
+- .github/workflows/staging-namespace-create-e2e.yml
+- .github/workflows/web-review-canary.yml
+**Working tree:**
+- M docs/context/PROGRESS.md
+**Next:** _set by next session_
 <!-- END AUTOLOG -->

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -1688,6 +1688,11 @@ class Supervisor:
                     effective_photo,
                     tenant_id=resolved_tenant,
                 )
+            # Snapshot kb_status immediately after the RAG await, before any
+            # subsequent awaits (self-critique LLM call at line below) where a
+            # concurrent rag.process() for another session could overwrite the
+            # shared instance attribute.  Fixes issue #1520.
+            _kb_status_snapshot = dict(getattr(self.rag, "kb_status", None) or {})
         except Exception as _re:
             logger.error(
                 "RAG_WORKER_ERROR chat_id=%s fsm=%s error=%s",
@@ -1920,7 +1925,7 @@ class Supervisor:
 
         self._save_state(chat_id, state)
 
-        formatted = self._format_reply(parsed, user_message=message)
+        formatted = self._format_reply(parsed, user_message=message, kb_status=_kb_status_snapshot)
         # Phase 3 — prepend honest crawl-failure message if a prior doc-crawl exhausted.
         if _honest_prefix:
             formatted = _honest_prefix + formatted
@@ -4405,9 +4410,18 @@ class Supervisor:
         """Advance FSM state. Delegates to fsm.advance_state."""
         return advance_state(state, parsed)
 
-    def _format_reply(self, parsed: dict, user_message: str = "") -> str:
-        """Format parsed response for display. Delegates to response_formatter.format_reply."""
-        kb_status = getattr(self.rag, "kb_status", None) or {}
+    def _format_reply(
+        self, parsed: dict, user_message: str = "", kb_status: dict | None = None
+    ) -> str:
+        """Format parsed response for display. Delegates to response_formatter.format_reply.
+
+        Pass ``kb_status`` explicitly when the caller has already snapshotted it before
+        any intervening await — this avoids the shared-instance race where a concurrent
+        rag.process() call overwrites self.rag._kb_status between the RAG await and this
+        formatting step (issue #1520).
+        """
+        if kb_status is None:
+            kb_status = getattr(self.rag, "kb_status", None) or {}
         return format_reply(parsed, user_message, kb_status)
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Captures `self.rag.kb_status` into a local `_kb_status_snapshot` immediately after `_call_with_correction()` returns, before the `await self._self_critique_diagnosis()` that opens the race window
- Passes the snapshot explicitly to `_format_reply()` so the citation footer always reflects the correct tenant's KB coverage
- `_format_reply()` gains an optional `kb_status` parameter; the two other callers (ELECTRICAL_PRINT path, `_handle_session_followup`) have no intervening await and continue to use the instance attribute via the `None` default — no behaviour change for them

Follows the same local-snapshot pattern already used for `_last_neon_chunks` (fixes #1082, Nemotron rerank race).

**Root cause (from #1520):** `RAGWorker._kb_status` is a mutable attribute on a single shared instance. In the DIAGNOSIS path of `process_full()` there is an `await` (the self-critique LLM call, line ~1763) between when `rag.process()` writes `_kb_status` and when `_format_reply()` reads it. A concurrent session for a different tenant can call `rag.process()` during that window and overwrite `_kb_status`, causing the wrong tenant's citation metadata (manufacturer, model, source URL) to be appended to the first tenant's reply.

## Test plan

- [ ] Existing unit tests pass (`pytest tests/`)
- [ ] Manual smoke: two concurrent DIAGNOSIS-state sessions on different tenants produce citation footers matching their own KB chunks, not each other's
- [ ] `engine.py` AST parses cleanly (verified pre-push)

https://claude.ai/code/session_019P37gt2JH3VD7yXdFwzcKe

---
_Generated by [Claude Code](https://claude.ai/code/session_019P37gt2JH3VD7yXdFwzcKe)_