### PR TITLE
fix(scan-monday): alias legacy Doppler names into Monday OAuth env block

### DIFF
--- a/mira-scan-monday/docker-compose.yml
+++ b/mira-scan-monday/docker-compose.yml
@@ -18,9 +18,28 @@ services:
       # `doppler run -- docker compose up` interpolates these from the
       # shell env at compose-up time. env_file (above) covers local dev
       # where Mike hand-edits .env; this block covers production deploys.
-      MONDAY_OAUTH_CLIENT_ID: ${MONDAY_OAUTH_CLIENT_ID:-}
-      MONDAY_OAUTH_CLIENT_SECRET: ${MONDAY_OAUTH_CLIENT_SECRET:-}
-      MONDAY_WEBHOOK_SIGNING_SECRET: ${MONDAY_WEBHOOK_SIGNING_SECRET:-}
+      #
+      # The MONDAY_* aliases below cover the case where Doppler holds the
+      # value under a legacy name (e.g. MONDAY_CLIENT_SECRETS predates the
+      # _OAUTH_ prefix the code now reads). The fallback chain is:
+      # explicit-target → legacy-Doppler-name → empty.
+      MONDAY_OAUTH_CLIENT_ID: ${MONDAY_OAUTH_CLIENT_ID:-${MONDAY_CLIENT_ID:-}}
+      MONDAY_OAUTH_CLIENT_SECRET: ${MONDAY_OAUTH_CLIENT_SECRET:-${MONDAY_CLIENT_SECRETS:-}}
+      MONDAY_OAUTH_REDIRECT_URI: ${MONDAY_OAUTH_REDIRECT_URI:-}
+      MONDAY_OAUTH_SCOPES: ${MONDAY_OAUTH_SCOPES:-me:read boards:read boards:write}
+      MONDAY_SIGNING_SECRET: ${MONDAY_SIGNING_SECRET:-${MONDAY_CLIENT_SECRETS:-}}
+      MONDAY_WEBHOOK_SIGNING_SECRET: ${MONDAY_WEBHOOK_SIGNING_SECRET:-${MONDAY_CLIENT_SECRETS:-}}
+      MONDAY_API_TOKEN: ${MONDAY_API_TOKEN:-${MONDAY_API_KEY:-}}
+      # Vision + KB plumbing — also Doppler-managed, also previously
+      # missing from the env block (default empty meant the container
+      # silently degraded to standalone-fallback paths).
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
+      VISION_MODEL: ${VISION_MODEL:-gpt-4o}
+      MIRA_KB_BASE_URL: ${MIRA_KB_BASE_URL:-}
+      MIRA_KB_API_KEY: ${MIRA_KB_API_KEY:-}
+      NEON_DATABASE_URL: ${NEON_DATABASE_URL:-}
+      SERPER_API_KEY: ${SERPER_API_KEY:-}
       # Manufacturer-scoped RAG (vendor_rag.py) — direct LLM cascade.
       GROQ_API_KEY: ${GROQ_API_KEY:-}
       GROQ_MODEL: ${GROQ_MODEL:-llama-3.3-70b-versatile}


### PR DESCRIPTION
## Summary

- Phase 1A OAuth code reads `MONDAY_OAUTH_CLIENT_ID/_SECRET`, `MONDAY_WEBHOOK_SIGNING_SECRET`, `MONDAY_API_TOKEN`, but Doppler `factorylm/prd` holds those under legacy names `MONDAY_CLIENT_ID`, `MONDAY_CLIENT_SECRETS`, `MONDAY_API_KEY`. Result: container starts with empty OAuth values and `/api/scanbe/oauth/monday/install` returns `503 OAuth is not configured`.
- Adds inline fallback aliases inside `docker-compose.yml` env block — no Doppler rename required.
- Also plumbs `NEON_DATABASE_URL`, `OPENAI_API_KEY`, `MIRA_KB_*`, `MONDAY_OAUTH_REDIRECT_URI`, `MONDAY_OAUTH_SCOPES`, `MONDAY_SIGNING_SECRET` which the code reads at startup but were silently empty in prod.

## Why this is keystone for tester-install flow

Without this PR, no Monday account can install — install endpoint 503s before redirecting to Monday's consent screen. Steps 1–8 in the goal flow all blocked downstream.

## Test plan

- [ ] Merge + deploy mira-scan-backend on VPS
- [ ] Probe: `curl -sI https://app.factorylm.com/api/scanbe/oauth/monday/install` → expect `302 Location: https://auth.monday.com/oauth2/authorize?...`
- [ ] Inspect the 302 `Location` header — confirm `redirect_uri=` matches Monday Dev Center registration
- [ ] If redirect_uri mismatch: Mike updates Dev Center or Doppler `MONDAY_OAUTH_REDIRECT_URI`

🤖 Generated with [Claude Code](https://claude.com/claude-code)