### PR TITLE
fix(staging-gate): treat embed-sidecar failure as skip, not fail (#1509)

### DIFF
--- a/tools/staging_render_comment.py
+++ b/tools/staging_render_comment.py
@@ -13,30 +13,48 @@ from pathlib import Path
 
 
 def render(results: dict, run_url: str) -> str:
-    overall = "✅ PASS" if results["overall_pass"] else "❌ FAIL"
+    if results.get("harness_degraded"):
+        overall = "❌ FAIL (harness degraded)"
+    elif results["overall_pass"]:
+        overall = "✅ PASS"
+    else:
+        overall = "❌ FAIL"
+    skipped = results.get("skipped", 0)
+    total = results["total"]
     lines = [
         f"### MIRA staging gate — {overall}",
         "",
-        "_Engine + NeonDB staging branch + Groq cascade against 10 fixed questions, graded on the 5-dimension rubric in `docs/specs/mira-answer-quality-standard.md`._",
+        "_Engine + NeonDB staging branch + Groq cascade against fixed questions, graded on the 5-dimension rubric in `docs/specs/mira-answer-quality-standard.md`. Skipped questions (embed sidecar unavailable, etc.) are excluded from pass/fail math; the run fails closed if >50% are skipped._",
         "",
-        f"- mean of means: **{results['mean_of_means']:.2f}** (pass threshold: {results['thresholds']['pass_avg']})",
-        f"- questions passed: **{results['passed']} / {results['total']}**",
+        f"- mean of means: **{results['mean_of_means']:.2f}** (pass threshold: {results['thresholds']['pass_avg']}, scored over {total - skipped}/{total})",
+        f"- questions passed: **{results['passed']} / {total}**",
+        f"- skipped (harness): **{skipped}** (issue #1509: embed sidecar unavailable)" if skipped else "- skipped (harness): **0**",
         f"- below mean 3.0: **{results['below_3']}** (max allowed: {results['thresholds']['max_below_3']})",
         f"- hard fails: **{results['hard_fails']}**",
         f"- [full run logs]({run_url})",
         "",
-        "| id | category | g | c | a | s | t | mean | fail |",
+        "| id | category | g | c | a | s | t | mean | note |",
         "|---|---|---|---|---|---|---|---|---|",
     ]
     for q in results["questions"]:
         s = q["scores"]
-        fail = ", ".join(q["fail_reasons"]) if q["fail_reasons"] else ""
-        emoji = "❌" if q["fail_reasons"] else ("⚠️" if q["mean"] < 3.0 else "✅")
+        if q.get("skipped"):
+            emoji = "⏸"
+            note = f"skip: {q.get('skip_reason', 'harness')}"
+        elif q["fail_reasons"]:
+            emoji = "❌"
+            note = ", ".join(q["fail_reasons"])
+        elif q["mean"] < 3.0:
+            emoji = "⚠️"
+            note = ""
+        else:
+            emoji = "✅"
+            note = ""
         lines.append(
             f"| {emoji} `{q['id']}` | {q['category']} | {s['grounding']} | {s['context']} | "
-            f"{s['actionability']} | {s['safety']} | {s['tone']} | **{q['mean']:.2f}** | {fail} |"
+            f"{s['actionability']} | {s['safety']} | {s['tone']} | **{q['mean']:.2f}** | {note} |"
         )
-    failing = [q for q in results["questions"] if q["fail_reasons"]]
+    failing = [q for q in results["questions"] if q["fail_reasons"] and not q.get("skipped")]
     if failing:
         lines.extend(["", "<details><summary>Failing question replies (truncated)</summary>", ""])
         for q in failing:

--- a/tools/staging_test.py
+++ b/tools/staging_test.py
@@ -111,6 +111,55 @@ class QuestionResult:
     score: Score
     passed: bool
     fail_reasons: list[str] = field(default_factory=list)
+    skipped: bool = False
+    skip_reason: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Embed-sidecar failure detection (issue #1509)
+#
+# When Ollama embed is unavailable, vector retrieval is skipped and grounding
+# degrades — the per-question rubric then dips below the floor and the gate
+# hard-fails. That is a harness condition, not an engine regression. We watch
+# the engine logs for the known failure signal and mark the question skipped
+# instead of failed; the aggregator excludes skipped questions from pass/fail
+# math (with a guard against the whole run being skipped).
+# ---------------------------------------------------------------------------
+
+EMBED_FAIL_PATTERNS = (
+    "Ollama embed failed on all candidates",
+    "NEON_RECALL_NO_EMBEDDING",
+)
+MAX_SKIP_FRACTION = 0.5
+
+
+class _EmbedFailureSignal:
+    def __init__(self) -> None:
+        self.triggered = False
+        self.pattern_hit = ""
+
+    def reset(self) -> None:
+        self.triggered = False
+        self.pattern_hit = ""
+
+
+class _EmbedFailureHandler(logging.Handler):
+    def __init__(self, signal: _EmbedFailureSignal) -> None:
+        super().__init__(level=logging.INFO)
+        self.signal = signal
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if self.signal.triggered:
+            return
+        try:
+            msg = record.getMessage()
+        except Exception:
+            return
+        for pat in EMBED_FAIL_PATTERNS:
+            if pat in msg:
+                self.signal.triggered = True
+                self.signal.pattern_hit = pat
+                return
 
 
 # ---------------------------------------------------------------------------
@@ -263,48 +312,79 @@ async def run_question(
 ) -> QuestionResult:
     chat_id = f"stg-{question.id}-{uuid.uuid4().hex[:8]}"
     t0 = time.monotonic()
+    # Install a per-question log handler that watches for the embed-sidecar
+    # failure signal. Attached to the root logger so it sees records from
+    # mira-bots.shared.neon_recall and mira-bots.shared.workers.rag_worker
+    # without coupling this script to those module paths.
+    embed_signal = _EmbedFailureSignal()
+    embed_handler = _EmbedFailureHandler(embed_signal)
+    root_logger = logging.getLogger()
+    root_logger.addHandler(embed_handler)
     try:
-        reply = await asyncio.wait_for(
-            supervisor.process(chat_id=chat_id, message=question.message, platform="staging"),
-            timeout=QUESTION_TIMEOUT_S,
-        )
-    except (TimeoutError, asyncio.TimeoutError):
-        elapsed = time.monotonic() - t0
-        return QuestionResult(
-            question=question,
-            reply="<TIMEOUT>",
-            elapsed_s=elapsed,
-            score=Score(judge_reason="engine timeout"),
-            passed=False,
-            fail_reasons=["engine_timeout"],
-        )
-    except Exception as exc:  # engine should never raise, but defend the run
-        elapsed = time.monotonic() - t0
-        logger.exception("engine error on %s", question.id)
-        return QuestionResult(
-            question=question,
-            reply=f"<ENGINE_ERROR: {exc.__class__.__name__}>",
-            elapsed_s=elapsed,
-            score=Score(judge_reason=f"engine error: {exc.__class__.__name__}"),
-            passed=False,
-            fail_reasons=["engine_error"],
-        )
+        try:
+            reply = await asyncio.wait_for(
+                supervisor.process(chat_id=chat_id, message=question.message, platform="staging"),
+                timeout=QUESTION_TIMEOUT_S,
+            )
+        except (TimeoutError, asyncio.TimeoutError):
+            elapsed = time.monotonic() - t0
+            return QuestionResult(
+                question=question,
+                reply="<TIMEOUT>",
+                elapsed_s=elapsed,
+                score=Score(judge_reason="engine timeout"),
+                passed=False,
+                fail_reasons=["engine_timeout"],
+            )
+        except Exception as exc:  # engine should never raise, but defend the run
+            elapsed = time.monotonic() - t0
+            logger.exception("engine error on %s", question.id)
+            return QuestionResult(
+                question=question,
+                reply=f"<ENGINE_ERROR: {exc.__class__.__name__}>",
+                elapsed_s=elapsed,
+                score=Score(judge_reason=f"engine error: {exc.__class__.__name__}"),
+                passed=False,
+                fail_reasons=["engine_error"],
+            )
 
-    elapsed = time.monotonic() - t0
-    score = await judge_reply(judge_client, question, reply)
-    fail_reasons = []
-    if score.min_dim() < HARD_FAIL_BELOW:
-        fail_reasons.append(f"dim_below_{HARD_FAIL_BELOW}")
-    if score.safety <= SAFETY_HARD_FAIL:
-        fail_reasons.append("safety_hard_fail")
-    return QuestionResult(
-        question=question,
-        reply=reply,
-        elapsed_s=elapsed,
-        score=score,
-        passed=not fail_reasons,
-        fail_reasons=fail_reasons,
-    )
+        elapsed = time.monotonic() - t0
+
+        # If the embed sidecar failed during this question, skip the judge —
+        # the reply is degraded by harness, not by engine. Run-level guard in
+        # summarize() fails the gate if too many questions get skipped.
+        if embed_signal.triggered:
+            logger.warning(
+                "skipping %s — embed sidecar unavailable (%s)",
+                question.id,
+                embed_signal.pattern_hit,
+            )
+            return QuestionResult(
+                question=question,
+                reply=reply,
+                elapsed_s=elapsed,
+                score=Score(judge_reason=f"skipped: {embed_signal.pattern_hit}"),
+                passed=False,
+                skipped=True,
+                skip_reason=embed_signal.pattern_hit,
+            )
+
+        score = await judge_reply(judge_client, question, reply)
+        fail_reasons = []
+        if score.min_dim() < HARD_FAIL_BELOW:
+            fail_reasons.append(f"dim_below_{HARD_FAIL_BELOW}")
+        if score.safety <= SAFETY_HARD_FAIL:
+            fail_reasons.append("safety_hard_fail")
+        return QuestionResult(
+            question=question,
+            reply=reply,
+            elapsed_s=elapsed,
+            score=score,
+            passed=not fail_reasons,
+            fail_reasons=fail_reasons,
+        )
+    finally:
+        root_logger.removeHandler(embed_handler)
 
 
 # ---------------------------------------------------------------------------
@@ -316,19 +396,35 @@ async def run_question(
 class RunSummary:
     total: int
     passed: int
+    skipped: int
     mean_of_means: float
     below_3: int
     hard_fails: int
     overall_pass: bool
+    harness_degraded: bool
     per_question: list[dict]
 
 
 def summarize(results: list[QuestionResult]) -> RunSummary:
-    means = [r.score.mean() for r in results]
+    scored = [r for r in results if not r.skipped]
+    skipped = sum(1 for r in results if r.skipped)
+    means = [r.score.mean() for r in scored]
     below_3 = sum(1 for m in means if m < 3.0)
-    hard_fails = sum(1 for r in results if r.fail_reasons)
+    hard_fails = sum(1 for r in scored if r.fail_reasons)
     mean_of_means = sum(means) / len(means) if means else 0.0
-    overall_pass = hard_fails == 0 and mean_of_means >= PASS_AVG and below_3 <= MAX_BELOW_3
+    # If too many questions were skipped (embed sidecar dead, etc.), the
+    # harness itself is broken — fail closed instead of letting a tiny
+    # surviving sample fluke a green gate.
+    harness_degraded = (
+        len(results) > 0 and skipped / len(results) > MAX_SKIP_FRACTION
+    )
+    overall_pass = (
+        not harness_degraded
+        and len(scored) > 0
+        and hard_fails == 0
+        and mean_of_means >= PASS_AVG
+        and below_3 <= MAX_BELOW_3
+    )
     per_question = [
         {
             "id": r.question.id,
@@ -341,16 +437,20 @@ def summarize(results: list[QuestionResult]) -> RunSummary:
             "elapsed_s": round(r.elapsed_s, 2),
             "passed": r.passed,
             "fail_reasons": r.fail_reasons,
+            "skipped": r.skipped,
+            "skip_reason": r.skip_reason,
         }
         for r in results
     ]
     return RunSummary(
         total=len(results),
         passed=sum(1 for r in results if r.passed),
+        skipped=skipped,
         mean_of_means=round(mean_of_means, 2),
         below_3=below_3,
         hard_fails=hard_fails,
         overall_pass=overall_pass,
+        harness_degraded=harness_degraded,
         per_question=per_question,
     )
 
@@ -362,12 +462,18 @@ def print_table(summary: RunSummary) -> None:
     for q in summary.per_question:
         s = q["scores"]
         marks = f"{s['grounding']} {s['context']} {s['actionability']} {s['safety']} {s['tone']}"
-        fail_tag = ",".join(q["fail_reasons"]) if q["fail_reasons"] else ""
-        print(f"{q['id'][:32]:32} {q['category'][:14]:14} {marks}  {q['mean']:>4.2f}  {fail_tag}")
+        if q.get("skipped"):
+            tag = f"SKIP: {q.get('skip_reason', '')}"
+        else:
+            tag = ",".join(q["fail_reasons"]) if q["fail_reasons"] else ""
+        print(f"{q['id'][:32]:32} {q['category'][:14]:14} {marks}  {q['mean']:>4.2f}  {tag}")
     print("-" * 78)
     verdict = "PASS" if summary.overall_pass else "FAIL"
+    if summary.harness_degraded:
+        verdict = "FAIL (harness degraded)"
     print(
         f"{verdict}  questions={summary.total}  passed={summary.passed}  "
+        f"skipped={summary.skipped}  "
         f"mean={summary.mean_of_means:.2f}  below_3={summary.below_3}  "
         f"hard_fails={summary.hard_fails}"
     )
@@ -397,17 +503,20 @@ async def amain() -> int:
         json.dumps(
             {
                 "overall_pass": summary.overall_pass,
+                "harness_degraded": summary.harness_degraded,
                 "mean_of_means": summary.mean_of_means,
                 "below_3": summary.below_3,
                 "hard_fails": summary.hard_fails,
                 "total": summary.total,
                 "passed": summary.passed,
+                "skipped": summary.skipped,
                 "questions": summary.per_question,
                 "thresholds": {
                     "pass_avg": PASS_AVG,
                     "hard_fail_below": HARD_FAIL_BELOW,
                     "safety_hard_fail": SAFETY_HARD_FAIL,
                     "max_below_3": MAX_BELOW_3,
+                    "max_skip_fraction": MAX_SKIP_FRACTION,
                 },
             },
             indent=2,


### PR DESCRIPTION
## Summary

Closes the long-standing intermittent flake in `staging-gate` where the `session-followup` (and other) cases hard-fail because the Ollama embed sidecar is unavailable in CI. Per @Mikecranesync's diagnosis on #1509 (2026-05-30): "Ollama embed failed on all candidates → NEON_RECALL_NO_EMBEDDING → vector retrieval skipped → degraded grounding → followup case dips below per-dimension floor → hard_fails=1."

This treats the embed-sidecar-unavailable condition as a **harness skip**, not an engine regression — the question is excluded from pass/fail math and surfaced as ⏸ in the PR comment. A run-level guard fails the gate closed if >50% of questions get skipped, so a fully-dead embed sidecar can never silently turn into a green gate.

## Changes

- `tools/staging_test.py`:
  - `QuestionResult` gains `skipped: bool` + `skip_reason: str`.
  - New `_EmbedFailureSignal` + `_EmbedFailureHandler` watch the root logger for `"Ollama embed failed on all candidates"` (from `rag_worker.py:919`) and `"NEON_RECALL_NO_EMBEDDING"` (from `neon_recall.py:638`).
  - `run_question()` installs/removes the handler per question; if triggered, returns a skipped `QuestionResult` and skips the judge call.
  - `summarize()` excludes skipped from `mean_of_means`/`below_3`/`hard_fails`; adds `harness_degraded` (>50% skipped) which forces fail.
  - `RunSummary`, JSON output, and `print_table()` surface the new `skipped` + `harness_degraded` fields.
- `tools/staging_render_comment.py`: shows `scored over X/Y` in the header, a dedicated `skipped (harness)` line, ⏸ emoji + `skip:` label per skipped row, and a `FAIL (harness degraded)` header when applicable.

## What this preserves

- Real engine regressions (hard-fail on a scored question) still fail the gate.
- The 5-dimension rubric, thresholds (PASS_AVG=3.5, MAX_BELOW_3=2, SAFETY_HARD_FAIL=1), and Groq-judge call are unchanged.
- The dependabot skip path in the workflow is unchanged.

## Verification

7 synthetic cases verified locally:

| Case | Result |
|---|---|
| 10/10 pass | ✅ gate passes |
| 2 skipped + 8 pass | ✅ gate passes (skipped excluded from math) |
| 6 of 10 skipped → harness degraded | ❌ gate fails closed |
| 1 hard-fail + 9 pass | ❌ gate still fails on real regression |
| Handler detects `"Ollama embed failed"` | ✅ |
| Handler detects `"NEON_RECALL_NO_EMBEDDING"` | ✅ |
| Handler ignores unrelated logs | ✅ no false positives |

`ruff check tools/staging_test.py tools/staging_render_comment.py` passes.

## Test plan

- [ ] Staging Gate runs green on this PR (and on PRs against this branch that touch retrieval code).
- [ ] If a PR run reports `skipped > 0`, confirm the PR comment shows ⏸ for those rows + a `skipped (harness)` count linking #1509.
- [ ] If the harness fully fails (no embed at all), confirm the gate fails closed with the `FAIL (harness degraded)` header instead of silently passing on a tiny sample.

## Follow-up

R5-option-A — provision an Ollama embed sidecar service container in `.github/workflows/staging-gate.yml` so the embed path is actually exercised in CI. Skip semantics are the floor; service-side embed is the ceiling. Will file as a separate issue.

## Related

- Closes #1509
- Audit: staging-gate architectural review 2026-05-31 (R5)
- Doctrine: `.claude/skills/bot-grounding-tests` (GS11 lesson from 2026-05-18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)