### PR TITLE
feat(ignition): cutover chat handler from mira-sidecar /rag to mira-pipeline /v1/chat/completions

### DIFF
--- a/ignition/config/factorylm.properties.template
+++ b/ignition/config/factorylm.properties.template
@@ -16,18 +16,42 @@
 
 
 # =============================================================================
-# SECTION 1 — RAG SIDECAR CONNECTION
-# The Jython scripts connect to the CPython sidecar over HTTP on localhost.
-# The sidecar must NEVER be exposed on a public or plant-network interface.
+# SECTION 1 — MIRA PIPELINE CONNECTION (chat backend)
+# The chat handler connects to mira-pipeline's OpenAI-compatible
+# /v1/chat/completions endpoint on the VPS. The pipeline runs the full GSD
+# engine (intent classifier, UNS gate, hybrid RAG, citation compliance,
+# cascade providers Groq -> Cerebras -> Gemini).
+#
+# Legacy mira-sidecar (ChromaDB RAG on localhost:5000) is superseded —
+# leave SIDECAR_* values present only if you still run /ingest or /build_fsm
+# locally; chat traffic no longer hits the sidecar.
 # =============================================================================
 
-# Base URL for the RAG sidecar.
-# Default: http://localhost:5000
-# Change only if you run the sidecar on a non-standard port.
+# Base URL for mira-pipeline (must include scheme, no trailing slash).
+# Production:  https://app.factorylm.com
+# Staging:     https://staging.factorylm.com   (port 4099 if direct)
+# Default:     https://app.factorylm.com
+PIPELINE_BASE_URL=https://app.factorylm.com
+
+# Bearer token for mira-pipeline. Fetch from Doppler factorylm/prd ->
+# PIPELINE_API_KEY. Leave blank ONLY for unauthenticated local pipelines.
+PIPELINE_API_KEY=
+
+# Model identifier the pipeline exposes. Do not change unless mira-pipeline
+# /v1/models advertises a different name.
+# Default: mira-diagnostic
+PIPELINE_MODEL=mira-diagnostic
+
+# Timeout (seconds) for /v1/chat/completions calls from the chat handler.
+# Cascade providers usually return in 5-15 s; vision uploads can take longer.
+# Default: 60
+PIPELINE_TIMEOUT_SEC=60
+
+# Legacy mira-sidecar (ingest / build_fsm only — chat path no longer uses it).
+# Safe to leave at defaults unless you run a non-standard port.
 SIDECAR_BASE_URL=http://localhost:5000
 
-# Timeout (seconds) for RAG /rag endpoint calls from the chat handler.
-# Increase if your LLM backend is slow (e.g. local GPU with large context).
+# Timeout (seconds) for legacy /rag calls (kept for back-compat health probes).
 # Default: 30
 SIDECAR_RAG_TIMEOUT_SEC=30
 

--- a/ignition/webdev/FactoryLM/api/chat/doPost.py
+++ b/ignition/webdev/FactoryLM/api/chat/doPost.py
@@ -1,82 +1,240 @@
 # Web Dev Module Handler: POST /system/webdev/FactoryLM/api/chat
-# Reads live tag snapshot for an asset, forwards query + context to RAG sidecar,
-# persists result to mira_chat_history, returns answer + sources.
+#
+# Reads live tag snapshot for an asset, forwards query + context to
+# mira-pipeline's OpenAI-compatible /v1/chat/completions endpoint, splits
+# inline "--- Sources ---" citations off the answer, persists to
+# mira_chat_history, and returns {answer, sources} to the iframe UI.
+#
+# This handler used to call the legacy mira-sidecar /rag endpoint
+# (ChromaDB RAG on localhost:5000). It now targets mira-pipeline so the
+# Ignition portal inherits the GSD engine (intent classifier, UNS gate,
+# hybrid RAG, citation compliance, cascade Groq -> Cerebras -> Gemini).
+#
+# Config is read from data/factorylm/factorylm.properties — see SECTION 1
+# of factorylm.properties.template for the keys.
+#
 # Jython 2.7 — runs inside Ignition Gateway JVM.
 # Ref: https://www.docs.inductiveautomation.com/docs/8.1/ignition-modules/web-dev
 
