### PR TITLE
fix(hooks): redirect Stop-hook auto-log to gitignored PROGRESS.local.md

### DIFF
--- a/.claude/hooks/stop.sh
+++ b/.claude/hooks/stop.sh
@@ -14,10 +14,27 @@
 #     environments to avoid noisy churn (override with FORCE_LOG=1).
 
 set -u
-PROGRESS_FILE="docs/context/PROGRESS.md"
-[ -f "$PROGRESS_FILE" ] || exit 0
+
+# Auto-log target. Gitignored — see .gitignore + docs/context/PROGRESS.local.md.
+# Previously wrote to docs/context/PROGRESS.md, which polluted git status every
+# session and blocked branch switches during merge cleanup.
+PROGRESS_FILE="docs/context/PROGRESS.local.md"
 
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)" || exit 0
+
+if [ ! -f "$PROGRESS_FILE" ]; then
+  mkdir -p "$(dirname "$PROGRESS_FILE")"
+  cat > "$PROGRESS_FILE" <<'EOF'
+# Session auto-log (gitignored)
+
+Auto-appended by `.claude/hooks/stop.sh` on every Claude Code Stop event.
+Gitignored — never enters version control. To disable, remove the Stop entry
+from `.claude/settings.json`.
+
+<!-- BEGIN AUTOLOG -->
+<!-- END AUTOLOG -->
+EOF
+fi
 
 BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
 TS="$(date -u +'%Y-%m-%d %H:%M UTC')"

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ mira_copy/outputs/*
 .worktrees/
 .claude/scratchpad/
 
+# Auto-log target for .claude/hooks/stop.sh — per-machine session history
+docs/context/PROGRESS.local.md
+
 # Skill eval workspaces (skill-creator iteration runs; rebuilt locally per session)
 .claude/skills/*-workspace/
 


### PR DESCRIPTION
## Summary

- The Claude Code Stop hook (`.claude/hooks/stop.sh`) was writing session entries into the tracked `docs/context/PROGRESS.md`. Nobody commits those entries → working tree was permanently dirty → blocked `gh pr merge --delete-branch` on PR #1523 tonight (and has been quietly noisy for weeks).
- Hook now writes to `docs/context/PROGRESS.local.md`, which is gitignored. Per-machine session history is preserved; tracked file is no longer a moving target.
- Hook auto-creates the local file (with header + AUTOLOG markers) on first run so new clones work without manual setup.

## Test plan

- [x] Ran `bash .claude/hooks/stop.sh` on this branch — `PROGRESS.local.md` was created and appended; `PROGRESS.md` stayed clean.
- [x] Verified `git status` only shows the intentional changes (no PROGRESS.local.md leakage).
- [ ] Reviewer sanity-check: confirm `.gitignore` entry doesn't conflict with anything in `docs/context/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)