### PR TITLE
docs(miradrop): v2 ingest design lock — ADR-0019, spec, plan

### DIFF
--- a/docs/adr/0019-miradrop-ingest-v2.md
+++ b/docs/adr/0019-miradrop-ingest-v2.md
@@ -1,0 +1,103 @@
+# ADR-0019: MiraDrop Ingest v2 — auto-splitter, KG flywheel, UNS templated artifact
+
+**Status:** Accepted
+**Date:** 2026-05-26
+**Supersedes:** none
+**Related:** ADR-0008 (sidecar deprecation), ADR-0013 (UNS schema canonicalization), ADR-0014 (AI suggestions as work queue), `docs/specs/maintenance-namespace-builder-spec.md`
+
+## Context
+
+`~/MiraDrop/inbox/` is the desktop drop-folder UX where a technician (today: Mike on CHARLIE; tomorrow: any tenant) drops a manual, photo, or wiring diagram and walks away. The watcher daemon (`tools/mira-drop-watcher/`) forwards files to Hub's `/api/uploads/folder` endpoint.
+
+Today's path:
+1. Watcher → Hub `local-upload.ts` (buffers entire file in RAM via `await file.arrayBuffer()`, hard 20 MB cap)
+2. Hub → `mira-core/mira-ingest` (`/document`, also hard 20 MB cap — comment: "Telegram limit, enforced universally")
+3. Open WebUI chunks + embeds + stores
+4. No KG attribution. No UNS path. No dialogue with the technician.
+
+A 33 MB Rockwell PowerFlex 525 reference manual dropped 2026-05-24 was rejected with `exceeds_20mb_limit`. The cap exists because the in-memory buffer is unbounded and the 8 GB VPS has OOM'd twice from docling in May 2026 (memory: `project_vps_oom_docling_incidents.md`). Lifting the cap naively reintroduces the OOM risk; keeping it caps the product wedge to ~20 % of real OEM manuals.
+
+The deeper problem isn't the cap. It's that ingest is silent: chunks land in KB but nothing connects them to the technician's actual work context. The KG stays empty of evidence-grounded facts. There is no "templated item" a future reader can recognize.
+
+## Decision
+
+Build **mira-ingest-v2**, a new ingest service that replaces the OW path for MiraDrop. The pipeline is dialogue-driven, KG-attributed, and tech-confirmed.
+
+### Architecture summary
+
+| Layer | Choice |
+|---|---|
+| Splitting unit | Text-chunk granularity (not physical PDF split). One Drop → one logical document → one `hub_uploads` row → N chunks in `knowledge_entries`. |
+| Network path | Watcher → Hub (streams) → mira-ingest-v2. Hub remains the multi-tenant gateway; never buffers the file. |
+| Execution model | Async worker. HTTP returns 202 after the file lands on disk; worker advances `hub_uploads.status` through phases. |
+| Queue | `hub_uploads` row IS the queue. Worker holds rows via `SELECT ... FOR UPDATE SKIP LOCKED WHERE ingest_route='v2' AND status='queued'`. |
+| Schema strategy | Extend `hub_uploads` and `knowledge_entries` in place. No sibling tables. Nullable columns preserve legacy OW-path behavior. |
+| Where v2 runs | CHARLIE only, this build. Cloud-side instance is a Day-2 deployment when a customer channel needs it. |
+| Docling RAM control | `do_ocr=False` when the PDF has a text layer (the common case); spawn-per-job subprocess lifecycle. |
+| Extraction | Hybrid — filename heuristic → rule-based first-N-pages → LLM cascade fallback. `extraction_method` annotated per drop. |
+| UNS resolution | **Tech-confirmed via Slack dialogue**, not unilaterally assigned. The UNS Location-Confirmation Gate (from the namespace-builder spec) fires on drop. |
+| KG promotion model | Two states (`proposed`/`verified`) with `verified_by` provenance (`tech` / `admin` / `system_consensus`). Tech's Slack tap promotes the manual binding. Derived facts (fault codes, components) promote only via corroboration or explicit admin action. |
+| Revision handling | Detect-and-prompt the tech via Slack ("looks like a newer revision — replace, append, separate, cancel?"). Default-on-TTL-expiry = append. |
+| Failure semantics | Per-phase checkpoints. Each phase commits idempotently. Crashed jobs resume from last phase via stale-claim sweep. |
+| Readiness integration | After binding, the Slack confirmation DM reports the L0–L6 score delta and the next-action CTA from `health_scores.missing`. |
+| Photos | Out of scope this build. PDFs only; photos continue on `mira-core/mira-ingest`. Path C (v2 orchestrates photo-ingest as a downstream) is the explicit follow-up. |
+| Artifact | A model-level QR PNG sidecar in `~/MiraDrop/done/`, encoding the tech-confirmed UNS path's Hub URL. |
+
+### Doctrine alignments
+
+- **UNS Location-Confirmation Gate** (`.claude/CLAUDE.md` § Non-negotiable): the drop is treated as a new input event to the existing gate machinery. No KG writes before tech confirmation.
+- **No silent KG promotion** (`.claude/CLAUDE.md` § Knowledge graph proposals): every `verified` row carries `verified_by` provenance. Pure transitive auto-verification is forbidden.
+- **Environment doctrine** (`docs/environments.md`): all schema changes ship dev → staging → prod via `apply-migrations.yml`. v2 itself runs CHARLIE-local only; never on the prod VPS this round.
+- **Slack is the front door** (North Star): the dialogue lives in Slack, mirroring the troubleshooting flow.
+- **Provider cascade** (PRD §4 + memory `feedback_llm_cascade_default`): LLM-fallback extraction goes through Groq → Cerebras → Gemini. No Anthropic, ever.
+- **Single source of truth**: `hub_uploads` is the queue, the audit log, and the row Hub UI renders. No sibling tables (the dual-truth pattern bit us with `kg_relationships` columns — `project_kg_relationships_schema.md`).
+
+## Consequences
+
+### Positive
+- The 20 MB rejection goes away by removing the in-memory buffer, not by raising a number. Streaming end-to-end means the cap is determined by disk, not RAM.
+- Every drop produces a tech-confirmed UNS path, a KG entity, a verified manual binding, and a scannable QR sidecar. The "templated item future readers understand" goal is met per drop, not per-batch-admin-review.
+- The L0 → L6 readiness score moves visibly per drop, giving the tech a continuous feedback loop and FactoryLM a visible value-prop artifact.
+- The KG accumulates corroborating evidence across drops without auto-promoting unverified extractions. The two-state + `verified_by` model gives future readers a clear audit chain.
+- No new infrastructure (no Redis, no separate queue service). Queue-by-table reuses what Hub already runs.
+- Per-phase checkpoints make long jobs (1000+ page manuals) resumable and observable.
+
+### Negative
+- Two ingest surfaces during the cutover: v2 (new) + OW path (legacy, still serving photos). The `ingest_route` column on `knowledge_entries` and `hub_uploads` is the discriminator. This is the "dual-truth" risk we accept; it stops the day v2 absorbs photos.
+- The Slack dialogue adds a step. A tech who drops 50 manuals at once will be asked to confirm bindings — mitigated by batching ("3 of 50 look like revisions — review?") but never zero-friction.
+- Schema changes touch live tables (`hub_uploads`, `knowledge_entries`, possibly `kg_relationships`). All additive, but each migration is one more thing to roll forward through dev → staging → prod.
+- Docling subprocess-per-job costs ~3 – 5 s of cold-start per drop. Acceptable for an async ingest; would be unacceptable for a sync API.
+- LLM cascade fallback consumes free-tier quota when rules miss. Bounded but non-zero.
+
+### Risks tracked elsewhere
+- VPS OOM if v2 is later deployed cloud-side without the two docling levers. → `project_vps_oom_docling_incidents.md` is mandatory reading before that deployment.
+- Recall regression on legacy chunks if `knowledge_entries` migration changes column behavior. → New columns are nullable; recall path is untouched.
+- Slack DM noise if the tech is doing a bulk-drop. → Batching policy in the spec (Q12 default-on-TTL is the cap).
+
+## Alternatives rejected
+
+| Considered | Rejected because |
+|---|---|
+| Raise the 20 MB cap to 200 MB | Would solve the immediate rejection but not the OOM or the missing KG attribution. The cap is a symptom, not the cause. |
+| Physical PDF split (qpdf → sub-PDFs) | Breaks page anchors; creates multiple "documents" per source; reinvents what `chunker.py` already does at text level. |
+| Sync HTTP all the way through | A 1200-page manual exceeds every reasonable timeout. Hub's connection holds for tens of minutes. One slow job blocks the next. |
+| Redis-backed queue (arq) | Adds Redis as a MiraDrop dependency for no win over queue-by-table. Postgres-as-queue scales fine at single-user / single-digit-drops-per-hour. |
+| Sibling `mira_ingest_jobs` table | Dual-truth with `hub_uploads`. The pattern keeps biting us. |
+| LLM-only extraction | Wrong on ~5 – 15 % of weird PDFs; silent corruption of KG identity. Rules-first is conservative; LLM is fallback. |
+| Auto-promote all extracted facts after tech confirmation | Violates the "verification → admin" doctrine. Transitive promotion without corroboration is exactly the bug the doctrine names. |
+| Latest revision supersedes older | Silently revokes tech-verified facts from the older revision. Violates "verification once granted, never silently revoked." |
+| v2 includes photo path now | Doubles the build for unproven need. Photos work today on the existing path. |
+
+## Open questions deferred to implementation
+
+1. TTL for the Q10 dialogue (24 h default; revisit after observing real usage).
+2. Whether the LLM fallback for extraction is sync (one call per drop) or batched per worker tick.
+3. Exact Slack block-kit shape for the binding + readiness DM (owned by `slack-technician-ux-writer` skill).
+4. Whether `verified_by='system_consensus'` requires N=2 or N=3 corroborating sources (start at 2, monitor false-positive rate).
+
+## References
+
+- Spec: `docs/specs/miradrop-ingest-v2-spec.md`
+- Plan: `docs/plans/2026-05-26-miradrop-auto-splitter.md`
+- Sibling specs: `docs/specs/maintenance-namespace-builder-spec.md`, `docs/specs/mira-component-intelligence-architecture.md`, `docs/specs/uns-message-resolver-spec.md`
+- Memory: `project_miradrop_tracks`, `project_vps_oom_docling_incidents`, `project_recall_embedding_gate`, `project_uns_schema_canonicalization`, `project_kg_relationships_schema`

