### PR TITLE
feat(plc): A2/A7/A12 anomaly rules + bridge runs on Windows bench laptop

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,7 +10,7 @@ Each MIRA module falls into one of four layers. Dependencies flow **downward onl
 ```
 ┌─────────────────────────────────────────────────────────┐
 │  PRESENTATION (user-facing surfaces)                     │
-│  mira-web · mira-hud · atlas-frontend                   │
+│  mira-web · mira-hub · mira-hud · atlas-frontend        │
 ├─────────────────────────────────────────────────────────┤
 │  ADAPTERS (protocol translation → engine)                │
 │  mira-bots/{telegram,slack,reddit} · mira-pipeline       │
@@ -72,4 +72,8 @@ Alpha (Celery orchestrator) ──tailscale──→ Bravo (Ollama compute)
 | mira-pipeline | Adapter | mira-pipeline | 9099 | ✓ |
 | mira-bots/{tg,slack} | Adapter | mira-bot-{telegram,slack} | — | via shared |
 | mira-web | Presentation | mira-web | 3200→3000 | ✓ |
-| mira-hud | Presentation | — (standalone) | — | ✓ |
+| mira-hub | Presentation | mira-hub | 3101→3000 | ✓ |
+| mira-hud | Presentation | — (standalone, heads-up display) | — | ✓ |
+| live-plc-bridge | Infra | mira-live-plc-bridge | — | (bench Modbus→MQTT ingest, read-only) |
+| conv_simple_anomaly | Engine | mira-conv-simple-anomaly | — | (bench machine-card rule engine) |
+| mira-fault-detective | Engine | mira-fault-detective | — | (cv101 demo rule engine) |

--- a/docker-compose.fault-detective.yml
+++ b/docker-compose.fault-detective.yml
@@ -80,6 +80,27 @@ services:
       - core-net
     restart: unless-stopped
 
+  conv-simple-anomaly:
+    build:
+      context: ./plc/conv_simple_anomaly
+    container_name: mira-conv-simple-anomaly
+    mem_limit: 256m
+    memswap_limit: 256m
+    environment:
+      MQTT_HOST: mosquitto
+      MQTT_PORT: "1883"
+      UNS_PREFIX: demo/cell1/conveyor/cv101
+      DB_PATH: /mira-db/mira.db
+      LOG_LEVEL: INFO
+    volumes:
+      - ./mira-bridge/data:/mira-db
+    depends_on:
+      mosquitto:
+        condition: service_healthy
+    networks:
+      - core-net
+    restart: unless-stopped
+
   # Stream A: live Micro 820 Modbus TCP -> MQTT ingest (real bench PLC data).
   # Publishes source-qualified _streams/bridge/* topics; the Node-RED flow runs
   # a redundant Stream B under _streams/nr/*, and the dashboard selector picks

--- a/docker-compose.fault-detective.yml
+++ b/docker-compose.fault-detective.yml
@@ -90,6 +90,7 @@ services:
       MQTT_HOST: mosquitto
       MQTT_PORT: "1883"
       UNS_PREFIX: demo/cell1/conveyor/cv101
+      UNS_EQUIPMENT_PATH: enterprise.factorylm.site.bench.area.conv_simple.equipment.cv101
       DB_PATH: /mira-db/mira.db
       LOG_LEVEL: INFO
     volumes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ Each MIRA module falls into one of four layers. Dependencies flow **downward onl
 ```
 ┌─────────────────────────────────────────────────────────┐
 │  PRESENTATION (user-facing surfaces)                     │
-│  mira-web · mira-hud · atlas-frontend                   │
+│  mira-web · mira-hub · mira-hud · atlas-frontend        │
 ├─────────────────────────────────────────────────────────┤
 │  ADAPTERS (protocol translation → engine)                │
 │  mira-bots/{telegram,slack,reddit} · mira-pipeline       │
@@ -72,4 +72,8 @@ Alpha (Celery orchestrator) ──tailscale──→ Bravo (Ollama compute)
 | mira-pipeline | Adapter | mira-pipeline | 9099 | ✓ |
 | mira-bots/{tg,slack} | Adapter | mira-bot-{telegram,slack} | — | via shared |
 | mira-web | Presentation | mira-web | 3200→3000 | ✓ |
-| mira-hud | Presentation | — (standalone) | — | ✓ |
+| mira-hub | Presentation | mira-hub | 3101→3000 | ✓ |
+| mira-hud | Presentation | — (standalone, heads-up display) | — | ✓ |
+| live-plc-bridge | Infra | mira-live-plc-bridge | — | (bench Modbus→MQTT ingest, read-only) |
+| conv_simple_anomaly | Engine | mira-conv-simple-anomaly | — | (bench machine-card rule engine) |
+| mira-fault-detective | Engine | mira-fault-detective | — | (cv101 demo rule engine) |

