### PR TITLE
fix(cmms-sync): quota-aware Atlas forward sync (stop retry-loop flood)

### DIFF
--- a/mira-hub/src/lib/atlas/__tests__/sync-quota-breaker.test.ts
+++ b/mira-hub/src/lib/atlas/__tests__/sync-quota-breaker.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect } from "vitest";
+
+import { isQuotaError, createCooldownBreaker } from "../sync";
+import { AtlasHttpError } from "../client";
+
+const QUOTA_BODY =
+  "com.grash.exception.CustomException: You need a license to add a new work order. Free Limit of 30 incomplete work orders reached";
+
+describe("isQuotaError", () => {
+  test("true for a 4xx whose body names the free-tier limit", () => {
+    expect(isQuotaError(new AtlasHttpError(400, QUOTA_BODY, "/work-orders"))).toBe(true);
+  });
+
+  test("true on the 'license' / 'free limit' wording (case-insensitive)", () => {
+    expect(isQuotaError(new AtlasHttpError(402, "Valid LICENSE required", "/work-orders"))).toBe(true);
+    expect(isQuotaError(new AtlasHttpError(403, "FREE LIMIT reached", "/work-orders"))).toBe(true);
+  });
+
+  test("false for a 5xx even if the body matches (that path already backs off)", () => {
+    expect(isQuotaError(new AtlasHttpError(500, QUOTA_BODY, "/work-orders"))).toBe(false);
+  });
+
+  test("false for an unrelated 4xx", () => {
+    expect(isQuotaError(new AtlasHttpError(404, "Not Found", "/work-orders"))).toBe(false);
+  });
+
+  test("false for non-AtlasHttpError values", () => {
+    expect(isQuotaError(new Error(QUOTA_BODY))).toBe(false);
+    expect(isQuotaError(null)).toBe(false);
+    expect(isQuotaError("Free Limit reached")).toBe(false);
+  });
+});
+
+describe("createCooldownBreaker", () => {
+  test("starts closed", () => {
+    const b = createCooldownBreaker(1000, 8000);
+    expect(b.isOpen(0)).toBe(false);
+    expect(b.remainingMs(0)).toBe(0);
+  });
+
+  test("trip opens the breaker for the base cooldown, then it closes again", () => {
+    const b = createCooldownBreaker(1000, 8000);
+    const cooldown = b.trip(0);
+    expect(cooldown).toBe(1000);
+    expect(b.isOpen(500)).toBe(true);
+    expect(b.remainingMs(500)).toBe(500);
+    expect(b.isOpen(1000)).toBe(false); // skipUntil is exclusive
+    expect(b.isOpen(1001)).toBe(false);
+  });
+
+  test("successive trips back off exponentially, capped at maxMs", () => {
+    const b = createCooldownBreaker(1000, 8000);
+    expect(b.trip(0)).toBe(1000); // 1000 * 2^0
+    expect(b.trip(0)).toBe(2000); // 1000 * 2^1
+    expect(b.trip(0)).toBe(4000); // 1000 * 2^2
+    expect(b.trip(0)).toBe(8000); // 1000 * 2^3
+    expect(b.trip(0)).toBe(8000); // capped (would be 16000)
+  });
+
+  test("reset clears trip count and cooldown", () => {
+    const b = createCooldownBreaker(1000, 8000);
+    b.trip(0);
+    b.trip(0); // would be 2000 next
+    b.reset();
+    expect(b.isOpen(0)).toBe(false);
+    expect(b.trip(0)).toBe(1000); // backoff restarted from base
+  });
+});

