### PR TITLE
ci(staging-gate): skip engine eval for non-runtime PRs + retry (#1680)

### DIFF
--- a/.github/workflows/staging-gate.yml
+++ b/.github/workflows/staging-gate.yml
@@ -12,11 +12,15 @@ name: Staging Gate
 # Runbook: docs/runbooks/staging-environment.md
 
 on:
-  # Runs on every PR to main — no path filter. The deploy-vps.yml gate
-  # verifies this workflow succeeded on the PR head SHA before deploying,
-  # so a docs-only PR still needs a passing Staging Gate. Path filters
-  # would break that contract once a non-gated PR landed on main and the
-  # deploy looked for a Staging Gate run that never fired.
+  # Runs on every PR to main — NO trigger-level path filter (on purpose). The
+  # deploy-vps.yml gate verifies this workflow succeeded on the PR head SHA
+  # before deploying, so the run must always FIRE and report a conclusion; a
+  # `paths:` filter would skip the whole workflow and break that contract.
+  # Instead, the "Scope check" step below decides whether to RUN the engine
+  # eval: for non-runtime-only PRs (docs/CI/wiki/.claude) or Dependabot bumps
+  # it skips the eval and the job still exits success (#1680). So the required
+  # check stays green + the deploy contract holds, without a flaky engine eval
+  # blocking unrelated PRs.
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -70,6 +74,43 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Scope check (#1680): the engine eval only catches diagnostic/retrieval/
+      # cascade regressions, so it adds no signal for docs-only / CI-only /
+      # non-runtime PRs — yet it's the only required check, and it's flaky
+      # (LLM-graded), so it was blocking unrelated PRs. Skip the eval (report
+      # success) when a PR touches ONLY non-runtime paths, OR is a Dependabot
+      # bump. The job still exits `completed:success`, so deploy-vps.yml's
+      # "a Staging Gate passed for this SHA" contract holds (same mechanism the
+      # Dependabot skip already relied on). Default is RUN — skip only when the
+      # PR is provably non-runtime-only.
+      - name: Scope check (skip eval for non-runtime / Dependabot PRs)
+        id: scope
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          run_eval=true
+          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+            run_eval=false
+            echo "Dependabot PR — staging-gate eval skipped (offline deepeval + CI cover the bump)."
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            files="$(gh pr view "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --json files -q '.files[].path')"
+            runtime=false
+            while IFS= read -r f; do
+              [ -z "$f" ] && continue
+              case "$f" in
+                docs/*|wiki/*|*.md|.github/*|.claude/*) : ;;   # non-runtime — ignore
+                *) runtime=true; break ;;                       # any other path -> run the gate
+              esac
+            done <<< "$files"
+            if [ "$runtime" = false ]; then
+              run_eval=false
+              echo "Non-runtime-only PR (docs/CI/wiki/.claude) — staging-gate eval skipped, reporting success (#1680)."
+            fi
+          fi
+          echo "run_eval=$run_eval" >> "$GITHUB_OUTPUT"
+          echo "run_eval=$run_eval"
+
       # Dependabot PRs cannot access GitHub environment secrets (security
       # default — only `dependabot` secrets are exposed). That makes
       # NEON_STG_DATABASE_URL / STAGING_GROQ_API_KEY empty, the engine
@@ -91,20 +132,20 @@ jobs:
           echo "can deploy the squashed merge commit on main."
 
       - uses: actions/setup-python@v6
-        if: github.actor != 'dependabot[bot]'
+        if: steps.scope.outputs.run_eval == 'true'
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: mira-bots/telegram/requirements.txt
 
       - name: Install engine dependencies
-        if: github.actor != 'dependabot[bot]'
+        if: steps.scope.outputs.run_eval == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r mira-bots/telegram/requirements.txt
 
       - name: Wait for Ollama and pre-pull embed model
-        if: github.actor != 'dependabot[bot]'
+        if: steps.scope.outputs.run_eval == 'true'
         run: |
           set -euo pipefail
           # Service container starts in parallel with steps; poll until ready.
@@ -126,7 +167,7 @@ jobs:
           curl -sf http://localhost:11434/api/tags | grep -q nomic-embed-text
 
       - name: Run staging gate
-        if: github.actor != 'dependabot[bot]'
+        if: steps.scope.outputs.run_eval == 'true'
         env:
           NEON_DATABASE_URL: ${{ secrets.NEON_STG_DATABASE_URL }}
           GROQ_API_KEY: ${{ secrets.STAGING_GROQ_API_KEY }}
@@ -158,10 +199,17 @@ jobs:
           QUALITY_GATE_ENABLED: "1"
           QUALITY_GATE_JUDGE: "0"
         run: |
-          python tools/staging_test.py
+          # Retry the flaky LLM/retrieval-graded eval once before failing (#1680).
+          for attempt in 1 2; do
+            if python tools/staging_test.py; then exit 0; fi
+            echo "::warning::staging gate attempt ${attempt} failed (flaky LLM grading); retrying in 5s..."
+            sleep 5
+          done
+          echo "::error::staging gate failed after 2 attempts"
+          exit 1
 
       - name: Upload results artifact
-        if: always() && github.actor != 'dependabot[bot]'
+        if: always() && steps.scope.outputs.run_eval == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: staging-results-${{ github.run_number }}
@@ -169,7 +217,7 @@ jobs:
           retention-days: 30
 
       - name: Render PR comment
-        if: always() && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+        if: always() && github.event_name == 'pull_request' && steps.scope.outputs.run_eval == 'true'
         run: |
           python tools/staging_render_comment.py \
             --in tools/staging_results.json \
@@ -177,7 +225,7 @@ jobs:
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Post / update PR comment
-        if: always() && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && hashFiles('staging_comment.md') != ''
+        if: always() && github.event_name == 'pull_request' && steps.scope.outputs.run_eval == 'true' && hashFiles('staging_comment.md') != ''
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: staging-gate


### PR DESCRIPTION
Implements the **#1680** decision (content-scope + retry) so the flaky required gate stops blocking docs/CI/cleanup PRs.

## The problem
`staging-gate` is the **only required check** and runs the LLM/retrieval-graded engine eval on **every** PR (no path filter). It's flaky, so docs-only (#1676) and CI-only (#1675) PRs were stuck behind a gate that can't be relevant to them.

## The fix — one file, `staging-gate.yml`
- **Scope check** step → `run_eval`. It's `false` (skip the eval) **only** when a PR touches *exclusively* non-runtime paths (`docs/`, `wiki/`, `*.md`, `.github/`, `.claude/`) — or is a Dependabot bump. **Default is RUN**; anything touching code/migrations/tests still runs the full gate. All eval + artifact steps gate on `run_eval`.
- When skipped, the job still exits `completed:success`, so **`deploy-vps.yml`'s "a Staging Gate passed for this SHA" contract holds** — the *same mechanism the existing Dependabot skip already relied on*. **No `deploy-vps.yml` change.**
- **Retry** the flaky eval once (2 attempts) before failing, on runtime PRs.

## Why no deploy-vps change (the safe part)
`deploy-vps` only checks the gate's *conclusion = success*. A skipped-but-green run satisfies it. The Dependabot path has worked this way for months.

## Validated locally
- YAML valid.
- Classifier: docs-only/CI-only/`README.md` → skip; `mira-bots/shared/engine.py` / `mira-hub/db/migrations/038_*.sql` → run (even mixed with docs).
- **This PR changes only `.github/` → it skips its own gate → green** (self-certifying).

After merge: re-running `staging-gate` on #1675/#1676 uses the new logic → skip → green → mergeable. Runtime PRs (#1657, #1603, #1619) still run the gate (correct).

Closes #1680.

🤖 Generated with [Claude Code](https://claude.com/claude-code)