### PR TITLE
fix(deploy): staging-gate-bypass audit issue non-fatal (unblock prod hotfix)

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -105,10 +105,16 @@ jobs:
             echo ""
             echo "_Auto-filed by \`.github/workflows/deploy-vps.yml\` (R8, staging-gate architectural review 2026-05-31). The title carries the short SHA for cross-referencing._"
           } > bypass_issue_body.md
+          # Non-fatal: an audit-log failure must NOT block a production hotfix.
+          # The GITHUB_TOKEN may lack issues:write (GraphQL "Resource not accessible
+          # by integration") — in that case warn + record the reason in the run log,
+          # and let the deploy proceed. (Prod incident 2026-06-02: this createIssue
+          # error aborted every hotfix deploy while prod chat was down.)
           gh issue create \
             --repo "$REPO" \
             --title "staging-gate bypass: deploy by @${ACTOR} at ${SHORT_SHA}" \
-            --body-file bypass_issue_body.md
+            --body-file bypass_issue_body.md \
+            || echo "::warning::Could not auto-open the staging-gate-bypass audit issue (token may lack issues:write). Deploy continues — record the bypass manually. Reason: ${REASON}"
 
       - name: Verify Staging Gate passed
         # Refuse to deploy a commit that hasn't been graded by the staging gate.


### PR DESCRIPTION
During the 2026-06-02 prod-chat outage, every hotfix deploy aborted because the bypass step's `gh issue create` fails with `Resource not accessible by integration (createIssue)` (token lacks issues:write). Make it non-fatal — warn + record the reason, let the deploy proceed. Workflow-only change; no engine/token-perm change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)