### PR TITLE
feat(conveyor): wire up live monitoring pipeline for garage demo

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,15 @@
+services:
+  mira-relay:
+    build: ./mira-relay
+    container_name: mira-relay
+    ports:
+      - "127.0.0.1:8765:8765"
+    environment:
+      - MIRA_DB_PATH=/mira-db/mira.db
+      - RELAY_PORT=8765
+      - RELAY_API_KEY=
+    volumes:
+      - ./mira-bridge/data:/mira-db
+    networks:
+      - core-net
+    restart: unless-stopped

--- a/plc/live_monitor.py
+++ b/plc/live_monitor.py
@@ -20,22 +20,23 @@ Keyboard:
 """
 
 import argparse
+import os
 import sys
-import time
 import threading
+import time
 
 try:
     from pymodbus.client import ModbusTcpClient
 except ImportError:
     from pymodbus.client.sync import ModbusTcpClient
 
-from rich.console import Console
-from rich.live import Live
-from rich.table import Table
-from rich.panel import Panel
-from rich.layout import Layout
-from rich.text import Text
 from rich import box
+from rich.console import Console
+from rich.layout import Layout
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
 
 # -- Modbus addresses (zero-indexed) -----------------------------------------
 # Coils: C1-C22 → address 0-21
@@ -117,7 +118,7 @@ def bool_text(val, true_color="green", false_color="dim"):
 def alarm_text(val, label=""):
     if val:
         return Text(f"TRUE  {label}", style="red bold")
-    return Text(f"FALSE", style="green")
+    return Text("FALSE", style="green")
 
 
 class PLCMonitor:
@@ -234,7 +235,7 @@ class PLCMonitor:
         if self.last_command:
             header.append(f"\n  Last cmd: {self.last_command}")
         if self.last_error and not self.connected:
-            header.append(f"\n  ")
+            header.append("\n  ")
             header.append(Text(self.last_error, style="red"))
 
         # -- State Machine table ----------------------------------------------
@@ -350,38 +351,75 @@ class PLCMonitor:
         return layout
 
 
-def key_listener(monitor):
-    """Non-blocking keyboard listener (Windows msvcrt)."""
+def _handle_key(monitor, key):
+    if key == "q":
+        monitor.running = False
+    elif key == "f":
+        monitor.write_vfd_cmd(18)  # GS10 FWD+RUN
+    elif key == "r":
+        monitor.write_vfd_cmd(20)  # GS10 REV+RUN
+    elif key == "s":
+        monitor.write_vfd_cmd(1)   # GS10 STOP
+    elif key == "x":
+        monitor.write_vfd_cmd(7)   # Fault reset
+    elif key == "+":
+        monitor.write_speed(monitor.speed_setpoint + 200)
+    elif key == "-":
+        monitor.write_speed(monitor.speed_setpoint - 200)
+    elif key == "0":
+        monitor.write_speed(0)
+
+
+def _key_listener_windows(monitor):
     import msvcrt
     while monitor.running:
-        if msvcrt.kbhit():
-            ch = msvcrt.getch()
+        if msvcrt.kbhit():  # type: ignore[attr-defined]
+            ch = msvcrt.getch()  # type: ignore[attr-defined]
             try:
                 key = ch.decode("utf-8", errors="ignore").lower()
             except Exception:
                 key = ""
-            if key == "q":
-                monitor.running = False
-            elif key == "f":
-                monitor.write_vfd_cmd(18)  # GS10 FWD+RUN
-            elif key == "r":
-                monitor.write_vfd_cmd(20)  # GS10 REV+RUN
-            elif key == "s":
-                monitor.write_vfd_cmd(1)   # GS10 STOP
-            elif key == "x":
-                monitor.write_vfd_cmd(7)   # Fault reset
-            elif key == "+":
-                monitor.write_speed(monitor.speed_setpoint + 200)
-            elif key == "-":
-                monitor.write_speed(monitor.speed_setpoint - 200)
-            elif key == "0":
-                monitor.write_speed(0)
+            if key:
+                _handle_key(monitor, key)
         time.sleep(0.05)
+
+
+def _key_listener_posix(monitor):
+    import select
+    import termios
+    import tty
+
+    fd = sys.stdin.fileno()
+    try:
+        old = termios.tcgetattr(fd)
+    except termios.error:
+        return  # Not a real TTY.
+
+    try:
+        tty.setcbreak(fd)
+        while monitor.running:
+            r, _, _ = select.select([sys.stdin], [], [], 0.05)
+            if not r:
+                continue
+            ch = sys.stdin.read(1)
+            if ch:
+                _handle_key(monitor, ch.lower())
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
+def key_listener(monitor):
+    """Non-blocking keyboard listener (Windows msvcrt / POSIX termios)."""
+    if os.name == "nt":
+        _key_listener_windows(monitor)
+    elif sys.stdin.isatty():
+        _key_listener_posix(monitor)
+    # else: not a TTY — keyboard control silently disabled.
 
 
 def main():
     parser = argparse.ArgumentParser(description="MIRA PLC Live Monitor")
-    parser.add_argument("--host", default="169.254.32.93", help="PLC IP address")
+    parser.add_argument("--host", default=os.getenv("DEMO_PLC_IP", "192.168.1.100"), help="PLC IP address")
     parser.add_argument("--port", type=int, default=502, help="Modbus TCP port")
     parser.add_argument("--poll", type=float, default=0.5, help="Poll interval (seconds)")
     args = parser.parse_args()

--- a/tools/bench-test-conveyor.sh
+++ b/tools/bench-test-conveyor.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "=== Conveyor Pipeline Bench Test ==="
+echo "This tests the full chain: Simulator → Poller → Relay → Node-RED Dashboard"
+echo ""
+
+# Step 1: Start Node-RED + mira-relay
+echo "[1/4] Starting Node-RED + mira-relay..."
+docker compose up -d node-red mira-relay
+sleep 5
+
+# Step 2: Health checks
+echo "[2/4] Health checks..."
+curl -sf http://localhost:1880/ > /dev/null && echo "  Node-RED: OK" || echo "  Node-RED: FAIL"
+curl -sf http://localhost:8765/health > /dev/null && echo "  Relay: OK" || echo "  Relay: FAIL"
+
+# Step 3: Start simulator in background
+echo "[3/4] Starting PLC simulator on port 5020..."
+python3 -m tools.demo_plc_simulator --port 5020 &
+SIM_PID=$!
+sleep 2
+
+# Step 4: Start poller pointed at simulator
+echo "[4/4] Starting poller (Ctrl+C to stop)..."
+echo ""
+echo "  Dashboard: http://localhost:1880/dashboard"
+echo "  Relay:     http://localhost:8765/health"
+echo ""
+python3 -m tools.demo_plc_poller \
+  --plc-ip 127.0.0.1 --plc-port 5020 \
+  --relay-url http://localhost:8765 \
+  --poll-interval 1.0
+
+# Cleanup
+kill $SIM_PID 2>/dev/null
+echo "Simulator stopped."

--- a/tools/demo_plc_poller.py
+++ b/tools/demo_plc_poller.py
@@ -107,7 +107,7 @@ ADDRESS_MAP: list[PLCPoint] = [
     PLCPoint("error_code",       HOLDING, 105, 1.0,  "demo/training/conveyor001/faults/code",              "Conveyor.ErrorCode",          "faultCode"),
 ]
 
-EQUIPMENT_ID = "conveyor001"
+EQUIPMENT_ID = "CONV-001"
 DEFAULT_TENANT_ID = "garage-demo"
 AGENT_ID = "demo-plc-poller"
 
@@ -460,7 +460,7 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p.add_argument("--plc-ip", default=os.getenv("DEMO_PLC_IP", "192.168.1.100"))
     p.add_argument("--plc-port", type=int, default=int(os.getenv("DEMO_PLC_PORT", "502")))
     p.add_argument("--poll-interval", type=float, default=float(os.getenv("DEMO_PLC_POLL_INTERVAL", "1.0")))
-    p.add_argument("--relay-url", default=os.getenv("MIRA_RELAY_URL"))
+    p.add_argument("--relay-url", default=os.getenv("MIRA_RELAY_URL", "http://localhost:8765"))
     p.add_argument("--relay-api-key", default=os.getenv("RELAY_API_KEY"))
     p.add_argument("--db-url", default=os.getenv("NEON_DATABASE_URL"))
     p.add_argument("--tenant-id", default=os.getenv("MIRA_TENANT_ID", DEFAULT_TENANT_ID))

--- a/tools/run-conveyor-live.sh
+++ b/tools/run-conveyor-live.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PLC_IP="${1:-192.168.1.100}"
+echo "=== Live Conveyor Monitor ==="
+echo "PLC: $PLC_IP"
+
+# Verify PLC reachable
+echo "[1/3] Testing PLC connectivity..."
+python3 plc/test_modbus.py "$PLC_IP" || { echo "FAIL: Cannot reach PLC at $PLC_IP"; exit 1; }
+
+# Start services
+echo "[2/3] Starting Node-RED + relay..."
+docker compose up -d node-red mira-relay
+sleep 3
+
+# Start poller
+echo "[3/3] Starting live poller (Ctrl+C to stop)..."
+echo "  Dashboard: http://localhost:1880/dashboard"
+python3 -m tools.demo_plc_poller \
+  --plc-ip "$PLC_IP" \
+  --relay-url http://localhost:8765 \
+  --poll-interval 1.0


### PR DESCRIPTION
## Summary

Tomorrow-morning prep so Mike can plug the Micro820 into the garage demo end-to-end. Closes the gaps the audit flagged.

- **Fix `EQUIPMENT_ID` mismatch** in `tools/demo_plc_poller.py` — was `conveyor001`, dashboard SQL expects `CONV-001`. Without this fix the Node-RED dashboard renders empty.
- **Add `docker-compose.override.yml`** at repo root so `mira-relay` comes up alongside the local CHARLIE stack on `127.0.0.1:8765` (binds to loopback only, mounts `mira-bridge/data` for the shared SQLite).
- **Add `tools/bench-test-conveyor.sh`** — one-shot simulator → poller → relay → Node-RED chain. Brings Node-RED + relay up, health-checks both, starts `tools.demo_plc_simulator` on port 5020, then runs the poller against it. Verifies the full pipeline before plugging into real hardware.
- **Add `tools/run-conveyor-live.sh`** — same chain pointed at the real PLC. First arg is the PLC IP (default `192.168.1.100`); fails fast via `plc/test_modbus.py` if the PLC is unreachable.
- **Fix macOS keyboard control in `plc/live_monitor.py`** — `key_listener()` was Windows-only (`msvcrt`). Added a POSIX path using `termios` + `select` in cbreak mode (set once at thread start, restored on exit). Falls through cleanly when stdin isn't a TTY (so headless runs don't crash).

## Test plan

- [ ] `bash tools/bench-test-conveyor.sh` brings up Node-RED + relay, both health checks pass, simulator + poller start, dashboard at `http://localhost:1880/dashboard` shows live values
- [ ] `bash tools/run-conveyor-live.sh 192.168.1.100` succeeds against the real Micro820 in the garage
- [ ] `python plc/live_monitor.py --host 192.168.1.100` on CHARLIE: F/R/S/X/+/-/0/Q all work from the keyboard
- [ ] Verify `live_signal_cache.equipment_id` rows are `CONV-001` after a poll cycle (no orphaned `conveyor001` rows)

## Safety

Poller stays strictly read-only (no `write_coil`/`write_register` calls). Override is loopback-bound, no public exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)