### PR TITLE
fix(uns): family-marker alias falls back to model — unblocks UNS gate loop (refs #1572 cluster 1)

### DIFF
--- a/mira-bots/shared/uns_resolver.py
+++ b/mira-bots/shared/uns_resolver.py
@@ -777,6 +777,15 @@ def resolve_uns_path(
         # alias is a model token from FAMILY_FROM_ALIAS we already populated.
         product_family = None
 
+    # When the alias matched a family-marker (gs10, gs20, powerflex, micromaster,
+    # sinamics, fr-e/a/d/f, aqua drive) AND no separate model token was extracted,
+    # fall back to the family token as the model. The family token IS the model
+    # class for these aliases — without this, confidence stays at 0.5 (mfr only)
+    # and engine.py never sets state["asset_identified"], which loops the UNS
+    # Confirmation Gate on every turn. See #1572 cluster 1.
+    if model is None and family_token:
+        model = family_token
+
     uns_path = _build_uns_path(mfr, product_family, model, fault_code, category)
 
     fresh = UNSContext(

--- a/mira-bots/shared/uns_resolver.py
+++ b/mira-bots/shared/uns_resolver.py
@@ -540,6 +540,12 @@ def _build_uns_path(
         return None
 
     family = product_family
+    # The family-marker model fallback (see resolve_uns_path) can set model
+    # equal to the family token for openers like "GS20 OC". Both occupy
+    # distinct path slots, so without this guard the path doubles the segment
+    # (.../automationdirect/gs20/gs20/...). Drop the duplicate.
+    if model and family and model.lower() == family.lower():
+        model = None
     if fault_code:
         # fault_code_path handles the "no model" fallback internally
         return _uns.fault_code_path(manufacturer, fault_code, model=model, family=family)

--- a/tests/test_uns_resolver.py
+++ b/tests/test_uns_resolver.py
@@ -398,6 +398,47 @@ def test_family_aliases_set_product_family():
 
 
 # ---------------------------------------------------------------------------
+# #1572 cluster 1 — family-marker aliases must populate model + reach 0.7
+# confidence so engine.py sets state["asset_identified"] and the UNS gate
+# stops re-firing on every turn.
+# ---------------------------------------------------------------------------
+
+
+def test_family_marker_alias_populates_model():
+    """gs10/gs20/powerflex etc. without a separate model token must still
+    expose a model so confidence reaches the 0.7 asset_identified threshold."""
+    for alias, family in FAMILY_FROM_ALIAS.items():
+        ctx = resolve_uns_path(f"my {alias} drive")
+        assert ctx.model == family, (
+            f"alias {alias!r} (no separate model token) should fall back to "
+            f"model={family!r}, got {ctx.model!r}"
+        )
+        assert ctx.confidence >= 0.7, (
+            f"alias {alias!r} should yield confidence >= 0.7 once family-marker "
+            f"falls back to model, got {ctx.confidence}"
+        )
+
+
+def test_gs20_oc_reaches_asset_identified_threshold():
+    """Fixture vague_opener_stuck_state_05 turn 2 — gate must skip after
+    this message resolves to manufacturer + family + fault."""
+    ctx = resolve_uns_path("It's a GS20, showing OC fault on the display")
+    assert ctx.manufacturer == "AutomationDirect"
+    assert ctx.model == "GS20"
+    assert ctx.fault_code == "OC"
+    assert ctx.confidence == 0.9
+
+
+def test_gs10_overcurrent_reaches_threshold():
+    """Fixture asset_change_mid_session_08 / reset_new_session_09 / 01 — gate
+    must skip even without a fault code pattern (word 'overcurrent' alone)."""
+    ctx = resolve_uns_path("GS10 VFD overcurrent fault on startup")
+    assert ctx.manufacturer == "AutomationDirect"
+    assert ctx.model == "GS10"
+    assert ctx.confidence == 0.7
+
+
+# ---------------------------------------------------------------------------
 # Offline guarantee — these must pass without a NeonDB connection
 # ---------------------------------------------------------------------------
 

--- a/tests/test_uns_resolver.py
+++ b/tests/test_uns_resolver.py
@@ -438,6 +438,23 @@ def test_gs10_overcurrent_reaches_threshold():
     assert ctx.confidence == 0.7
 
 
+def test_family_marker_path_does_not_double_segment():
+    """When model fell back to family-token, _build_uns_path must not insert
+    both as separate slots (would produce .../gs20/gs20/...).  The model
+    field still reads GS20 for downstream consumers, but the path drops the
+    duplicate slot."""
+    ctx = resolve_uns_path("GS20 OC fault")
+    assert ctx.model == "GS20"
+    assert ctx.product_family == "GS20"
+    assert ctx.uns_path is not None
+    # No "gs20.gs20" doubled segment anywhere in the path
+    assert "gs20.gs20" not in ctx.uns_path, ctx.uns_path
+    # And the manufacturer + fault still appear (path is well-formed)
+    assert "automationdirect" in ctx.uns_path
+    assert "fault_codes" in ctx.uns_path
+    assert "oc" in ctx.uns_path
+
+
 # ---------------------------------------------------------------------------
 # Offline guarantee — these must pass without a NeonDB connection
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Partial fix for #1572 — addresses **cluster 1 (UNS gate over-firing)**.

> _Issue #1572 stays open; clusters 2 and 3 tracked separately so #1572 closes only when the full eval pass rate is restored._

When a vendor alias is a **family-marker** (`gs10`, `gs20`, `powerflex`, `micromaster`, `sinamics`, `fr-e/a/d/f`, `aqua drive`), the alias-as-model strip at `uns_resolver.py:L763-771` leaves `model=None` even though the family token IS the model class. `_confidence()` then returns 0.5 (manufacturer-only), which is below the **0.7 threshold** `engine.py:L1183` uses to set `state["asset_identified"]`. The UNS Confirmation Gate then re-fires on every turn — fixtures loop at `AWAITING_UNS_CONFIRMATION` instead of advancing to Q1/Q2/DIAGNOSIS.

## Fix

After the alias-strip, if `model is None` and `family_token` is present, fall back to the family token as the model. Single new conditional. Plus a path-dedupe guard in `_build_uns_path` so the path doesn't double the segment when model==family.

## Confidence band changes (cluster-1 fixture openers)

| Fixture turn | Before | After |
|---|---|---|
| `05 turn 2` "It's a GS20, showing OC fault" | 0.5 | **0.9** |
| `08 turn 1` "GS10 VFD overcurrent fault" | 0.5 | **0.7** |
| `09 turn 1` "GS10 VFD overcurrent fault" | 0.5 | **0.7** |
| `01 turn 1` "GS10 overcurrent fault on startup" | 0.5 | **0.7** |
| `05 turn 1` "Something is wrong with the drive" | 0.0 | 0.0 (unchanged — gate correctly fires here) |

After the fix, asset_identified is set on these turns, the gate skips, and the LLM is dispatched normally per Rule 9 in `prompts/diagnose/active.yaml`.

## Scope

**In scope:**
- Cluster 1 fixtures that hit family-marker aliases (5 of 7).
- Path-dedupe guard.

**Deliberately out of scope (file follow-up issues before #1572 closes):**
- `10_abbreviation_heavy` ("pf525 oc flt") — needs `pf###` alias pattern.
- `29_sew_overcurrent` — needs `sew` vendor alias.
- Cluster 2 (doc-ask routing not exiting to IDLE) — investigation of `_handle_documentation` path.
- Cluster 3 (Q1-skip stuck on word-symptoms like "overcurrent") — `prompts/diagnose/active.yaml` Rule 9 or `FAULT_PATTERNS` extension.

## Test plan

- [x] `tests/test_uns_resolver.py` — **86/86 pass**. New tests:
  - `test_family_marker_alias_populates_model` parametrizes over `FAMILY_FROM_ALIAS`.
  - `test_gs20_oc_reaches_asset_identified_threshold` pins fixture 05 turn 2.
  - `test_gs10_overcurrent_reaches_threshold` pins fixtures 01/08/09.
  - `test_family_marker_path_does_not_double_segment` pins the path-dedupe guard.
- [x] `mira-bots/tests/test_uns_resolver_multi_vendor.py` — 12/12 pass.
- [x] `tests/conversation_suite/fixtures/cases/uns_gate/` — 9/10 (unchanged; single pre-existing failure on `uns_powerflex_f004_01` verified against `origin/main` without patch).
- [ ] **Nightly offline eval** — needs Doppler + LLM API keys; CI will confirm 2026-05-27 fixtures land at expected FSM states.

## Coordination

- PR #1563 (`feat/conversational-engine-v2`) adds a Layer 1 routing branch before the UNS gate (engine.py L1438). Files don't conflict (uns_resolver.py untouched by #1563). Whichever merges second can rebase trivially.

## Why no auto-close keyword

Title says `refs #1572` instead of the close-keyword form — this PR addresses cluster 1 only. Once clusters 2 + 3 ship in follow-up PRs, the last one of those can flip #1572 to resolved. Avoids losing the umbrella tracker on this merge.

