### PR TITLE
feat(scan-monday): /readyz config-state probe

### DIFF
--- a/mira-scan-monday/backend/main.py
+++ b/mira-scan-monday/backend/main.py
@@ -75,6 +75,37 @@ async def healthz() -> dict[str, str]:
     return {"status": "ok"}
 
 
+@app.get("/readyz")
+async def readyz() -> dict[str, Any]:
+    """Config-state probe — never returns secret values, only boolean
+    "did this env var get populated?" flags.
+
+    Used to verify the docker-compose env-plumbing fix (PR #1557) landed
+    correctly without having to dump live container env (which would
+    leak production secrets into a transcript). Read post-deploy:
+
+        curl -s https://app.factorylm.com/api/scanbe/readyz | jq
+
+    Any `false` here is a deploy-config bug, not a code bug.
+    """
+    return {
+        "status": "ok",
+        "monday_oauth_configured": oauth.configured(),
+        "monday_signing_secret_present": bool(session.MONDAY_SIGNING_SECRET),
+        "monday_webhook_secret_present": bool(webhooks.MONDAY_WEBHOOK_SIGNING_SECRET),
+        "monday_api_token_fallback_present": bool(monday_api.MONDAY_API_TOKEN),
+        "monday_oauth_redirect_uri": oauth.MONDAY_OAUTH_REDIRECT_URI,
+        "neon_database_url_present": bool(os.getenv("NEON_DATABASE_URL", "")),
+        "openai_api_key_present": bool(os.getenv("OPENAI_API_KEY", "")),
+        "serper_api_key_present": bool(os.getenv("SERPER_API_KEY", "")),
+        "mira_kb_base_url_present": bool(os.getenv("MIRA_KB_BASE_URL", "")),
+        "free_tier_monthly_cap": usage.FREE_TIER_MONTHLY_CAP,
+        "free_tier_monthly_chat_cap": usage.FREE_TIER_MONTHLY_CHAT_CAP,
+        "chat_rate_limit_per_window": rate_limit.CHAT_RATE_LIMIT_PER_WINDOW,
+        "chat_rate_limit_window_seconds": rate_limit.CHAT_RATE_LIMIT_WINDOW_SECONDS,
+    }
+
+
 # ── OAuth install flow ─────────────────────────────────────────────────────
 # When a customer installs the app from monday.com's marketplace, Monday
 # redirects them through these two endpoints. The install URL is what


### PR DESCRIPTION
## Summary

Adds `/readyz` — non-secret-leaking config probe. Each field is a boolean "did this env var get populated?" (never the value), plus the resolved redirect URI (non-secret) and runtime tier caps.

```bash
curl -s https://app.factorylm.com/api/scanbe/readyz | jq
```

Any `false` is a deploy-config bug. Lets the next session prove PR #1557's env-plumbing fix took effect from outside the container without dumping production secrets into a transcript.

## Test plan

- [ ] After deploy, `curl /api/scanbe/readyz` returns all-true for the Monday OAuth flags
- [ ] `monday_oauth_redirect_uri` matches what Monday Dev Center has registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)