### PR TITLE
ci: add mira-pipeline docker build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,3 +345,31 @@ jobs:
 
       - name: Scan mira-mcp
         run: trivy image --severity HIGH,CRITICAL --ignore-unfixed --exit-code 1 mira-mcp:scan
+
+      # --- mira-pipeline (added 2026-06-03 after the prod-chat outage) ------------
+      # mira-pipeline was the only saas image NOT built in CI, so the Ignition
+      # cutover's missing Dockerfile COPYs slipped to prod (ModuleNotFoundError:
+      # ignition_chat, then ignition_audit -> crash-loop). See
+      # docs/incidents/2026-06-02-prod-pipeline-deploy.md.
+      - name: Build mira-pipeline
+        # Context is the repo root (.) to match docker-compose.saas.yml — the
+        # Dockerfile COPYs mira-bots/shared/, mira-pipeline/*.py, VERSION (repo root).
+        run: |
+          docker buildx build \
+            -f mira-pipeline/Dockerfile . \
+            --cache-from type=gha,scope=mira-pipeline \
+            --cache-to type=gha,mode=max,scope=mira-pipeline \
+            -t mira-pipeline:scan --load
+
+      - name: Import smoke-test mira-pipeline
+        # A successful BUILD does NOT catch a module that main.py imports but the
+        # Dockerfile forgot to COPY — that only fails at container startup
+        # (uvicorn main:app -> import main). This reproduces that import so a
+        # missing/uncopied module fails CI here instead of crash-looping prod.
+        # No secrets needed: main.py's module level only declares the app + routers
+        # (DB/engine init happens in the lifespan handler, not at import).
+        run: |
+          if ! timeout 120 docker run --rm --entrypoint python mira-pipeline:scan -c "import main"; then
+            echo "::error::mira-pipeline image failed 'import main' — a module imported by main.py is missing from the image (check Dockerfile COPYs). This is the 2026-06-02 outage class (ModuleNotFoundError at startup)."
+            exit 1
+          fi

