### PR TITLE
fix(scan-monday): trigger redirectToInstall on reinstall_required error

### DIFF
--- a/mira-scan-monday/frontend/src/components/AssetCard.jsx
+++ b/mira-scan-monday/frontend/src/components/AssetCard.jsx
@@ -1,6 +1,9 @@
 import { Button } from "@vibe/core";
 import { mondayUpdateItem } from "../lib/api.js";
+import { redirectToInstall } from "../lib/monday.js";
 import { useState } from "react";
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "";
 
 const FIELDS = [
   ["make", "Make"],
@@ -37,6 +40,11 @@ export default function AssetCard({ plate, mondayContext, sessionToken }) {
       );
       if (res.ok) {
         setSavedId(res.monday_item_id);
+      } else if (typeof res.error === "string" && res.error.startsWith("reinstall_required")) {
+        // Backend says the per-account OAuth token was revoked. Bounce
+        // the user through the install flow so monday issues a fresh one.
+        redirectToInstall(API_BASE_URL);
+        return;
       } else {
         setSaveError(res.error || "Save failed");
       }


### PR DESCRIPTION
## Summary

- Backend returns `{ok:false, error:'reinstall_required: ...'}` when an installation's Monday access_token has been revoked.
- `frontend/src/lib/monday.js` already exports `redirectToInstall()` but **no caller** wires it. `AssetCard.handleSave` only set the error text.
- This PR detects the `reinstall_required:` prefix in `handleSave` and routes the iframe top-window through `/oauth/monday/install` so Monday issues a fresh token.

## Why

Closes step-8 (uninstall→revoke→reinstall path) of the tester-install audit — without it, an uninstalled+reinstalled tester gets stuck on a permanent save error instead of being walked back through consent.

## Test plan

- [ ] After merge + redeploy, manually revoke the test install in Monday admin
- [ ] Click "Save to monday item" in AssetCard
- [ ] Expect top-window redirect to `/api/scanbe/oauth/monday/install` (then on to Monday consent screen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)