### PR TITLE
Conv_Simple machine-card anomaly rules (additive) + live PLC check

### DIFF
--- a/plc/conv_simple_anomaly/README.md
+++ b/plc/conv_simple_anomaly/README.md
@@ -47,6 +47,10 @@ Adding these = a CCW `MbSrvConf.xml` change + reflash (see the `modbus-slave` sk
 # logic (no broker needed):
 pytest plc/conv_simple_anomaly/                # 15 tests
 
+# LIVE check against the real PLC (no broker / no Docker — reads 192.168.1.100:502 and runs the rules):
+python plc/conv_simple_anomaly/live_check.py --secs 4
+# (verified 2026-06-01 on the bench: correctly fired A1 when vfd_comm_ok was False)
+
 # live (needs the broker + live-plc-bridge running):
 pip install -r plc/conv_simple_anomaly/requirements.txt
 MQTT_HOST=100.68.120.99 UNS_PREFIX=demo/cell1/conveyor/cv101 \

--- a/plc/conv_simple_anomaly/README.md
+++ b/plc/conv_simple_anomaly/README.md
@@ -1,0 +1,57 @@
+# Conv_Simple anomaly engine (machine-card invariants)
+
+**What this is:** an *additive* anomaly detector for the **real Conv_Simple bench** (Micro820 +
+GS10), separate from the `mira-fault-detective` **cv101 demo** (vision + PE-101/102 + fuses). It
+applies the invariants from `MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md` to the live tag stream that
+`plc/live-plc-bridge` already publishes, and routes anomalies through the **existing** surfaces.
+
+It does **not** modify the demo. It reuses: the Mosquitto broker, the `live-plc-bridge` UNS stream,
+the shared `conveyor_events` SQLite table (so Telegram `/fault` + MCP `/api/faults/active` show
+these for free), and ntfy push.
+
+## Pipeline
+```
+live-plc-bridge ──(UNS JSON)──▶ Mosquitto ──▶ conv_simple_anomaly.engine
+   {prefix}/_streams/bridge/#                     ├─ rules.evaluate(snapshot, derived, cfg)
+                                                   ├─ conveyor_events row (per new anomaly)
+                                                   ├─ {prefix}/diagnostics/conv_simple_anomaly
+                                                   └─ ntfy (HIGH/CRITICAL)
+```
+
+## Rules implemented (computable from today's bridge stream)
+| ID | Anomaly | Signals |
+|---|---|---|
+| A0 | PLC/bridge offline | no fresh data ≥ `offline_s` |
+| A1 | GS10 RS-485 link down (trust gate) | `vfd/vfd101/comm_ok` = False |
+| A3 | E-stop dual-channel wiring fault | `safety/wiring` or `di02_estop_nc == di03_estop_no` |
+| A4 | Direction fault | `di00_fwd` and `di01_rev` |
+| A5 | Belt running while not permitted | `motor running` ∧ (estop ∨ wiring ∨ ¬contactor) |
+| A6 | Drive not responding to RUN | `cmd_word∈{18,20}` ∧ ¬running ≥ `cmd_run_grace_s` |
+| A8 | Output over motor FLA | `current_a` > `motor_fla_a` |
+| A9 | DC bus out of range | `dc_bus_v` ∉ [`dc_bus_lo_v`,`dc_bus_hi_v`] |
+| A10 | Output frequency frozen | RUN ∧ `freq` unchanged ≥ `freq_frozen_s` |
+
+VFD-value rules (A6/A8/A9/A10) are gated by the §7 trust gate — suppressed when `comm_ok` is False
+(values are stale; A1 fires instead).
+
+## NOT yet implemented — need a PLC Modbus-slave-map extension
+The deployed 502 slave (13 coils + 5 HRs) does **not** expose these, so the bridge can't publish them:
+- **A2** GS10 fault-code decode — needs `0x2100` low byte in the slave map (decode table = machine card §5).
+- **A7** frequency-not-tracking-setpoint — needs the freq **setpoint** (only the cmd echo is published).
+- **A12** photo-eye jam — needs `DI_05` / `pe_latched` (not in the bridge map; the demo uses vision/PE-102).
+Adding these = a CCW `MbSrvConf.xml` change + reflash (see the `modbus-slave` skill) **then** extend
+`live-plc-bridge` reads. Tracked as follow-on.
+
+## Run
+```bash
+# logic (no broker needed):
+pytest plc/conv_simple_anomaly/                # 15 tests
+
+# live (needs the broker + live-plc-bridge running):
+pip install -r plc/conv_simple_anomaly/requirements.txt
+MQTT_HOST=100.68.120.99 UNS_PREFIX=demo/cell1/conveyor/cv101 \
+MIRA_DB=/mira-db/mira.db NTFY_URL=https://ntfy.sh NTFY_TOPIC=mira-factorylm-alerts \
+python plc/conv_simple_anomaly/engine.py
+```
+Confirm the starred thresholds in `config.yaml` (motor FLA, DC-bus window) against the nameplate / a golden run.
+A Docker service can be added to `docker-compose.fault-detective.yml` later (mirrors `fault-detective`).

--- a/plc/conv_simple_anomaly/config.yaml
+++ b/plc/conv_simple_anomaly/config.yaml
@@ -1,0 +1,9 @@
+# Conv_Simple anomaly thresholds. Starred values must be CONFIRMED on the bench
+# (motor nameplate FLA, GS10 DC-bus envelope from a golden run). See rules.DEFAULT_CFG.
+motor_fla_a: 5.0        # * motor full-load amps (A8 overcurrent) — set from the nameplate
+dc_bus_lo_v: 250.0      # * DC-bus undervoltage (A9); idle nominal ~327 V
+dc_bus_hi_v: 410.0      # * DC-bus overvoltage (A9)
+freq_frozen_s: 5.0      # A10 — output Hz unchanged this long while commanded RUN
+cmd_run_grace_s: 3.0    # A6 — RUN commanded but motor not running this long
+offline_s: 30.0         # A0 — no fresh PLC data this long
+run_cmd_values: [18, 20]  # GS10 cmd word 18=FWD+RUN, 20=REV+RUN

--- a/plc/conv_simple_anomaly/engine.py
+++ b/plc/conv_simple_anomaly/engine.py
@@ -1,0 +1,178 @@
+"""
+Conv_Simple anomaly engine — additive subscriber.
+
+Consumes the real PLC stream from `plc/live-plc-bridge` on the existing Mosquitto broker,
+applies the machine-card invariants in `rules.py`, debounces, and routes anomalies the SAME
+way the cv101 demo does so existing surfaces pick them up for free:
+  - writes rows to the shared `conveyor_events` SQLite table (Telegram /fault + MCP /api/faults/active read it)
+  - publishes the current top anomaly JSON to `{UNS_PREFIX}/diagnostics/conv_simple_anomaly`
+  - ntfy push for HIGH/CRITICAL (NTFY_URL/NTFY_TOPIC)
+
+It does NOT modify mira-fault-detective (the demo's cv101 rules) — it runs alongside.
+Reuses the project's aiomqtt pattern (see plc/live-plc-bridge/bridge.py, mira-fault-detective/engine.py).
+
+NOTE: not exercised in CI yet (needs a broker). The pure rule logic is covered by test_rules.py.
+"""
+from __future__ import annotations
+import asyncio, json, logging, os, sqlite3, time, urllib.request
+from pathlib import Path
+
+import aiomqtt  # type: ignore
+
+import rules
+
+MQTT_HOST = os.environ.get("MQTT_HOST", "100.68.120.99")
+MQTT_PORT = int(os.environ.get("MQTT_PORT", "1883"))
+UNS_PREFIX = os.environ.get("UNS_PREFIX", "demo/cell1/conveyor/cv101")
+BRIDGE_SUB = f"{UNS_PREFIX}/_streams/bridge/#"
+DIAG_TOPIC = f"{UNS_PREFIX}/diagnostics/conv_simple_anomaly"
+DB_PATH = os.environ.get("MIRA_DB", "/mira-db/mira.db")
+TICK_MS = int(os.environ.get("TICK_MS", "500"))
+CLEAR_S = float(os.environ.get("CLEAR_S", "3.0"))
+NTFY_URL = os.environ.get("NTFY_URL", "")
+NTFY_TOPIC = os.environ.get("NTFY_TOPIC", "")
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+
+logging.basicConfig(level=LOG_LEVEL, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("conv-simple-anomaly")
+
+
+def load_cfg() -> dict:
+    p = Path(__file__).with_name("config.yaml")
+    cfg = dict(rules.DEFAULT_CFG)
+    if p.exists():
+        try:
+            import yaml  # optional
+            data = yaml.safe_load(p.read_text()) or {}
+            cfg.update({k: v for k, v in data.items() if k in rules.DEFAULT_CFG})
+        except Exception as e:  # pragma: no cover
+            log.warning("config.yaml ignored (%s); using defaults", e)
+    return cfg
+
+
+class Tracker:
+    """Latest snapshot + the temporal facts the rules need (derived)."""
+    def __init__(self):
+        self.snap: dict = {}
+        self.last_seen: dict = {}
+        self.last_any: float = 0.0
+        self._freq_val = None
+        self._freq_change_ts = 0.0
+        self._cmd_run_since = 0.0
+
+    def update(self, rel_topic: str, value, ts: float):
+        self.snap[rel_topic] = value
+        self.last_seen[rel_topic] = ts
+        self.last_any = max(self.last_any, ts)
+        if rel_topic == rules.T_FREQ:
+            if value != self._freq_val:
+                self._freq_val = value
+                self._freq_change_ts = ts
+        if rel_topic == rules.T_CMD:
+            running_cmd = value in rules.DEFAULT_CFG["run_cmd_values"]
+            if running_cmd and self._cmd_run_since == 0.0:
+                self._cmd_run_since = ts
+            elif not running_cmd:
+                self._cmd_run_since = 0.0
+
+    def derived(self, now: float) -> dict:
+        return {
+            "now": now,
+            "max_stale_s": (now - self.last_any) if self.last_any else 1e9,
+            "freq_frozen_s": (now - self._freq_change_ts) if self._freq_change_ts else 0.0,
+            "cmd_run_for_s": (now - self._cmd_run_since) if self._cmd_run_since else 0.0,
+        }
+
+
+def _init_db():
+    try:
+        conn = sqlite3.connect(DB_PATH, timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("""CREATE TABLE IF NOT EXISTS conveyor_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL, fault TEXT NOT NULL, confidence REAL NOT NULL,
+            evidence_json TEXT NOT NULL DEFAULT '[]', affected_json TEXT NOT NULL DEFAULT '[]',
+            resolved_ts TEXT)""")
+        conn.commit()
+        return conn
+    except Exception as e:  # pragma: no cover
+        log.warning("SQLite unavailable (%s) — events not persisted", e)
+        return None
+
+
+def _persist(conn, a: rules.Anomaly):
+    if not conn:
+        return
+    try:
+        conn.execute(
+            "INSERT INTO conveyor_events (ts, fault, confidence, evidence_json, affected_json) "
+            "VALUES (?,?,?,?,?)",
+            (time.strftime("%Y-%m-%dT%H:%M:%S"), f"{a.rule_id}: {a.title}", a.confidence,
+             json.dumps(a.evidence, default=str), json.dumps(a.components)))
+        conn.commit()
+    except Exception as e:  # pragma: no cover
+        log.warning("persist failed: %s", e)
+
+
+def _ntfy(a: rules.Anomaly):
+    if not (NTFY_URL and NTFY_TOPIC and a.severity in (rules.HIGH, rules.CRITICAL)):
+        return
+    try:  # pragma: no cover
+        req = urllib.request.Request(
+            f"{NTFY_URL.rstrip('/')}/{NTFY_TOPIC}", data=a.message.encode(),
+            headers={"Title": f"[{a.severity}] {a.title}", "Priority": "urgent",
+                     "Tags": "rotating_light"})
+        urllib.request.urlopen(req, timeout=5)
+    except Exception as e:
+        log.warning("ntfy failed: %s", e)
+
+
+async def run():  # pragma: no cover (needs a broker)
+    cfg = load_cfg()
+    conn = _init_db()
+    tr = Tracker()
+    active: dict[str, float] = {}   # rule_id -> last_seen_active ts
+    log.info("subscribing %s @ %s:%s", BRIDGE_SUB, MQTT_HOST, MQTT_PORT)
+    async with aiomqtt.Client(hostname=MQTT_HOST, port=MQTT_PORT) as client:
+        await client.subscribe(BRIDGE_SUB)
+
+        async def reader():
+            async for m in client.messages:
+                try:
+                    payload = json.loads(m.payload)
+                    value, ts = payload.get("value"), float(payload.get("ts", time.time()))
+                except Exception:
+                    continue
+                rel = str(m.topic).split("/_streams/bridge/", 1)[-1]
+                tr.update(rel, value, ts)
+
+        async def ticker():
+            while True:
+                await asyncio.sleep(TICK_MS / 1000.0)
+                now = time.time()
+                found = {a.rule_id: a for a in rules.evaluate(tr.snap, tr.derived(now), cfg)}
+                for rid, a in found.items():
+                    if rid not in active:
+                        log.warning("ANOMALY %s [%s] %s", rid, a.severity, a.message)
+                        _persist(conn, a)
+                        _ntfy(a)
+                    active[rid] = now
+                # publish current worst + clear stale latches
+                order = {rules.CRITICAL: 0, rules.HIGH: 1, rules.MED: 2, rules.LOW: 3, rules.INFO: 4}
+                worst = min(found.values(), key=lambda a: order.get(a.severity, 9), default=None)
+                await client.publish(DIAG_TOPIC, json.dumps({
+                    "ts": now,
+                    "active": [{"rule_id": a.rule_id, "severity": a.severity, "title": a.title}
+                               for a in found.values()],
+                    "top": None if not worst else {"rule_id": worst.rule_id, "severity": worst.severity,
+                                                   "title": worst.title, "message": worst.message},
+                }, default=str))
+                for rid in [r for r, t in active.items() if now - t > CLEAR_S]:
+                    log.info("cleared %s", rid)
+                    active.pop(rid, None)
+
+        await asyncio.gather(reader(), ticker())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    asyncio.run(run())

--- a/plc/conv_simple_anomaly/live_check.py
+++ b/plc/conv_simple_anomaly/live_check.py
@@ -1,0 +1,123 @@
+"""
+Live check — read the REAL PLC over Modbus TCP and run the machine-card anomaly rules,
+no broker / no Docker required. Verifies the rules against actual hardware and prints the
+current machine snapshot.
+
+  python plc/conv_simple_anomaly/live_check.py [--host 192.168.1.100] [--secs 4]
+
+Uses the SAME register map as plc/live-plc-bridge (kept in sync here so this tool has no
+aiomqtt dependency). Read-only: never writes to the PLC.
+"""
+from __future__ import annotations
+import argparse, sys, time
+from pymodbus.client import ModbusTcpClient
+
+try:  # Windows consoles default to cp1252; rule messages are UTF-8
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+import rules
+
+# --- bridge map (0-based pymodbus offsets) -- mirror of live-plc-bridge ---
+COIL_TOPICS = {
+    0: "motor/m101/running", 3: "vfd/vfd101/comm_ok", 5: "safety/estop", 9: "safety/wiring",
+    11: "plc/di/di00_fwd", 12: "plc/di/di01_rev", 13: "plc/di/di02_estop_nc",
+    14: "plc/di/di03_estop_no", 15: "plc/di/di04_pbrun", 16: "plc/do/do00_green",
+    17: "plc/do/do01_red", 18: "safety/contactor_q1", 19: "plc/do/do03_pbrun_led",
+}
+HR_SPECS = {106: ("vfd/vfd101/freq", 100.0), 107: ("vfd/vfd101/current_a", 100.0),
+            108: ("vfd/vfd101/voltage_v", 10.0), 109: ("vfd/vfd101/dc_bus_v", 10.0),
+            114: ("vfd/vfd101/cmd_word", 1.0)}
+COIL_READS = [(0, 1), (3, 1), (5, 1), (9, 1), (11, 9)]
+HR_READS = [(106, 4), (114, 1)]
+UNIT = 1
+
+
+def _read(fn, addr, count):
+    for kw in ({"count": count, "slave": UNIT}, {"count": count, "device_id": UNIT}):
+        try:
+            return fn(addr, **kw)
+        except TypeError:
+            continue
+    return fn(addr, count)
+
+
+def poll(client) -> dict:
+    snap: dict = {}
+    for off, cnt in COIL_READS:
+        rr = _read(client.read_coils, off, cnt)
+        if rr.isError():
+            raise RuntimeError(f"coil read @{off} failed: {rr}")
+        for i in range(cnt):
+            if off + i in COIL_TOPICS:
+                snap[COIL_TOPICS[off + i]] = bool(rr.bits[i])
+    for off, cnt in HR_READS:
+        rr = _read(client.read_holding_registers, off, cnt)
+        if rr.isError():
+            raise RuntimeError(f"HR read @{off} failed: {rr}")
+        for i in range(cnt):
+            if off + i in HR_SPECS:
+                topic, div = HR_SPECS[off + i]
+                snap[topic] = rr.registers[i] / div if div != 1.0 else rr.registers[i]
+    return snap
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="192.168.1.100")
+    ap.add_argument("--port", type=int, default=502)
+    ap.add_argument("--secs", type=float, default=4.0)
+    args = ap.parse_args()
+
+    client = ModbusTcpClient(args.host, port=args.port, timeout=2)
+    if not client.connect():
+        print(f"FAIL: cannot connect to PLC {args.host}:{args.port}")
+        return 2
+
+    last_any = 0.0
+    freq_val, freq_ts = None, 0.0
+    cmd_run_since = 0.0
+    t_end = time.time() + args.secs
+    snap: dict = {}
+    try:
+        while time.time() < t_end:
+            now = time.time()
+            try:
+                snap = poll(client)
+                last_any = now
+            except Exception as e:
+                print("poll error:", e)
+                time.sleep(0.5)
+                continue
+            if snap.get(rules.T_FREQ) != freq_val:
+                freq_val, freq_ts = snap.get(rules.T_FREQ), now
+            cmd_run = snap.get(rules.T_CMD) in rules.DEFAULT_CFG["run_cmd_values"]
+            cmd_run_since = (cmd_run_since or now) if cmd_run else 0.0
+            time.sleep(0.5)
+    finally:
+        client.close()
+
+    now = time.time()
+    derived = {"now": now, "max_stale_s": (now - last_any) if last_any else 1e9,
+               "freq_frozen_s": (now - freq_ts) if freq_ts else 0.0,
+               "cmd_run_for_s": (now - cmd_run_since) if cmd_run_since else 0.0}
+
+    print("\n=== LIVE PLC SNAPSHOT ===")
+    for k in sorted(snap):
+        print(f"  {k:32} = {snap[k]}")
+    print(f"  (derived: stale {derived['max_stale_s']:.1f}s, freq_frozen {derived['freq_frozen_s']:.1f}s, "
+          f"cmd_run_for {derived['cmd_run_for_s']:.1f}s)")
+
+    anomalies = rules.evaluate(snap, derived)
+    print("\n=== ANOMALIES ===")
+    if not anomalies:
+        print("  none — machine state is within all machine-card invariants.")
+    else:
+        for a in anomalies:
+            print(f"  [{a.severity}] {a.rule_id}: {a.message}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plc/conv_simple_anomaly/requirements.txt
+++ b/plc/conv_simple_anomaly/requirements.txt
@@ -1,0 +1,3 @@
+aiomqtt==2.3.0
+PyYAML>=6.0
+# rules.py + test_rules.py are pure stdlib (run: pytest plc/conv_simple_anomaly/)

--- a/plc/conv_simple_anomaly/rules.py
+++ b/plc/conv_simple_anomaly/rules.py
@@ -1,0 +1,177 @@
+"""
+Conv_Simple machine-card anomaly rules (additive — does NOT touch the cv101 demo).
+
+These are the invariants from `MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md`, applied to the
+live tag stream published by `plc/live-plc-bridge` (UNS relative topics). Pure functions:
+`evaluate(snap, derived, cfg) -> list[Anomaly]` — no I/O, fully unit-testable.
+
+`snap`    : latest value keyed by the bridge's UNS-relative topic (see live-plc-bridge COIL_TOPICS / HR_SPECS).
+`derived` : temporal facts the engine computes from history:
+            {now, max_stale_s, freq_frozen_s, cmd_run_for_s}
+`cfg`     : thresholds (see DEFAULT_CFG; bench values marked CONFIRM).
+
+Covers A0,A1,A3,A4,A5,A6,A8,A9,A10. NOT covered (need a PLC Modbus-slave-map extension —
+the deployed slave does not expose these): A2 GS10 fault-code (0x2100), A7 freq setpoint,
+A12 photo-eye DI_05 / pe_latched. See README.
+"""
+from __future__ import annotations
+from dataclasses import dataclass, field
+
+CRITICAL, HIGH, MED, LOW, INFO = "CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"
+_CONF = {CRITICAL: 1.0, HIGH: 0.9, MED: 0.75, LOW: 0.6, INFO: 0.5}
+
+
+@dataclass
+class Anomaly:
+    rule_id: str
+    severity: str
+    title: str
+    message: str
+    evidence: list = field(default_factory=list)
+    components: list = field(default_factory=list)
+
+    @property
+    def confidence(self) -> float:
+        return _CONF.get(self.severity, 0.6)
+
+
+# Bench-tunable thresholds. CONFIRM the starred ones against the motor nameplate / a golden run.
+DEFAULT_CFG = {
+    "motor_fla_a": 5.0,        # * motor full-load amps (A8 overcurrent)
+    "dc_bus_lo_v": 250.0,      # * DC-bus undervoltage (A9); nominal ~327 V idle
+    "dc_bus_hi_v": 410.0,      # * DC-bus overvoltage (A9)
+    "freq_frozen_s": 5.0,      # A10 — Hz unchanged this long while commanded RUN
+    "cmd_run_grace_s": 3.0,    # A6 — RUN commanded but not running this long
+    "offline_s": 30.0,         # A0 — no fresh data this long
+    "run_cmd_values": (18, 20),  # GS10 cmd word: 18=FWD+RUN, 20=REV+RUN (§4)
+}
+
+# bridge UNS-relative topics (from live-plc-bridge)
+T_RUN = "motor/m101/running"
+T_COMM = "vfd/vfd101/comm_ok"
+T_ESTOP = "safety/estop"
+T_WIRING = "safety/wiring"
+T_CONTACTOR = "safety/contactor_q1"
+T_DI00, T_DI01 = "plc/di/di00_fwd", "plc/di/di01_rev"
+T_DI02, T_DI03 = "plc/di/di02_estop_nc", "plc/di/di03_estop_no"
+T_FREQ, T_CUR, T_DCBUS, T_CMD = (
+    "vfd/vfd101/freq", "vfd/vfd101/current_a", "vfd/vfd101/dc_bus_v", "vfd/vfd101/cmd_word")
+
+
+def _ev(snap, *keys):
+    return [{"topic": k, "value": snap.get(k)} for k in keys]
+
+
+def _vfd_trustworthy(snap) -> bool:
+    """The §7 trust gate: VFD analog/echo values are stale when comm_ok is explicitly False."""
+    return snap.get(T_COMM) is not False
+
+
+# ---- rules (each returns Anomaly | None) ----
+def r_a0_offline(snap, d, cfg):
+    if d.get("max_stale_s", 0.0) >= cfg["offline_s"]:
+        return Anomaly("A0_OFFLINE", CRITICAL, "PLC/bridge offline",
+                       f"No fresh PLC data for {d['max_stale_s']:.0f}s (>= {cfg['offline_s']:.0f}s).",
+                       [{"topic": "_stale_s", "value": round(d.get("max_stale_s", 0.0), 1)}],
+                       ["plc", "bridge"])
+    return None
+
+
+def r_a1_comm(snap, d, cfg):
+    if snap.get(T_COMM) is False:
+        return Anomaly("A1_COMM_STALE", CRITICAL, "GS10 RS-485 link down",
+                       "vfd_comm_ok is FALSE — the PLC↔GS10 serial link is down; all VFD "
+                       "values are stale (frozen from the last good poll).",
+                       _ev(snap, T_COMM), ["gs10", "rs485"])
+    return None
+
+
+def r_a3_estop_wiring(snap, d, cfg):
+    a, b = snap.get(T_DI02), snap.get(T_DI03)            # healthy: DI_02 NC=True, DI_03 NO=False
+    mismatch = a is not None and b is not None and a == b  # same state = broken/shorted wire
+    if snap.get(T_WIRING) is True or mismatch:
+        return Anomaly("A3_ESTOP_WIRING", HIGH, "E-stop wiring fault",
+                       "Dual-channel e-stop disagreement (DI_02 NC and DI_03 NO read the SAME) "
+                       "or the wiring-fault flag is set — broken/shorted e-stop wire; drive not permitted.",
+                       _ev(snap, T_WIRING, T_DI02, T_DI03), ["estop", "wiring"])
+    return None
+
+
+def r_a4_direction(snap, d, cfg):
+    if snap.get(T_DI00) and snap.get(T_DI01):
+        return Anomaly("A4_DIRECTION_FAULT", MED, "Direction fault",
+                       "FWD (DI_00) and REV (DI_01) are both commanded — the PLC commands STOP.",
+                       _ev(snap, T_DI00, T_DI01), ["selector"])
+    return None
+
+
+def r_a5_illegal_run(snap, d, cfg):
+    if not snap.get(T_RUN):
+        return None
+    reasons = []
+    if snap.get(T_ESTOP):
+        reasons.append("e-stop active")
+    if snap.get(T_WIRING):
+        reasons.append("wiring fault")
+    if snap.get(T_CONTACTOR) is False:
+        reasons.append("contactor open")
+    if reasons:
+        return Anomaly("A5_ILLEGAL_RUN", HIGH, "Belt running while not permitted",
+                       "Motor reports RUNNING but it should not be: " + ", ".join(reasons) + ".",
+                       _ev(snap, T_RUN, T_ESTOP, T_WIRING, T_CONTACTOR), ["motor", "safety"])
+    return None
+
+
+def r_a6_not_responding(snap, d, cfg):
+    if (snap.get(T_CMD) in cfg["run_cmd_values"] and _vfd_trustworthy(snap)
+            and not snap.get(T_RUN) and d.get("cmd_run_for_s", 0.0) >= cfg["cmd_run_grace_s"]):
+        return Anomaly("A6_DRIVE_NOT_RESPONDING", MED, "Drive not responding to RUN",
+                       f"Command word is RUN ({snap.get(T_CMD)}) for {d['cmd_run_for_s']:.0f}s "
+                       "but the motor is not running.",
+                       _ev(snap, T_CMD, T_RUN), ["gs10", "motor"])
+    return None
+
+
+def r_a8_overcurrent(snap, d, cfg):
+    cur = snap.get(T_CUR)
+    if _vfd_trustworthy(snap) and isinstance(cur, (int, float)) and cur > cfg["motor_fla_a"]:
+        return Anomaly("A8_OVERCURRENT", HIGH, "VFD output over motor FLA",
+                       f"Output current {cur:.2f} A exceeds motor FLA {cfg['motor_fla_a']:.2f} A — "
+                       "possible overload/jam (cf. GS10 oL fault 21).",
+                       _ev(snap, T_CUR), ["motor", "belt"])
+    return None
+
+
+def r_a9_dcbus(snap, d, cfg):
+    v = snap.get(T_DCBUS)
+    if _vfd_trustworthy(snap) and isinstance(v, (int, float)) and (v < cfg["dc_bus_lo_v"] or v > cfg["dc_bus_hi_v"]):
+        return Anomaly("A9_DC_BUS", MED, "DC bus voltage out of range",
+                       f"DC bus {v:.0f} V is outside [{cfg['dc_bus_lo_v']:.0f}, {cfg['dc_bus_hi_v']:.0f}] V "
+                       "(nominal ~327 V; low → GS10 Lvd 12).",
+                       _ev(snap, T_DCBUS), ["gs10", "power"])
+    return None
+
+
+def r_a10_freq_frozen(snap, d, cfg):
+    if (snap.get(T_CMD) in cfg["run_cmd_values"] and _vfd_trustworthy(snap)
+            and d.get("freq_frozen_s", 0.0) >= cfg["freq_frozen_s"]):
+        return Anomaly("A10_FREQ_FROZEN", MED, "Output frequency frozen",
+                       f"Commanded RUN but output Hz unchanged for {d['freq_frozen_s']:.0f}s — "
+                       "stale read or the drive is not following.",
+                       _ev(snap, T_FREQ, T_CMD), ["gs10"])
+    return None
+
+
+RULES = [r_a0_offline, r_a1_comm, r_a3_estop_wiring, r_a4_direction, r_a5_illegal_run,
+         r_a6_not_responding, r_a8_overcurrent, r_a9_dcbus, r_a10_freq_frozen]
+
+
+def evaluate(snap: dict, derived: dict, cfg: dict | None = None) -> list[Anomaly]:
+    """Run every rule against a snapshot; return the list of active anomalies."""
+    merged = {**DEFAULT_CFG, **(cfg or {})}
+    out = []
+    for rule in RULES:
+        a = rule(snap, derived or {}, merged)
+        if a is not None:
+            out.append(a)
+    return out

--- a/plc/conv_simple_anomaly/test_rules.py
+++ b/plc/conv_simple_anomaly/test_rules.py
@@ -1,0 +1,112 @@
+"""Unit tests for the Conv_Simple machine-card anomaly rules. Run: pytest plc/conv_simple_anomaly/"""
+import rules
+from rules import evaluate
+
+
+def healthy_snap():
+    return {
+        "motor/m101/running": False,
+        "vfd/vfd101/comm_ok": True,
+        "safety/estop": False,
+        "safety/wiring": False,
+        "safety/contactor_q1": True,
+        "plc/di/di00_fwd": False,
+        "plc/di/di01_rev": False,
+        "plc/di/di02_estop_nc": True,   # NC healthy = True
+        "plc/di/di03_estop_no": False,  # NO healthy = False
+        "vfd/vfd101/freq": 0.0,
+        "vfd/vfd101/current_a": 0.0,
+        "vfd/vfd101/dc_bus_v": 327.0,
+        "vfd/vfd101/cmd_word": 1,       # STOP
+    }
+
+
+D0 = {"now": 0.0, "max_stale_s": 0.0, "freq_frozen_s": 0.0, "cmd_run_for_s": 0.0}
+
+
+def ids(snap, d=D0, cfg=None):
+    return {a.rule_id for a in evaluate(snap, d, cfg)}
+
+
+def test_healthy_is_silent():
+    assert ids(healthy_snap()) == set()
+
+
+def test_running_healthy_is_silent():
+    s = healthy_snap()
+    s.update({"motor/m101/running": True, "vfd/vfd101/freq": 30.0,
+              "vfd/vfd101/current_a": 2.0, "vfd/vfd101/cmd_word": 18, "plc/di/di00_fwd": True})
+    assert ids(s) == set()
+
+
+def test_a0_offline():
+    assert "A0_OFFLINE" in ids(healthy_snap(), {**D0, "max_stale_s": 31.0})
+
+
+def test_a1_comm_loss():
+    s = healthy_snap(); s["vfd/vfd101/comm_ok"] = False
+    assert "A1_COMM_STALE" in ids(s)
+
+
+def test_a1_gates_vfd_rules():
+    # comm down -> overcurrent/dcbus must be suppressed (values are stale), only A1 fires
+    s = healthy_snap()
+    s.update({"vfd/vfd101/comm_ok": False, "vfd/vfd101/current_a": 99.0, "vfd/vfd101/dc_bus_v": 10.0})
+    got = ids(s)
+    assert got == {"A1_COMM_STALE"}
+
+
+def test_a3_wiring_flag():
+    s = healthy_snap(); s["safety/wiring"] = True
+    assert "A3_ESTOP_WIRING" in ids(s)
+
+
+def test_a3_dual_channel_mismatch():
+    s = healthy_snap(); s["plc/di/di03_estop_no"] = True   # now both True = mismatch
+    assert "A3_ESTOP_WIRING" in ids(s)
+
+
+def test_a4_direction_fault():
+    s = healthy_snap(); s["plc/di/di00_fwd"] = True; s["plc/di/di01_rev"] = True
+    assert "A4_DIRECTION_FAULT" in ids(s)
+
+
+def test_a5_illegal_run_estop():
+    s = healthy_snap(); s["motor/m101/running"] = True; s["safety/estop"] = True
+    assert "A5_ILLEGAL_RUN" in ids(s)
+
+
+def test_a5_illegal_run_contactor_open():
+    s = healthy_snap(); s["motor/m101/running"] = True; s["safety/contactor_q1"] = False
+    assert "A5_ILLEGAL_RUN" in ids(s)
+
+
+def test_a6_not_responding_after_grace():
+    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18  # RUN, but motor not running
+    assert "A6_DRIVE_NOT_RESPONDING" not in ids(s, {**D0, "cmd_run_for_s": 1.0})  # within grace
+    assert "A6_DRIVE_NOT_RESPONDING" in ids(s, {**D0, "cmd_run_for_s": 4.0})      # past grace
+
+
+def test_a8_overcurrent():
+    s = healthy_snap(); s["vfd/vfd101/current_a"] = 7.5  # > default FLA 5.0
+    assert "A8_OVERCURRENT" in ids(s)
+    # custom FLA raises the bar
+    assert "A8_OVERCURRENT" not in ids(s, cfg={"motor_fla_a": 10.0})
+
+
+def test_a9_dc_bus_low_and_high():
+    lo = healthy_snap(); lo["vfd/vfd101/dc_bus_v"] = 120.0
+    hi = healthy_snap(); hi["vfd/vfd101/dc_bus_v"] = 999.0
+    assert "A9_DC_BUS" in ids(lo)
+    assert "A9_DC_BUS" in ids(hi)
+
+
+def test_a10_freq_frozen_while_running():
+    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18
+    assert "A10_FREQ_FROZEN" in ids(s, {**D0, "freq_frozen_s": 6.0})
+    assert "A10_FREQ_FROZEN" not in ids(s, {**D0, "freq_frozen_s": 1.0})
+
+
+def test_confidence_mapping():
+    a = rules.r_a1_comm({"vfd/vfd101/comm_ok": False}, D0, rules.DEFAULT_CFG)
+    assert a.confidence == 1.0  # CRITICAL


### PR DESCRIPTION
## What & why
Adds anomaly detection for the **real Conv_Simple bench** (Micro820 + GS10) without touching the `mira-fault-detective` **cv101 demo** (which targets a richer vision/PE-101-102/fuse cell). Applies the invariants from `MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md` to the existing `live-plc-bridge` stream, reusing the broker, the shared `conveyor_events` table (Telegram `/fault` + MCP `/api/faults/active` surface it), and ntfy.

## `plc/conv_simple_anomaly/`
- `rules.py` — pure invariants **A0,A1,A3,A4,A5,A6,A8,A9,A10**, trust-gated by `vfd_comm_ok` (§7).
- `test_rules.py` — **15 unit tests, all passing** (pure stdlib).
- `live_check.py` — reads the real PLC (502) and runs the rules, **no broker/Docker**. Verified on the bench 2026-06-01: correctly fired **A1 (CRITICAL)** while the GS10 RS-485 link was down, VFD-value rules suppressed by the trust gate.
- `engine.py` — aiomqtt subscriber + debounce/latch + routing (conveyor_events / diagnostics / ntfy).
- `config.yaml`, `README.md`.

## Not implemented (need a PLC slave-map extension, not just code)
A2 GS10 fault-code (`0x2100`), A7 freq-setpoint, A12 photo-eye (`DI_05`/`pe_latched`) — the deployed 502 slave doesn't expose them. Needs a CCW `MbSrvConf.xml` change + reflash, then a `live-plc-bridge` read extension.

## Verify
```
pytest plc/conv_simple_anomaly/                 # 15 pass
python plc/conv_simple_anomaly/live_check.py    # runs rules vs the real PLC
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)