### PR TITLE
Conv_Simple anomaly: A10 startup-transient fix + live --watch (bench-validated)

### DIFF
--- a/plc/conv_simple_anomaly/live_check.py
+++ b/plc/conv_simple_anomaly/live_check.py
@@ -63,17 +63,65 @@ def poll(client) -> dict:
     return snap
 
 
+def watch(client, secs):
+    """Continuous monitor: poll + evaluate every 0.5s, print when anomalies fire/clear,
+    with a periodic heartbeat. For tripping faults at the bench and watching live."""
+    freq_val, freq_ts, cmd_run_since, last_any = None, 0.0, 0.0, 0.0
+    prev: dict = {}
+    t_end = time.time() + secs
+    next_hb = 0.0
+    print(f"WATCHING {secs:.0f}s — trip a fault and watch (Ctrl-C to stop)\n")
+    while time.time() < t_end:
+        now = time.time()
+        try:
+            snap = poll(client); last_any = now
+        except Exception as e:
+            print(f"  {time.strftime('%H:%M:%S')}  poll error: {e}"); time.sleep(0.5); continue
+        if snap.get(rules.T_FREQ) != freq_val:
+            freq_val, freq_ts = snap.get(rules.T_FREQ), now
+        cmd_run = snap.get(rules.T_CMD) in rules.DEFAULT_CFG["run_cmd_values"]
+        cmd_run_since = (cmd_run_since or now) if cmd_run else 0.0
+        derived = {"now": now, "max_stale_s": now - last_any,
+                   "freq_frozen_s": (now - freq_ts) if freq_ts else 0.0,
+                   "cmd_run_for_s": (now - cmd_run_since) if cmd_run_since else 0.0}
+        cur = {a.rule_id: a for a in rules.evaluate(snap, derived)}
+        ts = time.strftime("%H:%M:%S")
+        for rid in cur.keys() - prev.keys():
+            a = cur[rid]; print(f"  {ts}  >>> FIRED  [{a.severity}] {rid}: {a.message}")
+        for rid in prev.keys() - cur.keys():
+            print(f"  {ts}  --- cleared {rid}")
+        if now >= next_hb:
+            print(f"  {ts}  · run={snap.get(rules.T_RUN)} cmd={snap.get(rules.T_CMD)} "
+                  f"comm={snap.get(rules.T_COMM)} estop={snap.get(rules.T_ESTOP)} "
+                  f"freq={snap.get(rules.T_FREQ)} cur={snap.get(rules.T_CUR)} "
+                  f"dcbus={snap.get(rules.T_DCBUS)} active={sorted(cur) or '[]'}")
+            next_hb = now + 5
+        prev = cur
+        time.sleep(0.5)
+    print("\nwatch done.")
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--host", default="192.168.1.100")
     ap.add_argument("--port", type=int, default=502)
     ap.add_argument("--secs", type=float, default=4.0)
+    ap.add_argument("--watch", action="store_true", help="continuous live monitor")
     args = ap.parse_args()
+    if args.watch and args.secs < 30:
+        args.secs = 240.0
 
     client = ModbusTcpClient(args.host, port=args.port, timeout=2)
     if not client.connect():
         print(f"FAIL: cannot connect to PLC {args.host}:{args.port}")
         return 2
+
+    if args.watch:
+        try:
+            watch(client, args.secs)
+        finally:
+            client.close()
+        return 0
 
     last_any = 0.0
     freq_val, freq_ts = None, 0.0

--- a/plc/conv_simple_anomaly/rules.py
+++ b/plc/conv_simple_anomaly/rules.py
@@ -152,18 +152,24 @@ def r_a9_dcbus(snap, d, cfg):
     return None
 
 
