### PR TITLE
fix(staging-gate): require STAGING_TENANT_ID, drop prod-UUID fallback

### DIFF
--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -101,10 +101,12 @@ jobs:
           INFERENCE_BACKEND: cloud
           # tenant_id must be a real UUID — `kg_entities.tenant_id` is a uuid
           # column; passing the literal string "staging" trips a Postgres cast
-          # error that disables BM25 for every question. Use the prod shared
-          # tenant UUID; the staging Neon branch is forked from prod so the
-          # row exists.
-          MIRA_TENANT_ID: ${{ secrets.STAGING_TENANT_ID || '78917b56-f85f-43bb-9a08-1bb98a6cd6c3' }}
+          # error that disables BM25 for every question. The value is stored
+          # as the STAGING_TENANT_ID secret on the `staging` environment so
+          # the prod tenant UUID is not baked into the public workflow file.
+          # If unset, `tools/staging_test.py` fails closed (exit 2) before any
+          # DB write — a missing secret cannot silently target the prod tenant.
+          MIRA_TENANT_ID: ${{ secrets.STAGING_TENANT_ID }}
           # `mira-bots/shared/chat_tenant.py` reads MIRA_DB_PATH at module
           # import time and opens a SQLite file. The default `/data/mira.db`
           # does not exist on ubuntu-latest; point it at the runner temp dir.

--- a/tools/staging_test.py
+++ b/tools/staging_test.py
@@ -195,6 +195,12 @@ def build_supervisor() -> Supervisor:
     """
     require_env("NEON_DATABASE_URL")
     require_env("GROQ_API_KEY")
+    # MIRA_TENANT_ID must be set explicitly (R4, 2026-05-31). The previous
+    # workflow-level fallback to the prod tenant UUID created a latent
+    # cross-env-bleed risk: a missing STAGING_TENANT_ID secret silently
+    # routed gate writes through the prod tenant on the staging Neon branch.
+    # Fail closed here so a forgotten secret is loud, not silent.
+    require_env("MIRA_TENANT_ID")
     os.environ.setdefault("INFERENCE_BACKEND", "cloud")
 
     db_path = Path(tempfile.mkdtemp(prefix="mira-stg-")) / "mira.db"


### PR DESCRIPTION
## Summary

The staging-gate workflow defaulted `MIRA_TENANT_ID` to the prod tenant UUID `78917b56-f85f-43bb-9a08-1bb98a6cd6c3` **baked directly into `.github/workflows/staging-gate.yml`** when `STAGING_TENANT_ID` was unset. Latent cross-env-bleed risk: a missing secret silently routed gate writes through the prod tenant on the staging Neon branch. If a future migration ever provisions a fresh staging branch without the prod row, or if a separate staging tenant is wanted, the silent default hides that mismatch behind a green gate.

## Pre-merge prep (already done)

`STAGING_TENANT_ID` secret was set on the `staging` environment via `gh secret set` (2026-05-31), holding the same UUID — opaque now instead of public in the workflow file:

```
$ gh secret list --env staging --repo Mikecranesync/MIRA | grep TENANT
STAGING_TENANT_ID  2026-05-31T14:44:35Z
```

So the gate keeps working seamlessly across this PR's merge.

## Changes

- `.github/workflows/staging-gate.yml:99` — drop the `|| '78917b56-…'` fallback. Comment updated to document the failure mode if the secret goes missing.
- `tools/staging_test.py:build_supervisor()` — add `require_env("MIRA_TENANT_ID")` alongside the existing `NEON_DATABASE_URL` + `GROQ_API_KEY` checks. Missing or whitespace-only → exit code 2 before any DB write.

## Verification

Local sanity tests (mocked `Supervisor`):

| Case | Result |
|---|---|
| All 3 required vars set | Supervisor builds — OK |
| `MIRA_TENANT_ID` unset | `exit 2` — OK |
| Empty string `""` | `exit 2` — OK |
| Whitespace-only `"   "` | `exit 2` — OK |

## Test plan

- [ ] Staging Gate runs on this PR and resolves the secret → still passes (no behavior change from prod-UUID default)
- [ ] If `STAGING_TENANT_ID` secret is removed from the `staging` environment after merge, the gate fails closed with `missing env var MIRA_TENANT_ID` (loud, not silent)
- [ ] No future PR can land a workflow that re-introduces a hardcoded UUID fallback

## Related

- Audit: staging-gate architectural review 2026-05-31 (R4)
- Stack: independent of #1605 / #1606 / #1608; can merge in any order

🤖 Generated with [Claude Code](https://claude.com/claude-code)