### PR TITLE
security(scan-monday): CRA-159 per-account burst rate limit on /chat/message

### DIFF
--- a/mira-scan-monday/backend/main.py
+++ b/mira-scan-monday/backend/main.py
@@ -17,6 +17,7 @@ from . import (
     mira_rag,
     monday_api,
     oauth,
+    rate_limit,
     scan_queue,
     session,
     usage,
@@ -331,6 +332,23 @@ async def chat_message(req: ChatMessageRequest, request: Request) -> ChatMessage
     # Chat is downstream of scan — bump last_seen so we know the install
     # is active, but don't bump scan_count (that would double-count).
     account_id = session.account_id_from_headers(request.headers)
+    rate = await rate_limit.check_and_record(account_id)
+    if not rate.allowed:
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "error": "rate_limit_exceeded",
+                "used": rate.used,
+                "limit": rate.limit,
+                "window_seconds": rate.window_seconds,
+                "retry_after": rate.retry_after,
+                "message": (
+                    f"Too many requests — limit is {rate.limit} per "
+                    f"{rate.window_seconds}s. Retry in {rate.retry_after}s."
+                ),
+            },
+            headers={"Retry-After": str(rate.retry_after)},
+        )
     if account_id:
         await oauth.touch_last_seen(account_id)
         used = await usage.month_chat_count(account_id)

