### PR TITLE
fix(engine): analyze schematic photos with vision LLM when a question is attached

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -80,6 +80,7 @@ from .nemotron import NemotronClient
 from .neon_recall import kb_has_coverage, kb_has_pair_coverage
 from .notifications.push import push_safety_alert, push_wo_created
 from .photo_handler import (
+    DEFAULT_PHOTO_CAPTION,
     build_print_reply,
     clear_session_photo,
     load_session_photo,
@@ -606,6 +607,108 @@ class Supervisor:
 
     def _build_print_reply(self, vision_data: dict) -> str:
         return build_print_reply(vision_data)
+
+    async def _analyze_schematic_with_question(
+        self,
+        photo_b64: str,
+        question: str,
+        vision_data: dict,
+        chat_id: str,
+    ) -> str:
+        """Send schematic photo + technician question to the vision LLM and
+        return a circuit-analysis reply.
+
+        Used when the user attaches a real question to a schematic photo
+        (not the bot's default ``Analyze this equipment photo`` caption).
+        The model is asked to identify components, trace paths, and answer
+        the specific question. OCR labels already extracted by the vision
+        worker are fed in as ground-truth so the model doesn't have to
+        re-read every wire number from pixels.
+
+        Returns the empty string when the inference cascade has no vision
+        provider available or every provider failed — the caller MUST fall
+        back to ``_build_print_reply`` in that case so the user is never
+        left with nothing.
+        """
+        ocr_items = vision_data.get("ocr_items") or []
+        drawing_type = vision_data.get("drawing_type") or "electrical drawing"
+        ocr_block = (
+            "OCR labels extracted from the drawing (ground truth — use these "
+            "verbatim, do not invent new labels):\n"
+            + "\n".join(f"- {item}" for item in ocr_items[:80])
+            if ocr_items
+            else "No OCR labels were extracted; rely on the image."
+        )
+
+        system_prompt = (
+            "You are MIRA, an industrial maintenance intelligence assistant "
+            "with 30 years of experience reading electrical schematics, "
+            "wiring diagrams, PLC prints, and control-circuit drawings.\n\n"
+            "When shown a schematic or wiring diagram:\n"
+            "1. Identify the circuit type (motor control, safety circuit, "
+            "sensor circuit, communication, power distribution, etc.).\n"
+            "2. List the major components with their designations "
+            "(K10, R11, CR1, etc.) using the OCR labels when available.\n"
+            "3. Trace the signal/power paths and explain what the circuit "
+            "does.\n"
+            "4. Identify safety-critical elements (emergency stops, "
+            "interlocks, ground-fault paths).\n"
+            "5. Note component values where visible (resistance, voltage "
+            "ratings).\n"
+            "6. Answer the technician's specific question directly.\n"
+            "7. Flag any unusual configurations or potential issues.\n\n"
+            "Be specific. Use the actual designations from the drawing. "
+            "Explain in terms a maintenance technician would understand. "
+            "If you cannot read a label or value clearly, say so — do not "
+            "guess. Keep the reply under 350 words; bullet lists are fine."
+        )
+
+        user_text = (
+            f"Drawing type (auto-detected): {drawing_type}.\n\n"
+            f"{ocr_block}\n\n"
+            f"Technician's question: {question}"
+        )
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": f"data:image/jpeg;base64,{photo_b64}",
+                        },
+                    },
+                    {"type": "text", "text": user_text},
+                ],
+            },
+        ]
+
+        try:
+            reply, usage = await self.router.complete(
+                messages,
+                max_tokens=900,
+                session_id=str(chat_id),
+            )
+        except Exception as exc:
+            logger.warning("SCHEMATIC_ANALYSIS_ROUTER_ERROR error=%s", exc)
+            return ""
+        if reply:
+            InferenceRouter.log_usage(usage)
+            logger.info(
+                "SCHEMATIC_ANALYSIS_OK chat_id=%s provider=%s tokens=%s",
+                chat_id,
+                usage.get("provider", "unknown") if isinstance(usage, dict) else "unknown",
+                usage.get("total_tokens", "?") if isinstance(usage, dict) else "?",
+            )
+        else:
+            logger.warning(
+                "SCHEMATIC_ANALYSIS_EMPTY chat_id=%s — cascade returned nothing, "
+                "falling back to OCR-only reply",
+                chat_id,
+            )
+        return reply or ""
 
     async def _extract_schematic(self, photo_b64: str) -> dict:
         """Call mira-mcp's /api/kg/schematic endpoint to run the schematic
@@ -1491,7 +1594,23 @@ class Supervisor:
                 ctx["drawing_type"] = vision_data["drawing_type"]
                 state["context"] = ctx
 
-                reply = self._build_print_reply(vision_data)
+                # If the technician sent a real question with the schematic,
+                # send image + question to the vision LLM for circuit analysis.
+                # Otherwise (just the default "Analyze this equipment photo"
+                # caption) keep the OCR-label preview + prompt-for-question.
+                has_real_question = bool(message) and message != DEFAULT_PHOTO_CAPTION
+                reply = ""
+                if has_real_question:
+                    reply = await self._analyze_schematic_with_question(
+                        photo_b64=photo_b64,
+                        question=message,
+                        vision_data=vision_data,
+                        chat_id=chat_id,
+                    )
+                if not reply:
+                    reply = self._build_print_reply(vision_data)
+                    if not has_real_question:
+                        reply += "\n\nWhat would you like to know about this circuit?"
 
                 # Phase 5 schematic intelligence — opportunistically run the
                 # IEC/ANSI symbol + connection extractor on the same photo.

--- a/tests/test_schematic_qa.py
+++ b/tests/test_schematic_qa.py
@@ -1,0 +1,115 @@
+"""Tests for the schematic-question path in Supervisor (engine.py).
+
+Bug fixed: when the technician sent a real question with a schematic photo,
+MIRA replied with a generic OCR-label preview instead of analyzing the
+circuit. Fix: the ELECTRICAL_PRINT branch now sends image + question to the
+vision LLM cascade and only falls back to the OCR preview when the cascade
+returns nothing OR the user attached no real question.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+SCHEMATIC_VISION_DATA = {
+    "classification": "ELECTRICAL_PRINT",
+    "classification_confidence": 0.92,
+    "vision_result": (
+        "Electrical drawing — wiring diagram with three stators "
+        "(S1, S2, S3) wired through relay K10 and resistors R11, R12, R13."
+    ),
+    "ocr_items": ["K10", "R11", "R12", "R13", "S1", "S2", "S3", "PE", "L1"],
+    "tesseract_text": "K10 R11 R12 R13",
+    "drawing_type": "wiring diagram",
+    "drawing_type_confidence": 0.85,
+}
+
+
+def _make_engine():
+    """Construct a Supervisor instance with all heavy deps mocked out."""
+    with patch("shared.engine.Supervisor.__init__", return_value=None):
+        from shared.engine import Supervisor
+
+        eng = Supervisor.__new__(Supervisor)
+
+    eng.db_path = ":memory:"
+    eng.router = MagicMock()
+    return eng
+
+
+@pytest.mark.asyncio
+async def test_schematic_with_question_invokes_vision_cascade():
+    """A real question + schematic photo → router.complete is called with
+    a multipart image+text message and the cascade reply is returned."""
+    eng = _make_engine()
+    expected_reply = (
+        "Circuit type: continuity test through three stators.\n"
+        "K10 closes momentarily for each phase, R11/R12/R13 limit the "
+        "test current. Trip threshold is the coil pickup on K10."
+    )
+    eng.router.complete = AsyncMock(return_value=(expected_reply, {"provider": "groq"}))
+
+    photo_b64 = "ZmFrZWltYWdlYnl0ZXM="
+    question = "Explain how this circuit manages to measure continuity through these three stators"
+
+    reply = await eng._analyze_schematic_with_question(
+        photo_b64=photo_b64,
+        question=question,
+        vision_data=SCHEMATIC_VISION_DATA,
+        chat_id="chat-1",
+    )
+
+    assert reply == expected_reply
+    eng.router.complete.assert_awaited_once()
+    call_messages = eng.router.complete.call_args.args[0]
+    # System prompt is the first message and tells the model it's MIRA reading schematics
+    assert call_messages[0]["role"] == "system"
+    assert "schematic" in call_messages[0]["content"].lower()
+    # User message is multipart with an image_url block carrying the photo
+    user_content = call_messages[1]["content"]
+    assert isinstance(user_content, list)
+    types = [b["type"] for b in user_content]
+    assert "image_url" in types and "text" in types
+    image_block = next(b for b in user_content if b["type"] == "image_url")
+    assert image_block["image_url"]["url"] == f"data:image/jpeg;base64,{photo_b64}"
+    text_block = next(b for b in user_content if b["type"] == "text")
+    # The technician's question is forwarded verbatim
+    assert question in text_block["text"]
+    # OCR labels we already extracted are passed in as ground truth
+    assert "K10" in text_block["text"]
+
+
+@pytest.mark.asyncio
+async def test_schematic_cascade_failure_returns_empty_string():
+    """If every vision provider in the cascade returns empty, the helper
+    returns "" so the caller can fall back to the OCR-only reply."""
+    eng = _make_engine()
+    eng.router.complete = AsyncMock(return_value=("", {}))
+
+    reply = await eng._analyze_schematic_with_question(
+        photo_b64="ZmFrZQ==",
+        question="What does this circuit do?",
+        vision_data=SCHEMATIC_VISION_DATA,
+        chat_id="chat-2",
+    )
+
+    assert reply == ""
+
+
+@pytest.mark.asyncio
+async def test_schematic_cascade_exception_returns_empty_string():
+    """A router exception must NOT bubble — we degrade gracefully to the
+    OCR-only reply path."""
+    eng = _make_engine()
+    eng.router.complete = AsyncMock(side_effect=RuntimeError("network down"))
+
+    reply = await eng._analyze_schematic_with_question(
+        photo_b64="ZmFrZQ==",
+        question="Trace the safety circuit",
+        vision_data=SCHEMATIC_VISION_DATA,
+        chat_id="chat-3",
+    )
+
+    assert reply == ""


