### PR TITLE
chore: disable prod-guard hook + add VPS cleanup/amux workflows

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -71,10 +71,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo \"$CLAUDE_TOOL_INPUT\" | bash tools/hooks/prod-guard.sh 2>/dev/null || true"
-          },
-          {
-            "type": "command",
             "command": "echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'git commit|git push' && gitleaks protect --staged --config .gitleaks.toml 2>/dev/null || true"
           }
         ]

--- a/.github/workflows/vps-cleanup.yml
+++ b/.github/workflows/vps-cleanup.yml
@@ -1,0 +1,52 @@
+name: VPS Cleanup
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type CLEANUP to confirm'
+        required: true
+
+jobs:
+  cleanup:
+    if: github.event.inputs.confirm == 'CLEANUP'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/vps_deploy_key
+          chmod 600 ~/.ssh/vps_deploy_key
+          ssh-keyscan -H 165.245.138.91 >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Run cleanup
+        run: |
+          ssh -i ~/.ssh/vps_deploy_key -o StrictHostKeyChecking=no \
+            root@165.245.138.91 "bash -s" << 'ENDSSH'
+          set -uo pipefail
+
+          echo "=== BEFORE ==="
+          df -h /
+          free -h
+
+          echo "=== Docker prune ==="
+          docker system prune -a --volumes -f
+
+          echo "=== Log trim ==="
+          journalctl --vacuum-size=100M
+
+          echo "=== APT clean ==="
+          apt-get clean
+
+          echo "=== Tmp clean ==="
+          find /tmp -mindepth 1 -maxdepth 1 -mtime +1 -exec rm -rf {} + 2>/dev/null || true
+          find /var/tmp -mindepth 1 -maxdepth 1 -mtime +1 -exec rm -rf {} + 2>/dev/null || true
+
+          echo "=== AFTER ==="
+          df -h /
+          free -h
+
+          echo "=== Docker stats ==="
+          docker ps --format 'table {{.Names}}\t{{.Status}}'
+          docker system df
+          ENDSSH

--- a/.github/workflows/vps-install-amux.yml
+++ b/.github/workflows/vps-install-amux.yml
@@ -1,0 +1,32 @@
+name: Install amux on VPS
+
+on:
+  workflow_dispatch:
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/vps_deploy_key
+          chmod 600 ~/.ssh/vps_deploy_key
+          ssh-keyscan -H 165.245.138.91 >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Install tmux + amux
+        run: |
+          ssh -i ~/.ssh/vps_deploy_key -o StrictHostKeyChecking=no \
+            root@165.245.138.91 "bash -s" << 'ENDSSH'
+          set -uo pipefail
+
+          apt-get update && apt-get install -y tmux
+          which amux || pip install amux --break-system-packages
+
+          tmux -V
+          amux --version || echo "amux installed but no --version flag"
+
+          echo "=== Resources ==="
+          df -h /
+          free -h
+          ENDSSH


### PR DESCRIPTION
## Summary
- Remove `prod-guard.sh` from PreToolUse Bash hooks in `.claude/settings.json` (script retained at `tools/hooks/prod-guard.sh` for future re-enable; just unwired)
- Add `.github/workflows/vps-cleanup.yml` — workflow_dispatch with `CLEANUP` confirm input; runs docker prune + journal trim + apt clean + tmp clean against prod VPS
- Add `.github/workflows/vps-install-amux.yml` — workflow_dispatch; installs tmux + amux

Both workflows reuse the `VPS_SSH_KEY` secret + raw `ssh -i` pattern from `deploy-vps.yml` (no environment gate, no appleboy/ssh-action dependency).

**Why disable prod-guard:** hook was blocking SSH/docker/diagnostic commands during normal development, even read-only ones. Mike asked for it gone.

## Test plan
- [ ] Merge to main so `workflow_dispatch` workflows become visible to `gh workflow run`
- [ ] `gh workflow run vps-cleanup.yml -f confirm=CLEANUP` and verify BEFORE/AFTER disk + free output in run log
- [ ] `gh workflow run vps-install-amux.yml` and verify `tmux -V` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)