### PR TITLE
fix(plc): align demo poller + simulator to v4 Modbus map

### DIFF
--- a/tools/demo_plc_poller.py
+++ b/tools/demo_plc_poller.py
@@ -69,8 +69,17 @@ logger = logging.getLogger("mira-plc-poller")
 # ---------------------------------------------------------------------------
 # Address map — single source of truth for the garage demo conveyor.
 #
-# Reflects /Users/charlienode/factorylm/CLAUDE.md (PLC / Factory IO section)
-# and research/variable-manifest.json. Do not edit without updating both.
+# MUST match the Micro820 Modbus server map actually deployed on the PLC:
+# `plc/MbSrvConf_v4.xml` (22 coils + 17 HRs, v4.1.9 ladder). Modbus PDU address
+# = CCW display address − 1, so read_coils(address=0) → coil 000001 = motor_running.
+# The variable names below are the ladder globals (also used by the Node-RED
+# fault-detective flow), NOT the old "Conveyor.MTR001_*" CCW aliases.
+#
+# We read the first 7 coils (000001-000007) and HR 100-105 (400101-400106) — the
+# subset the live dashboard needs. The v4 map also exposes coils 8-22 and
+# HR 107-117 (VFD freq/current/voltage/dc-bus, conv_state, poll-state); surfacing
+# those is a follow-up that needs the ladder's scaling documented first.
+# Do not edit without updating `plc/MbSrvConf_v4.xml` and `tools/demo_plc_simulator.py`.
 # ---------------------------------------------------------------------------
 
 
@@ -85,31 +94,35 @@ class PLCPoint:
     address: int
     scale: float         # raw → engineering value (raw / scale, or 1 = passthrough)
     uns_topic: str       # ISA-95 style UNS topic