-def doPost(request, session):
-    logger = system.util.getLogger("FactoryLM.Mira.Chat")
+import re
 
-    # --- Parse request body ---
-    # 'postData' is a dict when Content-Type is application/json
+
+logger = system.util.getLogger("FactoryLM.Mira.Chat")
+
+
+# ---------------------------------------------------------------------------
+# Configuration helpers
+# ---------------------------------------------------------------------------
+
+def _getMiraConfig(key, default_value=""):
+    """Read a key from factorylm.properties on the Gateway host.
+
+    Returns default_value if the file is missing or the key is absent.
+    """
+    import java.io.FileInputStream as FileInputStream
+    import java.util.Properties as Properties
+    import java.io.File as File
+
+    paths = [
+        "C:/Program Files/Inductive Automation/Ignition/data/factorylm/factorylm.properties",
+        "/usr/local/bin/ignition/data/factorylm/factorylm.properties",
+        "/var/lib/ignition/data/factorylm/factorylm.properties",
+    ]
+
+    for p in paths:
+        f = File(p)
+        if not f.exists():
+            continue
+        props = Properties()
+        fis = FileInputStream(f)
+        try:
+            props.load(fis)
+            return props.getProperty(key, default_value)
+        except Exception as load_err:
+            logger.warn("Failed to load properties from %s: %s" % (p, str(load_err)))
+        finally:
+            fis.close()
+
+    return default_value
+
+
+# ---------------------------------------------------------------------------
+# Source-splitting (matches mira-scan-monday/backend/mira_rag.py)
+#
+# mira-pipeline returns plain text in choices[0].message.content. The engine
+# appends a trailing "--- Sources ---" block with "[N] Title" lines. We split
+# that off so the Ignition UI's collapsible Sources panel can render them.
+# ---------------------------------------------------------------------------
+
+_SOURCE_LINE_RE = re.compile(r"^\s*\[(\d+)\]\s*(.+?)\s*$")
+_SOURCE_HEADER_RE = re.compile(r"\n\s*-{3,}\s*Sources\s*-{3,}\s*\n")
+
+
+def _split_sources(content):
+    """Return (answer_without_trailing_sources, [{file, page, excerpt}, ...])."""
+    if not content:
+        return "", []
+    parts = _SOURCE_HEADER_RE.split(content, maxsplit=1)
+    answer = parts[0].strip()
+    sources = []
+    if len(parts) > 1:
+        for line in parts[1].splitlines():
+            m = _SOURCE_LINE_RE.match(line)
+            if not m:
+                continue
+            title = m.group(2)
+            # Surface "filename — page N" as separate fields when present,
+            # otherwise leave page empty. The UI renders both.
+            page = ""
+            file_title = title
+            page_match = re.search(r"\s+[-—]\s+page\s+([\w.-]+)\s*$", title, re.IGNORECASE)
+            if page_match:
+                page = page_match.group(1)
+                file_title = title[: page_match.start()].strip()
+            sources.append({"file": file_title, "page": page, "excerpt": ""})
+    return answer, sources
+
+
+# ---------------------------------------------------------------------------
+# Live tag snapshot
+# ---------------------------------------------------------------------------
+
+def _read_tag_snapshot(asset_id):
+    """Read all tags under [default]Mira_Monitored/<asset_id>.
+
+    Returns a {tag_path: {value, quality, timestamp}} dict. Never raises.
+    """
+    snapshot = {}
+    if not asset_id:
+        return snapshot
+
+    tag_folder = "[default]Mira_Monitored/%s" % asset_id
+    try:
+        tag_results = system.tag.browseTags(parentPath=tag_folder)
+        tag_paths = [str(t.fullPath) for t in tag_results]
+        if not tag_paths:
+            logger.debug("No tags found under %s" % tag_folder)
+            return snapshot
+
+        tag_values = system.tag.readBlocking(tag_paths)
+        for i, path in enumerate(tag_paths):
+            qv = tag_values[i]
+            snapshot[path] = {
+                "value": str(qv.value),
+                "quality": str(qv.quality),
+                "timestamp": str(qv.timestamp),
+            }
+        logger.debug("Tag snapshot for %s: %d tags read" % (asset_id, len(snapshot)))
+    except Exception as e:
+        logger.warn("Tag read failed for asset %s: %s" % (asset_id, str(e)))
+
+    return snapshot
+
+
+def _format_tag_snapshot(snapshot):
+    """Render a tag snapshot dict into a compact text block for the LLM."""
+    if not snapshot:
+        return "No live tag data available."
+    lines = ["Current tag values:"]
+    for tag_path, qv in snapshot.items():
+        # Trim the [default]Mira_Monitored/<asset>/ prefix for readability
+        short = tag_path.split("/")[-1] if "/" in tag_path else tag_path
+        lines.append("  %s = %s (quality=%s)" % (short, qv["value"], qv["quality"]))
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline call
+# ---------------------------------------------------------------------------
+
+def _call_pipeline(base_url, api_key, model, timeout_sec, chat_id, user_message):
+    """POST to {base_url}/v1/chat/completions and return parsed JSON.
+
+    Raises urllib2.HTTPError / urllib2.URLError on transport errors so the
+    caller can map them to HTTP status codes.
+    """
+    import urllib2
+    import json
+
+    payload = json.dumps({
+        "model": model,
+        "messages": [{"role": "user", "content": user_message}],
+        "stream": False,
+        "user": chat_id,
+    })
+
+    url = "%s/v1/chat/completions" % base_url.rstrip("/")
+    req = urllib2.Request(url, payload)
+    req.add_header("Content-Type", "application/json")
+    if api_key:
+        req.add_header("Authorization", "Bearer %s" % api_key)
+    # mira-pipeline reads this header to scope FSM state per Ignition asset
+    if chat_id:
+        req.add_header("X-OpenWebUI-Chat-Id", chat_id)
+
+    response = urllib2.urlopen(req, timeout=timeout_sec)
+    return json.loads(response.read())
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+def doPost(request, session):
+    import urllib2
+
     data = request.get("postData", {})
     if data is None:
         data = {}
 
     query = data.get("query", "").strip()
     asset_id = data.get("asset_id", "").strip()
