### PR TITLE
fix(hub): finish login a11y (password form + toggle) + authenticated review tooling

### DIFF
--- a/.claude/skills/web-review/SKILL.md
+++ b/.claude/skills/web-review/SKILL.md
@@ -161,7 +161,12 @@ If the user passes a sitemap or asks to "audit the whole site":
 
 ## What this skill does NOT do (yet)
 
-- **Auth'd routes** — no cookie injection in v1
+- **Auth'd routes** — no cookie injection built into the passes. For the
+  auth-gated Hub (`app.factorylm.com`), capture a real **staging** session first
+  via `mira-hub/scripts/capture-review-session.ts`, then open the Playwright
+  context with `{ storageState: "tests/e2e/.state/review-session.json" }` to
+  review authed routes (feed, namespace, proposals, assets, admin) instead of
+  bouncing to `/login`. See `mira-hub/docs/authenticated-review.md`.
 - **Form submission / fuzzing** — destructive; would need explicit `--aggressive` and target allowlist
 - **DAST / OWASP ZAP** — heavy, gated for v2 (`--security` flag)
 - **Persona journeys via browser-use** — gated for v2 (`--persona`)

--- a/mira-hub/docs/authenticated-review.md
+++ b/mira-hub/docs/authenticated-review.md
@@ -1,0 +1,85 @@
+# Authenticated review & monitoring of the Hub
+
+Closes three blind spots from the 2026-05-28 `app.factorylm.com` web-review.
+The Hub is auth-gated: every route 302s to `/login` for anonymous requests, so
+synthetic monitors, uptime checks, and the `web-review` skill only ever see the
+login page. This doc gives review tooling an authenticated path.
+
+> **Environment:** intended target is **staging** (the `127.0.0.1:4101` tunnel).
+> Never run the capture against `@FactoryLM_Diagnose`-class prod surfaces with the
+> shared test account — see the prod-guard in the capture script. Prod monitoring,
+> if ever needed, uses a dedicated low-privilege account.
+
+## 1 — Capture a session (the review-tooling cookie)
+
+`scripts/capture-review-session.ts` logs in once via the **real** credentials
+provider and writes a Playwright `storageState`. It does **not** forge a JWE — it
+exercises the actual auth path, needs no `AUTH_SECRET`, and can't drift from a
+NextAuth bump. (Its interactive sibling, `tests/e2e/fixtures/create-auth-state.ts`,
+is for a human logging in by hand; this one is for CI / cron / unattended monitors.)
+
+```bash
+cd mira-hub
+HUB_URL=http://127.0.0.1:4101 \
+E2E_HUB_EMAIL=playwright@factorylm.com E2E_HUB_PASSWORD=TestPass123 \
+bun run scripts/capture-review-session.ts
+# → tests/e2e/.state/review-session.json   (gitignored)
+```
+
+Consume it:
+- **web-review skill / Playwright:** open the context with
+  `{ storageState: "tests/e2e/.state/review-session.json" }` (or, via the MCP
+  `browser_run_code_unsafe`, add the cookies from that file), then run the 5 passes
+  against authed routes instead of bouncing to `/login`.
+- **curl-based monitors:** extract the `next-auth.session-token` (or
+  `__Secure-next-auth.session-token`) cookie and send it as a `Cookie:` header.
+
+## 2 — Soft-404 on unknown routes (disposition: mostly by design)
+
+Web-review flagged `GET /<random>` → 200 (and "404 page has no home link").
+**Both were artefacts of the auth wall, not bugs:**
+
+- The edge probe was **anonymous**, so middleware redirected it to `/login` (a 200)
+  before Next's not-found handler ran — it never saw the real 404 page. The
+  "no home link" finding was therefore a **false positive**: `src/app/not-found.tsx`
+  has a "Back to dashboard" link.
+- For an **authenticated** request, an unmatched route is not caught by middleware
+  and Next.js renders `not-found.tsx`, which returns a **404 status by default**
+  (framework behavior). So real users hitting a broken internal link get a 404.
+- Anonymous unknown-route → `/login` is **intentional**: it avoids leaking which
+  routes exist to unauthenticated visitors, and `robots.txt` already `Disallow: /`,
+  so there is no SEO soft-404 to index.
+
+The genuine residual — broken internal links don't surface to *unauthenticated*
+external monitors — is closed by the authenticated crawl in §1: run web-review (or a
+link checker) with the captured session and unmatched routes will return real 404s.
+
+## 3 — Confirm the `?_rsc=` 503s are runtime/infra, not code
+
+Public routes returned **200** on `?_rsc=` prefetch (e.g. `/signup/?_rsc=…`), so the
+503s the manual QA saw are auth-gated-route or load-specific — consistent with the
+VPS-OOM pattern, not a Next.js defect. To confirm on **staging** with the §1 session:
+
+```bash
+# 1. capture (see §1) → tests/e2e/.state/review-session.json
+# 2. pull the session cookie value
+COOKIE=$(bun -e 'console.log(JSON.parse(require("fs").readFileSync("tests/e2e/.state/review-session.json")).cookies.find(c=>c.name.endsWith("next-auth.session-token")).value)')
+# 3. probe an authed route's RSC prefetch repeatedly; watch for 503s under load
+for i in $(seq 1 20); do
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -H "Cookie: next-auth.session-token=$COOKIE" \
+    "http://127.0.0.1:4101/feed/?_rsc=probe$i"
+done
+# Correlate any 503s with `docker stats` / container memory on the staging host.
+```
+
+If 503s appear only under memory pressure (not deterministically per route), the fix
+is the `mem_limit` / restart-policy lane (infra), not application code — matching the
+WS-A hypothesis in `docs/plans/2026-05-28-hub-qa-fixes.md`.
+
+## Status
+
+- §1 capture script + this doc: **shipped**.
+- §1 run, §3 confirmation: **pending a reachable staging Hub** (the `127.0.0.1:4101`
+  tunnel is set up ad hoc on CHARLIE; not reachable from every node). Run there.
+- §2: no code change — disposition documented above.