--- a/mira-hub/src/lib/atlas/sync.ts
+++ b/mira-hub/src/lib/atlas/sync.ts
@@ -129,6 +129,10 @@ export function createCooldownBreaker(
 
 // Module-level breaker shared across ticks (the worker calls runForwardSync once
 // per tick inside one long-lived process).
+// TODO(per-tenant): key woBreaker by Atlas base URL once per-tenant Atlas
+// provisioning ships — today all tenants share one Atlas instance (one quota),
+// so a single global breaker is correct; after that, one tenant hitting its cap
+// would wrongly pause forward WO push for every tenant.
 const woBreaker = createCooldownBreaker();
 
 // ─── Forward sync: Assets (NeonDB → Atlas) ────────────────────────────────────

--- a/mira-hub/src/lib/atlas/sync.ts
+++ b/mira-hub/src/lib/atlas/sync.ts
@@ -80,6 +80,57 @@ async function withWorkerClient<T>(fn: (c: PoolClient) => Promise<T>): Promise<T
   }
 }
 
+// ─── Atlas free-tier quota breaker ────────────────────────────────────────────
+// Atlas rejects new work orders past the free-tier cap ("You need a license to
+// add a new work order. Free Limit of 30 incomplete work orders reached") with a
+// 4xx. That is a standing condition, not a transient error — retrying the whole
+// backlog every tick floods both this worker's log and the Atlas backend's
+// stack-trace log (the May 2026 9.8 GB-log / 37 %-CPU incident). We detect it,
+// stop the batch, and skip forward WO push for an exponentially-growing cooldown
+// until incomplete-WO capacity frees up.
+
+const QUOTA_ERROR_RE = /licen[cs]e|free limit|incomplete work orders/i;
+
+export function isQuotaError(err: unknown): err is AtlasHttpError {
+  return (
+    err instanceof AtlasHttpError &&
+    err.status >= 400 &&
+    err.status < 500 &&
+    QUOTA_ERROR_RE.test(err.body)
+  );
+}
+
+const WO_BREAKER_BASE_COOLDOWN_MS = 5 * 60_000; // first trip pauses 5 min
+const WO_BREAKER_MAX_COOLDOWN_MS = 60 * 60_000; // cap the backoff at 1 h
+
+// Exponential-backoff breaker. `now` is injected so it is deterministically
+// testable; callers pass Date.now().
+export function createCooldownBreaker(
+  baseMs = WO_BREAKER_BASE_COOLDOWN_MS,
+  maxMs = WO_BREAKER_MAX_COOLDOWN_MS,
+) {
+  let trips = 0;
+  let skipUntil = 0;
+  return {
+    isOpen: (now: number) => now < skipUntil,
+    remainingMs: (now: number) => Math.max(0, skipUntil - now),
+    /** Trip the breaker; returns the cooldown applied, in ms. */
+    trip: (now: number) => {
+      trips += 1;
+      skipUntil = now + Math.min(baseMs * 2 ** (trips - 1), maxMs);
+      return skipUntil - now;
+    },
+    reset: () => {
+      trips = 0;
+      skipUntil = 0;
+    },
+  };
+}
+
+// Module-level breaker shared across ticks (the worker calls runForwardSync once
+// per tick inside one long-lived process).
+const woBreaker = createCooldownBreaker();
+
 // ─── Forward sync: Assets (NeonDB → Atlas) ────────────────────────────────────
 // Assets MUST be pushed before WOs because a WO's `asset.id` reference is the
 // Atlas-side numeric ID, only known after the asset's first push.
@@ -140,6 +191,10 @@ async function pushPendingAssets(c: PoolClient, atlas: AtlasClient): Promise<Syn
       );
     } catch (err) {
       stats.errors++;
+      if (isQuotaError(err)) {
+        console.warn(`[cmms-sync] asset push stopped — Atlas quota/license limit: ${(err as AtlasHttpError).message}`);
+        break;
+      }
       console.error(`[cmms-sync] asset push failed id=${row.id}:`, err instanceof Error ? err.message : err);
       if (err instanceof AtlasHttpError && err.status >= 500) break; // back off on Atlas down
     }