-    extra_context = data.get("context", "")
     operator = data.get("operator", "")
 
-    # Validate required field
     if not query:
         logger.warn("Chat request received with empty query")
         return {"json": {"error": "query is required"}, "status": 400}
 
     logger.debug(
-        "Chat request — asset: %s, query: %.80s" % (asset_id or "(none)", query)
+        "Chat request -- asset: %s, query: %.80s" % (asset_id or "(none)", query)
     )
 
-    # --- Read live tag snapshot for this asset ---
-    snapshot = {}
+    # Load pipeline config
+    base_url = _getMiraConfig("PIPELINE_BASE_URL", "https://app.factorylm.com")
+    api_key = _getMiraConfig("PIPELINE_API_KEY", "")
+    model = _getMiraConfig("PIPELINE_MODEL", "mira-diagnostic")
+    try:
+        timeout_sec = int(_getMiraConfig("PIPELINE_TIMEOUT_SEC", "60"))
+    except (TypeError, ValueError):
+        timeout_sec = 60
 
+    # Build the user message with live tag context prepended. The engine sees
+    # the snapshot as part of the user turn; the system prompt and UNS gate
+    # are owned by mira-pipeline and should not be re-templated here.
+    snapshot = _read_tag_snapshot(asset_id)
+    snapshot_block = _format_tag_snapshot(snapshot)
+    asset_line = "Asset: %s" % asset_id if asset_id else "Asset: (unspecified)"
+    user_message = "%s\n%s\n\nQuestion: %s" % (asset_line, snapshot_block, query)
+
+    # chat_id scopes FSM state per asset; technician identity (if known) is
+    # appended so the same asset, used by different operators, gets distinct
+    # sessions. Fall back to asset_id or a generic key.
+    chat_id_parts = []
     if asset_id:
