### PR TITLE
docs(staging-gate): clarify cascade env vars — engine vs judge

### DIFF
--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -40,11 +40,19 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
-    # Secrets required (set under repo "Staging Gate" environment):
-    #   NEON_STG_DATABASE_URL   — connection string to the NeonDB staging branch
-    #   STAGING_GROQ_API_KEY    — Groq key dedicated to staging (rate-limit isolation)
-    #   STAGING_CEREBRAS_API_KEY (optional cascade fallback)
-    #   STAGING_GEMINI_API_KEY   (optional cascade fallback)
+    # Secrets required (set under repo "staging" environment):
+    #   NEON_STG_DATABASE_URL    — connection string to the NeonDB staging branch
+    #   STAGING_TENANT_ID        — UUID for kg_entities.tenant_id (fail-closed if unset; see R4)
+    #   STAGING_GROQ_API_KEY     — Groq key (rate-limit isolated from prod)
+    #   STAGING_CEREBRAS_API_KEY — used by BOTH the engine cascade (answering)
+    #                              and the judge cascade (scoring), as fallback
+    #                              for Groq under outage / 429 / 5xx
+    #   STAGING_GEMINI_API_KEY   — second fallback for the same two cascades
+    # The engine cascade lives in mira-bots/shared/inference/router.py and
+    # answers the technician's question. The judge cascade lives in
+    # tools/staging_test.py and grades the resulting reply on the 5-dim
+    # rubric. Both layers fall through Groq → Cerebras → Gemini; a Groq
+    # outage no longer halts the gate (see R2).
     environment: staging
 
     steps:


### PR DESCRIPTION
## Summary

The "Secrets required" comment block in `.github/workflows/staging-gate.yml` lumped `CEREBRAS_API_KEY` and `GEMINI_API_KEY` under "optional cascade fallback" without distinguishing the **two distinct cascades** they serve. Also misnamed the GitHub environment as "Staging Gate" (actual name: `staging`, case-sensitive) and didn't list `STAGING_TENANT_ID` (added by R4).

## The two cascades

1. **Engine cascade** (`mira-bots/shared/inference/router.py`) — answers the technician's question. Falls Groq → Cerebras → Gemini.
2. **Judge cascade** (`tools/staging_test.py`, added by R2) — grades the engine's reply on the 5-dim rubric. Falls Groq → Cerebras → Gemini.

Same env vars feed both. A Groq outage no longer halts the gate (R2 wired the judge cascade; the engine cascade was already there).

## Changes

Comment block only. No behavior change.

## Test plan

- [ ] Confirm comment renders correctly on GitHub's web view (no markdown stripped)
- [ ] Confirm comment references match the actual secret names returned by `gh secret list --env staging --repo Mikecranesync/MIRA`

## Related

- Audit: staging-gate architectural review 2026-05-31 (R9)
- Cross-refs: R2 (judge cascade), R4 (STAGING_TENANT_ID required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)