### PR TITLE
fix(hub): login form accessibility — htmlFor, method=post, min-w on submit

### DIFF
--- a/mira-hub/src/app/login/login-form.tsx
+++ b/mira-hub/src/app/login/login-form.tsx
@@ -145,10 +145,11 @@ function LoginFormInner() {
               </button>
             </div>
           ) : (
-            <form onSubmit={handleMagicLink} className="mb-4">
-              <label className="block text-xs font-medium text-slate-400 mb-1.5">Email magic link</label>
+            <form onSubmit={handleMagicLink} method="post" className="mb-4">
+              <label htmlFor="magic-email" className="block text-xs font-medium text-slate-400 mb-1.5">Email magic link</label>
               <div className="flex gap-2">
                 <Input
+                  id="magic-email"
                   type="email"
                   value={magicEmail}
                   onChange={(e) => setMagicEmail(e.target.value)}
@@ -161,7 +162,7 @@ function LoginFormInner() {
                   type="submit"
                   aria-label="Send magic link"
                   disabled={magicLoading || !magicEmail}
-                  className="px-4 h-11 rounded-md font-medium text-white text-sm disabled:opacity-50 flex items-center gap-1.5"
+                  className="px-4 h-11 min-w-[44px] rounded-md font-medium text-white text-sm disabled:opacity-50 flex items-center justify-center gap-1.5"
                   style={{ background: "linear-gradient(135deg,#2563EB,#0891B2)" }}
                 >
                   {magicLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Mail className="w-4 h-4" />}


### PR DESCRIPTION
## Summary

- Added `htmlFor`/`id` pairing on the magic-link email input (screen reader label association)
- Added `method="post"` to the magic-link form element
- Added `min-w-[44px]` + `justify-center` to submit button for 44px touch target compliance

## Test plan

- [ ] Open Hub login page, verify magic-link email input is focusable via label click
- [ ] Verify submit button is at least 44px wide at all viewport sizes
- [ ] Build passes (`npm run build` in `mira-hub/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)