### PR TITLE
chore(dev): integrate CodeGraph into development workflow

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -118,6 +118,20 @@ See `.claude/skills/slack-technician-ux-writer/SKILL.md` for sample message temp
 
 `tools/hooks/prod-guard.sh` enforces the obvious blast-radius cases (`PreToolUse(Bash)`). It is a floor, not a ceiling. The full rule set lives in `docs/environments.md`.
 
+## Code exploration: CodeGraph first
+
+CodeGraph is the SQLite semantic index of every symbol, edge, file, and call path in the workspace. It is wired into every Claude Code session via the `codegraph` MCP server in `.mcp.json`. Use it BEFORE grep / Read for any symbol-shaped question.
+
+- **First call for any task in indexed code:** `codegraph_context "<task>"` — composes search + node + callers + callees in one call. Cheapest possible orientation.
+- **Before editing `engine.py` or any shared module:** `codegraph_impact <symbol>` to see the blast radius. Modules in scope: `mira-bots/shared/engine.py`, `mira-bots/shared/inference/router.py`, `mira-bots/shared/uns_resolver.py`, `mira-bots/shared/citation_compliance.py`, `mira-bots/shared/guardrails.py`, `mira-crawler/ingest/uns.py`, `mira-mcp/server.py`, plus anything imported by >5 files. **Never ignore an unexpected symbol in the blast-radius output** — narrow the change first.
+- **"How does X reach Y" / call-path questions:** `codegraph_trace` — handles dynamic-dispatch hops (callbacks, async workers, FSM transitions) that grep can't follow.
+- **Multi-symbol surveys:** `codegraph_explore` — one capped call for several related symbols. Don't loop `codegraph_node` or `Read`.
+- **Do NOT re-read files CodeGraph already returned source for.** `codegraph_node` / `codegraph_explore` include the symbol body.
+- **Only fall back to `Grep` / `Read`** for plain-text matches (prompt strings, log lines, comments), file-level inspection of files CodeGraph didn't index, or details the CodeGraph response didn't cover.
+- **Index freshness:** `.githooks/post-merge` and `.githooks/post-checkout` run `codegraph sync` automatically (incremental, <1 s, no-op when codegraph isn't installed). After cherry-picks or hand-edits, run `npx -y @colbymchenry/codegraph sync` manually.
+
+Full rules: `.claude/rules/codegraph-usage.md`. Reference: `wiki/references/codegraph.md`.
+
 ## Rules for code changes
 
 - **Conventional Commits**: `feat/fix/security/docs/refactor/test/chore/BREAKING`. Scope hint: module name (`feat(slack):`, `fix(uns):`, `fix(engine):`).
@@ -126,6 +140,7 @@ See `.claude/skills/slack-technician-ux-writer/SKILL.md` for sample message temp
 - **Python: ruff + httpx + `Optional[X]` (3.12 target)** — see `.claude/rules/python-standards.md`.
 - **Security boundaries** — see `.claude/rules/security-boundaries.md` (PII sanitization, safety keywords, Doppler).
 - **UNS compliance** — see `.claude/rules/uns-compliance.md` (every asset row has `uns_path` or `equipment_entity_id` FK).
+- **CodeGraph-first exploration** — see `.claude/rules/codegraph-usage.md` (use `codegraph_context` / `codegraph_impact` before grep + Read for any symbol-shaped question).
 - **Karpathy principles** — think before coding, simplicity first, surgical changes, goal-driven execution. See `.claude/rules/karpathy-principles.md`.
 - **Don't break the UNS confirmation gate.** Run `mira-run-hallucination-audit` after engine/bot edits.
 
@@ -160,6 +175,7 @@ See `.claude/skills/slack-technician-ux-writer/SKILL.md` for sample message temp
 - `.claude/rules/security-boundaries.md` — secrets, PII, safety keywords
 - `.claude/rules/python-standards.md` — ruff, httpx, NeonDB, async
 - `.claude/rules/karpathy-principles.md` — coding behavior
+- `.claude/rules/codegraph-usage.md` — when to use CodeGraph vs grep/Read (CodeGraph-first for symbol-shaped questions)
 - `docs/specs/uns-kg-unification-spec.md` — UNS authority (data architecture)
 - `docs/specs/mira-component-intelligence-architecture.md` — implementation-level architecture (component templates, KG mechanics)
 - `docs/specs/dialogue-state-tracker-spec.md` — FSM the UNS gate plugs into

--- a/.claude/rules/codegraph-usage.md
+++ b/.claude/rules/codegraph-usage.md
@@ -1,0 +1,95 @@
+# CodeGraph Usage
+
+CodeGraph is the SQLite semantic index of the MIRA codebase (symbols, edges,
+files, call paths). It is wired into every Claude Code session via the
+`codegraph` MCP server in `.mcp.json`. Reference: `wiki/references/codegraph.md`.
+
+These rules govern **when** to use CodeGraph vs. grep / Read. They complement
+`karpathy-principles.md` (think before coding, surgical changes) — CodeGraph is
+the "think" step's cheapest, fastest information source.
+
+## Rules
+
+1. **CodeGraph is the primary exploration tool.** For any "how does X work",
+   "where is Y", "what calls Z", "what would breaking W impact" question, the
+   first 1–3 tool calls MUST be CodeGraph. Reach for `Grep` / `Read` only for
+   details CodeGraph didn't cover (a specific string match, a comment, a
+   line-level detail in a file CodeGraph already pointed you at).
+
+2. **Use `codegraph_context` FIRST to map any task area.** Before editing,
+   designing, or even diagnosing a feature, call `codegraph_context` with the
+   task description. It composes search + node + callers + callees in one
+   call — the cheapest possible orientation.
+
+3. **Use `codegraph_impact` BEFORE editing `engine.py` or any shared module.**
+   Before any code change to `mira-bots/shared/engine.py`,
+   `mira-bots/shared/inference/router.py`, `mira-bots/shared/uns_resolver.py`,
+   `mira-bots/shared/citation_compliance.py`, `mira-bots/shared/guardrails.py`,
+   `mira-crawler/ingest/uns.py`, `mira-mcp/server.py`, or any other module
+   that >5 files import, run `codegraph_impact <target_symbol>` and read the
+   blast-radius result. If the impact list is non-trivial, surface it in the
+   PR description.
+
+4. **Never ignore a blast-radius warning.** If `codegraph_impact` returns a
+   symbol you weren't expecting to touch (e.g. an alias in another adapter,
+   a test that depends on a private helper, a cross-module callback), stop
+   and decide explicitly: do you intend the change to propagate there? If
+   not, the change isn't surgical — narrow it before continuing.
+
+5. **Use `codegraph_trace` for "how does X reach Y" questions.** Trace
+   handles dynamic-dispatch hops (callbacks, async workers, FSM transitions)
+   that grep + read can't follow. One trace call beats a dozen file reads.
+
+6. **Use `codegraph_explore` for multi-symbol surveys.** When you need source
+   for several related symbols (e.g. the four classifier methods, the three
+   engine state handlers), `codegraph_explore` returns them in one capped
+   call. Don't loop `codegraph_node` or `Read`.
+
+7. **Do NOT re-read files CodeGraph already returned source for.** The
+   `codegraph_node` / `codegraph_explore` responses include the symbol's
+   source body. Re-opening the file with `Read` for the same range repeats
+   work and bloats context.
+
+8. **Run `codegraph sync` after major branch operations.** The
+   `.githooks/post-merge` and `.githooks/post-checkout` hooks do this
+   automatically. If you've cherry-picked, hand-edited, or used a worktree
+   without those hooks active, run `npx -y @colbymchenry/codegraph sync`
+   manually before the next exploration call. The file watcher debounces
+   for ~500 ms after edits — don't query immediately after a `Write`.
+
+9. **Skip CodeGraph only when it cannot help.** Plain-text searches in
+   comments, prompts, markdown, log lines, env vars, and shell scripts are
+   `Grep`'s job. Inspecting a fresh file you've never seen is `Read`'s job.
+   Anything *symbol-shaped* (function, class, method, route, import,
+   variable) goes to CodeGraph first.
+
+10. **Trust CodeGraph's signature/kind output.** It returns `kind` (function /
+    class / method / route / etc.), file path, line, and the symbol body. If
+    CodeGraph says `foo` is a method on class `Bar` at `path/x.py:123`, do
+    not re-verify with grep before acting — the index is built from the AST.
+
+## When this applies
+
+- Any task in `mira-bots/`, `mira-core/`, `mira-mcp/`, `mira-crawler/`,
+  `mira-pipeline/`, `mira-bridge/`, `mira-hub/`, `mira-web/`, `mira-cmms/`,
+  or any other indexed module.
+- Any architecture, impact, trace, or "where is" question.
+- Any pre-edit orientation on a module touched by >1 caller.
+
+## When this does NOT apply
+
+- Pure documentation edits (`docs/`, `wiki/` markdown).
+- Pure config edits (`docker-compose*.yml`, `.env*`, `pyproject.toml`).
+- One-line fixes to a file you just opened from a stack trace.
+- Searching prompt text, log strings, or test fixtures — `Grep` is correct.
+
+## Anti-patterns to avoid
+
+- ❌ Calling `Grep` for a symbol name before trying `codegraph_search`.
+- ❌ Looping `codegraph_node` over a list — use `codegraph_explore`.
+- ❌ Editing `engine.py` without a prior `codegraph_impact` on the target.
+- ❌ Re-reading a file CodeGraph already returned the relevant source from.
+- ❌ Delegating CodeGraph lookups to a sub-agent — the index is pre-built;
+  spawning an exploration agent just re-does the work CodeGraph already did.
+- ❌ Querying CodeGraph immediately after a `Write` — wait ~500 ms or run
+  `codegraph sync` first.

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# MIRA post-checkout hook — refresh CodeGraph index after branch switches.
+# Installed via: git config core.hooksPath .githooks
+#
+# Git invokes post-checkout with: $1 = prev HEAD, $2 = new HEAD,
+# $3 = 1 for branch checkout / 0 for file checkout. We only sync on
+# branch checkouts ($3 == 1) — a `git checkout -- somefile` would
+# otherwise trigger a sync on every file restore.
+
+set -u
+
+# $3 is set by git; default to 0 if invoked manually for testing.
+IS_BRANCH_CHECKOUT="${3:-0}"
+if [ "$IS_BRANCH_CHECKOUT" != "1" ]; then
+  exit 0
+fi
+
+# Skip when CodeGraph isn't installed in this checkout.
+if [ ! -d ".codegraph" ]; then
+  exit 0
+fi
+
+# Skip when npx is unavailable.
+if ! command -v npx >/dev/null 2>&1; then
+  exit 0
+fi
+
+(
+  npx -y @colbymchenry/codegraph sync >/dev/null 2>&1 || true
+) &
+disown 2>/dev/null || true
+
+exit 0

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# MIRA post-merge hook — refresh CodeGraph index after merges and pulls.
+# Installed via: git config core.hooksPath .githooks
+#
+# Runs `codegraph sync` quietly. Sync is incremental (<1 s on the current
+# ~1,200-file index) and a no-op when nothing changed. The hook never
+# blocks the merge — codegraph missing, npx offline, or sync failure all
+# degrade to a single warning line and exit 0.
+
+set -u
+
+# Skip when CodeGraph isn't installed in this checkout (e.g. fresh clone
+# before `npx -y @colbymchenry/codegraph init -i`, or a worktree that
+# was created before install).
+if [ ! -d ".codegraph" ]; then
+  exit 0
+fi
+
+# Skip when npx is unavailable (CI minimal images, restricted shells).
+if ! command -v npx >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Background + detached so a slow npm cache check never delays the merge.
+# Output is silenced; the next `codegraph status` call surfaces health.
+(
+  npx -y @colbymchenry/codegraph sync >/dev/null 2>&1 || true
+) &
+disown 2>/dev/null || true
+
+exit 0