--- a/docs/incidents/2026-06-02-prod-pipeline-deploy.md
+++ b/docs/incidents/2026-06-02-prod-pipeline-deploy.md
@@ -1,0 +1,46 @@
+# Incident: prod chat outage on the #1593 deploy (2026-06-02)
+
+**Resolved:** 2026-06-03. **Prod healthy:** `app.factorylm.com` 200, `/api/health` 200,
+`mira-pipeline-saas` Up/healthy.
+
+## What happened
+
+Merging the #1593 umbrella (Command Center + Ignition-Module secure edge) auto-deployed
+to prod, and `mira-pipeline-saas` (the chat backend) crash-looped on
+`ModuleNotFoundError`, failing the deploy. Chat was down until the fix landed.
+
+## Two linked root causes
+
+1. **Per-file `COPY` drift in `mira-pipeline/Dockerfile`.** The Dockerfile listed each
+   module by name. The Ignition chat cutover added `ignition_chat.py` (which imports
+   `ignition_audit.py`) but no `COPY` lines, so those files were never in the image →
+   `ModuleNotFoundError: ignition_chat`, then `ignition_audit` (whack-a-mole across two
+   deploys). **Fixed (#1667 → #1670):** `COPY mira-pipeline/*.py .` — ships all current
+   and future source modules. Tests live in `mira-pipeline/tests/` (a subdir, not matched).
+
+2. **The deploy hotfix-bypass was itself fragile.** `deploy-vps.yml`'s "Validate + audit
+   staging-gate bypass" step calls `gh issue create`, but the Actions `GITHUB_TOKEN`
+   lacks `issues:write` → `GraphQL: Resource not accessible by integration (createIssue)`
+   → the step exited 1 and **aborted every hotfix deploy** before docker ran. **Fixed
+   (#1673):** made `gh issue create` non-fatal (warn + log the reason, continue). Token
+   permissions were **not** broadened.
+
+## Why CI didn't catch it
+
+`Smoke Test` checks routes, not the saas image build — and `mira-pipeline` was the only
+saas image **not** built in `docker-build-check`. Worse, a missing-`COPY`-of-an-imported
+module **does not fail `docker build`** (the image builds; it crashes at `import` on
+startup).
+
+## Prevention (this PR)
+
+`docker-build-check` in `.github/workflows/ci.yml` now **builds `mira-pipeline`** (context
+= repo root, matching `docker-compose.saas.yml`) **and runs an import smoke-test**
+(`docker run --entrypoint python … -c "import main"`) — reproducing container startup so a
+missing/uncopied module fails CI instead of crash-looping prod. Verified locally: passes
+on fixed `main`, fails (`ModuleNotFoundError`) on the pre-incident Dockerfile.
+
+## Restore sequence
+
+#1593 merge (broke) → #1667 → #1670 (code) → #1673 (deploy tooling) → `deploy-vps`
+dispatch (`skip_staging_gate=true` + `skip_reason`) → `mira-pipeline-saas Up (healthy)`.

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -1,5 +1,11 @@
 # Hot Cache — 2026-05-29 — ALPHA
 
+## Session — 2026-06-03 (CHARLIE) — prod pipeline outage + CI prevention
+
+- **Prod chat outage (2026-06-02), resolved.** Merging #1593 (Command Center + Ignition-Module umbrella) crash-looped `mira-pipeline-saas` on `ModuleNotFoundError` (the Ignition cutover added `ignition_chat.py`/`ignition_audit.py` but `mira-pipeline/Dockerfile` used per-file `COPY` and didn't list them). Fixed: `COPY mira-pipeline/*.py .` (#1667 → #1670). Prod healthy: `app.factorylm.com` 200, `/api/health` 200, pipeline Up/healthy. Full writeup: `docs/incidents/2026-06-02-prod-pipeline-deploy.md`.
+- **Deploy hotfix-bypass was itself broken** — its audit `gh issue create` failed (token lacks `issues:write`) and aborted every hotfix deploy. Fixed by making issue-creation **non-fatal** (#1673) — **not** by broadening token permissions.
+- **CI prevention (this work):** `docker-build-check` in `ci.yml` now **builds `mira-pipeline` + runs an `import main` smoke-test** (a successful build alone does NOT catch a missing imported module — it crashes at startup). Verified locally: passes on fixed main, fails (`ModuleNotFoundError`) on the pre-incident Dockerfile.
+
 ## Session — 2026-05-29 (printing-press toolchain bootstrap + Linear/Stripe CLIs)
 
 Work spanned 2026-05-10 → 2026-05-29; landing now as one continuity entry. Local `main` was 447 commits behind origin when commit happened — reset to origin/main, re-applied this block on top of current hot.md.


### PR DESCRIPTION
## Purpose — prevent the 2026-06-02 prod-chat outage class
`mira-pipeline` was the **only** saas image not built in `docker-build-check`, so the Ignition cutover's missing `Dockerfile` `COPY`s slipped to prod → `mira-pipeline-saas` crash-looped on `ModuleNotFoundError` (`ignition_chat`, then `ignition_audit`). **Crucially, a successful `docker build` does NOT catch this** — a module imported by `main.py` but not `COPY`'d only fails at container startup (`uvicorn main:app` → `import main`).

## What changed
- `.github/workflows/ci.yml` — extended the existing **`docker-build-check`** job (no duplicate CI; matches the other 4 image builds' style) with two steps:
  - **Build mira-pipeline** — `docker buildx build -f mira-pipeline/Dockerfile .` (context = repo root, matching `docker-compose.saas.yml`), gha-cached.
  - **Import smoke-test** — `docker run --entrypoint python mira-pipeline:scan -c "import main"` — reproduces startup so a missing/uncopied module fails CI here instead of prod.
- `docs/incidents/2026-06-02-prod-pipeline-deploy.md` — incident writeup.
- `wiki/hot.md` — short status note.

## What CI runs
On every code PR (ci.yml runs on `pull_request` to main; `paths-ignore` only excludes docs/images), `docker-build-check` now builds mira-pipeline and runs `import main`.

## Validated locally (Colima)
- ✅ Build + `import main` **pass** on current `main` (has `COPY *.py`). The "DB not yet reachable" log is graceful deferred-init — no secrets needed.
- ✅ Built the **pre-incident** Dockerfile (per-file COPY, no ignition modules): build *succeeded* but `import main` **failed with `ModuleNotFoundError: No module named 'ignition_chat'`** — confirming the smoke-test catches the regression a build-only check misses.

## Guardrails
- No production systems touched. No deploy. No images pushed to any registry (`--load` local only). **No GitHub token permissions broadened.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)