### PR TITLE
docs(scan-monday): tester-install walkthrough runbook + e2e spec scaffolding

### DIFF
--- a/docs/wip/phase1-tester-install/WALKTHROUGH.md
+++ b/docs/wip/phase1-tester-install/WALKTHROUGH.md
@@ -1,0 +1,231 @@
+# Tester-Install Walkthrough Runbook
+
+**Use this once PR #1557 + #1558 are merged + deployed.** Every command is
+copy-paste reproducible. Mike runs the steps marked **[MIKE]**; the rest
+the agent can drive next session.
+
+## Pre-flight (verify keystone PR landed)
+
+```powershell
+# Expect: HTTP/2 302 with Location: https://auth.monday.com/oauth2/authorize?...
+curl -sI https://app.factorylm.com/api/scanbe/oauth/monday/install
+
+# Extract redirect_uri to compare against Monday Dev Center
+curl -sI https://app.factorylm.com/api/scanbe/oauth/monday/install `
+  | findstr -i "location" `
+  | ForEach-Object { [uri]::UnescapeDataString($_) }
+```
+
+If still `503 OAuth is not configured` → PR #1557 didn't deploy. Stop.
+
+## Step 0 — Tester Monday workspace **[MIKE]**
+
+Mike creates (or uses existing) a Monday workspace **other than his
+main**. Note the workspace slug + account_id (visible in URL when
+logged in to monday.com → `https://<slug>.monday.com/`).
+
+Document creds in 1Password (NOT in repo):
+- Workspace slug: __________
+- Tester email: __________
+
+Doppler additions (optional, only if agent needs to drive future
+runs):
+
+```bash
+doppler secrets set --project factorylm --config prd `
+  MONDAY_TESTER_ACCOUNT_ID="<numeric account_id>" `
+  MONDAY_TESTER_SLUG="<slug>"
+```
+
+## Step 1 — Install from Dev Center **[MIKE]**
+
+Monday Developer Center → MIRA Scan app → Sandbox → "Install on a
+workspace". Pick the tester workspace from Step 0. Click Install.
+
+**Open browser DevTools → Network tab → record HAR** before clicking.
+After consent screen + redirect back, save HAR as:
+
+```
+tools/web-review-runs/2026-05-26-tester-install/01-oauth-callback.har
+```
+
+Expected flow in HAR:
+1. `GET auth.monday.com/oauth2/authorize?...` → 302 to Monday consent
+2. After click-allow → `GET https://app.factorylm.com/api/scanbe/oauth/monday/callback?code=...&state=...` → 200 HTML
+3. Browser meta-refresh → `https://<slug>.monday.com/apps/installed_apps`
+
+## Step 2 — Verify token persisted (NOT Mike's)
+
+```sql
+-- Run against Neon prod. Replace <tester_account_id> with the value
+-- returned in the Step-1 HTML response (visible in the page body).
+SELECT
+  account_id,
+  scope,
+  user_id,
+  installed_at,
+  last_seen_at,
+  revoked_at,
+  subscription_status,
+  LEFT(access_token, 10) AS token_prefix,
+  LENGTH(access_token)   AS token_len
+FROM monday_installations
+WHERE account_id = '<tester_account_id>';
+```
+
+Save output → `tools/web-review-runs/2026-05-26-tester-install/02-db-row-after-install.txt`
+
+**Assertion:** `account_id` is the **tester's**, not Mike's main
+workspace id. `token_prefix` starts with `eyJ` (JWT) and is **not**
+the same value as Mike's `MONDAY_API_KEY` (Doppler).
+
+## Step 3 — Open item-view, verify sessionToken→account_id resolves
+
+In the tester workspace, add a board with the MIRA Scan app to an
+item view. Open any item. Open browser DevTools → Network. The first
+calls go to `/api/scanbe/kb/lookup` or `/api/scanbe/queue/status`.
+
+Inspect request headers:
+```
+X-Monday-Session-Token: eyJhbGciOi...
+```
+
+Then immediately probe backend logs (replace timestamp):
+
+```bash
+ssh root@165.245.138.91 `
+  "docker logs mira-scan-backend --since 5m 2>&1 | grep -E 'account_id|session'" `
+  > tools/web-review-runs/2026-05-26-tester-install/03-backend-session-logs.txt
+```
+
+**Assertion:** logs reference the tester's account_id, not Mike's. If
+sessionToken is rejected (`session token rejected: ...`) the
+`MONDAY_SIGNING_SECRET` aliasing in PR #1557 didn't land — escalate.
+
+## Step 4 — Scan a nameplate
+
+In the iframe, click "Scan". Use phone or upload a JPG of any
+nameplate. Expected: AssetCard populates with make/model.
+
+Save the rendered card screenshot → `04-assetcard-populated.png`.
+
+```sql
+-- Verify scan_queue insert carries tester's account_id
+SELECT id, make, model, status, tenant_id, source, first_seen
+FROM mira_scan_queue
+WHERE tenant_id = '<tester_account_id>'
+ORDER BY first_seen DESC
+LIMIT 5;
+```
+
+Save → `04-scan-queue-rows.txt`.
+
+## Step 5 — MiraChat
+
+Open the chat tab. Ask: `What is the rated current of this asset?`
+Save the reply + sources to `05-chat-response.json` (right-click →
+"Copy response" in DevTools).
+
+```sql
+-- Verify chat_count bumped for tester
+SELECT account_id, usage_date, scan_count, chat_count, last_seen_at
+FROM account_usage_daily
+WHERE account_id = '<tester_account_id>'
+  AND usage_date = CURRENT_DATE;
+```
+
+Save → `05-usage-row.txt`.
+
+## Step 6 — Save to monday item (CRITICAL — Monday GraphQL writes)
+
+Click "Save to monday item" in AssetCard. Watch DevTools Network for
+`POST /api/scanbe/monday/update-item`. Save response body →
+`06-monday-update-response.json`.
+
+**Assertion:** `{ok: true, monday_item_id: <numeric>}`. NOT
+`reinstall_required` (would mean token broken). NOT
+`monday_api.MondayError` (would mean GraphQL rejected the call).
+
+**Verify in Monday's audit log, not just our DB:**
+- `https://<slug>.monday.com/admin/audit` → filter on the item id →
+  expect to see "Column value changed by MIRA Scan (app token)"
+- Screenshot → `06-monday-audit-log.png`
+
+If the audit log credits **Mike** as the actor → PR #1557 didn't take
+effect and the standalone `MONDAY_API_TOKEN` fallback fired instead
+of the tester's OAuth token. P0 escalation.
+
+## Step 7 — Rate-limit + monthly-cap
+
+Burst test (will trip the per-account rate limit after 30 requests):
+
+```bash
+for i in {1..35}; do
+  curl -s -o /dev/null -w "%{http_code}\n" `
+    -X POST https://app.factorylm.com/api/scanbe/chat/message `
+    -H "Content-Type: application/json" `
+    -H "X-Monday-Session-Token: <tester_session_token_from_step3>" `
+    -d '{"message":"test","history":[]}'
+done | tee tools/web-review-runs/2026-05-26-tester-install/07-rate-limit-burst.txt
+```
+
+**Assertion:** first ~30 requests return 200, rest return 429 with
+JSON body containing `"error":"rate_limit_exceeded"` and
+`"used":30,"limit":30`.
+
+## Step 8 — Uninstall + reinstall CTA
+
+In tester workspace: Settings → Installed Apps → MIRA Scan → Uninstall.
+
+```sql
+-- Webhook should mark revoked_at NOT NULL within seconds
+SELECT account_id, revoked_at, last_seen_at
+FROM monday_installations
+WHERE account_id = '<tester_account_id>';
+```
+
+Save → `08-db-row-after-uninstall.txt`.
+
+Now reload the iframe (still cached) or open scanner direct at
+`https://app.factorylm.com/scan/`. Click "Save to monday item" again.
+
+**Assertion:** AssetCard does NOT show a generic error. Browser
+top-window redirects to `/api/scanbe/oauth/monday/install` (then on to
+Monday consent). Screenshot → `08-reinstall-redirect.png`.
+
+## Final report
+
+Append to `tools/web-review-runs/2026-05-26-tester-install/REPORT.md`:
+
+```markdown
+# Tester-Install Receipts — <DATE>
+
+**Tester workspace:** <slug>
+**Tester account_id:** <numeric>
+
+| Step | Result | Receipt |
+|------|--------|---------|
+| 1 OAuth | ✅ | 01-oauth-callback.har |
+| 2 Token persisted | ✅ | 02-db-row-after-install.txt |
+| 3 sessionToken | ✅ | 03-backend-session-logs.txt |
+| 4 Scan | ✅ | 04-assetcard-populated.png + 04-scan-queue-rows.txt |
+| 5 Chat | ✅ | 05-chat-response.json + 05-usage-row.txt |
+| 6 Monday write | ✅ | 06-monday-update-response.json + 06-monday-audit-log.png |
+| 7 Rate-limit | ✅ | 07-rate-limit-burst.txt |
+| 8 Uninstall + reinstall CTA | ✅ | 08-db-row-after-uninstall.txt + 08-reinstall-redirect.png |
+
+## Summary
+
+<one paragraph: what worked, what broke first time, what unblocked it>
+```
+
+## When this runbook reports done
+
+- All 8 receipts present in `tools/web-review-runs/2026-05-26-tester-install/`
+- `monday_installations.account_id` for the tester is NOT Mike's
+- Monday audit log shows the column write attributed to the app token (not Mike)
+- `revoked_at` is NOT NULL after uninstall
+- Reinstall CTA fires top-window redirect
+
+Update `docs/wip/phase1-tester-install/AUDIT.md` "Done-when" checkboxes
+and PR the result.