### PR DESCRIPTION
## Summary

Closes the #1 photo-driven product gap on Telegram: when a tech sent a wiring diagram / schematic with a real question (\"Explain how this circuit measures continuity through these three stators\"), MIRA replied with a generic OCR-label preview instead of analyzing the circuit. ChatGPT gave detailed analyses from the same images.

**Before:** photo → vision worker → classified ELECTRICAL_PRINT → \`_build_print_reply()\` → \"Wiring diagram — Good read — 42 labels. Ask me to trace a wire run.\"

**After:** photo + real question → vision LLM cascade (Groq llama-4 scout, then Gemini) with a 30-year-electrician system prompt + already-extracted OCR labels as ground truth → circuit type, component list, path trace, direct answer to the question.

## What changed

\`mira-bots/shared/engine.py\`:
- Imports \`DEFAULT_PHOTO_CAPTION\` from \`photo_handler\` instead of re-hardcoding the string.
- New \`Supervisor._analyze_schematic_with_question(photo_b64, question, vision_data, chat_id)\` — multipart message (image_url + text) to \`self.router.complete\`, schematic-analysis system prompt, OCR labels passed in as ground truth so the model doesn't have to re-read every wire number from pixels.
- ELECTRICAL_PRINT branch in \`_handle_photo\` now branches on \"did the user attach a real question?\":
  - **Yes** (\`message != DEFAULT_PHOTO_CAPTION\`) → call vision LLM, return its reply.
  - **No** → keep the existing OCR-label preview + add \"What would you like to know about this circuit?\".
  - Cascade returned empty or raised → fall back to OCR-label preview (never leaves the user with nothing).
- Everything else in the branch preserved: state transition to ELECTRICAL_PRINT, \`drawing_type\` on ctx, opportunistic \`_extract_schematic\`, history append, \`exchange_count\`, \`_make_result\`.
- NAMEPLATE branch untouched.

\`tests/test_schematic_qa.py\` (new, 3 cases):
1. Real question + schematic → \`router.complete\` is called with multipart image+text; question + OCR labels reach the model; cascade reply is returned verbatim.
2. Cascade returns \`(\"\", {})\` → helper returns \`\"\"\` so caller falls back.
3. Cascade raises → helper swallows + returns \`\"\"\` (no bubbling).

\`\`\`
tests/test_schematic_qa.py::test_schematic_with_question_invokes_vision_cascade PASSED
tests/test_schematic_qa.py::test_schematic_cascade_failure_returns_empty_string PASSED
tests/test_schematic_qa.py::test_schematic_cascade_exception_returns_empty_string PASSED
3 passed in 0.06s
\`\`\`

## Out of scope (v2)

- **Follow-up text turns still route to PrintWorker** (text-only, OCR-table prompt). The session photo is already saved to disk via \`save_session_photo\`; passing it back into the vision cascade on follow-ups is a one-line PrintWorker change scoped separately so this PR stays surgical.
- **KB enrichment from identified equipment in the schematic** — opportunistic \`_extract_schematic\` already runs and writes to ctx; adding RAG pull from there is a follow-on PR.

## Constraints respected

- ✅ Uses existing \`InferenceRouter\` cascade (Groq → Cerebras → Gemini); no new providers, no Anthropic.
- ✅ Router auto-skips non-vision providers (Cerebras has no \`vision_model\`).
- ✅ Sanitization is automatic and preserves the \`image_url\` block (router.py:267-278).
- ✅ Surgical: 1 new method + 1 conditional + 1 import. No worker class, no abstraction.
- ✅ Pre-existing Pyright \`trace_id: None\` diagnostics in engine.py are untouched (not in scope).

## Test plan

- [x] Unit tests pass (3/3).
- [x] No regression in \`tests/test_multi_photo.py\` (15/15 pass; the 2 failing \`test_nameplate_e2e.py\` cases pre-exist on \`main\`, confirmed via \`git stash\`).
- [ ] Deploy to staging via \`docker-compose.staging.yml\` rebuild of \`stg-mira-bot-telegram\`. **Note for operator:** \`docker-compose.staging.yml:82\` reads \`\${STAGING_TELEGRAM_BOT_TOKEN}\`, but Doppler \`factorylm/stg\` currently has \`TELEGRAM_BOT_TOKEN_STG\`. Either rename in Doppler or set \`STAGING_TELEGRAM_BOT_TOKEN\` to the BotFather token for \`@Mira_stagong_bot\` before \`docker compose -f docker-compose.staging.yml up -d --build mira-bot-telegram\`.
- [ ] Send a wiring-diagram photo + question to \`@Mira_stagong_bot\` — confirm a circuit analysis comes back (not the OCR-label preview).
- [ ] Send a photo with no caption — confirm the OCR-label preview + \"What would you like to know about this circuit?\" prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)