### PR TITLE
feat(ask-api): ground MIRA in conveyor machine card + decoded live state (Phase 1)

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -373,6 +373,10 @@ services:
       - "100.68.120.99:8011:8011"
     environment:
       <<: *bot-common-env
+      # Kiosk is bolted to one machine (the garage conveyor). Skip the
+      # "which equipment?" UNS confirmation gate so MIRA answers directly.
+      # Scoped to mira-ask ONLY — the Telegram/Slack bots keep the gate.
+      MIRA_UNS_GATE_ENABLED: "0"
     volumes:
       - /opt/mira/data:/mira-db
     networks:

--- a/mira-bots/ask_api/app.py
+++ b/mira-bots/ask_api/app.py
@@ -17,6 +17,8 @@ import uuid
 
 from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel
+
+from ask_api.machine_context import MACHINE_CONTEXT
 from shared.engine import Supervisor
 
 logging.basicConfig(
@@ -55,6 +57,24 @@ class AskRequest(BaseModel):
     session_id: str | None = None
 
 
+# --- GS10 decode tables (mirror MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md) ---
+# Status word (reg 0x2101) low 2 bits -> run state.
+_STATUS_BITS = {0: "STOPPED", 1: "DECEL", 2: "STANDBY", 3: "RUNNING"}
+# GS10 fault/error codes (vfd_fault_code, low byte of reg 0x2100) -> short name.
+_FAULT_CODES = {
+    0: "no active fault",
+    4: "GFF ground fault",
+    12: "Lvd undervoltage",
+    21: "oL overload",
+    49: "EF external fault",
+    54: "CE1 comm illegal cmd",
+    55: "CE2 comm illegal addr",
+    56: "CE3 comm illegal data",
+    57: "CE4 comm fail",
+    58: "CE10 modbus timeout",
+}
+
+
 def _build_status_block(tags: dict | None) -> str:
     """Decode known live conveyor/VFD tags into a human-readable status block.
 
@@ -82,9 +102,15 @@ def _build_status_block(tags: dict | None) -> str:
         elif key == "vfd_cmd_word":
             lines.append(f"Command: {cmd_word_map.get(value, f'cmd {value}')}")
         elif key == "vfd_status_word":
-            lines.append(f"status word {value}")
+            state = _STATUS_BITS.get(value & 0b11, "?")
+            lines.append(f"Drive state: {state} (status word {value})")
         elif key == "vfd_fault_code":
-            lines.append("no active fault" if value == 0 else f"FAULT CODE {value}")
+            if value == 0:
+                lines.append("no active fault")
+            elif value in _FAULT_CODES:
+                lines.append(f"FAULT: {_FAULT_CODES[value]} (code {value})")
+            else:
+                lines.append(f"FAULT code {value} (unmapped)")
         elif key == "vfd_comm_ok":
             lines.append(f"VFD comms {'OK' if value else 'LOST'}")
         elif key == "pe_latched":
@@ -119,9 +145,11 @@ async def ask(req: AskRequest, x_mira_key: str = Header(None)):
 
     try:
         status_block = _build_status_block(req.tags)
-        enriched = (
-            f"{status_block}\n\n[QUESTION]\n{req.question}" if status_block else req.question
-        )
+        parts = [MACHINE_CONTEXT]
+        if status_block:
+            parts.append(status_block)
+        parts.append("[QUESTION]\n" + req.question)
+        enriched = "\n\n".join(parts)
 
         chat_id = req.session_id or ("ignition:" + uuid.uuid4().hex)
 

--- a/mira-bots/ask_api/machine_context.py
+++ b/mira-bots/ask_api/machine_context.py
@@ -1,0 +1,51 @@
+"""Always-on machine-context block injected into every /ask call.
+
+This module holds ONE constant, ``MACHINE_CONTEXT`` — a condensed distillation
+of ``MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md`` (the single source of truth about
+THIS garage conveyor). It grounds MIRA in the real Micro820 + GS10 machine so it
+answers from the actual iron, not generic VFD trivia.
+
+It lives in its own module so the facts can be edited independently of the
+/ask handler logic in ``app.py``. Keep it dense and factual (~400-600 tokens):
+it is prepended to every question, so brevity directly costs tokens on each call.
+When the machine card changes, update this block (and the decode dicts in app.py).
+"""
+
+MACHINE_CONTEXT = """[MACHINE: GARAGE CONVEYOR]
+Garage conveyor belt. PLC: Allen-Bradley Micro820 2080-LC20-20QBB @192.168.1.100
+(EtherNet/IP :44818; Modbus TCP slave :502 unit 1). VFD: AutomationDirect GS10
+(DURApulse) spinning the belt motor. PLC↔VFD: RS-485 Modbus RTU, PLC=master, GS10=slave 1,
+9600 8N1. PLC reads buttons/sensors+GS10 status, decides if belt may run, writes
+run/stop/direction to GS10. Dashboard reads unpacked values from the PLC's Modbus TCP slave.
+
+RUN PERMIT = contactor DO_02 in AND e-stop healthy AND photo-eye not latched. Direction:
+DI_00=FWD, DI_01=REV, neither=OFF; both = direction fault→STOP. Start=DI_04 (re-arms
+photo-eye latch with beam clear, resumes drive).
+
+VFD COMMAND WORD (reg 0x2000, FC06): 1=STOP, 18=FWD+RUN, 20=REV+RUN (REV may be 34 on some
+configs—verify on bench). Freq setpoint reg 0x2001=Hz×10. Fault reset=write 2 to 0x2002.
+GS10 only accepts Modbus when P00.21=2 (run src RS-485) AND P00.20=1 (freq src RS-485).
+
+E-STOP (dual-channel, must disagree when healthy): DI_02=NC healthy=TRUE; DI_03=NO
+healthy=FALSE. Pressed→DI_02 FALSE/DI_03 TRUE→e-stop active, drive STOP. Both channels SAME
+state (both TRUE or both FALSE)=wiring fault (broken/shorted)—unsafe, drive not permitted.
+
+PHOTO-EYE DI_05 (TRUE=beam blocked) = LATCHING soft-stop. Beam break latches pe_latched
+TRUE→run permit FALSE, VFD STOP—but main contactor DO_02 STAYS ENERGIZED (power present,
+motor stopped). Clearing beam alone does NOT restart; operator must press Start (DI_04) with
+beam clear to clear pe_latched and resume.
+
+GS10 FAULT CODES (vfd_fault_code, 0=none): 4=GFF ground fault; 12=Lvd undervoltage on decel;
+21=oL overload (load/jam); 49=EF external fault; 54=CE1 comm illegal cmd (bad function code);
+55=CE2 comm illegal addr; 56=CE3 comm illegal data; 57=CE4 slave error (power-cycle);
+58=CE10 modbus timeout (check 9600 8N1/wiring). Clear via keypad STOP/RESET or write 2 to
+0x2002; if stuck, power-cycle.
+
+GS10 STATUS WORD (reg 0x2101) low 2 bits: 00=stopped, 01=decel, 10=standby, 11=running.
+
+KEY TAGS+scaling: vfd_comm_ok=MASTER TRUST GATE (FALSE→all VFD values below are stale).
+vfd_frequency=output Hz×100 (6000=60.00Hz). vfd_freq_sp=setpoint Hz×100. vfd_current=A×100.
+vfd_dc_bus=V×10 (~3270=327V idle). vfd_cmd_word=command echo (1/18/20). vfd_status_word=see
+above. vfd_fault_code=see table. vfd_run_permit=DO_02 AND e_stop_ok AND NOT pe_latched.
+pe_latched=photo-eye jam latch. DI_02=e-stop ch A (healthy TRUE). DI_05=photo-eye
+(TRUE=blocked). DO_02=main contactor (TRUE=power enabled, stays in during soft-stop)."""


### PR DESCRIPTION
## What this does
Phase 1 of `specs/ASK_MIRA_GROUNDING.md`. Makes the **Ask MIRA** dashboard endpoint **machine-aware** so answers are about THIS garage conveyor (Micro820 2080-LC20 + GS10 VFD), not generic VFD trivia. No infra dependency — all inside the `mira-ask` service + one authored doc.

## Changes
- **`mira-bots/ask_api/machine_context.py`** (new): a condensed (~640 token) `[MACHINE: GARAGE CONVEYOR]` block distilled from `MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md` — identity, command words (1=STOP/18=FWD+RUN/20=REV+RUN), dual-channel e-stop logic, photo-eye DI_05 latching soft-stop, compact GS10 fault table, tag meanings + scaling, `vfd_comm_ok` trust gate.
- **`mira-bots/ask_api/app.py`**: every `/ask` now sends `MACHINE_CONTEXT` → live status block → question last. `_build_status_block` now **decodes** `vfd_status_word` (bits 1-0 → RUNNING/STOPPED/STANDBY/DECEL) and `vfd_fault_code` (→ GS10 fault name) instead of raw numbers.
- **`docker-compose.saas.yml`**: `MIRA_UNS_GATE_ENABLED="0"` on **`mira-ask` only** (verified no leak to other services), so the kiosk answers directly instead of "which equipment?". Telegram/Slack bots keep the gate.

## Deploy
New env var on an existing service — after merge, deploy with:
`gh workflow run deploy-vps.yml -f services=mira-ask` (staging gate enforced).

## Verify (real round-trip, not curl-only)
- `POST /ask` `{"question":"belt won't start, photo-eye light is on","tags":{"pe_latched":true,"vfd_cmd_word":1}}` → answer should name the **latching photo-eye soft-stop** + **press Start with beam clear** to rearm, and NOT ask "which equipment?".
- `POST /ask` `{"tags":{"vfd_fault_code":55}}` → answer references **CE2 comm illegal addr**, not a bare number.

Spec: `MIRA_PLC/specs/ASK_MIRA_GROUNDING.md` (Phase 1). Machine card: `MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