--- a/docs/plans/2026-05-26-miradrop-auto-splitter.md
+++ b/docs/plans/2026-05-26-miradrop-auto-splitter.md
@@ -1,0 +1,293 @@
+# Plan — MiraDrop Auto-Splitter / Ingest v2 (CHARLIE prove-it)
+
+**Date:** 2026-05-26
+**Locked through:** 2026-06-30 (5-week build window for v2 prove-it on CHARLIE)
+**Companion docs:** [ADR-0019](../adr/0019-miradrop-ingest-v2.md) · [Spec](../specs/miradrop-ingest-v2-spec.md)
+**Trigger:** 2026-05-24 drop of `2080-rm001_-en-e.pdf` (33 MB Rockwell ref manual) rejected with `exceeds_20mb_limit`.
+
+---
+
+## Currently in-flight
+
+_Update before claiming work in this plan. Last verified: 2026-05-26 (post-grilling design lock; nothing built yet)._
+
+- [ ] No work started. Design lock only.
+- [ ] Coordinate with: `2026-04-19-mira-90-day-mvp.md` (this work fits under Unit 9b — ingestion intelligence), `2026-05-15-maintenance-namespace-builder.md` (this consumes the namespace builder's readiness scoring + dialogue gate).
+- [ ] Pre-flight: run `git fetch origin/main` and rebase before starting any phase below (per memory `feedback_fetch_origin_before_state_claims`).
+
+---
+
+## Goal
+
+Drop *anything* of any size into `~/MiraDrop/inbox/`. End state: rich, page-anchored chunks in KB; tech-confirmed UNS-pathed Equipment + Manual in KG; QR PNG sidecar; readiness score moves. All proven on CHARLIE before any cloud-side deployment.
+
+## Locked decisions (from grilling 2026-05-26)
+
+Each one is also in ADR-0019 § Architecture summary. Anchor reference only:
+
+| # | Decision |
+|---|---|
+| Q1 | Text-chunk granularity (no physical PDF split) |
+| Q2 | Track 2 / mira-ingest-v2 / OW-free path |
+| Q3 | Watcher → Hub (streams) → v2 |
+| Q4 | Async worker (HTTP 202; phases advance off-thread) |
+| Q5 | CHARLIE only, this build |
+| Q6 | `hub_uploads` IS the queue (`FOR UPDATE SKIP LOCKED`) |
+| Q7 | Extend `hub_uploads` in place |
+| Q8 | Extend `knowledge_entries` in place |
+| Q9 | Hybrid extractor: filename → rules → LLM fallback |
+| Q10 | Drop opens Slack dialogue; D-hybrid seed |
+| Q11 | Two-state + `verified_by` provenance |
+| Q12 | Detect-and-prompt for revisions; default-on-TTL = append |
+| Q13 | Per-phase checkpoints, idempotent writes |
+| Q14 | Slack confirmation DM reports L0–L6 delta + next-action CTA |
+| Q15 | PDFs only this build; photos stay on existing path |
+
+## Out of scope (this build)
+
+- Photos in v2 (deferred to v2.1)
+- Cloud-side v2 deployment (deferred to when a customer channel needs it)
+- Replacing OW for non-MiraDrop ingest paths (Drive/Dropbox)
+- Renaming the `knowledge_entries.source_page` column wart
+- Multi-tenant isolation refinements beyond what `hub_uploads.tenant_id` already provides
+
+## Phases
+
+Each phase is independently mergeable behind feature flags. Slice 1 must land before Slice 2 (queue depends on schema). Slices 3-7 can interleave once Slice 2 lands.
+
+### Slice 0 — Pre-flight (~half day)
+
+**Branch:** `feat/miradrop-v2-preflight`
+
+- [ ] `git fetch origin/main && git rebase` from current branch baseline.
+- [ ] Confirm CHARLIE has free disk for `~/MiraDrop/processing/` and a target ingest spool (e.g. `~/MIRA/var/ingest-v2/spool/`).
+- [ ] Verify `tools/mira-drop-watcher/main.py` is running and processing drops on the OW path (current production state).
+- [ ] Confirm the 2026-05-24 failed PDF (`~/MiraDrop/failed/2080-rm001_-en-e.pdf`) is preserved — we'll use it as the canary test case.
+- [ ] Snapshot the current `hub_uploads` row count and the current `knowledge_entries` row count. Both should not change during Slice 1.
+- [ ] Open a tracking issue in GitHub. Link to ADR-0019 and the spec.
+
+**Exit criteria:** branch ready, baseline preserved, canary PDF ready.
+
+### Slice 1 — Schema migrations (1-2 days)
+
+**Branch:** `feat/miradrop-v2-schema`
+
+Migrations only. No code reads or writes the new columns yet — additive surface for everything that follows.
+
+- [ ] Write `mira-hub/db/migrations/030_hub_uploads_v2.sql` per Spec § 4.1.
+- [ ] Write `docs/migrations/002_knowledge_entries_chunk_anchors.sql` per Spec § 4.2.
+- [ ] Write `mira-hub/db/migrations/031_kg_relationship_provenance.sql` per Spec § 4.3.
+- [ ] Local apply against dev Neon. Confirm row counts unchanged.
+- [ ] PR; run `apply-migrations.yml` with `dry-run` against staging, then `apply`.
+- [ ] Prod migrations: hold until Slice 2 lands and is partially verified. (Schema changes are safe to land, but no value until code uses them — bundle.)
+
+**Tests:** `pytest tests/migrations/` (if the suite exists) + manual `psql \d hub_uploads` and `\d knowledge_entries` against dev + staging.
+
+**Exit criteria:** all three migrations applied to dev + staging without errors. Prod hold.
+
+### Slice 2 — v2 HTTP endpoint + worker skeleton (3-4 days)
+
+**Branch:** `feat/miradrop-v2-worker-skeleton`
+
+The smallest possible v2 service that accepts streamed uploads, claims rows, runs a no-op pipeline, advances status to `parsed`. No docling yet. No extraction yet. No Slack dialogue yet. Proves the queue and per-phase checkpoint model.
+
+- [ ] New service: `mira-ingest-v2/` (FastAPI + uvicorn). Sibling of `mira-core/mira-ingest/`.
+- [ ] Endpoint: `POST /v2/uploads` streams body to disk, creates a `hub_uploads` row with `ingest_route='v2'`, `status='queued'`. Returns 202.
+- [ ] Worker process: `mira-ingest-v2/worker.py`. Single-process, single-concurrency. `SELECT … FOR UPDATE SKIP LOCKED LIMIT 1 WHERE ingest_route='v2' AND status='queued'`. Heartbeat every 30 s.
+- [ ] No-op pipeline: `queued → parsing → embedding → kg_proposing → parsed` advances over ~5 s with sleeps. Proves the state machine, not the work.
+- [ ] launchd plist: `com.factorylm.mira-ingest-v2.{api,worker}.plist`.
+- [ ] Hub side: `local-upload.ts` gains a branch — when `kind === 'document'` AND the new feature flag is on, route to v2 via streamed fetch instead of `forwardToIngest`. **Stream `req.body` directly — do NOT call `await file.arrayBuffer()`**. Keep the existing OW branch as fallback when flag is off.
+- [ ] Feature flag: `HUB_MIRADROP_V2_ENABLED` env var on Hub. Default off.
+- [ ] Hub also drops the `MAX = 20 * 1024 * 1024` check from the v2 branch (the check stays on the OW branch).
+
+**Tests:**
+- Unit: worker claim/release under concurrent claim (use two threads).
+- Integration: `curl` a 50 MB random PDF through Hub with the flag on. Expect `hub_uploads.status='parsed'` within 30 s.
+- Regression: with the flag off, OW path still works for a small PDF.
+- Stale-claim recovery: kill the worker mid-job, restart, confirm the row resets to `queued` after 5 min.
+
+**Exit criteria:** the 33 MB canary PDF round-trips through v2 to `status='parsed'` without errors. OW path still works for non-MiraDrop drops.
+
+### Slice 3 — Docling + chunker + embedder integration (3-5 days)
+
+**Branch:** `feat/miradrop-v2-docling`
+
+Replace the no-op pipeline phases with real work. PDFs come out the other end as chunks in `knowledge_entries`.
+
+- [ ] New module: `mira-ingest-v2/pipeline/parse.py`. Spawns the docling subprocess.
+- [ ] `mira-ingest-v2/docling_runner/__main__.py`: subprocess entrypoint. Reads a path, runs DoclingAdapter (`do_ocr` flag determined by `pypdf` text-layer detection), emits JSON-lines per chunk on stdout. Exits 0 on success.
+- [ ] Worker: spawn subprocess via `subprocess.Popen`. Read stdout incrementally. Per-chunk JSON → chunker.py → batched embeddings → `INSERT INTO knowledge_entries` (50 chunks per transaction, with `ON CONFLICT (doc_id, chunk_index) DO NOTHING`).
+- [ ] Use the existing `mira-crawler/ingest/chunker.py` and `mira-crawler/ingest/converter.py` — don't reinvent.
+- [ ] Embedder backend: reuse the existing embedder used by `mira-core/mira-ingest/main.py`. Don't fork; the embedding dimensions must match `knowledge_entries.embedding vector(768)`.
+- [ ] Fill `doc_id`, `page_start`, `page_end`, `section_path`, `ingest_route='v2'` for every row.
+- [ ] No KG, no extraction, no Slack yet. Just chunks landing.
+
+**Tests:**
+- Drop the canary PDF. Expect ~500-1200 rows in `knowledge_entries WHERE doc_id=…`, all with `page_start IS NOT NULL`.
+- Spot-check three random chunks: do `page_start` / `page_end` actually correspond to the PDF page? (Open the PDF, find the text, verify.)
+- Memory: worker process resident memory before docling subprocess vs. during vs. after. Confirm post-job is within ~50 MB of pre-job (subprocess kill releases PyTorch pools).
+- Resume: kill worker during embedding phase, restart, confirm no duplicate chunks (idempotency).
+
+**Exit criteria:** canary PDF produces page-anchored chunks in `knowledge_entries`. Memory returns to baseline between jobs.
+
+### Slice 4 — Extraction + KG writes (3-4 days)
+
+**Branch:** `feat/miradrop-v2-extraction-kg`
+
+The KG part of the pipeline. Still no Slack — the binding is auto-applied to `model_only` for this slice. Slice 5 adds the dialogue.
+
+- [ ] New module: `mira-ingest-v2/pipeline/extract.py`. Implements the D-hybrid extractor (filename → rules → LLM fallback per Spec § 6.1, but used here only for the *candidate* binding before Slack).
+- [ ] Filename heuristic: small lookup table of vendor catalog prefixes. Lives in `mira-ingest-v2/pipeline/vendor_prefixes.py`. Initial vendors: Rockwell (`2080`, `1734`, `1756`, `5069`), ABB (`ACS\d+`), Siemens (`6SL\d+`, `6ES\d+`), Allen-Bradley shared.
+- [ ] Rule extractor: reuse `mira-bots/shared/uns_resolver.py`'s alias table + `_looks_like_model_number`. Run over the first 10 pages' text.
+- [ ] LLM fallback: cascade `Groq → Cerebras → Gemini` (existing `mira-bots/shared/inference/router.py`). Single call per drop, JSON-mode prompt: `{manufacturer, model, equipment_type, confidence}`. **Never Anthropic.**
+- [ ] Write `hub_uploads.extracted_manufacturer`, `extracted_model`, `extraction_method`, `extraction_confidence`.
+- [ ] If extraction succeeds: call `kg_writer.register_equipment_and_manual` with `binding_state='model_only'`, `verified_by=NULL` (proposed).
+- [ ] Run `fault_codes.extract_from_text` over all chunks. For each match, `kg_writer.register_fault_code` with confidence 0.85 → `proposed`.
+- [ ] Update `hub_uploads.kg_entity_id` + `kg_relationship_count`.
+
+**Tests:**
+- Canary PDF: expect `extracted_manufacturer='Rockwell Automation'`, `extracted_model='2080'` or `Micro820`, `extraction_method='filename'` or `'rule'`.
+- A PDF with no clear branding: expect `extraction_method='llm'`.
+- A PDF the LLM also fails on: expect `extracted_manufacturer=NULL`, `error_class='extraction_failed'`, drop lands in `awaiting_review` admin queue (which is just a `hub_uploads` filtered query, no new UI).
+- KG: confirm `kg_entities` has one new Equipment + one new Manual, and `kg_relationships` has Equipment-HAS_MANUAL with `verified_by IS NULL`.
+- Fault codes: confirm at least 5 `proposed` HAS_FAULT rows for the canary.
+
+**Exit criteria:** drop produces KG entities + proposed relationships. No facts are `verified` yet (Slice 5).
+
+### Slice 5 — Slack dialogue (UNS gate for ingest) (4-5 days)
+
+**Branch:** `feat/miradrop-v2-slack-dialogue`
+
+The dialogue layer. This is where "drop opens a conversation" becomes real.
+
+- [ ] Worker phase 4: instead of auto-binding to `model_only`, send a Slack DM via the existing `mira-bots/slack/bot.py` adapter.
+- [ ] DM block-kit shape per Spec § 6.1 (defer button text wording to `slack-technician-ux-writer` skill before write).
+- [ ] Seed buttons via D-hybrid:
+  - Query the FSM session log for `dropping_user_id`'s active thread context.
+  - Query last 48 h confirmed contexts from session log.
+  - Always include "model template" and "type UNS path" buttons.
+- [ ] Button taps land on a new Hub route `POST /api/v2/ingest/:upload_id/bind` with `{uns_path, source: 'tech_tap'}`. Hub validates against `uns.is_valid_path`, writes to `hub_uploads.uns_path`, fires worker continuation (publishes event to a small Redis channel or polls `hub_uploads`).
+- [ ] On revision detection (Phase 4b), send the second prompt per Spec § 6.2. Write `hub_uploads.revision_handling`.
+- [ ] On TTL expiry (24 h, configurable via env `MIRADROP_V2_BINDING_TTL_SECS`): default to model template; mark `binding_state='model_only'`.
+- [ ] After binding, promote the Manual-HAS_EQUIPMENT relationship to `verified_by='tech'` (Spec § 4.3 promotion rules).
+
+**Tests:**
+- Drop the canary. Expect a Slack DM with 3-4 buttons.
+- Tap "model template" → `hub_uploads.uns_path` becomes `enterprise.knowledge_base.rockwell_automation.micro820`. Relationship promotes to verified.
+- Don't respond for 24 h (or set TTL to 60 s for the test). Confirm default-to-model fires.
+- Drop a revision of the same manual. Expect the second prompt. Tap "append". Confirm both manuals exist in KG, neither superseded.
+- Tap "cancel — wrong file". Confirm `status='cancelled'`, no KG writes, chunks remain in KB (debatable — see open Q below).
+
+**Open Q for Slice 5:** what happens to chunks when the tech cancels the binding? Recommend: keep them (they're useful for retrieval), but never link them to an Equipment. Effectively orphan chunks with `doc_id` set but no KG relationship pointing at them. Surface in admin queue for cleanup.
+
+**Exit criteria:** end-to-end drop → DM → tap → KG verified. The wedge is live.
+
+### Slice 6 — Artifacts + readiness DM (2 days)
+
+**Branch:** `feat/miradrop-v2-artifacts`
+
+The visible "templated item" output the tech walks away with.
+
+- [ ] New module: `mira-ingest-v2/pipeline/artifact.py`. Generates the QR PNG (use `qrcode[pil]`) encoding the Hub URL.
+- [ ] Update sidecar shape: extend `~/MiraDrop/done/{file}.ingest.json` per Spec § 7.
+- [ ] Hub route: `GET /hub/kg/[unsPath]` renders the entity page (this may already exist via the namespace-builder work — check `mira-hub/src/app/(hub)/namespace/`). If not, scaffold.
+- [ ] Worker phase 6: call `recalculate_health_score(tenant_id, uns_path)` (or its equivalent — check Spec § 5.2 of the namespace-builder spec for the actual function name). Read back the new level + first item from `missing`.
+- [ ] Slack `chat.update` on the original binding DM with the confirmation reply per Spec § 6.3.
+- [ ] Watcher: update `tools/mira-drop-watcher/main.py` to log the QR path location to its sidecar (no behavioral change needed; v2 writes the file directly).
+
+**Tests:**
+- Drop → done folder contains `.qr.png` next to original.
+- Scan the QR with a phone → opens the Hub entity page.
+- Confirmation DM contains a real L_old → L_new delta and a real next-action string.
+- Drop a manual for an unrelated equipment → confirm readiness score for OTHER nodes doesn't change.
+
+**Exit criteria:** every successful drop ends with a Slack DM celebrating the level-up. Canary PDF takes us from whatever-state to whatever-next-state visibly.
+
+### Slice 7 — Citation formatter + retrieval polish (2-3 days)
+
+**Branch:** `feat/miradrop-v2-citations`
+
+Make the new chunks visible in bot replies.
+
+- [ ] Update `mira-bots/shared/citation_compliance.py`: when a retrieved chunk has `page_start IS NOT NULL` AND `ingest_route='v2'`, format citation as *"…per the {extracted_model} manual, p. {page_start}, §{section_path} ([source]({hub_url}))…"*. Legacy chunks fall through unchanged.
+- [ ] Update the recall path's reply formatter (`mira-bots/shared/engine.py` or `rag_worker.py` — check current shape after PR #1385).
+- [ ] Regression: existing OW-path chunks still cite the same way they do today.
+- [ ] Add a v2-specific golden case to `tests/golden_factorylm.csv`: "What does the PowerFlex 525 manual say about F004?" expected reply must cite the manual + a real page number.
+
+**Tests:**
+- Run the GS-suite (`tests/golden_*.csv`) post-change; no regressions on existing cases.
+- Manually ask the Slack bot about F004 after the canary is ingested. Reply should contain *"per the Rockwell Automation Micro820 manual, p. {N}, §{section}"* (or the actual extracted model).
+
+**Exit criteria:** bot replies cite v2-route chunks with page + section. Recall stays correct for legacy chunks.
+
+### Slice 8 — Hub admin surface for v2 (2-3 days)
+
+**Branch:** `feat/miradrop-v2-hub-admin`
+
+The "you have a queue of things to look at" surface.
+
+- [ ] Hub UI page: `/hub/ingest/v2-queue`. Lists `hub_uploads` rows where:
+  - `status='awaiting_confirmation'` AND `claimed_at < now() - interval '6 hours'` (long-pending dialogues).
+  - `status='failed'` (with retry button).
+  - `extracted_manufacturer IS NULL AND ingest_route='v2'` (extraction failures).
+- [ ] Hub UI page: `/hub/proposals/from-drops`. Lists `kg_relationships WHERE status='proposed' AND source_id IN (chunks FROM v2-route)`. Admin can bulk-approve via existing approval flow (per ADR-0014 / `ai_suggestions`).
+- [ ] Retry button: `POST /api/v2/ingest/:upload_id/retry`. Resets row to `queued`. Worker re-runs from last completed phase (idempotency keeps the work clean).
+
+**Tests:**
+- Force a docling failure (drop a 5 MB JPG renamed `.pdf`). Confirm row lands in `failed` with `error_class='docling_failed'`. Click retry → fails again. Confirm same row, retry count tracked (add a `retry_count INTEGER DEFAULT 0` column if it doesn't already exist).
+- Confirm Hub admin queue page renders the failed row.
+
+**Exit criteria:** Mike can see and fix stuck/failed drops in the Hub UI without touching SQL.
+
+### Slice 9 — Cleanup, docs, smoke-test (1 day)
+
+**Branch:** `feat/miradrop-v2-finalize`
+
+- [ ] Flip `HUB_MIRADROP_V2_ENABLED=true` as default. Keep the OW path code paths intact but unreachable for MiraDrop drops.
+- [ ] Update `tools/mira-drop-watcher/README.md` with the new pipeline.
+- [ ] Update `CLAUDE.md` root § "Pointers" to mention this spec + plan.
+- [ ] Update `wiki/hot.md` (per CLAUDE.md "Session start: read wiki/hot.md").
+- [ ] Add to the eval-watcher set (`tests/eval/watch_set.txt`) the v2 golden case from Slice 7.
+- [ ] Run `bash install/smoke_test.sh` (per CLAUDE.md verification workflow).
+- [ ] Take a screenshot pair (per the Screenshot Rule):
+  - `docs/promo-screenshots/{date}_miradrop-v2-drop-slack-dm_desktop.png`
+  - `docs/promo-screenshots/{date}_miradrop-v2-readiness-delta_desktop.png`
+
+**Exit criteria:** v2 is the default path for MiraDrop. OW path stays available as the legacy fallback. Docs reflect reality.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Docling subprocess still OOMs on a pathological PDF | The two levers (do_ocr=False on text PDFs, subprocess-per-job) drop expected peak to ~2 GiB. Add an explicit `resource.setrlimit(RLIMIT_AS, 4 * GiB)` in the subprocess entry as a hard ceiling — kills the subprocess instead of the worker. |
+| Slack rate limits during a bulk-drop session | Batch the binding DMs ("3 of 50 manuals look like revisions — review?"). The first cut: send one DM per drop, monitor, batch only if pain materializes. |
+| LLM fallback exhausts free-tier quota | Cascade Groq → Cerebras → Gemini. Each has independent quotas. Track 429s; if all three fail, drop lands in extraction-failure queue, not blocked. |
+| Schema migration on prod NeonDB fails | All migrations are additive (nullable columns). Roll-forward only. `apply-migrations.yml --dry-run` precedes every prod apply. |
+| Watcher polls Hub stale data during the awaiting_confirmation phase | TTL = 24 h for the dialogue. Watcher's existing `INGEST_POLL_TIMEOUT_SECS=180` is too short for v2 — bump it to 86_400 for v2 rows or change the watcher to return early on `awaiting_confirmation` and let the sidecar update later. Recommend the latter (lower friction). |
+| `kg_relationships` schema drift between Hub migrations and engine migrations | Memory `project_uns_schema_canonicalization` is mandatory pre-reading before Slice 4. Hub migration `031` extends the prod-canonical column set (`source_id`/`target_id`/`relationship_type` per memory `project_kg_relationships_schema`). |
+
+## Dependencies on other in-flight work
+
+- **90-day MVP plan (Unit 9b — ingestion intelligence):** this work IS the implementation of Unit 9b's "drop → tech-confirmed UNS-pathed Equipment + Manual" outcome.
+- **Namespace-builder plan (2026-05-15):** v2 consumes the readiness scoring + UNS gate machinery defined there. Phase 2 of that plan (decide endpoint, drag-drop, recompute worker) is shipped per memory `project_phase2_slice1` — usable from Slice 6 onward.
+- **PR #1385 recall-embedding-gate fix:** required to be on `main` (it is, per memory `project_recall_embedding_gate`) before Slice 7's citation work.
+- **Slack-technician-ux-writer skill:** consult before locking the block-kit shape for any DM in Slice 5 or Slice 6.
+
+## Verification gates per slice
+
+Each slice must, before merge:
+- Pass `ruff check .` and `ruff format --check .` (per `.claude/rules/python-standards.md`).
+- Pass relevant `tests/regime*/` suite for any module it touches.
+- Add at least one new test that would catch the regression it's introducing.
+- Run the canary drop (`2080-rm001_-en-e.pdf`) end-to-end and capture the result in the PR description.
+- Update this plan's "Currently in-flight" section.
+
+## Definition of done (overall)
+
+All Spec § 13 acceptance criteria pass on CHARLIE with the 33 MB canary PDF and at least one revision drop. `HUB_MIRADROP_V2_ENABLED=true` is the default. OW path remains available behind the flag for non-MiraDrop ingest.
+
+## When to revisit
+
+- After 50 real drops through v2 (empirical data on `extraction_method` distribution, TTL ghost rate, revision-handling distribution).
+- Before the first customer-channel ingest (triggers the Day-2 cloud-side deployment work).
+- If the readiness L-delta feedback isn't visibly driving more drops within 2 weeks of Slice 6 shipping (UX hypothesis falsified — revise the DM, not the architecture).

--- a/docs/specs/miradrop-ingest-v2-spec.md
+++ b/docs/specs/miradrop-ingest-v2-spec.md
@@ -1,0 +1,385 @@
+# MiraDrop Ingest v2 — Specification
+
+**Status:** Draft → Active 2026-05-26
+**Owners:** Mike (product), MIRA engine team (implementation)
+**Companion docs:** `docs/adr/0019-miradrop-ingest-v2.md` · `docs/plans/2026-05-26-miradrop-auto-splitter.md`
+**Doctrine references:** `.claude/CLAUDE.md`, `docs/specs/maintenance-namespace-builder-spec.md`, `docs/environments.md`, `.claude/rules/uns-compliance.md`
+
+## 1. Purpose
+
+Define the contract for **mira-ingest-v2**, the replacement ingest path for drops landing in `~/MiraDrop/inbox/`. v2 turns a dropped file (any size, PDF this build) into:
+
+1. Page-anchored, section-tagged chunks in `knowledge_entries` (KB).
+2. A tech-confirmed UNS-pathed Equipment entity + Manual relationship in `kg_entities`/`kg_relationships` (KG).
+3. Extracted fault codes / components as **proposed** relationships pending corroboration.
+4. A model-level QR PNG sidecar the technician can stick on the physical asset.
+5. A readiness-score delta surfaced to the technician via Slack ("L1 → L2; next step: …").
+
+A successful drop is one where any future reader of the KB or KG can see exactly **what the document is, what equipment it describes, who confirmed that binding, and what's still proposed pending review**.
+
+## 2. Non-goals
+
+- **No physical PDF splitting.** Splitting is done at the text-chunk layer by `mira-crawler/ingest/chunker.py`. The PDF stays one logical document.
+- **No new queue infrastructure.** `hub_uploads` is the queue.
+- **No photo path.** Out of scope this build (see ADR-0019 § Alternatives).
+- **No replacement of the OW path for non-MiraDrop ingest.** OW continues to serve Google Drive / Dropbox uploads + existing collections.
+- **No promotion of extracted facts to `verified` without a human signal in the dependency chain.** Auto-promotion is forbidden by `.claude/CLAUDE.md`.
+- **No cloud-side v2 instance this round.** v2 runs on CHARLIE only.
+
+## 3. Pipeline
+
+```
+MiraDrop watcher
+        │  (HTTPS multipart, streamed body)
+        ▼
+mira-hub  /api/uploads/folder
+        │  (auth + tenant resolution; INSERTs hub_uploads row;
+        │   pipes req.body straight to v2 — no in-memory buffer)
+        ▼
+mira-ingest-v2  HTTP endpoint    ── returns 202 once file lands on disk ──┐
+        │                                                                  │
+        ▼                                                                  │
+File on local disk + hub_uploads row claimed by worker                     │
+        │                                                                  │
+        ▼                                                                  │
+v2 worker — single concurrency, SELECT FOR UPDATE SKIP LOCKED              │
+                                                                           │
+  ┌─────────────────────────────────────────────────────────────────┐      │
+  │  Phase 1: parsing                                                │      │
+  │    - docling subprocess (do_ocr=False if PDF has text layer)     │      │
+  │    - converter.py + chunker.py over result.document              │      │
+  │    - HEARTBEAT every 30 s                                        │      │
+  │  COMMIT: file_parsed, page_count, chunk_count_estimate           │      │
+  ├─────────────────────────────────────────────────────────────────┤      │
+  │  Phase 2: embedding                                              │      │
+  │    - batch embed via existing embedder backend                   │      │
+  │    - INSERT into knowledge_entries with                          │      │
+  │      doc_id = hub_uploads.id, ingest_route='v2',                 │      │
+  │      page_start, page_end, section_path                          │      │
+  │    - 50-chunk batches; commit after each batch                   │      │
+  │  COMMIT: status='embedding' → status='awaiting_confirmation'     │      │
+  ├─────────────────────────────────────────────────────────────────┤      │
+  │  Phase 3: extraction                                             │      │
+  │    - filename heuristic → vendor catalog prefixes                │      │
+  │    - rule extractor over first 10 pages (uns_resolver alias)     │      │
+  │    - LLM cascade fallback if rules miss                          │      │
+  │    - writes extracted_manufacturer, extracted_model,             │      │
+  │      extraction_method to hub_uploads                            │      │
+  ├─────────────────────────────────────────────────────────────────┤      │
+  │  Phase 4: Slack dialogue (UNS Location-Confirmation Gate)        │      │
+  │    - sends DM to dropping user via slack-bolt bot                │      │
+  │    - buttons seeded from D-hybrid:                               │      │
+  │        a) current open thread context                            │      │
+  │        b) recent confirmed contexts (last 24-48h)                │      │
+  │        c) model template only (cold)                             │      │
+  │        d) type UNS path manually                                 │      │
+  │    - on revision detection: second prompt (Q12)                  │      │
+  │  WAIT: tech confirmation, or TTL=24h → default to model template │      │
+  ├─────────────────────────────────────────────────────────────────┤      │
+  │  Phase 5: kg_proposing                                           │      │
+  │    - register_equipment_and_manual() with tech-confirmed UNS     │      │
+  │    - Manual binding: verified_by='tech'                          │      │
+  │    - fault-code sweep across all chunks                          │      │
+  │    - HAS_FAULT relationships: proposed (or system_consensus      │      │
+  │      if corroborated by ≥1 other manual)                         │      │
+  │    - link_chunk_to_equipment for each chunk                      │      │
+  │  COMMIT: hub_uploads.kg_entity_id, kg_relationship_count         │      │
+  ├─────────────────────────────────────────────────────────────────┤      │
+  │  Phase 6: artifact                                               │      │
+  │    - render QR PNG to ~/MiraDrop/done/{file}.qr.png              │      │
+  │    - update ingest.json sidecar with uns_path, hub_url, qr_image │      │
+  │    - call recalculate_health_score(tenant_id, uns_path)          │      │
+  │    - update or send follow-up Slack DM with score delta + CTA    │      │
+  │  COMMIT: status='parsed'                                         │      │
+  └─────────────────────────────────────────────────────────────────┘
+```
+
+## 4. Schema changes
+
+### 4.1 `hub_uploads` (extend in place)
+
+```sql
+-- mira-hub/db/migrations/030_hub_uploads_v2.sql
+ALTER TABLE hub_uploads
+  ADD COLUMN IF NOT EXISTS claimed_at             TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS claimed_by             TEXT,
+  ADD COLUMN IF NOT EXISTS worker_heartbeat_at    TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS kg_entity_id           UUID,
+  ADD COLUMN IF NOT EXISTS kg_relationship_count  INTEGER DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS extracted_manufacturer TEXT,
+  ADD COLUMN IF NOT EXISTS extracted_model        TEXT,
+  ADD COLUMN IF NOT EXISTS extraction_method      TEXT,   -- 'rule' | 'llm' | 'filename' | 'manual'
+  ADD COLUMN IF NOT EXISTS extraction_confidence  TEXT,   -- 'high' | 'medium' | 'low'
+  ADD COLUMN IF NOT EXISTS revision_handling      TEXT,   -- 'append' | 'supersede' | 'separate' | 'cancelled'
+  ADD COLUMN IF NOT EXISTS error_class            TEXT,
+  ADD COLUMN IF NOT EXISTS ingest_route           TEXT;   -- 'ow' | 'v2'
+
+CREATE INDEX IF NOT EXISTS idx_hub_uploads_v2_queue
+  ON hub_uploads (status, created_at)
+  WHERE ingest_route = 'v2' AND status = 'queued';
+
+CREATE INDEX IF NOT EXISTS idx_hub_uploads_stale_claim
+  ON hub_uploads (status, worker_heartbeat_at)
+  WHERE status IN ('parsing','embedding','awaiting_confirmation','kg_proposing');
+```
+
+**Status enum (widened):**
+
+| Status | Set by | Terminal? | Meaning |
+|---|---|---|---|
+| `queued` | v2 HTTP | no | File on disk, awaiting worker claim |
+| `parsing` | worker | no | docling subprocess running |
+| `embedding` | worker | no | chunks being written to `knowledge_entries` |
+| `awaiting_confirmation` | worker | no | Slack DM sent, awaiting tech tap |
+| `kg_proposing` | worker | no | tech confirmed; KG writes in progress |
+| `parsed` | worker | yes | success |
+| `failed` | worker | yes | terminal failure; `error_class` populated |
+| `cancelled` | tech via Slack | yes | tech tapped "cancel — wrong file" |
+| `fetching` | legacy OW path | no | preserved for backwards compat |
+
+### 4.2 `knowledge_entries` (extend in place)
+
+```sql
+-- docs/migrations/002_knowledge_entries_chunk_anchors.sql
+ALTER TABLE knowledge_entries
+  ADD COLUMN IF NOT EXISTS doc_id       UUID,
+  ADD COLUMN IF NOT EXISTS page_start   INTEGER,
+  ADD COLUMN IF NOT EXISTS page_end     INTEGER,
+  ADD COLUMN IF NOT EXISTS section_path TEXT,
+  ADD COLUMN IF NOT EXISTS ingest_route TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_entries_doc
+  ON knowledge_entries (tenant_id, doc_id)
+  WHERE doc_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_knowledge_entries_route
+  ON knowledge_entries (tenant_id, ingest_route, created_at DESC)
+  WHERE ingest_route = 'v2';
+```
+
+`doc_id` = the source `hub_uploads.id`. All chunks of one drop share one `doc_id`.
+
+The legacy `source_page` column (currently stores `chunk_index`, not PDF page number) stays unchanged; v2 fills the new `page_start`/`page_end` columns. Renaming `source_page` is out of scope (see ADR-0019 § Open questions).
+
+### 4.3 `kg_relationships` (extend in place)
+
+```sql
+-- mira-hub/db/migrations/031_kg_relationship_provenance.sql
+ALTER TABLE kg_relationships
+  ADD COLUMN IF NOT EXISTS verified_by         TEXT,    -- 'tech' | 'admin' | 'system_consensus' | NULL when proposed
+  ADD COLUMN IF NOT EXISTS verified_by_user_id TEXT,    -- Slack user_id or admin email
+  ADD COLUMN IF NOT EXISTS verified_at         TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS corroboration_count INTEGER DEFAULT 1;
+```
+
+Promotion rules:
+- `proposed → verified` requires `verified_by` populated.
+- `verified_by='tech'` requires a Slack tap event on a confirmation block.
+- `verified_by='admin'` requires an explicit click in the Hub admin queue.
+- `verified_by='system_consensus'` requires `corroboration_count ≥ 2` AND a prior human signal in the source dependency chain (i.e., at least one of the corroborating sources was tech- or admin-verified).
+
+Pure transitive auto-promotion without a human signal anywhere in the chain is **forbidden**.
+
+### 4.4 No changes to
+
+- `kg_entities` — existing unique on `(tenant_id, entity_type, name)` already supports idempotent upserts via `kg_writer.upsert_entity`.
+- `knowledge_entries`-side dedup index — preserved.
+- OW path code in `mira-core/mira-ingest` — untouched.
+
+## 5. HTTP API (v2)
+
+### 5.1 `POST /v2/uploads` — accept a streamed file
+
+| Field | Type | Notes |
+|---|---|---|
+| Headers | `X-Tenant-Id`, `X-Request-Id` | Hub-set; never trusted from the watcher |
+| Body | `application/octet-stream` (streamed) | The raw file bytes |
+| Query | `?filename=…&mime=…&uns_path_hint=…&kind=document` | metadata |
+
+**Response 202:**
+```json
+{
+  "upload_id": "uuid",
+  "status": "queued",
+  "doc_id": "uuid (=upload_id)"
+}
+```
+
+v2 never returns the chunk count or KG result from this endpoint. Status is polled via Hub's existing `GET /api/uploads/:id`.
+
+**Errors:**
+- 400 `unsupported_mime` (only `application/pdf` accepted this build)
+- 409 `duplicate_sha256` (file is byte-identical to an existing successful drop; caller should treat as no-op)
+- 500 `disk_write_failed` (worker host out of space, file system error)
+
+There is **no size cap** in v2. Disk is the limit.
+
+### 5.2 `GET /v2/jobs/:upload_id/state` — internal observability
+
+Returns the phase, heartbeat age, last error if any. Used by Hub UI's job-detail view. Not exposed publicly.
+
+## 6. Slack dialogue protocol (UNS Location-Confirmation Gate for ingest)
+
+### 6.1 Binding prompt (Phase 4)
+
+Sent when `extraction_method != 'manual'` AND `extracted_manufacturer` is non-NULL.
+
+**Seed options** (presented as Slack buttons, max 4):
+
+1. **Current thread context.** If the dropping user has an active troubleshooting thread with MIRA, button text = the thread's confirmed asset / line / equipment. Example: *"the noisy VFD on Line 2"*.
+2. **Recent confirmed contexts** (up to 2 from the last 48 h FSM session log). Example: *"Line 4 conveyor drive"*.
+3. **Model template only.** *"File as model reference — not bound to a physical asset"*. UNS path = `enterprise.knowledge_base.{mfr_slug}.{model_slug}`.
+4. **Type UNS path.** Opens a modal. Validates against the `uns.is_valid_path` grammar.
+
+The DM also surfaces: extracted manufacturer + model, source chunk excerpt (cover page), extraction method + confidence.
+
+### 6.2 Revision prompt (Phase 4b, conditional)
+
+Fires only if the tech's chosen binding lands on an Equipment that already has a Manual at the same `manual_type` UNS path.
+
+Buttons:
+1. *"Append — keep both revisions"* (default on TTL = 24 h)
+2. *"Replace — newer supersedes"*
+3. *"Separate manual — different document type"*
+4. *"Cancel — wrong file"*
+
+Result writes `hub_uploads.revision_handling`.
+
+### 6.3 Confirmation reply (Phase 6)
+
+Sent when `status` transitions to `parsed`. Edits the original binding DM in place (Slack `chat.update`).
+
+```
+✅ Filed *PowerFlex 525 user manual* under Line 2
+   472 chunks · 23 fault codes extracted · page-anchored
+
+📈 Line 2 readiness: *L1 → L2*
+   1 of 4 components now has a linked manual.
+
+🎯 Next: Upload manuals for conveyor motor, photoeye, air valve.
+
+[View namespace] [Show fault codes] [Print model QR]
+```
+
+Score delta + next-action come from `recalculate_health_score()` returning the new level and the top item from `health_scores.missing`.
+
+### 6.4 Failure DM
+
+If the job lands in `failed`, the DM includes the `error_class` and a "[Retry]" button. Retry posts `POST /v2/jobs/:id/retry`, which resets the row to `queued` (sweeping any partial writes via idempotent upserts).
+
+## 7. Filesystem artifacts
+
+For each successful drop, the watcher's `~/MiraDrop/done/` gets:
+
+```
+20260526_120000_abc_powerflex-525-manual.pdf           # original
+20260526_120000_abc_powerflex-525-manual.pdf.ingest.json
+20260526_120000_abc_powerflex-525-manual.pdf.qr.png     # NEW
+```
+
+**`ingest.json` schema:**
+```json
+{
+  "upload_id": "uuid",
+  "status": "parsed",
+  "doc_id": "uuid",
+  "uns_path": "enterprise.factory.line_2.vfd_001.manuals.user_manual",
+  "model_uns_path": "enterprise.knowledge_base.rockwell_automation.powerflex_525",
+  "hub_url": "https://app.factorylm.com/hub/kg/...",
+  "qr_image": "20260526_120000_abc_powerflex-525-manual.pdf.qr.png",
+  "extraction_method": "rule",
+  "extraction_confidence": "high",
+  "binding_state": "instance_bound",            // or 'model_only'
+  "revision_handling": "append",                 // present only on revision events
+  "kg_entity_id": "uuid",
+  "kg_relationship_count": 24,
+  "kb_chunk_count": 472,
+  "readiness_delta": { "from": "L1", "to": "L2", "next": "..." },
+  "completed_at": "2026-05-26T12:14:33Z"
+}
+```
+
+**QR contents:** the Hub URL string. The Hub route (`/hub/kg/[unsPath]`) renders the entity page with model/instance state and any subsequent binding actions.
+
+## 8. Worker lifecycle
+
+### 8.1 Process model
+
+- One launchd-managed Python process: `mira-ingest-v2-worker`.
+- Concurrency: 1 (enforced by `SELECT … FOR UPDATE SKIP LOCKED LIMIT 1`).
+- Heartbeat: every 30 s, updates `hub_uploads.worker_heartbeat_at`.
+- Stale-claim sweep: at startup and every 5 min, resets rows where `status IN (parsing, embedding, kg_proposing) AND worker_heartbeat_at < now() - interval '5 min'` back to `queued`.
+
+### 8.2 Docling RAM levers
+
+- `do_ocr=False` when `pypdf.PdfReader(...).pages[0].extract_text()` returns non-empty text (i.e., the PDF has a text layer). OEM manuals always do.
+- One-shot subprocess per job: `subprocess.Popen([sys.executable, "-m", "docling_runner", str(path)], …)`. The subprocess prints JSON-line chunks to stdout, the worker reads and embeds. Subprocess is `wait()`-ed and goes away at end of job. PyTorch allocator pools cannot accumulate.
+- `torch.set_num_threads(1)` inside the subprocess.
+
+### 8.3 Idempotency keys
+
+| Phase | Key | Behavior on duplicate |
+|---|---|---|
+| chunks insert | `(doc_id, chunk_index)` | `ON CONFLICT DO NOTHING` |
+| kg_entities | `(tenant_id, entity_type, name)` | existing `kg_writer.upsert_entity` |
+| kg_relationships | `(tenant_id, source_id, target_id, relationship_type)` | existing `kg_writer.upsert_relationship`; `corroboration_count` increments on conflict |
+
+## 9. Retrieval contract
+
+Bot side (`mira-bots/shared/neon_recall.py`):
+
+- Continues to query `knowledge_entries` as today; no recall code changes required for v2 chunks to be retrieved.
+- Citation formatter in `mira-bots/shared/citation_compliance.py` gains a v2 path: when a retrieved chunk has `page_start IS NOT NULL`, cite as *"…per the {extracted_model} manual, p. {page_start}, §{section_path} ([source]({hub_url}))…"*. Legacy chunks fall through to the existing citation shape.
+
+## 10. Environment & deployment
+
+| Env | Where v2 runs | Doppler config | Notes |
+|---|---|---|---|
+| Dev | CHARLIE | `factorylm/dev` | Today's prove-it target |
+| Staging | CHARLIE (same process, different Doppler config) OR VPS staging stack | `factorylm/stg` | Decided at Phase 5 (see plan) |
+| Prod (this build) | CHARLIE | `factorylm/dev` | "Prove it on CHARLIE first" |
+| Cloud (Day-2) | VPS via `docker-compose.saas.yml` | `factorylm/prd` | Not built this round. When built: must include `mem_limit: 3g`, the two docling levers, and concurrency=1. |
+
+Migrations ship dev → staging → prod via `apply-migrations.yml` (`dry-run` then `apply`). Never hand-edited.
+
+## 11. Telemetry
+
+Each phase emits a log line with `upload_id`, `tenant_id`, `phase`, `duration_ms`. Per `hub_uploads.error_class`, a daily Hub-UI panel surfaces failure counts grouped by class for triage.
+
+Metrics worth tracking from day 1:
+- p50 / p95 end-to-end duration (drop → `parsed`)
+- `extraction_method` distribution (rule / llm / filename / manual)
+- TTL-expiry rate for Q10 (how often does the tech ghost?)
+- `revision_handling` distribution (append / supersede / separate / cancelled)
+- `verified_by` distribution on `kg_relationships`
+- Per-drop readiness delta (L_old → L_new)
+
+## 12. Glossary (terms specific to this spec)
+
+| Term | Meaning |
+|---|---|
+| Drop | One file placed in `~/MiraDrop/inbox/`. SHA-256-identified, idempotent. |
+| Logical document | One Drop. One `hub_uploads.id`. Many chunks. |
+| Binding | The Equipment-HAS_MANUAL relationship that ties a logical document to a tenant-confirmed Equipment entity. |
+| Binding state | `model_only` (UNS path is the per-model template) or `instance_bound` (UNS path is a specific physical asset). |
+| Extraction method | How manufacturer/model were resolved: `rule | llm | filename | manual`. |
+| Tech confirmation | A Slack button tap by the dropping user on a Phase-4 prompt. Promotes the binding relationship to `verified_by='tech'`. |
+| System consensus | Two or more corroborating sources for the same fact, with at least one source ultimately traceable to a tech or admin signal. Promotes to `verified_by='system_consensus'`. |
+| Readiness level | L0–L6 from `docs/specs/maintenance-namespace-builder-spec.md` § Levels. Surfaced per drop. |
+
+## 13. Acceptance criteria
+
+A drop of the 33 MB Rockwell PowerFlex 525 manual (`2080-rm001_-en-e.pdf` or equivalent) succeeds end-to-end with:
+
+- ✅ File copied into `~/MiraDrop/processing/`, never rejected for size.
+- ✅ Hub never holds the full file in RAM (verified by streaming `req.body` to v2).
+- ✅ `hub_uploads` row advances through phases without skips.
+- ✅ Docling subprocess peaks ≤ 2 GiB RSS, returns to 0 GiB between jobs.
+- ✅ At least 1 `knowledge_entries` row with `ingest_route='v2'`, `doc_id` set, `page_start IS NOT NULL`.
+- ✅ Slack DM sent within 60 s of drop completion (or sooner — phase 4 fires after embedding, not after every chunk).
+- ✅ Tech tap on a binding button → `kg_relationships` row with `verified_by='tech'` for the Manual binding.
+- ✅ Fault-code sweep produces ≥ 5 `proposed` HAS_FAULT relationships.
+- ✅ `~/MiraDrop/done/` contains the original PDF, an `ingest.json` with `status=parsed`, and a `.qr.png`.
+- ✅ Confirmation DM shows a real readiness delta (not L? → L?).
+- ✅ Re-dropping the same PDF byte-for-byte is a no-op (SHA-256 dedup).
+- ✅ Re-dropping a modified PDF with the same manufacturer/model triggers the Phase-4b revision prompt.


### PR DESCRIPTION
## Summary

Design lock for **MiraDrop Ingest v2** — the replacement ingest path that fixes the 33 MB Rockwell PDF rejection (2026-05-24) by removing the in-memory buffer cap, adding KG attribution, and routing every drop through the existing UNS location-confirmation gate.

**Docs only. No code. No migrations applied.** The actual implementation follows the 10 slices in the plan.

## Files
- `docs/adr/0019-miradrop-ingest-v2.md` — decision record + rejected alternatives
- `docs/specs/miradrop-ingest-v2-spec.md` — schemas, pipeline phases, HTTP API, Slack dialogue protocol, acceptance criteria
- `docs/plans/2026-05-26-miradrop-auto-splitter.md` — 10-slice execution plan with verification gates per slice

## 15 locked decisions

| # | Choice |
|---|---|
| Q1 | Text-chunk granularity (no physical PDF split) |
| Q2 | Track 2 — new `mira-ingest-v2`, OW-free for MiraDrop |
| Q3 | Watcher → Hub (streamed) → v2; cap dies because RAM buffer dies |
| Q4 | Async worker; HTTP returns 202 |
| Q5 | CHARLIE only this build; cloud-side is Day-2 |
| Q6 | `hub_uploads` IS the queue (`FOR UPDATE SKIP LOCKED`) |
| Q7 | Extend `hub_uploads` in place (additive nullable columns) |
| Q8 | Extend `knowledge_entries` in place; `doc_id` + `page_start` + `section_path` + `ingest_route` |
| Q9 | Hybrid extractor: filename → rules → LLM cascade fallback |
| Q10 | Drop opens Slack dialogue (UNS gate fires for ingest) |
| Q11 | Two-state KG with `verified_by` provenance (`tech`/`admin`/`system_consensus`) |
| Q12 | Revision detect-and-prompt; default-on-TTL = append |
| Q13 | Per-phase checkpoints, idempotent writes, stale-claim sweep |
| Q14 | Confirmation DM reports L0–L6 readiness delta + next-action CTA |
| Q15 | Photos out of scope this build; v2.1 follow-up |

## Doctrine alignments
- UNS Location-Confirmation Gate (`.claude/CLAUDE.md` § Non-negotiable) fires on drop
- No silent KG promotion — every `verified` row carries `verified_by` provenance
- Provider cascade: Groq → Cerebras → Gemini for LLM fallback. Never Anthropic
- All migrations dev → staging → prod via `apply-migrations.yml`
- Single source of truth: `hub_uploads` row is queue + audit + UI rendering target

## Numbering history
Original draft used ADR-0017 + migrations 028/029. Origin/main had `0017-proposal-state-machine-mapping`, `028_drives_relationship_type`, `029_kg_approval_state` already. Renumbered to **ADR-0019** + migrations **030/031** before this PR.

## Test plan
- [ ] Reviewer: confirm ADR cross-references resolve (ADR-0008, 0013, 0014 all exist on main).
- [ ] Reviewer: spec acceptance criteria (§ 13) match the plan's exit criteria per slice.
- [ ] Reviewer: doctrine alignments are accurate against current `.claude/CLAUDE.md`.
- [ ] No code paths to test — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)