### PR TITLE
fix(pipeline): COPY ignition_chat.py into image — restore prod chat (deploy fix for #1593)

### DIFF
--- a/mira-pipeline/Dockerfile
+++ b/mira-pipeline/Dockerfile
@@ -17,6 +17,7 @@ COPY mira-pipeline/memory.py .
 COPY mira-pipeline/feedback_sync.py .
 COPY mira-pipeline/eval_api.py .
 COPY mira-pipeline/qr_bridge.py .
+COPY mira-pipeline/ignition_chat.py .
 COPY VERSION .
 
 RUN addgroup --system --gid 1001 mira && \


### PR DESCRIPTION
**Prod hotfix.** #1593's merge crash-looped `mira-pipeline-saas` with `ModuleNotFoundError: No module named 'ignition_chat'` and failed the prod deploy — the chat cutover added the import + module but the Dockerfile didn't COPY `ignition_chat.py`. One-line fix. Verified `ignition_chat` is the only uncopied local import in main.py. Merging re-triggers Smoke → Deploy to VPS → pipeline comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)