--- a/mira-scan-monday/backend/rate_limit.py
+++ b/mira-scan-monday/backend/rate_limit.py
@@ -1,0 +1,88 @@
+"""Per-account sliding-window rate limiter for /chat/message burst protection.
+
+Companion to `usage.FREE_TIER_MONTHLY_CHAT_CAP` (the monthly ceiling).
+The monthly cap bounds total cost; this module bounds burst rate so a
+runaway client can't drain a month's allowance in seconds.
+
+State is per-process and in-memory. The mira-scan-monday backend runs
+single-replica today (n=1 marketplace), so a per-process map is correct.
+When this service goes multi-replica, swap the backing store for Redis;
+the API surface (`check_and_record`) stays the same.
+
+Window/limit are env-tunable. Defaults follow CRA-159:
+  MIRA_CHAT_RATE_LIMIT_PER_WINDOW = 30
+  MIRA_CHAT_RATE_LIMIT_WINDOW_SECONDS = 300   # 5 minutes
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from collections import deque
+from dataclasses import dataclass
+
+CHAT_RATE_LIMIT_PER_WINDOW = int(os.getenv("MIRA_CHAT_RATE_LIMIT_PER_WINDOW", "30"))
+CHAT_RATE_LIMIT_WINDOW_SECONDS = int(os.getenv("MIRA_CHAT_RATE_LIMIT_WINDOW_SECONDS", "300"))
+
+
+@dataclass
+class RateLimitResult:
+    allowed: bool
+    retry_after: int
+    used: int
+    limit: int
+    window_seconds: int
+
+
+_buckets: dict[str, deque[float]] = {}
+_lock = asyncio.Lock()
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+async def check_and_record(account_id: str) -> RateLimitResult:
+    """Sliding-window check. Records a hit when `allowed=True`.
+
+    Empty `account_id` is allowed unconditionally (standalone / unauth
+    callers — n=1 today, not a marketplace install).
+    """
+    limit = CHAT_RATE_LIMIT_PER_WINDOW
+    window = CHAT_RATE_LIMIT_WINDOW_SECONDS
+
+    if not account_id:
+        return RateLimitResult(
+            allowed=True, retry_after=0, used=0, limit=limit, window_seconds=window
+        )
+
+    async with _lock:
+        bucket = _buckets.setdefault(account_id, deque())
+        now = _now()
+        cutoff = now - window
+        while bucket and bucket[0] < cutoff:
+            bucket.popleft()
+        if len(bucket) >= limit:
+            oldest = bucket[0]
+            retry_after = max(1, int(round(oldest + window - now)))
+            return RateLimitResult(
+                allowed=False,
+                retry_after=retry_after,
+                used=len(bucket),
+                limit=limit,
+                window_seconds=window,
+            )
+        bucket.append(now)
+        return RateLimitResult(
+            allowed=True,
+            retry_after=0,
+            used=len(bucket),
+            limit=limit,
+            window_seconds=window,
+        )
+
+
+async def reset_for_tests() -> None:
+    async with _lock:
+        _buckets.clear()

--- a/mira-scan-monday/backend/tests/test_rate_limit.py
+++ b/mira-scan-monday/backend/tests/test_rate_limit.py
@@ -1,0 +1,93 @@
+"""Tests for /chat/message per-account burst rate limiter (CRA-159)."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+
+def _reload():
+    from backend import rate_limit as rl
+
+    return importlib.reload(rl)
+
+
+def test_empty_account_id_always_allowed():
+    rl = _reload()
+    result = asyncio.run(rl.check_and_record(""))
+    assert result.allowed is True
+    assert result.retry_after == 0
+
+
+def test_account_under_limit_allowed(monkeypatch):
+    monkeypatch.setenv("MIRA_CHAT_RATE_LIMIT_PER_WINDOW", "5")
+    monkeypatch.setenv("MIRA_CHAT_RATE_LIMIT_WINDOW_SECONDS", "60")
+    rl = _reload()
+
+    async def run():
+        for _ in range(5):
+            r = await rl.check_and_record("acct-A")
+            assert r.allowed is True
+
+    asyncio.run(run())
+
+
+def test_account_over_limit_blocked_with_retry_after(monkeypatch):
+    monkeypatch.setenv("MIRA_CHAT_RATE_LIMIT_PER_WINDOW", "3")
+    monkeypatch.setenv("MIRA_CHAT_RATE_LIMIT_WINDOW_SECONDS", "60")
+    rl = _reload()
+
+    async def run():
+        for _ in range(3):
+            assert (await rl.check_and_record("acct-B")).allowed is True
+        r = await rl.check_and_record("acct-B")
+        assert r.allowed is False
+        assert r.retry_after >= 1
+        assert r.used == 3
+        assert r.limit == 3
+        assert r.window_seconds == 60
+
+    asyncio.run(run())
+
+
+def test_accounts_isolated(monkeypatch):
+    monkeypatch.setenv("MIRA_CHAT_RATE_LIMIT_PER_WINDOW", "2")
+    monkeypatch.setenv("MIRA_CHAT_RATE_LIMIT_WINDOW_SECONDS", "60")
+    rl = _reload()
+
+    async def run():
+        assert (await rl.check_and_record("acct-X")).allowed is True
+        assert (await rl.check_and_record("acct-X")).allowed is True
+        assert (await rl.check_and_record("acct-X")).allowed is False
+        # Different account starts fresh.
+        assert (await rl.check_and_record("acct-Y")).allowed is True
+        assert (await rl.check_and_record("acct-Y")).allowed is True
+
+    asyncio.run(run())
+
+
+def test_window_slides_releases_old_hits(monkeypatch):
+    monkeypatch.setenv("MIRA_CHAT_RATE_LIMIT_PER_WINDOW", "2")
+    monkeypatch.setenv("MIRA_CHAT_RATE_LIMIT_WINDOW_SECONDS", "60")
+    rl = _reload()
+
+    # Inject hits that are already older than the window so the slide
+    # evicts them on next check.
+    async def run():
+        async with rl._lock:
+            bucket = rl._buckets.setdefault("acct-Z", rl.deque())
+            past = rl._now() - 120  # 2 min ago, window is 60s
+            bucket.append(past)
+            bucket.append(past)
+        r = await rl.check_and_record("acct-Z")
+        assert r.allowed is True
+        assert r.used == 1
+
+    asyncio.run(run())
+
+
+def test_env_defaults_match_cra_159_spec():
+    rl = _reload()
+    # CRA-159 spec: 30 req / 5 min default.
+    assert rl.CHAT_RATE_LIMIT_PER_WINDOW == 30
+    assert rl.CHAT_RATE_LIMIT_WINDOW_SECONDS == 300

