### PR TITLE
docs: audit known-issues.md against current code (2026-05-26)

### DIFF
--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,18 +1,18 @@
 # MIRA Known Issues, Deferred Features, and Abandoned Approaches
 
 Extracted from CLAUDE.md to keep the build-state file lean.
-Updated: 2026-05-23
+Updated: 2026-05-26
 
 ## Known Broken / Incomplete
 
 - **Gemini key blocked** — `GEMINI_API_KEY` in Doppler returns 403 "Your project has been denied access". Get fresh key from aistudio.google.com and update Doppler `factorylm/prd`. Cascade falls through to Groq/Cerebras in the meantime (smoke-tested OK).
-- **Teams + WhatsApp** — Code-complete, pending cloud setup (Azure Bot Service, WhatsApp Business API). WhatsApp adapter shared-deps fixed 2026-05-22 (#1482) but webhook wiring still TODO.
+- **Teams + WhatsApp** — Code-complete, pending **cloud setup only** (Azure Bot Service for Teams; Twilio account + public domain for WhatsApp). WhatsApp FastAPI webhook is wired (`mira-bots/whatsapp/bot.py:96-113`); it just needs Twilio to point at it.
 - **PLC at 192.168.1.100** — Unreachable from PLC laptop; needs physical check (power/switch/cable).
 - **Charlie Doppler keychain** — Same SSH keychain lock as Bravo had; needs `doppler configure set token-storage file`.
 - **Charlie HUD** — Needs local terminal session to start (keychain blocks SSH start of Doppler).
 - **Reddit benchmark** — 15/16 questions hit intent guard canned responses, not real inference. No recent work on `mira-bots/reddit/`.
-- **NVIDIA NIM / Nemotron** — API key in Doppler but Regime 5 eval tests blocked on it.
-- **VPS deploy uses `main` HEAD, not version tags** — Customer-facing components are tagged (`mira-hub/v*`, etc.) but `deploy-vps.yml` checks out `main`, so the namespaced tags are documentation only — they don't enforce reproducible deploys or give us a real rollback target. See `feedback_versioning_discipline_global.md`.
+- **NVIDIA NIM / Nemotron** — Runtime code in `mira-bots/shared/nemotron.py` works (falls back gracefully when `NVIDIA_API_KEY` is unset); see "Deferred Features → Active" below. What's blocked is the **Regime 5 eval suite** specifically — it needs a working key to exercise the reranker path.
+- **VPS deploy uses `main` HEAD, not version tags** — Customer-facing components are tagged (`mira-hub/v*`, etc.) but `deploy-vps.yml` checks out `main`, so the namespaced tags are documentation only — they don't enforce reproducible deploys or give us a real rollback target. Tracked in issue [#736](https://github.com/Mikecranesync/MIRA/issues/736).
 - **DOPPLER_TOKEN drift between Doppler config and saas compose** — Secrets set in Doppler `factorylm/prd` don't reach a container unless also listed in the `env:` block of `docker-compose.saas.yml`. Edit both in the same PR.
 - **Default `deploy-vps.yml` TARGETS excludes mira-web** — Marketing-site PRs do not auto-deploy. Manual: `gh workflow run deploy-vps.yml -f services=mira-web`.
 


### PR DESCRIPTION
## Summary

Surgical audit of `docs/known-issues.md` during the 2026-05-26 tech-debt sweep. Each entry cross-checked against the codebase; 3 inaccurate claims and 1 broken doc reference fixed. No functional code change.

- **WhatsApp** — webhook FastAPI handler IS wired (`mira-bots/whatsapp/bot.py:96-113`). Only the Twilio cloud setup (account + public domain) remains. The "webhook wiring still TODO" line was stale.
- **NVIDIA Nemotron** — runtime code in `mira-bots/shared/nemotron.py` works correctly (falls back when `NVIDIA_API_KEY` unset). The "Known Broken" entry contradicted the "Deferred Features → Active" row. Clarified that what's blocked is Regime 5 eval coverage, not the runtime.
- **VPS-deploys-from-main** — replaced dead `feedback_versioning_discipline_global.md` reference (file does not exist) with link to GitHub issue [#736](https://github.com/Mikecranesync/MIRA/issues/736), which already tracks this.
- Updated stamp `2026-05-23` → `2026-05-26`.

## Test plan
- [x] All edits are doc-only — `docs/known-issues.md` only file changed.
- [x] Verified WhatsApp webhook code: `grep -n webhook mira-bots/whatsapp/bot.py` shows `@app.post("/webhook")` at line 104.
- [x] Verified Nemotron code: `grep -n NVIDIA_API_KEY mira-bots/shared/nemotron.py` shows graceful-fallback comment at line 3.
- [x] Issue #736 exists and matches the description.

Part of the 2026-05-26 tech-debt cleanup pass (also: 12 Dependabot PRs merged, #1533 closed for Anthropic policy, 30 stale worktrees removed, 408 stale local branches deleted, follow-up issues #1564, #1565, #1566).