### PR TITLE
docs(mira): canonical industrial asset-graph architecture (Phase 0–2 + North Star)

### DIFF
--- a/NORTH_STAR.md
+++ b/NORTH_STAR.md
@@ -26,6 +26,41 @@ Infrastructure first. AI second. Every customer engagement starts with **"what d
 
 Everything in the repo — `mira-pipeline`, `mira-mcp`, `mira-bots`, `mira-web`, `mira-cmms`, `mira-crawler` — is supporting infrastructure for delivering and operating that namespace.
 
+## The Canonical Asset Graph (the next evolution)
+
+> Added 2026-06-02. This sharpens — does not replace — the doctrine above. The "Maintenance
+> Intelligence Namespace" and the "canonical asset graph" are the same artifact at two altitudes:
+> the namespace is what we *sell*; the asset graph is what it *is* under the hood.
+
+"AI-ready infrastructure" has a concrete shape: a **canonical industrial asset graph** that is the
+**translation layer between plant-floor OT and enterprise maintenance systems.**
+
+- **In:** semi-structured customer reality from every direction — IBM Maximo, SAP, MaintainX,
+  Fiix, Limble; Ignition, MQTT/Sparkplug B, OPC UA, historians; manuals, wiring diagrams, PLC
+  tags, nameplates, and technician knowledge.
+- **Through:** one canonical graph (`kg_entities` + `kg_relationships`, ISA-95 `uns_path`
+  addressing, `proposed → verified` approval state, confidence on every edge) — with the
+  **original source record preserved**, never normalized-and-discarded.
+- **Out:** the reasoning layer AI agents ground in, *and* a bidirectional bridge — OT signal
+  meaning flows up to enterprise CMMS/ERP; enterprise asset structure flows down to the plant
+  floor — without MIRA replacing either system or ever writing to a PLC.
+
+**The graph IS the product.** The copilot, the connectors, the Hub, the bots are how the graph
+gets built and used. Two architectural commitments make this defensible:
+
+1. **Build the canonical graph first, connectors around it.** No connector owns a shape; each maps
+   *into* the canonical model and keeps its raw record. We never hardcode around one system.
+2. **Read-only for OT by default.** MIRA observes the plant floor; it never controls it.
+
+This reframes the Knowledge Cooperative moat: every plant we structure deepens a *shared canonical
+graph* of OEM components, fault patterns, and tag-mapping heuristics — so each new plant maps onto
+existing canonical nodes instead of starting blank. The asset graph is what compounds.
+
+**Architecture docs:** `docs/mira/canonical-asset-graph.md` (the model),
+`docs/mira/source-record-preservation.md` (raw-record layer),
+`docs/mira/current-repo-inventory.md` (what's built), governed by
+`docs/plans/2026-06-01-mira-master-architecture-plan.md`.
+
 ## The Decision Filter
 
 Before building any feature, ask: **"Does this make the flywheel spin faster?"**

--- a/docs/mira/canonical-asset-graph.md
+++ b/docs/mira/canonical-asset-graph.md
@@ -1,0 +1,248 @@
+# MIRA — Canonical Industrial Asset Graph
+
+**Status:** Phase 1 deliverable of the canonical-asset-graph initiative — **design + additive
+schema proposals (docs-only)**
+**Authored:** 2026-06-02
+**Owner:** Lead architect (MIRA)
+**Builds on:** `docs/mira/current-repo-inventory.md` · `docs/plans/2026-06-01-mira-master-architecture-plan.md` · `docs/specs/uns-kg-unification-spec.md` · `docs/specs/mira-component-intelligence-architecture.md`
+**Pairs with:** `docs/mira/source-record-preservation.md` (the source-identity mechanism is defined there and referenced here)
+
+---
+
+## 0. Thesis and the one rule that shapes everything
+
+MIRA's value is a **canonical industrial asset graph** that is simultaneously:
+
+- the **memory** a grounded copilot reasons over, and
+- the **translation layer** between plant-floor OT (PLC / Ignition / MQTT / OPC UA / historian)
+  and enterprise maintenance systems (Maximo / SAP / MaintainX / Fiix / manuals / tribal knowledge).
+
+**The rule:** build the canonical graph first, connectors around it. A connector never owns a
+shape; it *maps into* the canonical shape and keeps its original record (Phase 2). So this
+document does **not** invent a new store — it confirms `kg_entities` + `kg_relationships` as the
+canonical spine and specifies the **minimal additive** changes that turn today's KG into the full
+graph. Postgres-first; no Neo4j (master-plan Phase 13 trigger gate stands).
+
+---
+
+## 1. The model in one picture
+
+```
+                       ┌──────────────────────────────────────────────┐
+   ENTERPRISE SYSTEMS  │            source_objects  (Phase 2)          │  OT SYSTEMS
+   Maximo / SAP /      │  raw imported record + connector + version    │  Ignition / MQTT /
+   MaintainX / Fiix    │  + mapping_status  (never destroyed)          │  OPC UA / historian / PLC
+        │              └───────────────────┬──────────────────────────┘        │
+        │  connector adapters              │ source_object_id FK                │  tag collector
+        ▼                                  ▼                                    ▼
+   ┌───────────────────────────────────────────────────────────────────────────────┐
+   │  CANONICAL SPINE   kg_entities (node)  ──  kg_relationships (edge)             │
+   │  • uns_path (ltree, ISA-95)     • approval_state (proposed→verified)          │
+   │  • entity_type (discriminator)  • confidence    • source_object_id (NEW)      │
+   └───────────────┬───────────────────────────────────────────────────────────────┘
+                   │ FK / source_chunk_id / equipment_entity_id  (typed projections)
+     ┌─────────────┼───────────────┬──────────────┬───────────────┬────────────────┐
+     ▼             ▼               ▼              ▼               ▼                ▼
+ tag_entities  knowledge_     cmms_equipment  component_    installed_       fault_codes /
+ (signals/    entries        + work orders    templates     component_       tag_events
+  tags)       (manuals/docs) (CMMS assets)    (per-model)   instances        (fault events)
+```
+
+**Spine + typed projections (hybrid).** `kg_entities` is the *addressed, approvable node*; the
+specialized tables carry domain columns and link back. The graph is the index; the projections
+are the detail. This is already how the repo is shaped — we are formalizing it, not rebuilding it.
+
+---
+
+## 2. Entity model — requested vocabulary → existing schema
+
+`kg_entities.entity_type` is **free `TEXT` with no CHECK constraint** (Hub 001; verified). New
+entity types therefore need **no migration** — only a governed vocabulary so writers agree.
+"Spine row" = a `kg_entities` row carrying the canonical address. "Typed projection" = a
+specialized table that holds the columns and links to the spine.
+
+| Requested entity | `entity_type` | Spine row? | Typed projection (detail) | Status |
+|---|---|---|---|---|
+| Enterprise | `enterprise` | ✅ | — (root of `uns_path`) | ✅ exists |
+| Site | `site` | ✅ | `cmms_equipment` (site rows) | ✅ |
+| Area | `area` | ✅ | — | ✅ |
+| Line | `line` | ✅ | — | ✅ |
+| Cell | `cell` | ✅ | — | ⚠️ supported, rarely populated |
+| Asset | `asset` / `equipment` | ✅ | `cmms_equipment` (`equipment_entity_id`) | ✅ |
+| Component | `component` | ✅ | `installed_component_instances` (per-instance) | ✅ |
+| (Component model) | `component_template` | reference | `component_templates` (per-model) | ✅ |
+| Signal / feedback signal | `signal` | ✅ | `tag_entities` | ✅ |
+| PLC tag | `tag` (`tag_kind=plc`) | ✅ | `tag_entities` | ✅ |
+| SCADA tag | `tag` (`tag_kind=scada`) | ✅ | `tag_entities` | ✅ |
+| Historian signal | `tag` (`tag_kind=historian`) | ✅ | `tag_entities` + `live_signal_cache` | ✅ |
+| Alarm | `alarm` | ✅ | `tag_events` (alarm windows) | ⚠️ new entity_type + edge (§3) |
+| Fault event | `fault_event` | ✅ | `tag_events` (`fault_window_open/close`, DT branch) | ✅ stream; node optional |
+| (Fault code catalog) | `fault_code` | ✅ | `fault_codes` (engine 002) | ✅ |
+| Work order | `work_order` | ✅ | CMMS work-order rows (`cmms_*`) | ⚠️ node not always materialized |
+| PM task | `pm_task` | ✅ | `pm_schedules` | ✅ |
+| Failure mode | `failure_mode` | ✅ | `properties` JSONB | ✅ |
+| Root cause | `root_cause` | ✅ | `properties` JSONB | ✅ |
+| Remedy / fix | `remedy` | ✅ | `properties` JSONB | ✅ |
+| Part / spare | `part` | ✅ | `properties` JSONB + `manufacturer_part_number` | ✅ |
+| Manual / document | `document` | ✅ | `knowledge_entries` (`source_chunk_id`) | ✅ |
+| Wiring diagram | `wiring_diagram` | ✅ | `knowledge_entries` + `wiring_connections` (Hub 026) | ✅ |
+| Procedure | `procedure` | ✅ | `knowledge_entries` | ✅ |
+| Technician confirmation | — | ✗ | `approval_state` transition + `CONFIRMED_BY` edge | ✅ not a node |
+| External system | `external_system` | ✅ (registry) | `source_systems` (Phase 2) | ⚠️ Phase 2 |
+| External object | — | ✗ | `source_objects` (Phase 2) — **raw record, not a graph node** | ⚠️ Phase 2 |
+| Relationship | — | edge | `kg_relationships` / `relationship_proposals` | ✅ |
+| Confidence score | — | column | `confidence` on entity/edge/suggestion | ✅ |
+
+**Takeaway:** of 25 requested entity kinds, **all are expressible today** on the spine + existing
+projections. Only `alarm` and a materialized `work_order` node need new `entity_type` *values*
+(free-text, no migration) plus the edges in §3. `external_system` / `external_object` are
+deliberately **not** graph nodes — they live in the Phase 2 source layer and attach via FK.
+
+### 2.1 Governance: an `entity_type` registry (no schema change)
+
+Because `entity_type` is unconstrained TEXT, the failure mode is writer drift (`asset` vs
+`equipment` vs `machine`). Fix is documentation + a shared constant, not a CHECK (a CHECK would
+make the cooperative's open-vocabulary growth a migration every time). Canonical list lives here;
+writers import it. (If we later want enforcement, a `kg_entity_types` reference table + soft FK is
+the additive path — deferred until drift is observed.)
+
+---
+
+## 3. Relationship model — requested vocabulary → existing 28-type set
+
+`relationship_proposals.relationship_type` **has a CHECK** (Hub 028, 28 values; verified).
+`kg_relationships.relationship_type` is free TEXT. To keep the proposal path authoritative
+(master-plan Phase 3), new edge types are added by **extending the Hub 028 CHECK**.
+
+| Requested edge | Existing type (Hub 028) | Action |
+|---|---|---|
+| `is_located_at` | `LOCATED_IN` | ✅ use as-is |
+| `belongs_to` | `LOCATED_IN` / `INSTANCE_OF` (by context) | ✅ |
+| `contains` | `HAS_COMPONENT` (inverse) | ✅ store canonical direction parent→child |
+| `is_part_of` | `HAS_PART` (inverse) | ✅ store HAS_PART parent→child |
+| `is_controlled_by` | `DRIVES` / `IS_DRIVEN_BY` / `USED_IN_LOGIC` | ✅ |
+| `has_feedback_signal` | `HAS_SIGNAL` | ✅ |
+| `has_manual` | `HAS_DOCUMENT` | ✅ |
+| `has_failure_mode` | `HAS_FAILURE_MODE` | ✅ |
+| `caused_by` | `CAUSES` (inverse) | ✅ |
+| `fixed_by` | `RESOLVED_BY` | ✅ |
+| `uses_part` | `HAS_PART` (containment) | ⚠️ propose **`USES_PART`** for *consumption* semantics (a WO consumes a spare ≠ an asset contains a part) |
+| `maps_to_external_object` | `MAPS_TO` | ✅ — but the **canonical** mechanism is `source_object_id` FK (§4), MAPS_TO is the graph-visible mirror |
+| `proposed_match` | (status, not type) | ✅ a `MAPS_TO` edge with `approval_state='proposed'` |
+| `technician_confirmed` | `CONFIRMED_BY` | ✅ + `approval_state='verified'` |
+| `supersedes` | `REPLACES` | ✅ |
+| `conflicts_with` | `CONTRADICTED_BY` | ✅ (or propose symmetric `CONFLICTS_WITH`) |
+| `has_alarm` | — | ⚠️ propose **`HAS_ALARM`** |
+| `has_work_order` | — | ⚠️ propose **`HAS_WORK_ORDER`** |
+| (`has_pm_task`) | — | ⚠️ propose **`HAS_PM_TASK`** (implied by PM-task entity) |
+
+**16 of 18 requested edges map onto the existing 28-type vocabulary as-is.** Only four genuinely
+new types are needed: `HAS_ALARM`, `HAS_WORK_ORDER`, `HAS_PM_TASK`, `USES_PART` (+ optional
+`CONFLICTS_WITH`). Direction convention: store the **canonical** direction (parent→child,
+asset→signal, fault→cause-of) and let queries traverse inverses; don't store both directions.
+
+---
+
+## 4. The seven requirements — how each is met
+
+| # | Requirement | Mechanism | Today | Proposal |
+|---|---|---|---|---|
+| 1 | Preserve **source-system identity** on every node | `kg_entities.source_object_id` FK → `source_objects` (Phase 2) | ⚠️ only `source_chunk_id`/`source_conversation_id` | **add `source_object_id`** (mig 039) |
+| 2 | Reference **≥1 external record** per normalized node | many-to-one via `source_objects` (a node ← N source rows) + `cmms_equipment` external-ID columns (Hub 013) + `ai_suggestions.source_*` | ⚠️ ID columns only, no payload | Phase 2 layer + §4.1 |
+| 3 | **Confidence scoring** | `confidence FLOAT` on `kg_relationships`, `ai_suggestions`; `extraction_confidence` on template sources | ✅ | none |
+| 4 | **Technician confirmation** | `approval_state` (proposed→verified) + `CONFIRMED_BY` edge + `relationship_evidence` | ✅ | enforce `proposed` default (Phase 3 / G4) |
+| 5 | **Uncertain / proposed** relationships | `ai_suggestions` (6 types) + `relationship_proposals` + `approval_state='proposed'` | ✅ | make proposal path the *only* writer (Phase 3) |
+| 6 | **ISA-95 hierarchy without rigid structure** | `uns_path ltree` as a *cached projection* over the `LOCATED_IN`/`parent_of` edge graph (Hub 010) | ✅ | none — graph is source of truth, path is the index |
+| 7 | **Future UNS/MQTT topic generation** | `uns_path` + `cmms_equipment.uns_topic_path` + `uns.py` builders + Sparkplug mapping (`.claude/rules/...`) | ⚠️ column-only | topic generator (post-MVP) |
+
+### 4.1 Source-identity is ONE mechanism (not a parallel scheme)
+
+Requirement 1 (node-level) and the Phase 2 `source_objects` table are **the same thing**. A node
+does not get its own provenance columns; it gets **one FK** (`source_object_id`) into the Phase 2
+raw-record store, plus the graph-visible `MAPS_TO` mirror edge for traversal. The existing
+`cmms_equipment` external-ID columns (Hub 013) and `ai_suggestions.source_kind/source_id` are
+*compatible* with this — they become *derived* views of the source layer, not competing stores.
+The authoritative definition lives in `source-record-preservation.md`; this doc only consumes it.
+
+---
+
+## 5. Additive schema proposals (docs-only — do NOT write migration files)
+
+Slots 032–037 are consumed by the DT branch (`feat/dt2026-gap-closure`). New work starts at
+**038**. These are **proposals for review**, not files to apply — applying crosses the
+dev→staging→prod migration discipline and `apply-migrations.yml` flow. Author the real files only
+after sign-off and after re-checking the live tail of `mira-hub/db/migrations/`.
+
+```sql
+-- 038_relationship_type_asset_graph.sql  (PROPOSAL)
+-- Extend the Hub-028 relationship_type CHECK with the 4 genuinely-new edge types.
+-- Keeps the proposal path (relationship_proposals) authoritative per master-plan Phase 3.
+ALTER TABLE relationship_proposals
+  DROP CONSTRAINT IF EXISTS relationship_proposals_relationship_type_check;
+ALTER TABLE relationship_proposals
+  ADD CONSTRAINT relationship_proposals_relationship_type_check
+  CHECK (relationship_type IN (
+    -- existing 28 (Hub 028) ...
+    'HAS_COMPONENT','INSTANCE_OF','LOCATED_IN','HAS_PART','HAS_DOCUMENT','HAS_CHUNK',
+    'REFERENCES','HAS_PROCEDURE','WIRED_TO','POWERED_BY','MAPS_TO','PUBLISHED_AS',
+    'USED_IN_LOGIC','TRIGGERS','CAUSES','DRIVES','IS_DRIVEN_BY','OCCURS_ON','RESOLVED_BY',
+    'HAS_FAILURE_MODE','HAS_SIGNAL','HAS_ALIAS','DEPENDS_ON','UPSTREAM_OF','DOWNSTREAM_OF',
+    'REPLACES','CONFIRMED_BY','CONTRADICTED_BY',
+    -- NEW for the asset-graph vision:
+    'HAS_ALARM','HAS_WORK_ORDER','HAS_PM_TASK','USES_PART'
+  ));
+-- kg_relationships.relationship_type stays free TEXT (no CHECK); the gate is the proposal table.
+
+-- 039_kg_entities_source_object.sql  (PROPOSAL)
+-- Canonical source-system identity on a node = one FK into the Phase 2 source layer.
+-- Nullable: organic (chat/photo) nodes have no external source object; that's normal.
+ALTER TABLE kg_entities
+  ADD COLUMN IF NOT EXISTS source_object_id UUID;   -- FK-by-convention -> source_objects(id), Phase 2
+CREATE INDEX IF NOT EXISTS idx_kg_entities_source_object
+  ON kg_entities (tenant_id, source_object_id)
+  WHERE source_object_id IS NOT NULL;
+-- A node may derive from N source rows (manual + CMMS + nameplate). source_object_id holds the
+-- PRIMARY/origin row; the full N is the set of source_objects rows whose mapped_entity_id = this
+-- node (reverse FK, defined in Phase 2). One-to-one column + one-to-many reverse index = both.
+```
+
+No other DDL. `entity_type` additions (`alarm`, `work_order` node, etc.) are free-text and need
+no migration. The `entity_type` vocabulary registry (§2.1) is documentation, not schema.
+
+---
+
+## 6. What this explicitly does NOT change
+
+- ❌ No new node/edge store. `kg_entities`/`kg_relationships` remain canonical (no Neo4j —
+  Phase 13 triggers unchanged).
+- ❌ No rename of `source_id`/`target_id`/`relationship_type` (the PR #1443 trap).
+- ❌ No CHECK on `entity_type` (would tax the open cooperative vocabulary).
+- ❌ No second provenance scheme — source identity is the single Phase 2 FK.
+- ❌ No migration files written from this doc — proposals only, slots 038+.
+
+---
+
+## 7. Acceptance (when this model is "real")
+
+1. Every requested entity kind resolves to a documented `entity_type` + projection (§2). ✅ by design.
+2. Every requested edge resolves to an existing or proposed `relationship_type` (§3). ✅ by design.
+3. A node carries `source_object_id` when it originated from a connector import (after mig 039 +
+   Phase 2) — verified by: import a MaintainX asset → `kg_entities` row has `source_object_id`
+   pointing at the preserved raw record.
+4. `uns_path` remains a projection over the edge graph, not a parallel hierarchy (no writer sets
+   `uns_path` without a corresponding `LOCATED_IN` edge).
+5. New edge types only enter via `relationship_proposals` (proposal path authoritative).
+
+---
+
+## 8. Cross-references
+
+- `docs/mira/current-repo-inventory.md` — verified baseline this builds on
+- `docs/mira/source-record-preservation.md` — the source-identity FK target (Phase 2)
+- `docs/plans/2026-06-01-mira-master-architecture-plan.md` — Phase 3 (proposal path), Phase 6
+  (hierarchy gate), Phase 11 (`get_asset_context` bundle), Phase 13 (graph-DB trigger gate)
+- `docs/specs/uns-kg-unification-spec.md` — UNS authority
+- `docs/specs/mira-component-intelligence-architecture.md` — template/instance mechanics
+- `.claude/rules/uns-compliance.md` — path builders, lowercase, reserved labels
+- ADR-0013 (Hub-canonical schema), ADR-0014 (`ai_suggestions` broad queue), ADR-0017 (status
+  transitions through helpers)

--- a/docs/mira/current-repo-inventory.md
+++ b/docs/mira/current-repo-inventory.md
@@ -1,0 +1,264 @@
+# MIRA — Current Repo Inventory (Asset-Graph Lens)
+
+**Status:** Phase 0 deliverable of the canonical-asset-graph initiative
+**Authored:** 2026-06-02
+**Owner:** Lead architect (MIRA)
+**Companion to:** `docs/plans/2026-06-01-mira-master-architecture-plan.md` §1 ("What already exists")
+
+---
+
+## 0. What this document is (and is not)
+
+The master plan's §1 already enumerates the engine, MCP tools, schema, ingestion, tag
+collector, Ignition and Hub surfaces. **This inventory does not restate that.** It adds the
+three things §1 does not carry, framed through the question that now governs the build:
+*does MIRA hold a **canonical industrial asset graph** that is the translation layer between
+plant-floor OT data (PLC / Ignition / MQTT / OPC UA / historian) and enterprise maintenance
+systems (Maximo / SAP / MaintainX / Fiix / manuals / tribal knowledge)?*
+
+The three deltas:
+
+1. **The OT↔enterprise asset-graph lens** over each existing piece — what role it plays in a
+   canonical graph, and where it stops short.
+2. **As-built reconciliation of the DT gap-closure branch** (`feat/dt2026-gap-closure`), which
+   shipped Hub migrations 032–037 and the tag-event layer — and **diverged from the master
+   plan's proposed 036/037**. The record below matches the branch, not the plan's intent.
+3. **The two architectural gaps** for the full vision: (a) no canonical *source-system identity*
+   on a graph node, (b) no *raw imported-record preservation* layer. These are the subjects of
+   the two sibling docs (`canonical-asset-graph.md`, `source-record-preservation.md`).
+
+Everything below was verified against the working tree on 2026-06-02, not inherited from §1.
+
+---
+
+## 1. Verification preflight (2026-06-02)
+
+```
+branch:        feat/hub-command-center
+origin/main:   ahead — includes #1634 (master plan → North Star), #1593 umbrella
+               (Command Center + Ignition secure edge), #1641 (garage-conveyor KB seed)
+DT branch:     feat/dt2026-gap-closure present locally AND on origin
+               (24 files, +3736 / −204 vs feat/hub-command-center)
+```
+
+Verified code anchors (CodeGraph + grep, not inherited):
+
+| Claim (master plan §1) | Verified |
+|---|---|
+| `Supervisor` class | ✅ `mira-bots/shared/engine.py:467` |
+| `_should_fire_uns_gate` | ✅ `engine.py:4541` |
+| `Supervisor.process` / `process_full` | ✅ `engine.py:838` / `engine.py:1103` |
+| `resolve_uns_path` / `_multi` | ✅ `mira-bots/shared/uns_resolver.py:717` / `:808` |
+| "26 MCP tools" | ✅ exactly 26 `@mcp.tool` in `mira-mcp/server.py` |
+
+---
+
+## 2. The canonical-graph spine — what exists
+
+### 2.1 `kg_entities` / `kg_relationships` (the node + edge tables)
+
+**Authoritative DDL is the Hub line, not the engine line.** `docs/migrations/004_kg_entities.sql`
+and `005_kg_relationships.sql` are headed *"PLANNED — do not run / NOT YET CREATED"* and are
+**not** the live schema (ADR-0013). The live tables are created by Hub
+`001_knowledge_graph.sql` and mutated by 010/024/025/026/028/029 (+ engine 007/008 add the same
+columns idempotently). **True column set as of 2026-06-02:**
+
+`kg_entities`
+| Column | Source migration | Notes |
+|---|---|---|
+| `id UUID PK` | Hub 001 | |
+| `tenant_id UUID` | Hub 001 | RLS policy `app.current_tenant_id` |
+| `entity_type TEXT` | Hub 001 | the type discriminator — see §canonical doc |
+| `entity_id TEXT` (nullable) | Hub 001 → 025 | legacy aux; natural key moved off it |
+| `name TEXT` | Hub 001 | |
+| `properties JSONB` | Hub 001 | |
+| `uns_path ltree` | Hub 010 | GIST + compound `(tenant_id, uns_path)` GIST |
+| `source_chunk_id UUID` | Hub 024 | FK-by-convention → `knowledge_entries.id` |
+| `approval_state TEXT` | Hub 029 | `proposed`\|`verified`\|`rejected`\|`needs_review`\|`deprecated` |
+| `proposed_by`, `evidence_summary` | engine 008 / Hub 029 | |
+| `created_at`, `updated_at` | Hub 001 | |
+| natural key | Hub 025 | `UNIQUE (tenant_id, entity_type, name)` |
+
+`kg_relationships`
+| Column | Source migration | Notes |
+|---|---|---|
+| `id UUID PK` | Hub 001 | |
+| `tenant_id UUID` | Hub 001 | RLS |
+| `source_id UUID` FK→`kg_entities(id)` | Hub 001 | **`source_id` / `target_id`, NOT `source_entity`** |
+| `target_id UUID` FK→`kg_entities(id)` | Hub 001 | `no_self_loop` CHECK |
+| `relationship_type TEXT` | Hub 001 | |
+| `properties JSONB`, `confidence FLOAT` | Hub 001 | confidence already present |
+| `source_conversation_id UUID` | Hub 001 | |
+| `source_chunk_id UUID` | Hub 024 | |
+| `approval_state TEXT` | Hub 029 | `proposed`\|`verified`\|`rejected`\|`needs_review` |
+
+> ⚠️ **Naming trap (do not re-introduce):** the engine `005` file names columns
+> `source_entity / target_entity / relation_type`. The **live** columns are
+> `source_id / target_id / relationship_type`. `kg_writer.py` once wrote the wrong names →
+> fixed in PR #1443. Any new code or schema doc **must** use the live names.
+
+> ⚠️ **approval_state default drift:** Hub 029 defaults new rows to **`proposed`**
+> (human-in-the-loop, correct per TOO Invariant #4). Engine 008 defaults to **`verified`**
+> (legacy auto-insert). Where both ran, last-writer-wins on the column default. The flywheel
+> requires `proposed` to be the default; treat any `verified`-default path as a bug to close
+> (master-plan Phase 3).
+
+**Asset-graph lens:** this *is* the canonical node+edge spine. `entity_type` + `uns_path` +
+`approval_state` + `confidence` already deliver requirements 3 (confidence), 4 (technician
+confirmation via approval_state), 5 (proposed/uncertain), and 6 (ISA-95 ltree). **What it lacks
+for the OT↔enterprise vision:** a *source-system identity* on the node (today provenance is only
+`source_chunk_id` → a manual chunk, or `source_conversation_id` → a chat turn; there is no pointer
+to "row 4471 of the customer's Maximo asset export"). That is the Phase 1/2 gap.
+
+`kg_triples_log` (Hub 001) is the raw extraction log (subject/predicate/object + source) — a
+provenance breadcrumb, not the graph itself.
+
+### 2.2 The proposal / confirmation layer (the "MIRA proposes, human confirms" wedge)
+
+| Surface | Where | Role in the graph |
+|---|---|---|
+| `relationship_proposals` + `relationship_evidence` | Hub 018 | edge-with-evidence staging before `kg_relationships` |
+| **28-value `relationship_type` vocabulary** | Hub 028 (CHECK on `relationship_proposals`) | see §canonical doc — already covers most of the requested edge types |
+| `ai_suggestions` | Hub 027 | 6-type Hub work queue; `kg_edge` rows header onto a proposal; carries `source_kind`/`source_id`/`source_document_id`/`source_page` provenance + `confidence` |
+| `approval_state` on `kg_*` | Hub 029 | `proposed → verified` is the human gate |
+
+**Asset-graph lens:** the uncertain/proposed-match machinery the vision calls for (req 4/5) is
+**already built** — `ai_suggestions` even has a polymorphic source-provenance pointer. The gap is
+that the proposal path is not yet the *only* write path (`kg_writer` still inserts directly;
+master-plan Phase 3 closes this).
+
+### 2.3 Component intelligence (reusable per-model vs per-instance)
+
+| Table | Migration | Layer |
+|---|---|---|
+| `component_templates` | Hub 016 | per-model reusable asset (the Knowledge Cooperative unit) |
+| `component_template_sources` | Hub 016 | template provenance (doc id, page, excerpt, `extracted_by`) — **pointer, not raw payload** |
+| `installed_component_instances` | Hub 017 | per-tenant per-instance, `uns_path`-addressed |
+
+---
+
+## 3. UNS address layer
+
+| Piece | Where | Status |
+|---|---|---|
+| Path builders (`slug`, `*_path`, `RESERVED_LABELS`, `is_valid_path`) | `mira-crawler/ingest/uns.py` | ✅ canonical builders (UNS-001) |
+| Message → UNS resolver (`resolve_uns_path`, `_multi`, `UNSContext`) | `mira-bots/shared/uns_resolver.py:717/808` | ✅ vendor/model/fault scope; hierarchy (site→component) is the master-plan Phase 6 extension |
+| Location-confirmation gate (`_should_fire_uns_gate`) | `engine.py:4541` | ✅ chat scope; direct-connection `source="direct_connection"` wiring is the Phase 6 gap |
+| `uns_path` storage | `kg_entities.uns_path` (Hub 010), engine 007 format CHECK | ✅ ltree, GIST-indexed, lowercase CHECK |
+| MQTT/UNS topic projection | `cmms_equipment.uns_topic_path` (Hub 013) + `uns.py` | ⚠️ column exists; generation path is post-MVP |
+
+**Asset-graph lens:** the ISA-95 address space (req 6) and future UNS/MQTT topic generation
+(req 7) are in place at the column + builder level. Requirement 6's "without rigid structure" is
+satisfied: `uns_path` is a *cached projection* over the `parent_of`/`LOCATED_IN` edge graph (Hub
+010 comment), so the hierarchy is graph-driven, not a fixed-depth column scheme.
+
+---
+
+## 4. Tag / signal / OT-live layer
+
+| Piece | Where | Status |
+|---|---|---|
+| `tag_entities` (first-class PLC/Sparkplug/OPC UA tag) | Hub 025 | ✅ |
+| `live_signal_cache` + diagnostic trend tables | Hub 020 | ✅ latest-value snapshot |
+| `live_signal_events` (per-session) | Hub 019 | ✅ session-bound |
+| Read-only Modbus poller + diff pattern | `tools/demo_plc_poller.py` (`detect_events`) | 🟦 bench reference |
+| Mock Modbus server | `tools/demo_plc_simulator.py` | 🟦 bench |
+| Relay cloud ingest (HMAC `/ingest`, WS) | `mira-relay/relay_server.py` | ✅ |
+
+**DT gap-closure branch (`feat/dt2026-gap-closure`) — as-built, NOT yet on main:**
+
+| Shipped on the branch | File | Reconciliation note |
+|---|---|---|
+| `032_decision_traces.sql` | Hub migrations | matches plan |
+| `033_tag_events.sql` | Hub migrations | append-only meaningful-change stream |
+| `034_flaky_input_signals.sql` | Hub migrations | matches plan |
+| `035_approved_tags.sql` | Hub migrations | allowlist as a table |
+| **`036_current_tag_state_freshness.sql`** | Hub migrations | ⚠️ **supersedes** plan's proposed `036_decision_trace_session_link` |
+| **`037_tag_event_diffs.sql`** | Hub migrations | ⚠️ **supersedes** plan's proposed `037_kg_relationships_evidence_ref` |
+| `tag_ingest.py`, `tag_diff_logger.py` (+ tests) | `mira-relay/` | Phase 5 diff-logger, already built here |
+| `POST /api/v1/tags/ingest` | `mira-relay/relay_server.py` | |
+| Ignition HMAC collector | `ignition/webdev/FactoryLM/api/tags/collector.py`, `ignition/gateway-scripts/tag-stream.py` | |
+| Command Center freshness | `mira-hub/src/lib/command-center-freshness.ts` (+ test) | |
+| ADR-0022 (decision-trace + tag-stream storage) | `docs/adr/0022-decision-trace-and-tag-stream-storage.md` | |
+
+> **Numbering reality:** migration slots **032–037 are consumed** by the DT branch. Any new
+> schema (including the proposals in the two sibling docs) must start at **038+**, and the
+> master plan's §3.D2 first-pass 036/037 are now historical.
+
+---
+
+## 5. Enterprise-system connectors (the "OT↔enterprise" half)
+
+| Connector | Where | Preserves original fields? |
+|---|---|---|
+| Atlas CMMS (sync) | `mira-mcp/cmms/atlas.py` + `cmms_sync_state`/`cmms_sync_conflicts` (Hub 007) | ⚠️ **only on conflict** — `cmms_sync_conflicts.atlas_payload JSONB`. Happy path normalizes into `cmms_equipment` and discards the raw record. |
+| MaintainX | `mira-mcp/cmms/maintainx.py` | via factory; same normalize-and-discard shape |
+| Limble | `mira-mcp/cmms/limble.py` | same |
+| Fiix | `mira-mcp/cmms/fiix.py` | same |
+| Adapter base + factory | `mira-mcp/cmms/base.py`, `factory.py` | unified interface |
+| External-ID cross-reference | `cmms_equipment` columns (Hub 013): `cmms_id`, `plc_tag`, `scada_path`, `manufacturer_part_number`, `uns_topic_path`, `erp_asset_id`, `drawing_reference` | ✅ **ID mapping** (req 2, partial) — but flat TEXT columns on one table, no payload, CMMS-asset-shaped only |
+
+**Asset-graph lens:** the connector *adapters* exist and the i3X external-ID columns (Hub 013)
+give a real "this MIRA asset = that Maximo asset" mapping. **The gap is structural:** there is no
+connector-agnostic place that stores the *original imported record* (Maximo asset row, SAP
+functional location, MaintainX work order, OPC UA browse node) with its raw payload, the
+connector version that produced it, and a remappable mapping status. Today raw payload survives
+**only** in `cmms_sync_conflicts.atlas_payload`, **only on conflict, only for Atlas.** This is the
+single sharpest gap for the vision — addressed in `source-record-preservation.md`.
+
+---
+
+## 6. Knowledge / evidence layer
+
+| Piece | Where | Status |
+|---|---|---|
+| `knowledge_entries` (text + `embedding` + `metadata` JSONB + `equipment_entity_id` FK) | engine 001 + 006_kg_bridge | ✅ ~25K+ chunks; **chunk-level** source metadata only |
+| PDF → chunk → embed → dedup → store + KG side-effect | `mira-crawler/ingest/` (`converter`/`chunker`/`embedder`/`dedup`/`store`/`kg_writer`) | ✅ works; first-class ingest API is master-plan Phase 2 |
+| `fault_codes` | engine 002 | ✅ |
+| `namespace_direct_uploads` | Hub 027 | ✅ upload metadata (filename/mime/size), no payload preservation |
+| Open WebUI (chunk/embed/retrieve backend) | container `mira-core` | ✅ service-sunset, still the embed/retrieve engine |
+| MiraDrop watcher | `tools/mira-drop-watcher/` | ✅ drop-folder → Hub → OW path |
+
+---
+
+## 7. MCP tool surface (26 verified)
+
+26 `@mcp.tool` across 7 domains (equipment/live-signal, diagnostic-case, CMMS, asset/nameplate,
+agent-control, knowledge-graph, namespace/UNS, schematic-vision) — full list in master plan §1.2.
+**Asset-graph lens:** there is no single `get_asset_context(uns_path)` that returns the unified
+asset+component+tag+document+WO+edge bundle an agent needs — the graph is queryable in pieces, not
+as one node-centric view. Master-plan Phase 11 adds it; the canonical-graph doc specifies the
+bundle shape that tool should return.
+
+---
+
+## 8. The gap list for the full asset-graph vision
+
+| # | Gap | Severity | Where it's solved |
+|---|---|---|---|
+| G1 | No canonical **source-system identity** on a graph node (provenance is chunk/chat only) | High | `canonical-asset-graph.md` §node-identity → FK into G2 |
+| G2 | No **raw imported-record preservation** layer; raw payload survives only in `cmms_sync_conflicts` (conflict-only, Atlas-only) | **Highest** | `source-record-preservation.md` |
+| G3 | Proposal path is not the *only* KG write path (`kg_writer` still direct-inserts) | Medium | master-plan Phase 3 |
+| G4 | `approval_state` default drift (`proposed` vs `verified`) | Medium | master-plan Phase 3 |
+| G5 | No node-centric `get_asset_context` agent bundle | Medium | master-plan Phase 11 + `canonical-asset-graph.md` |
+| G6 | Hierarchy resolution (site→component) + direct-connection gate wiring | Medium | master-plan Phase 6 |
+| G7 | UNS/MQTT topic generation from `uns_path` is column-only, no generator | Low | post-MVP |
+
+**Not gaps (already built, do not rebuild):** the node/edge spine, the 28-type relationship
+vocabulary, confidence scoring, approval-state machine, `ai_suggestions` work queue with
+polymorphic provenance, component template/instance split, ltree addressing, tag_entities, the
+tag-event stream (DT branch), CMMS adapters, external-ID mapping columns, KB ingest.
+
+---
+
+## 9. Cross-references
+
+- `docs/plans/2026-06-01-mira-master-architecture-plan.md` — phase 0–13 execution (this doc is the
+  asset-graph lens over its §1)
+- `docs/mira/canonical-asset-graph.md` — the canonical node/edge model + additive schema proposals
+- `docs/mira/source-record-preservation.md` — the raw-record preservation layer (G2)
+- `docs/THEORY_OF_OPERATIONS.md` — primary doctrine
+- `docs/adr/0013-...` — Hub-canonical schema lineage
+- `docs/adr/0017-...` — status transitions through helpers
+- `docs/adr/0022-decision-trace-and-tag-stream-storage.md` — DT branch ADR
+- `.claude/rules/uns-compliance.md`, `.claude/rules/direct-connection-uns-certified.md`

--- a/docs/mira/source-record-preservation.md
+++ b/docs/mira/source-record-preservation.md
@@ -1,0 +1,286 @@
+# MIRA — Source-Record Preservation Layer
+
+**Status:** Phase 2 deliverable of the canonical-asset-graph initiative — **design + additive
+schema proposals (docs-only)**
+**Authored:** 2026-06-02
+**Owner:** Lead architect (MIRA)
+**Builds on:** `docs/mira/current-repo-inventory.md` · `docs/mira/canonical-asset-graph.md`
+**Defines:** the FK target (`source_objects`) that `kg_entities.source_object_id` points at
+
+---
+
+## 0. The problem in one sentence
+
+Today, raw imported records survive in exactly one place — **`cmms_sync_conflicts.atlas_payload`**
+(Hub 007) — and only **on conflict**, only for **Atlas**. Every successful import normalizes
+straight into `cmms_equipment` and **discards the original record.** That violates the rule
+"never destroy original customer fields" and makes "remap if the schema changes" impossible:
+once normalized, the source row is gone.
+
+This layer fixes that for **every connector** (Maximo, SAP, MaintainX, Fiix, Ignition, MQTT/
+Sparkplug, OPC UA, historian, manuals, CSV exports) by storing the **raw record before
+normalization**, immutably enough to remap, with full connector provenance.
+
+---
+
+## 1. Design principles
+
+1. **Store raw, then map — never map-and-discard.** The connector's job is to *land* the record;
+   normalization is a separate, re-runnable step that reads from the stored raw record.
+2. **One mechanism, all connectors.** `cmms_sync_conflicts.atlas_payload` is the right idea at the
+   wrong scope. Generalize it: any source, any object type, happy path *and* conflict.
+3. **The graph references the source, not vice-versa.** `kg_entities.source_object_id` →
+   `source_objects.id` (the FK proposed in `canonical-asset-graph.md` mig 039). The source layer
+   is upstream; the graph is downstream and re-derivable.
+4. **Remapping is re-reading, not re-fetching.** A schema/mapping change re-runs the mapper over
+   stored `raw_payload` — no second call to the customer's Maximo. `content_hash` dedups re-imports.
+5. **Tenant-isolated, RLS-enabled** — same posture as `kg_entities` (Hub 001 RLS), *unlike*
+   `hub_uploads` (which has no RLS — a known footgun; don't repeat it here).
+
+---
+
+## 2. The three tables
+
+```
+source_systems       1 ──< source_import_runs       1 ──< source_objects >── 1  kg_entities
+(connected external      (one connector execution)       (one raw record)       (mapped node)
+ system per tenant)                                        mapped_entity_id ─────────┘
+```
+
+### 2.1 `source_systems` — registry of connected external systems
+
+The FK target for `entity_type='external_system'` (canonical-graph §2). One row per
+tenant×connected-system (a specific Maximo instance, a MaintainX account, an Ignition gateway, an
+OPC UA endpoint). Supersedes the implicit single-CMMS assumption in `tenant_cmms_config`.
+
+### 2.2 `source_import_runs` — one row per connector execution
+
+Generalizes `cmms_sync_state` (which is just a cursor) into a full run record: connector name +
+**version**, window, counts, status, errors. This is where requirement 2 (import timestamp,
+connector version, errors/warnings) lives at batch granularity; `source_objects` carries it at
+record granularity.
+
+### 2.3 `source_objects` — the raw imported record (the core)
+
+Generalizes `cmms_sync_conflicts` to all sources and the happy path. **This is the table that
+"never destroys original customer fields."**
+
+---
+
+## 3. Additive schema proposals (docs-only — do NOT write migration files)
+
+Slots 032–037 consumed by the DT branch; `canonical-asset-graph.md` proposes 038/039. This doc
+proposes **040–042**. Proposals for review — author real files only after sign-off and after
+re-checking the live migration tail (`ls mira-hub/db/migrations/ | tail`).
+
+```sql
+-- 040_source_systems.sql  (PROPOSAL)
+CREATE TABLE IF NOT EXISTS source_systems (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id       UUID NOT NULL,
+  system_kind     TEXT NOT NULL,          -- 'maximo'|'sap'|'maintainx'|'fiix'|'limble'|'atlas'
+                                          -- |'ignition'|'mqtt_sparkplug'|'opcua'|'historian'
+                                          -- |'manual_upload'|'csv_export'|'plc_bridge'
+  display_name    TEXT NOT NULL,          -- "Plant 2 Maximo", "MaintainX (East)"
+  external_base   TEXT,                   -- base URL / broker / gateway id (no secrets here)
+  config          JSONB DEFAULT '{}',     -- non-secret connector config; secrets stay in Doppler
+  uns_root        ltree,                  -- optional: where this system's objects attach by default
+  status          TEXT NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active','paused','disconnected','error')),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, system_kind, display_name)
+);
+CREATE INDEX IF NOT EXISTS idx_source_systems_tenant ON source_systems (tenant_id);
+ALTER TABLE source_systems ENABLE ROW LEVEL SECURITY;
+CREATE POLICY source_systems_tenant ON source_systems
+  USING (tenant_id = current_setting('app.current_tenant_id')::UUID);
+
+-- 041_source_import_runs.sql  (PROPOSAL)
+CREATE TABLE IF NOT EXISTS source_import_runs (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id         UUID NOT NULL,
+  source_system_id  UUID NOT NULL REFERENCES source_systems(id) ON DELETE CASCADE,
+  connector_name    TEXT NOT NULL,        -- 'mira-mcp/cmms/maintainx.py' etc.
+  connector_version TEXT NOT NULL,        -- semver/git-sha of the adapter that produced this run
+  object_type       TEXT,                 -- NULL = mixed/full sync; else the resource swept
+  started_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  finished_at       TIMESTAMPTZ,
+  status            TEXT NOT NULL DEFAULT 'running'
+                      CHECK (status IN ('running','succeeded','partial','failed')),
+  cursor_before     JSONB,                -- replaces cmms_sync_state.last_poll_at, generalized
+  cursor_after      JSONB,
+  objects_seen      INT NOT NULL DEFAULT 0,
+  objects_new       INT NOT NULL DEFAULT 0,
+  objects_updated   INT NOT NULL DEFAULT 0,
+  errors            JSONB DEFAULT '[]',   -- [{external_object_id, stage, message}]
+  warnings          JSONB DEFAULT '[]'
+);
+CREATE INDEX IF NOT EXISTS idx_import_runs_system ON source_import_runs (source_system_id, started_at DESC);
+ALTER TABLE source_import_runs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY source_import_runs_tenant ON source_import_runs
+  USING (tenant_id = current_setting('app.current_tenant_id')::UUID);
+
+-- 042_source_objects.sql  (PROPOSAL) — the raw record store
+CREATE TABLE IF NOT EXISTS source_objects (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id         UUID NOT NULL,
+  source_system_id  UUID NOT NULL REFERENCES source_systems(id) ON DELETE CASCADE,
+  object_type       TEXT NOT NULL,        -- 'asset'|'work_order'|'pm'|'location'|'part'
+                                          -- |'tag'|'opcua_node'|'manual'|'fault'...
+  external_object_id TEXT NOT NULL,       -- the source system's own ID for this record
+  raw_payload       JSONB NOT NULL,       -- ORIGINAL record, unmodified. requirement 4.
+  content_hash      TEXT NOT NULL,        -- sha256 of canonicalized raw_payload (re-import dedup)
+  first_import_run_id UUID REFERENCES source_import_runs(id) ON DELETE SET NULL,
+  last_import_run_id  UUID REFERENCES source_import_runs(id) ON DELETE SET NULL,
+  first_seen_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  connector_version TEXT NOT NULL,        -- version that last wrote raw_payload
+  mapping_status    TEXT NOT NULL DEFAULT 'unmapped'
+                      CHECK (mapping_status IN
+                        ('unmapped','mapped','conflict','stale','superseded','error')),
+  mapped_entity_id  UUID,                 -- -> kg_entities(id) when normalized; reverse of
+                                          --    kg_entities.source_object_id (canonical-graph mig 039)
+  mapping_errors    JSONB DEFAULT '[]',   -- requirement 2: per-record warnings/errors
+  mapped_at         TIMESTAMPTZ,
+  mapped_by         TEXT,                 -- 'llm'|'rule'|'human'|connector name
+  UNIQUE (tenant_id, source_system_id, object_type, external_object_id)
+);
+CREATE INDEX IF NOT EXISTS idx_source_objects_lookup
+  ON source_objects (tenant_id, source_system_id, object_type, external_object_id);
+CREATE INDEX IF NOT EXISTS idx_source_objects_mapped
+  ON source_objects (tenant_id, mapped_entity_id) WHERE mapped_entity_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_source_objects_status
+  ON source_objects (tenant_id, mapping_status) WHERE mapping_status IN ('unmapped','conflict','error');
+ALTER TABLE source_objects ENABLE ROW LEVEL SECURITY;
+CREATE POLICY source_objects_tenant ON source_objects
+  USING (tenant_id = current_setting('app.current_tenant_id')::UUID);
+
+-- 042b_ai_suggestions_source_object.sql  (PROPOSAL — ships with 042)
+-- ai_suggestions.source_kind has a CHECK (Hub 027). To let a suggestion cite a raw source
+-- record (§5), extend it — same DROP/ADD pattern as the relationship_type CHECK in
+-- canonical-asset-graph.md proposal 038. Without this, source_kind='source_object' fails the CHECK.
+ALTER TABLE ai_suggestions DROP CONSTRAINT IF EXISTS ai_suggestions_source_kind_check;
+ALTER TABLE ai_suggestions
+  ADD CONSTRAINT ai_suggestions_source_kind_check
+  CHECK (source_kind IS NULL OR source_kind IN (
+    -- existing 9 (Hub 027) ...
+    'knowledge_entry','work_order','tag_entity','photo','session',
+    'manifest_row','technician_note','live_event','manual_entry',
+    -- NEW: a suggestion can cite the preserved raw record it was derived from
+    'source_object'
+  ));
+
+-- OPTIONAL 043_source_object_versions.sql  (PROPOSAL, defer until drift auditing is needed)
+-- Append-only history when raw_payload changes between imports, for true immutability /
+-- schema-drift forensics. Until requested, the upsert in §4 just refreshes raw_payload +
+-- last_seen_at; content_hash tells you whether it changed.
+```
+
+---
+
+## 4. Lifecycle (how the four requirements are satisfied)
+
+```
+CONNECTOR RUN
+  source_import_runs row opened (connector_name + version, cursor_before)         [req 2: batch]
+        │
+        ▼  for each external record:
+  compute content_hash(raw_payload)
+  UPSERT source_objects ON (tenant_id, source_system_id, object_type, external_object_id):
+     - new            → INSERT raw_payload, mapping_status='unmapped'              [req 1,4]
+     - unchanged hash → bump last_seen_at, last_import_run_id (raw kept)           [req 4]
+     - changed hash   → refresh raw_payload + connector_version, mapping_status='stale'
+                        (+ optional source_object_versions append)                 [req 3,4]
+        │
+        ▼  NORMALIZE (separate, re-runnable step — reads raw_payload only)         [req 3]
+  mapper(raw_payload, connector_version) → upsert kg_entities (+ typed projection)
+     - set kg_entities.source_object_id = this row        (canonical-graph mig 039)
+     - set source_objects.mapped_entity_id = node id, mapping_status='mapped'
+     - parse failure → mapping_status='error', mapping_errors=[...]               [req 2]
+     - newer-than-graph → mapping_status='conflict' (replaces cmms_sync_conflicts) [req 2]
+        │
+        ▼  REMAP (schema/mapping change, NO re-fetch)                             [req 3]
+  re-run mapper over stored raw_payload for all rows where
+     connector_version < current OR mapping_status IN ('stale','error')
+  → new/updated kg_entities, mapping_status back to 'mapped'
+        │
+        ▼
+  source_import_runs row closed (status, counts, cursor_after)                    [req 2]
+```
+
+- **Requirement 1 (source system, object type, object ID, payload):** `source_objects`
+  (`source_system_id` → `source_systems.system_kind`, `object_type`, `external_object_id`,
+  `raw_payload`).
+- **Requirement 2 (timestamp, connector version, mapping status, errors/warnings):**
+  `source_import_runs` (batch) + `source_objects.{connector_version, mapping_status,
+  mapping_errors, first/last_seen_at}` (record).
+- **Requirement 3 (remap on schema change):** the REMAP step re-reads `raw_payload`; no re-fetch.
+  Triggered by `connector_version` drift or `mapping_status IN ('stale','error')`.
+- **Requirement 4 (never destroy originals):** `raw_payload` is the unmodified record; normalize
+  reads from it and never overwrites it with normalized data. Optional
+  `source_object_versions` adds full immutability when drift forensics are needed.
+
+---
+
+## 5. Relationship to what already exists (subsume, don't duplicate)
+
+| Existing | New role |
+|---|---|
+| `cmms_sync_conflicts.atlas_payload` (Hub 007) | special case → `source_objects` rows with `mapping_status='conflict'`. Migrate Atlas conflicts into the general table; keep the view name for back-compat if callers read it. |
+| `cmms_sync_state` (Hub 007) | cursor bookkeeping → `source_import_runs.cursor_before/after`. |
+| `cmms_equipment` external-ID columns (Hub 013) | **derived** from `source_objects` (a node's external IDs = the `external_object_id`s of its mapped source rows). Keep columns as a denormalized read cache; source layer is authoritative. |
+| `ai_suggestions.source_kind/source_id` (Hub 027) | add `source_kind='source_object'` so a suggestion can cite the raw record it came from — **requires extending the Hub-027 `source_kind` CHECK** (proposal 042b in §3). |
+| `tenant_cmms_config` (Hub 008) | folds into `source_systems` (one CMMS = one `source_systems` row of the matching `system_kind`). |
+| `component_template_sources` (Hub 016) | unchanged — it cites *documents*; orthogonal to connector records. |
+
+---
+
+## 6. What this explicitly does NOT do
+
+- ❌ Does not change any connector adapter's external API calls (Phase 2 of the master plan owns
+  the ingest API; this is the storage shape it writes into).
+- ❌ Does not write migration files — proposals only, slots 040–042 (043 deferred).
+- ❌ Does not make `source_objects` a graph node — it is upstream raw data; the graph references
+  it by FK.
+- ❌ Does not store secrets in `source_systems.config` — secrets remain Doppler-managed.
+- ❌ Does not add a parallel provenance scheme — this *is* the single mechanism
+  `canonical-asset-graph.md` §4.1 points `kg_entities.source_object_id` at.
+
+---
+
+## 7. Acceptance (when this layer is "real")
+
+1. Import a MaintainX asset → a `source_objects` row holds the unmodified MaintainX JSON; a
+   `kg_entities` row has `source_object_id` pointing at it; `cmms_equipment` external IDs match.
+2. Re-run the same import → no duplicate row (content_hash dedup); `last_seen_at` bumped.
+3. Change the mapper, run REMAP → graph node updates from stored `raw_payload` with **zero**
+   calls to the customer's MaintainX.
+4. A parse failure lands `mapping_status='error'` + `mapping_errors`, and the raw record is still
+   present and retryable.
+5. RLS: a query without `app.current_tenant_id` set returns zero rows from all three tables.
+
+---
+
+## 8. Open questions (decide before authoring migrations)
+
+1. **`source_object_versions` now or deferred?** Proposal: defer until a connector's schema
+   actually drifts in production (YAGNI; content_hash already detects change).
+2. **`raw_payload` size ceiling.** Maximo/SAP records can be large; cap + offload oversized
+   payloads (e.g. full manuals) to blob storage with a pointer? Manuals already go to
+   `knowledge_entries`, so `source_objects` should hold *structured* records, not document bodies.
+3. **Conflict resolution UX.** `mapping_status='conflict'` should surface in Hub `/proposals` as
+   an `ai_suggestions` row — confirm the reviewer flow before wiring.
+4. **Backfill of existing `cmms_sync_conflicts`.** One-time migration into `source_objects`, or
+   leave historical conflicts in place and start fresh? (Lean: start fresh, document the cutover.)
+
+---
+
+## 9. Cross-references
+
+- `docs/mira/canonical-asset-graph.md` §4.1 — the `source_object_id` FK this table backs
+- `docs/mira/current-repo-inventory.md` §5 — the connector + sync-state inventory this generalizes
+- `docs/plans/2026-06-01-mira-master-architecture-plan.md` — Phase 2 (ingest API), Phase 3 (proposal path)
+- ADR-0013 (Hub-canonical schema), ADR-0014 (`ai_suggestions`), ADR-0017 (status transitions)
+- `.claude/rules/security-boundaries.md` — RLS / Doppler / no-secrets-in-config posture
+- Memory: `project_hub_uploads_no_rls` — why these tables MUST enable RLS


### PR DESCRIPTION
Foundational architecture for MIRA as the **canonical industrial asset graph** — the translation layer between plant-floor OT (PLC / Ignition / MQTT / OPC UA / historian) and enterprise maintenance systems (Maximo / SAP / MaintainX / Fiix / manuals / tribal knowledge).

Extends — does not replace — `docs/plans/2026-06-01-mira-master-architecture-plan.md`. **Docs + proposals only; no migration files written, no code paths changed.**

## What's in here

- **`docs/mira/current-repo-inventory.md`** — Phase 0. Verified baseline through the asset-graph lens (does *not* restate master-plan §1). Reconciles the as-built `feat/dt2026-gap-closure` branch and names the two real gaps: no canonical source-system identity on a node, and no raw imported-record preservation.
- **`docs/mira/canonical-asset-graph.md`** — Phase 1. The 25 requested entity kinds + 18 edge types mapped onto the live `kg_entities`/`kg_relationships` spine + typed projections. **All 25 entities and 16/18 edges already expressible**; only `HAS_ALARM`/`HAS_WORK_ORDER`/`HAS_PM_TASK`/`USES_PART` are new. Additive proposals (mig 038/039, docs-only).
- **`docs/mira/source-record-preservation.md`** — Phase 2. `source_systems`/`source_import_runs`/`source_objects` generalizing the only existing raw-payload store (`cmms_sync_conflicts.atlas_payload`, conflict-only/Atlas-only) to every connector, with remap-without-refetch + RLS. Proposals 040–042 (+042b for the `ai_suggestions.source_kind` CHECK).
- **`NORTH_STAR.md`** — "The Canonical Asset Graph (the next evolution)" framing; flywheel / Three Offers / Knowledge Cooperative preserved intact.

## Grounding

Schema claims verified against the **live** Hub line (`001_knowledge_graph.sql` + alterations 010/024/025/026/028/029), not the engine `docs/migrations/004/005` files (headed "PLANNED — do not run"). Live edge columns are `source_id`/`target_id`/`relationship_type` (avoids the PR #1443 trap). Code anchors confirmed via CodeGraph (Supervisor `engine.py:467`, gate `:4541`, 26 MCP tools, resolver `:717/:808`).

## Load-bearing precondition (reviewers note)

Migration slots **032–037 are consumed by `feat/dt2026-gap-closure`** (its `036_current_tag_state_freshness` / `037_tag_event_diffs` supersede the master plan's proposed 036/037). New schema therefore starts at **038** — but that assumes the DT branch merges as-is. **Merge the DT branch before authoring any real migration from these proposals**, and re-check the live `mira-hub/db/migrations/` tail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)