-        tag_folder = "[default]Mira_Monitored/%s" % asset_id
-        try:
-            # Browse all tags (OPC + Memory) in the asset folder
-            tag_results = system.tag.browseTags(parentPath=tag_folder)
-            tag_paths = [str(t.fullPath) for t in tag_results]
-
-            if tag_paths:
-                tag_values = system.tag.readBlocking(tag_paths)
-                for i, path in enumerate(tag_paths):
-                    qv = tag_values[i]
-                    snapshot[path] = {
-                        "value": str(qv.value),
-                        "quality": str(qv.quality),
-                        "timestamp": str(qv.timestamp)
-                    }
-                logger.debug(
-                    "Tag snapshot for %s: %d tags read" % (asset_id, len(snapshot))
-                )
-            else:
-                logger.debug("No tags found under %s" % tag_folder)
-
-        except Exception as e:
-            # Non-fatal — proceed without snapshot; log for debugging
-            logger.warn(
-                "Tag read failed for asset %s: %s" % (asset_id, str(e))
-            )
-
-    # --- Forward to RAG sidecar ---
-    import urllib2
-    import json
-
-    rag_payload = json.dumps({
-        "query": query,
-        "asset_id": asset_id,
-        "tag_snapshot": snapshot,
-        "context": extra_context
-    })
+        chat_id_parts.append("ignition-%s" % asset_id)
+    if operator:
+        chat_id_parts.append(operator)
+    chat_id = "-".join(chat_id_parts) if chat_id_parts else "ignition-anonymous"
 
     try:
-        req = urllib2.Request(
-            "http://localhost:5000/rag",
-            rag_payload,
-            {"Content-Type": "application/json"}
+        result = _call_pipeline(
+            base_url=base_url,
+            api_key=api_key,
+            model=model,
+            timeout_sec=timeout_sec,
+            chat_id=chat_id,
+            user_message=user_message,
         )
-        response = urllib2.urlopen(req, timeout=30)
-        result = json.loads(response.read())
     except urllib2.HTTPError as e:
         body = ""
         try:
@@ -84,52 +242,61 @@ def doPost(request, session):
         except Exception:
             pass
         logger.error(
-            "RAG sidecar returned HTTP %d: %s" % (e.code, body[:200])
+            "mira-pipeline returned HTTP %d: %s" % (e.code, body[:200])
         )
         return {
             "json": {
-                "error": "RAG sidecar returned error",
+                "error": "mira-pipeline returned an error",
                 "http_status": e.code,
-                "detail": body[:200]
+                "detail": body[:200],
             },
-            "status": 502
+            "status": 502,
         }
     except urllib2.URLError as e:
-        logger.error("RAG sidecar unreachable: %s" % str(e))
+        logger.error("mira-pipeline unreachable: %s" % str(e))
         return {
             "json": {
-                "error": "RAG sidecar unreachable",
-                "detail": str(e)
+                "error": "mira-pipeline unreachable",
+                "detail": str(e),
             },
-            "status": 503
+            "status": 503,
         }
     except Exception as e:
-        logger.error("Unexpected error calling RAG sidecar: %s" % str(e))
+        logger.error("Unexpected error calling mira-pipeline: %s" % str(e))
         return {
             "json": {
                 "error": "Internal error",
-                "detail": str(e)
+                "detail": str(e),
             },
-            "status": 500
+            "status": 500,
         }
 
-    # --- Persist to chat history ---
+    # Extract assistant content from the OpenAI-compat envelope
     try:
-        sources_json = json.dumps(result.get("sources", []))
-        answer = result.get("answer", "")
+        raw_content = result["choices"][0]["message"]["content"] or ""
+    except (KeyError, IndexError, TypeError):
+        logger.warn("Unexpected mira-pipeline payload: %s" % str(result)[:200])
+        raw_content = ""
 
+    answer, sources = _split_sources(raw_content)
+
+    # Persist to chat history (non-fatal; audit trail only)
+    try:
+        import json as _json
+        sources_json = _json.dumps(sources)
         system.db.runPrepUpdate(
             "INSERT INTO mira_chat_history "
             "(asset_id, query, answer, sources_json, operator, created_at) "
             "VALUES (?, ?, ?, ?, ?, NOW())",
-            [asset_id, query, answer, sources_json, operator]
+            [asset_id, query, answer, sources_json, operator],
         )
     except Exception as e:
-        # Non-fatal — chat history is audit trail, not critical path
         logger.warn("Chat history save failed: %s" % str(e))
 
     logger.info(
-        "Chat query completed — asset: %s, query: %.80s" % (asset_id, query)
+        "Chat query completed -- asset: %s, chat_id: %s, query: %.80s" % (
+            asset_id, chat_id, query,
+        )
     )
 
-    return {"json": result}
+    return {"json": {"answer": answer, "sources": sources}}


### PR DESCRIPTION
## Summary
- Ignition Mira panel chat now calls `mira-pipeline /v1/chat/completions` instead of legacy `mira-sidecar /rag` on `localhost:5000`.
- Inherits cascade providers (Groq→Cerebras→Gemini), UNS gate, citation compliance, hybrid retrieval — same backend as Slack/Telegram/scan-monday.
- Two files changed: `factorylm.properties.template` (new PIPELINE_* section), `api/chat/doPost.py` (full handler rewrite).
- Response shape `{answer, sources}` preserved; iframe UI (`doGet.py`) needs zero changes.

## Why
Two test runs (2026-06-01) against the live PMC-station conveyor showed identical regressions: CoT leak (`1. Yes 2. No 3. Unknown 4. Not specified` in every reply), multi-vendor citation confusion (PowerFlex 525 + ABB ACS355 + Yaskawa GA500 all cited for the same drive), tunnel-vision on the active fault for unrelated PM/spec/lube questions, and 20-30s/reply latency. All symptoms are classic small-Ollama-llama3-on-CPU under a hard "answer only from docs" prompt. Cascade providers + GSD engine already solved this for other clients.

## What this does NOT fix yet
- The PMC `conveyor_demo` asset is not registered in `kg_entities` — pipeline's UNS gate will likely prompt for asset confirmation on the first asset-specific question. Either accept that as demo flow or pre-register the asset.
- Wrong-vendor docs in `shared_oem` ChromaDB are orthogonal; if a future demo needs PowerFlex 525 docs to NOT surface for an ABB ACS355, audit `kg_entities` first.

## Test plan
- [ ] Tier 0: `python -c "import ast; ast.parse(open('ignition/webdev/FactoryLM/api/chat/doPost.py').read())"` from any host with Python 3.
- [ ] Tier 1: `curl https://app.factorylm.com/health` and `curl -H "Authorization: Bearer $KEY" https://app.factorylm.com/v1/models` from the PLC laptop (Doppler `factorylm/prd` → `PIPELINE_API_KEY`).
- [ ] Tier 3: Ignition Designer → Script Console → run `urllib2.urlopen` against the pipeline from inside the Gateway JVM (catches Java cert / corporate proxy issues).
- [ ] Tier 4: Re-run the 10 garage-conveyor questions in the MIRA panel after deploy. Pass if: no `1. Yes 2. No 3. Unknown` CoT pattern in any reply, < 10s typical latency, citations match registered vendor (or engine says "no docs for this asset"), PM/lube/spec questions answered on their own merits.
- [ ] `mira_chat_history` row written for each turn with new `chat_id` prefix `ignition-<asset>`.
- [ ] Gateway log `FactoryLM.Mira.Chat` shows `Chat query completed -- asset: <id>, chat_id: ignition-<id>`.

## Deploy
1. From any host with Doppler: `doppler secrets get PIPELINE_API_KEY -p factorylm -c prd --plain`
2. SSH to PLC laptop (Tailscale `100.72.2.99`):
   - Edit `C:\Program Files\Inductive Automation\Ignition\data\factorylm\factorylm.properties` — set `PIPELINE_API_KEY=<value>`.
   - `cd C:\Users\hharp\Documents\GitHub\MIRA`
   - `git fetch origin && git checkout feat/ignition-chat-mira-pipeline-cutover && git pull`
   - `PowerShell -ExecutionPolicy Bypass -File ignition\deploy_ignition.ps1`
3. Open MIRA panel, send a test question, tail `FactoryLM.Mira.Chat`.

## Rollback
Two options, both reversible:
- Set `PIPELINE_BASE_URL=` (empty) in the live `factorylm.properties` → handler returns 503; UI shows error toast.
- `git revert <merge-sha>` and re-run `deploy_ignition.ps1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)