--- a/mira-scan-monday/tests/e2e/tester-install.spec.ts
+++ b/mira-scan-monday/tests/e2e/tester-install.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Playwright spec — Phase 1 tester-install walkthrough automation.
+ *
+ * Designed to be run AFTER:
+ *   - PRs #1557 + #1558 are merged + deployed
+ *   - A tester Monday workspace exists (separate from Mike's main)
+ *   - Mike has done the one-time install click in Monday Dev Center
+ *
+ * Drives Steps 3-7 of the goal flow. Steps 1 (Install button click)
+ * and 8 (Uninstall click) require Mike inside Monday's admin UI; this
+ * spec verifies the *server-side* effects of those clicks.
+ *
+ * Required env (set via Doppler `factorylm/dev` for safety — never run
+ * destructive tests against prod with the prod tester account without
+ * a separate test workspace):
+ *   MONDAY_TESTER_SESSION_TOKEN   — JWT from devtools, scoped to tester
+ *   MONDAY_TESTER_ACCOUNT_ID      — numeric account_id Monday issued
+ *   MIRA_SCAN_API_BASE            — defaults to https://app.factorylm.com/api/scanbe
+ *
+ * Receipts land in tools/web-review-runs/2026-05-26-tester-install/.
+ */
+import { test, expect, request, type APIRequestContext } from "@playwright/test";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+const API_BASE =
+  process.env.MIRA_SCAN_API_BASE ?? "https://app.factorylm.com/api/scanbe";
+const TESTER_TOKEN = process.env.MONDAY_TESTER_SESSION_TOKEN ?? "";
+const TESTER_ACCOUNT_ID = process.env.MONDAY_TESTER_ACCOUNT_ID ?? "";
+
+const RECEIPTS_DIR = path.resolve(
+  __dirname,
+  "../../../tools/web-review-runs/2026-05-26-tester-install"
+);
+
+async function saveReceipt(name: string, body: string | Buffer): Promise<void> {
+  await fs.mkdir(RECEIPTS_DIR, { recursive: true });
+  await fs.writeFile(path.join(RECEIPTS_DIR, name), body);
+}
+
+test.describe("tester-install — server-side effects of Mike's Dev Center click", () => {
+  test.skip(
+    !TESTER_TOKEN || !TESTER_ACCOUNT_ID,
+    "needs MONDAY_TESTER_SESSION_TOKEN + MONDAY_TESTER_ACCOUNT_ID"
+  );
+
+  let api: APIRequestContext;
+
+  test.beforeAll(async () => {
+    api = await request.newContext({
+      baseURL: API_BASE,
+      extraHTTPHeaders: {
+        "X-Monday-Session-Token": TESTER_TOKEN,
+        "Content-Type": "application/json",
+      },
+    });
+  });
+
+  test.afterAll(async () => {
+    await api.dispose();
+  });
+
+  test("Step 2 keystone — /oauth/monday/install returns 302 to auth.monday.com", async () => {
+    // Independent of session token; just checks the env-plumbing fix landed.
+    const raw = await request.newContext({ baseURL: API_BASE });
+    const resp = await raw.get("/oauth/monday/install", {
+      maxRedirects: 0,
+    });
+    expect(resp.status(), `expected 302 got ${resp.status()}`).toBe(302);
+    const location = resp.headers()["location"] ?? "";
+    expect(location).toContain("auth.monday.com/oauth2/authorize");
+    expect(location).toContain("client_id=");
+    expect(location).toContain("redirect_uri=");
+    await saveReceipt("02a-install-redirect-location.txt", location);
+    await raw.dispose();
+  });
+
+  test("Step 3 — kb/lookup with tester sessionToken returns 200, not 401", async () => {
+    const resp = await api.get("/kb/lookup?make=Allen-Bradley&model=PowerFlex+525");
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    await saveReceipt("03-kb-lookup-tester.json", JSON.stringify(body, null, 2));
+  });
+
+  test("Step 5 — /chat/message returns sourced reply for tester", async () => {
+    const resp = await api.post("/chat/message", {
+      data: {
+        message: "What is the rated current of a PowerFlex 525 5HP at 480V?",
+        history: [],
+      },
+    });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body).toHaveProperty("reply");
+    expect(body).toHaveProperty("sources");
+    await saveReceipt("05-chat-response.json", JSON.stringify(body, null, 2));
+  });
+
+  test("Step 7 — rate-limit fires for tester after 30 messages", async () => {
+    const statuses: number[] = [];
+    for (let i = 0; i < 35; i += 1) {
+      const resp = await api.post("/chat/message", {
+        data: { message: `burst test ${i}`, history: [] },
+      });
+      statuses.push(resp.status());
+      if (resp.status() === 429) {
+        const body = await resp.json();
+        expect(body.detail.error).toBe("rate_limit_exceeded");
+        break;
+      }
+    }
+    await saveReceipt("07-rate-limit-statuses.txt", statuses.join("\n"));
+    expect(statuses).toContain(429);
+  });
+});