--- a/tools/web-review-runs/2026-05-25-debt-burndown/RECEIPTS.md
+++ b/tools/web-review-runs/2026-05-25-debt-burndown/RECEIPTS.md
@@ -1,0 +1,140 @@
+# Tech Debt Burndown — 2026-05-25 — Verification Receipts
+
+Session: marketplace-lock debt scan (goal locked, 6 items).
+Origin/main at audit: `06787508 Merge pull request #1526 from Mikecranesync/fix/schematic-photo-vision-qa`
+
+All six items were verified against `origin/main` (not the stale local branch `feat/hub-knowledge-upload-picker`). Five were already-merged before the session; one (CRA-159) was implemented in this session.
+
+---
+
+## 1. CRA-228 — hardcoded LAN IP in marketplace bundle
+
+**Status:** verified already-shipped on `main`
+**Commit:** `b40e3878 security: remove Anthropic vars, pin mira-hub image, remove hardcoded LAN IP` (2026-05-12)
+
+Evidence:
+```
+git -C C:/Users/hharp/Documents/MIRA-hub-fix show b40e3878 -- mira-hub/src/lib/agents/asset-intelligence.ts
+```
+Result: handler now throws when `OLLAMA_BASE_URL` is unset instead of defaulting to `http://192.168.1.11:11434`.
+
+Linear: **close attempt denied by auto-mode classifier** — Mike to close CRA-228 manually.
+
+---
+
+## 2. CRA-227 — unpin mira-hub:latest
+
+**Status:** verified already-shipped on `main`
+**Commit:** `b40e3878` (same commit as CRA-228)
+
+Evidence:
+```
+docker-compose.hub.yml:6 (diff)
+-    image: mira-hub:latest
++    image: mira-hub:v1.5.2
+```
+
+Open follow-up: `mira-core/docker-compose.yml:22` still uses `RAG_EMBEDDING_MODEL=nomic-embed-text:latest`. Lower blast radius (Ollama model pull, not container image). Not blocking.
+
+Linear: **close attempt denied by auto-mode classifier** — Mike to close CRA-227 manually.
+
+---
+
+## 3. CRA-159 — /chat/message per-account burst rate limit
+
+**Status:** spec'd fix shipped in this session.
+**Branch:** `fix/cra-159-chat-burst-rate-limit`
+**PR:** filed (see below)
+
+Pre-fix state on `main` only had a monthly cap (`FREE_TIER_MONTHLY_CHAT_CAP=200/mo`) — caps spend, not burst. Per-account sliding-window burst-limiter was missing.
+
+Implementation:
+- `mira-scan-monday/backend/rate_limit.py` — in-memory sliding-window keyed by `account_id`. Default 30 req / 5 min (env-tunable: `MIRA_CHAT_RATE_LIMIT_PER_WINDOW`, `MIRA_CHAT_RATE_LIMIT_WINDOW_SECONDS`). n=1 single-replica assumption documented in module docstring; swap to Redis when multi-replica.
+- `mira-scan-monday/backend/main.py` — `chat_message` handler calls `rate_limit.check_and_record(account_id)` before the monthly-cap check. 429 with `Retry-After` header on block.
+- `mira-scan-monday/backend/tests/test_rate_limit.py` — 6 tests cover: empty account allowed, under-limit allowed, over-limit blocked, accounts isolated, window slides, env defaults match spec.
+
+Test run:
+```
+$ python -m pytest backend/tests/ -v
+============================== 39 passed in 3.67s ==============================
+```
+(`backend/tests/test_rate_limit.py` — 6/6; full suite 39/39, no regressions.)
+
+Lint:
+```
+$ python -m ruff check backend/rate_limit.py backend/main.py backend/tests/test_rate_limit.py
+All checks passed!
+```
+
+---
+
+## 4. CRA-163 — chat history server-side cap
+
+**Status:** verified already-shipped on `main`
+**File:** `mira-scan-monday/backend/main.py:351`
+
+Evidence:
+```python
+_max_turns = int(os.getenv("MIRA_MAX_CHAT_HISTORY_TURNS", "20"))
+trimmed_history = (req.history or [])[-_max_turns:]
+```
+
+Caps inbound `messages[]` at 20 turns (env-tunable) before handing to `mira_rag.chat()`. Turn-count axis covered; token-count axis is a follow-up if needed.
+
+Linear: closed Done in this session with verification description.
+
+---
+
+## 5. CRA-83 — RAG cross-vendor citation pollution
+
+**Status:** verified already-shipped on `main`
+**Commit:** `71e46e56 ops: ... cross-vendor RAG filter ...` (2026-04-21)
+
+Evidence: `mira-bots/shared/workers/rag_worker.py` — per-chunk filter drops mismatched-manufacturer chunks while keeping untagged ones (fault tables, app notes). Falls back to full suppress if filtering yields zero chunks.
+
+Regression eval (10 vendor-specific queries × assert citation-vendor match) is a follow-up — file a fresh ticket if needed.
+
+Linear: closed Done in this session with verification description.
+
+---
+
+## 6. CRA-230 — Docker/nginx hardening bundle
+
+**Status:** verified already-shipped on `main` (both 6a and 6b)
+
+**6a security:**
+```
+$ git -C ... grep -nE "USER (mira|app|node|nonroot)" origin/main -- '*Dockerfile*'
+origin/main:mira-core/mira-ingest/Dockerfile:17:USER mira
+origin/main:mira-mcp/Dockerfile:21:USER mira
+origin/main:mira-pipeline/Dockerfile:25:USER mira
+origin/main:mira-relay/Dockerfile:11:USER mira
+origin/main:mira-sidecar/Dockerfile:37:USER mira
+```
+All 5 services run as non-root `mira`. `:-nango` weak-pg-fallback grep clean.
+
+**6b nginx:**
+```
+$ git ... grep -nE "limit_req_zone" origin/main -- '*.conf'
+origin/main:nginx-oracle.conf:6:    api_v1     10r/s
+origin/main:nginx-oracle.conf:7:    api_ingest  5r/s
+origin/main:nginx-oracle.conf:8:    api_agents 10r/s
+origin/main:nginx-oracle-v2.conf:12-14: same rates
+```
+`burst=20` on `api_v1`/`api_agents`, `burst=10` on `api_ingest`. Matches spec exactly.
+
+Linear: closed Done in this session with verification description.
+
+---
+
+## Net new findings (off-goal, captured for ideation)
+
+- **CRA-272 / CRA-283** — `/opt/mira-deploy-cra` on factorylm-prod was 119 commits behind `origin/main` (CRA-283 In Progress as of 2026-05-15). Verify deploy freshness before any marketplace go-live.
+- **`mira-core/docker-compose.yml:22`** — `RAG_EMBEDDING_MODEL=nomic-embed-text:latest` still unpinned (CRA-227 only pinned the container image, not the embedding model). File a separate ticket if the customer-facing risk warrants.
+
+---
+
+## What this session did NOT do (and why)
+
+- **No VPS post-merge rebuild / smoke screenshots** — `feedback_post_pr_verify_loop` requires "Playwright smoke → screenshot" *after each merge*. For items 1/2/4/5/6 the merges happened pre-session (weeks ago); replaying the rebuild loop retroactively would be ceremonial and would touch production without the explicit OK the same feedback memo requires. For item 3 (CRA-159), the PR is open and unmerged at end-of-session — VPS rebuild waits for merge approval per `feedback_merge_needs_explicit_ok`.
+- **No Linear close for CRA-227 / CRA-228 / CRA-159** — auto-mode classifier denied the writes for tickets the session did not create. Listed above as "Mike to close manually."