@@ -165,6 +220,13 @@ interface PendingWorkOrder {
 
 async function pushPendingWorkOrders(c: PoolClient, atlas: AtlasClient): Promise<SyncStats> {
   const stats = { ...ZERO_STATS };
+  if (woBreaker.isOpen(Date.now())) {
+    console.warn(
+      `[cmms-sync] forward WO push paused (Atlas free-tier quota) — retrying in ` +
+        `${Math.ceil(woBreaker.remainingMs(Date.now()) / 60_000)}m.`,
+    );
+    return stats;
+  }
   const { rows } = await c.query<PendingWorkOrder>(
     `SELECT wo.id, wo.tenant_id, wo.atlas_id,
             wo.title, wo.description, wo.fault_description, wo.resolution,
@@ -218,8 +280,17 @@ async function pushPendingWorkOrders(c: PoolClient, atlas: AtlasClient): Promise
          WHERE id = $3 AND tenant_id = $4`,
         [atlasId, etag, row.id, row.tenant_id],
       );
+      woBreaker.reset(); // capacity confirmed — clear any prior quota cooldown
     } catch (err) {
       stats.errors++;
+      if (isQuotaError(err)) {
+        const pausedMs = woBreaker.trip(Date.now());
+        console.warn(
+          `[cmms-sync] Atlas free-tier WO quota reached — pausing forward WO push for ` +
+            `${Math.ceil(pausedMs / 60_000)}m. (${(err as AtlasHttpError).message})`,
+        );
+        break;
+      }
       console.error(`[cmms-sync] wo push failed id=${row.id}:`, err instanceof Error ? err.message : err);
       if (err instanceof AtlasHttpError && err.status >= 500) break;
     }
@@ -295,6 +366,10 @@ async function pushPendingPMs(c: PoolClient, atlas: AtlasClient): Promise<SyncSt
       );
     } catch (err) {
       stats.errors++;
+      if (isQuotaError(err)) {
+        console.warn(`[cmms-sync] pm push stopped — Atlas quota/license limit: ${(err as AtlasHttpError).message}`);
+        break;
+      }
       console.error(`[cmms-sync] pm push failed id=${row.id}:`, err instanceof Error ? err.message : err);
       if (err instanceof AtlasHttpError && err.status >= 500) break;
     }


### PR DESCRIPTION
## Problem

Atlas/Grash enforces a free-tier cap of **30 incomplete work orders**. Past the cap, every `POST /work-orders` is rejected with a 4xx `com.grash.exception.CustomException: You need a license to add a new work order. Free Limit of 30 incomplete work orders reached`.

The forward-sync push loops in `sync.ts` only backed off on `status >= 500`. The license error is a **4xx**, so each tick:
- kept trying every remaining pending WO (all failing identically), and
- never set `atlas_id`, so the **same backlog was re-pushed every 60s, forever**.

Every rejection makes the Atlas Java backend emit a full Tomcat stack trace. On the VPS staging stack this produced a **9.8 GB container log** and **~37% sustained CPU** on `stg-atlas-api`. (Acute on staging; prod's Atlas log was ~29 MB.)

## Fix

- `isQuotaError()` — a 4xx `AtlasHttpError` whose body matches `/licen[cs]e|free limit|incomplete work orders/i`.
- `createCooldownBreaker()` — exponential-backoff breaker (5 min → 1 h cap); `now` is injected for deterministic tests. A module-level instance gates forward WO push across ticks.
- `pushPendingWorkOrders`: skip the batch while the breaker is open; on a quota rejection, trip the breaker + log a **single** warn (no stack trace) + `break`; reset on a successful push (capacity confirmed).
- `pushPendingAssets` / `pushPendingPMs`: batch-stop on the same quota error.
- Unit tests for `isQuotaError` and the breaker backoff/reset (9 tests).

## Test

- `vitest run src/lib/atlas/__tests__/sync-quota-breaker.test.ts` → 9 passed
- existing `cmms-sync.test.ts` → 12 passed (no regression)
- `tsc --noEmit` clean on `lib/atlas/*`; eslint clean

## Companion action (not in this PR)

Set `CMMS_SYNC_ENABLED=false` in Doppler `factorylm/stg` — staging should never forward-push to Atlas (the worker's documented safety flag; staging booted with it `=true`, which is what triggered the incident). The compose default is already `:-false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)