-    plc_tag: str         # symbolic CCW tag name
+    plc_tag: str         # ladder global / MbSrvConf variable name
     relay_tag: str | None = None  # name to use in relay payload (uses tag-column map)
 
 
 ADDRESS_MAP: list[PLCPoint] = [
-    # Coils 0-6 — boolean I/O
-    PLCPoint("motor_running",    COIL, 0, 1, "demo/training/conveyor001/motor/mtr001/running",  "Conveyor.MTR001_RunFb",      "motor_running"),
-    PLCPoint("motor_stopped",    COIL, 1, 1, "demo/training/conveyor001/motor/mtr001/stopped",  "Conveyor.MTR001_StopFb",     "motor_stopped"),
-    PLCPoint("fault_alarm",      COIL, 2, 1, "demo/training/conveyor001/faults/active",         "Conveyor.FaultAlarm",        "fault_alarm"),
-    PLCPoint("conveyor_running", COIL, 3, 1, "demo/training/conveyor001/state/running",         "Conveyor.RunFb",             "conveyor_running"),
-    PLCPoint("sensor_1",         COIL, 4, 1, "demo/training/conveyor001/prox/pe001/state",      "Conveyor.PE001_State",       "sensor_1"),
-    PLCPoint("sensor_2",         COIL, 5, 1, "demo/training/conveyor001/prox/pe002/state",      "Conveyor.PE002_State",       "sensor_2"),
-    PLCPoint("e_stop",           COIL, 6, 1, "demo/training/conveyor001/safety/estop",          "Conveyor.EStop_Active",      "e_stop"),
-    # Holding 100-105 — analog values
-    PLCPoint("motor_speed",      HOLDING, 100, 1.0,  "demo/training/conveyor001/motor/mtr001/speed",       "Conveyor.MTR001_Speed",       "speed_rpm"),
-    PLCPoint("motor_current",    HOLDING, 101, 10.0, "demo/training/conveyor001/motor/mtr001/current",     "Conveyor.MTR001_Current",     "current_amps"),
-    PLCPoint("temperature",      HOLDING, 102, 10.0, "demo/training/conveyor001/motor/mtr001/temperature", "Conveyor.MTR001_Temperature", "temperature_c"),
-    PLCPoint("pressure",         HOLDING, 103, 1.0,  "demo/training/conveyor001/pneumatic/pressure",       "Conveyor.Pressure",           "pressure_psi"),
-    PLCPoint("conveyor_speed",   HOLDING, 104, 1.0,  "demo/training/conveyor001/state/speed",              "Conveyor.Speed",              "conveyor_speed"),
-    PLCPoint("error_code",       HOLDING, 105, 1.0,  "demo/training/conveyor001/faults/code",              "Conveyor.ErrorCode",          "faultCode"),
+    # Coils 000001-000007 (read as PDU address 0-6) — booleans, per MbSrvConf_v4.xml
+    PLCPoint("motor_running",    COIL, 0, 1, "demo/training/conveyor001/motor/mtr001/running",  "motor_running",    "motor_running"),
+    PLCPoint("conveyor_running", COIL, 1, 1, "demo/training/conveyor001/state/running",         "conveyor_running", "conveyor_running"),
+    PLCPoint("fault_alarm",      COIL, 2, 1, "demo/training/conveyor001/faults/active",         "fault_alarm",      "fault_alarm"),
+    PLCPoint("vfd_comm_ok",      COIL, 3, 1, "demo/training/conveyor001/vfd/vfd001/comm_ok",     "vfd_comm_ok",      "vfd_comm_ok"),
+    PLCPoint("system_ready",     COIL, 4, 1, "demo/training/conveyor001/state/ready",           "system_ready",     "system_ready"),
+    PLCPoint("e_stop_active",    COIL, 5, 1, "demo/training/conveyor001/safety/estop",          "e_stop_active",    "e_stop_active"),
+    PLCPoint("dir_fwd",          COIL, 6, 1, "demo/training/conveyor001/motor/mtr001/dir_fwd",  "dir_fwd",          "dir_fwd"),
+    # Holding 400101-400106 (read as PDU address 100-105) — analog, per MbSrvConf_v4.xml
+    PLCPoint("motor_speed",      HOLDING, 100, 1.0,  "demo/training/conveyor001/motor/mtr001/speed",       "motor_speed",    "motor_speed"),
+    PLCPoint("motor_current",    HOLDING, 101, 10.0, "demo/training/conveyor001/motor/mtr001/current",     "motor_current",  "motor_current"),
+    PLCPoint("temperature",      HOLDING, 102, 10.0, "demo/training/conveyor001/motor/mtr001/temperature", "temperature",    "temperature"),
+    PLCPoint("pressure",         HOLDING, 103, 1.0,  "demo/training/conveyor001/pneumatic/pressure",       "pressure",       "pressure"),
+    PLCPoint("conveyor_speed",   HOLDING, 104, 1.0,  "demo/training/conveyor001/state/speed",              "conveyor_speed", "conveyor_speed"),
+    PLCPoint("error_code",       HOLDING, 105, 1.0,  "demo/training/conveyor001/faults/code",              "error_code",     "error_code"),
 ]
 
 EQUIPMENT_ID = "CONV-001"
 DEFAULT_TENANT_ID = "garage-demo"
 AGENT_ID = "demo-plc-poller"
+
+# Resilience tuning for the poll loop.
+FEED_DOWN_THRESHOLD = 5   # consecutive failures before one loud, actionable warning
+ERROR_LOG_EVERY = 30      # after the first, log a one-line error every Nth failure
 
 
 # ---------------------------------------------------------------------------
@@ -267,8 +280,9 @@ class DemoPLCPoller:
 
     async def run(self) -> None:
         assert self._modbus is not None
+        consecutive_failures = 0
         while not self._stop.is_set():
-            cycle_start = asyncio.get_event_loop().time()
+            cycle_start = asyncio.get_running_loop().time()
             try:
                 snapshot = await self._poll_once()
                 events = detect_events(self._prev, snapshot)
@@ -280,19 +294,49 @@ class DemoPLCPoller:
                     return_exceptions=False,
                 )
 
+                if consecutive_failures:
+                    logger.info("PLC feed RECOVERED after %d failed cycle(s)", consecutive_failures)
+                consecutive_failures = 0
                 logger.debug(
                     "Cycle ok values=%d events=%d",
                     len(snapshot.values), len(events),
                 )