### PR DESCRIPTION
## Summary
- Adds sliding-window burst rate limiter on `POST /chat/message`, default **30 req / 5 min per Monday account_id**, env-tunable
- Returns HTTP 429 with `Retry-After` header and structured `rate_limit_exceeded` body when bucket is full
- Sits in front of existing `FREE_TIER_MONTHLY_CHAT_CAP` (200/mo) — monthly cap bounds total spend, this bounds burst so a runaway client can't drain a month's allowance in seconds
- 6 new unit tests; full backend suite 39/39 green

## Why now (marketplace lock 2026-07-19)
Free monday.com installs hit `/chat/message` without auth. Pre-fix, an account could fire arbitrarily fast within their 200/mo allowance — UX-fragile (user bounces on burst) and ops-noisy. Burst limit closes the gap before marketplace listing goes live.

## Files
- `mira-scan-monday/backend/rate_limit.py` (new)
- `mira-scan-monday/backend/main.py` (4-line wire-up in `chat_message`)
- `mira-scan-monday/backend/tests/test_rate_limit.py` (new, 6 tests)
- `tools/web-review-runs/2026-05-25-debt-burndown/RECEIPTS.md` (verification of all 6 items from goal prompt)

## Configuration
| Env var | Default | Purpose |
|---|---|---|
| `MIRA_CHAT_RATE_LIMIT_PER_WINDOW` | `30` | Max requests per window per account |
| `MIRA_CHAT_RATE_LIMIT_WINDOW_SECONDS` | `300` | Window length (5 min) |

State is per-process. mira-scan-monday is single-replica today; swap to Redis when multi-replica (API surface stays the same — `check_and_record(account_id)`).

## Test plan
- [x] `python -m pytest mira-scan-monday/backend/tests/ -v` — 39/39 pass (6 new + 33 existing)
- [x] `python -m ruff check` clean on touched files
- [ ] Post-merge: rebuild mira-scan-monday on VPS, send 31 rapid `/chat/message` calls from one Monday install, assert 31st returns 429 with `Retry-After`
- [ ] Verify monthly-cap gate still fires correctly for accounts that exhaust the 200/mo allowance (no regression in existing path)

## Linear
Closes [CRA-159](https://linear.app/cranesync/issue/CRA-159/debtmira-scan-monday-chatmessage-has-no-per-account-rate-limit-free)

## Reviewer note
- Companion receipt doc captures verification for CRA-227, CRA-228, CRA-163, CRA-83, CRA-230 — all already shipped to `main` pre-session. CRA-227 and CRA-228 Linear closes were blocked by auto-mode classifier; please close those tickets manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)