--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ tools/monday-marketplace-setup/.chrome-profile/
 # Staging test output (regenerable; never commit result snapshots)
 staging_results.json
 tools/staging_results.json
+
+# CodeGraph local index (machine-specific, regenerable via `npx @colbymchenry/codegraph index`)
+.codegraph/

--- a/.mcp.json
+++ b/.mcp.json
@@ -39,6 +39,17 @@
         "--headless"
       ],
       "env": {}
+    },
+    "codegraph": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@colbymchenry/codegraph",
+        "serve",
+        "--mcp"
+      ],
+      "env": {}
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ Every Playwright proof-of-work screenshot must ALSO be saved to `docs/promo-scre
 - **Enforcement layer:** `docs/specs/enforcement-layer-spec.md` — Playwright audit, write-path round-trip, enum drift, spec staleness, PR template, NeonDB canary
 - **Claude Code v2.1+ defaults (Opus 4.7, xhigh, /effort, /autofix-pr, Routines):** `wiki/references/claude-code-v2.1.md`
 - **MIRA Routines (cloud-side scheduled work):** `wiki/references/routines.md`
+- **CodeGraph (semantic code index + MCP):** `wiki/references/codegraph.md` — usage rules in `.claude/rules/codegraph-usage.md`
 
 ---
 

--- a/wiki/references/codegraph.md
+++ b/wiki/references/codegraph.md
@@ -1,0 +1,81 @@
+# CodeGraph
+
+Local-first semantic index of the MIRA codebase for faster AI-assisted navigation.
+
+- **Package:** `@colbymchenry/codegraph` (npm, v0.9.4 at install)
+- **Installed:** 2026-05-25 on CHARLIE
+- **Index location:** `.codegraph/codegraph.db` (gitignored — local + regenerable)
+- **Backend:** node:sqlite with WAL journal
+
+## Install / re-index
+
+```bash
+npx -y @colbymchenry/codegraph init -i      # first time
+npx -y @colbymchenry/codegraph sync          # incremental update
+npx -y @colbymchenry/codegraph index -f      # force full re-index
+npx -y @colbymchenry/codegraph status        # stats
+```
+
+## Index stats (2026-05-25 baseline)
+
+| Metric | Value |
+|---|---|
+| Files indexed | 1,221 (of 1,444 scanned) |
+| Nodes | 18,955 |
+| Edges | 35,361 |
+| DB size | ~35 MB |
+| Index time | ~5 s |
+
+Languages: 744 Python · 364 TypeScript · 223 YAML · 79 TSX · 28 JS · 6 JSX.
+Node kinds: 5,374 imports · 5,008 functions · 2,957 variables · 2,352 methods · 1,221 files · 874 constants · 690 classes · 275 interfaces · 135 type aliases · 69 routes.
+
+## Useful queries
+
+```bash
+codegraph query <symbol>          # fuzzy symbol search with scores
+codegraph callers <symbol>        # who calls this
+codegraph callees <symbol>        # what does this call
+codegraph impact <symbol>         # blast radius of changing this
+codegraph affected <files...>     # tests touched by file changes
+codegraph context "<task>"        # markdown context bundle for a task
+codegraph files                   # project tree with per-file symbol counts
+```
+
+## MCP server
+
+**Enabled 2026-05-25** — wired into `.mcp.json` (project-scoped, not global). Every Claude Code session in this repo gets 10 codegraph tools without bash:
+
+| Tool | When to call |
+|---|---|
+| `codegraph_context` | PRIMARY — "how does X work / what's the deal with this feature" |
+| `codegraph_search` | Quick name lookup |
+| `codegraph_callers` / `codegraph_callees` | Caller / callee audit |
+| `codegraph_impact` | Blast radius of changing a symbol |
+| `codegraph_trace` | "How does X reach Y" — call path with dynamic-dispatch hops |
+| `codegraph_node` | One symbol's signature/docstring + trail |
+| `codegraph_explore` | Source for several related symbols in one call |
+| `codegraph_files` | File/folder structure |
+| `codegraph_status` | Index health |
+
+**Anti-patterns** (per the server's own instructions):
+- Don't grep first when looking up a symbol — `codegraph_search` is faster and returns kind + location + signature.
+- Don't loop `codegraph_node` — use `codegraph_explore` to batch.
+- Don't query immediately after editing — watcher needs ~500 ms to debounce.
+
+To disable: remove the `codegraph` entry from `.mcp.json`.
+
+Validation: see [codegraph-benchmark-2026-05-25.md](../../docs/evaluations/codegraph-benchmark-2026-05-25.md) — 49/49 caller relationships verified, 5/5 impact samples valid.
+
+## Workflow integration
+
+- **Mandatory exploration tool:** `.claude/rules/codegraph-usage.md` — CodeGraph-first before grep/Read for any architecture, impact, or trace question.
+- **Auto-sync hook:** `.githooks/post-merge` and `.githooks/post-checkout` run `codegraph sync` after every merge / pull / branch-switch (incremental, <1 s, no-op if codegraph not installed).
+- **Manual sync:** `npx -y @colbymchenry/codegraph sync` — run if hook didn't fire (e.g. cherry-pick, hand-edit) or after large file moves.
+
+## Rollback
+
+```bash
+npx -y @colbymchenry/codegraph uninit    # deletes .codegraph/
+```
+
+Pre-install state tagged `pre-codegraph-install` (commit `748bf2b4`).


### PR DESCRIPTION
## Summary

Locks CodeGraph (`@colbymchenry/codegraph` MCP server, already wired in `.mcp.json` on the previous branch and now landed here) into the dev workflow so every Claude Code session uses it as the default exploration tool — not a manual fallback.

- **MCP wiring:** `.mcp.json` registers the `codegraph serve --mcp` entry; `.gitignore` excludes the local `.codegraph/` index (regenerable).
- **CodeGraph-first rule:** `.claude/rules/codegraph-usage.md` — `codegraph_context` before grep/Read, `codegraph_impact` before editing `engine.py` / shared modules, `codegraph_trace` for cross-call-path questions, `codegraph_explore` for multi-symbol surveys. Forbids re-reading files CodeGraph already returned source for and ignoring blast-radius warnings.
- **CLAUDE.md updates:** new "Code exploration: CodeGraph first" section in `.claude/CLAUDE.md` + cross-reference + rule-list entry. Root `CLAUDE.md` Pointers references both the wiki doc and the rule.
- **Auto-sync hooks:** `.githooks/post-merge` and `.githooks/post-checkout` run `codegraph sync` quietly in the background after merges / pulls / branch-switches. Incremental (<1 s), no-op when `.codegraph/` isn't initialised or `npx` isn't on PATH, never blocks the git operation. Activated by the existing `core.hooksPath=.githooks` setup.
- **Wiki:** `wiki/references/codegraph.md` adds a "Workflow integration" section pointing at the rule + hooks.

Karpathy §3 (surgical changes): no code or test edits, no behavioural change to MIRA itself. The existing `.githooks/pre-commit` is untouched.

## Test plan

- [ ] `npx -y @colbymchenry/codegraph status` shows the index is present and fresh.
- [ ] `cat .git/config | grep hooksPath` returns `.githooks` (or run `git config core.hooksPath .githooks`).
- [ ] Simulate the merge hook: `bash .githooks/post-merge && echo OK` — exits 0, no blocking output.
- [ ] Simulate the branch-switch hook: `bash .githooks/post-checkout HEAD HEAD 1 && echo OK` — exits 0.
- [ ] With `.codegraph/` removed: `bash .githooks/post-merge && echo OK` — still exits 0 (graceful degradation).
- [ ] Open a fresh Claude Code session in this repo and verify the codegraph tools are listed (look for `mcp__codegraph__codegraph_context` etc.).
- [ ] Spot-check a real edit flow: ask the agent to summarise `mira-bots/shared/engine.py` — first tool call should be `codegraph_context`, not `Read`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)