### PR TITLE
fix(test): exercise the real Ignition chat proxy path (green Eval Offline)

### DIFF
--- a/tests/regime7_ignition/conftest.py
+++ b/tests/regime7_ignition/conftest.py
@@ -214,6 +214,35 @@ def mock_urllib2():
 
 
 @pytest.fixture
+def mira_gateway_configured(mock_ignition_system):
+    """Simulate a configured Ignition gateway.
+
+    The chat handler (`api/chat/doPost.py`) reads MIRA_IGNITION_HMAC_KEY / MIRA_TENANT_ID /
+    MIRA_CLOUD_URL from `factorylm.properties` via `getMiraConfig()`, and **fail-closes with
+    503 when the HMAC key is absent** (no unsigned requests). The default java mocks report
+    the properties file as missing, so without this fixture every chat request hits that
+    fail-closed branch.
+
+    This fixture flips the mocked `java.io.File` to report the properties file present and
+    makes `java.util.Properties.getProperty` return real config — so the handler proceeds to
+    the (mocked) sidecar proxy path, exactly as a configured gateway would. Returns the config
+    dict so tests can assert against it.
+    """
+    config = {
+        "MIRA_IGNITION_HMAC_KEY": "test-hmac-key-0123456789abcdef",
+        "MIRA_TENANT_ID": "00000000-0000-0000-0000-0000000000aa",
+        "MIRA_CLOUD_URL": "https://api.example.test/api/v1/ignition/chat",
+    }
+    file_mock = sys.modules["java.io.File"]
+    file_mock.return_value.exists.return_value = True
+    props_mock = sys.modules["java.util.Properties"]
+    props_mock.return_value.getProperty.side_effect = (
+        lambda key, default="": config.get(key, default)
+    )
+    return config
+
+
+@pytest.fixture
 def webdev_scripts_dir() -> Path:
     """Path to the Web Dev handler scripts."""
     return Path(__file__).parent.parent.parent / "ignition" / "webdev" / "FactoryLM"

--- a/tests/regime7_ignition/test_webdev_handlers.py
+++ b/tests/regime7_ignition/test_webdev_handlers.py
@@ -57,7 +57,9 @@ class TestStatusHandler:
 
 
 class TestChatHandler:
-    def test_chat_proxies_to_sidecar(self, webdev_scripts_dir):
+    def test_chat_proxies_to_sidecar(self, webdev_scripts_dir, mira_gateway_configured):
+        """A configured gateway signs the request, proxies to the sidecar (mocked via
+        the autouse `mock_urllib2`), and returns the sidecar's answer."""
         handler = load_handler(webdev_scripts_dir / "api" / "chat" / "doPost.py", "doPost")
         request = {
             "postData": {
@@ -69,17 +71,35 @@ class TestChatHandler:
 
         assert "json" in result
         data = result["json"]
-        # Should have proxied to sidecar and got back mock answer
-        assert "answer" in data or "error" not in data
+        # Proxied successfully — no error, and the sidecar's mock answer came back
+        # (mock_urllib2 returns {"answer": "Test answer about VFD faults.", ...}).
+        assert "error" not in data, "handler returned an error: %s" % data
+        assert data["answer"] == "Test answer about VFD faults."
+        assert "sources" in data
 
-    def test_chat_empty_query_rejected(self, webdev_scripts_dir):
+    def test_chat_unconfigured_hmac_fails_closed(self, webdev_scripts_dir):
+        """No HMAC key configured → fail closed with 503, never an unsigned proxy call.
+
+        This is the security contract: doPost refuses to forward unsigned requests."""
+        handler = load_handler(webdev_scripts_dir / "api" / "chat" / "doPost.py", "doPost")
+        request = {"postData": {"query": "What does OC mean?", "asset_id": "conveyor_demo"}}
+        result = handler(request, {})
+
+        assert result["status"] == 503
+        assert result["json"]["error"] == "MIRA HMAC key not configured"
+
+    def test_chat_empty_query_rejected(self, webdev_scripts_dir, mira_gateway_configured):
+        """A configured gateway still validates input: empty query → 400 'query is required'.
+
+        (Requires the gateway-configured fixture; otherwise the handler fail-closes on the
+        HMAC check before it ever reaches query validation.)"""
         handler = load_handler(webdev_scripts_dir / "api" / "chat" / "doPost.py", "doPost")
         request = {"postData": {"query": "", "asset_id": ""}}
         result = handler(request, {})
 
         assert "json" in result
-        data = result["json"]
-        assert "error" in data
+        assert result["status"] == 400
+        assert result["json"]["error"] == "query is required"
 
 
 class TestAlertsHandler:


### PR DESCRIPTION
## Summary

Turns the **Eval Offline** CI job green. It has been red on `main` (and on every PR) because `tests/regime7_ignition/test_webdev_handlers.py::TestChatHandler::test_chat_proxies_to_sidecar` failed with `{'error': 'MIRA HMAC key not configured'}`.

**This was a test gap, not a handler bug.** `ignition/webdev/FactoryLM/api/chat/doPost.py` correctly **fail-closes with 503** when `MIRA_IGNITION_HMAC_KEY` is absent (the security contract: no unsigned requests forwarded). The test never configured the gateway, so it hit the fail-closed branch while asserting the success path. (`test_chat_empty_query_rejected` was also green only by accident — it was hitting the same 503, not the query-validation path it claims to test.)

## Fix — the right way, no papering over

- New `mira_gateway_configured` conftest fixture simulates `factorylm.properties` present with the HMAC key + tenant id (flips the mocked `java.io.File` / `java.util.Properties`), so the handler runs the real path: `getMiraConfig` → `signing.build_headers` → POST via the autouse `mock_urllib2` sidecar stub → parse.
- `test_chat_proxies_to_sidecar` now asserts the **actual proxied answer** (`"Test answer about VFD faults."`) + `sources` — proving the sign→POST→parse path executes, not just "no error".
- Added `test_chat_unconfigured_hmac_fails_closed` — keeps explicit coverage of the 503 fail-closed security contract that the old test implicitly (and wrongly) relied on.
- `test_chat_empty_query_rejected` now exercises real input validation (400 `"query is required"`).

**No handler change. No weakened assertions. Nothing skipped/xfail'd.**

## Verification

Ran the exact CI `Run offline eval tests` command locally:
```
pytest tests/ -n auto -m "not network and not slow" -p no:deepeval --ignore=... --deselect=...
→ 1109 passed, 19 skipped, 0 failed
```
(regime7 file alone: 12 passed.) Confirmed no second hidden failure — the stale `test_symlink_outside_base_returns_403` comment in the workflow no longer applies; it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