-def r_a10_freq_frozen(snap, d, cfg):
+def r_a10_freq_stuck_zero(snap, d, cfg):
+    # Commanded RUN but output Hz stuck at ~0 -> drive not producing output.
+    # (A constant NON-zero Hz at steady speed is normal and must NOT trip this.)
+    # Gate on time SINCE the RUN command (cmd_run_for_s), not absolute freq-frozen time,
+    # so the idle period where Hz legitimately sat at 0 doesn't count (no startup transient).
+    freq = snap.get(T_FREQ)
     if (snap.get(T_CMD) in cfg["run_cmd_values"] and _vfd_trustworthy(snap)
-            and d.get("freq_frozen_s", 0.0) >= cfg["freq_frozen_s"]):
-        return Anomaly("A10_FREQ_FROZEN", MED, "Output frequency frozen",
-                       f"Commanded RUN but output Hz unchanged for {d['freq_frozen_s']:.0f}s — "
-                       "stale read or the drive is not following.",
+            and isinstance(freq, (int, float)) and freq <= 0.1
+            and d.get("cmd_run_for_s", 0.0) >= cfg["freq_frozen_s"]):
+        return Anomaly("A10_FREQ_STUCK_ZERO", MED, "Output frequency stuck at zero",
+                       f"Commanded RUN for {d['cmd_run_for_s']:.0f}s but output Hz is still 0 — "
+                       "the drive is not following the run command.",
                        _ev(snap, T_FREQ, T_CMD), ["gs10"])
     return None
 
 
 RULES = [r_a0_offline, r_a1_comm, r_a3_estop_wiring, r_a4_direction, r_a5_illegal_run,
-         r_a6_not_responding, r_a8_overcurrent, r_a9_dcbus, r_a10_freq_frozen]
+         r_a6_not_responding, r_a8_overcurrent, r_a9_dcbus, r_a10_freq_stuck_zero]
 
 
 def evaluate(snap: dict, derived: dict, cfg: dict | None = None) -> list[Anomaly]:

--- a/plc/conv_simple_anomaly/test_rules.py
+++ b/plc/conv_simple_anomaly/test_rules.py
@@ -101,10 +101,25 @@ def test_a9_dc_bus_low_and_high():
     assert "A9_DC_BUS" in ids(hi)
 
 
-def test_a10_freq_frozen_while_running():
+def test_a10_freq_stuck_at_zero_fires():
+    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18  # RUN, freq stuck at 0.0
+    assert "A10_FREQ_STUCK_ZERO" in ids(s, {**D0, "cmd_run_for_s": 6.0})
+    assert "A10_FREQ_STUCK_ZERO" not in ids(s, {**D0, "cmd_run_for_s": 1.0})  # within grace
+
+
+def test_a10_no_startup_transient():
+    # the instant RUN is pressed (cmd_run_for_s ~0) freq is still 0 after a long idle —
+    # must NOT fire even though freq had been frozen at 0 for ages.
     s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18
-    assert "A10_FREQ_FROZEN" in ids(s, {**D0, "freq_frozen_s": 6.0})
-    assert "A10_FREQ_FROZEN" not in ids(s, {**D0, "freq_frozen_s": 1.0})
+    assert "A10_FREQ_STUCK_ZERO" not in ids(s, {**D0, "cmd_run_for_s": 0.5, "freq_frozen_s": 120.0})
+
+
+def test_a10_steady_speed_does_not_fire():
+    # constant NON-zero Hz at steady running must NOT be flagged frozen
+    s = healthy_snap(); s.update({"vfd/vfd101/cmd_word": 18, "motor/m101/running": True,
+                                  "vfd/vfd101/freq": 30.0, "vfd/vfd101/current_a": 2.0})
+    assert "A10_FREQ_STUCK_ZERO" not in ids(s, {**D0, "freq_frozen_s": 60.0})
+    assert ids(s, {**D0, "freq_frozen_s": 60.0}) == set()  # fully healthy running
 
 
 def test_confidence_mapping():


### PR DESCRIPTION
Follow-up to #1635 (merged). Bench-validated the engine on the real PLC 2026-06-01:
- **A1** fired on RS-485 unplug, cleared on replug (×2).
- **A9 + A1** fired on a drive power-down (DC bus collapsed to 122 V), auto-cleared on power-up.
- Steady 30 Hz running + repeated start/stops → **no false anomalies**.

**Fix:** A10 flashed a 1 s false positive at startup (it counted idle time Hz sat at 0). Now gates on time-since-RUN (`cmd_run_for_s`); renamed `A10_FREQ_STUCK_ZERO`; added `test_a10_no_startup_transient`. **17 tests pass.**

**Adds** `live_check.py --watch` (continuous fire/clear + heartbeat, no broker/Docker).

**Follow-up:** VFD current read 0.0 A even at 30 Hz — confirm the current register/scale populates under load before trusting A8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)