--- a/tools/web-review-runs/2026-05-26-tester-install/README.md
+++ b/tools/web-review-runs/2026-05-26-tester-install/README.md
@@ -1,0 +1,30 @@
+# Tester-install receipts — 2026-05-26
+
+Pre-staged for the Phase 1 tester-install walkthrough described in
+`docs/wip/phase1-tester-install/WALKTHROUGH.md`. Files land here as
+the 8-step flow runs.
+
+## Expected files (post-walkthrough)
+
+| File | Source | Format |
+|------|--------|--------|
+| 01-oauth-callback.har | Browser DevTools Network export during install | HAR |
+| 02-db-row-after-install.txt | `psql` against Neon, `monday_installations` SELECT | text |
+| 03-backend-session-logs.txt | `docker logs mira-scan-backend` filtered on account_id | text |
+| 04-assetcard-populated.png | Screenshot of populated AssetCard | PNG |
+| 04-scan-queue-rows.txt | `mira_scan_queue` SELECT scoped to tester | text |
+| 05-chat-response.json | DevTools "Copy response" on `/chat/message` | JSON |
+| 05-usage-row.txt | `account_usage_daily` SELECT | text |
+| 06-monday-update-response.json | DevTools "Copy response" on `/monday/update-item` | JSON |
+| 06-monday-audit-log.png | Screenshot of Monday admin audit log filtered to the item | PNG |
+| 07-rate-limit-burst.txt | Output of the bash burst loop | text |
+| 08-db-row-after-uninstall.txt | `monday_installations` SELECT after uninstall | text |
+| 08-reinstall-redirect.png | Screenshot of reinstall CTA top-window redirect | PNG |
+| REPORT.md | Final one-paragraph report + 8-row receipts table | markdown |
+
+## Status as of 2026-05-26
+
+Walkthrough blocked — PRs #1557 + #1558 awaiting one-word OK + redeploy.
+Once deployed and Mike has clicked Install in a tester workspace, the
+agent can drive Steps 3, 4, 5, 7 (and the SQL portions of 2 + 6 + 8)
+on the next session. Steps 1 + 6-audit-log + 8-uninstall require Mike.


### PR DESCRIPTION
## Summary

Pre-stages everything the agent + Mike need to capture the 8-step tester-install proof the moment PRs #1557 + #1558 land + a tester Monday workspace exists.

- **WALKTHROUGH.md** — copy-pasteable commands per step. Marks which need Mike's hand vs agent-drivable.
- **tester-install.spec.ts** — Playwright drives Steps 2-keystone, 3, 5, 7 against the deployed backend with a tester sessionToken. Self-skips when env vars missing.
- **receipts dir README** — expected-files index so a reviewer can tell whether a run is complete.

No code behavior change. Doc + test scaffold only.

## Stacking order

Open in chat order: **#1557 (keystone env aliasing) → #1558 (reinstall CTA) → #1559 (AUDIT.md) → #1560 (this PR).** All four together unblock the live walkthrough; this PR is the only one that needs nothing else to merge first.

## Test plan

- [ ] Reviewer reads WALKTHROUGH.md — confirm every step has a runnable command
- [ ] Reviewer checks tester-install.spec.ts compiles (`bun x tsc --noEmit` from `mira-scan-monday/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)