--- a/mira-core/scripts/seed_fault_codes.py
+++ b/mira-core/scripts/seed_fault_codes.py
@@ -11,6 +11,9 @@ Target families (issue #193):
   - Siemens G120 (supplement existing sparse coverage)
   - AutomationDirect GS10/GS20 (supplement existing sparse coverage)
   - Rockwell PowerFlex 525/40 (supplement existing sparse coverage)
+  - AutomationDirect DURApulse GS10 NUMERIC codes (the bench Conv_Simple machine
+    reports faults as the numeric low byte of Modbus register 0x2100, not the keypad
+    mnemonic; these rows let conv_simple_anomaly A2 faults join the KB by numeric code)
 
 Usage:
     doppler run --project factorylm --config prd -- \
@@ -1010,6 +1013,37 @@ POWERFLEX_SUPPLEMENT: list[tuple[str, str, str, str, str, str, str]] = [
 ]
 
 
+# DURApulse GS10 NUMERIC fault codes — the value of the low byte of Modbus register
+# 0x2100 (high byte = warning). This is what the Conv_Simple bench actually reports over
+# Modbus, vs. the keypad mnemonics in GS_SUPPLEMENT above. Both formats are seeded so a
+# numeric bench fault (e.g. 21) AND a keypad mnemonic (e.g. "OL") resolve for GS10.
+# Source: DURApulse GS10 User Manual, P06.17 fault-record ranges (same source as
+# conv_simple_anomaly/rules.py GS10_FAULT_CODES). description = "<mnemonic> — <meaning>".
+GS10_NUMERIC: dict[int, str] = {
+    1: "ocA — over-current during acceleration", 2: "ocd — over-current during deceleration",
+    3: "ocn — over-current at constant speed", 4: "GFF — ground fault",
+    6: "ocS — over-current at stop", 7: "ovA — over-voltage during acceleration",
+    8: "ovd — over-voltage during deceleration", 9: "ovn — over-voltage at constant speed",
+    10: "ovS — over-voltage at stop", 11: "LvA — low-voltage during acceleration",
+    12: "Lvd — low-voltage during deceleration", 13: "Lvn — low-voltage at constant speed",
+    14: "LvS — low-voltage at stop", 15: "orP — input phase loss",
+    16: "oH1 — IGBT overheating", 18: "tH1o — IGBT temperature detection failure",
+    21: "oL — overload", 22: "EoL1 — electronic thermal relay 1 protection",
+    23: "EoL2 — electronic thermal relay 2 protection", 24: "oH3 — motor PTC overheating",
+    26: "ot1 — over-torque 1", 27: "ot2 — over-torque 2", 28: "uC — under-current",
+    31: "cF2 — EEPROM read error", 33: "cd1 — U-phase error", 34: "cd2 — V-phase error",
+    35: "cd3 — W-phase error", 36: "Hd0 — cc (current clamp) hardware error",
+    37: "Hd1 — oc (over-current) hardware error", 40: "AUE — auto-tuning error",
+    41: "AFE — PID loss (AI-V)", 48: "ACE — AI-C loss", 49: "EF — external fault",
+    50: "EF1 — emergency stop", 51: "bb — external base block", 52: "Pcod — password locked",
+    54: "CE1 — illegal command", 55: "CE2 — illegal data address", 56: "CE3 — illegal data value",
+    57: "CE4 — data written to read-only address", 58: "CE10 — Modbus transmission time-out",
+    63: "oSL — over-slip error", 82: "oPL1 — output phase loss U", 83: "oPL2 — output phase loss V",
+    84: "oPL3 — output phase loss W", 87: "oL3 — low-frequency overload protection",
+    140: "Hd6 — oc hardware error", 141: "b4GF — ground fault before run", 159: "Hd7 — gate driver error",
+}
+
+
 def _insert(
     conn,
     text_fn,
@@ -1083,7 +1117,17 @@ def main() -> None:
     all_codes.extend(GS_SUPPLEMENT)
     all_codes.extend(POWERFLEX_SUPPLEMENT)
 
-    log.info("Seeding %d fault codes across 6 VFD families", len(all_codes))
+    # DURApulse GS10 numeric (Modbus 0x2100) codes — what the Conv_Simple bench reports.
+    for num, desc in sorted(GS10_NUMERIC.items()):
+        all_codes.append((
+            str(num), desc,
+            "GS10 trips and records this fault in P06.17; read over Modbus as the low byte of register 0x2100.",
+            "Identify the named condition, clear the root cause, then reset the drive. "
+            "See the DURApulse GS10 User Manual fault-code (P06.17) section.",
+            "trip", "AutomationDirect", "GS10",
+        ))
+
+    log.info("Seeding %d fault codes across 6 VFD families (+ GS10 numeric Modbus codes)", len(all_codes))
 
     if args.dry_run:
         for code, desc, cause, action, sev, mfr, model in all_codes:

--- a/plc/conv_simple_anomaly/DEPLOY.md
+++ b/plc/conv_simple_anomaly/DEPLOY.md
@@ -1,0 +1,68 @@
+# Deploying the Conv_Simple anomaly engine (always-on alerts)
+
+**What this gives you:** real bench-PLC faults surfaced in Telegram `/fault`, the MCP
+`/api/faults/active` API, and ntfy push — always-on, no laptop session required.
+
+Verified end-to-end live on 2026-06-01 (laptop bridge → VPS broker → engine, idle-clean).
+
+## Topology (why it's two services on two hosts)
+```
+  PLC laptop (bench LAN)                     VPS factorylm-prod (100.68.120.99)
+  ┌─────────────────────┐   MQTT 1883        ┌──────────────────────────────┐
+  │ live-plc-bridge.py  │ ───(Tailscale)───▶ │ mira-mosquitto                │
+  │ reads PLC 192.168.. │                    │   ▲                          │
+  └─────────────────────┘                    │   │ _streams/bridge/#        │
+                                              │ conv_simple_anomaly engine   │
+                                              │   └▶ conveyor_events (mira.db)│
+                                              │      + diagnostics + ntfy    │
+                                              └──────────────────────────────┘
+```
+The **VPS cannot reach the PLC** (no route to `192.168.1.0/24`, per the Tailscale route
+gotcha), so the bridge MUST run on the **PLC laptop**. Only the engine runs on the VPS.
+
+> ⚠️ Enable BOTH together. A persistent engine with no running bridge will see stale data
+> and fire `A0_OFFLINE` into the fault table (spurious "PLC offline" pages). Don't deploy
+> one without the other.
+
+## 1. Laptop bridge (PLC laptop, Windows) — must be persistent
+```powershell
+# one-off (this session):
+$env:PLC_HOST="192.168.1.100"; $env:MQTT_HOST="100.68.120.99"
+$env:UNS_PREFIX="demo/cell1/conveyor/cv101"
+python -u plc\live-plc-bridge\bridge.py     # needs: pip install aiomqtt pymodbus
+```
+For always-on, register it as a **Scheduled Task** (Trigger: At log on / At startup;
+Action: the command above; Restart on failure). The bridge auto-reconnects to both PLC and
+broker, so a task that simply keeps it running is enough.
+
+## 2. Engine (VPS) — reversible container
+```bash
+# stage code (any dir; does NOT touch the /opt/mira git checkout):
+mkdir -p /opt/conv-simple-anomaly
+scp plc/conv_simple_anomaly/{rules.py,engine.py,config.yaml,requirements.txt} \
+    factorylm-prod:/opt/conv-simple-anomaly/
+
+ssh factorylm-prod 'docker run -d --restart unless-stopped --name mira-conv-simple-anomaly \
+  --network mira-plc-dash_default \
+  -v /opt/conv-simple-anomaly:/app -w /app \
+  -v /opt/mira/mira-bridge/data:/mira-db \
+  -e MQTT_HOST=mira-mosquitto -e MQTT_PORT=1883 \
+  -e UNS_PREFIX=demo/cell1/conveyor/cv101 \
+  -e DB_PATH=/mira-db/mira.db -e LOG_LEVEL=INFO \
+  -e NTFY_URL=https://ntfy.sh -e NTFY_TOPIC=mira-factorylm-alerts \
+  python:3.12-slim sh -c "pip install -q aiomqtt PyYAML && python -u engine.py"'
+```
+- `mira-mosquitto` lives on the `mira-plc-dash_default` network (not `core-net`).
+- The shared fault DB is the host dir `/opt/mira/mira-bridge/data` → container `/mira-db`.
+- Omit `NTFY_*` to run without push (DB + diagnostics only).
+- Roll back: `ssh factorylm-prod 'docker rm -f mira-conv-simple-anomaly'`.
+
+## 3. Verify
+```bash
+ssh factorylm-prod 'docker logs --tail 20 mira-conv-simple-anomaly'   # "subscribing ..."
+# engine heartbeat (should show active:[] at idle):
+ssh factorylm-prod 'timeout 4 docker exec mira-mosquitto mosquitto_sub -h localhost \
+  -t demo/cell1/conveyor/cv101/diagnostics/conv_simple_anomaly -v'
+```
+Then trip a fault at the bench (unplug RS-485 → A1; e-stop → A5) and confirm it appears in
+Telegram `/fault`.

--- a/plc/conv_simple_anomaly/DEPLOY.md
+++ b/plc/conv_simple_anomaly/DEPLOY.md
@@ -55,6 +55,7 @@ ssh factorylm-prod 'docker run -d --restart unless-stopped --name mira-conv-simp
   -v /opt/mira/mira-bridge/data:/mira-db \
   -e MQTT_HOST=mira-mosquitto -e MQTT_PORT=1883 \
   -e UNS_PREFIX=demo/cell1/conveyor/cv101 \
+  -e UNS_EQUIPMENT_PATH=enterprise.factorylm.site.bench.area.conv_simple.equipment.cv101 \
   -e DB_PATH=/mira-db/mira.db -e LOG_LEVEL=INFO \
   -e NTFY_URL=https://ntfy.sh -e NTFY_TOPIC=mira-factorylm-alerts \
   python:3.12-slim sh -c "pip install -q aiomqtt PyYAML && python -u engine.py"'

--- a/plc/conv_simple_anomaly/DEPLOY.md
+++ b/plc/conv_simple_anomaly/DEPLOY.md
@@ -35,6 +35,13 @@ For always-on, register it as a **Scheduled Task** (Trigger: At log on / At star
 Action: the command above; Restart on failure). The bridge auto-reconnects to both PLC and
 broker, so a task that simply keeps it running is enough.
 
+> ⚠️ **Use a boot-scoped Scheduled Task, not a Startup-folder launcher.** A Startup-folder
+> (or "At log on") launcher is **logon-scoped** — it stops the moment the user logs out, which
+> with the always-on engine produces spurious `A0_OFFLINE` alerts every time someone logs off
+> the laptop. The correct always-on mechanism is a **boot-scoped Scheduled Task**: Trigger
+> **"At startup"**, **"Run whether user is logged on or not"**, and **"Restart on failure"**.
+> Registering a task that runs whether logged on or not requires **administrator rights**.
+
 ## 2. Engine (VPS) — reversible container
 ```bash
 # stage code (any dir; does NOT touch the /opt/mira git checkout):
@@ -52,9 +59,18 @@ ssh factorylm-prod 'docker run -d --restart unless-stopped --name mira-conv-simp
   -e NTFY_URL=https://ntfy.sh -e NTFY_TOPIC=mira-factorylm-alerts \
   python:3.12-slim sh -c "pip install -q aiomqtt PyYAML && python -u engine.py"'
 ```
-- `mira-mosquitto` lives on the `mira-plc-dash_default` network (not `core-net`).
+- `mira-mosquitto` lives on the `mira-plc-dash_default` network (not `core-net`). This is
+  the network the engine `docker run` above joins and is correct for the current VPS.
+  > ⚠️ **Network-name drift:** the committed `docker-compose.fault-detective.yml` instead
+  > declares an **external `core-net`** and refers to the broker by service name
+  > **`mosquitto`** (not container `mira-mosquitto`). Both facts are accurate for their
+  > respective contexts, but a future compose-based deploy of this engine must target the
+  > network/service name that the broker actually runs on for that deploy — reconcile before
+  > switching from this `docker run` recipe to compose.
 - The shared fault DB is the host dir `/opt/mira/mira-bridge/data` → container `/mira-db`.
 - Omit `NTFY_*` to run without push (DB + diagnostics only).
+- `A0_OFFLINE` now pages at **LOW** priority by design (infrastructure-liveness signal), so a
+  brief bridge outage will **not** send an urgent page — only genuine machine faults do.
 - Roll back: `ssh factorylm-prod 'docker rm -f mira-conv-simple-anomaly'`.
 
 ## 3. Verify

--- a/plc/conv_simple_anomaly/Dockerfile
+++ b/plc/conv_simple_anomaly/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY engine.py rules.py config.yaml ./
+CMD ["python", "-u", "engine.py"]

--- a/plc/conv_simple_anomaly/README.md
+++ b/plc/conv_simple_anomaly/README.md
@@ -31,21 +31,31 @@ live-plc-bridge ──(UNS JSON)──▶ Mosquitto ──▶ conv_simple_anomal
 | A9 | DC bus out of range | `dc_bus_v` ∉ [`dc_bus_lo_v`,`dc_bus_hi_v`] |
 | A10 | Output frequency frozen | RUN ∧ `freq` unchanged ≥ `freq_frozen_s` |
 
-VFD-value rules (A6/A8/A9/A10) are gated by the §7 trust gate — suppressed when `comm_ok` is False
-(values are stale; A1 fires instead).
+VFD-value rules (A2/A6/A7/A8/A9/A10) are gated by the §7 trust gate — suppressed when `comm_ok` is
+False (values are stale; A1 fires instead).
 
-## NOT yet implemented — need a PLC Modbus-slave-map extension
-The deployed 502 slave (13 coils + 5 HRs) does **not** expose these, so the bridge can't publish them:
-- **A2** GS10 fault-code decode — needs `0x2100` low byte in the slave map (decode table = machine card §5).
-- **A7** frequency-not-tracking-setpoint — needs the freq **setpoint** (only the cmd echo is published).
-- **A12** photo-eye jam — needs `DI_05` / `pe_latched` (not in the bridge map; the demo uses vision/PE-102).
-Adding these = a CCW `MbSrvConf.xml` change + reflash (see the `modbus-slave` skill) **then** extend
-`live-plc-bridge` reads. Tracked as follow-on.
+## Rules implemented but awaiting slave-map v2 (degrade silently until reflash)
+The rule logic for these is **written and unit-tested** (`rules.py` + `test_rules.py`); they fire
+the moment the bridge publishes their topics. Until the PLC slave map is extended + reflashed, the
+deployed 502 slave (13 coils + 5 HRs) does not publish them, so `snap.get(...) -> None` and they
+stay silent (verified live 2026-06-01 — no false fires).
+
+| ID | Anomaly | New topic needed | Source register |
+|---|---|---|---|
+| A2 | GS10 drive fault active (decoded) | `vfd/vfd101/fault_code` (+`warn_code`) | `0x2100` low byte / high byte |
+| A7 | Output Hz not tracking setpoint | `vfd/vfd101/freq_setpoint` | `0x2101` (freq command) |
+| A12 | Photo-eye soft-stop (jam/blockage) | `safety/pe_latched` (+`plc/di/di05_photoeye`) | `DI_05` latch (ladder global) |
+
+To activate: **(1)** add the registers to the CCW `MbSrvConf.xml` (`modbus-slave` skill) + reflash
+(`ccw-build`); **(2)** uncomment the matching entries in `live-plc-bridge/bridge.py` (`COIL_TOPICS` /
+`HR_SPECS` + the `COIL_READS` / `HR_READS` plan) and `live_check.py`. The GS10 fault decode table
+lives in `rules.GS10_FAULT_CODES` (sourced from the DURApulse GS10 UM §P06.17) and the invariants in
+`MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md`.
 
 ## Run
 ```bash
 # logic (no broker needed):
-pytest plc/conv_simple_anomaly/                # 15 tests
+pytest plc/conv_simple_anomaly/                # 26 tests
 
 # LIVE check against the real PLC (no broker / no Docker — reads 192.168.1.100:502 and runs the rules):
 python plc/conv_simple_anomaly/live_check.py --secs 4

--- a/plc/conv_simple_anomaly/config.yaml
+++ b/plc/conv_simple_anomaly/config.yaml
@@ -5,5 +5,5 @@ dc_bus_lo_v: 250.0      # * DC-bus undervoltage (A9); idle nominal ~327 V
 dc_bus_hi_v: 410.0      # * DC-bus overvoltage (A9)
 freq_frozen_s: 5.0      # A10 — output Hz unchanged this long while commanded RUN
 cmd_run_grace_s: 3.0    # A6 — RUN commanded but motor not running this long
-offline_s: 30.0         # A0 — no fresh PLC data this long
+offline_s: 120.0        # A0 — no fresh PLC data this long; longer grace reduces spurious A0_OFFLINE pages from brief bridge/network blips
 run_cmd_values: [18, 20]  # GS10 cmd word 18=FWD+RUN, 20=REV+RUN

--- a/plc/conv_simple_anomaly/engine.py
+++ b/plc/conv_simple_anomaly/engine.py
@@ -28,6 +28,13 @@ MQTT_PORT = int(os.environ.get("MQTT_PORT", "1883"))
 UNS_PREFIX = os.environ.get("UNS_PREFIX", "demo/cell1/conveyor/cv101")
 BRIDGE_SUB = f"{UNS_PREFIX}/_streams/bridge/#"
 DIAG_TOPIC = f"{UNS_PREFIX}/diagnostics/conv_simple_anomaly"
+# Canonical ISA-95 UNS path for THIS bench machine — decoupled from UNS_PREFIX above
+# (the live MQTT topic stays demo/cell1/... so the existing dashboard keeps working).
+# Stamped onto every event + diagnostics publish so a fault is addressable to its
+# equipment node and can later join the knowledge graph (kg_entities). Override per deploy.
+UNS_EQUIPMENT_PATH = os.environ.get(
+    "UNS_EQUIPMENT_PATH",
+    "enterprise.factorylm.site.bench.area.conv_simple.equipment.cv101")
 DB_PATH = os.environ.get("MIRA_DB", "/mira-db/mira.db")
 TICK_MS = int(os.environ.get("TICK_MS", "500"))
 CLEAR_S = float(os.environ.get("CLEAR_S", "3.0"))
@@ -108,8 +115,11 @@ def _persist(conn, a: rules.Anomaly):
     # The conveyor_events table is shared with mira-fault-detective on the same SQLite
     # WAL, so an INSERT can lose the write lock momentarily. Retry up to 5 times with a
     # short backoff on "database is locked" (mirrors mira-fault-detective/engine.py).
+    # affected_json carries the canonical UNS equipment path first, so a stored fault
+    # is addressable to its namespace node (joinable to kg_entities downstream).
     row = (time.strftime("%Y-%m-%dT%H:%M:%S"), f"{a.rule_id}: {a.title}", a.confidence,
-           json.dumps(a.evidence, default=str), json.dumps(a.components))
+           json.dumps(a.evidence, default=str),
+           json.dumps([{"uns_path": UNS_EQUIPMENT_PATH}, *a.components]))
     for attempt in range(5):
         try:
             conn.execute(
@@ -185,6 +195,7 @@ async def run():  # pragma: no cover (needs a broker)
                 worst = min(found.values(), key=lambda a: order.get(a.severity, 9), default=None)
                 await client.publish(DIAG_TOPIC, json.dumps({
                     "ts": now,
+                    "uns_path": UNS_EQUIPMENT_PATH,
                     "active": [{"rule_id": a.rule_id, "severity": a.severity, "title": a.title}
                                for a in found.values()],
                     "top": None if not worst else {"rule_id": worst.rule_id, "severity": worst.severity,

--- a/plc/conv_simple_anomaly/engine.py
+++ b/plc/conv_simple_anomaly/engine.py
@@ -21,7 +21,9 @@ import aiomqtt  # type: ignore
 
 import rules
 
-MQTT_HOST = os.environ.get("MQTT_HOST", "100.68.120.99")
+# Broker host must be set via env (MQTT_HOST) at deploy time; "localhost" is a safe
+# default that does not hardcode any specific VPS/broker IP.
+MQTT_HOST = os.environ.get("MQTT_HOST", "localhost")
 MQTT_PORT = int(os.environ.get("MQTT_PORT", "1883"))
 UNS_PREFIX = os.environ.get("UNS_PREFIX", "demo/cell1/conveyor/cv101")
 BRIDGE_SUB = f"{UNS_PREFIX}/_streams/bridge/#"
@@ -103,24 +105,45 @@ def _init_db():
 def _persist(conn, a: rules.Anomaly):
     if not conn:
         return
-    try:
-        conn.execute(
-            "INSERT INTO conveyor_events (ts, fault, confidence, evidence_json, affected_json) "
-            "VALUES (?,?,?,?,?)",
-            (time.strftime("%Y-%m-%dT%H:%M:%S"), f"{a.rule_id}: {a.title}", a.confidence,
-             json.dumps(a.evidence, default=str), json.dumps(a.components)))
-        conn.commit()
-    except Exception as e:  # pragma: no cover
-        log.warning("persist failed: %s", e)
+    # The conveyor_events table is shared with mira-fault-detective on the same SQLite
+    # WAL, so an INSERT can lose the write lock momentarily. Retry up to 5 times with a
+    # short backoff on "database is locked" (mirrors mira-fault-detective/engine.py).
+    row = (time.strftime("%Y-%m-%dT%H:%M:%S"), f"{a.rule_id}: {a.title}", a.confidence,
+           json.dumps(a.evidence, default=str), json.dumps(a.components))
+    for attempt in range(5):
+        try:
+            conn.execute(
+                "INSERT INTO conveyor_events (ts, fault, confidence, evidence_json, affected_json) "
+                "VALUES (?,?,?,?,?)", row)
+            conn.commit()
+            return
+        except sqlite3.OperationalError as e:  # pragma: no cover
+            if attempt == 4:
+                log.warning("persist failed after retries: %s", e)
+                return
+            time.sleep(0.2 * (attempt + 1))
+        except Exception as e:  # pragma: no cover
+            log.warning("persist failed: %s", e)
+            return
 
 
 def _ntfy(a: rules.Anomaly):
     if not (NTFY_URL and NTFY_TOPIC and a.severity in (rules.HIGH, rules.CRITICAL)):
         return
+    # A0_OFFLINE is an infrastructure-liveness signal that false-fires whenever the
+    # laptop bridge stops (restart/logout/network blip). De-prioritize it to "low" with
+    # an [infra] title so it does not send a spurious URGENT page; all other
+    # HIGH/CRITICAL anomalies keep "urgent".
+    if a.rule_id == "A0_OFFLINE":
+        title = f"[infra] [{a.severity}] {a.title}"
+        priority = "low"
+    else:
+        title = f"[{a.severity}] {a.title}"
+        priority = "urgent"
     try:  # pragma: no cover
         req = urllib.request.Request(
             f"{NTFY_URL.rstrip('/')}/{NTFY_TOPIC}", data=a.message.encode(),
-            headers={"Title": f"[{a.severity}] {a.title}", "Priority": "urgent",
+            headers={"Title": title, "Priority": priority,
                      "Tags": "rotating_light"})
         urllib.request.urlopen(req, timeout=5)
     except Exception as e:

--- a/plc/conv_simple_anomaly/requirements.txt
+++ b/plc/conv_simple_anomaly/requirements.txt
@@ -1,3 +1,3 @@
 aiomqtt==2.3.0
-PyYAML>=6.0
+PyYAML==6.0.2
 # rules.py + test_rules.py are pure stdlib (run: pytest plc/conv_simple_anomaly/)

--- a/plc/conv_simple_anomaly/rules.py
+++ b/plc/conv_simple_anomaly/rules.py
@@ -10,9 +10,10 @@ live tag stream published by `plc/live-plc-bridge` (UNS relative topics). Pure f
             {now, max_stale_s, freq_frozen_s, cmd_run_for_s}
 `cfg`     : thresholds (see DEFAULT_CFG; bench values marked CONFIRM).
 
-Covers A0,A1,A3,A4,A5,A6,A8,A9,A10. NOT covered (need a PLC Modbus-slave-map extension —
-the deployed slave does not expose these): A2 GS10 fault-code (0x2100), A7 freq setpoint,
-A12 photo-eye DI_05 / pe_latched. See README.
+Covers A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,A10,A12. A2/A7/A12 read slave-map v2 signals
+(GS10 fault-code 0x2100, freq setpoint 0x2101, photo-eye DI_05 / pe_latched) that the
+currently-deployed slave does NOT yet publish — those rules degrade silently (snap.get -> None)
+until the PLC Modbus-slave-map extension is reflashed. See README + specs/CONVEYOR_MACHINE_CARD.md.
 """
 from __future__ import annotations
 from dataclasses import dataclass, field
@@ -44,7 +45,32 @@ DEFAULT_CFG = {
     "cmd_run_grace_s": 3.0,    # A6 — RUN commanded but not running this long
     "offline_s": 30.0,         # A0 — no fresh data this long
     "run_cmd_values": (18, 20),  # GS10 cmd word: 18=FWD+RUN, 20=REV+RUN (§4)
+    "freq_track_tol_hz": 3.0,  # A7 — allowed |output Hz − setpoint Hz| at steady state
+    "freq_track_grace_s": 5.0, # A7 — accel grace after RUN before A7 may fire
 }
+
+# GS10 fault/error codes — low byte of register 0x2100 (manual §P06.17 ranges,
+# DURApulse GS10 UM 1st Ed Rev B). Used by A2 to decode vfd/vfd101/fault_code.
+GS10_FAULT_CODES = {
+    1: "ocA (over-current accel)", 2: "ocd (over-current decel)", 3: "ocn (over-current run)",
+    4: "GFF (ground fault)", 6: "ocS (over-current at stop)", 7: "ovA (over-voltage accel)",
+    8: "ovd (over-voltage decel)", 9: "ovn (over-voltage run)", 10: "ovS (over-voltage stop)",
+    11: "LvA (low-voltage accel)", 12: "Lvd (low-voltage decel)", 13: "Lvn (low-voltage run)",
+    14: "LvS (low-voltage stop)", 15: "orP (phase loss)", 16: "oH1 (IGBT overheat)",
+    18: "tH1o (IGBT temp sensor)", 21: "oL (overload)", 22: "EoL1 (thermal relay 1)",
+    23: "EoL2 (thermal relay 2)", 24: "oH3 (motor PTC overheat)", 26: "ot1 (over-torque 1)",
+    27: "ot2 (over-torque 2)", 28: "uC (under-current)", 31: "cF2 (EEPROM read)",
+    33: "cd1 (U-phase)", 34: "cd2 (V-phase)", 35: "cd3 (W-phase)", 36: "Hd0 (cc hardware)",
+    37: "Hd1 (oc hardware)", 40: "AUE (auto-tune)", 41: "AFE (PID loss AI-V)", 48: "ACE (AI-C loss)",
+    49: "EF (external fault)", 50: "EF1 (emergency stop)", 51: "bb (base block)",
+    52: "Pcod (password locked)", 54: "CE1 (illegal command)", 55: "CE2 (illegal data address)",
+    56: "CE3 (illegal data value)", 57: "CE4 (write to read-only)", 58: "CE10 (Modbus timeout)",
+    63: "oSL (over-slip)", 82: "oPL1 (output phase loss U)", 83: "oPL2 (output phase loss V)",
+    84: "oPL3 (output phase loss W)", 87: "oL3 (low-freq overload)", 140: "Hd6 (oc hardware)",
+    141: "b4GF (GFF before run)", 159: "Hd7 (gate driver)",
+}
+# Codes that trip the drive hard / risk damage → CRITICAL; everything else HIGH.
+_GS10_CRITICAL = {1, 2, 3, 4, 6, 7, 8, 9, 10, 15, 16, 33, 34, 35, 36, 37, 82, 83, 84, 140, 141, 159}
 
 # bridge UNS-relative topics (from live-plc-bridge)
 T_RUN = "motor/m101/running"
@@ -56,6 +82,12 @@ T_DI00, T_DI01 = "plc/di/di00_fwd", "plc/di/di01_rev"
 T_DI02, T_DI03 = "plc/di/di02_estop_nc", "plc/di/di03_estop_no"
 T_FREQ, T_CUR, T_DCBUS, T_CMD = (
     "vfd/vfd101/freq", "vfd/vfd101/current_a", "vfd/vfd101/dc_bus_v", "vfd/vfd101/cmd_word")
+# slave-map v2 topics (A2/A7/A12) — published once the PLC slave map is extended + reflashed
+T_FAULT = "vfd/vfd101/fault_code"      # low byte of GS10 0x2100
+T_WARN = "vfd/vfd101/warn_code"        # high byte of GS10 0x2100
+T_FREQ_SP = "vfd/vfd101/freq_setpoint" # commanded Hz (GS10 0x2101)
+T_PE_LATCH = "safety/pe_latched"       # photo-eye latching soft-stop engaged
+T_DI05 = "plc/di/di05_photoeye"        # raw photo-eye beam state
 
 
 def _ev(snap, *keys):
@@ -168,8 +200,53 @@ def r_a10_freq_stuck_zero(snap, d, cfg):
     return None
 
 
-RULES = [r_a0_offline, r_a1_comm, r_a3_estop_wiring, r_a4_direction, r_a5_illegal_run,
-         r_a6_not_responding, r_a8_overcurrent, r_a9_dcbus, r_a10_freq_stuck_zero]
+def r_a2_vfd_fault(snap, d, cfg):
+    # GS10 active fault (low byte of 0x2100). Trust-gated: stale when comm is down.
+    code = snap.get(T_FAULT)
+    if _vfd_trustworthy(snap) and isinstance(code, (int, float)) and int(code) != 0:
+        code = int(code)
+        name = GS10_FAULT_CODES.get(code, "unknown")
+        sev = CRITICAL if code in _GS10_CRITICAL else HIGH
+        return Anomaly("A2_VFD_FAULT", sev, "GS10 drive fault active",
+                       f"GS10 reports fault code {code}: {name} — the drive has tripped "
+                       "(0x2100 low byte). Clear the cause and reset the drive.",
+                       _ev(snap, T_FAULT, T_WARN), ["gs10"])
+    return None
+
+
+def r_a7_freq_not_tracking(snap, d, cfg):
+    # Commanded RUN with a nonzero speed setpoint, but output Hz is not reaching it
+    # (after the accel grace). Distinct from A10 (output stuck at ~0): A7 catches
+    # "running but can't hold commanded speed" (drag / current-limit / load).
+    sp, out = snap.get(T_FREQ_SP), snap.get(T_FREQ)
+    if (snap.get(T_CMD) in cfg["run_cmd_values"] and _vfd_trustworthy(snap)
+            and isinstance(sp, (int, float)) and sp > 0.1
+            and isinstance(out, (int, float))
+            and abs(out - sp) > cfg["freq_track_tol_hz"]
+            and d.get("cmd_run_for_s", 0.0) >= cfg["freq_track_grace_s"]):
+        return Anomaly("A7_FREQ_NOT_TRACKING", MED, "Output Hz not tracking setpoint",
+                       f"Commanded {sp:.1f} Hz but output is {out:.1f} Hz "
+                       f"(off by {abs(out - sp):.1f} Hz > {cfg['freq_track_tol_hz']:.1f}) for "
+                       f"{d['cmd_run_for_s']:.0f}s — drive not reaching commanded speed "
+                       "(mechanical drag, current-limit, or load).",
+                       _ev(snap, T_FREQ_SP, T_FREQ, T_CUR), ["gs10", "motor", "belt"])
+    return None
+
+
+def r_a12_photoeye_jam(snap, d, cfg):
+    # Photo-eye latching soft-stop engaged (DI_05 beam blocked → PLC latched a STOP).
+    # The authoritative signal is pe_latched (PLC latch); DI_05 is the raw beam.
+    if snap.get(T_PE_LATCH) is True:
+        return Anomaly("A12_PHOTOEYE_JAM", HIGH, "Photo-eye soft-stop (jam/blockage)",
+                       "Photo-eye DI_05 latched a soft-stop — an object is blocking the infeed "
+                       "beam (jam/backup); the belt is held stopped until Start re-arms it.",
+                       _ev(snap, T_PE_LATCH, T_DI05), ["photoeye", "belt"])
+    return None
+
+
+RULES = [r_a0_offline, r_a1_comm, r_a2_vfd_fault, r_a3_estop_wiring, r_a4_direction,
+         r_a5_illegal_run, r_a6_not_responding, r_a7_freq_not_tracking, r_a8_overcurrent,
+         r_a9_dcbus, r_a10_freq_stuck_zero, r_a12_photoeye_jam]
 
 
 def evaluate(snap: dict, derived: dict, cfg: dict | None = None) -> list[Anomaly]:

--- a/plc/conv_simple_anomaly/test_rules.py
+++ b/plc/conv_simple_anomaly/test_rules.py
@@ -18,6 +18,12 @@ def healthy_snap():
         "vfd/vfd101/current_a": 0.0,
         "vfd/vfd101/dc_bus_v": 327.0,
         "vfd/vfd101/cmd_word": 1,       # STOP
+        # --- slave-map v2 signals (A2/A7/A12); healthy defaults ---
+        "vfd/vfd101/fault_code": 0,     # 0 = no fault record
+        "vfd/vfd101/warn_code": 0,
+        "vfd/vfd101/freq_setpoint": 0.0,
+        "safety/pe_latched": False,     # photo-eye soft-stop not engaged
+        "plc/di/di05_photoeye": False,  # beam clear
     }
 
 
@@ -125,3 +131,67 @@ def test_a10_steady_speed_does_not_fire():
 def test_confidence_mapping():
     a = rules.r_a1_comm({"vfd/vfd101/comm_ok": False}, D0, rules.DEFAULT_CFG)
     assert a.confidence == 1.0  # CRITICAL
+
+
+# --- A2/A7/A12: slave-map v2 signals (degrade silently when topics absent) ---
+
+def test_new_rules_silent_when_signals_absent():
+    # the currently-deployed slave does not publish these topics; rules must not
+    # fire on missing data (snap.get -> None), only on real values.
+    s = healthy_snap()
+    for k in ("vfd/vfd101/fault_code", "vfd/vfd101/warn_code",
+              "vfd/vfd101/freq_setpoint", "safety/pe_latched", "plc/di/di05_photoeye"):
+        s.pop(k, None)
+    assert {"A2_VFD_FAULT", "A7_FREQ_NOT_TRACKING", "A12_PHOTOEYE_JAM"} & ids(s) == set()
+
+
+def test_a2_vfd_fault_code_fires_and_decodes():
+    s = healthy_snap(); s["vfd/vfd101/fault_code"] = 21  # oL overload
+    got = {a.rule_id: a for a in evaluate(s, D0)}
+    assert "A2_VFD_FAULT" in got
+    assert "oL" in got["A2_VFD_FAULT"].message  # decoded from the GS10 manual table
+
+
+def test_a2_no_fault_when_zero():
+    assert "A2_VFD_FAULT" not in ids(healthy_snap())  # fault_code 0 = no fault
+
+
+def test_a2_gated_by_comm():
+    # comm down -> fault_code is stale; A2 suppressed, only A1 fires
+    s = healthy_snap(); s["vfd/vfd101/comm_ok"] = False; s["vfd/vfd101/fault_code"] = 21
+    assert "A2_VFD_FAULT" not in ids(s)
+
+
+def test_a7_freq_not_tracking_setpoint():
+    # commanded RUN, setpoint 30 Hz, output stuck at 12 Hz past the grace -> A7
+    s = healthy_snap()
+    s.update({"vfd/vfd101/cmd_word": 18, "motor/m101/running": True,
+              "vfd/vfd101/freq_setpoint": 30.0, "vfd/vfd101/freq": 12.0,
+              "vfd/vfd101/current_a": 2.0})
+    assert "A7_FREQ_NOT_TRACKING" in ids(s, {**D0, "cmd_run_for_s": 8.0})
+    # within the accel grace -> must NOT fire (ramp-up is normal)
+    assert "A7_FREQ_NOT_TRACKING" not in ids(s, {**D0, "cmd_run_for_s": 2.0})
+
+
+def test_a7_silent_when_tracking():
+    # output within tolerance of setpoint -> healthy, no A7
+    s = healthy_snap()
+    s.update({"vfd/vfd101/cmd_word": 18, "motor/m101/running": True,
+              "vfd/vfd101/freq_setpoint": 30.0, "vfd/vfd101/freq": 29.5,
+              "vfd/vfd101/current_a": 2.0})
+    assert "A7_FREQ_NOT_TRACKING" not in ids(s, {**D0, "cmd_run_for_s": 8.0})
+
+
+def test_a7_silent_when_setpoint_zero():
+    # setpoint 0 (no speed commanded) -> A7 must not fire even if output is 0
+    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18
+    assert "A7_FREQ_NOT_TRACKING" not in ids(s, {**D0, "cmd_run_for_s": 8.0})
+
+
+def test_a12_photoeye_latched_fires():
+    s = healthy_snap(); s["safety/pe_latched"] = True
+    assert "A12_PHOTOEYE_JAM" in ids(s)
+
+
+def test_a12_silent_when_clear():
+    assert "A12_PHOTOEYE_JAM" not in ids(healthy_snap())

--- a/plc/live-plc-bridge/MIRA-LivePLCBridge-Boot.xml
+++ b/plc/live-plc-bridge/MIRA-LivePLCBridge-Boot.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<!-- Boot-scoped Scheduled Task for the live-plc-bridge (the bench PLC->MQTT bridge).
+     Runs at startup whether or not a user is logged on, restarts on failure, and uses
+     LogonType S4U (the user's own account, NO stored password, NO SYSTEM escalation).
+     This is the always-on mechanism DEPLOY.md prescribes — it replaces the logon-scoped
+     Startup-folder launcher, so it does NOT stop on logout (which would have produced
+     spurious A0_OFFLINE pages).
+
+     INSTALL (run in an ADMIN PowerShell/cmd):
+       schtasks /Create /TN "MIRA-LivePLCBridge" /XML "C:\Users\hharp\Documents\MIRA-monorepo\plc\live-plc-bridge\MIRA-LivePLCBridge-Boot.xml" /F
+     Then REMOVE the old logon-scoped launcher so the bridge doesn't double-run:
+       Remove-Item "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\MIRA-LivePLCBridge.vbs"
+     Verify:  schtasks /Query /TN "MIRA-LivePLCBridge" /V /FO LIST
+-->
+<Task version="1.3" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Always-on live-plc-bridge: streams the bench Micro 820 / GS10 PLC to the VPS MQTT broker for anomaly detection.</Description>
+    <URI>\MIRA-LivePLCBridge</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <BootTrigger>
+      <Enabled>true</Enabled>
+    </BootTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>LAPTOP-0KA3C70H\hharp</UserId>
+      <LogonType>S4U</LogonType>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RestartOnFailure>
+      <Interval>PT1M</Interval>
+      <Count>999</Count>
+    </RestartOnFailure>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>C:\Users\hharp\Documents\MIRA-monorepo\plc\live-plc-bridge\run_bridge_laptop.bat</Command>
+    </Exec>
+  </Actions>
+</Task>

--- a/plc/live-plc-bridge/bridge.py
+++ b/plc/live-plc-bridge/bridge.py
@@ -29,6 +29,7 @@ import asyncio
 import json
 import logging
 import os
+import sys
 import time
 from typing import Optional
 
@@ -121,7 +122,17 @@ def _envelope(value, ts: Optional[float] = None) -> str:
 
 
 async def _read_block(fn, offset: int, count: int):
-    rr = await fn(offset, count=count, slave=PLC_UNIT)
+    # pymodbus renamed the unit kwarg (slave -> device_id) across 3.x; try both,
+    # then positional, so the bridge runs on whatever the bench laptop has installed.
+    rr = None
+    for kw in ({"count": count, "device_id": PLC_UNIT}, {"count": count, "slave": PLC_UNIT}):
+        try:
+            rr = await fn(offset, **kw)
+            break
+        except TypeError:
+            continue
+    if rr is None:
+        rr = await fn(offset, count)
     if rr.isError():
         raise IOError(f"modbus read error @{offset} x{count}: {rr}")
     return rr
@@ -183,4 +194,10 @@ async def run() -> None:
 
 
 if __name__ == "__main__":
+    # On Windows the default ProactorEventLoop lacks add_reader/add_writer, which
+    # pymodbus' async client + aiomqtt require. The bench bridge runs on the
+    # Windows PLC laptop (only host with a route to 192.168.1.0/24), so select the
+    # SelectorEventLoop there. No effect on the Linux container deploy.
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     asyncio.run(run())

--- a/plc/live-plc-bridge/bridge.py
+++ b/plc/live-plc-bridge/bridge.py
@@ -67,6 +67,9 @@ COIL_TOPICS: dict[int, str] = {
     17: "plc/do/do01_red",
     18: "safety/contactor_q1",
     19: "plc/do/do03_pbrun_led",
+    # --- slave-map v2 (A12 photo-eye): enable after the MbSrvConf.xml reflash ---
+    # 20: "plc/di/di05_photoeye",   # raw photo-eye beam
+    # 21: "safety/pe_latched",      # photo-eye latching soft-stop engaged
 }
 
 # HR offset -> (relative topic, scale divisor). vfd_comm_ok (coil 3) is the
@@ -77,9 +80,15 @@ HR_SPECS: dict[int, tuple[str, float]] = {
     108: ("vfd/vfd101/voltage_v", 10.0),   # output V x10
     109: ("vfd/vfd101/dc_bus_v", 10.0),    # DC bus V x10
     114: ("vfd/vfd101/cmd_word", 1.0),     # GS10 command echo (1=STOP 18=FWD 20=REV)
+    # --- slave-map v2 (A2 fault decode / A7 setpoint): enable after the reflash ---
+    # 110: ("vfd/vfd101/fault_raw", 1.0),    # GS10 0x2100: hi byte=warn, lo byte=fault (split in decode)
+    # 111: ("vfd/vfd101/freq_setpoint", 100.0),  # GS10 0x2101 freq command x100
 }
 
 # Read plan: blocks that are fully mapped (no unmapped address inside a span).
+# The Micro 820 rejects a read that spans an unmapped address, so the plan only
+# covers mapped blocks. After the slave-map v2 reflash, widen these spans (e.g.
+# HR (106, 6) to pick up 110/111) and uncomment the HR_SPECS/COIL_TOPICS above.
 COIL_READS = [(0, 1), (3, 1), (5, 1), (9, 1), (11, 9)]  # (offset, count)
 HR_READS = [(106, 4), (114, 1)]
 

--- a/plc/live-plc-bridge/run_bridge_laptop.bat
+++ b/plc/live-plc-bridge/run_bridge_laptop.bat
@@ -1,0 +1,14 @@
+@echo off
+REM Always-on launcher for the live-plc-bridge on the PLC laptop (bench LAN host).
+REM Publishes real Micro 820 / GS10 data to the VPS broker so the VPS anomaly
+REM engine can run 24/7. Registered as a Scheduled Task (at log on). See DEPLOY.md.
+set PLC_HOST=192.168.1.100
+set PLC_PORT=502
+set MQTT_HOST=100.68.120.99
+set MQTT_PORT=1883
+set UNS_PREFIX=demo/cell1/conveyor/cv101
+set STREAM=bridge
+set SOURCE=plc-bridge
+set POLL_MS=500
+set LOG_LEVEL=INFO
+"C:\Users\hharp\AppData\Local\Python\pythoncore-3.14-64\python.exe" -u "C:\Users\hharp\Documents\MIRA-monorepo\plc\live-plc-bridge\bridge.py" >> "%LOCALAPPDATA%\mira-live-plc-bridge.log" 2>&1

--- a/tools/create_bench_equipment_node.py
+++ b/tools/create_bench_equipment_node.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Create the Conv_Simple bench equipment node in the knowledge graph.
+
+Models the real bench as a site-side equipment instance under the canonical
+ISA-95 UNS, links its VFD component to the GS10 catalog node so the drive's
+manuals + fault codes are reachable by graph traversal, and stamps the live
+data hooks (Modbus host, MQTT prefix, diagnostics topic) as properties.
+
+All writes go through the canonical idempotent helpers (ingest.kg_writer), so
+re-running is safe. Entities land approval_state='verified' (the column
+default) — this is a deliberate, human-authorized assertion, not an AI proposal.
+
+Usage (dry run prints the plan, NO DB writes):
+    python tools/create_bench_equipment_node.py
+Commit (writes to NeonDB — run under doppler so NEON_DATABASE_URL/MIRA_TENANT_ID resolve):
+    doppler run --project factorylm --config prd -- \\
+      python tools/create_bench_equipment_node.py --commit
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "mira-crawler"))
+
+from ingest import kg_writer, uns  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("create-bench-equipment-node")
+
+# Bench identity (slugs feed the ISA-95 path builder).
+COMPANY, SITE, AREA, EQUIPMENT_ID = "factorylm", "bench", "conv_simple", "cv101"
+
+BENCH_PROPS = {
+    "description": "Conv_Simple bench conveyor (Micro820 + GS10 demo rig)",
+    "plc": "Allen-Bradley Micro820 2080-LC20-20QBB",
+    "drive": "AutomationDirect DURApulse GS10",
+    "modbus_tcp": "192.168.1.100:502",
+    "mqtt_prefix": "demo/cell1/conveyor/cv101",
+    "diagnostics_topic": "demo/cell1/conveyor/cv101/diagnostics/conv_simple_anomaly",
+    "anomaly_engine": "conv_simple_anomaly",
+    "source": "create_bench_equipment_node.py",
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--commit", action="store_true", help="write to NeonDB (else dry-run)")
+    args = ap.parse_args()
+
+    tenant = os.environ.get("MIRA_TENANT_ID")
+
+    bench_path = uns.assigned_equipment_path(COMPANY, SITE, AREA, EQUIPMENT_ID)
+    gs10_path = uns.equipment_unassigned_path("AutomationDirect", "GS10")
+    vfd_path = uns.equipment_subnode_path(bench_path, "component", "vfd")
+
+    plan = [
+        ("equipment", "Conv_Simple cv101", bench_path, BENCH_PROPS),
+        ("equipment", "GS10", gs10_path,
+         {"manufacturer": "AutomationDirect", "catalog_node": True}),
+        ("component", "cv101 VFD (GS10)", vfd_path,
+         {"manufacturer": "AutomationDirect", "model": "GS10", "role": "conveyor drive"}),
+    ]
+    edges = [
+        ("Conv_Simple cv101", "has_component", "cv101 VFD (GS10)"),
+        ("cv101 VFD (GS10)", "instance_of", "GS10"),
+    ]
+
+    log.info("Planned entities:")
+    for etype, name, path, _ in plan:
+        ok = uns.is_valid_path(path)
+        log.info("  [%s] %-18s %s  %s", etype, name, path, "OK" if ok else "INVALID PATH")
+        if not ok:
+            log.error("invalid uns_path — aborting"); return 2
+    log.info("Planned edges:")
+    for s, rel, t in edges:
+        log.info("  %s -[%s]-> %s", s, rel, t)
+
+    if not args.commit:
+        log.info("DRY RUN — no DB writes. Re-run with --commit (under doppler) to apply.")
+        return 0
+
+    if not tenant or not os.environ.get("NEON_DATABASE_URL"):
+        log.error("MIRA_TENANT_ID and NEON_DATABASE_URL required (run under doppler)."); return 2
+
+    ids: dict[str, str] = {}
+    for etype, name, path, props in plan:
+        eid = kg_writer.upsert_entity(tenant, etype, name, path, properties=props)
+        if not eid:
+            log.error("upsert_entity failed for %s/%s", etype, name); return 1
+        ids[name] = eid
+        log.info("upserted %-18s -> %s", name, eid)
+    for s, rel, t in edges:
+        rid = kg_writer.upsert_relationship(tenant, ids[s], ids[t], rel)
+        log.info("edge %s -[%s]-> %s : %s", s, rel, t, rid or "FAILED")
+    log.info("Done. Bench equipment node id = %s", ids["Conv_Simple cv101"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Builds on the merged Conv_Simple machine-card ruleset (#1635/#1636). Adds the three
invariants that were stubbed pending a PLC slave-map extension, fixes the live-plc-bridge
so it runs on the Windows PLC laptop, and documents the always-on deploy.

## A2/A7/A12 rules (rules.py + test_rules.py)
- **A2_VFD_FAULT** — decodes GS10 register `0x2100` low byte via `GS10_FAULT_CODES`, a table
  sourced from the local DURApulse GS10 UM (`docs/vfd/GS10_UM.txt`, §P06.17). Trust-gated;
  CRITICAL for hard trips (oc/ov/GFF/IGBT/phase), HIGH otherwise.
- **A7_FREQ_NOT_TRACKING** — commanded RUN with a nonzero setpoint but output Hz not reaching
  it past the accel grace (distinct from A10 stuck-at-zero).
- **A12_PHOTOEYE_JAM** — photo-eye DI_05 latching soft-stop engaged.
- All three **degrade silently** (`snap.get -> None`) until the slave map publishes their
  topics — re-verified live 2026-06-01 against the real PLC (no false fires).
- **26 unit tests pass** (was 17); written test-first.

## Bridge fixes (live-plc-bridge/bridge.py) — must run on the Windows bench laptop
- Windows ProactorEventLoop lacks `add_reader`/`add_writer` → select
  `WindowsSelectorEventLoopPolicy` on win32 (no effect on the Linux container).
- pymodbus 3.11 dropped the `slave=` kwarg → `_read_block` tries `device_id`/`slave`/positional.
- v2 register map entries prepped (commented; enable after the slave-map reflash).

## Deploy
- **Verified end-to-end live**: laptop bridge → VPS broker (`mira-mosquitto`) → engine,
  idle-clean, diagnostics publishing, 0 spurious fault rows.
- `DEPLOY.md`: always-on topology + reversible engine container + persistent laptop-bridge recipe.

Machine card (the invariants this implements) added in the MIRA_PLC repo:
`specs/CONVEYOR_MACHINE_CARD.md`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)