-            except Exception:
-                logger.exception("Poll cycle failed; will retry next tick")
+            except Exception as exc:
+                consecutive_failures += 1
+                await self._handle_poll_failure(consecutive_failures, exc)
 
-            elapsed = asyncio.get_event_loop().time() - cycle_start
+            elapsed = asyncio.get_running_loop().time() - cycle_start
             sleep_for = max(0.0, self.poll_interval - elapsed)
             try:
                 await asyncio.wait_for(self._stop.wait(), timeout=sleep_for)
             except asyncio.TimeoutError:
                 pass
+
+    async def _handle_poll_failure(self, n: int, exc: Exception) -> None:
+        """Rate-limited logging + best-effort reconnect on a failed poll.
+
+        We deliberately do NOT write anything to the relay / cache on failure, so
+        downstream freshness (``live_signal_cache.last_seen_at``) decays and the UI
+        can flag the feed as stale instead of showing stale data as live.
+        """
+        # First failure + every Nth after: one clear line, not a traceback-per-tick.
+        if n == 1 or n % ERROR_LOG_EVERY == 0:
+            logger.error("Poll cycle failed (%d in a row): %s", n, exc)
+        # One loud, actionable warning when the feed is clearly down.
+        if n == FEED_DOWN_THRESHOLD:
+            logger.warning(
+                "PLC FEED DOWN — %d consecutive Modbus failures. If these are "
+                "ILLEGAL_FUNCTION (exception 1), the Micro820 Modbus map is not "
+                "deployed: run `python plc/deploy_modbus_map.py --auto`, then download "
+                "to the PLC in CCW and set RUN.",
+                n,
+            )
+        # Reconnect in case the socket dropped (AsyncModbusTcpClient may not auto-heal).
+        try:
+            if self._modbus is not None and not self._modbus.connected:
+                await self._modbus.connect()
+        except Exception as reconnect_exc:  # pragma: no cover - best effort
+            logger.debug("Reconnect attempt failed: %s", reconnect_exc)
 
     # -- read path ----------------------------------------------------------
 
@@ -305,6 +349,12 @@ class DemoPLCPoller:
         hregs_resp = await self._modbus.read_holding_registers(address=100, count=6)
         if hregs_resp.isError():
             raise RuntimeError(f"read_holding_registers failed: {hregs_resp}")
+
+        if len(coils_resp.bits) < 7 or len(hregs_resp.registers) < 6:
+            raise RuntimeError(
+                f"short Modbus read: {len(coils_resp.bits)} coils / "
+                f"{len(hregs_resp.registers)} registers (expected ≥7 / ≥6)"
+            )
 
         values: dict[str, float] = {}
         for p in ADDRESS_MAP:

--- a/tools/demo_plc_simulator.py
+++ b/tools/demo_plc_simulator.py
@@ -6,10 +6,11 @@ with ``tools/demo_plc_poller.py`` so that the rest of the stack
 the actual PLC + Factory IO.
 
 The simulator drives coils 0-6 and holding registers 100-105 to match the
