### PR TITLE
feat(kg): live relationship graph on the Command Center (Phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-kg-graph-phase1-live-render.md
+++ b/docs/superpowers/plans/2026-06-02-kg-graph-phase1-live-render.md
@@ -1,0 +1,604 @@
+# KG Relationship Graph — Phase 1 (Live Render) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render the knowledge graph's *existing* edges live in a new `/hub/graph` page in the FactoryLM Hub, querying NeonDB directly — replacing the static `kg_relationship_sphere.html` snapshot.
+
+**Architecture:** A new session-authed `GET /api/kg/graph` endpoint reads `kg_entities` + `kg_relationships` for the caller's tenant, runs a pure transform into `{nodes, links}` (degree precomputed, dangling links dropped), and returns JSON. A client page renders it with `react-force-graph-2d` (Obsidian-style: degree sizing, color-by-type, search, type filters, orphan toggle, click→detail panel). The pure transform is unit-tested; the thin SQL follows the existing `withTenantContext` pattern.
+
+**Tech Stack:** Next.js App Router, TypeScript, `pg` + `withTenantContext` (RLS), vitest, bun, `react-force-graph-2d`.
+
+**Scope decision (no silent caps):** The MVP loads the *full tenant graph at once* (current data is ~578 nodes / 289 edges — trivial for the renderer) and implements "expand/focus" as **client-side neighbor highlighting**. A server-side depth-limited neighborhood query (`?focus=&depth=`) and dashed "proposed" suggestion edges are **deferred to Phase 2** per the design spec. The endpoint caps nodes at 5000 and the response states if the cap was hit.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-kg-relationship-graph-design.md`
+
+---
+
+### Task 1: Pure graph-builder transform (the testable core)
+
+**Files:**
+- Create: `mira-hub/src/lib/knowledge-graph/graph-view.ts`
+- Test: `mira-hub/src/lib/knowledge-graph/__tests__/graph-view.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// mira-hub/src/lib/knowledge-graph/__tests__/graph-view.test.ts
+import { describe, test, expect } from "vitest";
+import { buildGraphPayload, type EntityRow, type RelRow } from "../graph-view";
+
+const entities: EntityRow[] = [
+  { id: "a", entity_type: "equipment", name: "VFD-07", uns_path: "ent.site.vfd07" },
+  { id: "b", entity_type: "manual", name: "PowerFlex Manual", uns_path: null },
+  { id: "c", entity_type: "fault_code", name: "F004", uns_path: null }, // orphan
+];
+
+describe("buildGraphPayload", () => {
+  test("maps nodes and labels (name, fallback to id)", () => {
+    const p = buildGraphPayload(
+      [{ id: "x", entity_type: "part", name: null, uns_path: null }],
+      [],
+    );
+    expect(p.nodes[0]).toMatchObject({ id: "x", type: "part", label: "x", degree: 0 });
+  });
+
+  test("computes degree on both endpoints", () => {
+    const rels: RelRow[] = [
+      { source_id: "a", target_id: "b", relationship_type: "has_manual", confidence: 1, approval_state: "verified" },
+    ];
+    const p = buildGraphPayload(entities, rels);
+    const byId = Object.fromEntries(p.nodes.map((n) => [n.id, n]));
+    expect(byId["a"].degree).toBe(1);
+    expect(byId["b"].degree).toBe(1);
+    expect(byId["c"].degree).toBe(0); // orphan retained at degree 0
+  });
+
+  test("drops links whose endpoint is missing", () => {
+    const rels: RelRow[] = [
+      { source_id: "a", target_id: "ZZZ", relationship_type: "has_manual", confidence: 1, approval_state: "verified" },
+    ];
+    const p = buildGraphPayload(entities, rels);
+    expect(p.links).toHaveLength(0);
+    expect(p.nodes.find((n) => n.id === "a")?.degree).toBe(0);
+  });
+
+  test("defaults confidence=1 and state=verified when null", () => {
+    const rels: RelRow[] = [
+      { source_id: "a", target_id: "b", relationship_type: "has_manual", confidence: null, approval_state: null },
+    ];
+    const p = buildGraphPayload(entities, rels);
+    expect(p.links[0]).toMatchObject({ confidence: 1, state: "verified" });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd mira-hub && bun run test -- graph-view`
+Expected: FAIL — cannot find module `../graph-view`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+// mira-hub/src/lib/knowledge-graph/graph-view.ts
+/**
+ * Pure transform from KG table rows into the {nodes, links} shape every
+ * force-graph library consumes. No DB, no IO — unit-tested in isolation.
+ * Degree is precomputed server-side so the client just maps nodeVal.
+ */
+
+export interface EntityRow {
+  id: string;
+  entity_type: string;
+  name: string | null;
+  uns_path: string | null;
+}
+
+export interface RelRow {
+  source_id: string;
+  target_id: string;
+  relationship_type: string;
+  confidence: number | null;
+  approval_state: string | null;
+}
+
+export interface GraphNode {
+  id: string;
+  type: string;
+  label: string;
+  degree: number;
+  unsPath: string | null;
+}
+
+export interface GraphLink {
+  source: string;
+  target: string;
+  type: string;
+  confidence: number;
+  state: string;
+}
+
+export interface GraphPayload {
+  nodes: GraphNode[];
+  links: GraphLink[];
+}
+
+export function buildGraphPayload(entities: EntityRow[], rels: RelRow[]): GraphPayload {
+  const nodes = new Map<string, GraphNode>();
+  for (const e of entities) {
+    nodes.set(e.id, {
+      id: e.id,
+      type: e.entity_type,
+      label: e.name && e.name.length > 0 ? e.name : e.id,
+      degree: 0,
+      unsPath: e.uns_path,
+    });
+  }
+
+  const links: GraphLink[] = [];
+  for (const r of rels) {
+    const src = nodes.get(r.source_id);
+    const tgt = nodes.get(r.target_id);
+    if (!src || !tgt) continue; // drop dangling edges
+    src.degree += 1;
+    tgt.degree += 1;
+    links.push({
+      source: r.source_id,
+      target: r.target_id,
+      type: r.relationship_type,
+      confidence: r.confidence ?? 1,
+      state: r.approval_state ?? "verified",
+    });
+  }
+
+  return { nodes: [...nodes.values()], links };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd mira-hub && bun run test -- graph-view`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add mira-hub/src/lib/knowledge-graph/graph-view.ts mira-hub/src/lib/knowledge-graph/__tests__/graph-view.test.ts
+git commit -m "feat(kg): pure graph-view transform (rows -> nodes/links) with degree"
+```
+
+---
+
+### Task 2: `GET /api/kg/graph` endpoint
+
+**Files:**
+- Create: `mira-hub/src/app/api/kg/graph/route.ts`
+
+Follows the exact pattern of `mira-hub/src/app/api/proposals/route.ts`: `NEON_DATABASE_URL` guard → 503, `sessionOr401()` for tenant, `withTenantContext` for the query, explicit `tenant_id = $1::uuid` filter.
+
+- [ ] **Step 1: Write the route**
+
+```ts
+// mira-hub/src/app/api/kg/graph/route.ts
+/**
+ * GET /api/kg/graph — live {nodes, links} for the caller's tenant.
+ *
+ * Reads kg_entities + kg_relationships and returns the force-graph payload
+ * for the /hub/graph page. Session-authed (NOT the service-token internal
+ * KG endpoint). Full-tenant graph for now; neighborhood/proposal edges are
+ * Phase 2 (see design spec).
+ *
+ * Query params:
+ *   types — optional comma-separated entity_type allow-list (e.g. "equipment,manual").
+ */
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { buildGraphPayload, type EntityRow, type RelRow } from "@/lib/knowledge-graph/graph-view";
+
+export const dynamic = "force-dynamic";
+
+const NODE_CAP = 5000;
+
+export async function GET(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const url = new URL(req.url);
+  const typeParam = url.searchParams.get("types");
+
+  try {
+    const { entities, rels } = await withTenantContext(ctx.tenantId, async (c) => {
+      const e = await c.query<EntityRow>(
+        `SELECT id, entity_type, name, uns_path::text AS uns_path
+           FROM kg_entities
+          WHERE tenant_id = $1::uuid
+          LIMIT $2`,
+        [ctx.tenantId, NODE_CAP],
+      );
+      const r = await c.query<RelRow>(
+        `SELECT source_id, target_id, relationship_type, confidence, approval_state
+           FROM kg_relationships
+          WHERE tenant_id = $1::uuid`,
+        [ctx.tenantId],
+      );
+      return { entities: e.rows, rels: r.rows };
+    });
+
+    let payload = buildGraphPayload(entities, rels);
+
+    if (typeParam) {
+      const types = new Set(typeParam.split(",").map((s) => s.trim()).filter(Boolean));
+      const keep = new Set(payload.nodes.filter((n) => types.has(n.type)).map((n) => n.id));
+      payload = {
+        nodes: payload.nodes.filter((n) => keep.has(n.id)),
+        links: payload.links.filter((l) => keep.has(l.source) && keep.has(l.target)),
+      };
+    }
+
+    return NextResponse.json({
+      ...payload,
+      capped: entities.length >= NODE_CAP,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "internal error" },
+      { status: 500 },
+    );
+  }
+}
+```
+
+- [ ] **Step 2: Type-check and lint**
+
+Run: `cd mira-hub && bunx tsc --noEmit && bun run lint`
+Expected: no errors for the new file. (If `kg_entities.uns_path` does not exist in a given branch, the query errors at runtime, not compile — verified live in Task 6.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add mira-hub/src/app/api/kg/graph/route.ts
+git commit -m "feat(kg): GET /api/kg/graph live nodes/links endpoint (session-authed)"
+```
+
+---
+
+### Task 3: `GraphCanvas` client component
+
+**Files:**
+- Create: `mira-hub/src/components/kg/GraphCanvas.tsx`
+- Modify: `mira-hub/package.json` (add `react-force-graph-2d`)
+
+- [ ] **Step 1: Install the renderer**
+
+Run: `cd mira-hub && bun add react-force-graph-2d`
+Expected: `react-force-graph-2d` appears in `package.json` dependencies; `bun.lock` updated.
+
+- [ ] **Step 2: Write the component**
+
+```tsx
+// mira-hub/src/components/kg/GraphCanvas.tsx
+"use client";
+
+import dynamic from "next/dynamic";
+import type { GraphNode, GraphLink } from "@/lib/knowledge-graph/graph-view";
+
+// react-force-graph-2d touches window/canvas → must be client-only.
+const ForceGraph2D = dynamic(() => import("react-force-graph-2d"), { ssr: false });
+
+export interface GraphCanvasData {
+  nodes: GraphNode[];
+  links: GraphLink[];
+}
+
+export function GraphCanvas({
+  data,
+  onNodeClick,
+}: {
+  data: GraphCanvasData;
+  onNodeClick?: (node: GraphNode) => void;
+}) {
+  return (
+    <ForceGraph2D
+      graphData={data}
+      backgroundColor="#0b0f1a"
+      nodeAutoColorBy="type"
+      nodeVal={(n: GraphNode) => 1 + n.degree}
+      nodeLabel={(n: GraphNode) => `${n.label} — ${n.type}`}
+      nodeRelSize={4}
+      linkColor={(l: GraphLink) => (l.state === "proposed" ? "#6b7280" : "#3a4252")}
+      linkWidth={(l: GraphLink) => (l.state === "proposed" ? 0.5 : 1)}
+      onNodeClick={(n: object) => onNodeClick?.(n as GraphNode)}
+      cooldownTicks={120}
+    />
+  );
+}
+```
+
+Note: `react-force-graph-2d` ships its own type declarations. If `bunx tsc --noEmit` reports the generic-prop signatures don't match, narrow the offending callbacks to `(n: any)` with an inline `// eslint-disable-next-line @typescript-eslint/no-explicit-any` rather than fighting the upstream generics — the runtime contract above is correct.
+
+- [ ] **Step 3: Type-check**
+
+Run: `cd mira-hub && bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add mira-hub/src/components/kg/GraphCanvas.tsx mira-hub/package.json mira-hub/bun.lock
+git commit -m "feat(kg): GraphCanvas force-graph component (react-force-graph-2d, ssr:false)"
+```
+
+---
+
+### Task 4: `/hub/graph` page — fetch + render
+
+**Files:**
+- Create: `mira-hub/src/app/(hub)/graph/page.tsx`
+
+- [ ] **Step 1: Write the page (basic fetch + render)**
+
+```tsx
+// mira-hub/src/app/(hub)/graph/page.tsx
+"use client";
+
+import { useEffect, useState } from "react";
+import { GraphCanvas } from "@/components/kg/GraphCanvas";
+import type { GraphNode, GraphLink } from "@/lib/knowledge-graph/graph-view";
+
+interface GraphResponse {
+  nodes: GraphNode[];
+  links: GraphLink[];
+  capped?: boolean;
+  error?: string;
+}
+
+export default function GraphPage() {
+  const [data, setData] = useState<GraphResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch("/api/kg/graph")
+      .then((r) => r.json())
+      .then((j: GraphResponse) => {
+        if (j.error) setError(j.error);
+        else setData(j);
+      })
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  if (error) return <div className="p-6 text-red-400">Graph error: {error}</div>;
+  if (!data) return <div className="p-6 text-slate-400">Loading relationship graph…</div>;
+
+  return (
+    <div className="relative h-[calc(100vh-4rem)] w-full">
+      <div className="absolute left-4 top-4 z-10 rounded-md bg-slate-900/70 px-3 py-2 text-sm text-slate-200">
+        <div className="font-semibold text-white">Relationship Graph</div>
+        <div className="text-slate-400">
+          {data.nodes.length} nodes · {data.links.length} edges
+          {data.capped ? " (capped)" : ""}
+        </div>
+      </div>
+      <GraphCanvas data={data} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+Run: `cd mira-hub && bunx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "mira-hub/src/app/(hub)/graph/page.tsx"
+git commit -m "feat(kg): /hub/graph page renders live KG via /api/kg/graph"
+```
+
+---
+
+### Task 5: Page controls — search, type filter, orphan toggle, detail panel
+
+**Files:**
+- Modify: `mira-hub/src/app/(hub)/graph/page.tsx`
+
+- [ ] **Step 1: Add controls and a node-detail panel**
+
+Replace the body of `GraphPage` with the version below (adds: derived list of entity types with toggles, a search box that highlights/filters, an orphan toggle, and a right-hand detail panel populated on node click).
+
+```tsx
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { GraphCanvas } from "@/components/kg/GraphCanvas";
+import type { GraphNode, GraphLink } from "@/lib/knowledge-graph/graph-view";
+
+interface GraphResponse {
+  nodes: GraphNode[];
+  links: GraphLink[];
+  capped?: boolean;
+  error?: string;
+}
+
+export default function GraphPage() {
+  const [raw, setRaw] = useState<GraphResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [hiddenTypes, setHiddenTypes] = useState<Set<string>>(new Set());
+  const [showOrphans, setShowOrphans] = useState(true);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<GraphNode | null>(null);
+
+  useEffect(() => {
+    fetch("/api/kg/graph")
+      .then((r) => r.json())
+      .then((j: GraphResponse) => (j.error ? setError(j.error) : setRaw(j)))
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  const types = useMemo(
+    () => [...new Set((raw?.nodes ?? []).map((n) => n.type))].sort(),
+    [raw],
+  );
+
+  const view = useMemo(() => {
+    if (!raw) return { nodes: [], links: [] };
+    const q = query.trim().toLowerCase();
+    const keep = new Set(
+      raw.nodes
+        .filter((n) => !hiddenTypes.has(n.type))
+        .filter((n) => showOrphans || n.degree > 0)
+        .filter((n) => !q || n.label.toLowerCase().includes(q))
+        .map((n) => n.id),
+    );
+    return {
+      nodes: raw.nodes.filter((n) => keep.has(n.id)),
+      links: raw.links.filter((l) => keep.has(l.source) && keep.has(l.target)),
+    };
+  }, [raw, hiddenTypes, showOrphans, query]);
+
+  if (error) return <div className="p-6 text-red-400">Graph error: {error}</div>;
+  if (!raw) return <div className="p-6 text-slate-400">Loading relationship graph…</div>;
+
+  return (
+    <div className="relative h-[calc(100vh-4rem)] w-full">
+      {/* HUD */}
+      <div className="absolute left-4 top-4 z-10 w-64 space-y-2 rounded-md bg-slate-900/80 p-3 text-sm text-slate-200">
+        <div className="font-semibold text-white">Relationship Graph</div>
+        <div className="text-xs text-slate-400">
+          {view.nodes.length}/{raw.nodes.length} nodes · {view.links.length} edges
+          {raw.capped ? " (capped)" : ""}
+        </div>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search nodes…"
+          className="w-full rounded border border-slate-700 bg-slate-800 px-2 py-1 text-xs outline-none"
+        />
+        <label className="flex items-center gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={showOrphans}
+            onChange={(e) => setShowOrphans(e.target.checked)}
+          />
+          Show orphans
+        </label>
+        <div className="space-y-1">
+          {types.map((t) => (
+            <label key={t} className="flex cursor-pointer items-center gap-2 text-xs">
+              <input
+                type="checkbox"
+                checked={!hiddenTypes.has(t)}
+                onChange={(e) => {
+                  setHiddenTypes((prev) => {
+                    const next = new Set(prev);
+                    if (e.target.checked) next.delete(t);
+                    else next.add(t);
+                    return next;
+                  });
+                }}
+              />
+              {t}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Detail panel */}
+      {selected && (
+        <div className="absolute right-4 top-4 z-10 w-72 rounded-md bg-slate-900/90 p-4 text-sm text-slate-200">
+          <button
+            onClick={() => setSelected(null)}
+            className="float-right text-slate-500 hover:text-slate-300"
+          >
+            ✕
+          </button>
+          <div className="mb-1 font-semibold text-white">{selected.label}</div>
+          <div className="text-xs text-slate-400">type: {selected.type}</div>
+          <div className="text-xs text-slate-400">degree: {selected.degree}</div>
+          {selected.unsPath && (
+            <div className="mt-2 break-words text-xs text-slate-400">
+              {selected.unsPath}
+            </div>
+          )}
+        </div>
+      )}
+
+      <GraphCanvas data={view} onNodeClick={setSelected} />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check and lint**
+
+Run: `cd mira-hub && bunx tsc --noEmit && bun run lint`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "mira-hub/src/app/(hub)/graph/page.tsx"
+git commit -m "feat(kg): graph page controls — search, type filter, orphan toggle, detail panel"
+```
+
+---
+
+### Task 6: Wire into Hub nav + live verification
+
+**Files:**
+- Modify: the Hub navigation config (locate in Step 1)
+
+- [ ] **Step 1: Locate the nav config**
+
+Run: `cd mira-hub && grep -rnE "href=\"/(hub/)?(proposals|namespace|knowledge)\"|/hub/proposals" src/app src/components | head`
+This finds where existing hub destinations (e.g. `proposals`, `namespace`) are registered. Add a sibling entry for Graph pointing at `/hub/graph` (or `/graph` if the group uses bare paths — match the neighbors exactly), using a `lucide-react` icon already imported in that file (e.g. `Share2` or `Network`).
+
+- [ ] **Step 2: Add the nav entry**
+
+In the file found above, add an item mirroring the adjacent ones. Example shape (match the surrounding array's exact field names):
+
+```tsx
+{ label: "Graph", href: "/hub/graph", icon: Network },
+```
+
+If `Network` is not already imported from `lucide-react` in that file, add it to the existing `lucide-react` import line.
+
+- [ ] **Step 3: Live verification against Neon**
+
+```bash
+cd mira-hub && bun run dev
+```
+Then, in a browser logged into a tenant that has KG data:
+- Visit `http://localhost:3000/hub/graph`.
+- Confirm: the HUD shows a non-zero node/edge count; nodes are colored by type; dragging/zoom works; typing in Search filters; toggling a type hides those nodes; "Show orphans" off removes degree-0 nodes; clicking a node opens the detail panel with type/degree/UNS path.
+
+Capture a screenshot for the PR (Playwright MCP `browser_navigate` → `browser_take_screenshot`, or manual). Expected: the equipment↔manual web renders live, sourced from `/api/kg/graph` (verify in the Network tab the response is real JSON, not the static HTML).
+
+- [ ] **Step 4: Run the full unit suite + type-check**
+
+Run: `cd mira-hub && bun run test && bunx tsc --noEmit`
+Expected: all tests pass (including `graph-view`), no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A mira-hub/src
+git commit -m "feat(kg): add Graph to hub nav; verify live render against Neon"
+```
+
+- [ ] **Step 6: Request code review**
+
+Use superpowers:requesting-code-review before opening the PR. Confirm: tenant isolation (every query filters `tenant_id = $1`), no service-token endpoint exposed to the browser, `ssr:false` on the canvas, and the static `kg_relationship_sphere.html` is now superseded by the live page.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** render existing edges live (Tasks 1–5 ✓), Obsidian-style degree sizing + color-by-type + search + orphan toggle + detail panel (Tasks 3–5 ✓), live from Neon not static (Task 2, Task 6 verify ✓), nav entry (Task 6 ✓). Deferred-by-design and stated explicitly: server-side neighborhood `?focus=&depth=`, dashed proposal/suggestion edges, 3D toggle, GraphRAG wiring (Phases 2–3).
+- **Placeholder scan:** none — every code/test/command step is concrete. The two discovery steps (Task 6 nav location; the react-force-graph type-narrowing note) give exact commands/fallbacks rather than "TBD".
+- **Type consistency:** `EntityRow`/`RelRow`/`GraphNode`/`GraphLink`/`GraphPayload` and `buildGraphPayload` are defined once in Task 1 and reused verbatim in Tasks 2–5. `state` values `"verified"|"proposed"` are consistent between the transform default and the `GraphCanvas` link styling.

--- a/docs/superpowers/specs/2026-06-02-kg-relationship-graph-design.md
+++ b/docs/superpowers/specs/2026-06-02-kg-relationship-graph-design.md
@@ -1,0 +1,186 @@
+# Live Relationship Graph for the Command Center — Design
+
+**Date:** 2026-06-02
+**Status:** Design approved, ready for plan
+**Target surface:** FactoryLM Hub (`mira-hub`, Next.js) — a new `/hub/graph` module
+**Graph source:** the production knowledge graph in NeonDB (`kg_entities` / `kg_relationships`)
+**Companion brief:** `MIRA_PLC/specs/FactoryLM_Hub_Command_Center_Brief.typ`
+
+---
+
+## Why this matters (read this first)
+
+A maintenance technician's question is rarely about one fact. It is "this drive keeps
+faulting — what causes ErrorID 55, has it happened on the identical drive on Line 2, and
+what fixed it last time?" Answering that means **walking relationships**: fault → cause →
+remedy → part, and equipment → same-model → other equipment → its history. A node alone is a
+fact; **an edge is a reasoning path.** The intelligence of the system lives in its edges, not
+its nodes.
+
+We already have the graph that the AI agents traverse. What we do **not** have is (a) a way
+for a human to *see* that web live in the Command Center, and (b) enough edges in it for the
+web to be worth seeing. Today the graph is 578 nodes but only 289 edges, and **269 of those
+289 (93%) are a single relationship type** (`has_manual`) — equipment-to-manual star pairs.
+The richer relationships are defined in the schema but sit unpopulated or unapproved.
+
+This design does three things, in plain terms:
+
+1. **Explains** how connections are created in the KG and what they are used for.
+2. **Draws** the connections that already exist — live, in the Hub, Obsidian-style.
+3. **Enriches** the web so the relationships that make it intelligent actually exist.
+
+The model is Obsidian's graph view and the "Karpathy wiki" / evergreen-notes principle:
+*link density, not the notes themselves, is the asset.* Our industrial version of Obsidian's
+"unlinked mentions" is the existing **proposals queue** — candidate edges waiting for a human
+to promote them.
+
+---
+
+## Part 1 — How connections are created and used (the explainer)
+
+### Where connections live
+
+| Table | Role |
+|---|---|
+| `kg_entities` | Nodes. `entity_type` (equipment, manual, fault_code, work_order, part, component, plant/area/line, …), `name`, `properties JSONB`, per-tenant RLS. |
+| `kg_relationships` | **Edges.** `source_id`, `target_id`, `relationship_type`, `confidence (0–1)`, `approval_state` (proposed/verified/rejected/needs_review), `proposed_by` (`llm:groq`, `human:user_…`), `evidence_summary`. |
+| `relationship_proposals` + `relationship_evidence` | Candidate edges before promotion, each with an evidence chain (document page, PLC rung, work order, technician note, live data…). The industrial "unlinked mention." |
+| `kg_triples_log` | Low-confidence / unvetted assertions parked before promotion. |
+| `kg_asset_hierarchy` (view) | Recursive CTE over `parent_of` + `has_component` → ISA-95 roll-up/drill-down with cycle protection. |
+
+Relationship types already defined in `types.ts`: `parent_of`, `has_component`, `located_at`,
+`has_work_order`, `has_pm`, `caused_by`, `resolved_by`, `requires_part`, `had_fault`,
+`feeds`, `similar_to`, `electrically_connected`, `controls`, `protects`,
+`references_drawing`, `instance_of`, and more (30+ in the proposal allow-list).
+
+### The four pathways that create edges
+
+| Pathway | What it creates | Confidence / gate | Source file |
+|---|---|---|---|
+| **CMMS auto-sync** | `equipment→located_at→site`, `→has_work_order`, `→has_pm` | 1.0, auto-verified | `mira-hub/src/lib/knowledge-graph/cmms-sync.ts` |
+| **LLM extractor** (after a diagnostic chat) | `caused_by`, `resolved_by`, `feeds`, `requires_part`, `triggered_pm`, `had_fault` (6 allow-listed) | ≥0.6 → `kg_relationships`; else `kg_triples_log` | `…/relationship-extractor.ts` |
+| **Human proposals queue** | structural: `has_component`, `wired_to`, `instance_of`, `references_drawing` (from schematics, OCR, manuals) | proposed → human **Verify** → promoted | `db/migrations/018_relationship_proposals.sql`, `…/api/proposals/[id]/decide` |
+| **Manual binding** | `has_manual` (bulk fuzzy match model→manual) | 1.0 | (ingest/curation) |
+
+**Why the web is thin:** CMMS sync only emits 3 edge types; the structural edges that would
+make the graph dense are stuck in the proposals queue awaiting approval; the LLM extractor
+only fires when a diagnostic conversation happens; so the only densely-created edge is
+`has_manual`. The edges are *queued or unenabled, not impossible.*
+
+### How the agents actually use the graph (what they "see")
+
+Agents do **not** read raw tables. They call `/api/internal/kg` (8 operations), exposed as 8
+MCP tools (`mira-mcp/server.py`):
+
+- `kg_maintenance_context` — given equipment, gather hierarchy + components + recent faults +
+  work orders + parts + manuals + PM schedule in one call.
+- `kg_impact_analysis` — walk `feeds` forward → what downstream is blocked.
+- `kg_root_cause_chain` — walk `caused_by` backward → cause chain + sibling alternates.
+- `kg_traverse_chain` — follow a fixed predicate sequence (e.g. `parent_of, parent_of,
+  has_component`) from plant to every component.
+- `kg_flag_pm_mismatches`, `mira_browse_namespace`, `mira_get_equipment`,
+  `kg_extract_schematic`.
+
+All traversals are PostgreSQL recursive CTEs with cycle protection (`traversal.ts`). **This is
+"the underlying background connections that the agents actually see and use."** The live
+visual we build queries the *same* edges, so what the human sees == what the agent reasons over.
+
+### What the edges are for: GraphRAG
+
+Plain vector RAG retrieves similar text chunks. **GraphRAG** traverses typed edges, so it can
+answer multi-hop questions that no single chunk contains, with fewer hallucinations and — the
+part that matters for safety — a **traceable citation: the path itself.** "ErrorID 55 →
+`caused_by` → RS-485 response-delay too fast → `resolved_by` → set P09.09=10ms" is an answer a
+technician can trust because they can see the chain. This is the payoff that makes drawing and
+enriching the graph worth doing.
+
+---
+
+## Part 2 — The visual (drawing the connections, live)
+
+### Approach (chosen: A)
+
+A new **`/hub/graph`** page backed by a new **`GET /api/kg/graph`** endpoint, rendered with
+**`react-force-graph-2d`** (vasturiano) imported via `next/dynamic` with `ssr:false`. It
+mirrors Obsidian:
+
+- **Degree-based node sizing** (precomputed server-side), **color-by-`entity_type`**.
+- **Global view** + **click-to-expand local graph** (N-hop neighborhood, like Obsidian's depth
+  slider) instead of loading everything.
+- **Search** to seed the focus node; **type/predicate filters**; **orphan toggle**.
+- **Click → detail panel** reusing `mira_get_equipment` / entity properties.
+- **Dashed "suggested" edges** drawn from the proposals queue; one-click **Verify** promotes a
+  proposal to a solid edge — the industrial "unlinked mention" promotion.
+- **3D toggle** reusing the proven `3d-force-graph` for demo flair (same data).
+
+Rejected alternatives:
+- **B — iframe the existing static `kg_relationship_sphere.html`:** fast but a dead snapshot;
+  doesn't solve "live" or interactivity. Acceptable only as a stopgap.
+- **C — Sigma.js + graphology (WebGL):** the right escape hatch above ~10k visible nodes
+  (in-browser Louvain communities); overkill at ~600 nodes today.
+
+### API shape
+
+```
+GET /api/kg/graph?focus=<entityId>&depth=<n>&types=<csv>&includeProposals=<bool>
+→ { "nodes": [ { id, type, label, degree, unsPath } ],
+    "links": [ { source, target, type, confidence, state } ] }
+```
+
+Backed by the existing `traversal.ts` CTEs. `state: "verified" | "proposed"` drives
+solid-vs-dashed rendering. Degree precomputed in the query so the client just maps `nodeVal`.
+
+---
+
+## Part 3 — Enriching the web (making relationships exist)
+
+Two kinds of new edges:
+
+**a) Promote what's already queued.** Run the structural extractors (schematic / manual /
+namespace) so `has_component`, `instance_of`, `located_at`, `feeds` land as proposals, then
+clear the approval queue. These already have code paths — this is throughput, not new logic.
+
+**b) Infer new edges (the unlinked-mention analog), as proposals:**
+- `same_model_as` — group `kg_entities` of type equipment by `properties.manufacturer +
+  model`; propose an edge between identical units. Answers "has this failure happened on an
+  identical drive elsewhere?"
+- `co_failed_with` — from work-order co-occurrence (two assets repeatedly in the same
+  outage/WO window); surfaces hidden failure correlations.
+
+Both are written with `confidence < 1`, `created_by='rule'`, `requires_human_review=true`, so
+they flow through the **existing** proposal/approval machinery — no new trust path, full
+auditability. In the UI they appear as dashed suggestions the user promotes.
+
+---
+
+## Phased plan
+
+| Phase | Goal | Acceptance | Skills / sub-agents |
+|---|---|---|---|
+| **0 — Explain & make safe** | This spec + the connection-model explainer, committed | Spec on branch, pointer in MIRA_PLC | writing-plans, elements-of-style |
+| **1 — Render existing edges LIVE** | `/api/kg/graph` + `/hub/graph` page | The real 289 edges render live from Neon; search + click-to-expand + detail panel work | feature-dev, test-driven-development, verification-before-completion |
+| **2 — Enrich the web** | Clear proposal queue; infer `same_model_as` + `co_failed_with` as proposals; dashed suggestions promotable in UI | Non-`has_manual` edge share rises materially; suggested edges appear and promote correctly | dispatching-parallel-agents (one agent per edge type / inference) |
+| **3 — Close the loop to intelligence** | Wire the graph into Ask MIRA (Local + Global GraphRAG); highlight the subgraph MIRA traversed to answer | An answer shows its traversal path on the graph | ai:claude-api |
+| **4 — Live & embedded** | SSE deltas; community clustering for readability; focused mini-graph on each Asset page | Graph updates without full reload; per-asset neighborhood embeds | subagent-driven-development, requesting-code-review |
+
+### Build sequence for Phase 1 (the first plan)
+
+1. `GET /api/kg/graph` endpoint over `traversal.ts` (nodes+links+degree+state). TDD.
+2. `npm install react-force-graph-2d`; `GraphCanvas.tsx` (dynamic, ssr:false).
+3. `/hub/graph/page.tsx`: search seed → focus, force graph, color-by-type, degree sizing.
+4. Detail panel (reuse `mira_get_equipment`), type filters, orphan toggle.
+5. Click-to-expand neighborhood (depth+1 fetch, merge into in-memory graph).
+6. Verify against live Neon snapshot; screenshot; request code review before merge.
+
+---
+
+## Risks / open questions
+
+- **Tenant scoping:** every query is per-`tenant_id` (RLS). The graph page must take tenant
+  from session, never a client param. (Carry into the plan.)
+- **Inference precision:** `co_failed_with` from WO co-occurrence can be noisy — start with a
+  high co-occurrence threshold and require human approval (it already does).
+- **Performance:** ~600 nodes is trivial for `react-force-graph-2d`; revisit Sigma.js only if a
+  single tenant's graph passes ~10k visible nodes.
+- **Cross-repo:** the static export lives in `MIRA_PLC/specs/`; the live feature lives here in
+  `mira-hub`. This spec is the bridge; a pointer is kept in `MIRA_PLC/specs/`.

--- a/mira-hub/package-lock.json
+++ b/mira-hub/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mira-hub",
-  "version": "1.5.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mira-hub",
-      "version": "1.5.0",
+      "version": "1.9.1",
       "dependencies": {
         "@node-saml/node-saml": "^5.0.0",
         "@radix-ui/react-avatar": "^1.1.11",
@@ -47,6 +47,7 @@
         "qrcode": "^1.5.4",
         "react": "19.2.4",
         "react-dom": "19.2.4",
+        "react-force-graph-2d": "^1.29.1",
         "recharts": "^3.8.1",
         "rrule": "^2.8.1",
         "tailwind-merge": "^3.5.0",
@@ -5221,6 +5222,12 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-25.0.0.tgz",
+      "integrity": "sha512-XKLA6syeBUaPzx4j3qwMqzzq+V4uo72BnlbOjmuljLrRqdsd3qnzvZZoxvMHZ23ndsRS4aufU6JOZYpCbU6T1A==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -6174,6 +6181,15 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accessor-fn": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/accessor-fn/-/accessor-fn-1.5.3.tgz",
+      "integrity": "sha512-rkAofCwe/FvYFUlMB0v0gWmhqtfAtV1IUkdPbfhTUyYniu5LrC0A0UJkTH0Jv3S8SvwkmfuAlY+mQIJATdocMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -6762,6 +6778,16 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/bezier-js": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.4.tgz",
+      "integrity": "sha512-PA0FW9ZpcHbojUCMu28z9Vg/fNkwTj5YhusSAjHHDfHDGLxJ6YUKrAN2vk1fP2MMOxVw4Oko16FMlRGVBGqLKg==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
+      }
+    },
     "node_modules/bit-twiddle": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
@@ -6971,6 +6997,18 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-color-tracker": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/canvas-color-tracker/-/canvas-color-tracker-1.3.2.tgz",
+      "integrity": "sha512-ryQkDX26yJ3CXzb3hxUVNlg1NKE4REc5crLBq661Nxzr8TNd236SaEf2ffYLXyI5tSABSeguHLqcVq4vf9L3Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "tinycolor2": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -7291,6 +7329,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-binarytree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d3-binarytree/-/d3-binarytree-1.0.2.tgz",
+      "integrity": "sha512-cElUNH+sHu95L04m92pG73t2MEJXKu+GeKUN1TJkFsu93E5W8E9Sc3kHEGJKgenGvj19m6upSn2EunvMgMD2Yw==",
+      "license": "MIT"
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
@@ -7300,11 +7344,49 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force-3d": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/d3-force-3d/-/d3-force-3d-3.0.6.tgz",
+      "integrity": "sha512-4tsKHUPLOVkyfEffZo1v6sFHvGFwAIIjt/W8IThbp08DYAsXZck+2pSHEG5W1+gQgEvFLdZkYvmJAbRM2EzMnA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-binarytree": "1",
+        "d3-dispatch": "1 - 3",
+        "d3-octree": "1",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -7330,10 +7412,25 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-octree": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/d3-octree/-/d3-octree-1.1.0.tgz",
+      "integrity": "sha512-F8gPlqpP+HwRPMO/8uOu5wjH110+6q4cgJvgJT6vlpy3BEaDIKlTZrgHKZSp/i1InRpVfh4puY/kvL6MxK930A==",
+      "license": "MIT"
+    },
     "node_modules/d3-path": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
       "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -7351,6 +7448,28 @@
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -7396,6 +7515,41 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -8615,6 +8769,20 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/float-tooltip": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/float-tooltip/-/float-tooltip-1.7.5.tgz",
+      "integrity": "sha512-/kXzuDnnBqyyWyhDMH7+PfP8J/oXiAavGzcRxASOMRHFuReDtofizLLJsf7nnDLAfEaMW4pVWaXrAjtnglpEkg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-selection": "2 - 3",
+        "kapsule": "^1.16",
+        "preact": "10"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
@@ -8674,6 +8842,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/force-graph": {
+      "version": "1.51.4",
+      "resolved": "https://registry.npmjs.org/force-graph/-/force-graph-1.51.4.tgz",
+      "integrity": "sha512-TdJ2KbkoiDQ7NIRx8IPGD0mAXXpLhamS7c+b7W98b0MHG7lphnda1VOQX/98UDTsttIAdH4TcP0l0MauSnLK8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tweenjs/tween.js": "18 - 25",
+        "accessor-fn": "1",
+        "bezier-js": "3 - 6",
+        "canvas-color-tracker": "^1.3",
+        "d3-array": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-force-3d": "2 - 3",
+        "d3-scale": "1 - 4",
+        "d3-scale-chromatic": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-zoom": "2 - 3",
+        "float-tooltip": "^1.7",
+        "index-array-by": "1",
+        "kapsule": "^1.16",
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/foreground-child": {
@@ -8748,7 +8942,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9291,6 +9484,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/index-array-by": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/index-array-by/-/index-array-by-1.4.2.tgz",
+      "integrity": "sha512-SP23P27OUKzXWEC/TOyWlwLviofQkCSCKONnc62eItjp69yCZZPqDQtr3Pw5gJDnPeUMqExmKydNZaJO0FU9pw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -9809,6 +10011,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jerrypick": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jerrypick/-/jerrypick-1.1.2.tgz",
+      "integrity": "sha512-YKnxXEekXKzhpf7CLYA0A+oDP8V0OhICNCr5lv96FvSsDEmrb0GKM776JgQvHTMjr7DTTPEVv/1Ciaw0uEWzBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -9839,7 +10050,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -9916,6 +10126,18 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/kapsule": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/kapsule/-/kapsule-1.16.3.tgz",
+      "integrity": "sha512-4+5mNNf4vZDSwPhKprKwz3330iisPrb08JyMgbsdFrimBCKNHecua/WBwvVg3n7vwx0C1ARjfhwIpbrbd9n5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "4"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/keyv": {
@@ -10344,7 +10566,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -10799,17 +11020,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -11638,7 +11848,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -11650,7 +11859,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
@@ -11764,12 +11972,44 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-force-graph-2d": {
+      "version": "1.29.1",
+      "resolved": "https://registry.npmjs.org/react-force-graph-2d/-/react-force-graph-2d-1.29.1.tgz",
+      "integrity": "sha512-1Rl/1Z3xy2iTHKj6a0jRXGyiI86xUti81K+jBQZ+Oe46csaMikp47L5AjrzA9hY9fNGD63X8ffrqnvaORukCuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "force-graph": "^1.51",
+        "prop-types": "15",
+        "react-kapsule": "^2.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
       "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-kapsule": {
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/react-kapsule/-/react-kapsule-2.5.7.tgz",
+      "integrity": "sha512-kifAF4ZPD77qZKc4CKLmozq6GY1sBzPEJTIJb0wWFK6HsePJatK3jXplZn2eeAt3x67CDozgi7/rO8fNQ/AL7A==",
+      "license": "MIT",
+      "dependencies": {
+        "jerrypick": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
@@ -13013,6 +13253,12 @@
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT"
     },
     "node_modules/tinyexec": {

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -57,6 +57,7 @@
     "qrcode": "^1.5.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-force-graph-2d": "^1.29.1",
     "recharts": "^3.8.1",
     "rrule": "^2.8.1",
     "tailwind-merge": "^3.5.0",

--- a/mira-hub/src/app/(hub)/graph/page.tsx
+++ b/mira-hub/src/app/(hub)/graph/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { GraphCanvas } from "@/components/kg/GraphCanvas";
+import type { GraphNode, GraphLink } from "@/lib/knowledge-graph/graph-view";
+
+interface GraphResponse {
+  nodes: GraphNode[];
+  links: GraphLink[];
+  capped?: boolean;
+  error?: string;
+}
+
+export default function GraphPage() {
+  const [raw, setRaw] = useState<GraphResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [hiddenTypes, setHiddenTypes] = useState<Set<string>>(new Set());
+  const [showOrphans, setShowOrphans] = useState(true);
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<GraphNode | null>(null);
+
+  useEffect(() => {
+    fetch("/api/kg/graph")
+      .then((r) => r.json())
+      .then((j: GraphResponse) => (j.error ? setError(j.error) : setRaw(j)))
+      .catch((e) => setError(String(e)));
+  }, []);
+
+  const types = useMemo(
+    () => [...new Set((raw?.nodes ?? []).map((n) => n.type))].sort(),
+    [raw],
+  );
+
+  const view = useMemo(() => {
+    if (!raw) return { nodes: [], links: [] };
+    const q = query.trim().toLowerCase();
+    const keep = new Set(
+      raw.nodes
+        .filter((n) => !hiddenTypes.has(n.type))
+        .filter((n) => showOrphans || n.degree > 0)
+        .filter((n) => !q || n.label.toLowerCase().includes(q))
+        .map((n) => n.id),
+    );
+    return {
+      nodes: raw.nodes.filter((n) => keep.has(n.id)),
+      links: raw.links.filter((l) => keep.has(l.source) && keep.has(l.target)),
+    };
+  }, [raw, hiddenTypes, showOrphans, query]);
+
+  if (error) return <div className="p-6 text-red-400">Graph error: {error}</div>;
+  if (!raw) return <div className="p-6 text-slate-400">Loading relationship graph…</div>;
+
+  return (
+    <div className="relative h-[calc(100vh-4rem)] w-full">
+      {/* HUD */}
+      <div className="absolute left-4 top-4 z-10 w-64 space-y-2 rounded-md bg-slate-900/80 p-3 text-sm text-slate-200">
+        <div className="font-semibold text-white">Relationship Graph</div>
+        <div className="text-xs text-slate-400">
+          {view.nodes.length}/{raw.nodes.length} nodes · {view.links.length} edges
+          {raw.capped ? " (capped)" : ""}
+        </div>
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search nodes…"
+          className="w-full rounded border border-slate-700 bg-slate-800 px-2 py-1 text-xs outline-none"
+        />
+        <label className="flex items-center gap-2 text-xs">
+          <input
+            type="checkbox"
+            checked={showOrphans}
+            onChange={(e) => setShowOrphans(e.target.checked)}
+          />
+          Show orphans
+        </label>
+        <div className="space-y-1">
+          {types.map((t) => (
+            <label key={t} className="flex cursor-pointer items-center gap-2 text-xs">
+              <input
+                type="checkbox"
+                checked={!hiddenTypes.has(t)}
+                onChange={(e) => {
+                  setHiddenTypes((prev) => {
+                    const next = new Set(prev);
+                    if (e.target.checked) next.delete(t);
+                    else next.add(t);
+                    return next;
+                  });
+                }}
+              />
+              {t}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Detail panel */}
+      {selected && (
+        <div className="absolute right-4 top-4 z-10 w-72 rounded-md bg-slate-900/90 p-4 text-sm text-slate-200">
+          <button
+            onClick={() => setSelected(null)}
+            className="float-right text-slate-500 hover:text-slate-300"
+          >
+            ✕
+          </button>
+          <div className="mb-1 font-semibold text-white">{selected.label}</div>
+          <div className="text-xs text-slate-400">type: {selected.type}</div>
+          <div className="text-xs text-slate-400">degree: {selected.degree}</div>
+          {selected.unsPath && (
+            <div className="mt-2 break-words text-xs text-slate-400">
+              {selected.unsPath}
+            </div>
+          )}
+        </div>
+      )}
+
+      <GraphCanvas data={view} onNodeClick={setSelected} />
+    </div>
+  );
+}

--- a/mira-hub/src/app/(hub)/graph/page.tsx
+++ b/mira-hub/src/app/(hub)/graph/page.tsx
@@ -41,9 +41,11 @@ export default function GraphPage() {
         .filter((n) => !q || n.label.toLowerCase().includes(q))
         .map((n) => n.id),
     );
+    const endId = (v: unknown): string =>
+      typeof v === "string" ? v : (v as { id: string }).id;
     return {
       nodes: raw.nodes.filter((n) => keep.has(n.id)),
-      links: raw.links.filter((l) => keep.has(l.source) && keep.has(l.target)),
+      links: raw.links.filter((l) => keep.has(endId(l.source)) && keep.has(endId(l.target))),
     };
   }, [raw, hiddenTypes, showOrphans, query]);
 

--- a/mira-hub/src/app/api/kg/graph/route.ts
+++ b/mira-hub/src/app/api/kg/graph/route.ts
@@ -1,0 +1,71 @@
+// src/app/api/kg/graph/route.ts
+/**
+ * GET /api/kg/graph — live {nodes, links} for the caller's tenant.
+ *
+ * Reads kg_entities + kg_relationships and returns the force-graph payload
+ * for the /hub/graph page. Session-authed (NOT the service-token internal
+ * KG endpoint). Full-tenant graph for now; neighborhood/proposal edges are
+ * Phase 2 (see design spec).
+ *
+ * Query params:
+ *   types — optional comma-separated entity_type allow-list (e.g. "equipment,manual").
+ */
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { buildGraphPayload, type EntityRow, type RelRow } from "@/lib/knowledge-graph/graph-view";
+
+export const dynamic = "force-dynamic";
+
+const NODE_CAP = 5000;
+
+export async function GET(req: Request) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const url = new URL(req.url);
+  const typeParam = url.searchParams.get("types");
+
+  try {
+    const { entities, rels } = await withTenantContext(ctx.tenantId, async (c) => {
+      const e = await c.query<EntityRow>(
+        `SELECT id, entity_type, name, uns_path::text AS uns_path
+           FROM kg_entities
+          WHERE tenant_id = $1::uuid
+          LIMIT $2`,
+        [ctx.tenantId, NODE_CAP],
+      );
+      const r = await c.query<RelRow>(
+        `SELECT source_id, target_id, relationship_type, confidence, approval_state
+           FROM kg_relationships
+          WHERE tenant_id = $1::uuid`,
+        [ctx.tenantId],
+      );
+      return { entities: e.rows, rels: r.rows };
+    });
+
+    let payload = buildGraphPayload(entities, rels);
+
+    if (typeParam) {
+      const types = new Set(typeParam.split(",").map((s) => s.trim()).filter(Boolean));
+      const keep = new Set(payload.nodes.filter((n) => types.has(n.type)).map((n) => n.id));
+      payload = {
+        nodes: payload.nodes.filter((n) => keep.has(n.id)),
+        links: payload.links.filter((l) => keep.has(l.source) && keep.has(l.target)),
+      };
+    }
+
+    return NextResponse.json({
+      ...payload,
+      capped: entities.length >= NODE_CAP,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "internal error" },
+      { status: 500 },
+    );
+  }
+}

--- a/mira-hub/src/app/api/kg/graph/route.ts
+++ b/mira-hub/src/app/api/kg/graph/route.ts
@@ -18,6 +18,7 @@ import { buildGraphPayload, type EntityRow, type RelRow } from "@/lib/knowledge-
 export const dynamic = "force-dynamic";
 
 const NODE_CAP = 5000;
+const EDGE_CAP = 20000;
 
 export async function GET(req: Request) {
   if (!process.env.NEON_DATABASE_URL) {
@@ -41,8 +42,9 @@ export async function GET(req: Request) {
       const r = await c.query<RelRow>(
         `SELECT source_id, target_id, relationship_type, confidence, approval_state
            FROM kg_relationships
-          WHERE tenant_id = $1::uuid`,
-        [ctx.tenantId],
+          WHERE tenant_id = $1::uuid
+          LIMIT $2`,
+        [ctx.tenantId, EDGE_CAP],
       );
       return { entities: e.rows, rels: r.rows };
     });
@@ -60,7 +62,7 @@ export async function GET(req: Request) {
 
     return NextResponse.json({
       ...payload,
-      capped: entities.length >= NODE_CAP,
+      capped: entities.length >= NODE_CAP || rels.length >= EDGE_CAP,
     });
   } catch (err) {
     return NextResponse.json(

--- a/mira-hub/src/components/kg/GraphCanvas.tsx
+++ b/mira-hub/src/components/kg/GraphCanvas.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { GraphNode, GraphLink } from "@/lib/knowledge-graph/graph-view";
+
+// react-force-graph-2d touches window/canvas → must be client-only.
+const ForceGraph2D = dynamic(() => import("react-force-graph-2d"), { ssr: false });
+
+export interface GraphCanvasData {
+  nodes: GraphNode[];
+  links: GraphLink[];
+}
+
+export function GraphCanvas({
+  data,
+  onNodeClick,
+}: {
+  data: GraphCanvasData;
+  onNodeClick?: (node: GraphNode) => void;
+}) {
+  return (
+    <ForceGraph2D
+      graphData={data}
+      backgroundColor="#0b0f1a"
+      nodeAutoColorBy="type"
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      nodeVal={(n: any) => 1 + (n as GraphNode).degree}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      nodeLabel={(n: any) => `${(n as GraphNode).label} — ${(n as GraphNode).type}`}
+      nodeRelSize={4}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      linkColor={(l: any) => ((l as GraphLink).state === "proposed" ? "#6b7280" : "#3a4252")}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      linkWidth={(l: any) => ((l as GraphLink).state === "proposed" ? 0.5 : 1)}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      onNodeClick={(n: any) => onNodeClick?.(n as GraphNode)}
+      cooldownTicks={120}
+    />
+  );
+}

--- a/mira-hub/src/components/layout/sidebar.tsx
+++ b/mira-hub/src/components/layout/sidebar.tsx
@@ -9,7 +9,7 @@ import {
   Wrench, Radio, Plug, BarChart2, Users, Settings,
   ClipboardList, CalendarDays, Inbox, Package, FileText, TrendingUp,
   Factory, ChevronLeft, ChevronRight, LogOut, Sun, Moon, HelpCircle, Cpu,
-  Layers, Sparkles,
+  Layers, Sparkles, Network,
 } from "lucide-react";
 import { restartTour } from "@/components/onboarding/tour";
 import { cn } from "@/lib/utils";
@@ -21,7 +21,7 @@ const ICON_MAP: Record<string, React.ElementType> = {
   Activity, MessageSquare, AlertTriangle, BookOpen,
   Wrench, Radio, Plug, BarChart2, Users, Settings,
   ClipboardList, CalendarDays, Inbox, Package, FileText, TrendingUp,
-  Cpu, Layers, Sparkles,
+  Cpu, Layers, Sparkles, Network,
 };
 
 type NavItemProps = {
@@ -103,6 +103,7 @@ export function Sidebar({ role = "admin" }: { role?: string }) {
       "namespace":     "Namespace",
       "channels":      t("channels"),
       "knowledge":     t("knowledge"),
+      "graph":         "Graph",
       "proposals":     "Proposals",
       "assets":        t("assets"),
       "workorders":    "CMMS",

--- a/mira-hub/src/lib/knowledge-graph/__tests__/graph-view.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/graph-view.test.ts
@@ -1,0 +1,47 @@
+// src/lib/knowledge-graph/__tests__/graph-view.test.ts
+import { describe, test, expect } from "vitest";
+import { buildGraphPayload, type EntityRow, type RelRow } from "../graph-view";
+
+const entities: EntityRow[] = [
+  { id: "a", entity_type: "equipment", name: "VFD-07", uns_path: "ent.site.vfd07" },
+  { id: "b", entity_type: "manual", name: "PowerFlex Manual", uns_path: null },
+  { id: "c", entity_type: "fault_code", name: "F004", uns_path: null }, // orphan
+];
+
+describe("buildGraphPayload", () => {
+  test("maps nodes and labels (name, fallback to id)", () => {
+    const p = buildGraphPayload(
+      [{ id: "x", entity_type: "part", name: null, uns_path: null }],
+      [],
+    );
+    expect(p.nodes[0]).toMatchObject({ id: "x", type: "part", label: "x", degree: 0 });
+  });
+
+  test("computes degree on both endpoints", () => {
+    const rels: RelRow[] = [
+      { source_id: "a", target_id: "b", relationship_type: "has_manual", confidence: 1, approval_state: "verified" },
+    ];
+    const p = buildGraphPayload(entities, rels);
+    const byId = Object.fromEntries(p.nodes.map((n) => [n.id, n]));
+    expect(byId["a"].degree).toBe(1);
+    expect(byId["b"].degree).toBe(1);
+    expect(byId["c"].degree).toBe(0);
+  });
+
+  test("drops links whose endpoint is missing", () => {
+    const rels: RelRow[] = [
+      { source_id: "a", target_id: "ZZZ", relationship_type: "has_manual", confidence: 1, approval_state: "verified" },
+    ];
+    const p = buildGraphPayload(entities, rels);
+    expect(p.links).toHaveLength(0);
+    expect(p.nodes.find((n) => n.id === "a")?.degree).toBe(0);
+  });
+
+  test("defaults confidence=1 and state=verified when null", () => {
+    const rels: RelRow[] = [
+      { source_id: "a", target_id: "b", relationship_type: "has_manual", confidence: null, approval_state: null },
+    ];
+    const p = buildGraphPayload(entities, rels);
+    expect(p.links[0]).toMatchObject({ confidence: 1, state: "verified" });
+  });
+});

--- a/mira-hub/src/lib/knowledge-graph/graph-view.ts
+++ b/mira-hub/src/lib/knowledge-graph/graph-view.ts
@@ -1,0 +1,73 @@
+// src/lib/knowledge-graph/graph-view.ts
+/**
+ * Pure transform from KG table rows into the {nodes, links} shape every
+ * force-graph library consumes. No DB, no IO — unit-tested in isolation.
+ * Degree is precomputed server-side so the client just maps nodeVal.
+ */
+
+export interface EntityRow {
+  id: string;
+  entity_type: string;
+  name: string | null;
+  uns_path: string | null;
+}
+
+export interface RelRow {
+  source_id: string;
+  target_id: string;
+  relationship_type: string;
+  confidence: number | null;
+  approval_state: string | null;
+}
+
+export interface GraphNode {
+  id: string;
+  type: string;
+  label: string;
+  degree: number;
+  unsPath: string | null;
+}
+
+export interface GraphLink {
+  source: string;
+  target: string;
+  type: string;
+  confidence: number;
+  state: string;
+}
+
+export interface GraphPayload {
+  nodes: GraphNode[];
+  links: GraphLink[];
+}
+
+export function buildGraphPayload(entities: EntityRow[], rels: RelRow[]): GraphPayload {
+  const nodes = new Map<string, GraphNode>();
+  for (const e of entities) {
+    nodes.set(e.id, {
+      id: e.id,
+      type: e.entity_type,
+      label: e.name && e.name.length > 0 ? e.name : e.id,
+      degree: 0,
+      unsPath: e.uns_path,
+    });
+  }
+
+  const links: GraphLink[] = [];
+  for (const r of rels) {
+    const src = nodes.get(r.source_id);
+    const tgt = nodes.get(r.target_id);
+    if (!src || !tgt) continue; // drop dangling edges
+    src.degree += 1;
+    tgt.degree += 1;
+    links.push({
+      source: r.source_id,
+      target: r.target_id,
+      type: r.relationship_type,
+      confidence: r.confidence ?? 1,
+      state: r.approval_state ?? "verified",
+    });
+  }
+
+  return { nodes: [...nodes.values()], links };
+}

--- a/mira-hub/src/providers/access-control.ts
+++ b/mira-hub/src/providers/access-control.ts
@@ -82,6 +82,7 @@ export const NAV_ITEMS: ReadonlyArray<{
   { key: "namespace",     label: "Namespace",     icon: "Layers",        href: "/namespace",     roles: [...ALL_ROLES], group: "primary" },
   { key: "channels",      label: "Channels",      icon: "Radio",         href: "/channels",      roles: [...ADMIN_ROLES, "scheduler"], group: "primary" },
   { key: "knowledge",     label: "Knowledge",     icon: "BookOpen",      href: "/knowledge",     roles: [...ALL_ROLES], group: "primary" },
+  { key: "graph",         label: "Graph",         icon: "Network",       href: "/graph",         roles: [...ALL_ROLES], group: "primary" },
   { key: "proposals",     label: "Proposals",     icon: "Sparkles",      href: "/proposals",     roles: [...ALL_ROLES], group: "primary" },
 
   // ── SECONDARY (collapsed under "More") ─────────────────────────────────────


### PR DESCRIPTION
@
## Summary
Draws the knowledge graphs real connections **live** in the Hub at route `/graph` — replacing the static `kg_relationship_sphere.html` snapshot. Obsidian-style force graph, sourced from the same `kg_entities`/`kg_relationships` the agents traverse.

- **Pure transform** `buildGraphPayload` (rows → `{nodes, links}`, degree precomputed, dangling edges dropped) — TDD, 4 unit tests.
- **`GET /api/kg/graph`** — session-authed, tenant-isolated (`tenant_id` from session only, both queries filtered, RLS second layer), node cap 5k / edge cap 20k with a `capped` flag.
- **`GraphCanvas`** — `react-force-graph-2d` via `next/dynamic` `ssr:false`; degree sizing, color-by-type, proposed-vs-verified link styling.
- **`/graph` page** — search, per-type filters, orphan toggle, click→detail panel.
- **Nav** — "Graph" entry wired into `NAV_ITEMS` + sidebar `ICON_MAP`.

Design + plan: `docs/superpowers/specs/2026-06-02-kg-relationship-graph-design.md`, `docs/superpowers/plans/2026-06-02-kg-graph-phase1-live-render.md`.

### Why
Relationships are the intelligence (GraphRAG: an edge is a reasoning path). Today 269/289 edges are `has_manual` star pairs because richer edges sit unpromoted in the proposals queue — this PR makes that web visible and live; **Phase 2** enriches it (promote queued + infer `same_model_as` / `co_failed_with`), **Phase 3** wires it into Ask MIRA.

### Review fixes included
- d3-force mutates `link.source/target` string→object → edges vanished on filter. Fixed with an id-normalizer.
- Unbounded `kg_relationships` query → added `EDGE_CAP`.

## Test Plan
- [x] `npx vitest run` — graph-view 4/4 pass
- [x] `npx tsc --noEmit` — zero new errors (7 pre-existing unrelated)
- [x] `npx eslint` — clean on all new/changed files
- [ ] `npm run dev` → open `/graph` logged into a tenant with KG data; confirm live render, search/filter/orphan toggle, click→panel, and Network tab shows real `/api/kg/graph` JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@