### PR TITLE
fix(hub): resync package-lock.json (add missing @swc/helpers@0.5.23)

### DIFF
--- a/mira-hub/package-lock.json
+++ b/mira-hub/package-lock.json
@@ -8942,6 +8942,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11020,6 +11021,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {


### PR DESCRIPTION
## Summary

Fixes the **E2E smoke** / **Smoke Test** CI failure that's red on `main` and blocking every PR's smoke gate. The `npm ci --ignore-scripts` step in `mira-hub` (node 20 / npm 10) fails because `package.json` and `package-lock.json` are out of sync:

```
npm error Missing: @swc/helpers@0.5.23 from lock file
```

`@swc/helpers@0.5.23` is an optional peer pulled in via `next-intl`; it's required by the resolved tree but was never recorded in the lockfile (committed out of sync).

## Fix

Regenerated the lockfile with **npm 10** (matching CI's node 20 — local npm 11 considered it already in sync, which is why the drift wasn't caught) via `npm install --package-lock-only`.

- **Lockfile-only change.** No `package.json` / dependency edits.
- Minimal diff: adds the missing `@swc/helpers@0.5.23` entry (+ an `fsevents` dev-flag correction npm emitted during resync).
- **Verified:** `npm ci --ignore-scripts` now succeeds locally (864 packages) — the exact failing CI step.

## Why it wasn't caught earlier

The connector PR (#1684) merged when smoke was green; this drift landed on `main` between then and now from an unrelated change that bumped the tree without regenerating `mira-hub/package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
