### PR TITLE
feat(connectors): generic connector framework + technician confirmation gate

### DIFF
--- a/docs/mira/connector-framework.md
+++ b/docs/mira/connector-framework.md
@@ -1,0 +1,210 @@
+# MIRA Connector Framework
+
+**Status:** Phase 3 — framework + mock connectors shipped (this PR)
+**Code:** `mira-connectors/`
+**Companion:** `docs/mira/technician-confirmation-gate.md` (Phase 6 — how imported data becomes graph truth)
+
+---
+
+## 1. Why this exists
+
+MIRA already integrates with external systems through purpose-built adapters:
+
+- **CMMS** — `mira-mcp/cmms/` (`CMMSAdapter` ABC + Atlas / MaintainX / Limble / Fiix).
+- **SCADA (Ignition)** — `mira-pipeline/ignition_chat.py`, `mira-relay/relay_server.py` tag streaming.
+- **Documents** — `mira-crawler/ingest/` (PDF → chunk → embed → dedup → store → kg_writer).
+- **MQTT / UNS** — `mira-bridge`, `mira-relay`.
+
+Each is excellent at its job, and each has a *different shape*. The connector framework
+is the **common contract** that lets MIRA onboard a new external system — a new CMMS, a
+historian (AVEVA PI), a customer's MQTT broker — without re-inventing import/normalize/
+validate/log/dry-run/read-only every time. It **extends** the existing adapters; it does
+not replace them. A real `MaintainXConnector` is a thin wrapper over the already-working
+`mira-mcp/cmms/maintainx.py`.
+
+The framework's north star: **turn any external system into MIRA's canonical model, then
+route every proposed mapping through the technician confirmation gate** so a human
+confirms before the knowledge graph changes (TOO Invariant #4; `.claude/rules/
+uns-confirmation-gate.md`).
+
+---
+
+## 2. The ten capabilities
+
+Every connector satisfies this contract (`mira_connectors/base.py`):
+
+| # | Capability | Where |
+|---|---|---|
+| 1 | **Discover** schema / capabilities | `discover() -> ConnectorCapabilities` |
+| 2 | **Import** raw records | `import_records(record_type, since=, limit=) -> list[RawRecord]` |
+| 3 | **Normalize** into MIRA canonical model | `normalize(raw) -> list[CanonicalRecord]` |
+| 4 | **Validate** mappings | `validate_mappings(records) -> ValidationResult` |
+| 5 | **Export** enriched records back | `export_records(enriched) -> ExportResult` |
+| 6 | **Auth / config** | `ConnectorConfig` + `configured` property |
+| 7 | **Log** sync results | `sync(...) -> (records, SyncResult)` |
+| 8 | **Dry-run** mode | `ConnectorConfig.dry_run` → writes become planned no-ops |
+| 9 | **Mock** mode | `is_mock` flag; fixture-backed mock connectors |
+| 10 | **Read-only default** | `ConnectorConfig.mode` defaults to `READ_ONLY` |
+
+`derive_relationships(records)` is an **optional 11th** capability: relationships are
+cross-record (asset→parent, tag→asset, asset→document) so they cannot come from per-type
+`normalize()`. The confirmation gate calls it to seed `relationship_proposals`.
+
+### Never-raise contract
+
+Mirroring the existing `CMMSAdapter`: remote/IO failures **never raise**. They degrade
+gracefully and surface in `SyncResult.errors` / `ExportResult.errors`. Only programming/
+config mistakes raise (`ConnectorError`). `sync()` catches everything and always returns a
+`SyncResult` you can log.
+
+---
+
+## 3. Class hierarchy
+
+```
+Connector (ABC)                         # the 10-capability contract
+└── BaseConnector                       # read-only/dry-run guards, validate, sync, derive
+    ├── CMMSConnector                   # CMMS/EAM — write-back allowed (to CMMS API, not plant)
+    │   └── MaximoMockConnector         # ← fixture-backed reference (mocks/maximo_mock.py)
+    ├── SCADAConnector                  # read-only BY CONSTRUCTION (plant-facing)
+    │   └── IgnitionMockConnector       # ← fixture-backed reference (mocks/ignition_mock.py)
+    ├── HistorianConnector              # read-only BY CONSTRUCTION (PI/OSIsoft/Canary) — NEW type
+    ├── DocumentConnector               # hands CanonicalDocument to mira-crawler ingest
+    └── MQTTConnector                   # read-only BY CONSTRUCTION (subscribe, never publish)
+```
+
+A connector is selected by provider name via `create_connector(provider, config)`
+(`mira_connectors/factory.py`) — the same registry pattern as
+`mira-mcp/cmms/factory.py:create_cmms_adapter`.
+
+---
+
+## 4. Canonical model
+
+`mira_connectors/canonical.py`. Each canonical record is provider-agnostic and maps onto
+MIRA's **existing** Postgres tables — the framework adds **no new tables**.
+
+| Canonical record | Target MIRA table(s) |
+|---|---|
+| `CanonicalAsset` | `kg_entities` / `installed_component_instances` / `cmms_equipment` |
+| `CanonicalLocation` | `kg_entities` (LOCATED_IN hierarchy) |
+| `CanonicalTag` | `tag_entities` (Hub 025) |
+| `CanonicalWorkOrder` | CMMS work-order store (Atlas `cmms_*`) |
+| `CanonicalPMTask` | `pm_schedules` |
+| `CanonicalFailureCode` | `fault_codes` |
+| `CanonicalMeter` | `live_signal_cache` / meter store |
+| `CanonicalPart` | parts / inventory store |
+| `CanonicalDocument` | `knowledge_entries` / documents |
+| `CanonicalRelationship` | `relationship_proposals` + `relationship_evidence` (Hub 018) |
+
+### UNS discipline
+
+`proposed_uns_path` is a **candidate only**. Connectors never mint a final UNS path — the
+authoritative builders live in `mira-crawler/ingest/uns.py` (`uns.slug()`,
+`manufacturer_path`, …) per `.claude/rules/uns-compliance.md`. The connector emits a
+candidate path (via `_uns.candidate_uns_path`, clearly marked candidate-only) plus the
+structured location components, and the confirmation gate canonicalizes before any write.
+
+### Controlled vocabularies stay in sync with the schema
+
+`RELATIONSHIP_TYPES` and `EVIDENCE_TYPES` in `canonical.py` are copied from the CHECK
+constraints in `mira-hub/db/migrations/018_relationship_proposals.sql`. If that migration's
+vocab changes, update `canonical.py` to match (there is a comment marker on both sides).
+
+---
+
+## 5. Export & the read-only doctrine
+
+Capability #10 (read-only default) is a *floor* for CMMS/Document connectors and a *hard
+wall* for plant-facing ones:
+
+- **CMMS / Document** — `export_records` is gated by `ConnectorConfig.mode`. In `READ_ONLY`
+  (default) it refuses; in `READ_WRITE` it writes back **to the CMMS API / document
+  metadata**, never to the plant. (Maximo mock write-back: only work orders are writable.)
+- **SCADA / Historian / MQTT** — read-only **by construction**. `export_records` refuses
+  regardless of `mode`, because **no customer-shipped MIRA surface writes to the plant**
+  (`.claude/rules/fieldbus-readonly.md`, ADR-0021, the Ignition-is-the-read-path rule).
+  Enrichment flows the *other* way: from the connector into MIRA's graph via the gate.
+  Trying to set `READ_WRITE` on a SCADA connector does not enable plant writes — the
+  override is intentional and tested (`tests/test_ignition_mock.py::test_export_refused_read_only`).
+
+Dry-run (`#8`) sits above all of this: when `dry_run=True`, even a writable connector
+returns `ExportResult(planned=N)` and performs no side effects.
+
+---
+
+## 6. Mock connectors (capability #9)
+
+Fixture-backed, no network, `is_mock = True`. They unblock every downstream phase without a
+live Maximo/Ignition and serve as the reference implementation of each type.
+
+### `MaximoMockConnector` — `mocks/maximo_mock.py` + `fixtures/maximo.json`
+
+Realistic IBM Maximo (MAS 8) data with **native field names**: `ASSETNUM`, `LOCATION`,
+`PARENT`, `MANUFACTURER`, `SERIALNUM`, `CUSTOM.MODELNUM` (Maximo has no native model field —
+modeled as a custom attribute, as real sites do); `WORKORDER` with `WONUM` / `WORKTYPE` /
+`STATUS` (WAPPR/APPR/INPRG/COMP/CLOSE) / `FAILUREREPORT` (FAILURECODE→PROBLEM→CAUSE→REMEDY);
+`PM` (PMNUM/FREQUENCY/FREQUNIT/JPNUM/NEXTDATE); `METER` (METERNAME/MEASUREUNITID/METERTYPE);
+`INVENTORY`/`SPAREPART`; `FAILURELIST` hierarchy; `DOCLINKS`. Models the **Bedford** plant
+(Line 16 conveyor, DuraPulse GS10 VFD, 1HP motor, PE photo-eye) so the demo flywheel lines
+up with MIRA's Lake Wales bench.
+
+Derived relationships: `HAS_COMPONENT` (PARENT), `LOCATED_IN` (LOCATION), `HAS_DOCUMENT`
+(DOCLINKS), `OCCURS_ON` (failure code ↔ asset, evidence = the work order).
+
+### `IgnitionMockConnector` — `mocks/ignition_mock.py` + `fixtures/ignition.json`
+
+Realistic Ignition 8.1 tag export: provider `[default]`, `Lake_Wales/Bench/Conveyor/...`
+folder hierarchy, OPC tags bound to a Modbus device (`Mira_PLC`, register map mirroring
+`plc/MbSrvConf_v4.xml` — DC bus `HR400110`), with `dataType` (Float8/Int4/Boolean),
+`opcItemPath`, `engUnit`, `deadband`, `historyEnabled`, and alarms. Flattens the tree into
+`CanonicalTag` rows; derives `HAS_SIGNAL` (asset folder → tags) and `LOCATED_IN` (folder
+hierarchy). Read-only — `export_records` refuses.
+
+---
+
+## 7. Adding a real connector
+
+1. Subclass the right type base (`CMMSConnector`, `SCADAConnector`, …).
+2. Implement `configured`, `health_check`, `discover`, `import_records`, `normalize`.
+   Keep `normalize`/`derive_relationships` identical to the mock where possible — only the
+   IO layer (`import_records`) changes.
+3. For CMMS/Document write-back, override `_do_export` (NOT `export_records` — the base
+   guards mode/dry-run for you). Plant-facing types must not override the refusal.
+4. Pull secrets from Doppler-managed env vars in `__init__` (never store plaintext in
+   `ConnectorConfig`). Set `configured` from their presence — same as `CMMSAdapter`.
+5. Register it in `factory._REGISTRY`.
+6. Add a fixture-backed test mirroring `tests/test_maximo_mock.py`.
+
+---
+
+## 8. Testing
+
+`mira-connectors/tests/` — 37 tests, offline (in-memory, no DB, no network):
+
+- `test_canonical.py` — relationship/evidence validation (self-loop with kind-awareness,
+  unknown type, missing evidence, confidence bounds).
+- `test_base_connector.py` — read-only refusal, dry-run planning, READ_WRITE export,
+  SCADA refusal even in READ_WRITE, `sync()` structured result, validation errors/warnings.
+- `test_maximo_mock.py` / `test_ignition_mock.py` — full import→normalize→derive→export
+  lifecycle per connector.
+- `test_factory.py` — provider registry.
+
+Run: `cd mira-connectors && pytest` (asyncio auto-mode from `pyproject.toml`).
+
+---
+
+## 9. Relationship to the master plan
+
+This framework is a **parallel workstream** to the 14-phase master plan
+(`docs/plans/2026-06-01-mira-master-architecture-plan.md`). It does not touch `engine.py`,
+the shared modules, or any governed migration — it is a new top-level package. Where it
+overlaps:
+
+- The confirmation gate (Phase 6 of *this* brief) reuses `ai_suggestions` /
+  `relationship_proposals` and is designed to **delegate to ADR-0017's
+  `proposal_transition.py` once that helper lands** (master-plan Phase 3 / Agent 4). Until
+  then the gate keeps its transition logic connector-local. See the gate doc.
+- A future `IgnitionConnector` complements (does not replace) `mira-relay`'s live tag
+  stream: the connector imports the *tag catalog / definitions*; the relay carries *live
+  values + events* (master-plan Phases 4–5).

--- a/docs/mira/technician-confirmation-gate.md
+++ b/docs/mira/technician-confirmation-gate.md
@@ -1,0 +1,170 @@
+# Technician Confirmation Gate (connector context)
+
+**Status:** Phase 6 — connector-originated confirmation gate shipped (this PR)
+**Code:** `mira-connectors/mira_connectors/confirmation_gate.py`, `store.py`, `service.py`
+**Companion:** `docs/mira/connector-framework.md` (Phase 3 — how external data becomes canonical records)
+
+---
+
+## 1. What already exists (don't reinvent)
+
+MIRA already has the *confirmation* discipline in three places. This phase extends them to
+**connector-originated data**; it does not replace them.
+
+| Existing piece | Where | What it does |
+|---|---|---|
+| **UNS Location-Confirmation Gate** | `mira-bots/shared/engine.py` (`_should_fire_uns_gate`) | A technician's *chat* turn must confirm site/area/line/asset before troubleshooting (TOO Invariant #7; `.claude/rules/uns-confirmation-gate.md`). |
+| **`ai_suggestions`** | Hub mig 027 | The broad `/proposals` work queue. Six `suggestion_type`s incl. `kg_edge` + `kg_entity`. Already has `proposed_by='import:<format>'` and a `pending→accepted/rejected/deferred/superseded` lifecycle. |
+| **`relationship_proposals` + `relationship_evidence`** | Hub mig 018 | Edge proposals with `created_by='import'`, confidence, status, and 1..N evidence rows (incl. `evidence_type` `work_order`/`tag_list`/`manifest`/`oem_kb`/`human_observation`). |
+| **`/api/proposals/[id]/decide`** | `mira-hub/src/app/api/proposals/[id]/decide/route.ts` | The Hub "verify/reject" action: on verify it sets `relationship_proposals.status='verified'` **and** upserts `kg_relationships` (dedupe on tenant+source+target+type). |
+| **ADR-0017** | `docs/adr/0017-*.md` | The canonical status mapping across the three tables. |
+
+**The key discovery:** the schema was *built* to accept imported, human-confirmed data
+(`created_by='import'`, `evidence_type='work_order'|'tag_list'|...`, `proposed_by='import:…'`).
+The connector gate uses these tables directly. **No new tables.**
+
+---
+
+## 2. The connector confirmation workflow
+
+```
+1. A connector imports + normalizes external data         (Phase 3: connector framework)
+2. MIRA proposes asset / component / location / tag        →  ai_suggestions (kg_entity, pending)
+   + relationship mappings                                 →  relationship_proposals (proposed)
+                                                               + relationship_evidence
+                                                               + ai_suggestions (kg_edge, pending)
+3. Each proposal shows its SOURCE EVIDENCE                  →  the CMMS asset id, the SCADA tag
+                                                               path, the manual page, the prior WO
+4. A technician CONFIRMS, CORRECTS, or REJECTS             →  gate.confirm / correct / reject
+5. Confirmed mappings are written to the graph             →  kg_entities / kg_relationships (verified)
+6. Troubleshooting can begin                               →  the engine now reads verified context
+```
+
+Nothing reaches `kg_entities` / `kg_relationships` until step 4. This is TOO Invariant #4
+("promotion to `verified` is a human action") applied to connector imports, and Invariant
+#7 ("confirmation over guessing") applied to *where things are* in the namespace.
+
+---
+
+## 3. Status mapping (ADR-0017 — enforced by the gate)
+
+| Action | `ai_suggestions` | `relationship_proposals` | `kg_*` |
+|---|---|---|---|
+| Connector proposes | `pending` | `proposed` (`created_by='import'`) | — |
+| Technician **confirms** | `accepted` | `verified` | write/upsert `kg_entities` or `kg_relationships` (`approval_state='verified'`) |
+| Technician **corrects** | `superseded` | `deprecated` | (a *new* proposal → `verified`) |
+| Technician **rejects** | `rejected` | `rejected` | (no write) |
+
+On confirm of an edge the gate mirrors the Hub decide route exactly: proposal → `verified`,
+then UPSERT `kg_relationships` deduped on `(tenant, source, target, type)`.
+
+> **ADR-0017 helpers.** `mira_bots/shared/proposal_transition.py` and
+> `mira-hub/lib/proposal-transition.ts` are specified by ADR-0017 but **do not exist yet**
+> (master-plan Phase 3 / Agent 4 owns them). Until they land, the gate's transition logic
+> is connector-local. When they land, `PostgresProposalStore` should delegate its status
+> writes to the Python helper — this is the single intended integration point.
+
+---
+
+## 4. The five requirements, and how they're met
+
+| Requirement | How |
+|---|---|
+| **Store who confirmed, when, evidence used** | `ai_suggestions.reviewed_by` (`human:<id>`) + `reviewed_at` + `review_note`; `relationship_proposals.reviewed_by`/`reviewed_at`; a `relationship_evidence` row of type `human_observation` records the confirmation itself. |
+| **Confidence before AND after** | The connector's original confidence is preserved in `ai_suggestions.extracted_data.confidence_prior` and on `relationship_proposals.confidence` — **never overwritten**. The "after" signal is the technician's `human_observation` evidence row (`confidence_contribution = +0.4`), the schema-native way to record that a human raised confidence. |
+| **Allow corrections** | `gate.correct(suggestion_id, corrections={...})` — supersedes the original, deprecates its proposal, creates a new human-authored proposal with the corrections applied, and confirms it. |
+| **Preserve conflicting mappings for review** | Corrections **supersede** (don't delete) the original. When two systems propose different UNS paths for the same physical device (same `conflict_key`, e.g. serial), both are kept `pending` and tagged with a shared `conflict_group` — surfaced for a human to resolve, never auto-rejected. |
+| **Use existing tables** | `ai_suggestions`, `relationship_proposals`, `relationship_evidence`, `kg_entities`, `kg_relationships`. No new tables, no new migration. |
+
+---
+
+## 5. API / service surface
+
+`ConnectorConfirmationGate` (`confirmation_gate.py`) is the service function. An HTTP route
+(FastAPI / Hub API) is a thin async wrapper; the methods map 1:1 onto route handlers:
+
+```python
+gate = ConnectorConfirmationGate(store)             # store: ProposalStore (Postgres or in-memory)
+
+# Propose (read-only — nothing hits the graph)
+result = gate.propose(tenant_id=..., provider="maximo", entities=[...], relationships=[...])
+#   → ProposeResult(entity_suggestion_ids, edge_suggestion_ids, conflict_groups)
+
+# Technician actions
+gate.confirm(tenant_id, suggestion_id, reviewed_by="user_42", note="confirmed on the floor")
+gate.correct(tenant_id, suggestion_id, reviewed_by="user_42", corrections={"target_ref": "TB2-15"})
+gate.reject(tenant_id,  suggestion_id, reviewed_by="user_42", note="not real")
+
+# Queue
+gate.pending(tenant_id, suggestion_type="kg_edge")
+```
+
+One-call wiring of a connector to the gate (`service.py`):
+
+```python
+from mira_connectors import create_connector, ConnectorConfirmationGate, import_and_propose
+from mira_connectors.store import PostgresProposalStore
+
+conn = create_connector("maximo", ConnectorConfig(tenant_id=tid))
+gate = ConnectorConfirmationGate(PostgresProposalStore())
+res  = await import_and_propose(conn, gate, record_types=[RecordType.ASSET, RecordType.DOCUMENT])
+#   imports → normalizes → derives edges → proposes everything as pending. Confirms nothing.
+```
+
+### Suggested HTTP route shape (when wired into mira-mcp / Hub)
+
+```
+POST /api/connectors/{provider}/import        → import_and_propose  → {sync_results, propose}
+POST /api/proposals/{suggestion_id}/confirm   → gate.confirm        → {ok, kg_relationship_id}
+POST /api/proposals/{suggestion_id}/correct   → gate.correct        → {ok, new_suggestion_id}
+POST /api/proposals/{suggestion_id}/reject    → gate.reject         → {ok}
+GET  /api/proposals?status=pending&type=kg_edge → gate.pending
+```
+
+Tenant id comes from the authenticated session, never from a caller argument (same rule as
+the existing MCP tools and the Hub routes).
+
+---
+
+## 6. Persistence (`store.py`)
+
+`ProposalStore` is a Protocol with two implementations:
+
+- **`InMemoryProposalStore`** — deterministic, dependency-free. Backs the tests and any
+  offline/dev run ("offline mode is the floor").
+- **`PostgresProposalStore`** — SQLAlchemy + `NullPool` + `sslmode=require`, mirroring
+  `mira-bots/shared/neon_recall.py`. Every write runs inside a transaction with the RLS
+  tenant GUC set (`SET app.current_tenant_id`), exactly as the Hub `withTenantContext` does.
+  The `kg_relationships` upsert mirrors the decide route's dedupe logic.
+
+---
+
+## 7. Tests
+
+`mira-connectors/tests/test_confirmation_gate.py` + `test_service.py` (offline, in-memory):
+
+- propose → pending `kg_entity` / `kg_edge` suggestions; `confidence_prior` preserved.
+- confirm entity → `kg_entities` verified + entity becomes resolvable by natural key.
+- confirm edge → proposal `verified`, `kg_relationships` upserted, `human_observation`
+  evidence row written, dedupe on repeat confirm.
+- unresolved-at-propose edge → `endpoints_unresolved` until entities confirmed, then resolves.
+- correct → original `superseded` + proposal `deprecated`, corrected edge confirmed at the
+  new target; original preserved.
+- reject → `rejected`, no graph write.
+- conflicting mappings (same serial, different UNS path) → both preserved, `conflict_group` set.
+- guards: not-found, wrong-state, tenant isolation.
+- end-to-end: `MaximoMockConnector` import → propose → confirm entities → confirm edges →
+  verified `kg_relationships` in the graph.
+
+---
+
+## 8. What this phase deliberately does NOT do
+
+- **No engine edits.** The chat-side UNS gate in `engine.py` is untouched. This gate governs
+  *connector-imported* mappings, a different entry point.
+- **No `proposal_transition.py`.** That helper is master-plan Phase 3 / Agent 4's file
+  (ADR-0017). The gate is designed to delegate to it once it exists.
+- **No auto-verify.** Every connector-originated edge enters as `proposed` and requires a
+  human action to reach `verified` (Invariant #4).
+- **No plant writes.** Confirmation enriches MIRA's graph; it never writes back to a PLC,
+  SCADA, or historian (`.claude/rules/fieldbus-readonly.md`, ADR-0021).

--- a/docs/mira/technician-confirmation-gate.md
+++ b/docs/mira/technician-confirmation-gate.md
@@ -135,7 +135,15 @@ the existing MCP tools and the Hub routes).
 - **`PostgresProposalStore`** — SQLAlchemy + `NullPool` + `sslmode=require`, mirroring
   `mira-bots/shared/neon_recall.py`. Every write runs inside a transaction with the RLS
   tenant GUC set (`SET app.current_tenant_id`), exactly as the Hub `withTenantContext` does.
-  The `kg_relationships` upsert mirrors the decide route's dedupe logic.
+  The `kg_relationships` upsert mirrors the decide route's dedupe logic; `create_entity`
+  upserts on the `kg_entities` natural key `(tenant_id, entity_type, name)` (mig 025/026).
+
+  > **Not executed by the test suite.** The 53 offline tests run entirely on
+  > `InMemoryProposalStore`. `PostgresProposalStore`'s SQL was **schema-verified against the
+  > live migrations** (ai_suggestions 027, relationship_proposals/evidence 018, kg_entities
+  > 001/010/024/025/029, kg_relationships per the decide route) but never run against a real
+  > DB here. Exercise it on staging NeonDB before production use — that is the natural
+  > follow-up when this gate is wired into an HTTP route.
 
 ---
 

--- a/mira-connectors/README.md
+++ b/mira-connectors/README.md
@@ -1,0 +1,35 @@
+# mira-connectors
+
+Generic connector framework for MIRA. Turns external systems (CMMS/EAM, SCADA, Historian,
+document stores, MQTT/UNS) into MIRA's canonical model, then routes proposed asset /
+component / location / relationship mappings through a **technician confirmation gate** so a
+human confirms before the knowledge graph changes.
+
+It **extends** the existing integrations (`mira-mcp/cmms/`, Ignition, `mira-crawler`,
+`mira-relay`) — it does not replace them.
+
+## Layout
+
+```
+mira_connectors/
+├── canonical.py          # MIRA canonical record model (maps to existing tables)
+├── base.py               # Connector ABC + BaseConnector (the 10 capabilities)
+├── factory.py            # create_connector(provider, config)
+├── types/                # CMMS / SCADA / Historian / Document / MQTT type bases
+├── mocks/                # MaximoMockConnector + IgnitionMockConnector + fixtures
+├── store.py              # ProposalStore (InMemory + Postgres) — existing tables only
+├── confirmation_gate.py  # ConnectorConfirmationGate — propose/confirm/correct/reject (ADR-0017)
+└── service.py            # import_and_propose(connector, gate, ...) — one-call wiring
+```
+
+## Docs
+
+- `docs/mira/connector-framework.md` — the connector contract, types, read-only doctrine, mocks.
+- `docs/mira/technician-confirmation-gate.md` — the confirmation gate, status mapping, API surface.
+
+## Test
+
+```bash
+cd mira-connectors && pytest        # 53 offline tests, no DB / network
+ruff check mira_connectors tests
+```

--- a/mira-connectors/mira_connectors/__init__.py
+++ b/mira-connectors/mira_connectors/__init__.py
@@ -40,9 +40,32 @@ from mira_connectors.canonical import (
     RawRecord,
     RecordType,
 )
+from mira_connectors.confirmation_gate import (
+    ConfirmResult,
+    ConnectorConfirmationGate,
+    CorrectResult,
+    ProposeResult,
+    RejectResult,
+)
 from mira_connectors.factory import available_providers, create_connector
+from mira_connectors.service import ImportProposeResult, import_and_propose
+from mira_connectors.store import (
+    InMemoryProposalStore,
+    PostgresProposalStore,
+    ProposalStore,
+)
 
 __all__ = [
+    "ConnectorConfirmationGate",
+    "ImportProposeResult",
+    "import_and_propose",
+    "ConfirmResult",
+    "CorrectResult",
+    "ProposeResult",
+    "RejectResult",
+    "InMemoryProposalStore",
+    "PostgresProposalStore",
+    "ProposalStore",
     "BaseConnector",
     "Connector",
     "ConnectorCapabilities",

--- a/mira-connectors/mira_connectors/__init__.py
+++ b/mira-connectors/mira_connectors/__init__.py
@@ -1,0 +1,73 @@
+"""mira-connectors — generic connector framework for MIRA.
+
+A connector turns an external system (CMMS/EAM, SCADA, Historian, document store,
+MQTT/UNS broker) into MIRA's canonical model, then routes proposed asset/component/
+location/relationship mappings through the technician confirmation gate so a human
+confirms before the knowledge graph changes.
+
+Design + rules: ``docs/mira/connector-framework.md`` and
+``docs/mira/technician-confirmation-gate.md``.
+"""
+
+from __future__ import annotations
+
+from mira_connectors.base import (
+    BaseConnector,
+    Connector,
+    ConnectorCapabilities,
+    ConnectorConfig,
+    ConnectorError,
+    ConnectorKind,
+    ConnectorMode,
+    ExportResult,
+    SyncResult,
+    ValidationIssue,
+    ValidationResult,
+)
+from mira_connectors.canonical import (
+    CanonicalAsset,
+    CanonicalDocument,
+    CanonicalFailureCode,
+    CanonicalLocation,
+    CanonicalMeter,
+    CanonicalPart,
+    CanonicalPMTask,
+    CanonicalRecord,
+    CanonicalRelationship,
+    CanonicalTag,
+    CanonicalWorkOrder,
+    EvidenceRef,
+    RawRecord,
+    RecordType,
+)
+from mira_connectors.factory import available_providers, create_connector
+
+__all__ = [
+    "BaseConnector",
+    "Connector",
+    "ConnectorCapabilities",
+    "ConnectorConfig",
+    "ConnectorError",
+    "ConnectorKind",
+    "ConnectorMode",
+    "ExportResult",
+    "SyncResult",
+    "ValidationIssue",
+    "ValidationResult",
+    "CanonicalAsset",
+    "CanonicalDocument",
+    "CanonicalFailureCode",
+    "CanonicalLocation",
+    "CanonicalMeter",
+    "CanonicalPart",
+    "CanonicalPMTask",
+    "CanonicalRecord",
+    "CanonicalRelationship",
+    "CanonicalTag",
+    "CanonicalWorkOrder",
+    "EvidenceRef",
+    "RawRecord",
+    "RecordType",
+    "available_providers",
+    "create_connector",
+]

--- a/mira-connectors/mira_connectors/_uns.py
+++ b/mira-connectors/mira_connectors/_uns.py
@@ -1,0 +1,32 @@
+"""Candidate-only UNS path helpers for connectors.
+
+IMPORTANT — these produce *candidate* paths, not canonical ones. Per
+``.claude/rules/uns-compliance.md`` the authoritative ``enterprise.*`` path builders
+live in ``mira-crawler/ingest/uns.py`` (``manufacturer_path``, ``model_path``, …) and
+``uns.slug()``. A connector is upstream of NeonDB and of that module; it proposes a
+candidate path and stashes the structured components so the confirmation gate can
+rebuild the canonical path with the real builders before anything is written.
+
+Do NOT use these helpers to write a final UNS path into ``kg_entities``.
+"""
+
+from __future__ import annotations
+
+import re
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+
+
+def candidate_slug(value: str) -> str:
+    """Lowercase, collapse runs of non-alphanumerics to ``_``. Candidate use only.
+
+    Mirrors the intent of ``uns.slug()`` so candidate paths look right in review UIs,
+    but the gate re-slugs via the canonical builder before persistence.
+    """
+    return _NON_ALNUM.sub("_", value.strip().lower()).strip("_")
+
+
+def candidate_uns_path(*segments: str) -> str:
+    """Join slugged segments under ``enterprise.`` as a candidate path."""
+    slugs = [candidate_slug(s) for s in segments if s]
+    return ".".join(["enterprise", *slugs])

--- a/mira-connectors/mira_connectors/base.py
+++ b/mira-connectors/mira_connectors/base.py
@@ -1,0 +1,346 @@
+"""Generic connector framework — the base interface every MIRA connector implements.
+
+This generalizes the existing ``mira-mcp/cmms/base.py:CMMSAdapter`` pattern (a
+narrow CMMS-only interface: ``configured`` / ``health_check`` / ``list_*`` /
+``create_*``, never-raise-on-remote-error) into a connector contract that any
+external system can satisfy — CMMS/EAM, SCADA, Historian, Document store, MQTT/UNS.
+
+The ten capabilities (from the Phase 3 brief):
+
+1.  ``discover()``          — schema / capabilities of the source
+2.  ``import_records()``    — pull raw vendor records
+3.  ``normalize()``         — vendor record → MIRA canonical model
+4.  ``validate_mappings()`` — check normalized records before they touch the gate
+5.  ``export_records()``    — write enriched records back (gated; read-only by default)
+6.  auth / config           — ``ConnectorConfig`` + ``configured`` property
+7.  ``log_sync()``          — structured ``SyncResult`` per run
+8.  dry-run mode            — ``config.dry_run`` makes every write a planned no-op
+9.  mock mode               — ``is_mock`` / ``MockConnector`` read fixtures, no network
+10. read-only default       — ``config.mode`` defaults to READ_ONLY; export refuses to
+                              write unless the operator opts into READ_WRITE
+
+Doctrine: SCADA and Historian connectors are read-only **by construction** — MIRA
+does not write to the plant (``.claude/rules/fieldbus-readonly.md``, the
+Ignition-is-read-path rule, ADR-0021). Their ``export_records`` refuses plant writes
+regardless of ``mode``. See ``docs/mira/connector-framework.md`` §"Export & the
+read-only doctrine".
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+from mira_connectors.canonical import (
+    CanonicalRecord,
+    CanonicalRelationship,
+    RawRecord,
+    RecordType,
+)
+
+logger = logging.getLogger("mira-connectors")
+
+
+class ConnectorKind(str, Enum):
+    CMMS = "cmms"          # CMMS / EAM (Maximo, MaintainX, Limble, Fiix, Atlas)
+    SCADA = "scada"        # Ignition, other SCADA
+    HISTORIAN = "historian"  # AVEVA PI / OSIsoft, Canary, InfluxDB-as-historian
+    DOCUMENT = "document"  # manual / drawing / datasheet stores
+    MQTT = "mqtt"          # MQTT / Sparkplug B / UNS broker
+
+
+class ConnectorMode(str, Enum):
+    """Read-only is the default and the safe floor."""
+
+    READ_ONLY = "read_only"
+    READ_WRITE = "read_write"
+
+
+@dataclass(slots=True)
+class ConnectorConfig:
+    """Auth + behavior config for a connector instance (capability #6, #8, #10).
+
+    Secrets are never stored here in plaintext for production connectors — they are
+    pulled from Doppler-managed env vars by the concrete connector. ``settings`` is a
+    free-form bag for endpoints, providers, and non-secret options.
+    """
+
+    tenant_id: str
+    mode: ConnectorMode = ConnectorMode.READ_ONLY  # #10: read-only default
+    dry_run: bool = False  # #8: planned writes only, no side effects
+    settings: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def writable(self) -> bool:
+        return self.mode is ConnectorMode.READ_WRITE and not self.dry_run
+
+
+@dataclass(slots=True)
+class ConnectorCapabilities:
+    """What a source can do — returned by ``discover()`` (capability #1)."""
+
+    kind: ConnectorKind
+    provider: str
+    record_types: list[RecordType]  # which RecordTypes this source exposes
+    supports_export: bool = False  # can enriched data be written back?
+    supports_incremental: bool = False  # can import filter by ``since``?
+    schema: dict[str, Any] = field(default_factory=dict)  # field/tag-tree shape
+    notes: str = ""
+
+
+@dataclass(slots=True)
+class ValidationIssue:
+    record_id: str
+    severity: str  # "error" | "warning"
+    message: str
+
+
+@dataclass(slots=True)
+class ValidationResult:
+    """Outcome of ``validate_mappings()`` (capability #4)."""
+
+    issues: list[ValidationIssue] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not any(i.severity == "error" for i in self.issues)
+
+    @property
+    def errors(self) -> list[ValidationIssue]:
+        return [i for i in self.issues if i.severity == "error"]
+
+    @property
+    def warnings(self) -> list[ValidationIssue]:
+        return [i for i in self.issues if i.severity == "warning"]
+
+
+@dataclass(slots=True)
+class ExportResult:
+    """Outcome of ``export_records()`` (capability #5)."""
+
+    exported: int = 0
+    planned: int = 0  # dry-run: records that *would* have been written
+    refused: int = 0  # read-only / doctrine: records the connector declined to write
+    errors: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class SyncResult:
+    """Structured log of one sync run (capability #7).
+
+    A sync = discover → import → normalize → validate (+ optional export). The result
+    is the durable record of what happened, suitable for an ``ingest_status`` row or a
+    log line. Never contains secrets.
+    """
+
+    connector: str
+    tenant_id: str
+    record_type: Optional[RecordType] = None
+    imported: int = 0
+    normalized: int = 0
+    validation_errors: int = 0
+    validation_warnings: int = 0
+    exported: int = 0
+    dry_run: bool = False
+    mock: bool = False
+    started_at: float = 0.0
+    duration_ms: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors and self.validation_errors == 0
+
+    def as_dict(self) -> dict[str, Any]:
+        d = {
+            "connector": self.connector,
+            "tenant_id": self.tenant_id,
+            "record_type": self.record_type.value if self.record_type else None,
+            "imported": self.imported,
+            "normalized": self.normalized,
+            "validation_errors": self.validation_errors,
+            "validation_warnings": self.validation_warnings,
+            "exported": self.exported,
+            "dry_run": self.dry_run,
+            "mock": self.mock,
+            "duration_ms": self.duration_ms,
+            "ok": self.ok,
+            "errors": self.errors,
+        }
+        return d
+
+
+class ConnectorError(Exception):
+    """Raised only for programming / config errors (bad mode, unknown record type).
+
+    Remote/IO failures do NOT raise — they degrade gracefully and surface in the
+    ``SyncResult.errors`` / ``ExportResult.errors`` list, matching the never-raise
+    contract of the existing ``CMMSAdapter``.
+    """
+
+
+class Connector(ABC):
+    """Abstract base — the contract a connector must satisfy.
+
+    Concrete connectors should subclass a *type* base (``CMMSConnector``,
+    ``SCADAConnector``, …) which fixes ``kind`` and adds domain helpers, then a
+    *provider* class (``MaximoMockConnector``) which implements the abstract methods.
+    """
+
+    kind: ConnectorKind
+    provider: str
+    is_mock: bool = False  # #9: True for fixture-backed mock connectors
+
+    def __init__(self, config: ConnectorConfig) -> None:
+        self.config = config
+
+    # --- capability #6: auth / config ---------------------------------------
+    @property
+    @abstractmethod
+    def configured(self) -> bool:
+        """True when all required credentials/config are present."""
+
+    @abstractmethod
+    async def health_check(self) -> dict[str, Any]:
+        """Cheap liveness probe. Returns ``{"ok": bool, ...}``; never raises."""
+
+    # --- capability #1: discover ---------------------------------------------
+    @abstractmethod
+    async def discover(self) -> ConnectorCapabilities:
+        """Return the source's schema / tag tree / capabilities."""
+
+    # --- capability #2: import -----------------------------------------------
+    @abstractmethod
+    async def import_records(
+        self,
+        record_type: RecordType,
+        *,
+        since: Optional[str] = None,
+        limit: int = 500,
+    ) -> list[RawRecord]:
+        """Pull raw vendor records of ``record_type``."""
+
+    # --- capability #3: normalize --------------------------------------------
+    @abstractmethod
+    def normalize(self, raw: list[RawRecord]) -> list[CanonicalRecord]:
+        """Map raw vendor records to MIRA canonical records. Pure; no IO."""
+
+    # --- capability #5: export -----------------------------------------------
+    @abstractmethod
+    async def export_records(self, enriched: list[CanonicalRecord]) -> ExportResult:
+        """Write enriched records back to the source (if supported & writable)."""
+
+
+class BaseConnector(Connector):
+    """Shared machinery: read-only/dry-run guards, validation, sync orchestration.
+
+    Subclasses implement ``configured``, ``discover``, ``import_records``,
+    ``normalize``, and ``_do_export`` (the actual write). This class provides
+    ``validate_mappings`` (#4), ``export_records`` (#5 guards), and ``sync`` (#7).
+    """
+
+    # --- capability #4: validate ---------------------------------------------
+    def validate_mappings(self, records: list[CanonicalRecord]) -> ValidationResult:
+        result = ValidationResult()
+        for rec in records:
+            # CanonicalRelationship.validate() is a superset of base_validate()
+            # (it also checks the controlled vocab + evidence), so prefer it.
+            if isinstance(rec, CanonicalRelationship):
+                errs = rec.validate()
+            else:
+                errs = rec.base_validate()
+            for msg in errs:
+                result.issues.append(
+                    ValidationIssue(record_id=rec.source_record_id, severity="error", message=msg)
+                )
+            # A connector that proposes no UNS path for a locatable record is a
+            # warning, not an error — the gate can still resolve it from hints.
+            if rec.record_type in (RecordType.ASSET, RecordType.TAG) and not rec.proposed_uns_path:
+                result.issues.append(
+                    ValidationIssue(
+                        record_id=rec.source_record_id,
+                        severity="warning",
+                        message="no proposed_uns_path — gate must resolve location",
+                    )
+                )
+        return result
+
+    def derive_relationships(self, records: list[CanonicalRecord]) -> list[CanonicalRelationship]:
+        """Derive proposed edges across a normalized record set.
+
+        Optional capability — relationships are cross-record (asset→parent,
+        tag→asset, asset→document) so they can't be produced by per-type
+        ``normalize()``. The confirmation gate calls this to seed
+        ``relationship_proposals``. Default: none.
+        """
+        return []
+
+    # --- capability #5: export with #8 (dry-run) + #10 (read-only) guards ----
+    async def export_records(self, enriched: list[CanonicalRecord]) -> ExportResult:
+        if self.config.dry_run:
+            logger.info("[%s] dry-run: %d records would be exported", self.provider, len(enriched))
+            return ExportResult(planned=len(enriched))
+        if self.config.mode is not ConnectorMode.READ_WRITE:
+            logger.info(
+                "[%s] read-only mode: refusing to export %d records", self.provider, len(enriched)
+            )
+            return ExportResult(refused=len(enriched))
+        return await self._do_export(enriched)
+
+    async def _do_export(self, enriched: list[CanonicalRecord]) -> ExportResult:
+        """Actual write. Override in connectors that support write-back.
+
+        Default refuses — most connectors (and all plant-facing ones) are read-only.
+        """
+        return ExportResult(refused=len(enriched), errors=["export not supported by this connector"])
+
+    # --- capability #7: a full sync run with a structured log ----------------
+    async def sync(
+        self,
+        record_type: RecordType,
+        *,
+        since: Optional[str] = None,
+        limit: int = 500,
+        export: bool = False,
+    ) -> tuple[list[CanonicalRecord], SyncResult]:
+        """Run import → normalize → validate (+ optional export) and log the result."""
+        started = time.monotonic()
+        result = SyncResult(
+            connector=self.provider,
+            tenant_id=self.config.tenant_id,
+            record_type=record_type,
+            dry_run=self.config.dry_run,
+            mock=self.is_mock,
+        )
+        canonical: list[CanonicalRecord] = []
+        try:
+            if not self.configured:
+                result.errors.append("connector not configured")
+                return canonical, self._finish(result, started)
+            raw = await self.import_records(record_type, since=since, limit=limit)
+            result.imported = len(raw)
+            canonical = self.normalize(raw)
+            result.normalized = len(canonical)
+            validation = self.validate_mappings(canonical)
+            result.validation_errors = len(validation.errors)
+            result.validation_warnings = len(validation.warnings)
+            if export and canonical:
+                export_result = await self.export_records(canonical)
+                result.exported = export_result.exported
+                result.errors.extend(export_result.errors)
+        except ConnectorError as exc:  # programming/config error — surface, don't crash
+            result.errors.append(f"connector_error: {exc}")
+        except Exception as exc:  # noqa: BLE001 — IO failures degrade gracefully
+            logger.exception("[%s] sync failed", self.provider)
+            result.errors.append(f"{type(exc).__name__}: {exc}")
+        return canonical, self._finish(result, started)
+
+    @staticmethod
+    def _finish(result: SyncResult, started: float) -> SyncResult:
+        result.duration_ms = int((time.monotonic() - started) * 1000)
+        logger.info("sync %s", result.as_dict())
+        return result

--- a/mira-connectors/mira_connectors/canonical.py
+++ b/mira-connectors/mira_connectors/canonical.py
@@ -1,0 +1,292 @@
+"""MIRA canonical data model — the normalized shapes every connector maps into.
+
+A connector's job is to turn a vendor-specific record (a Maximo ``ASSETNUM`` row,
+an Ignition tag node, a PI point) into one of the canonical records below. The
+canonical record is provider-agnostic and maps onto MIRA's existing Postgres
+tables:
+
+| Canonical record        | Target MIRA table(s)                              |
+|-------------------------|---------------------------------------------------|
+| ``CanonicalAsset``      | ``kg_entities`` / ``installed_component_instances`` / ``cmms_equipment`` |
+| ``CanonicalLocation``   | ``kg_entities`` (LOCATED_IN hierarchy)            |
+| ``CanonicalTag``        | ``tag_entities``                                  |
+| ``CanonicalWorkOrder``  | CMMS work-order store (Atlas ``cmms_*``)          |
+| ``CanonicalPMTask``     | ``pm_schedules``                                  |
+| ``CanonicalFailureCode``| ``fault_codes``                                   |
+| ``CanonicalMeter``      | ``live_signal_cache`` / meter store               |
+| ``CanonicalPart``       | parts/inventory store                             |
+| ``CanonicalDocument``   | ``knowledge_entries`` / documents                 |
+| ``CanonicalRelationship``| ``relationship_proposals`` + ``relationship_evidence`` |
+
+Nothing here writes to those tables — normalization is pure. The Postgres write
+goes through the confirmation gate (``confirmation_gate.py``), which routes every
+proposed mapping through ``ai_suggestions`` / ``relationship_proposals`` so a human
+confirms before the knowledge graph changes (see
+``.claude/rules/uns-confirmation-gate.md`` and TOO Invariant #4).
+
+UNS rule: ``proposed_uns_path`` is a *candidate* only. Connectors never mint a final
+UNS path — they propose one and let the gate + ``mira-crawler/ingest/uns.py`` builders
+canonicalize it. See ``.claude/rules/uns-compliance.md``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Optional
+
+
+class RecordType(str, Enum):
+    """The kinds of record a connector can import and normalize."""
+
+    ASSET = "asset"
+    LOCATION = "location"
+    WORK_ORDER = "work_order"
+    PM_TASK = "pm_task"
+    FAILURE_CODE = "failure_code"
+    METER = "meter"
+    PART = "part"
+    DOCUMENT = "document"
+    TAG = "tag"
+    RELATIONSHIP = "relationship"
+
+
+# Relationship types — MUST stay in sync with the CHECK constraint on
+# relationship_proposals.relationship_type (mira-hub/db/migrations/018_*.sql) and
+# docs/specs/mira-component-intelligence-architecture.md §"Controlled vocabulary".
+RELATIONSHIP_TYPES: frozenset[str] = frozenset(
+    {
+        # Hierarchy
+        "HAS_COMPONENT", "INSTANCE_OF", "LOCATED_IN", "HAS_PART",
+        # Documentation
+        "HAS_DOCUMENT", "HAS_CHUNK", "REFERENCES", "HAS_PROCEDURE",
+        # Wiring & power
+        "WIRED_TO", "POWERED_BY", "MAPS_TO", "PUBLISHED_AS",
+        # Logic & control
+        "USED_IN_LOGIC", "TRIGGERS", "CAUSES",
+        # Faults & resolution
+        "OCCURS_ON", "RESOLVED_BY", "HAS_FAILURE_MODE",
+        # Signals
+        "HAS_SIGNAL", "HAS_ALIAS",
+        # Topology
+        "DEPENDS_ON", "UPSTREAM_OF", "DOWNSTREAM_OF", "REPLACES",
+        # Evidence meta
+        "CONFIRMED_BY", "CONTRADICTED_BY",
+    }
+)
+
+# Evidence types — MUST stay in sync with relationship_evidence.evidence_type
+# CHECK constraint (mira-hub/db/migrations/018_*.sql).
+EVIDENCE_TYPES: frozenset[str] = frozenset(
+    {
+        "document_page", "plc_rung", "tag_list", "work_order",
+        "technician_note", "live_data", "manifest", "oem_kb", "human_observation",
+    }
+)
+
+
+@dataclass(slots=True)
+class RawRecord:
+    """A single record exactly as the source system returned it.
+
+    ``fields`` preserves the vendor's native field names (ASSETNUM, WONUM, the
+    Ignition tag path, …) so we never lose provenance. Normalization reads from
+    here; nothing mutates it.
+    """
+
+    source_system: str  # "maximo" | "ignition" | "pi" | ...
+    record_type: RecordType
+    source_record_id: str  # the vendor's primary key for this row
+    fields: dict[str, Any]
+    fetched_at: Optional[str] = None  # ISO-8601; None in mock/offline mode
+
+
+@dataclass(slots=True)
+class EvidenceRef:
+    """One piece of evidence behind a proposed relationship.
+
+    Maps to a ``relationship_evidence`` row. ``confidence_contribution`` in
+    [-1.0, 1.0]; negative means the evidence *contradicts* the proposal.
+    """
+
+    evidence_type: str  # one of EVIDENCE_TYPES
+    source_description: str
+    page_or_location: Optional[str] = None  # "page 42", "Rung 12", "HR:104"
+    excerpt: Optional[str] = None
+    confidence_contribution: float = 0.0
+    source_id: Optional[str] = None  # FK resolved at the gate/store layer
+
+    def validate(self) -> list[str]:
+        errs: list[str] = []
+        if self.evidence_type not in EVIDENCE_TYPES:
+            errs.append(f"unknown evidence_type {self.evidence_type!r}")
+        if not (-1.0 <= self.confidence_contribution <= 1.0):
+            errs.append("confidence_contribution out of [-1.0, 1.0]")
+        return errs
+
+
+@dataclass(kw_only=True)
+class CanonicalRecord:
+    """Base for all normalized records.
+
+    ``kw_only=True`` so subclasses can add required fields without the
+    "non-default argument follows default argument" dataclass pitfall.
+    """
+
+    record_type: RecordType
+    source_system: str
+    source_record_id: str
+    confidence: float = 0.5  # 0..1; the connector's honest calibration
+    proposed_uns_path: Optional[str] = None  # candidate only — gate canonicalizes
+    raw: dict[str, Any] = field(default_factory=dict)  # original vendor fields
+
+    def base_validate(self) -> list[str]:
+        errs: list[str] = []
+        if not (0.0 <= self.confidence <= 1.0):
+            errs.append("confidence out of [0.0, 1.0]")
+        if not self.source_record_id:
+            errs.append("missing source_record_id")
+        return errs
+
+
+@dataclass(kw_only=True)
+class CanonicalAsset(CanonicalRecord):
+    name: str
+    manufacturer: Optional[str] = None
+    model: Optional[str] = None
+    serial: Optional[str] = None
+    asset_type: Optional[str] = None
+    parent_uns_path: Optional[str] = None
+    parent_source_id: Optional[str] = None
+    criticality: Optional[str] = None  # low|medium|high|safety_critical
+    location_path: Optional[str] = None
+    attributes: dict[str, Any] = field(default_factory=dict)
+    record_type: RecordType = RecordType.ASSET
+
+
+@dataclass(kw_only=True)
+class CanonicalLocation(CanonicalRecord):
+    name: str
+    location_type: Optional[str] = None  # site|area|line|cell
+    parent_uns_path: Optional[str] = None
+    parent_source_id: Optional[str] = None
+    record_type: RecordType = RecordType.LOCATION
+
+
+@dataclass(kw_only=True)
+class CanonicalWorkOrder(CanonicalRecord):
+    wo_number: str
+    title: str
+    description: str = ""
+    status: Optional[str] = None  # mapped to OPEN|IN_PROGRESS|COMPLETE|...
+    work_type: Optional[str] = None  # corrective|preventive|emergency
+    priority: Optional[str] = None
+    asset_source_id: Optional[str] = None
+    asset_uns_path: Optional[str] = None
+    failure_code: Optional[str] = None
+    reported_by: Optional[str] = None
+    reported_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    record_type: RecordType = RecordType.WORK_ORDER
+
+
+@dataclass(kw_only=True)
+class CanonicalPMTask(CanonicalRecord):
+    pm_number: str
+    description: str = ""
+    asset_source_id: Optional[str] = None
+    frequency: Optional[int] = None
+    frequency_unit: Optional[str] = None  # day|week|month|runtime_hours
+    job_plan: Optional[str] = None
+    next_due: Optional[str] = None
+    record_type: RecordType = RecordType.PM_TASK
+
+
+@dataclass(kw_only=True)
+class CanonicalFailureCode(CanonicalRecord):
+    code: str
+    description: str = ""
+    failure_class: Optional[str] = None
+    problem: Optional[str] = None
+    cause: Optional[str] = None
+    remedy: Optional[str] = None
+    record_type: RecordType = RecordType.FAILURE_CODE
+
+
+@dataclass(kw_only=True)
+class CanonicalMeter(CanonicalRecord):
+    name: str
+    asset_source_id: Optional[str] = None
+    last_reading: Optional[float] = None
+    unit: Optional[str] = None
+    meter_type: Optional[str] = None  # continuous|gauge|characteristic
+    record_type: RecordType = RecordType.METER
+
+
+@dataclass(kw_only=True)
+class CanonicalPart(CanonicalRecord):
+    item_number: str
+    description: str = ""
+    store_location: Optional[str] = None
+    issue_unit: Optional[str] = None
+    qty_on_hand: Optional[float] = None
+    record_type: RecordType = RecordType.PART
+
+
+@dataclass(kw_only=True)
+class CanonicalDocument(CanonicalRecord):
+    title: str
+    doc_type: Optional[str] = None  # manual|wiring|datasheet|sop
+    uri: Optional[str] = None
+    asset_source_id: Optional[str] = None
+    page_count: Optional[int] = None
+    record_type: RecordType = RecordType.DOCUMENT
+
+
+@dataclass(kw_only=True)
+class CanonicalTag(CanonicalRecord):
+    tag_id: str  # MIRA-side stable id, e.g. "Lake_Wales.Bench.Conveyor.Motor.Speed"
+    data_type: str = "float"  # bool|int|float|string|enum
+    engineering_unit: Optional[str] = None
+    scada_path: Optional[str] = None  # vendor path, e.g. "[default]Lake_Wales/..."
+    address: Optional[str] = None  # opcItemPath / Modbus HR / PI point id
+    history_enabled: bool = False
+    asset_source_id: Optional[str] = None
+    attributes: dict[str, Any] = field(default_factory=dict)
+    record_type: RecordType = RecordType.TAG
+
+
+@dataclass(kw_only=True)
+class CanonicalRelationship(CanonicalRecord):
+    """A proposed edge — maps to a ``relationship_proposals`` row + evidence.
+
+    ``source_ref`` / ``target_ref`` are connector-local references (source_system
+    record ids or proposed UNS paths). The gate resolves them to ``kg_entities``
+    UUIDs before insert.
+    """
+
+    relationship_type: str  # one of RELATIONSHIP_TYPES
+    source_ref: str
+    target_ref: str
+    # ref_kind tells the gate which entity type / table to resolve the ref against:
+    # asset|location|tag|document|failure_code|part|uns_path. Two refs with the same
+    # natural id but different kinds (e.g. asset "CONV16" LOCATED_IN location "CONV16")
+    # are NOT a self-loop — entity type disambiguates them.
+    source_ref_kind: str = "asset"
+    target_ref_kind: str = "asset"
+    risk_level: str = "low"  # low|medium|high|safety_critical
+    reasoning: Optional[str] = None
+    evidence: list[EvidenceRef] = field(default_factory=list)
+    record_type: RecordType = RecordType.RELATIONSHIP
+
+    def validate(self) -> list[str]:
+        errs = self.base_validate()
+        if self.relationship_type not in RELATIONSHIP_TYPES:
+            errs.append(f"unknown relationship_type {self.relationship_type!r}")
+        if self.source_ref == self.target_ref and self.source_ref_kind == self.target_ref_kind:
+            errs.append("self-loop relationship (same ref and kind)")
+        if not self.evidence:
+            errs.append("relationship has no evidence — cannot be promoted past 'proposed'")
+        for ev in self.evidence:
+            errs.extend(ev.validate())
+        return errs

--- a/mira-connectors/mira_connectors/confirmation_gate.py
+++ b/mira-connectors/mira_connectors/confirmation_gate.py
@@ -315,12 +315,15 @@ class ConnectorConfirmationGate:
 
     def _materialize_entity(self, tenant_id: str, sug: SuggestionRow) -> str:
         ed = sug.extracted_data
+        # kg_entities has no proposed_by column (only kg_relationships does, mig 029) —
+        # carry provenance in properties instead.
+        properties = {**ed.get("properties", {}), "proposed_by": sug.proposed_by}
         row = KgEntityRow(
             tenant_id=tenant_id,
-            uns_path=ed.get("uns_path"),
+            uns_path=ed.get("uns_path"),  # candidate; uns.py canonicalizes in the real wire-up
             entity_type=ed.get("entity_type", "entity"),
             name=ed.get("name", sug.id),
-            properties=ed.get("properties", {}),
+            properties=properties,
             approval_state="verified",
             proposed_by=sug.proposed_by,
         )

--- a/mira-connectors/mira_connectors/confirmation_gate.py
+++ b/mira-connectors/mira_connectors/confirmation_gate.py
@@ -1,0 +1,510 @@
+"""Connector confirmation gate (Phase 6).
+
+When a connector imports + normalizes records, MIRA must NOT silently write them into
+the knowledge graph. Per TOO Invariant #4 ("LLM/import-generated edges enter as
+``proposed``; promotion to ``verified`` is a human action") and Invariant #7
+("confirmation over guessing"), every connector-originated mapping becomes a *proposal* a
+technician confirms, corrects, or rejects.
+
+This service implements that gate on top of MIRA's **existing** tables — no new tables:
+
+- proposed asset / location / tag mappings → ``ai_suggestions`` rows (type ``kg_entity``),
+  ``proposed_by = 'import:<provider>'``
+- proposed relationships → ``relationship_proposals`` + ``relationship_evidence`` rows
+  (``created_by = 'import'``), surfaced via an ``ai_suggestions`` row of type ``kg_edge``
+
+Status transitions follow **ADR-0017** exactly:
+
+| Action | ai_suggestions | relationship_proposals | kg_*               |
+|--------|----------------|------------------------|--------------------|
+| import proposes        | pending     | proposed   | (none yet)            |
+| technician confirms    | accepted    | verified   | write/upsert kg_ row  |
+| technician corrects    | superseded  | deprecated | (new proposal → verified) |
+| technician rejects     | rejected    | rejected   | (no write)            |
+
+On confirm of an edge the gate mirrors the Hub ``/api/proposals/[id]/decide`` route:
+``relationship_proposals.status = verified`` THEN UPSERT into ``kg_relationships`` (dedupe
+on tenant+source+target+type). It also writes a ``relationship_evidence`` row of type
+``human_observation`` carrying the technician's confirmation — that is how "confidence
+*after* confirmation" is recorded; the connector's original confidence is preserved in
+``extracted_data.confidence_prior`` and never overwritten.
+
+NOTE on the ADR-0017 helpers: ``mira_bots/shared/proposal_transition.py`` and
+``mira-hub/lib/proposal-transition.ts`` do not exist yet (master-plan Phase 3 / Agent 4
+owns them). Until they land, this gate's transition logic is connector-local. When they
+land, ``PostgresProposalStore`` should delegate its status writes to the Python helper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from mira_connectors.canonical import (
+    CanonicalAsset,
+    CanonicalRecord,
+    CanonicalRelationship,
+    RecordType,
+)
+from mira_connectors.store import (
+    EvidenceRow,
+    KgEntityRow,
+    KgRelationshipRow,
+    ProposalRow,
+    ProposalStore,
+    SuggestionRow,
+    _now,
+)
+
+# Confidence that a technician's explicit confirmation adds (relationship_evidence row).
+_CONFIRMATION_CONTRIBUTION = 0.4
+
+# RecordType → (ai_suggestions entity_type label, ref_kind used by edges)
+_ENTITY_KIND = {
+    RecordType.ASSET: "asset",
+    RecordType.LOCATION: "location",
+    RecordType.TAG: "tag",
+    RecordType.DOCUMENT: "document",
+    RecordType.FAILURE_CODE: "failure_code",
+    RecordType.PART: "part",
+}
+
+
+@dataclass
+class ProposeResult:
+    entity_suggestion_ids: list[str] = field(default_factory=list)
+    edge_suggestion_ids: list[str] = field(default_factory=list)
+    conflict_groups: list[list[str]] = field(default_factory=list)
+
+
+@dataclass
+class ConfirmResult:
+    ok: bool
+    suggestion_id: Optional[str] = None
+    entity_id: Optional[str] = None
+    relationship_proposal_id: Optional[str] = None
+    kg_relationship_id: Optional[str] = None
+    reason: Optional[str] = None
+
+
+@dataclass
+class CorrectResult:
+    ok: bool
+    superseded_suggestion_id: Optional[str] = None
+    new_suggestion_id: Optional[str] = None
+    confirm: Optional[ConfirmResult] = None
+    reason: Optional[str] = None
+
+
+@dataclass
+class RejectResult:
+    ok: bool
+    suggestion_id: Optional[str] = None
+    reason: Optional[str] = None
+
+
+class ConnectorConfirmationGate:
+    """Routes connector-originated mappings through human confirmation into the graph."""
+
+    def __init__(self, store: ProposalStore) -> None:
+        self.store = store
+
+    # ── propose ─────────────────────────────────────────────────────────────
+    def propose(
+        self,
+        *,
+        tenant_id: str,
+        provider: str,
+        entities: Optional[list[CanonicalRecord]] = None,
+        relationships: Optional[list[CanonicalRelationship]] = None,
+    ) -> ProposeResult:
+        """Turn normalized records + derived relationships into pending proposals."""
+        proposed_by = f"import:{provider}"
+        result = ProposeResult()
+
+        for rec in entities or []:
+            sug = self._entity_suggestion(tenant_id, proposed_by, rec)
+            result.entity_suggestion_ids.append(self.store.insert_suggestion(sug))
+
+        result.conflict_groups = self._mark_conflicts(tenant_id)
+
+        for rel in relationships or []:
+            result.edge_suggestion_ids.append(self._propose_edge(tenant_id, proposed_by, rel))
+
+        return result
+
+    def _entity_suggestion(
+        self, tenant_id: str, proposed_by: str, rec: CanonicalRecord
+    ) -> SuggestionRow:
+        ref_kind = _ENTITY_KIND.get(rec.record_type, "entity")
+        conflict_key = self._conflict_key(rec)
+        properties: dict[str, Any] = dict(getattr(rec, "attributes", {}) or {})
+        properties.update(
+            {
+                "source_system": rec.source_system,
+                "source_record_id": rec.source_record_id,
+                "ref_kind": ref_kind,
+                "natural_key": f"{ref_kind}:{rec.source_record_id}",
+            }
+        )
+        if isinstance(rec, CanonicalAsset):
+            properties.update(
+                {"manufacturer": rec.manufacturer, "model": rec.model, "serial": rec.serial}
+            )
+        extracted = {
+            "entity_type": ref_kind,
+            "uns_path": rec.proposed_uns_path,  # candidate — uns.py canonicalizes on confirm
+            "name": getattr(rec, "name", None) or getattr(rec, "tag_id", rec.source_record_id),
+            "source_system": rec.source_system,
+            "source_record_id": rec.source_record_id,
+            "ref_kind": ref_kind,
+            "properties": properties,
+            "confidence_prior": rec.confidence,  # preserved; never overwritten on confirm
+            "conflict_key": conflict_key,
+        }
+        risk = "safety_critical" if getattr(rec, "criticality", None) == "safety_critical" else "low"
+        return SuggestionRow(
+            tenant_id=tenant_id,
+            suggestion_type="kg_entity",
+            extracted_data=extracted,
+            proposed_by=proposed_by,
+            confidence=rec.confidence,
+            risk_level=risk,
+            source_kind="manifest_row",
+            title=f"Propose {ref_kind} {extracted['name']} at {rec.proposed_uns_path or '(unresolved)'}",
+            body=f"Imported from {rec.source_system} record {rec.source_record_id}.",
+        )
+
+    @staticmethod
+    def _conflict_key(rec: CanonicalRecord) -> str:
+        # Two systems describing the same physical device should collide here.
+        serial = getattr(rec, "serial", None)
+        if serial:
+            return f"serial:{serial}"
+        return f"{rec.source_system}:{rec.source_record_id}"
+
+    def _mark_conflicts(self, tenant_id: str) -> list[list[str]]:
+        """Group pending kg_entity suggestions by conflict_key; flag groups whose members
+        propose DIFFERENT uns_paths. Conflicting mappings are preserved (not auto-rejected)
+        so a human resolves them."""
+        pending = self.store.list_suggestions(
+            tenant_id, status="pending", suggestion_type="kg_entity"
+        )
+        groups: dict[str, list[SuggestionRow]] = {}
+        for s in pending:
+            key = s.extracted_data.get("conflict_key")
+            if key:
+                groups.setdefault(key, []).append(s)
+
+        conflict_groups: list[list[str]] = []
+        for key, members in groups.items():
+            paths = {m.extracted_data.get("uns_path") for m in members}
+            if len(members) > 1 and len(paths) > 1:
+                group_id = members[0].id
+                for m in members:
+                    if m.extracted_data.get("conflict_group") != group_id:
+                        m.extracted_data["conflict_group"] = group_id
+                        self.store.update_suggestion(
+                            m.id, extracted_data=m.extracted_data, _tenant_id=tenant_id
+                        )
+                conflict_groups.append([m.id for m in members])
+        return conflict_groups
+
+    def _propose_edge(
+        self, tenant_id: str, proposed_by: str, rel: CanonicalRelationship
+    ) -> str:
+        evidence_dicts = [
+            {
+                "evidence_type": ev.evidence_type,
+                "source_description": ev.source_description,
+                "page_or_location": ev.page_or_location,
+                "excerpt": ev.excerpt,
+                "confidence_contribution": ev.confidence_contribution,
+            }
+            for ev in rel.evidence
+        ]
+        extracted: dict[str, Any] = {
+            "relationship_type": rel.relationship_type,
+            "source_ref": rel.source_ref,
+            "source_ref_kind": rel.source_ref_kind,
+            "target_ref": rel.target_ref,
+            "target_ref_kind": rel.target_ref_kind,
+            "confidence_prior": rel.confidence,
+            "evidence": evidence_dicts,
+            "reasoning": rel.reasoning,
+        }
+
+        src = self.store.resolve_entity(tenant_id, rel.source_ref, rel.source_ref_kind)
+        tgt = self.store.resolve_entity(tenant_id, rel.target_ref, rel.target_ref_kind)
+        if src and tgt:
+            proposal_id = self._create_proposal(tenant_id, rel, src, tgt)
+            extracted["relationship_proposal_id"] = proposal_id
+        else:
+            extracted["needs_resolution"] = True
+            extracted["unresolved"] = [
+                r for r, got in ((rel.source_ref, src), (rel.target_ref, tgt)) if not got
+            ]
+
+        sug = SuggestionRow(
+            tenant_id=tenant_id,
+            suggestion_type="kg_edge",
+            extracted_data=extracted,
+            proposed_by=proposed_by,
+            confidence=rel.confidence,
+            risk_level=rel.risk_level,
+            source_kind="manifest_row",
+            title=f"Propose {rel.relationship_type}: {rel.source_ref} → {rel.target_ref}",
+            body=rel.reasoning or "",
+        )
+        return self.store.insert_suggestion(sug)
+
+    def _create_proposal(
+        self, tenant_id: str, rel: CanonicalRelationship, src_id: str, tgt_id: str
+    ) -> str:
+        proposal = ProposalRow(
+            tenant_id=tenant_id,
+            source_entity_id=src_id,
+            source_entity_type=rel.source_ref_kind,
+            target_entity_id=tgt_id,
+            target_entity_type=rel.target_ref_kind,
+            relationship_type=rel.relationship_type,
+            confidence=rel.confidence,
+            status="proposed",
+            created_by="import",  # ADR-0017 / mig 018 vocab
+            risk_level=rel.risk_level,
+            requires_human_review=True,  # Invariant #4 — humans promote
+            reasoning=rel.reasoning,
+        )
+        proposal_id = self.store.insert_proposal(proposal)
+        for ev in rel.evidence:
+            self.store.insert_evidence(
+                EvidenceRow(
+                    proposal_id=proposal_id,
+                    evidence_type=ev.evidence_type,
+                    source_description=ev.source_description,
+                    page_or_location=ev.page_or_location,
+                    excerpt=ev.excerpt,
+                    confidence_contribution=ev.confidence_contribution,
+                )
+            )
+        return proposal_id
+
+    # ── confirm ───────────────────────────────────────────────────────────
+    def confirm(
+        self, tenant_id: str, suggestion_id: str, *, reviewed_by: str, note: Optional[str] = None
+    ) -> ConfirmResult:
+        sug = self.store.get_suggestion(tenant_id, suggestion_id)
+        if sug is None:
+            return ConfirmResult(ok=False, reason="not_found")
+        if sug.status != "pending":
+            return ConfirmResult(ok=False, reason=f"wrong_state:{sug.status}")
+        reviewer = f"human:{reviewed_by}"
+
+        if sug.suggestion_type == "kg_entity":
+            entity_id = self._materialize_entity(tenant_id, sug)
+            self.store.update_suggestion(
+                sug.id, status="accepted", reviewed_by=reviewer, reviewed_at=_now(),
+                review_note=note, _tenant_id=tenant_id,
+            )
+            return ConfirmResult(ok=True, suggestion_id=sug.id, entity_id=entity_id)
+
+        if sug.suggestion_type == "kg_edge":
+            return self._confirm_edge(tenant_id, sug, reviewer, note)
+
+        return ConfirmResult(ok=False, reason=f"unsupported_type:{sug.suggestion_type}")
+
+    def _materialize_entity(self, tenant_id: str, sug: SuggestionRow) -> str:
+        ed = sug.extracted_data
+        row = KgEntityRow(
+            tenant_id=tenant_id,
+            uns_path=ed.get("uns_path"),
+            entity_type=ed.get("entity_type", "entity"),
+            name=ed.get("name", sug.id),
+            properties=ed.get("properties", {}),
+            approval_state="verified",
+            proposed_by=sug.proposed_by,
+        )
+        return self.store.create_entity(row)
+
+    def _confirm_edge(
+        self, tenant_id: str, sug: SuggestionRow, reviewer: str, note: Optional[str]
+    ) -> ConfirmResult:
+        ed = sug.extracted_data
+        proposal_id = ed.get("relationship_proposal_id")
+
+        if not proposal_id:
+            # Was unresolved at propose time — try to resolve the endpoints now (the
+            # entities may have been confirmed since).
+            proposal_id = self._resolve_and_create_proposal(tenant_id, sug)
+            if not proposal_id:
+                return ConfirmResult(
+                    ok=False, suggestion_id=sug.id, reason="endpoints_unresolved"
+                )
+            ed["relationship_proposal_id"] = proposal_id
+            self.store.update_suggestion(sug.id, extracted_data=ed, _tenant_id=tenant_id)
+
+        proposal = self.store.get_proposal(proposal_id)
+        if proposal is None:
+            return ConfirmResult(ok=False, suggestion_id=sug.id, reason="proposal_missing")
+
+        # ADR-0017: proposal → verified
+        self.store.update_proposal(
+            proposal_id, status="verified", reviewed_by=reviewer, reviewed_at=_now(),
+            _tenant_id=tenant_id,
+        )
+        # Confidence AFTER confirmation: a human_observation evidence row (the prior stays
+        # in extracted_data.confidence_prior and on the proposal's own confidence column).
+        self.store.insert_evidence(
+            EvidenceRow(
+                proposal_id=proposal_id,
+                evidence_type="human_observation",
+                source_description=f"Technician confirmation by {reviewer}",
+                excerpt=note,
+                confidence_contribution=_CONFIRMATION_CONTRIBUTION,
+            )
+        )
+        # Materialize into kg_relationships (mirrors the Hub decide route).
+        kg_rel_id = self.store.upsert_relationship(
+            KgRelationshipRow(
+                tenant_id=tenant_id,
+                source_id=proposal.source_entity_id,
+                target_id=proposal.target_entity_id,
+                relationship_type=proposal.relationship_type,
+                confidence=proposal.confidence,
+                approval_state="verified",
+                proposed_by=proposal.created_by,
+                evidence_summary=proposal.reasoning,
+            )
+        )
+        self.store.update_suggestion(
+            sug.id, status="accepted", reviewed_by=reviewer, reviewed_at=_now(),
+            review_note=note, _tenant_id=tenant_id,
+        )
+        return ConfirmResult(
+            ok=True, suggestion_id=sug.id, relationship_proposal_id=proposal_id,
+            kg_relationship_id=kg_rel_id,
+        )
+
+    def _resolve_and_create_proposal(self, tenant_id: str, sug: SuggestionRow) -> Optional[str]:
+        ed = sug.extracted_data
+        src = self.store.resolve_entity(tenant_id, ed["source_ref"], ed["source_ref_kind"])
+        tgt = self.store.resolve_entity(tenant_id, ed["target_ref"], ed["target_ref_kind"])
+        if not (src and tgt):
+            return None
+        proposal = ProposalRow(
+            tenant_id=tenant_id,
+            source_entity_id=src,
+            source_entity_type=ed["source_ref_kind"],
+            target_entity_id=tgt,
+            target_entity_type=ed["target_ref_kind"],
+            relationship_type=ed["relationship_type"],
+            confidence=ed.get("confidence_prior", 0.5),
+            status="proposed",
+            created_by="import",
+            requires_human_review=True,
+            reasoning=ed.get("reasoning"),
+        )
+        proposal_id = self.store.insert_proposal(proposal)
+        for ev in ed.get("evidence", []):
+            self.store.insert_evidence(
+                EvidenceRow(
+                    proposal_id=proposal_id,
+                    evidence_type=ev["evidence_type"],
+                    source_description=ev["source_description"],
+                    page_or_location=ev.get("page_or_location"),
+                    excerpt=ev.get("excerpt"),
+                    confidence_contribution=ev.get("confidence_contribution", 0.0),
+                )
+            )
+        return proposal_id
+
+    # ── correct ───────────────────────────────────────────────────────────
+    def correct(
+        self,
+        tenant_id: str,
+        suggestion_id: str,
+        *,
+        reviewed_by: str,
+        corrections: dict[str, Any],
+        note: Optional[str] = None,
+    ) -> CorrectResult:
+        """Technician corrects a proposal (e.g. "it's TB2-15, not TB2-14").
+
+        ADR-0017: the original is *superseded* (and its proposal *deprecated*) — preserved,
+        not deleted, so the conflicting mapping stays auditable. A new human-authored
+        suggestion carrying the corrections is created and immediately confirmed.
+        """
+        sug = self.store.get_suggestion(tenant_id, suggestion_id)
+        if sug is None:
+            return CorrectResult(ok=False, reason="not_found")
+        if sug.status != "pending":
+            return CorrectResult(ok=False, reason=f"wrong_state:{sug.status}")
+        reviewer = f"human:{reviewed_by}"
+
+        # Supersede the original (kept for review).
+        self.store.update_suggestion(
+            sug.id, status="superseded", reviewed_by=reviewer, reviewed_at=_now(),
+            review_note=note or "corrected", _tenant_id=tenant_id,
+        )
+        old_proposal_id = sug.extracted_data.get("relationship_proposal_id")
+        if old_proposal_id:
+            self.store.update_proposal(
+                old_proposal_id, status="deprecated", reviewed_by=reviewer, reviewed_at=_now(),
+                _tenant_id=tenant_id,
+            )
+
+        # Build the corrected suggestion. Drop the stale proposal link so a fresh proposal
+        # is created against the corrected endpoints on confirm.
+        new_ed = {**sug.extracted_data, **corrections}
+        new_ed.pop("relationship_proposal_id", None)
+        new_ed.pop("needs_resolution", None)
+        new_ed.pop("unresolved", None)
+        new_ed["corrected_from"] = sug.id
+        new_sug = SuggestionRow(
+            tenant_id=tenant_id,
+            suggestion_type=sug.suggestion_type,
+            extracted_data=new_ed,
+            proposed_by=f"human:{reviewed_by}",
+            confidence=sug.confidence,
+            risk_level=sug.risk_level,
+            source_kind="manual_entry",
+            title=f"[corrected] {sug.title or ''}".strip(),
+            body=f"Correction of {sug.id} by {reviewer}.",
+        )
+        new_id = self.store.insert_suggestion(new_sug)
+
+        confirm = self.confirm(tenant_id, new_id, reviewed_by=reviewed_by, note=f"correction of {sug.id}")
+        return CorrectResult(
+            ok=confirm.ok, superseded_suggestion_id=sug.id, new_suggestion_id=new_id,
+            confirm=confirm, reason=confirm.reason,
+        )
+
+    # ── reject ──────────────────────────────────────────────────────────────
+    def reject(
+        self, tenant_id: str, suggestion_id: str, *, reviewed_by: str, note: Optional[str] = None
+    ) -> RejectResult:
+        sug = self.store.get_suggestion(tenant_id, suggestion_id)
+        if sug is None:
+            return RejectResult(ok=False, reason="not_found")
+        if sug.status != "pending":
+            return RejectResult(ok=False, reason=f"wrong_state:{sug.status}")
+        reviewer = f"human:{reviewed_by}"
+        self.store.update_suggestion(
+            sug.id, status="rejected", reviewed_by=reviewer, reviewed_at=_now(),
+            review_note=note, _tenant_id=tenant_id,
+        )
+        proposal_id = sug.extracted_data.get("relationship_proposal_id")
+        if proposal_id:
+            self.store.update_proposal(
+                proposal_id, status="rejected", reviewed_by=reviewer, reviewed_at=_now(),
+                _tenant_id=tenant_id,
+            )
+        return RejectResult(ok=True, suggestion_id=sug.id)
+
+    # ── queries ───────────────────────────────────────────────────────────
+    def pending(
+        self, tenant_id: str, *, suggestion_type: Optional[str] = None
+    ) -> list[SuggestionRow]:
+        return self.store.list_suggestions(
+            tenant_id, status="pending", suggestion_type=suggestion_type
+        )

--- a/mira-connectors/mira_connectors/factory.py
+++ b/mira-connectors/mira_connectors/factory.py
@@ -1,0 +1,46 @@
+"""Connector factory — selects a connector by provider name.
+
+Mirrors the existing ``mira-mcp/cmms/factory.py:create_cmms_adapter`` pattern
+(provider string → concrete class, returns ``None`` when unconfigured) and extends it
+across all connector kinds. Real connectors register here alongside the mocks.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from mira_connectors.base import Connector, ConnectorConfig
+from mira_connectors.mocks.ignition_mock import IgnitionMockConnector
+from mira_connectors.mocks.maximo_mock import MaximoMockConnector
+
+logger = logging.getLogger("mira-connectors")
+
+# provider name → constructor. Add real connectors here as they land.
+_REGISTRY: dict[str, Callable[[ConnectorConfig], Connector]] = {
+    "maximo_mock": MaximoMockConnector,
+    "ignition_mock": IgnitionMockConnector,
+    # Real connectors (future):
+    # "maximo": MaximoConnector,
+    # "ignition": IgnitionConnector,
+    # "pi": PIHistorianConnector,
+    # "maintainx": MaintainXConnector,  # wraps mira-mcp/cmms/maintainx.py
+}
+
+
+def available_providers() -> list[str]:
+    return sorted(_REGISTRY)
+
+
+def create_connector(provider: str, config: ConnectorConfig) -> Connector | None:
+    """Create a connector by provider name. Returns ``None`` if unknown/unconfigured."""
+    key = (provider or "").lower().strip()
+    ctor = _REGISTRY.get(key)
+    if ctor is None:
+        logger.error("Unknown connector provider: %s (have %s)", provider, available_providers())
+        return None
+    connector = ctor(config)
+    if not connector.configured:
+        logger.warning("Connector '%s' selected but not configured — disabled", provider)
+        return None
+    return connector

--- a/mira-connectors/mira_connectors/mocks/__init__.py
+++ b/mira-connectors/mira_connectors/mocks/__init__.py
@@ -1,0 +1,11 @@
+"""Fixture-backed mock connectors (capability #9: mock mode).
+
+These read realistic JSON fixtures instead of hitting a network. They make Phases
+downstream of the connector framework testable without a live Maximo/Ignition, and
+serve as the reference implementation of each connector type.
+"""
+
+from mira_connectors.mocks.ignition_mock import IgnitionMockConnector
+from mira_connectors.mocks.maximo_mock import MaximoMockConnector
+
+__all__ = ["IgnitionMockConnector", "MaximoMockConnector"]

--- a/mira-connectors/mira_connectors/mocks/fixtures/ignition.json
+++ b/mira-connectors/mira_connectors/mocks/fixtures/ignition.json
@@ -1,0 +1,55 @@
+{
+  "_comment": "Realistic Ignition 8.1 tag export. Provider [default], site/area/line folder hierarchy, OPC tags bound to a Modbus device (Mira_PLC) whose register map mirrors plc/MbSrvConf_v4.xml (DC bus = HR400110). Mirrors the Lake Wales bench conveyor so SCADA tags line up with the Maximo asset graph.",
+  "tagProvider": "default",
+  "opcServer": "Ignition OPC UA Server",
+  "device": "Mira_PLC",
+  "tags": [
+    {
+      "name": "Lake_Wales",
+      "tagType": "Folder",
+      "tags": [
+        {
+          "name": "Bench",
+          "tagType": "Folder",
+          "tags": [
+            {
+              "name": "Conveyor",
+              "tagType": "Folder",
+              "tags": [
+                {
+                  "name": "Motor",
+                  "tagType": "Folder",
+                  "tags": [
+                    { "name": "Speed", "tagType": "AtomicTag", "dataType": "Float8", "valueSource": "opc", "opcItemPath": "ns=1;s=[Mira_PLC]HR400101", "engUnit": "Hz", "deadband": 0.5, "historyEnabled": true },
+                    { "name": "Current", "tagType": "AtomicTag", "dataType": "Float8", "valueSource": "opc", "opcItemPath": "ns=1;s=[Mira_PLC]HR400102", "engUnit": "A", "deadband": 0.1, "historyEnabled": true },
+                    { "name": "Run", "tagType": "AtomicTag", "dataType": "Boolean", "valueSource": "opc", "opcItemPath": "ns=1;s=[Mira_PLC]C00000", "historyEnabled": true },
+                    { "name": "Stopped", "tagType": "AtomicTag", "dataType": "Boolean", "valueSource": "opc", "opcItemPath": "ns=1;s=[Mira_PLC]C00001", "historyEnabled": false }
+                  ]
+                },
+                {
+                  "name": "GS10",
+                  "tagType": "Folder",
+                  "tags": [
+                    { "name": "OutputFrequency", "tagType": "AtomicTag", "dataType": "Float8", "valueSource": "opc", "opcItemPath": "ns=1;s=[Mira_PLC]HR400103", "engUnit": "Hz", "deadband": 0.25, "historyEnabled": true },
+                    { "name": "DCBusVoltage", "tagType": "AtomicTag", "dataType": "Float8", "valueSource": "opc", "opcItemPath": "ns=1;s=[Mira_PLC]HR400110", "engUnit": "V", "deadband": 1.0, "historyEnabled": true },
+                    { "name": "FaultCode", "tagType": "AtomicTag", "dataType": "Int4", "valueSource": "opc", "opcItemPath": "ns=1;s=[Mira_PLC]HR400111", "historyEnabled": true },
+                    { "name": "Faulted", "tagType": "AtomicTag", "dataType": "Boolean", "valueSource": "opc", "opcItemPath": "ns=1;s=[Mira_PLC]C00002", "historyEnabled": true, "alarms": [ { "name": "VFD Faulted", "mode": "Equal", "setpointA": 1, "priority": "High" } ] }
+                  ]
+                },
+                {
+                  "name": "PE_B16_2",
+                  "tagType": "Folder",
+                  "tags": [
+                    { "name": "Occupied", "tagType": "AtomicTag", "dataType": "Boolean", "valueSource": "opc", "opcItemPath": "ns=1;s=[Mira_PLC]DI00016", "historyEnabled": true }
+                  ]
+                },
+                { "name": "State", "tagType": "AtomicTag", "dataType": "Int4", "valueSource": "opc", "opcItemPath": "ns=1;s=[Mira_PLC]HR400117", "historyEnabled": true, "tooltip": "0=IDLE 1=RUN 2=FAULT" },
+                { "name": "FaultAlarm", "tagType": "AtomicTag", "dataType": "Boolean", "valueSource": "opc", "opcItemPath": "ns=1;s=[Mira_PLC]C00006", "historyEnabled": true, "alarms": [ { "name": "Conveyor Fault", "mode": "Equal", "setpointA": 1, "priority": "Critical" } ] }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/mira-connectors/mira_connectors/mocks/fixtures/maximo.json
+++ b/mira-connectors/mira_connectors/mocks/fixtures/maximo.json
@@ -1,0 +1,110 @@
+{
+  "_comment": "Realistic IBM Maximo (MAS 8 / MXASSET, LOCATIONS, WORKORDER, PM, METER, INVENTORY, FAILURELIST, DOCLINKS) sample. Native field names preserved. Models the Bedford packaging plant: Line 16 conveyor with a DuraPulse GS10 VFD, 1HP motor, and a PE proximity sensor — mirroring MIRA's Lake Wales bench so the demo flywheel lines up.",
+  "sites": [
+    { "SITEID": "BEDFORD", "ORGID": "ACME", "DESCRIPTION": "Bedford Packaging Plant", "ACTIVE": true }
+  ],
+  "locations": [
+    { "LOCATION": "BEDFORD", "DESCRIPTION": "Bedford Packaging Plant", "SITEID": "BEDFORD", "ORGID": "ACME", "TYPE": "OPERATING", "STATUS": "OPERATING", "PARENT": null, "SYSTEMID": "PRIMARY" },
+    { "LOCATION": "PACK", "DESCRIPTION": "Packaging Area", "SITEID": "BEDFORD", "ORGID": "ACME", "TYPE": "OPERATING", "STATUS": "OPERATING", "PARENT": "BEDFORD", "SYSTEMID": "PRIMARY" },
+    { "LOCATION": "LINE16", "DESCRIPTION": "Packaging Line 16", "SITEID": "BEDFORD", "ORGID": "ACME", "TYPE": "OPERATING", "STATUS": "OPERATING", "PARENT": "PACK", "SYSTEMID": "PRIMARY" },
+    { "LOCATION": "CONV16", "DESCRIPTION": "Line 16 Infeed Conveyor", "SITEID": "BEDFORD", "ORGID": "ACME", "TYPE": "OPERATING", "STATUS": "OPERATING", "PARENT": "LINE16", "SYSTEMID": "PRIMARY" }
+  ],
+  "assets": [
+    {
+      "ASSETNUM": "CONV16",
+      "DESCRIPTION": "Line 16 Infeed Conveyor",
+      "SITEID": "BEDFORD", "ORGID": "ACME",
+      "LOCATION": "CONV16", "PARENT": null,
+      "ASSETTYPE": "PRODUCTION", "STATUS": "OPERATING",
+      "PRIORITY": 2, "MANUFACTURER": "DORNER", "VENDOR": "DORNER",
+      "SERIALNUM": "DRN-2200-44817", "INSTALLDATE": "2021-03-14T00:00:00Z",
+      "ISRUNNING": true, "FAILURECODE": "CONVEYOR",
+      "CUSTOM": { "MODELNUM": "2200 Series", "ASSETSPEC_CRITICALITY": "MEDIUM" }
+    },
+    {
+      "ASSETNUM": "VFD-16-1",
+      "DESCRIPTION": "Conveyor 16 VFD (DuraPulse GS10)",
+      "SITEID": "BEDFORD", "ORGID": "ACME",
+      "LOCATION": "CONV16", "PARENT": "CONV16",
+      "ASSETTYPE": "PRODUCTION", "STATUS": "OPERATING",
+      "PRIORITY": 1, "MANUFACTURER": "AUTOMATIONDIRECT", "VENDOR": "AUTOMATIONDIRECT",
+      "SERIALNUM": "GS10-1P-220-9931", "INSTALLDATE": "2021-03-14T00:00:00Z",
+      "ISRUNNING": true, "FAILURECODE": "VFD",
+      "CUSTOM": { "MODELNUM": "GS11-10P2", "ASSETSPEC_VOLTAGE": "230", "ASSETSPEC_HP": "1", "ASSETSPEC_CRITICALITY": "HIGH" }
+    },
+    {
+      "ASSETNUM": "MTR-16-1",
+      "DESCRIPTION": "Conveyor 16 Drive Motor 1HP",
+      "SITEID": "BEDFORD", "ORGID": "ACME",
+      "LOCATION": "CONV16", "PARENT": "CONV16",
+      "ASSETTYPE": "PRODUCTION", "STATUS": "OPERATING",
+      "PRIORITY": 2, "MANUFACTURER": "MARATHON", "VENDOR": "MARATHON",
+      "SERIALNUM": "MAR-56C-1HP-7741", "INSTALLDATE": "2021-03-14T00:00:00Z",
+      "ISRUNNING": true, "FAILURECODE": "MOTOR",
+      "CUSTOM": { "MODELNUM": "5K49MN4115", "ASSETSPEC_FLA": "3.6", "ASSETSPEC_CRITICALITY": "MEDIUM" }
+    },
+    {
+      "ASSETNUM": "PE-B16-2",
+      "DESCRIPTION": "Conveyor 16 Infeed Photo-Eye (occupancy)",
+      "SITEID": "BEDFORD", "ORGID": "ACME",
+      "LOCATION": "CONV16", "PARENT": "CONV16",
+      "ASSETTYPE": "PRODUCTION", "STATUS": "OPERATING",
+      "PRIORITY": 2, "MANUFACTURER": "BANNER", "VENDOR": "BANNER",
+      "SERIALNUM": "BNR-QS18VN6D-5523", "INSTALLDATE": "2021-03-14T00:00:00Z",
+      "ISRUNNING": true, "FAILURECODE": "SENSOR",
+      "CUSTOM": { "MODELNUM": "QS18VN6D", "ASSETSPEC_OUTPUT": "PNP", "ASSETSPEC_CRITICALITY": "MEDIUM" }
+    }
+  ],
+  "workorders": [
+    {
+      "WONUM": "1048817", "DESCRIPTION": "Conveyor 16 tripped on VFD comm fault CE10",
+      "ASSETNUM": "VFD-16-1", "LOCATION": "CONV16", "SITEID": "BEDFORD",
+      "STATUS": "COMP", "WORKTYPE": "CM", "WOPRIORITY": 1,
+      "REPORTEDBY": "JSMITH", "REPORTDATE": "2026-05-29T13:42:00Z",
+      "ACTSTART": "2026-05-29T14:05:00Z", "ACTFINISH": "2026-05-29T15:10:00Z",
+      "FAILUREREPORT": { "FAILURECODE": "VFD", "PROBLEMCODE": "COMMFAULT", "CAUSE": "LOOSEWIRE", "REMEDY": "RETERMINATE" }
+    },
+    {
+      "WONUM": "1048903", "DESCRIPTION": "Photo-eye intermittent at infeed — packages double-counting",
+      "ASSETNUM": "PE-B16-2", "LOCATION": "CONV16", "SITEID": "BEDFORD",
+      "STATUS": "INPRG", "WORKTYPE": "CM", "WOPRIORITY": 2,
+      "REPORTEDBY": "MGARCIA", "REPORTDATE": "2026-06-01T09:18:00Z",
+      "ACTSTART": "2026-06-01T10:00:00Z", "ACTFINISH": null,
+      "FAILUREREPORT": { "FAILURECODE": "SENSOR", "PROBLEMCODE": "INTERMITTENT", "CAUSE": "LOOSEWIRE", "REMEDY": null }
+    },
+    {
+      "WONUM": "1047221", "DESCRIPTION": "PM - Quarterly conveyor belt + bearing inspection",
+      "ASSETNUM": "CONV16", "LOCATION": "CONV16", "SITEID": "BEDFORD",
+      "STATUS": "CLOSE", "WORKTYPE": "PM", "WOPRIORITY": 3,
+      "REPORTEDBY": "PMGEN", "REPORTDATE": "2026-04-01T06:00:00Z",
+      "ACTSTART": "2026-04-02T07:30:00Z", "ACTFINISH": "2026-04-02T09:00:00Z",
+      "FAILUREREPORT": null
+    }
+  ],
+  "pmtasks": [
+    { "PMNUM": "PM-CONV16-Q", "DESCRIPTION": "Quarterly conveyor belt + bearing inspection", "ASSETNUM": "CONV16", "LOCATION": "CONV16", "FREQUENCY": 3, "FREQUNIT": "MONTHS", "JPNUM": "JP-CONV-INSP", "NEXTDATE": "2026-07-02T00:00:00Z", "STATUS": "ACTIVE", "LEADTIME": 7 },
+    { "PMNUM": "PM-VFD16-A", "DESCRIPTION": "Annual VFD cooling-fan + terminal-torque check", "ASSETNUM": "VFD-16-1", "LOCATION": "CONV16", "FREQUENCY": 12, "FREQUNIT": "MONTHS", "JPNUM": "JP-VFD-CHK", "NEXTDATE": "2026-03-14T00:00:00Z", "STATUS": "ACTIVE", "LEADTIME": 14 }
+  ],
+  "failurecodes": [
+    { "FAILURECODE": "VFD", "DESCRIPTION": "Variable Frequency Drive", "TYPE": "FAILURECLASS", "PARENT": null },
+    { "FAILURECODE": "COMMFAULT", "DESCRIPTION": "Communication fault", "TYPE": "PROBLEM", "PARENT": "VFD" },
+    { "FAILURECODE": "LOOSEWIRE", "DESCRIPTION": "Loose or back-out wire termination", "TYPE": "CAUSE", "PARENT": "COMMFAULT" },
+    { "FAILURECODE": "RETERMINATE", "DESCRIPTION": "Re-terminate and torque to spec", "TYPE": "REMEDY", "PARENT": "LOOSEWIRE" },
+    { "FAILURECODE": "SENSOR", "DESCRIPTION": "Discrete sensor / photo-eye", "TYPE": "FAILURECLASS", "PARENT": null },
+    { "FAILURECODE": "INTERMITTENT", "DESCRIPTION": "Intermittent / flickering signal", "TYPE": "PROBLEM", "PARENT": "SENSOR" }
+  ],
+  "meters": [
+    { "METERNAME": "RUNHOURS", "ASSETNUM": "MTR-16-1", "LASTREADING": 14820.5, "LASTREADINGDATE": "2026-06-01T00:00:00Z", "MEASUREUNITID": "HOURS", "METERTYPE": "CONTINUOUS" },
+    { "METERNAME": "VFD-OUTPUT-HZ", "ASSETNUM": "VFD-16-1", "LASTREADING": 48.2, "LASTREADINGDATE": "2026-06-01T11:59:00Z", "MEASUREUNITID": "HZ", "METERTYPE": "GAUGE" },
+    { "METERNAME": "MOTOR-AMPS", "ASSETNUM": "MTR-16-1", "LASTREADING": 3.1, "LASTREADINGDATE": "2026-06-01T11:59:00Z", "MEASUREUNITID": "AMPS", "METERTYPE": "GAUGE" }
+  ],
+  "parts": [
+    { "ITEMNUM": "GS11-10P2", "DESCRIPTION": "DuraPulse GS11 1HP 230V VFD", "ISSUEUNIT": "EA", "STORELOC": "CENTRAL", "CURBALTOTAL": 2, "SPAREPART_ASSETNUM": "VFD-16-1", "QUANTITY": 1 },
+    { "ITEMNUM": "QS18VN6D", "DESCRIPTION": "Banner QS18 PNP photo-eye", "ISSUEUNIT": "EA", "STORELOC": "CENTRAL", "CURBALTOTAL": 5, "SPAREPART_ASSETNUM": "PE-B16-2", "QUANTITY": 2 },
+    { "ITEMNUM": "BELT-2200-1200", "DESCRIPTION": "Dorner 2200 belt 1200mm", "ISSUEUNIT": "EA", "STORELOC": "LINE16-CRIB", "CURBALTOTAL": 1, "SPAREPART_ASSETNUM": "CONV16", "QUANTITY": 1 }
+  ],
+  "doclinks": [
+    { "DOCUMENT": "GS10-GS11-USERMANUAL", "DESCRIPTION": "DuraPulse GS10/GS11 User Manual", "URLNAME": "https://cdn.automationdirect.com/static/manuals/gs10m/gs10m.pdf", "URLTYPE": "URL", "OWNERTABLE": "ASSET", "OWNERID": "VFD-16-1" },
+    { "DOCUMENT": "QS18-DATASHEET", "DESCRIPTION": "Banner QS18 Datasheet", "URLNAME": "https://info.bannerengineering.com/cs/groups/public/documents/literature/qs18.pdf", "URLTYPE": "URL", "OWNERTABLE": "ASSET", "OWNERID": "PE-B16-2" }
+  ]
+}

--- a/mira-connectors/mira_connectors/mocks/ignition_mock.py
+++ b/mira-connectors/mira_connectors/mocks/ignition_mock.py
@@ -1,0 +1,206 @@
+"""IgnitionMockConnector — fixture-backed Ignition (SCADA) connector.
+
+Reads ``fixtures/ignition.json`` (a realistic 8.1 tag export: provider ``[default]``,
+site/area/line folders, OPC tags bound to a Modbus device). Exercises discover →
+import → normalize → derive_relationships. Read-only by construction (SCADA doctrine):
+``export_records`` refuses, inherited from ``SCADAConnector``.
+
+A real ``IgnitionConnector`` would replace ``_load()``/``import_records`` with the
+Ignition WebDev tag-browse endpoint (or the gateway tag export) and keep
+``normalize``/``derive_relationships`` verbatim.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from mira_connectors._uns import candidate_uns_path
+from mira_connectors.base import ConnectorCapabilities, ConnectorConfig, ConnectorKind
+from mira_connectors.canonical import (
+    CanonicalRecord,
+    CanonicalRelationship,
+    CanonicalTag,
+    EvidenceRef,
+    RawRecord,
+    RecordType,
+)
+from mira_connectors.types.scada import SCADA_RECORD_TYPES, SCADAConnector
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "ignition.json"
+
+# Ignition dataType → MIRA canonical data_type.
+_DT = {
+    "Boolean": "bool", "Int1": "int", "Int2": "int", "Int4": "int", "Int8": "int",
+    "Float4": "float", "Float8": "float", "String": "string",
+}
+# Folder names that denote a physical asset (not just a structural area). Used to
+# attach HAS_SIGNAL edges from the asset to its tags.
+_ASSET_FOLDERS = {"Motor", "GS10", "PE_B16_2"}
+
+
+class IgnitionMockConnector(SCADAConnector):
+    provider = "ignition"
+    is_mock = True
+
+    def __init__(self, config: ConnectorConfig) -> None:
+        super().__init__(config)
+        self._data: dict[str, Any] = {}
+
+    @property
+    def configured(self) -> bool:
+        return True
+
+    def _load(self) -> dict[str, Any]:
+        if not self._data:
+            self._data = json.loads(_FIXTURE.read_text())
+        return self._data
+
+    async def health_check(self) -> dict[str, Any]:
+        return {"ok": True, "provider": self.provider, "mock": True, "device": self._load().get("device")}
+
+    async def discover(self) -> ConnectorCapabilities:
+        data = self._load()
+        return ConnectorCapabilities(
+            kind=ConnectorKind.SCADA,
+            provider=self.provider,
+            record_types=SCADA_RECORD_TYPES,
+            supports_export=False,  # read-only by construction
+            supports_incremental=False,
+            schema={
+                "tagProvider": data.get("tagProvider"),
+                "opcServer": data.get("opcServer"),
+                "device": data.get("device"),
+                "tag_tree": _tree_outline(data.get("tags", [])),
+            },
+            notes="Mock Ignition. Read-only — MIRA does not write to the plant.",
+        )
+
+    # --- import: flatten the tag tree into one RawRecord per AtomicTag -------
+    async def import_records(
+        self, record_type: RecordType, *, since: str | None = None, limit: int = 500
+    ) -> list[RawRecord]:
+        if record_type is not RecordType.TAG:
+            return []  # locations/assets are *derived* from the tag tree, not imported
+        data = self._load()
+        provider = data.get("tagProvider", "default")
+        flat: list[RawRecord] = []
+        _flatten(data.get("tags", []), [], provider, flat, self.provider)
+        return flat[:limit]
+
+    def normalize(self, raw: list[RawRecord]) -> list[CanonicalRecord]:
+        out: list[CanonicalRecord] = []
+        for r in raw:
+            if r.record_type is not RecordType.TAG:
+                continue
+            f = r.fields
+            path_parts: list[str] = f["_path_parts"]  # ["Lake_Wales","Bench","Conveyor","Motor","Speed"]
+            out.append(
+                CanonicalTag(
+                    source_system=self.provider,
+                    source_record_id=r.source_record_id,
+                    tag_id=".".join(path_parts),
+                    data_type=_DT.get(f.get("dataType", ""), "float"),
+                    engineering_unit=f.get("engUnit"),
+                    scada_path=f["_scada_path"],
+                    address=f.get("opcItemPath"),
+                    history_enabled=bool(f.get("historyEnabled")),
+                    proposed_uns_path=candidate_uns_path(*path_parts),
+                    attributes={
+                        k: v for k, v in f.items()
+                        if k in ("deadband", "alarms", "tooltip", "valueSource")
+                    },
+                    confidence=0.85,  # Sparkplug/OPC path is a strong UNS identity source
+                    raw=f,
+                )
+            )
+        return out
+
+    # --- derive relationships: folder hierarchy + asset→tag HAS_SIGNAL -------
+    def derive_relationships(self, records: list[CanonicalRecord]) -> list[CanonicalRelationship]:
+        rels: list[CanonicalRelationship] = []
+        seen_located: set[tuple[str, str]] = set()
+        for rec in records:
+            if not isinstance(rec, CanonicalTag):
+                continue
+            parts = rec.tag_id.split(".")
+            # Find the nearest enclosing asset folder, if any.
+            asset_folder = next((p for p in reversed(parts[:-1]) if p in _ASSET_FOLDERS), None)
+            if asset_folder:
+                asset_path = candidate_uns_path(*parts[: parts.index(asset_folder) + 1])
+                rels.append(self._rel(
+                    "HAS_SIGNAL", asset_path, rec.tag_id,
+                    EvidenceRef("tag_list", f"Ignition tag {rec.scada_path}",
+                                page_or_location=rec.address, confidence_contribution=0.85),
+                    confidence=0.8, source_kind="uns_path", target_kind="tag_id",
+                ))
+            # Folder-to-folder LOCATED_IN chain (deduped).
+            for i in range(1, len(parts) - 1):
+                child = candidate_uns_path(*parts[: i + 1])
+                parent = candidate_uns_path(*parts[:i])
+                key = (child, parent)
+                if key in seen_located:
+                    continue
+                seen_located.add(key)
+                rels.append(self._rel(
+                    "LOCATED_IN", child, parent,
+                    EvidenceRef("tag_list", f"Ignition folder hierarchy under {parent}",
+                                page_or_location=rec.scada_path, confidence_contribution=0.6),
+                    confidence=0.65, source_kind="uns_path", target_kind="uns_path",
+                ))
+        return rels
+
+    def _rel(
+        self, rel_type: str, source_ref: str, target_ref: str, evidence: EvidenceRef,
+        *, confidence: float, source_kind: str, target_kind: str,
+    ) -> CanonicalRelationship:
+        return CanonicalRelationship(
+            source_system=self.provider,
+            source_record_id=f"{rel_type}:{source_ref}->{target_ref}",
+            relationship_type=rel_type,
+            source_ref=source_ref,
+            target_ref=target_ref,
+            source_ref_kind=source_kind,
+            target_ref_kind=target_kind,
+            confidence=confidence,
+            reasoning=f"Derived from Ignition {rel_type}",
+            evidence=[evidence],
+        )
+
+
+def _tree_outline(tags: list[dict[str, Any]], depth: int = 0) -> list[str]:
+    """Compact human-readable outline of the tag tree for the discover() schema."""
+    lines: list[str] = []
+    for t in tags:
+        kind = t.get("tagType")
+        marker = "📁" if kind == "Folder" else f"• {t.get('dataType')}"
+        lines.append(f"{'  ' * depth}{marker} {t['name']}")
+        if kind == "Folder":
+            lines.extend(_tree_outline(t.get("tags", []), depth + 1))
+    return lines
+
+
+def _flatten(
+    tags: list[dict[str, Any]], prefix: list[str], provider: str,
+    out: list[RawRecord], source_system: str,
+) -> None:
+    """Walk the tag tree; emit one RawRecord per AtomicTag with full path context."""
+    for t in tags:
+        name = t["name"]
+        parts = [*prefix, name]
+        if t.get("tagType") == "Folder":
+            _flatten(t.get("tags", []), parts, provider, out, source_system)
+        else:
+            scada_path = f"[{provider}]" + "/".join(parts)
+            fields = dict(t)
+            fields["_path_parts"] = parts
+            fields["_scada_path"] = scada_path
+            out.append(
+                RawRecord(
+                    source_system=source_system,
+                    record_type=RecordType.TAG,
+                    source_record_id=scada_path,
+                    fields=fields,
+                )
+            )

--- a/mira-connectors/mira_connectors/mocks/maximo_mock.py
+++ b/mira-connectors/mira_connectors/mocks/maximo_mock.py
@@ -1,0 +1,352 @@
+"""MaximoMockConnector — fixture-backed IBM Maximo (CMMS/EAM) connector.
+
+Reads ``fixtures/maximo.json`` (native Maximo field names) and exercises the full
+connector lifecycle: discover → import → normalize → validate → derive_relationships
+→ export. No network, no credentials. ``is_mock = True``.
+
+This is the reference CMMS connector. A real ``MaximoConnector`` would replace
+``_load()``/``import_records`` with Maximo REST (MAS ``oslc/os/mxapiasset`` etc.) and
+keep ``normalize``/``derive_relationships`` almost verbatim.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from mira_connectors._uns import candidate_uns_path
+from mira_connectors.base import (
+    ConnectorCapabilities,
+    ConnectorConfig,
+    ConnectorKind,
+    ExportResult,
+)
+from mira_connectors.canonical import (
+    CanonicalAsset,
+    CanonicalDocument,
+    CanonicalFailureCode,
+    CanonicalLocation,
+    CanonicalMeter,
+    CanonicalPart,
+    CanonicalPMTask,
+    CanonicalRecord,
+    CanonicalRelationship,
+    CanonicalWorkOrder,
+    EvidenceRef,
+    RawRecord,
+    RecordType,
+)
+from mira_connectors.types.cmms import CMMS_RECORD_TYPES, CMMSConnector
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "maximo.json"
+
+# Maximo WORKORDER.STATUS → MIRA work-order status.
+_WO_STATUS = {
+    "WAPPR": "OPEN", "APPR": "OPEN", "INPRG": "IN_PROGRESS",
+    "COMP": "COMPLETE", "CLOSE": "COMPLETE", "CAN": "CANCELLED",
+}
+# Maximo WORKORDER.WORKTYPE → MIRA work_type.
+_WORKTYPE = {"CM": "corrective", "PM": "preventive", "EM": "emergency"}
+# Maximo ASSETSPEC_CRITICALITY → MIRA criticality band.
+_CRIT = {"LOW": "low", "MEDIUM": "medium", "HIGH": "high", "SAFETY": "safety_critical"}
+
+
+class MaximoMockConnector(CMMSConnector):
+    provider = "maximo"
+    is_mock = True
+
+    def __init__(self, config: ConnectorConfig) -> None:
+        super().__init__(config)
+        self._data: dict[str, Any] = {}
+
+    # --- config (#6) ---------------------------------------------------------
+    @property
+    def configured(self) -> bool:
+        return True  # mock is always configured
+
+    def _load(self) -> dict[str, Any]:
+        if not self._data:
+            self._data = json.loads(_FIXTURE.read_text())
+        return self._data
+
+    async def health_check(self) -> dict[str, Any]:
+        data = self._load()
+        return {"ok": True, "provider": self.provider, "mock": True, "sites": len(data.get("sites", []))}
+
+    # --- discover (#1) -------------------------------------------------------
+    async def discover(self) -> ConnectorCapabilities:
+        return ConnectorCapabilities(
+            kind=ConnectorKind.CMMS,
+            provider=self.provider,
+            record_types=CMMS_RECORD_TYPES,
+            supports_export=True,  # CMMS write-back (work orders) is allowed (not a plant write)
+            supports_incremental=True,
+            schema={
+                "asset_object": "mxapiasset (MXASSET)",
+                "asset_fields": ["ASSETNUM", "DESCRIPTION", "SITEID", "LOCATION", "PARENT",
+                                 "MANUFACTURER", "VENDOR", "SERIALNUM", "ASSETTYPE", "STATUS", "CUSTOM.*"],
+                "workorder_object": "mxapiwodetail (WORKORDER)",
+                "workorder_fields": ["WONUM", "DESCRIPTION", "ASSETNUM", "STATUS", "WORKTYPE",
+                                     "FAILUREREPORT.FAILURECODE", "FAILUREREPORT.PROBLEMCODE"],
+                "location_hierarchy": "LOCATIONS + LOCHIERARCHY (SYSTEMID=PRIMARY)",
+            },
+            notes="Mock IBM Maximo. Real connector swaps _load() for MAS OSLC REST.",
+        )
+
+    # --- import (#2) ---------------------------------------------------------
+    async def import_records(
+        self, record_type: RecordType, *, since: str | None = None, limit: int = 500
+    ) -> list[RawRecord]:
+        data = self._load()
+        section_for = {
+            RecordType.LOCATION: ("locations", "LOCATION"),
+            RecordType.ASSET: ("assets", "ASSETNUM"),
+            RecordType.WORK_ORDER: ("workorders", "WONUM"),
+            RecordType.PM_TASK: ("pmtasks", "PMNUM"),
+            RecordType.FAILURE_CODE: ("failurecodes", "FAILURECODE"),
+            RecordType.METER: ("meters", "METERNAME"),
+            RecordType.PART: ("parts", "ITEMNUM"),
+            RecordType.DOCUMENT: ("doclinks", "DOCUMENT"),
+        }
+        if record_type not in section_for:
+            return []
+        section, pk = section_for[record_type]
+        rows = data.get(section, [])[:limit]
+        return [
+            RawRecord(
+                source_system=self.provider,
+                record_type=record_type,
+                source_record_id=str(row[pk]),
+                fields=row,
+            )
+            for row in rows
+        ]
+
+    # --- normalize (#3) ------------------------------------------------------
+    def normalize(self, raw: list[RawRecord]) -> list[CanonicalRecord]:
+        out: list[CanonicalRecord] = []
+        loc_index = {loc["LOCATION"]: loc for loc in self._load().get("locations", [])}
+        for r in raw:
+            f = r.fields
+            if r.record_type is RecordType.LOCATION:
+                out.append(self._loc(f))
+            elif r.record_type is RecordType.ASSET:
+                out.append(self._asset(f, loc_index))
+            elif r.record_type is RecordType.WORK_ORDER:
+                out.append(self._workorder(f))
+            elif r.record_type is RecordType.PM_TASK:
+                out.append(self._pm(f))
+            elif r.record_type is RecordType.FAILURE_CODE:
+                out.append(self._failurecode(f))
+            elif r.record_type is RecordType.METER:
+                out.append(self._meter(f))
+            elif r.record_type is RecordType.PART:
+                out.append(self._part(f))
+            elif r.record_type is RecordType.DOCUMENT:
+                out.append(self._doc(f))
+        return out
+
+    def _loc_path(self, location: str | None, loc_index: dict[str, Any]) -> list[str]:
+        """Walk LOCATIONS.PARENT up to the root, return descriptions root→leaf (slug source)."""
+        chain: list[str] = []
+        cur = location
+        seen: set[str] = set()
+        while cur and cur in loc_index and cur not in seen:
+            seen.add(cur)
+            chain.append(loc_index[cur]["DESCRIPTION"])
+            cur = loc_index[cur].get("PARENT")
+        return list(reversed(chain))
+
+    def _loc(self, f: dict[str, Any]) -> CanonicalLocation:
+        loc_index = {loc["LOCATION"]: loc for loc in self._load().get("locations", [])}
+        path = self._loc_path(f["LOCATION"], loc_index)
+        type_map = {0: "site", 1: "area", 2: "line", 3: "cell"}
+        depth = max(0, len(path) - 1)
+        return CanonicalLocation(
+            source_system=self.provider,
+            source_record_id=str(f["LOCATION"]),
+            name=f.get("DESCRIPTION", f["LOCATION"]),
+            location_type=type_map.get(depth, "cell"),
+            parent_source_id=f.get("PARENT"),
+            proposed_uns_path=candidate_uns_path(*path) if path else None,
+            confidence=0.7,
+            raw=f,
+        )
+
+    def _asset(self, f: dict[str, Any], loc_index: dict[str, Any]) -> CanonicalAsset:
+        custom = f.get("CUSTOM", {}) or {}
+        loc_path = self._loc_path(f.get("LOCATION"), loc_index)
+        path = candidate_uns_path(*loc_path, f["ASSETNUM"]) if loc_path else None
+        crit = _CRIT.get(str(custom.get("ASSETSPEC_CRITICALITY", "")).upper())
+        return CanonicalAsset(
+            source_system=self.provider,
+            source_record_id=str(f["ASSETNUM"]),
+            name=f.get("DESCRIPTION", f["ASSETNUM"]),
+            manufacturer=f.get("MANUFACTURER") or f.get("VENDOR"),
+            model=custom.get("MODELNUM"),
+            serial=f.get("SERIALNUM"),
+            asset_type=f.get("ASSETTYPE"),
+            parent_source_id=f.get("PARENT"),
+            criticality=crit,
+            location_path=".".join(loc_path) if loc_path else None,
+            proposed_uns_path=path,
+            attributes={k: v for k, v in custom.items() if k != "MODELNUM"},
+            confidence=0.6,
+            raw=f,
+        )
+
+    def _workorder(self, f: dict[str, Any]) -> CanonicalWorkOrder:
+        fr = f.get("FAILUREREPORT") or {}
+        return CanonicalWorkOrder(
+            source_system=self.provider,
+            source_record_id=str(f["WONUM"]),
+            wo_number=str(f["WONUM"]),
+            title=f.get("DESCRIPTION", ""),
+            description=f.get("DESCRIPTION", ""),
+            status=_WO_STATUS.get(f.get("STATUS", ""), f.get("STATUS")),
+            work_type=_WORKTYPE.get(f.get("WORKTYPE", ""), f.get("WORKTYPE")),
+            priority=str(f.get("WOPRIORITY")) if f.get("WOPRIORITY") is not None else None,
+            asset_source_id=f.get("ASSETNUM"),
+            failure_code=fr.get("FAILURECODE"),
+            reported_by=f.get("REPORTEDBY"),
+            reported_at=f.get("REPORTDATE"),
+            completed_at=f.get("ACTFINISH"),
+            confidence=0.9,
+            raw=f,
+        )
+
+    def _pm(self, f: dict[str, Any]) -> CanonicalPMTask:
+        return CanonicalPMTask(
+            source_system=self.provider,
+            source_record_id=str(f["PMNUM"]),
+            pm_number=str(f["PMNUM"]),
+            description=f.get("DESCRIPTION", ""),
+            asset_source_id=f.get("ASSETNUM"),
+            frequency=f.get("FREQUENCY"),
+            frequency_unit=str(f.get("FREQUNIT", "")).lower() or None,
+            job_plan=f.get("JPNUM"),
+            next_due=f.get("NEXTDATE"),
+            confidence=0.9,
+            raw=f,
+        )
+
+    def _failurecode(self, f: dict[str, Any]) -> CanonicalFailureCode:
+        t = f.get("TYPE", "")
+        return CanonicalFailureCode(
+            source_system=self.provider,
+            source_record_id=str(f["FAILURECODE"]),
+            code=str(f["FAILURECODE"]),
+            description=f.get("DESCRIPTION", ""),
+            failure_class=f.get("FAILURECODE") if t == "FAILURECLASS" else f.get("PARENT"),
+            problem=f.get("FAILURECODE") if t == "PROBLEM" else None,
+            cause=f.get("FAILURECODE") if t == "CAUSE" else None,
+            remedy=f.get("FAILURECODE") if t == "REMEDY" else None,
+            confidence=0.85,
+            raw=f,
+        )
+
+    def _meter(self, f: dict[str, Any]) -> CanonicalMeter:
+        return CanonicalMeter(
+            source_system=self.provider,
+            source_record_id=f"{f.get('ASSETNUM')}:{f['METERNAME']}",
+            name=str(f["METERNAME"]),
+            asset_source_id=f.get("ASSETNUM"),
+            last_reading=f.get("LASTREADING"),
+            unit=f.get("MEASUREUNITID"),
+            meter_type=str(f.get("METERTYPE", "")).lower() or None,
+            confidence=0.9,
+            raw=f,
+        )
+
+    def _part(self, f: dict[str, Any]) -> CanonicalPart:
+        return CanonicalPart(
+            source_system=self.provider,
+            source_record_id=str(f["ITEMNUM"]),
+            item_number=str(f["ITEMNUM"]),
+            description=f.get("DESCRIPTION", ""),
+            store_location=f.get("STORELOC"),
+            issue_unit=f.get("ISSUEUNIT"),
+            qty_on_hand=f.get("CURBALTOTAL"),
+            confidence=0.85,
+            raw=f,
+        )
+
+    def _doc(self, f: dict[str, Any]) -> CanonicalDocument:
+        return CanonicalDocument(
+            source_system=self.provider,
+            source_record_id=str(f["DOCUMENT"]),
+            title=f.get("DESCRIPTION", f["DOCUMENT"]),
+            doc_type="manual",
+            uri=f.get("URLNAME"),
+            asset_source_id=f.get("OWNERID") if f.get("OWNERTABLE") == "ASSET" else None,
+            confidence=0.8,
+            raw=f,
+        )
+
+    # --- derive relationships (cross-record) ---------------------------------
+    def derive_relationships(self, records: list[CanonicalRecord]) -> list[CanonicalRelationship]:
+        rels: list[CanonicalRelationship] = []
+        for rec in records:
+            if isinstance(rec, CanonicalAsset):
+                # asset → parent asset : HAS_COMPONENT (parent owns child)
+                if rec.parent_source_id:
+                    rels.append(self._rel(
+                        "HAS_COMPONENT", rec.parent_source_id, "asset", rec.source_record_id, "asset",
+                        EvidenceRef("manifest", f"Maximo ASSET.PARENT on {rec.source_record_id}",
+                                    page_or_location="MXASSET.PARENT", confidence_contribution=0.8),
+                        confidence=0.7,
+                    ))
+                # asset → location : LOCATED_IN (asset id and location id may coincide —
+                # distinct ref_kinds keep it from looking like a self-loop)
+                loc = rec.raw.get("LOCATION")
+                if loc:
+                    rels.append(self._rel(
+                        "LOCATED_IN", rec.source_record_id, "asset", str(loc), "location",
+                        EvidenceRef("manifest", f"Maximo ASSET.LOCATION on {rec.source_record_id}",
+                                    page_or_location="MXASSET.LOCATION", confidence_contribution=0.7),
+                        confidence=0.7,
+                    ))
+            elif isinstance(rec, CanonicalDocument) and rec.asset_source_id:
+                # asset → document : HAS_DOCUMENT
+                rels.append(self._rel(
+                    "HAS_DOCUMENT", rec.asset_source_id, "asset", rec.source_record_id, "document",
+                    EvidenceRef("manifest", f"Maximo DOCLINKS owner {rec.asset_source_id}",
+                                page_or_location="DOCLINKS.OWNERID", confidence_contribution=0.8),
+                    confidence=0.8,
+                ))
+            elif isinstance(rec, CanonicalWorkOrder) and rec.asset_source_id and rec.failure_code:
+                # failure code → asset : OCCURS_ON (evidence = the work order)
+                rels.append(self._rel(
+                    "OCCURS_ON", rec.failure_code, "failure_code", rec.asset_source_id, "asset",
+                    EvidenceRef("work_order", f"WO {rec.wo_number}: {rec.title}",
+                                page_or_location=f"WONUM {rec.wo_number}", confidence_contribution=0.6),
+                    confidence=0.55,
+                ))
+        return rels
+
+    def _rel(
+        self, rel_type: str, source_ref: str, source_kind: str, target_ref: str, target_kind: str,
+        evidence: EvidenceRef, *, confidence: float,
+    ) -> CanonicalRelationship:
+        return CanonicalRelationship(
+            source_system=self.provider,
+            source_record_id=f"{rel_type}:{source_kind}:{source_ref}->{target_kind}:{target_ref}",
+            relationship_type=rel_type,
+            source_ref=source_ref,
+            source_ref_kind=source_kind,
+            target_ref=target_ref,
+            target_ref_kind=target_kind,
+            confidence=confidence,
+            reasoning=f"Derived from Maximo {rel_type} link",
+            evidence=[evidence],
+        )
+
+    # --- export (#5): CMMS write-back (work orders) --------------------------
+    async def _do_export(self, enriched: list[CanonicalRecord]) -> ExportResult:
+        # Mock write-back: pretend to PATCH work orders back to Maximo. Only WOs are
+        # writable; everything else is refused. A real connector would POST/PATCH
+        # mxapiwodetail. This targets the CMMS API, not the plant — allowed by doctrine.
+        writable = [r for r in enriched if isinstance(r, CanonicalWorkOrder)]
+        refused = len(enriched) - len(writable)
+        return ExportResult(exported=len(writable), refused=refused)

--- a/mira-connectors/mira_connectors/service.py
+++ b/mira-connectors/mira_connectors/service.py
@@ -1,0 +1,77 @@
+"""Service layer wiring a connector to the confirmation gate.
+
+This is the "service function" deliverable for Phase 6: one call runs a connector's
+import → normalize → derive_relationships lifecycle and routes the results through the
+``ConnectorConfirmationGate`` as pending proposals. An HTTP route (FastAPI / Hub API)
+is a thin async wrapper over ``import_and_propose``; the confirm/correct/reject endpoints
+map 1:1 onto the gate methods.
+
+Read-only by default at every layer: importing + proposing never mutates the source and
+never writes the knowledge graph. Only a technician's ``gate.confirm()`` does.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from mira_connectors.base import Connector, SyncResult
+from mira_connectors.canonical import CanonicalRecord, CanonicalRelationship, RecordType
+from mira_connectors.confirmation_gate import ConnectorConfirmationGate, ProposeResult
+
+# Record types that become knowledge-graph *entities* (nodes). Work orders, PM tasks, and
+# meters are CMMS data that serve as *evidence*, not graph nodes, so they are not proposed
+# as kg_entity suggestions here.
+_ENTITY_RECORD_TYPES = {
+    RecordType.ASSET,
+    RecordType.LOCATION,
+    RecordType.TAG,
+    RecordType.DOCUMENT,
+    RecordType.FAILURE_CODE,
+    RecordType.PART,
+}
+
+
+@dataclass
+class ImportProposeResult:
+    provider: str
+    sync_results: list[SyncResult] = field(default_factory=list)
+    propose: Optional[ProposeResult] = None
+    record_count: int = 0
+    relationship_count: int = 0
+
+
+async def import_and_propose(
+    connector: Connector,
+    gate: ConnectorConfirmationGate,
+    *,
+    record_types: list[RecordType],
+    tenant_id: Optional[str] = None,
+    limit: int = 500,
+) -> ImportProposeResult:
+    """Import the given record types from ``connector`` and route them through ``gate``.
+
+    Returns the per-type sync logs and the resulting proposal ids. Does not confirm
+    anything — every mapping lands as a pending ``ai_suggestions`` row for a technician.
+    """
+    tenant = tenant_id or connector.config.tenant_id
+    out = ImportProposeResult(provider=connector.provider)
+
+    all_records: list[CanonicalRecord] = []
+    for rt in record_types:
+        records, sync = await connector.sync(rt, limit=limit)  # type: ignore[attr-defined]
+        out.sync_results.append(sync)
+        all_records.extend(records)
+
+    relationships: list[CanonicalRelationship] = connector.derive_relationships(all_records)  # type: ignore[attr-defined]
+    entities = [r for r in all_records if r.record_type in _ENTITY_RECORD_TYPES]
+
+    out.record_count = len(all_records)
+    out.relationship_count = len(relationships)
+    out.propose = gate.propose(
+        tenant_id=tenant,
+        provider=connector.provider,
+        entities=entities,
+        relationships=relationships,
+    )
+    return out

--- a/mira-connectors/mira_connectors/store.py
+++ b/mira-connectors/mira_connectors/store.py
@@ -1,0 +1,574 @@
+"""Persistence layer for the connector confirmation gate.
+
+The gate writes to MIRA's **existing** tables — no new tables (ADR-0014, ADR-0017):
+
+- ``ai_suggestions``         — the Hub ``/proposals`` work queue (one row per pending decision)
+- ``relationship_proposals`` + ``relationship_evidence`` — edge proposals + evidence (Hub 018)
+- ``kg_relationships``       — the verified graph (written on confirm, mirroring the Hub
+                               ``/api/proposals/[id]/decide`` route)
+- ``kg_entities``            — verified entities (written on confirm of a kg_entity suggestion)
+
+Two implementations:
+
+- ``InMemoryProposalStore`` — deterministic, dependency-free; backs the gate tests and
+  any offline/dev run ("offline mode is the floor", `.claude/rules/uns-compliance.md` §8).
+- ``PostgresProposalStore`` — SQLAlchemy + ``NullPool`` + ``sslmode=require``, mirroring
+  ``mira-bots/shared/neon_recall.py``. Sets the RLS tenant GUC per transaction the way the
+  Hub ``withTenantContext`` does. Not exercised by the offline tests.
+
+Status transitions follow ADR-0017 exactly. When the ADR-0017 helpers
+(``mira_bots/shared/proposal_transition.py`` / ``mira-hub/lib/proposal-transition.ts``)
+land, ``PostgresProposalStore`` should delegate its status writes to them. Until then the
+transition logic is connector-local (see ``confirmation_gate.py``).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from typing import Any, Optional, Protocol
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ── Row shapes (mirror the live table columns) ──────────────────────────────
+
+
+@dataclass
+class SuggestionRow:
+    """A row in ``ai_suggestions`` (Hub mig 027)."""
+
+    tenant_id: str
+    suggestion_type: str  # kg_edge|kg_entity|tag_mapping|component_profile|uns_confirmation|namespace_move
+    extracted_data: dict[str, Any]
+    proposed_by: str = "import:unknown"
+    confidence: float = 0.5
+    status: str = "pending"  # pending|accepted|rejected|deferred|superseded
+    risk_level: str = "low"
+    source_kind: Optional[str] = None
+    source_id: Optional[str] = None
+    source_document_id: Optional[str] = None
+    source_page: Optional[int] = None
+    title: Optional[str] = None
+    body: Optional[str] = None
+    reviewed_by: Optional[str] = None
+    reviewed_at: Optional[str] = None
+    review_note: Optional[str] = None
+    id: str = field(default_factory=_uuid)
+    created_at: str = field(default_factory=_now)
+    updated_at: str = field(default_factory=_now)
+
+
+@dataclass
+class ProposalRow:
+    """A row in ``relationship_proposals`` (Hub mig 018)."""
+
+    tenant_id: Optional[str]
+    source_entity_id: str
+    source_entity_type: str
+    target_entity_id: str
+    target_entity_type: str
+    relationship_type: str
+    confidence: float = 0.5
+    status: str = "proposed"  # proposed|reviewed|verified|rejected|deprecated|contradicted
+    created_by: str = "import"  # llm|human|import|rule
+    risk_level: str = "low"
+    requires_human_review: bool = True
+    reasoning: Optional[str] = None
+    reviewed_by: Optional[str] = None
+    reviewed_at: Optional[str] = None
+    id: str = field(default_factory=_uuid)
+    created_at: str = field(default_factory=_now)
+
+
+@dataclass
+class EvidenceRow:
+    """A row in ``relationship_evidence`` (Hub mig 018)."""
+
+    proposal_id: str
+    evidence_type: str
+    source_description: str
+    page_or_location: Optional[str] = None
+    excerpt: Optional[str] = None
+    confidence_contribution: float = 0.0
+    source_id: Optional[str] = None
+    id: str = field(default_factory=_uuid)
+
+
+@dataclass
+class KgEntityRow:
+    tenant_id: str
+    uns_path: Optional[str]
+    entity_type: str
+    name: str
+    properties: dict[str, Any] = field(default_factory=dict)
+    approval_state: str = "verified"
+    proposed_by: str = "import"
+    id: str = field(default_factory=_uuid)
+
+
+@dataclass
+class KgRelationshipRow:
+    tenant_id: str
+    source_id: str
+    target_id: str
+    relationship_type: str
+    confidence: float
+    approval_state: str = "verified"
+    proposed_by: str = "import"
+    evidence_summary: Optional[str] = None
+    id: str = field(default_factory=_uuid)
+
+
+# ── Store protocol ──────────────────────────────────────────────────────────
+
+
+class ProposalStore(Protocol):
+    """Everything the gate needs to persist. All ops are tenant-scoped."""
+
+    def insert_suggestion(self, row: SuggestionRow) -> str: ...
+    def get_suggestion(self, tenant_id: str, suggestion_id: str) -> Optional[SuggestionRow]: ...
+    def update_suggestion(self, suggestion_id: str, **fields: Any) -> None: ...
+    def list_suggestions(
+        self, tenant_id: str, *, status: Optional[str] = None, suggestion_type: Optional[str] = None
+    ) -> list[SuggestionRow]: ...
+
+    def insert_proposal(self, row: ProposalRow) -> str: ...
+    def get_proposal(self, proposal_id: str) -> Optional[ProposalRow]: ...
+    def update_proposal(self, proposal_id: str, **fields: Any) -> None: ...
+    def insert_evidence(self, row: EvidenceRow) -> str: ...
+
+    # entity resolution + writes
+    def resolve_entity(self, tenant_id: str, ref: str, ref_kind: str) -> Optional[str]: ...
+    def create_entity(self, row: KgEntityRow) -> str: ...
+    def upsert_relationship(self, row: KgRelationshipRow) -> str: ...
+
+
+# ── In-memory implementation (tests + offline) ──────────────────────────────
+
+
+class InMemoryProposalStore:
+    """Deterministic in-memory store. No DB, no network."""
+
+    def __init__(self) -> None:
+        self.suggestions: dict[str, SuggestionRow] = {}
+        self.proposals: dict[str, ProposalRow] = {}
+        self.evidence: dict[str, EvidenceRow] = {}
+        self.entities: dict[str, KgEntityRow] = {}
+        self.relationships: dict[str, KgRelationshipRow] = {}
+        # natural-key index for resolve_entity: (tenant, kind, ref) -> entity_id
+        self._entity_index: dict[tuple[str, str, str], str] = {}
+
+    # suggestions
+    def insert_suggestion(self, row: SuggestionRow) -> str:
+        self.suggestions[row.id] = row
+        return row.id
+
+    def get_suggestion(self, tenant_id: str, suggestion_id: str) -> Optional[SuggestionRow]:
+        row = self.suggestions.get(suggestion_id)
+        return row if row and row.tenant_id == tenant_id else None
+
+    def update_suggestion(self, suggestion_id: str, **fields: Any) -> None:
+        row = self.suggestions.get(suggestion_id)
+        if row is None:
+            return
+        for k, v in fields.items():
+            if k.startswith("_"):  # transport hints like _tenant_id (Postgres-only)
+                continue
+            setattr(row, k, v)
+        row.updated_at = _now()
+
+    def list_suggestions(
+        self, tenant_id: str, *, status: Optional[str] = None, suggestion_type: Optional[str] = None
+    ) -> list[SuggestionRow]:
+        out = [r for r in self.suggestions.values() if r.tenant_id == tenant_id]
+        if status is not None:
+            out = [r for r in out if r.status == status]
+        if suggestion_type is not None:
+            out = [r for r in out if r.suggestion_type == suggestion_type]
+        return sorted(out, key=lambda r: r.created_at)
+
+    # proposals + evidence
+    def insert_proposal(self, row: ProposalRow) -> str:
+        self.proposals[row.id] = row
+        return row.id
+
+    def get_proposal(self, proposal_id: str) -> Optional[ProposalRow]:
+        return self.proposals.get(proposal_id)
+
+    def update_proposal(self, proposal_id: str, **fields: Any) -> None:
+        row = self.proposals.get(proposal_id)
+        if row is None:
+            return
+        for k, v in fields.items():
+            if k.startswith("_"):
+                continue
+            setattr(row, k, v)
+
+    def insert_evidence(self, row: EvidenceRow) -> str:
+        self.evidence[row.id] = row
+        return row.id
+
+    # entities
+    def register_entity_key(self, tenant_id: str, kind: str, ref: str, entity_id: str) -> None:
+        """Seed the resolver — used by tests and by create_entity."""
+        self._entity_index[(tenant_id, kind, ref)] = entity_id
+
+    def resolve_entity(self, tenant_id: str, ref: str, ref_kind: str) -> Optional[str]:
+        return self._entity_index.get((tenant_id, ref_kind, ref))
+
+    def create_entity(self, row: KgEntityRow) -> str:
+        self.entities[row.id] = row
+        # make the new entity resolvable by uns_path and by its natural key, so edges
+        # referencing it (by source_record_id + kind) resolve once it's confirmed.
+        if row.uns_path:
+            self._entity_index[(row.tenant_id, "uns_path", row.uns_path)] = row.id
+        nat_ref = row.properties.get("source_record_id")
+        nat_kind = row.properties.get("ref_kind")
+        if nat_ref and nat_kind:
+            self._entity_index[(row.tenant_id, str(nat_kind), str(nat_ref))] = row.id
+        return row.id
+
+    def upsert_relationship(self, row: KgRelationshipRow) -> str:
+        # dedupe on (tenant, source, target, type) — mirrors the Hub decide route
+        for existing in self.relationships.values():
+            if (
+                existing.tenant_id == row.tenant_id
+                and existing.source_id == row.source_id
+                and existing.target_id == row.target_id
+                and existing.relationship_type == row.relationship_type
+            ):
+                existing.approval_state = "verified"
+                existing.confidence = max(existing.confidence, row.confidence)
+                existing.evidence_summary = existing.evidence_summary or row.evidence_summary
+                return existing.id
+        self.relationships[row.id] = row
+        return row.id
+
+
+# ── Postgres implementation (production; not exercised by offline tests) ─────
+
+
+class PostgresProposalStore:
+    """SQLAlchemy + NullPool store. Mirrors mira-bots/shared/neon_recall.py connection.
+
+    Every write runs inside ``engine.begin()`` with the RLS tenant GUC set
+    (``SET LOCAL app.current_tenant_id``), exactly as the Hub ``withTenantContext`` does.
+    Imported lazily so the offline tests never need SQLAlchemy installed.
+    """
+
+    def __init__(self, database_url: Optional[str] = None) -> None:
+        self._url = database_url or os.environ.get("NEON_DATABASE_URL")
+        self._engine = None
+
+    def _eng(self):  # noqa: ANN202 - SQLAlchemy Engine, imported lazily
+        if self._engine is None:
+            if not self._url:
+                raise RuntimeError("NEON_DATABASE_URL not set")
+            from sqlalchemy import create_engine  # noqa: PLC0415
+            from sqlalchemy.pool import NullPool  # noqa: PLC0415
+
+            self._engine = create_engine(
+                self._url,
+                poolclass=NullPool,
+                connect_args={"sslmode": "require"},
+                pool_pre_ping=True,
+            )
+        return self._engine
+
+    def _tx(self, tenant_id: str):  # noqa: ANN202 - context manager over a tenant-scoped tx
+        from contextlib import contextmanager  # noqa: PLC0415
+
+        from sqlalchemy import text  # noqa: PLC0415
+
+        @contextmanager
+        def _ctx():  # noqa: ANN202
+            with self._eng().begin() as conn:
+                # RLS scoping — same GUC the Hub sets via withTenantContext.
+                conn.execute(
+                    text("SELECT set_config('app.current_tenant_id', :tid, true)"),
+                    {"tid": tenant_id},
+                )
+                yield conn
+
+        return _ctx()
+
+    def insert_suggestion(self, row: SuggestionRow) -> str:
+        import json  # noqa: PLC0415
+
+        from sqlalchemy import text  # noqa: PLC0415
+
+        with self._tx(row.tenant_id) as conn:
+            res = conn.execute(
+                text(
+                    """
+                    INSERT INTO ai_suggestions
+                      (id, tenant_id, suggestion_type, source_kind, source_id,
+                       source_document_id, source_page, extracted_data, confidence,
+                       status, risk_level, proposed_by, title, body)
+                    VALUES
+                      (:id, :tenant_id, :suggestion_type, :source_kind, :source_id,
+                       :source_document_id, :source_page, CAST(:extracted_data AS JSONB),
+                       :confidence, :status, :risk_level, :proposed_by, :title, :body)
+                    RETURNING id
+                    """
+                ),
+                {
+                    "id": row.id, "tenant_id": row.tenant_id, "suggestion_type": row.suggestion_type,
+                    "source_kind": row.source_kind, "source_id": row.source_id,
+                    "source_document_id": row.source_document_id, "source_page": row.source_page,
+                    "extracted_data": json.dumps(row.extracted_data), "confidence": row.confidence,
+                    "status": row.status, "risk_level": row.risk_level, "proposed_by": row.proposed_by,
+                    "title": row.title, "body": row.body,
+                },
+            )
+            return str(res.scalar_one())
+
+    def get_suggestion(self, tenant_id: str, suggestion_id: str) -> Optional[SuggestionRow]:
+        from sqlalchemy import text  # noqa: PLC0415
+
+        with self._tx(tenant_id) as conn:
+            res = conn.execute(
+                text("SELECT * FROM ai_suggestions WHERE id = :id AND tenant_id = :tid"),
+                {"id": suggestion_id, "tid": tenant_id},
+            ).mappings().first()
+        if not res:
+            return None
+        return SuggestionRow(
+            id=str(res["id"]), tenant_id=str(res["tenant_id"]),
+            suggestion_type=res["suggestion_type"], extracted_data=res["extracted_data"] or {},
+            proposed_by=res["proposed_by"], confidence=res["confidence"], status=res["status"],
+            risk_level=res["risk_level"], source_kind=res["source_kind"],
+            source_id=str(res["source_id"]) if res["source_id"] else None,
+            title=res["title"], body=res["body"], reviewed_by=res["reviewed_by"],
+            reviewed_at=str(res["reviewed_at"]) if res["reviewed_at"] else None,
+            review_note=res["review_note"],
+        )
+
+    def update_suggestion(self, suggestion_id: str, **fields: Any) -> None:
+        import json  # noqa: PLC0415
+
+        from sqlalchemy import text  # noqa: PLC0415
+
+        tenant_id = fields.pop("_tenant_id", None)
+        if "extracted_data" in fields:
+            fields["extracted_data"] = json.dumps(fields["extracted_data"])
+        cols = ", ".join(
+            f"{k} = CAST(:{k} AS JSONB)" if k == "extracted_data" else f"{k} = :{k}"
+            for k in fields
+        )
+        params = {**fields, "id": suggestion_id}
+        sql = f"UPDATE ai_suggestions SET {cols}, updated_at = now() WHERE id = :id"
+        eng = self._eng()
+        with eng.begin() as conn:
+            if tenant_id:
+                conn.execute(
+                    text("SELECT set_config('app.current_tenant_id', :tid, true)"), {"tid": tenant_id}
+                )
+            conn.execute(text(sql), params)
+
+    def list_suggestions(
+        self, tenant_id: str, *, status: Optional[str] = None, suggestion_type: Optional[str] = None
+    ) -> list[SuggestionRow]:
+        from sqlalchemy import text  # noqa: PLC0415
+
+        clauses = ["tenant_id = :tid"]
+        params: dict[str, Any] = {"tid": tenant_id}
+        if status:
+            clauses.append("status = :status")
+            params["status"] = status
+        if suggestion_type:
+            clauses.append("suggestion_type = :stype")
+            params["stype"] = suggestion_type
+        sql = f"SELECT * FROM ai_suggestions WHERE {' AND '.join(clauses)} ORDER BY created_at"
+        with self._tx(tenant_id) as conn:
+            rows = conn.execute(text(sql), params).mappings().all()
+        return [
+            SuggestionRow(
+                id=str(r["id"]), tenant_id=str(r["tenant_id"]), suggestion_type=r["suggestion_type"],
+                extracted_data=r["extracted_data"] or {}, proposed_by=r["proposed_by"],
+                confidence=r["confidence"], status=r["status"], risk_level=r["risk_level"],
+                source_kind=r["source_kind"], title=r["title"], body=r["body"],
+            )
+            for r in rows
+        ]
+
+    def insert_proposal(self, row: ProposalRow) -> str:
+        from sqlalchemy import text  # noqa: PLC0415
+
+        with self._tx(row.tenant_id or "") as conn:
+            res = conn.execute(
+                text(
+                    """
+                    INSERT INTO relationship_proposals
+                      (id, tenant_id, source_entity_id, source_entity_type,
+                       target_entity_id, target_entity_type, relationship_type,
+                       confidence, status, created_by, risk_level, requires_human_review, reasoning)
+                    VALUES
+                      (:id, :tenant_id, :source_entity_id, :source_entity_type,
+                       :target_entity_id, :target_entity_type, :relationship_type,
+                       :confidence, :status, :created_by, :risk_level, :requires_human_review, :reasoning)
+                    RETURNING id
+                    """
+                ),
+                row.__dict__,
+            )
+            return str(res.scalar_one())
+
+    def get_proposal(self, proposal_id: str) -> Optional[ProposalRow]:
+        from sqlalchemy import text  # noqa: PLC0415
+
+        eng = self._eng()
+        with eng.connect() as conn:
+            r = conn.execute(
+                text("SELECT * FROM relationship_proposals WHERE id = :id"), {"id": proposal_id}
+            ).mappings().first()
+        if not r:
+            return None
+        return ProposalRow(
+            id=str(r["id"]), tenant_id=str(r["tenant_id"]) if r["tenant_id"] else None,
+            source_entity_id=str(r["source_entity_id"]), source_entity_type=r["source_entity_type"],
+            target_entity_id=str(r["target_entity_id"]), target_entity_type=r["target_entity_type"],
+            relationship_type=r["relationship_type"], confidence=r["confidence"], status=r["status"],
+            created_by=r["created_by"], risk_level=r["risk_level"],
+            requires_human_review=r["requires_human_review"], reasoning=r["reasoning"],
+        )
+
+    def update_proposal(self, proposal_id: str, **fields: Any) -> None:
+        from sqlalchemy import text  # noqa: PLC0415
+
+        tenant_id = fields.pop("_tenant_id", None)
+        cols = ", ".join(f"{k} = :{k}" for k in fields)
+        eng = self._eng()
+        with eng.begin() as conn:
+            if tenant_id:
+                conn.execute(
+                    text("SELECT set_config('app.current_tenant_id', :tid, true)"), {"tid": tenant_id}
+                )
+            conn.execute(
+                text(f"UPDATE relationship_proposals SET {cols} WHERE id = :id"),
+                {**fields, "id": proposal_id},
+            )
+
+    def insert_evidence(self, row: EvidenceRow) -> str:
+        from sqlalchemy import text  # noqa: PLC0415
+
+        eng = self._eng()
+        with eng.begin() as conn:
+            res = conn.execute(
+                text(
+                    """
+                    INSERT INTO relationship_evidence
+                      (id, proposal_id, evidence_type, source_id, source_description,
+                       page_or_location, excerpt, confidence_contribution)
+                    VALUES
+                      (:id, :proposal_id, :evidence_type, :source_id, :source_description,
+                       :page_or_location, :excerpt, :confidence_contribution)
+                    RETURNING id
+                    """
+                ),
+                row.__dict__,
+            )
+            return str(res.scalar_one())
+
+    def resolve_entity(self, tenant_id: str, ref: str, ref_kind: str) -> Optional[str]:
+        from sqlalchemy import text  # noqa: PLC0415
+
+        # uns_path is the strong resolver; natural keys land in properties->>'source_record_id'.
+        with self._tx(tenant_id) as conn:
+            if ref_kind == "uns_path":
+                r = conn.execute(
+                    text("SELECT id FROM kg_entities WHERE tenant_id = :tid AND uns_path = :ref"),
+                    {"tid": tenant_id, "ref": ref},
+                ).first()
+            else:
+                # natural-key match: properties.natural_key == "<kind>:<ref>" disambiguates
+                # an asset and a location that share a source id (e.g. CONV16).
+                r = conn.execute(
+                    text(
+                        "SELECT id FROM kg_entities WHERE tenant_id = :tid "
+                        "AND properties->>'natural_key' = :nk"
+                    ),
+                    {"tid": tenant_id, "nk": f"{ref_kind}:{ref}"},
+                ).first()
+        return str(r[0]) if r else None
+
+    def create_entity(self, row: KgEntityRow) -> str:
+        import json  # noqa: PLC0415
+
+        from sqlalchemy import text  # noqa: PLC0415
+
+        with self._tx(row.tenant_id) as conn:
+            res = conn.execute(
+                text(
+                    """
+                    INSERT INTO kg_entities
+                      (id, tenant_id, uns_path, entity_type, name, properties, approval_state)
+                    VALUES
+                      (:id, :tenant_id, :uns_path, :entity_type, :name,
+                       CAST(:properties AS JSONB), :approval_state)
+                    RETURNING id
+                    """
+                ),
+                {
+                    "id": row.id, "tenant_id": row.tenant_id, "uns_path": row.uns_path,
+                    "entity_type": row.entity_type, "name": row.name,
+                    "properties": json.dumps(row.properties), "approval_state": row.approval_state,
+                },
+            )
+            return str(res.scalar_one())
+
+    def upsert_relationship(self, row: KgRelationshipRow) -> str:
+        from sqlalchemy import text  # noqa: PLC0415
+
+        # Mirrors mira-hub /api/proposals/[id]/decide: dedupe on tenant+source+target+type.
+        with self._tx(row.tenant_id) as conn:
+            existing = conn.execute(
+                text(
+                    """SELECT id FROM kg_relationships
+                       WHERE tenant_id = :tid AND source_id = :s AND target_id = :t
+                         AND relationship_type = :rt"""
+                ),
+                {"tid": row.tenant_id, "s": row.source_id, "t": row.target_id, "rt": row.relationship_type},
+            ).first()
+            if existing:
+                conn.execute(
+                    text(
+                        """UPDATE kg_relationships
+                             SET approval_state = 'verified',
+                                 confidence = GREATEST(confidence, :c),
+                                 proposed_by = COALESCE(proposed_by, :pb),
+                                 evidence_summary = COALESCE(evidence_summary, :es)
+                           WHERE id = :id"""
+                    ),
+                    {"c": row.confidence, "pb": row.proposed_by, "es": row.evidence_summary, "id": existing[0]},
+                )
+                return str(existing[0])
+            res = conn.execute(
+                text(
+                    """INSERT INTO kg_relationships
+                         (id, tenant_id, source_id, target_id, relationship_type,
+                          confidence, approval_state, proposed_by, evidence_summary)
+                       VALUES (:id, :tid, :s, :t, :rt, :c, 'verified', :pb, :es)
+                       RETURNING id"""
+                ),
+                {
+                    "id": row.id, "tid": row.tenant_id, "s": row.source_id, "t": row.target_id,
+                    "rt": row.relationship_type, "c": row.confidence, "pb": row.proposed_by,
+                    "es": row.evidence_summary,
+                },
+            )
+            return str(res.scalar_one())
+
+
+def replace_row(row: Any, **changes: Any) -> Any:
+    """Dataclass ``replace`` re-export so the gate can clone rows for corrections."""
+    return replace(row, **changes)

--- a/mira-connectors/mira_connectors/store.py
+++ b/mira-connectors/mira_connectors/store.py
@@ -14,7 +14,11 @@ Two implementations:
   any offline/dev run ("offline mode is the floor", `.claude/rules/uns-compliance.md` §8).
 - ``PostgresProposalStore`` — SQLAlchemy + ``NullPool`` + ``sslmode=require``, mirroring
   ``mira-bots/shared/neon_recall.py``. Sets the RLS tenant GUC per transaction the way the
-  Hub ``withTenantContext`` does. Not exercised by the offline tests.
+  Hub ``withTenantContext`` does. **Its SQL is schema-verified against the live migrations**
+  (ai_suggestions mig 027, relationship_proposals/evidence mig 018, kg_entities mig
+  001/010/024/025/029, kg_relationships per the Hub decide route) **but is NOT executed by
+  the offline test suite** — the tests run entirely on ``InMemoryProposalStore``. Exercise it
+  against a staging NeonDB before relying on it in production (master-plan migration gate).
 
 Status transitions follow ADR-0017 exactly. When the ADR-0017 helpers
 (``mira_bots/shared/proposal_transition.py`` / ``mira-hub/lib/proposal-transition.ts``)
@@ -506,21 +510,33 @@ class PostgresProposalStore:
 
         from sqlalchemy import text  # noqa: PLC0415
 
+        # Real kg_entities columns (Hub mig 001 + 010 uns_path + 024 source_chunk_id +
+        # 029 approval_state). Natural key is UNIQUE(tenant_id, entity_type, name) per
+        # mig 025/026 — upsert on it so confirming the same entity twice is idempotent
+        # (entity_id is nullable post-025; we fill it with the source natural key, which
+        # also satisfies the pre-025 NOT NULL).
+        entity_id = str(row.properties.get("source_record_id") or row.name)
         with self._tx(row.tenant_id) as conn:
             res = conn.execute(
                 text(
                     """
                     INSERT INTO kg_entities
-                      (id, tenant_id, uns_path, entity_type, name, properties, approval_state)
+                      (id, tenant_id, entity_type, entity_id, name, uns_path,
+                       properties, approval_state)
                     VALUES
-                      (:id, :tenant_id, :uns_path, :entity_type, :name,
+                      (:id, :tenant_id, :entity_type, :entity_id, :name, :uns_path,
                        CAST(:properties AS JSONB), :approval_state)
+                    ON CONFLICT (tenant_id, entity_type, name) DO UPDATE
+                      SET uns_path = COALESCE(EXCLUDED.uns_path, kg_entities.uns_path),
+                          approval_state = EXCLUDED.approval_state,
+                          properties = kg_entities.properties || EXCLUDED.properties,
+                          updated_at = now()
                     RETURNING id
                     """
                 ),
                 {
-                    "id": row.id, "tenant_id": row.tenant_id, "uns_path": row.uns_path,
-                    "entity_type": row.entity_type, "name": row.name,
+                    "id": row.id, "tenant_id": row.tenant_id, "entity_type": row.entity_type,
+                    "entity_id": entity_id, "name": row.name, "uns_path": row.uns_path,
                     "properties": json.dumps(row.properties), "approval_state": row.approval_state,
                 },
             )

--- a/mira-connectors/mira_connectors/types/__init__.py
+++ b/mira-connectors/mira_connectors/types/__init__.py
@@ -1,0 +1,19 @@
+"""Connector *type* base classes.
+
+Each fixes ``kind`` and adds domain shape. Plant-facing types (SCADA, Historian,
+MQTT) refuse write-back by construction — MIRA does not write to the plant.
+"""
+
+from mira_connectors.types.cmms import CMMSConnector
+from mira_connectors.types.document import DocumentConnector
+from mira_connectors.types.historian import HistorianConnector
+from mira_connectors.types.mqtt import MQTTConnector
+from mira_connectors.types.scada import SCADAConnector
+
+__all__ = [
+    "CMMSConnector",
+    "DocumentConnector",
+    "HistorianConnector",
+    "MQTTConnector",
+    "SCADAConnector",
+]

--- a/mira-connectors/mira_connectors/types/cmms.py
+++ b/mira-connectors/mira_connectors/types/cmms.py
@@ -1,0 +1,36 @@
+"""CMMS / EAM connector type base.
+
+Generalizes the existing ``mira-mcp/cmms/base.py:CMMSAdapter`` (Atlas, MaintainX,
+Limble, Fiix) into the connector framework. CMMS is one of the two connector types
+that *can* write back (work-order create/complete) — but write-back is still gated by
+``ConnectorConfig.mode``/``dry_run`` and defaults to read-only.
+
+Concrete CMMS connectors implement the abstract ``Connector`` methods. ``export_records``
+write-back, when supported, goes to the CMMS API — NOT to the plant — so it is allowed
+under doctrine (unlike SCADA/Historian/MQTT).
+"""
+
+from __future__ import annotations
+
+from mira_connectors.base import BaseConnector, ConnectorKind
+from mira_connectors.canonical import RecordType
+
+CMMS_RECORD_TYPES = [
+    RecordType.LOCATION,
+    RecordType.ASSET,
+    RecordType.WORK_ORDER,
+    RecordType.PM_TASK,
+    RecordType.FAILURE_CODE,
+    RecordType.METER,
+    RecordType.PART,
+    RecordType.DOCUMENT,  # doclinks
+]
+
+
+class CMMSConnector(BaseConnector):
+    """Base for CMMS / EAM connectors (Maximo, MaintainX, Limble, Fiix, Atlas)."""
+
+    kind = ConnectorKind.CMMS
+    # CMMS write-back is permitted (work-order create/complete) — it targets the CMMS
+    # API, not the plant — but stays subject to the read-only-by-default mode guard in
+    # BaseConnector.export_records. Concrete connectors override _do_export to enable it.

--- a/mira-connectors/mira_connectors/types/document.py
+++ b/mira-connectors/mira_connectors/types/document.py
@@ -1,0 +1,26 @@
+"""Document / manual connector type base.
+
+Extends the existing ``mira-crawler/ingest/`` pipeline conceptually: a document
+connector discovers a manual/drawing/datasheet store (a folder, a SharePoint library,
+an OEM portal), imports document metadata, and normalizes into ``CanonicalDocument``
+rows. The heavy lifting — chunk → embed → dedup → store → kg_writer side-effect — stays
+in ``mira-crawler/ingest/`` (this connector hands off ``CanonicalDocument`` records and
+does not re-implement the tuned chunker/embedder/dedup).
+
+Write-back ("export enriched records") for a document store means writing back derived
+metadata (extracted UNS path, asset link, extracted fault codes) — never mutating the
+source PDFs. It is gated by mode like CMMS; default read-only.
+"""
+
+from __future__ import annotations
+
+from mira_connectors.base import BaseConnector, ConnectorKind
+from mira_connectors.canonical import RecordType
+
+DOCUMENT_RECORD_TYPES = [RecordType.DOCUMENT]
+
+
+class DocumentConnector(BaseConnector):
+    """Base for document/manual connectors. Hands canonical docs to mira-crawler ingest."""
+
+    kind = ConnectorKind.DOCUMENT

--- a/mira-connectors/mira_connectors/types/historian.py
+++ b/mira-connectors/mira_connectors/types/historian.py
@@ -1,0 +1,34 @@
+"""Historian connector type base — NEW type (AVEVA PI / OSIsoft, Canary, etc.).
+
+A historian connector discovers the PI point catalog (or equivalent) and imports point
+definitions + summarized history, normalizing into ``CanonicalTag`` (point metadata)
+and ``CanonicalMeter`` (rolled-up readings). It does NOT stream raw high-frequency
+samples — that firehose belongs to the relay/event-stream layer (master plan Phase 5).
+A historian is a *system of record for time-series metadata*; MIRA reads point names,
+units, and engineering ranges to enrich the asset graph.
+
+READ-ONLY BY CONSTRUCTION, same doctrine as SCADA — a historian sits on the plant/OT
+side. ``export_records`` refuses regardless of mode.
+"""
+
+from __future__ import annotations
+
+from mira_connectors.base import BaseConnector, ConnectorKind, ExportResult
+from mira_connectors.canonical import CanonicalRecord, RecordType
+
+HISTORIAN_RECORD_TYPES = [RecordType.TAG, RecordType.METER, RecordType.ASSET]
+
+
+class HistorianConnector(BaseConnector):
+    """Base for historian connectors (PI, OSIsoft, Canary). Read-only by construction."""
+
+    kind = ConnectorKind.HISTORIAN
+
+    async def export_records(self, enriched: list[CanonicalRecord]) -> ExportResult:
+        return ExportResult(
+            refused=len(enriched),
+            errors=[
+                "Historian connectors are read-only by construction — MIRA does not "
+                "write back to the plant historian (.claude/rules/fieldbus-readonly.md)"
+            ],
+        )

--- a/mira-connectors/mira_connectors/types/mqtt.py
+++ b/mira-connectors/mira_connectors/types/mqtt.py
@@ -1,0 +1,37 @@
+"""MQTT / UNS connector type base (MQTT, Sparkplug B).
+
+Extends the existing ``mira-bridge`` / ``mira-relay`` MQTT path conceptually: an MQTT
+connector discovers a broker's namespace (Sparkplug B group/edge/device topics, or a
+plain UNS topic tree) and imports the namespace structure + last-known values,
+normalizing topics into ``CanonicalTag`` and the topic hierarchy into
+``CanonicalLocation`` / ``CanonicalAsset`` candidates.
+
+The Sparkplug B namespace IS a UNS identity source (see
+``.claude/rules/direct-connection-uns-certified.md``) — so the proposed UNS paths from
+this connector are higher-confidence than free-text CMMS location strings.
+
+READ-ONLY BY CONSTRUCTION. Publishing back to the broker (writing tags) is a plant
+write and is refused regardless of mode. Subscribing/reading is the only mode.
+"""
+
+from __future__ import annotations
+
+from mira_connectors.base import BaseConnector, ConnectorKind, ExportResult
+from mira_connectors.canonical import CanonicalRecord, RecordType
+
+MQTT_RECORD_TYPES = [RecordType.TAG, RecordType.LOCATION, RecordType.ASSET]
+
+
+class MQTTConnector(BaseConnector):
+    """Base for MQTT / Sparkplug B / UNS broker connectors. Read-only by construction."""
+
+    kind = ConnectorKind.MQTT
+
+    async def export_records(self, enriched: list[CanonicalRecord]) -> ExportResult:
+        return ExportResult(
+            refused=len(enriched),
+            errors=[
+                "MQTT/UNS connectors are read-only by construction — MIRA subscribes, it "
+                "does not publish tag writes to the plant broker (ADR-0021)"
+            ],
+        )

--- a/mira-connectors/mira_connectors/types/scada.py
+++ b/mira-connectors/mira_connectors/types/scada.py
@@ -1,0 +1,36 @@
+"""SCADA connector type base (Ignition and other SCADA).
+
+Extends the existing Ignition integration (``mira-pipeline/ignition_chat.py``,
+``mira-relay/relay_server.py`` tag streaming) conceptually: a SCADA connector
+*discovers a tag tree* and *imports tag definitions / live values*, normalizing them
+into ``CanonicalTag`` rows that map to ``tag_entities``.
+
+READ-ONLY BY CONSTRUCTION. Per ``.claude/rules/fieldbus-readonly.md``, ADR-0021, and
+the Ignition-is-the-read-path rule, no customer-shipped MIRA surface writes to the
+plant. ``export_records`` refuses regardless of ``ConnectorConfig.mode`` — a SCADA
+connector physically cannot push values to the controller. Enrichment (UNS path,
+component links) flows the other way: into MIRA's graph via the confirmation gate.
+"""
+
+from __future__ import annotations
+
+from mira_connectors.base import BaseConnector, ConnectorKind, ExportResult
+from mira_connectors.canonical import CanonicalRecord, RecordType
+
+SCADA_RECORD_TYPES = [RecordType.TAG, RecordType.ASSET, RecordType.LOCATION]
+
+
+class SCADAConnector(BaseConnector):
+    """Base for SCADA connectors. Plant-facing → read-only by construction."""
+
+    kind = ConnectorKind.SCADA
+
+    async def export_records(self, enriched: list[CanonicalRecord]) -> ExportResult:
+        # Doctrine override: never write to the plant, even in READ_WRITE mode.
+        return ExportResult(
+            refused=len(enriched),
+            errors=[
+                "SCADA connectors are read-only by construction — MIRA does not write "
+                "to the plant (.claude/rules/fieldbus-readonly.md, ADR-0021)"
+            ],
+        )

--- a/mira-connectors/pyproject.toml
+++ b/mira-connectors/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "mira-connectors"
+version = "0.1.0"
+description = "Generic connector framework for MIRA — CMMS/SCADA/Historian/Document/MQTT → canonical model → confirmation gate"
+requires-python = ">=3.12"
+dependencies = []
+
+[project.optional-dependencies]
+# Postgres store (PostgresProposalStore). Tests use the in-memory store and need none of this.
+postgres = ["SQLAlchemy>=2.0"]
+
+[tool.setuptools.packages.find]
+include = ["mira_connectors*"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+pythonpath = ["."]
+testpaths = ["tests"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100

--- a/mira-connectors/tests/conftest.py
+++ b/mira-connectors/tests/conftest.py
@@ -1,0 +1,40 @@
+"""Make ``mira_connectors`` importable when pytest runs from anywhere."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_PKG_ROOT = Path(__file__).resolve().parent.parent  # mira-connectors/
+if str(_PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PKG_ROOT))
+
+from mira_connectors.base import ConnectorConfig, ConnectorMode  # noqa: E402
+from mira_connectors.mocks import IgnitionMockConnector, MaximoMockConnector  # noqa: E402
+
+
+@pytest.fixture
+def tenant_id() -> str:
+    return "00000000-0000-0000-0000-0000000000aa"
+
+
+@pytest.fixture
+def ro_config(tenant_id: str) -> ConnectorConfig:
+    return ConnectorConfig(tenant_id=tenant_id, mode=ConnectorMode.READ_ONLY)
+
+
+@pytest.fixture
+def rw_config(tenant_id: str) -> ConnectorConfig:
+    return ConnectorConfig(tenant_id=tenant_id, mode=ConnectorMode.READ_WRITE)
+
+
+@pytest.fixture
+def maximo(ro_config: ConnectorConfig) -> MaximoMockConnector:
+    return MaximoMockConnector(ro_config)
+
+
+@pytest.fixture
+def ignition(ro_config: ConnectorConfig) -> IgnitionMockConnector:
+    return IgnitionMockConnector(ro_config)

--- a/mira-connectors/tests/test_base_connector.py
+++ b/mira-connectors/tests/test_base_connector.py
@@ -1,0 +1,91 @@
+"""Base connector machinery: read-only default, dry-run, sync logging, validation."""
+
+from __future__ import annotations
+
+from mira_connectors.base import ConnectorConfig, ConnectorMode
+from mira_connectors.canonical import CanonicalAsset, RecordType
+from mira_connectors.mocks import IgnitionMockConnector, MaximoMockConnector
+
+
+async def test_read_only_export_refused(maximo: MaximoMockConnector):
+    raw = await maximo.import_records(RecordType.WORK_ORDER)
+    recs = maximo.normalize(raw)
+    result = await maximo.export_records(recs)
+    assert result.exported == 0
+    assert result.refused == len(recs)
+
+
+async def test_dry_run_plans_no_writes(tenant_id: str):
+    cfg = ConnectorConfig(tenant_id=tenant_id, mode=ConnectorMode.READ_WRITE, dry_run=True)
+    conn = MaximoMockConnector(cfg)
+    raw = await conn.import_records(RecordType.WORK_ORDER)
+    recs = conn.normalize(raw)
+    result = await conn.export_records(recs)
+    assert result.planned == len(recs)
+    assert result.exported == 0
+
+
+async def test_read_write_export_runs(rw_config: ConnectorConfig):
+    conn = MaximoMockConnector(rw_config)
+    raw = await conn.import_records(RecordType.WORK_ORDER)
+    recs = conn.normalize(raw)
+    result = await conn.export_records(recs)
+    # All fixture rows are work orders → all writable.
+    assert result.exported == len(recs)
+    assert result.refused == 0
+
+
+async def test_scada_export_refused_even_in_read_write(rw_config: ConnectorConfig):
+    conn = IgnitionMockConnector(rw_config)
+    raw = await conn.import_records(RecordType.TAG)
+    recs = conn.normalize(raw)
+    result = await conn.export_records(recs)
+    assert result.exported == 0
+    assert result.refused == len(recs)
+    assert any("read-only by construction" in e for e in result.errors)
+
+
+async def test_config_writable_property(tenant_id: str):
+    assert ConnectorConfig(tenant_id=tenant_id, mode=ConnectorMode.READ_ONLY).writable is False
+    assert ConnectorConfig(tenant_id=tenant_id, mode=ConnectorMode.READ_WRITE).writable is True
+    assert (
+        ConnectorConfig(tenant_id=tenant_id, mode=ConnectorMode.READ_WRITE, dry_run=True).writable
+        is False
+    )
+
+
+async def test_sync_produces_structured_result(maximo: MaximoMockConnector):
+    recs, result = await maximo.sync(RecordType.ASSET)
+    assert result.connector == "maximo"
+    assert result.mock is True
+    assert result.imported == 4
+    assert result.normalized == 4
+    assert result.imported == len(recs)
+    assert result.ok
+    assert result.duration_ms >= 0
+    d = result.as_dict()
+    assert d["record_type"] == "asset"
+    assert "errors" in d
+
+
+def test_validate_flags_warning_for_missing_uns(maximo: MaximoMockConnector):
+    # An asset with no proposed_uns_path → warning, not error.
+    asset = CanonicalAsset(source_system="maximo", source_record_id="orphan", name="Orphan")
+    result = maximo.validate_mappings([asset])
+    assert result.ok  # warning only
+    assert any("proposed_uns_path" in w.message for w in result.warnings)
+
+
+def test_validate_flags_error_for_bad_record(maximo: MaximoMockConnector):
+    bad = CanonicalAsset(source_system="maximo", source_record_id="", name="X", confidence=2.0)
+    result = maximo.validate_mappings([bad])
+    assert not result.ok
+    assert len(result.errors) >= 1
+
+
+async def test_unconfigured_connector_sync_errors(tenant_id: str, monkeypatch):
+    conn = MaximoMockConnector(ConnectorConfig(tenant_id=tenant_id))
+    monkeypatch.setattr(type(conn), "configured", property(lambda self: False))
+    _recs, result = await conn.sync(RecordType.ASSET)
+    assert not result.ok
+    assert any("not configured" in e for e in result.errors)

--- a/mira-connectors/tests/test_canonical.py
+++ b/mira-connectors/tests/test_canonical.py
@@ -1,0 +1,76 @@
+"""Canonical model validation tests."""
+
+from __future__ import annotations
+
+from mira_connectors.canonical import (
+    CanonicalAsset,
+    CanonicalRelationship,
+    EvidenceRef,
+)
+
+
+def _good_evidence() -> EvidenceRef:
+    return EvidenceRef(
+        evidence_type="work_order",
+        source_description="WO 1048817",
+        page_or_location="WONUM 1048817",
+        confidence_contribution=0.6,
+    )
+
+
+def test_asset_base_validate_ok():
+    a = CanonicalAsset(source_system="maximo", source_record_id="VFD-16-1", name="VFD", confidence=0.6)
+    assert a.base_validate() == []
+
+
+def test_asset_bad_confidence_flagged():
+    a = CanonicalAsset(source_system="maximo", source_record_id="X", name="X", confidence=1.5)
+    assert any("confidence" in e for e in a.base_validate())
+
+
+def test_asset_missing_source_id_flagged():
+    a = CanonicalAsset(source_system="maximo", source_record_id="", name="X")
+    assert any("source_record_id" in e for e in a.base_validate())
+
+
+def test_relationship_valid():
+    rel = CanonicalRelationship(
+        source_system="maximo", source_record_id="r1",
+        relationship_type="OCCURS_ON", source_ref="VFD", target_ref="CONV16",
+        evidence=[_good_evidence()],
+    )
+    assert rel.validate() == []
+
+
+def test_relationship_self_loop_rejected():
+    rel = CanonicalRelationship(
+        source_system="maximo", source_record_id="r1",
+        relationship_type="WIRED_TO", source_ref="A", target_ref="A",
+        evidence=[_good_evidence()],
+    )
+    assert any("self-loop" in e for e in rel.validate())
+
+
+def test_relationship_unknown_type_rejected():
+    rel = CanonicalRelationship(
+        source_system="maximo", source_record_id="r1",
+        relationship_type="FROBNICATES", source_ref="A", target_ref="B",
+        evidence=[_good_evidence()],
+    )
+    assert any("relationship_type" in e for e in rel.validate())
+
+
+def test_relationship_without_evidence_rejected():
+    rel = CanonicalRelationship(
+        source_system="maximo", source_record_id="r1",
+        relationship_type="OCCURS_ON", source_ref="A", target_ref="B",
+        evidence=[],
+    )
+    assert any("no evidence" in e for e in rel.validate())
+
+
+def test_evidence_bad_type_and_contribution():
+    ev = EvidenceRef(evidence_type="telepathy", source_description="x", confidence_contribution=2.0)
+    errs = ev.validate()
+    assert any("evidence_type" in e for e in errs)
+    assert any("confidence_contribution" in e for e in errs)

--- a/mira-connectors/tests/test_confirmation_gate.py
+++ b/mira-connectors/tests/test_confirmation_gate.py
@@ -1,0 +1,289 @@
+"""Technician confirmation gate — propose → confirm / correct / reject lifecycle.
+
+Uses the in-memory store (no DB) and the real MaximoMockConnector for end-to-end realism.
+Asserts the ADR-0017 status mapping and the kg_relationships materialization that mirrors
+the Hub /api/proposals/[id]/decide route.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from mira_connectors.canonical import (
+    CanonicalAsset,
+    CanonicalRelationship,
+    EvidenceRef,
+    RecordType,
+)
+from mira_connectors.confirmation_gate import ConnectorConfirmationGate
+from mira_connectors.mocks import MaximoMockConnector
+from mira_connectors.store import InMemoryProposalStore
+
+TENANT = "00000000-0000-0000-0000-0000000000aa"
+
+
+@pytest.fixture
+def store() -> InMemoryProposalStore:
+    return InMemoryProposalStore()
+
+
+@pytest.fixture
+def gate(store: InMemoryProposalStore) -> ConnectorConfirmationGate:
+    return ConnectorConfirmationGate(store)
+
+
+def _asset(record_id: str, uns_path: str, *, serial: str | None = None) -> CanonicalAsset:
+    return CanonicalAsset(
+        source_system="maximo", source_record_id=record_id, name=record_id,
+        manufacturer="ACME", model="M1", serial=serial, proposed_uns_path=uns_path, confidence=0.6,
+    )
+
+
+# ── propose / confirm entities ──────────────────────────────────────────────
+
+
+def test_propose_entities_creates_pending_suggestions(gate, store):
+    res = gate.propose(tenant_id=TENANT, provider="maximo", entities=[_asset("VFD-16-1", "enterprise.a.b.vfd")])
+    assert len(res.entity_suggestion_ids) == 1
+    sug = store.get_suggestion(TENANT, res.entity_suggestion_ids[0])
+    assert sug.suggestion_type == "kg_entity"
+    assert sug.status == "pending"
+    assert sug.proposed_by == "import:maximo"
+    assert sug.extracted_data["confidence_prior"] == 0.6
+
+
+def test_confirm_entity_materializes_kg_entity(gate, store):
+    res = gate.propose(tenant_id=TENANT, provider="maximo", entities=[_asset("VFD-16-1", "enterprise.a.b.vfd")])
+    sid = res.entity_suggestion_ids[0]
+    out = gate.confirm(TENANT, sid, reviewed_by="user_42")
+    assert out.ok and out.entity_id
+    assert store.entities[out.entity_id].approval_state == "verified"
+    sug = store.get_suggestion(TENANT, sid)
+    assert sug.status == "accepted"
+    assert sug.reviewed_by == "human:user_42"
+    # confidence_prior is preserved (never overwritten by confirmation)
+    assert sug.extracted_data["confidence_prior"] == 0.6
+    # the confirmed entity is now resolvable by its natural key (for edges)
+    assert store.resolve_entity(TENANT, "VFD-16-1", "asset") == out.entity_id
+
+
+# ── propose / confirm relationships (endpoints already resolve) ──────────────
+
+
+def test_propose_edge_with_resolved_endpoints(gate, store):
+    store.register_entity_key(TENANT, "asset", "CONV16", "ent-conv")
+    store.register_entity_key(TENANT, "asset", "VFD-16-1", "ent-vfd")
+    rel = CanonicalRelationship(
+        source_system="maximo", source_record_id="r1", relationship_type="HAS_COMPONENT",
+        source_ref="CONV16", source_ref_kind="asset", target_ref="VFD-16-1", target_ref_kind="asset",
+        confidence=0.7, evidence=[EvidenceRef("manifest", "PARENT link", confidence_contribution=0.8)],
+    )
+    res = gate.propose(tenant_id=TENANT, provider="maximo", relationships=[rel])
+    sug = store.get_suggestion(TENANT, res.edge_suggestion_ids[0])
+    pid = sug.extracted_data["relationship_proposal_id"]
+    prop = store.get_proposal(pid)
+    assert prop.status == "proposed"
+    assert prop.created_by == "import"
+    assert prop.source_entity_id == "ent-conv"
+    # evidence row created from the connector's evidence
+    assert any(e.proposal_id == pid for e in store.evidence.values())
+
+
+def test_confirm_edge_materializes_kg_relationship(gate, store):
+    store.register_entity_key(TENANT, "asset", "CONV16", "ent-conv")
+    store.register_entity_key(TENANT, "asset", "VFD-16-1", "ent-vfd")
+    rel = CanonicalRelationship(
+        source_system="maximo", source_record_id="r1", relationship_type="HAS_COMPONENT",
+        source_ref="CONV16", source_ref_kind="asset", target_ref="VFD-16-1", target_ref_kind="asset",
+        confidence=0.7, evidence=[EvidenceRef("manifest", "PARENT link", confidence_contribution=0.8)],
+    )
+    sid = gate.propose(tenant_id=TENANT, provider="maximo", relationships=[rel]).edge_suggestion_ids[0]
+    out = gate.confirm(TENANT, sid, reviewed_by="tech_7", note="confirmed on the floor")
+    assert out.ok and out.kg_relationship_id
+    # proposal → verified
+    pid = out.relationship_proposal_id
+    assert store.get_proposal(pid).status == "verified"
+    # kg_relationships row written (mirrors decide route)
+    kg = store.relationships[out.kg_relationship_id]
+    assert kg.approval_state == "verified"
+    assert (kg.source_id, kg.target_id, kg.relationship_type) == ("ent-conv", "ent-vfd", "HAS_COMPONENT")
+    # human_observation evidence row records "confidence after confirmation"
+    human_ev = [e for e in store.evidence.values() if e.evidence_type == "human_observation"]
+    assert len(human_ev) == 1
+    assert human_ev[0].confidence_contribution > 0
+    assert store.get_suggestion(TENANT, sid).status == "accepted"
+
+
+def test_confirm_edge_dedupes_kg_relationship(gate, store):
+    store.register_entity_key(TENANT, "asset", "CONV16", "ent-conv")
+    store.register_entity_key(TENANT, "asset", "VFD-16-1", "ent-vfd")
+
+    def mkrel():
+        return CanonicalRelationship(
+            source_system="maximo", source_record_id="r", relationship_type="HAS_COMPONENT",
+            source_ref="CONV16", source_ref_kind="asset", target_ref="VFD-16-1", target_ref_kind="asset",
+            confidence=0.7, evidence=[EvidenceRef("manifest", "x", confidence_contribution=0.5)],
+        )
+
+    s1 = gate.propose(tenant_id=TENANT, provider="maximo", relationships=[mkrel()]).edge_suggestion_ids[0]
+    s2 = gate.propose(tenant_id=TENANT, provider="maximo", relationships=[mkrel()]).edge_suggestion_ids[0]
+    r1 = gate.confirm(TENANT, s1, reviewed_by="t")
+    r2 = gate.confirm(TENANT, s2, reviewed_by="t")
+    # same edge identity → one kg_relationships row
+    assert r1.kg_relationship_id == r2.kg_relationship_id
+    assert len(store.relationships) == 1
+
+
+# ── unresolved-then-resolved edge ────────────────────────────────────────────
+
+
+def test_edge_unresolved_at_propose_then_resolves_after_entity_confirm(gate, store):
+    # Propose the asset entities AND the edge in one go (entities not yet confirmed).
+    conv = _asset("CONV16", "enterprise.a.b.conv16")
+    vfd = _asset("VFD-16-1", "enterprise.a.b.conv16.vfd")
+    rel = CanonicalRelationship(
+        source_system="maximo", source_record_id="r1", relationship_type="HAS_COMPONENT",
+        source_ref="CONV16", source_ref_kind="asset", target_ref="VFD-16-1", target_ref_kind="asset",
+        confidence=0.7, evidence=[EvidenceRef("manifest", "PARENT", confidence_contribution=0.8)],
+    )
+    res = gate.propose(tenant_id=TENANT, provider="maximo", entities=[conv, vfd], relationships=[rel])
+    edge_sid = res.edge_suggestion_ids[0]
+    assert store.get_suggestion(TENANT, edge_sid).extracted_data.get("needs_resolution") is True
+
+    # Confirming the edge now fails — endpoints not confirmed yet.
+    early = gate.confirm(TENANT, edge_sid, reviewed_by="t")
+    assert not early.ok and early.reason == "endpoints_unresolved"
+
+    # Confirm both entities, then the edge resolves + materializes.
+    for esid in res.entity_suggestion_ids:
+        assert gate.confirm(TENANT, esid, reviewed_by="t").ok
+    late = gate.confirm(TENANT, edge_sid, reviewed_by="t")
+    assert late.ok and late.kg_relationship_id
+    assert store.get_proposal(late.relationship_proposal_id).status == "verified"
+
+
+# ── correct ──────────────────────────────────────────────────────────────────
+
+
+def test_correct_supersedes_original_and_confirms_new(gate, store):
+    # Tech says "it's TB2-15, not TB2-14".
+    store.register_entity_key(TENANT, "asset", "PE-B16-2", "ent-pe")
+    store.register_entity_key(TENANT, "tag", "TB2-14", "ent-tb14")
+    store.register_entity_key(TENANT, "tag", "TB2-15", "ent-tb15")
+    rel = CanonicalRelationship(
+        source_system="maximo", source_record_id="r1", relationship_type="WIRED_TO",
+        source_ref="PE-B16-2", source_ref_kind="asset", target_ref="TB2-14", target_ref_kind="tag",
+        confidence=0.6, evidence=[EvidenceRef("technician_note", "photo crop", confidence_contribution=0.5)],
+    )
+    sid = gate.propose(tenant_id=TENANT, provider="maximo", relationships=[rel]).edge_suggestion_ids[0]
+    old_pid = store.get_suggestion(TENANT, sid).extracted_data["relationship_proposal_id"]
+
+    out = gate.correct(
+        TENANT, sid, reviewed_by="tech_7",
+        corrections={"target_ref": "TB2-15"}, note="actually TB2-15",
+    )
+    assert out.ok
+    # original superseded (preserved, not deleted) + its proposal deprecated
+    assert store.get_suggestion(TENANT, sid).status == "superseded"
+    assert store.get_proposal(old_pid).status == "deprecated"
+    # the corrected, confirmed edge points at TB2-15
+    kg = store.relationships[out.confirm.kg_relationship_id]
+    assert kg.target_id == "ent-tb15"
+    new_sug = store.get_suggestion(TENANT, out.new_suggestion_id)
+    assert new_sug.status == "accepted"
+    assert new_sug.extracted_data["corrected_from"] == sid
+
+
+# ── reject ─────────────────────────────────────────────────────────────────
+
+
+def test_reject_marks_rejected_no_graph_write(gate, store):
+    store.register_entity_key(TENANT, "asset", "CONV16", "ent-conv")
+    store.register_entity_key(TENANT, "asset", "VFD-16-1", "ent-vfd")
+    rel = CanonicalRelationship(
+        source_system="maximo", source_record_id="r1", relationship_type="HAS_COMPONENT",
+        source_ref="CONV16", source_ref_kind="asset", target_ref="VFD-16-1", target_ref_kind="asset",
+        confidence=0.7, evidence=[EvidenceRef("manifest", "x", confidence_contribution=0.5)],
+    )
+    sid = gate.propose(tenant_id=TENANT, provider="maximo", relationships=[rel]).edge_suggestion_ids[0]
+    pid = store.get_suggestion(TENANT, sid).extracted_data["relationship_proposal_id"]
+    out = gate.reject(TENANT, sid, reviewed_by="tech_7", note="not real")
+    assert out.ok
+    assert store.get_suggestion(TENANT, sid).status == "rejected"
+    assert store.get_proposal(pid).status == "rejected"
+    assert len(store.relationships) == 0  # no graph write
+
+
+# ── conflicts ────────────────────────────────────────────────────────────────
+
+
+def test_conflicting_mappings_preserved_for_review(gate, store):
+    # Two systems describe the same physical device (same serial) at different UNS paths.
+    a = _asset("MX-VFD", "enterprise.bedford.line16.vfd", serial="SN-999")
+    b = _asset("IGN-VFD", "enterprise.bedford.packaging.vfd", serial="SN-999")
+    res = gate.propose(tenant_id=TENANT, provider="maximo", entities=[a, b])
+    assert len(res.conflict_groups) == 1
+    assert set(res.conflict_groups[0]) == set(res.entity_suggestion_ids)
+    # both preserved as pending (not auto-rejected) with a shared conflict_group marker
+    pend = gate.pending(TENANT, suggestion_type="kg_entity")
+    assert len(pend) == 2
+    groups = {s.extracted_data.get("conflict_group") for s in pend}
+    assert len(groups) == 1 and None not in groups
+
+
+def test_no_conflict_when_same_path(gate, store):
+    a = _asset("MX-VFD", "enterprise.bedford.line16.vfd", serial="SN-1")
+    b = _asset("IGN-VFD", "enterprise.bedford.line16.vfd", serial="SN-1")  # same path
+    res = gate.propose(tenant_id=TENANT, provider="maximo", entities=[a, b])
+    assert res.conflict_groups == []
+
+
+# ── guards ───────────────────────────────────────────────────────────────────
+
+
+def test_confirm_not_found(gate):
+    assert gate.confirm(TENANT, "nope", reviewed_by="t").reason == "not_found"
+
+
+def test_confirm_wrong_state(gate, store):
+    sid = gate.propose(tenant_id=TENANT, provider="maximo", entities=[_asset("A", "enterprise.a")]).entity_suggestion_ids[0]
+    assert gate.confirm(TENANT, sid, reviewed_by="t").ok
+    second = gate.confirm(TENANT, sid, reviewed_by="t")
+    assert not second.ok and second.reason.startswith("wrong_state")
+
+
+def test_tenant_isolation(gate, store):
+    sid = gate.propose(tenant_id=TENANT, provider="maximo", entities=[_asset("A", "enterprise.a")]).entity_suggestion_ids[0]
+    assert gate.confirm("11111111-1111-1111-1111-111111111111", sid, reviewed_by="t").reason == "not_found"
+
+
+# ── end-to-end with the real Maximo mock ─────────────────────────────────────
+
+
+async def test_end_to_end_maximo_import_to_graph(gate, store, ro_config):
+    conn = MaximoMockConnector(ro_config)
+    # Import + normalize assets and documents; derive edges.
+    records = []
+    for rt in (RecordType.ASSET, RecordType.DOCUMENT, RecordType.WORK_ORDER):
+        records.extend(conn.normalize(await conn.import_records(rt)))
+    rels = conn.derive_relationships(records)
+    entities = [r for r in records if r.record_type in (RecordType.ASSET, RecordType.DOCUMENT)]
+
+    res = gate.propose(tenant_id=TENANT, provider="maximo", entities=entities, relationships=rels)
+    assert res.entity_suggestion_ids
+    assert res.edge_suggestion_ids
+
+    # Confirm every entity suggestion → entities become resolvable.
+    for esid in res.entity_suggestion_ids:
+        assert gate.confirm(TENANT, esid, reviewed_by="tech").ok
+
+    # Now confirm edges whose endpoints resolved (HAS_COMPONENT, HAS_DOCUMENT). LOCATED_IN
+    # targets a location entity we didn't import here, so some stay unresolved — that's fine.
+    confirmed_edges = 0
+    for sid in res.edge_suggestion_ids:
+        out = gate.confirm(TENANT, sid, reviewed_by="tech")
+        if out.ok:
+            confirmed_edges += 1
+    assert confirmed_edges >= 1
+    # at least one verified kg_relationship landed in the graph
+    assert any(r.approval_state == "verified" for r in store.relationships.values())

--- a/mira-connectors/tests/test_factory.py
+++ b/mira-connectors/tests/test_factory.py
@@ -1,0 +1,26 @@
+"""Connector factory registry tests."""
+
+from __future__ import annotations
+
+from mira_connectors.base import ConnectorConfig
+from mira_connectors.factory import available_providers, create_connector
+from mira_connectors.mocks import IgnitionMockConnector, MaximoMockConnector
+
+
+def test_available_providers():
+    providers = available_providers()
+    assert "maximo_mock" in providers
+    assert "ignition_mock" in providers
+
+
+def test_create_known(ro_config: ConnectorConfig):
+    assert isinstance(create_connector("maximo_mock", ro_config), MaximoMockConnector)
+    assert isinstance(create_connector("ignition_mock", ro_config), IgnitionMockConnector)
+
+
+def test_create_case_insensitive(ro_config: ConnectorConfig):
+    assert isinstance(create_connector("  Maximo_Mock ", ro_config), MaximoMockConnector)
+
+
+def test_create_unknown_returns_none(ro_config: ConnectorConfig):
+    assert create_connector("sap_pm", ro_config) is None

--- a/mira-connectors/tests/test_ignition_mock.py
+++ b/mira-connectors/tests/test_ignition_mock.py
@@ -1,0 +1,90 @@
+"""IgnitionMockConnector — tag-tree import → normalize → derive, read-only export."""
+
+from __future__ import annotations
+
+from mira_connectors.canonical import CanonicalTag, RecordType
+from mira_connectors.mocks import IgnitionMockConnector
+
+
+async def test_discover_tag_tree(ignition: IgnitionMockConnector):
+    caps = await ignition.discover()
+    assert caps.kind.value == "scada"
+    assert caps.supports_export is False  # read-only by construction
+    assert caps.schema["tagProvider"] == "default"
+    assert caps.schema["device"] == "Mira_PLC"
+    assert any("Conveyor" in line for line in caps.schema["tag_tree"])
+
+
+async def test_import_flattens_atomic_tags(ignition: IgnitionMockConnector):
+    raw = await ignition.import_records(RecordType.TAG)
+    # 4 motor + 4 gs10 + 1 pe + 2 conveyor-level = 11 atomic tags
+    assert len(raw) == 11
+    paths = {r.source_record_id for r in raw}
+    assert "[default]Lake_Wales/Bench/Conveyor/Motor/Speed" in paths
+    assert "[default]Lake_Wales/Bench/Conveyor/GS10/DCBusVoltage" in paths
+
+
+async def test_import_non_tag_types_empty(ignition: IgnitionMockConnector):
+    # Locations/assets are derived from the tag tree, not imported directly.
+    assert await ignition.import_records(RecordType.ASSET) == []
+
+
+async def test_normalize_tag_fields(ignition: IgnitionMockConnector):
+    raw = await ignition.import_records(RecordType.TAG)
+    recs = {r.tag_id: r for r in ignition.normalize(raw) if isinstance(r, CanonicalTag)}
+    speed = recs["Lake_Wales.Bench.Conveyor.Motor.Speed"]
+    assert speed.data_type == "float"  # Float8 → float
+    assert speed.engineering_unit == "Hz"
+    assert speed.address == "ns=1;s=[Mira_PLC]HR400101"
+    assert speed.history_enabled is True
+    assert speed.scada_path == "[default]Lake_Wales/Bench/Conveyor/Motor/Speed"
+    assert speed.proposed_uns_path == "enterprise.lake_wales.bench.conveyor.motor.speed"
+
+    occupied = recs["Lake_Wales.Bench.Conveyor.PE_B16_2.Occupied"]
+    assert occupied.data_type == "bool"  # Boolean → bool
+
+    faultcode = recs["Lake_Wales.Bench.Conveyor.GS10.FaultCode"]
+    assert faultcode.data_type == "int"  # Int4 → int
+
+
+async def test_derive_has_signal_and_located_in(ignition: IgnitionMockConnector):
+    recs = ignition.normalize(await ignition.import_records(RecordType.TAG))
+    rels = ignition.derive_relationships(recs)
+    by_type: dict[str, list] = {}
+    for r in rels:
+        by_type.setdefault(r.relationship_type, []).append(r)
+
+    # GS10 folder is an asset folder → HAS_SIGNAL from the GS10 asset to each of its tags.
+    has_signal = by_type["HAS_SIGNAL"]
+    gs10_path = "enterprise.lake_wales.bench.conveyor.gs10"
+    gs10_signals = [r for r in has_signal if r.source_ref == gs10_path]
+    assert len(gs10_signals) == 4  # OutputFrequency, DCBusVoltage, FaultCode, Faulted
+    assert all(r.target_ref_kind == "tag_id" for r in gs10_signals)
+
+    # LOCATED_IN chain is deduped (folder hierarchy appears once).
+    located = by_type["LOCATED_IN"]
+    pairs = [(r.source_ref, r.target_ref) for r in located]
+    assert len(pairs) == len(set(pairs))  # no dupes
+    assert (
+        "enterprise.lake_wales.bench.conveyor",
+        "enterprise.lake_wales.bench",
+    ) in pairs
+
+    for r in rels:
+        assert r.validate() == []
+
+
+async def test_export_refused_read_only(rw_config):
+    conn = IgnitionMockConnector(rw_config)  # even with READ_WRITE requested
+    recs = conn.normalize(await conn.import_records(RecordType.TAG))
+    result = await conn.export_records(recs)
+    assert result.exported == 0
+    assert result.refused == len(recs)
+
+
+async def test_full_sync(ignition: IgnitionMockConnector):
+    recs, result = await ignition.sync(RecordType.TAG)
+    assert result.ok
+    assert result.imported == 11
+    assert result.normalized == 11
+    assert len(recs) == 11

--- a/mira-connectors/tests/test_maximo_mock.py
+++ b/mira-connectors/tests/test_maximo_mock.py
@@ -1,0 +1,108 @@
+"""MaximoMockConnector — full import → normalize → derive → export lifecycle."""
+
+from __future__ import annotations
+
+from mira_connectors.canonical import (
+    CanonicalAsset,
+    CanonicalFailureCode,
+    CanonicalWorkOrder,
+    RecordType,
+)
+from mira_connectors.mocks import MaximoMockConnector
+
+
+async def test_discover(maximo: MaximoMockConnector):
+    caps = await maximo.discover()
+    assert caps.kind.value == "cmms"
+    assert caps.provider == "maximo"
+    assert RecordType.ASSET in caps.record_types
+    assert caps.supports_export is True
+    assert "asset_fields" in caps.schema
+
+
+async def test_health_check(maximo: MaximoMockConnector):
+    h = await maximo.health_check()
+    assert h["ok"] is True
+    assert h["mock"] is True
+
+
+async def test_import_assets(maximo: MaximoMockConnector):
+    raw = await maximo.import_records(RecordType.ASSET)
+    assert len(raw) == 4
+    assert {r.source_record_id for r in raw} == {"CONV16", "VFD-16-1", "MTR-16-1", "PE-B16-2"}
+    assert raw[0].fields["ASSETNUM"]  # native field preserved
+
+
+async def test_normalize_asset_uns_and_nameplate(maximo: MaximoMockConnector):
+    raw = await maximo.import_records(RecordType.ASSET)
+    recs = {r.source_record_id: r for r in maximo.normalize(raw)}
+    vfd = recs["VFD-16-1"]
+    assert isinstance(vfd, CanonicalAsset)
+    assert vfd.manufacturer == "AUTOMATIONDIRECT"
+    assert vfd.model == "GS11-10P2"  # from CUSTOM.MODELNUM
+    assert vfd.serial == "GS10-1P-220-9931"
+    assert vfd.criticality == "high"
+    # UNS candidate path walks the location hierarchy root→leaf then the asset.
+    assert vfd.proposed_uns_path == "enterprise.bedford_packaging_plant.packaging_area.packaging_line_16.line_16_infeed_conveyor.vfd_16_1"
+
+
+async def test_normalize_workorder_status_map(maximo: MaximoMockConnector):
+    raw = await maximo.import_records(RecordType.WORK_ORDER)
+    recs = {r.source_record_id: r for r in maximo.normalize(raw)}
+    assert isinstance(recs["1048817"], CanonicalWorkOrder)
+    assert recs["1048817"].status == "COMPLETE"  # COMP → COMPLETE
+    assert recs["1048903"].status == "IN_PROGRESS"  # INPRG → IN_PROGRESS
+    assert recs["1048817"].work_type == "corrective"  # CM → corrective
+    assert recs["1048817"].failure_code == "VFD"
+
+
+async def test_import_failure_codes(maximo: MaximoMockConnector):
+    raw = await maximo.import_records(RecordType.FAILURE_CODE)
+    recs = maximo.normalize(raw)
+    assert all(isinstance(r, CanonicalFailureCode) for r in recs)
+    assert any(r.code == "COMMFAULT" for r in recs)
+
+
+async def test_derive_relationships(maximo: MaximoMockConnector):
+    # Gather assets + docs + work orders, then derive cross-record edges.
+    all_recs = []
+    for rt in (RecordType.ASSET, RecordType.DOCUMENT, RecordType.WORK_ORDER):
+        all_recs.extend(maximo.normalize(await maximo.import_records(rt)))
+    rels = maximo.derive_relationships(all_recs)
+    by_type: dict[str, list] = {}
+    for r in rels:
+        by_type.setdefault(r.relationship_type, []).append(r)
+
+    # VFD-16-1 is a child of CONV16 → HAS_COMPONENT(parent=CONV16, child=VFD-16-1)
+    has_comp = by_type["HAS_COMPONENT"]
+    assert any(r.source_ref == "CONV16" and r.target_ref == "VFD-16-1" for r in has_comp)
+    # asset → location
+    assert any(r.source_ref == "VFD-16-1" and r.target_ref == "CONV16" for r in by_type["LOCATED_IN"])
+    # asset → doclink : HAS_DOCUMENT(source=asset, target=document)
+    assert any(r.source_ref == "VFD-16-1" for r in by_type["HAS_DOCUMENT"])
+    # failure code → asset (evidence is a work order)
+    occurs = by_type["OCCURS_ON"]
+    assert any(r.source_ref == "VFD" and r.target_ref == "VFD-16-1" for r in occurs)
+    # every derived relationship carries at least one evidence row
+    assert all(r.evidence for r in rels)
+    # and they all validate
+    for r in rels:
+        assert r.validate() == [], f"{r.relationship_type} failed: {r.validate()}"
+
+
+async def test_export_only_work_orders_writable(rw_config):
+    conn = MaximoMockConnector(rw_config)
+    assets = conn.normalize(await conn.import_records(RecordType.ASSET))
+    wos = conn.normalize(await conn.import_records(RecordType.WORK_ORDER))
+    result = await conn.export_records([*assets, *wos])
+    assert result.exported == len(wos)
+    assert result.refused == len(assets)
+
+
+async def test_full_sync_lifecycle(maximo: MaximoMockConnector):
+    recs, result = await maximo.sync(RecordType.ASSET)
+    assert result.ok
+    assert result.validation_errors == 0
+    # 4 assets, each with a UNS candidate → no warnings either
+    assert result.validation_warnings == 0
+    assert len(recs) == 4

--- a/mira-connectors/tests/test_service.py
+++ b/mira-connectors/tests/test_service.py
@@ -1,0 +1,43 @@
+"""Service layer — import_and_propose wires a connector to the gate in one call."""
+
+from __future__ import annotations
+
+from mira_connectors.canonical import RecordType
+from mira_connectors.confirmation_gate import ConnectorConfirmationGate
+from mira_connectors.mocks import IgnitionMockConnector, MaximoMockConnector
+from mira_connectors.service import import_and_propose
+from mira_connectors.store import InMemoryProposalStore
+
+
+async def test_import_and_propose_maximo(ro_config):
+    gate = ConnectorConfirmationGate(InMemoryProposalStore())
+    conn = MaximoMockConnector(ro_config)
+    res = await import_and_propose(
+        conn, gate,
+        record_types=[RecordType.ASSET, RecordType.DOCUMENT, RecordType.WORK_ORDER],
+        tenant_id="00000000-0000-0000-0000-0000000000aa",
+    )
+    assert res.provider == "maximo"
+    assert len(res.sync_results) == 3
+    assert all(s.ok for s in res.sync_results)
+    # assets + documents become entity suggestions; work orders do not (evidence only)
+    assert res.propose.entity_suggestion_ids
+    assert res.propose.edge_suggestion_ids
+    # everything proposed is pending — nothing auto-written to the graph
+    pending = gate.pending("00000000-0000-0000-0000-0000000000aa")
+    assert len(pending) == len(res.propose.entity_suggestion_ids) + len(res.propose.edge_suggestion_ids)
+
+
+async def test_import_and_propose_ignition_tags(ro_config):
+    store = InMemoryProposalStore()
+    gate = ConnectorConfirmationGate(store)
+    conn = IgnitionMockConnector(ro_config)
+    res = await import_and_propose(
+        conn, gate, record_types=[RecordType.TAG],
+        tenant_id="00000000-0000-0000-0000-0000000000aa",
+    )
+    # 11 tags → 11 kg_entity (tag) suggestions
+    assert len(res.propose.entity_suggestion_ids) == 11
+    # HAS_SIGNAL + LOCATED_IN edges proposed
+    assert res.propose.edge_suggestion_ids
+    assert res.relationship_count > 0


### PR DESCRIPTION
## Summary

Adds **`mira-connectors/`** — a generic connector framework + technician confirmation gate for MIRA. Parallel workstream to the master architecture plan; **new top-level package, touches no shared modules and no migrations** (additive only).

Builds on the existing patterns rather than reinventing them: extends `mira-mcp/cmms/base.py:CMMSAdapter`, the Ignition/relay integration, `mira-crawler` ingest, and the Hub `ai_suggestions`/`relationship_proposals` schema + `/api/proposals/[id]/decide` materialization route.

### Phase 3 — Connector framework
- `Connector` ABC + `BaseConnector` with all 10 capabilities (discover / import / normalize / validate / export / auth-config / sync-log / dry-run / mock / read-only-default) + optional `derive_relationships`. Never-raise-on-IO contract, factory-by-provider — same shape as the existing `CMMSAdapter`.
- Canonical model mapping to **existing tables — no new tables**. UNS paths are candidate-only; the gate canonicalizes via `mira-crawler/ingest/uns.py`.
- Type bases: `CMMSConnector` (CMMS-API write-back allowed), `SCADAConnector` / `HistorianConnector` / `MQTTConnector` (**read-only by construction** — refuse plant writes even in `READ_WRITE`, per `.claude/rules/fieldbus-readonly.md` + ADR-0021), `DocumentConnector`.
- Realistic mocks: `MaximoMockConnector` (native Maximo field names) + `IgnitionMockConnector` (real tag tree), both keyed to the Lake Wales bench.
- Doc: `docs/mira/connector-framework.md`.

### Phase 6 — Technician confirmation gate
- `ConnectorConfirmationGate`: `propose` / `confirm` / `correct` / `reject` + pending queue. Reuses `ai_suggestions` + `relationship_proposals` + `relationship_evidence` + `kg_entities` + `kg_relationships` (`created_by='import'`, `proposed_by='import:<provider>'`).
- **ADR-0017 status mapping enforced**; confirm mirrors the Hub decide route (proposal→`verified`, then UPSERT `kg_relationships` deduped on tenant+source+target+type). Confidence-prior preserved in `extracted_data`; confirmation recorded as a `human_observation` evidence row. Corrections supersede (don't delete); conflicting mappings preserved with a `conflict_group`.
- `store.py`: `ProposalStore` protocol + `InMemoryProposalStore` + `PostgresProposalStore` (SQLAlchemy + `NullPool` + RLS tenant GUC).
- `service.import_and_propose` — one-call connector→gate wiring.
- Doc: `docs/mira/technician-confirmation-gate.md`.

## Testing
- **53 offline tests passing, ruff clean.** Run on `InMemoryProposalStore` (no DB / network): `cd mira-connectors && pytest`.

## Honest caveats / follow-ups
- ⚠️ **`PostgresProposalStore` is NOT executed by the test suite** (tests use the in-memory store). Its SQL is **schema-verified** against the live migrations (ai_suggestions 027, relationship_proposals/evidence 018, kg_entities 001/010/024/025/029, kg_relationships per the decide route) — including a fix to match the real `kg_entities` natural key `(tenant_id, entity_type, name)` — but should be exercised against staging NeonDB before production use.
- Deliberately does **not** create the ADR-0017 helpers (`proposal_transition.py`/`.ts`) — those are master-plan Phase 3 / Agent 4's files. The gate keeps transition logic connector-local and delegates once they land.
- No auto-verify; no plant writes; no engine edits.

## Compliance
- No new tables/migrations. No LangChain/n8n. No Anthropic. Postgres-first. Read-only default; plant-facing connectors read-only by construction (ADR-0021 / fieldbus-readonly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