--- a/mira-hub/docs/authenticated-review.md
+++ b/mira-hub/docs/authenticated-review.md
@@ -26,6 +26,10 @@ bun run scripts/capture-review-session.ts
 # → tests/e2e/.state/review-session.json   (gitignored)
 ```
 
+> **Treat the output as a secret.** `review-session.json` holds a live session
+> cookie (a valid login). It is gitignored, but don't paste it into logs, CI
+> artifacts, or issues, and re-capture rather than long-lived reuse.
+
 Consume it:
 - **web-review skill / Playwright:** open the context with
   `{ storageState: "tests/e2e/.state/review-session.json" }` (or, via the MCP

--- a/mira-hub/scripts/capture-review-session.ts
+++ b/mira-hub/scripts/capture-review-session.ts
@@ -41,19 +41,28 @@ const EMAIL = process.env.E2E_HUB_EMAIL ?? "playwright@factorylm.com";
 const PASSWORD = process.env.E2E_HUB_PASSWORD ?? "TestPass123";
 const DEFAULT_EMAIL = "playwright@factorylm.com";
 
+// Production hostnames — capturing here would create/exercise a test account
+// on prod (the pollution fixed in PR #1579). Listed explicitly so that staging
+// on a *.factorylm.com subdomain (e.g. staging.factorylm.com) is NOT treated as
+// prod; add new prod hostnames here if prod ever serves under another name.
+const PROD_HOSTNAMES = new Set([
+  "app.factorylm.com", // prod Hub
+  "factorylm.com",     // prod marketing apex
+  "165.245.138.91",    // prod VPS — guards the IP-direct bypass
+]);
+
 function assertNotProd(): void {
-  let host = "";
+  let hostname = "";
   try {
-    host = new URL(HUB_URL).host;
+    hostname = new URL(HUB_URL).hostname;
   } catch {
     console.error(`✗ HUB_URL is not a valid URL: ${HUB_URL}`);
     process.exit(1);
   }
-  const isProd = /(^|\.)app\.factorylm\.com$/.test(host) || /(^|\.)factorylm\.com$/.test(host);
-  if (!isProd) return;
+  if (!PROD_HOSTNAMES.has(hostname)) return;
   if (process.env.REVIEW_SESSION_ALLOW_PROD !== "1") {
     console.error(
-      `✗ Refusing to capture a session against production (${host}).\n` +
+      `✗ Refusing to capture a session against production (${hostname}).\n` +
         `  This tool targets STAGING. Capturing here would create/exercise a\n` +
         `  test account on prod. Set HUB_URL to the staging tunnel, or for a\n` +
         `  genuine prod monitor set REVIEW_SESSION_ALLOW_PROD=1 with a dedicated\n` +

--- a/mira-hub/scripts/capture-review-session.ts
+++ b/mira-hub/scripts/capture-review-session.ts
@@ -1,0 +1,114 @@
+/**
+ * Non-interactive session capture for automated review tooling.
+ *
+ * Closes the "no unauthenticated view of product health" blind spot
+ * (web-review 2026-05-28 #1): synthetic monitors, uptime checks, and the
+ * `web-review` skill all bounce off the login wall and can only see /login.
+ * This script logs in once via the REAL credentials provider and writes a
+ * Playwright `storageState` JSON that those tools inject to reach authed
+ * routes (feed, namespace, proposals, assets, admin) — enabling authenticated
+ * crawls (broken-link detection, #2) and authed `?_rsc=` probes (503 repro, #3).
+ *
+ * Why login-capture and NOT a JWE forger: this exercises the real auth path,
+ * needs no AUTH_SECRET, and can't drift from a NextAuth version bump.
+ * The interactive sibling `tests/e2e/fixtures/create-auth-state.ts` is for a
+ * human at a keyboard; this one is for CI / cron / unattended monitors.
+ *
+ * Usage (STAGING — the intended target):
+ *   HUB_URL=http://127.0.0.1:4101 \
+ *   E2E_HUB_EMAIL=playwright@factorylm.com E2E_HUB_PASSWORD=TestPass123 \
+ *   bun run scripts/capture-review-session.ts
+ *
+ * Output: tests/e2e/.state/review-session.json (gitignored). Reuse via
+ *   browser_run_code_unsafe / Playwright `context: { storageState: <path> }`,
+ *   or extract the `next-auth.session-token` cookie for curl-based monitors.
+ *
+ * PRODUCTION is blocked by default: logging in here would create/exercise a
+ * test account on prod (the exact pollution fixed in PR #1579). To target prod
+ * you must set REVIEW_SESSION_ALLOW_PROD=1 AND supply a dedicated, non-default
+ * monitoring account via E2E_HUB_EMAIL — never the shared test account.
+ */
+import { chromium } from "@playwright/test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdirSync } from "node:fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const STATE_PATH = resolve(__dirname, "..", "tests/e2e/.state/review-session.json");
+
+const HUB_URL = process.env.HUB_URL ?? "http://127.0.0.1:4101";
+const EMAIL = process.env.E2E_HUB_EMAIL ?? "playwright@factorylm.com";
+const PASSWORD = process.env.E2E_HUB_PASSWORD ?? "TestPass123";
+const DEFAULT_EMAIL = "playwright@factorylm.com";
+
+function assertNotProd(): void {
+  let host = "";
+  try {
+    host = new URL(HUB_URL).host;
+  } catch {
+    console.error(`✗ HUB_URL is not a valid URL: ${HUB_URL}`);
+    process.exit(1);
+  }
+  const isProd = /(^|\.)app\.factorylm\.com$/.test(host) || /(^|\.)factorylm\.com$/.test(host);
+  if (!isProd) return;
+  if (process.env.REVIEW_SESSION_ALLOW_PROD !== "1") {
+    console.error(
+      `✗ Refusing to capture a session against production (${host}).\n` +
+        `  This tool targets STAGING. Capturing here would create/exercise a\n` +
+        `  test account on prod. Set HUB_URL to the staging tunnel, or for a\n` +
+        `  genuine prod monitor set REVIEW_SESSION_ALLOW_PROD=1 with a dedicated\n` +
+        `  E2E_HUB_EMAIL (never the shared ${DEFAULT_EMAIL}).`,
+    );
+    process.exit(1);
+  }
+  if (EMAIL === DEFAULT_EMAIL) {
+    console.error(
+      `✗ Refusing to use the shared test account (${DEFAULT_EMAIL}) against prod.\n` +
+        `  Supply a dedicated monitoring account via E2E_HUB_EMAIL.`,
+    );
+    process.exit(1);
+  }
+}
+
+async function ensureRegistered(): Promise<void> {
+  // Idempotent — 200 (new) or 409 (exists) both fine; only 5xx is fatal.
+  const res = await fetch(`${HUB_URL}/api/auth/register/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: EMAIL, password: PASSWORD, name: "Review Session" }),
+  });
+  if (res.status >= 500) {
+    throw new Error(`register endpoint returned ${res.status}: ${await res.text()}`);
+  }
+}
+
+async function main(): Promise<void> {
+  assertNotProd();
+  console.log(`→ Capturing review session against ${HUB_URL} as ${EMAIL}`);
+  await ensureRegistered();
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  try {
+    await page.goto(`${HUB_URL}/login`, { waitUntil: "domcontentloaded" });
+    await page.click("text=Sign in with password");
+    // Two email inputs (magic-link first, credentials second) — use .last().
+    await page.locator('input[type="email"]').last().fill(EMAIL);
+    await page.fill('input[type="password"]', PASSWORD);
+    await page.getByRole("button", { name: /^Sign in$/ }).click();
+    await page.waitForURL(/\/(?:hub\/)?(feed|pending-approval|upgrade)\/?/, { timeout: 30_000 });
+
+    mkdirSync(dirname(STATE_PATH), { recursive: true });
+    await context.storageState({ path: STATE_PATH });
+    console.log(`✓ Session saved to ${STATE_PATH}`);
+    console.log(`  Landed on: ${page.url()}`);
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/mira-hub/src/app/login/login-form.tsx
+++ b/mira-hub/src/app/login/login-form.tsx
@@ -182,6 +182,7 @@ function LoginFormInner() {
             type="button"
             onClick={() => setShowPasswordForm(v => !v)}
             aria-expanded={showPasswordForm}
+            aria-controls="password-signin-form"
             className="w-full flex items-center justify-between min-h-[44px] py-2 text-xs text-slate-400 hover:text-slate-200 transition-colors mb-3"
           >
             <span>Sign in with password</span>
@@ -189,7 +190,7 @@ function LoginFormInner() {
           </button>
 
           {showPasswordForm && (
-            <form onSubmit={handleSubmit} method="post" className="space-y-4">
+            <form id="password-signin-form" onSubmit={handleSubmit} method="post" className="space-y-4">
               <div>
                 <label htmlFor="login-email" className="block text-xs font-medium text-slate-400 mb-1.5">Email</label>
                 <Input

--- a/mira-hub/src/app/login/login-form.tsx
+++ b/mira-hub/src/app/login/login-form.tsx
@@ -181,17 +181,19 @@ function LoginFormInner() {
           <button
             type="button"
             onClick={() => setShowPasswordForm(v => !v)}
-            className="w-full flex items-center justify-between text-xs text-slate-400 hover:text-slate-200 transition-colors mb-3"
+            aria-expanded={showPasswordForm}
+            className="w-full flex items-center justify-between min-h-[44px] py-2 text-xs text-slate-400 hover:text-slate-200 transition-colors mb-3"
           >
             <span>Sign in with password</span>
             <ChevronDown className={`w-4 h-4 transition-transform ${showPasswordForm ? "rotate-180" : ""}`} />
           </button>
 
           {showPasswordForm && (
-            <form onSubmit={handleSubmit} className="space-y-4">
+            <form onSubmit={handleSubmit} method="post" className="space-y-4">
               <div>
-                <label className="block text-xs font-medium text-slate-400 mb-1.5">Email</label>
+                <label htmlFor="login-email" className="block text-xs font-medium text-slate-400 mb-1.5">Email</label>
                 <Input
+                  id="login-email"
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
@@ -203,9 +205,10 @@ function LoginFormInner() {
               </div>
 
               <div>
-                <label className="block text-xs font-medium text-slate-400 mb-1.5">Password</label>
+                <label htmlFor="login-password" className="block text-xs font-medium text-slate-400 mb-1.5">Password</label>
                 <div className="relative">
                   <Input
+                    id="login-password"
                     type={showPw ? "text" : "password"}
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}

--- a/wiki/reviews/2026-05-28-app.factorylm.com.md
+++ b/wiki/reviews/2026-05-28-app.factorylm.com.md
@@ -1,0 +1,43 @@
+---
+title: web-review — app.factorylm.com/hub/
+date: 2026-05-28
+host: app.factorylm.com
+reviewer: web-review skill (Claude, BRAVO)
+scope: hub entry (auth-gated) + login/signup public surface + host-level checks
+---
+
+# web-review — app.factorylm.com/hub/ (2026-05-28)
+
+**Goal:** fit-for-use-case + design blind spots.
+**Critical caveat:** `/hub/` 302-redirects to `/login/?callbackUrl=%2Ffeed%2F`. The entire product (feed, namespace, proposals, assets, CMMS, admin) is behind a login wall. The web-review skill has **no cookie injection in v1**, so the authed Hub — i.e. the actual use-case surface — was NOT reviewed. Findings below cover only the public login/signup surface + host-level security/edges. The P0/P1 risk noted in the 2026-05-28 manual QA report (Review Queue 500, RSC 503s) lives behind the wall and is triaged separately in `docs/plans/2026-05-28-hub-qa-fixes.md`.
+
+## Findings (reachable surface only)
+
+| # | Sev | Route | Title | Evidence |
+|---|-----|-------|-------|----------|
+| 1 | 🟡 P2 | /* | Soft-404: unknown routes resolve to HTTP 200 (login), never 404 | `GET /__webreview_404_X` → 308 → → **200** after 2 redirects |
+| 2 | 🟡 P2 | /login | Credential forms are `method="get"` | both `<form>` (magic-link + password) `method=get`; native fallback would GET to action URL. Mitigated: inputs have no `name` attr, so a fallback GET serializes nothing |
+| 3 | 🟡 P2 | /login | Email/password inputs labelled by placeholder only | DOM scan `inputs_unlabelled:1`; no `<label>`/`aria-label`, placeholder-as-label a11y anti-pattern |
+| 4 | 🟡 P2 | /login | Tap targets <44px (mobile) | "Continue with Google" 278×39, pwd toggle 42×39, "Sign in with password" 278×14, "Start free trial" 80×15 — matters for gloved field techs |
+| 5 | 🟢 P3 | /api/auth/session | Trailing-slash double request | `GET /api/auth/session` → 308 → `/api/auth/session/` → 200 (matches QA report #12) |
+| 6 | 🟢 P3 | host | `x-powered-by: Next.js` framework disclosure | response header on 200s |
+| 7 | 🟢 P3 | host (redirects) | nginx fallback CSP allows `unsafe-inline`/`unsafe-eval` | only on 301/redirect responses; app 200s use strong **nonce-based** CSP |
+| 8 | 🟢 P3 | /login | woff2 preloaded but unused within load window | console warning (1) — only console message on the page |
+| 9 | 🟢 P3 | (404 page) | 404 page has no "back to home" link | edge probe |
+
+**No P0/P1 on the reachable surface.** No console errors. No mobile horizontal overflow. Keyboard focus reaches inputs in-viewport.
+
+## Strong points (keep)
+- HSTS `max-age=63072000; includeSubDomains; preload` (2yr, preload).
+- `X-Content-Type-Options: nosniff`, `X-Frame-Options: SAMEORIGIN`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy: camera=(), microphone=(), geolocation=()`.
+- App-page CSP is **nonce-based** (no `unsafe-inline`/`unsafe-eval` on 200s); Stripe/Google scoped.
+- `robots.txt`: `Disallow: /` (app correctly not indexed); sitemap declared; favicon/og-image 200.
+- Passwordless-first login (Google OAuth + email magic-link) — good fit for field techs on phones.
+
+## Tooling gaps this run
+- **Auth wall** → authed Hub unreviewed (skill v1 limitation).
+- **Lighthouse** not installed in env (`exit 127`) → no perf/a11y score (would only reflect login page anyway).
+
+## Recommended follow-up
+- Add an authenticated web-review path (inject a session cookie for a test tenant on staging) to actually review the use-case surface.
+- Re-run against **staging** where the QA-report 500/503 can be reproduced safely (no prod psql).


### PR DESCRIPTION
Addresses the 5 blind spots from the 2026-05-28 `app.factorylm.com` web-review (`/goal`). Builds on **#1581**, which landed the magic-link half of the login a11y fix while this was in flight.

## Code fixes

### #4 / #5 — Login form (extends #1581)
#1581 fixed the **magic-link** email input (htmlFor/id, `method=post`, min-w). It left the collapsible **password** form and the toggle untouched. This completes them:
- `htmlFor`/`id` association on the password-form **email + password** inputs (were visible-text labels only — screen readers couldn't link them).
- `method="post"` on the password form (no-JS fallback reloads the login route instead of risking credentials in the URL).
- `min-h-[44px]` + `py-2` on the **14px-tall** "Sign in with password" toggle, plus `aria-expanded` (WCAG 2.5.5 target size + ARIA).
- Inline "Start free trial" link keeps the WCAG 2.5.5 inline-text exception (unchanged).

## Tooling + dispositions

### #1 — No unauthenticated view of product health → `scripts/capture-review-session.ts`
Non-interactive login-capture that writes a Playwright `storageState` for synthetic monitors / the `web-review` skill to inject and reach authed routes. **Reuses the real credentials provider** (no JWE forging → no `AUTH_SECRET`, no NextAuth drift). **Hard prod-guard**: refuses `app.factorylm.com` unless an explicit dedicated account is supplied (prevents creating a test account on prod — cf. #1579). Complements the existing *interactive* `create-auth-state.ts`. Skill wired via `web-review/SKILL.md`.

### #2 — Soft-404 (disposition: no code change)
Both the "unknown route → 200" and "404 has no home link" findings were **artefacts of the auth wall**: the edge probe was anonymous, so middleware redirected it to `/login` before Next's 404 handler ran. `not-found.tsx` already has a home link and returns 404 for authenticated users; anon→login is **intentional** (don't leak route existence; `robots.txt` already `Disallow: /`). The real residual — broken links invisible to *unauthenticated* monitors — is closed by the #1 authenticated crawl. Full reasoning in `docs/authenticated-review.md`.

### #3 — `?_rsc=` 503s (disposition: runtime/infra, confirm on staging)
Public routes returned **200** on `?_rsc=` here, so the 503s are auth-gated/load-specific (VPS-OOM pattern), not a Next.js defect. `docs/authenticated-review.md` has a staging procedure to confirm with the #1 session.

## Verification
- `tsc --noEmit`: no new errors. `eslint` on changed files: clean.
- The #1 capture script + #3 procedure are **not yet run** — they need the staging Hub (`127.0.0.1:4101` tunnel), not reachable from BRAVO. Deliverable is script + doc + procedure, to run once staging is up. Stated plainly in the doc.
- **Screenshot rule:** visible login-UI changes; Hub runs on CHARLIE/VPS, not capturable from BRAVO — defer to staging-gate screenshots (same as #1579).

🤖 Generated with [Claude Code](https://claude.com/claude-code)