-canonical address map (see CLAUDE.md "PLC / Factory IO — Modbus Address
-Map"). It owns its own register state and mutates it on a schedule:
+Micro820 map actually deployed on the PLC (``plc/MbSrvConf_v4.xml``) and the
+poller's ADDRESS_MAP. It owns its own register state and mutates it on a schedule:
 
-- ``sensor_1`` (coil 4) toggles every 5s
+- booleans (motor_running, conveyor_running, vfd_comm_ok, system_ready, dir_fwd)
+  idle steady true; ``e_stop_active`` stays clear
 - ``conveyor_speed`` (HR104) and ``motor_speed`` (HR100) ramp 0→100→0
 - ``motor_current`` (HR101) follows motor_speed * 0.1
 - ``temperature`` (HR102) idles at 25.0°C and creeps up under load
@@ -51,28 +52,38 @@ except ImportError as exc:  # pragma: no cover
 logger = logging.getLogger("mira-plc-simulator")
 
 
-# Coils and registers we expose (must match poller's ADDRESS_MAP).
-COIL_COUNT = 16
+# Coils and registers we expose — MUST match the deployed Micro820 map
+# (plc/MbSrvConf_v4.xml, 22 coils + 17 HRs) and tools/demo_plc_poller.py.
+# We size the blocks for the full v4 range so plc/live_monitor.py (reads 22
+# coils + HR 100-116) also runs against this simulator unchanged.
+COIL_COUNT = 22
 HR_BASE = 100
-HR_COUNT = 16
+HR_COUNT = 17
 
 
-# Coil indices
+# Coil indices (PDU address = MbSrvConf display address − 1, e.g. 0 = coil 000001)
 C_MOTOR_RUNNING = 0
-C_MOTOR_STOPPED = 1
+C_CONVEYOR_RUNNING = 1
 C_FAULT_ALARM = 2
-C_CONVEYOR_RUNNING = 3
-C_SENSOR_1 = 4
-C_SENSOR_2 = 5
-C_E_STOP = 6
+C_VFD_COMM_OK = 3
+C_SYSTEM_READY = 4
+C_E_STOP_ACTIVE = 5
+C_DIR_FWD = 6
+C_DIR_REV = 7
+C_HEARTBEAT = 8
 
-# Holding register indices (absolute Modbus addresses)
+# Holding register indices (absolute Modbus addresses, per MbSrvConf_v4.xml)
 HR_MOTOR_SPEED = 100
 HR_MOTOR_CURRENT = 101  # scale ÷10
 HR_TEMPERATURE = 102    # scale ÷10
 HR_PRESSURE = 103
 HR_CONVEYOR_SPEED = 104
 HR_ERROR_CODE = 105
+HR_VFD_FREQ = 106
+HR_VFD_CURRENT = 107
+HR_VFD_VOLTAGE = 108
+HR_VFD_DC_BUS = 109     # HR400110
+HR_CONV_STATE = 113     # 0=IDLE 1=STARTING 2=RUNNING 3=STOPPING 4=FAULT
 
 # pymodbus 3.x: slave id (unit) the server responds on
 SLAVE_ID = 1
@@ -103,11 +114,13 @@ class ConveyorSim:
     async def run(self, tick_hz: float = 2.0) -> None:
         """Tick the simulation at ``tick_hz`` Hz."""
         period = 1.0 / tick_hz
-        # Prime initial state
+        # Prime initial state (booleans steady; analogs ramp in _step)
         self._write_coil(C_MOTOR_RUNNING, True)
-        self._write_coil(C_MOTOR_STOPPED, False)
         self._write_coil(C_CONVEYOR_RUNNING, True)
-        self._write_coil(C_E_STOP, False)
+        self._write_coil(C_VFD_COMM_OK, True)
+        self._write_coil(C_SYSTEM_READY, True)
+        self._write_coil(C_E_STOP_ACTIVE, False)
+        self._write_coil(C_DIR_FWD, True)
         self._write_hr(HR_PRESSURE, 80)
 
         while not self._stop.is_set():
@@ -119,15 +132,9 @@ class ConveyorSim:
                 pass
 
     def _step(self) -> None:
-        # sensor_1 toggles every 5s (10 ticks at 2Hz)
-        if self._tick % 10 == 0:
-            cur = self._read_coil(C_SENSOR_1)
-            self._write_coil(C_SENSOR_1, not cur)
-
-        # sensor_2 toggles every 7s offset
-        if self._tick % 14 == 7:
-            cur = self._read_coil(C_SENSOR_2)
-            self._write_coil(C_SENSOR_2, not cur)
+        # Booleans idle steady (primed in run()); the analogs below provide the
+        # live movement, and faults pulse periodically. The v4 map has no prox
+        # sensors, so there are no per-tick coil toggles here.
 
         # Ramp motor_speed 0→100→0
         if self._tick % 6 == 0:
@@ -156,6 +163,17 @@ class ConveyorSim:
         else:
             self._temperature_x10 = max(self._temperature_x10 - 1, 250)
         self._write_hr(HR_TEMPERATURE, self._temperature_x10)
+
+        # Heartbeat toggles every tick (ladder liveness); state follows speed.
+        self._write_coil(C_HEARTBEAT, self._tick % 2 == 0)
+        self._write_hr(HR_CONV_STATE, 2 if self._speed_actual > 0 else 0)
+
+        # GS10 VFD telemetry. Frequency tracks speed (0-100% → 0-60Hz, raw ×10);
+        # DC bus ≈ 1.41·230V ≈ 325V steady with a little ripple under load.
+        self._write_hr(HR_VFD_FREQ, int(self._speed_actual * 6))      # 0-600 = 0-60.0Hz
+        self._write_hr(HR_VFD_CURRENT, self._speed_actual)            # raw, ÷10 downstream
+        self._write_hr(HR_VFD_VOLTAGE, int(self._speed_actual * 2.3))  # 0-230V
+        self._write_hr(HR_VFD_DC_BUS, 320 + (self._speed_actual % 12))  # ~320-331V
 
         # Occasional fault: ~every 60s of sim time (120 ticks), lasts ~5s
         if self._fault_ticks_left > 0:
@@ -205,11 +223,11 @@ class ConveyorSim:
 
 
 def _build_context() -> tuple[ModbusServerContext, ModbusSlaveContext]:
-    # Allocate enough room for the addresses we use.
-    # Block 1 (coils): 0..15
-    # Block 3 (holding): 0..115 (covers HR 100-105 with headroom)
-    co_block = ModbusSequentialDataBlock(0, [False] * COIL_COUNT)
-    hr_block = ModbusSequentialDataBlock(0, [0] * (HR_BASE + HR_COUNT))
+    # Allocate the full v4 address range plus headroom so reads that span the
+    # top of the map (live_monitor reads coils 0-21 and HR 100-116) don't trip
+    # pymodbus's end-of-block range check. +8 on each is slack, not magic.
+    co_block = ModbusSequentialDataBlock(0, [False] * (COIL_COUNT + 8))
+    hr_block = ModbusSequentialDataBlock(0, [0] * (HR_BASE + HR_COUNT + 8))
     slave = ModbusSlaveContext(
         co=co_block,  # discrete outputs / coils
         hr=hr_block,  # holding registers


### PR DESCRIPTION
## Why
The garage-demo poller (`tools/demo_plc_poller.py`) read coils 0-6 with a **stale pre-v4 layout** (`motor_stopped`/`sensor_1`/`sensor_2`), so 5 of 7 booleans were mislabeled against the actually-deployed `plc/MbSrvConf_v4.xml` — including **`e_stop`, which really read `dir_fwd`**. Holding registers 100-105 were already correct. Surfaced while diagnosing `read_coils ... ILLEGAL_FUNCTION` on the live PLC.

## What changed
- **`demo_plc_poller.py`** — `ADDRESS_MAP` coils → v4 ladder globals (`motor_running, conveyor_running, fault_alarm, vfd_comm_ok, system_ready, e_stop_active, dir_fwd`); `plc_tag`/`relay_tag` use the bare v4 names (match `MbSrvConf` + the Node-RED fault-detective flow). Resilient poll loop: consecutive-failure tracking, best-effort reconnect, rate-limited logging (no traceback-per-tick), one actionable **"FEED DOWN"** warning pointing at `deploy_modbus_map.py` when reads return `ILLEGAL_FUNCTION`. `get_running_loop()` + short-read guard.
- **`demo_plc_simulator.py`** — exposes the full v4 range (22 coils + 17 HRs incl. VFD freq/current/voltage/**dc_bus**, conv_state, heartbeat) so it faithfully stands in for the real PLC and `plc/live_monitor.py` runs against it. Fixed a register block with no headroom that made a full-range `count=17` read trip pymodbus's bounds check.

## Verified
`poller --dry-run` vs the simulator reads the correct v4 labels (e_stop_active is the real e-stop, not dir_fwd), **no stale tags**, values update live; `ruff` clean. Read-only contract preserved (no write FCs).

## Operational note (not in this PR)
The live PLC currently returns `ILLEGAL_FUNCTION` on every read — its Modbus map isn't deployed/active. Reload it on the PLC laptop: `python plc/deploy_modbus_map.py --auto` → CCW download → RUN, then `python3 plc/live_monitor.py --host 192.168.1.100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)