### PR TITLE
feat(deploy-vps): audit staging-gate bypass — require reason, auto-issue

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -24,13 +24,17 @@ on:
         required: false
         default: ""
       skip_staging_gate:
-        description: "Skip staging-gate verification (hotfix only — record reason in PR/issue)"
+        description: "Skip staging-gate verification (hotfix only — REQUIRES skip_reason)"
         required: false
         default: "false"
         type: choice
         options:
           - "false"
           - "true"
+      skip_reason:
+        description: "Why is the staging gate being skipped? (Required when skip_staging_gate=true; auto-opens an audit issue)"
+        required: false
+        default: ""
 
 concurrency:
   group: deploy-vps
@@ -50,6 +54,61 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      # When the operator dispatches with skip_staging_gate=true, the gate
+      # verification is bypassed. CLAUDE.md says "file a follow-up PR within
+      # 24h" but nothing enforced it — silent bypasses leaked the rule. Now:
+      #   1. skip_reason is required (else this step fails the deploy upfront)
+      #   2. an audit issue is auto-opened so the bypass is loud, not silent
+      #   3. the issue carries the actor, SHA, services, reason, run URL,
+      #      and the 24-hour follow-up-PR expectation
+      - name: Validate + audit staging-gate bypass
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.skip_staging_gate == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+          SHA: ${{ github.sha }}
+          SERVICES: ${{ github.event.inputs.services }}
+          REASON: ${{ github.event.inputs.skip_reason }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${REASON// /}" ]; then
+            echo "::error::skip_staging_gate=true requires a non-empty skip_reason. Re-dispatch with a reason (e.g., 'hotfix: prod login broken, sev-1 incident #N')."
+            exit 1
+          fi
+          SERVICES_DISPLAY="${SERVICES:-(all)}"
+          SHORT_SHA="${SHA:0:8}"
+          {
+            echo "## staging-gate bypass — audit record"
+            echo ""
+            echo "A production deploy was triggered with \`skip_staging_gate=true\`."
+            echo "The Staging Gate was NOT verified for the commit being shipped."
+            echo ""
+            echo "| Field | Value |"
+            echo "|---|---|"
+            echo "| Actor | @${ACTOR} |"
+            echo "| SHA | \`${SHA}\` |"
+            echo "| Services | \`${SERVICES_DISPLAY}\` |"
+            echo "| Reason | ${REASON} |"
+            echo "| Run | [${RUN_URL}](${RUN_URL}) |"
+            echo ""
+            echo "### 24-hour follow-up — required (per CLAUDE.md)"
+            echo ""
+            echo "- [ ] Open a normal PR that applies the same fix and lands via the Staging Gate. Reference this issue in the PR description."
+            echo "- [ ] Close this issue once the follow-up PR has merged green through the Staging Gate."
+            echo ""
+            echo "If the bypass hid a real regression, escalate immediately and open a SEV ticket."
+            echo ""
+            echo "---"
+            echo ""
+            echo "_Auto-filed by \`.github/workflows/deploy-vps.yml\` (R8, staging-gate architectural review 2026-05-31). The title carries the short SHA for cross-referencing._"
+          } > bypass_issue_body.md
+          gh issue create \
+            --repo "$REPO" \
+            --title "staging-gate bypass: deploy by @${ACTOR} at ${SHORT_SHA}" \
+            --body-file bypass_issue_body.md
 
       - name: Verify Staging Gate passed
         # Refuse to deploy a commit that hasn't been graded by the staging gate.


### PR DESCRIPTION
## Summary

`deploy-vps.yml` accepts `workflow_dispatch` with `skip_staging_gate=true` as a hotfix bypass. CLAUDE.md says "file a follow-up PR within 24h" but **nothing enforced it** — silent bypasses meant the audit trail lived only in the run log, easy to lose track of and impossible to follow up on systematically.

This makes the bypass loud, not silent.

## Changes

1. **New `skip_reason` input** — required (non-empty, non-whitespace) when `skip_staging_gate=true`. Workflow exits 1 with a clear error if missing:
   > `::error::skip_staging_gate=true requires a non-empty skip_reason. Re-dispatch with a reason (e.g., 'hotfix: prod login broken, sev-1 incident #N').`

2. **New "Validate + audit staging-gate bypass" step** that runs ONLY when the bypass is taken. Writes a structured markdown body covering:
   - Actor (who dispatched)
   - SHA (full body + short SHA in title for grep-friendly cross-ref)
   - Services (or `(all)`)
   - Reason (the operator's input)
   - Run URL (back to the dispatch log)
   - 24-hour follow-up checklist (per CLAUDE.md)

   And opens it as a GitHub issue via `gh issue create --body-file`. Pattern matches existing `dependency-check.yml`. No new secrets; uses default `GITHUB_TOKEN`. No labels (none exist for this category; operator can add post-creation).

3. **Title format:** `staging-gate bypass: deploy by @{actor} at {short_sha}` — short SHA in title makes audit reviews grep-friendly.

## Verification

Local synthetic test (run script + env):

| Case | Result |
|---|---|
| Non-empty reason | Body generates cleanly, title has correct short SHA |
| Empty reason | Exit 1 with helpful error message |
| Whitespace-only reason | Exit 1 (`"${REASON// /}"` strips spaces) |
| YAML schema | Valid (`yaml.safe_load` parses; all required steps present) |

## Test plan

- [ ] Dispatch `deploy-vps.yml` with `skip_staging_gate=true` AND `skip_reason="test bypass audit (R8)"` against a no-op commit → confirm an audit issue is opened in the repo with the expected body
- [ ] Dispatch with `skip_staging_gate=true` AND `skip_reason=""` → confirm the deploy fails fast (exit 1) BEFORE reaching the deploy step
- [ ] Dispatch with `skip_staging_gate=false` (the default) → confirm the audit step is skipped entirely (no spurious issue created)

## Out of scope (future)

- Auto-close the bypass issue when the follow-up PR merges (requires a PR template / convention for referencing the bypass issue number)
- Slack notification (would require a `SLACK_WEBHOOK_URL` secret on the `production` environment)

## Related

- Audit: staging-gate architectural review 2026-05-31 (R8)
- Doctrine: CLAUDE.md "Hotfix bypass" rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)