### PR TITLE
style: refine graph into spherical knowledge globe UI

### DIFF
--- a/mira-hub/src/app/(hub)/graph/page.tsx
+++ b/mira-hub/src/app/(hub)/graph/page.tsx
@@ -102,6 +102,7 @@ function GraphView() {
 
   const verifiedCount = useMemo(() => (raw?.links ?? []).filter((l) => l.state !== "proposed").length, [raw]);
   const proposedCount = useMemo(() => (raw?.links ?? []).filter((l) => l.state === "proposed").length, [raw]);
+  const density = Math.min(verifiedCount / 24, 1); // 0..1 → ambient glow + lattice brightness
 
   // Default "Show suggestions" ON the first time we load a graph with 0 verified
   // edges but >0 proposed — so the user isn't staring at disconnected dots.
@@ -169,7 +170,27 @@ function GraphView() {
   const showEmptyState = verifiedCount === 0 && proposedCount > 0;
 
   return (
-    <div className="relative h-[calc(100vh-4rem)] w-full">
+    <div className="relative h-[calc(100vh-4rem)] w-full overflow-hidden bg-[#05070d]">
+      {/* depth */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{ background: "radial-gradient(ellipse at 50% 45%, #0b1018 0%, #05070d 62%, #03040a 100%)" }}
+      />
+      {/* knowledge-density ambient sphere (more verified knowledge → stronger glow) */}
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+        <div
+          style={{
+            width: "62vmin",
+            height: "62vmin",
+            borderRadius: "50%",
+            background:
+              "radial-gradient(circle, rgba(94,234,212,0.16) 0%, rgba(94,234,212,0.05) 46%, rgba(0,0,0,0) 70%)",
+            opacity: 0.22 + 0.6 * density,
+            filter: "blur(8px)",
+          }}
+        />
+      </div>
+
       {showEmptyState && (
         <div className="absolute left-1/2 top-4 z-20 w-[min(92vw,640px)] -translate-x-1/2 rounded-md border border-sky-500/40 bg-sky-500/10 px-4 py-2 text-center text-sm text-sky-100">
           No verified relationships yet. MIRA found <span className="font-semibold">{proposedCount}</span> suggested connection
@@ -191,7 +212,7 @@ function GraphView() {
         </div>
       )}
 
-      <div className="absolute left-4 top-4 z-10 w-64 space-y-2 rounded-md bg-slate-900/80 p-3 text-sm text-slate-200">
+      <div className="absolute left-4 top-4 z-10 w-56 max-h-[44vh] overflow-y-auto space-y-2 rounded-md bg-slate-900/80 p-3 text-sm text-slate-200 sm:w-64">
         <div className="font-semibold text-white">Relationship Graph</div>
         <div className="text-xs text-slate-400">
           {view.nodes.length}/{raw.nodes.length} nodes · {view.links.length} edges{raw.capped ? " (capped)" : ""}
@@ -240,7 +261,7 @@ function GraphView() {
           const src = nodeById.get(endId(selectedEdge.source))?.label ?? "this component";
           const tgt = nodeById.get(endId(selectedEdge.target))?.label ?? "this item";
           return (
-            <div className="absolute right-4 top-4 z-10 w-80 rounded-md bg-slate-900/95 p-4 text-sm text-slate-200">
+            <div className="absolute inset-x-2 bottom-2 z-20 w-auto rounded-xl bg-slate-900/95 p-4 text-sm text-slate-200 sm:inset-x-auto sm:bottom-auto sm:right-4 sm:top-4 sm:w-80 sm:rounded-md">
               <button onClick={() => setSelectedEdge(null)} className="float-right text-slate-500 hover:text-slate-300">
                 ✕
               </button>
@@ -277,7 +298,7 @@ function GraphView() {
         })()}
 
       {selected && !selectedEdge && (
-        <div className="absolute right-4 top-4 z-10 w-72 rounded-md bg-slate-900/90 p-4 text-sm text-slate-200">
+        <div className="absolute inset-x-2 bottom-2 z-20 w-auto rounded-xl bg-slate-900/90 p-4 text-sm text-slate-200 sm:inset-x-auto sm:bottom-auto sm:right-4 sm:top-4 sm:w-72 sm:rounded-md">
           <button onClick={() => setSelected(null)} className="float-right text-slate-500 hover:text-slate-300">
             ✕
           </button>
@@ -288,15 +309,28 @@ function GraphView() {
         </div>
       )}
 
-      <GraphCanvas
-        data={view}
-        onNodeClick={(n) => {
-          setSelected(n);
-          setSelectedEdge(null);
-        }}
-        onLinkClick={(l) => setSelectedEdge(l.proposalId ? l : null)}
-        highlightNodeIds={trace?.ids}
-      />
+      <div className="absolute inset-0">
+        <GraphCanvas
+          data={view}
+          onNodeClick={(n) => {
+            setSelected(n);
+            setSelectedEdge(null);
+          }}
+          onLinkClick={(l) => setSelectedEdge(l.proposalId ? l : null)}
+          highlightNodeIds={trace?.ids}
+          intensity={density}
+        />
+      </div>
+
+      <div className="pointer-events-none absolute bottom-3 left-3 z-10 hidden rounded-md bg-slate-900/55 px-3 py-2 text-[10px] leading-relaxed text-slate-400 backdrop-blur-sm sm:block">
+        <div className="flex items-center gap-1.5">
+          <span className="inline-block h-px w-4" style={{ background: "rgba(94,234,212,0.7)" }} /> solid = verified
+        </div>
+        <div className="flex items-center gap-1.5">
+          <span className="inline-block w-4 border-t border-dashed" style={{ borderColor: "rgba(120,150,135,0.85)" }} /> dashed = proposed by MIRA
+        </div>
+        <div className="mt-0.5 text-slate-500">green network = connected knowledge</div>
+      </div>
     </div>
   );
 }

--- a/mira-hub/src/components/kg/GraphCanvas.tsx
+++ b/mira-hub/src/components/kg/GraphCanvas.tsx
@@ -11,59 +11,149 @@ export interface GraphCanvasData {
   links: GraphLink[];
 }
 
+// Muted, intentional palette — calm on near-black. RED IS RESERVED FOR FAULTS.
+const TYPE_COLORS: Record<string, string> = {
+  equipment: "#5e9bd1",
+  component: "#6fb39a",
+  electrical_component: "#6fb39a",
+  manual: "#9b8cc6",
+  work_order: "#c7a35a",
+  pm_task: "#c7a35a",
+  part: "#8aa0b3",
+  fault_code: "#d77a7a", // reserved red — faults/alerts only
+  fault: "#d77a7a",
+  plant: "#6c8ebf",
+  area: "#6c8ebf",
+  line: "#6c8ebf",
+};
+const DEFAULT_NODE = "#7c8aa0";
+
+// Restrained matrix/signal-green for relationship lines.
+const VERIFIED_LINK = "94,234,212";
+const PROPOSED_LINK = "120,150,135";
+const HALO = "94,234,212";
+const TRACE = "245,217,10";
+
+function rgba(rgb: string, a: number): string {
+  return `rgba(${rgb},${a})`;
+}
+function hexToRgba(hex: string, a: number): string {
+  const h = hex.replace("#", "");
+  const full = h.length === 3 ? h.split("").map((c) => c + c).join("") : h;
+  const n = parseInt(full, 16);
+  return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
+}
+function nodeRadius(deg: number): number {
+  return 2 + Math.min(deg, 8) * 0.45; // graph units, bounded (no giant bubbles)
+}
+
 export function GraphCanvas({
   data,
   onNodeClick,
   onLinkClick,
   highlightNodeIds,
+  intensity = 0,
 }: {
   data: GraphCanvasData;
   onNodeClick?: (node: GraphNode) => void;
   onLinkClick?: (link: GraphLink) => void;
   highlightNodeIds?: Set<string>;
+  /** 0..1 knowledge density → subtly brightens the verified lattice. */
+  intensity?: number;
 }) {
   const hasHighlight = !!highlightNodeIds && highlightNodeIds.size > 0;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const endId = (v: any): string => (typeof v === "string" ? v : v?.id);
   const traced = (l: GraphLink): boolean =>
     hasHighlight && highlightNodeIds!.has(endId(l.source)) && highlightNodeIds!.has(endId(l.target));
+  const lift = Math.min(Math.max(intensity, 0), 1);
+  // Skip the per-node glow gradient on very large graphs to protect mobile perf.
+  const heavy = data.nodes.length > 600;
 
   return (
     <ForceGraph2D
       graphData={data}
-      backgroundColor="#0b0f1a"
-      nodeAutoColorBy="type"
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      nodeVal={(n: any) => 1 + (n as GraphNode).degree}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      nodeLabel={(n: any) => `${(n as GraphNode).label} — ${(n as GraphNode).type}`}
+      backgroundColor="rgba(0,0,0,0)"
       nodeRelSize={4}
+      d3VelocityDecay={0.28}
+      cooldownTicks={120}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      nodeLabel={(n: any) => `${(n as GraphNode).label} · ${(n as GraphNode).type}`}
+      nodeCanvasObjectMode={() => "replace"}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      nodeCanvasObject={(node: any, ctx: CanvasRenderingContext2D, scale: number) => {
+        const n = node as GraphNode & { x: number; y: number };
+        const r = nodeRadius(n.degree ?? 0);
+        const isHi = hasHighlight && highlightNodeIds!.has(n.id);
+        const dim = hasHighlight && !isHi;
+        const base = nodeColor(n.type);
+        const alpha = dim ? 0.35 : 1;
+        // soft glow (depth cue)
+        if (!heavy) {
+          const g = ctx.createRadialGradient(n.x, n.y, 0, n.x, n.y, r * 2.6);
+          g.addColorStop(0, hexToRgba(base, (isHi ? 0.55 : 0.22) * alpha));
+          g.addColorStop(1, hexToRgba(base, 0));
+          ctx.fillStyle = g;
+          ctx.beginPath();
+          ctx.arc(n.x, n.y, r * 2.6, 0, 2 * Math.PI);
+          ctx.fill();
+        }
+        // core marker
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, r, 0, 2 * Math.PI);
+        ctx.fillStyle = hexToRgba(isHi ? "#f5d90a" : base, alpha);
+        ctx.fill();
+        // thin ring for depth
+        ctx.lineWidth = 0.6 / scale;
+        ctx.strokeStyle = `rgba(255,255,255,${0.18 * alpha})`;
+        ctx.stroke();
+        // selected / highlighted halo
+        if (isHi) {
+          ctx.beginPath();
+          ctx.arc(n.x, n.y, r + 2.5, 0, 2 * Math.PI);
+          ctx.strokeStyle = rgba(HALO, 0.85);
+          ctx.lineWidth = 1 / scale;
+          ctx.stroke();
+        }
+        // label only when zoomed in (text-fade), muted
+        if (scale > 1.6 && !dim) {
+          ctx.font = `${7 / scale}px ui-sans-serif, system-ui, sans-serif`;
+          ctx.fillStyle = "rgba(203,213,225,0.72)";
+          ctx.textAlign = "center";
+          ctx.fillText(n.label, n.x, n.y + r + 7 / scale);
+        }
+      }}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      nodePointerAreaPaint={(node: any, color: string, ctx: CanvasRenderingContext2D) => {
+        const n = node as GraphNode & { x: number; y: number };
+        ctx.fillStyle = color;
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, nodeRadius(n.degree ?? 0) + 2, 0, 2 * Math.PI);
+        ctx.fill();
+      }}
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       linkColor={(l: any) => {
         const link = l as GraphLink;
-        if (hasHighlight) return traced(link) ? "#f5d90a" : "#20242e";
-        return link.state === "proposed" ? "#6b7280" : "#3a4252";
+        if (hasHighlight) return traced(link) ? rgba(TRACE, 0.9) : "rgba(40,46,58,0.3)";
+        if (link.state === "proposed") return rgba(PROPOSED_LINK, 0.28);
+        return rgba(VERIFIED_LINK, 0.4 + 0.22 * lift); // verified lattice brightens with density
       }}
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       linkWidth={(l: any) => {
         const link = l as GraphLink;
         if (hasHighlight && traced(link)) return 2;
-        return link.state === "proposed" ? 0.5 : 1;
+        return link.state === "proposed" ? 0.5 : 1.1;
       }}
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      linkLineDash={(l: any) => ((l as GraphLink).state === "proposed" ? [3, 3] : null)}
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       onNodeClick={(n: any) => onNodeClick?.(n as GraphNode)}
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       onLinkClick={(l: any) => onLinkClick?.(l as GraphLink)}
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      linkLineDash={(l: any) => ((l as GraphLink).state === "proposed" ? [4, 3] : null)}
-      cooldownTicks={120}
-      {...(hasHighlight
-        ? {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            nodeColor: (n: any) =>
-              highlightNodeIds!.has((n as GraphNode).id) ? "#f5d90a" : "#2a2f3d",
-          }
-        : {})}
     />
   );
+}
+
+function nodeColor(type: string): string {
+  return TYPE_COLORS[type] ?? DEFAULT_NODE;
 }


### PR DESCRIPTION
@
## Design intent
Turn `/graph` from a flat, cartoonish node diagram into a calm **"knowledge globe"** — Obsidian-dark canvas, restrained matrix-green knowledge lattice, glowing globe-marker nodes, and an ambient glow that strengthens as verified knowledge grows. *Advanced through structure and restraint, not flashy sci-fi.* Core flow unchanged: MIRA proposes, human verifies, the graph explains.

## True 3D vs approximation — decision
**Spherical 2.5D approximation** (not true 3D). Rationale: the stack has only `react-force-graph-2d`; true 3D needs `react-force-graph-3d` + three.js (a heavyweight engine the brief says to avoid) and would **lose the native dashed-edge distinction** (a core requirement — dashed isnt supported on 3D lines), while looking like a tiny floating cluster on small tenants. The approximation delivers the globe feel via custom rendering + a density-scaled ambient sphere, at far lower risk and a small PR. **True 3D (`react-force-graph-3d`) is documented as a follow-up.**

## Node styling
- Custom canvas rendering replaces flat auto-colored circles: soft radial **glow** (depth cue), a thin light **ring**, degree-bounded **size variation** (no giant bubbles), and a green **selected/highlight halo**.
- **Muted, intentional palette** by type; **red is reserved for faults** only (fixes the "too loud, especially red" issue).
- Labels fade in only when zoomed (text-LOD); per-node glow auto-skips on >600-node graphs for mobile perf.

## Edge styling
- **Verified:** solid, cleaner, restrained **signal-green**, slightly thicker.
- **Proposed:** dashed, dimmer green-grey, still reviewable.
- Trace-highlight (Ask-MIRA reasoning) stays gold. Arrowheads not added (directionality not essential here).

## Knowledge-density visual feedback
- A centered ambient **"sphere" glow** behind the graph whose opacity scales with verified-edge density (`0.22 + 0.6·density`), plus the verified lattice brightening with density — so a more-connected, more-verified graph reads as a stronger glowing globe. Subtle "confidence field", not a laser show. Verified knowledge feels solid; proposed feels lighter.

## Canvas + mobile
- Deep near-black canvas with a subtle radial depth gradient (no cheap flat black). Graph canvas is transparent so the depth/glow layers show through.
- A subtle **legend** (desktop): solid = verified · dashed = proposed · green = connected knowledge.
- **Mobile:** inspector panels become full-width **bottom sheets** (no more awkward overlap with the top-left controls); HUD is width-capped + scrollable.

## Screenshots
Attempted via Playwright against a local dev server (logged in as the test account). The page shell + auth render correctly, but reliable visual capture was blocked by Next.js dev on-demand compile timeouts on the heavy `/graph` route + a local `basePath` mismatch (`/hub` vs stagings `""`). The change is verified by `npm run build` (✓ compiled), `tsc`, and `eslint`. Best viewed via a staging deploy or a local run with `NEXT_PUBLIC_BASE_PATH=""`.

## Confirmations
- ✅ **No backend relationship logic changed** — purely `GraphCanvas.tsx` + `graph/page.tsx` presentation.
- ✅ **No edges auto-verified**; the propose → human-confirm flow is untouched.
- ✅ **Production not touched** (no deploy/merge/prod). UNS confirmation gate unchanged.

## Deferred
True 3D (`react-force-graph-3d`) globe; community-cluster coloring; ambient slow drift; per-node performance tuning beyond the 600-node glow cutoff.

> Stacked on #1681. Base = `feat/graph-component-manual-proposals`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@