### PR TITLE
fix(ask-api): raise MIRA_PROCESS_TIMEOUT to 90s on mira-ask kiosk

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -377,6 +377,12 @@ services:
       # "which equipment?" UNS confirmation gate so MIRA answers directly.
       # Scoped to mira-ask ONLY — the Telegram/Slack bots keep the gate.
       MIRA_UNS_GATE_ENABLED: "0"
+      # Grounded diagnostic questions run the full RAG+rerank+LLM pipeline,
+      # measured ~45s on the kiosk — past the 30s default, which returns the
+      # "taking longer than usual" fallback instead of the answer. A wall-
+      # mounted kiosk can wait; raise the engine's internal process timeout.
+      # Scoped to mira-ask only.
+      MIRA_PROCESS_TIMEOUT: "90"
     volumes:
       - /opt/mira/data:/mira-db
     networks:


### PR DESCRIPTION
## Problem
After Phase-1 grounding deployed, grounded **diagnostic** questions to `/ask` (those with a `tags` payload) returned the engine's *"taking longer than usual"* fallback instead of an answer.

## Root cause (measured)
On the same warm session: a simple question returns in **2.1s**, but a tagged diagnostic question takes **45.2s** — the tags trigger MIRA's full diagnose pipeline (query decomposition → RAG recall → rerank → LLM), which exceeds the **30s** default `MIRA_PROCESS_TIMEOUT`. Not cold-start, not prompt size alone — the diagnostic path is just legitimately slower than 30s.

## Fix
Set `MIRA_PROCESS_TIMEOUT="90"` on the **`mira-ask` service only**. A wall-mounted kiosk can tolerate a ~45s answer; Telegram/Slack bots keep the 30s default. (Companion change in MIRA_PLC: the AskMira gateway script's HTTP client timeout raised 40s→95s so the browser waits long enough.)

## Deploy
`gh workflow run deploy-vps.yml -f services=mira-ask`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
