### PR TITLE
fix(ask-api): suppress CMMS WO + recurring-fault prompts on kiosk

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -332,6 +332,14 @@ _DST_ENABLED = os.getenv("MIRA_USE_DST", "0") == "1"
 # out in docs/plans/2026-05-15-maintenance-namespace-builder.md Phase 1 acceptance.
 _UNS_GATE_ENABLED = os.getenv("MIRA_UNS_GATE_ENABLED", "1") == "1"
 
+# Single-shot kiosk mode (e.g. the Ignition Ask-MIRA panel). When on, MIRA
+# answers directly (see rag_worker DIRECT_ANSWER_SYSTEM_PROMPT) AND the engine
+# suppresses interactive follow-ups that a kiosk operator can't act on: the
+# auto work-order prompt (which also arms cmms_pending and would corrupt the
+# next single-shot turn) and the recurring-fault "log a work order?" annotation.
+# Scoped per-container: bots leave it unset and keep the full interactive flow.
+_DIRECT_ANSWER_MODE = os.getenv("MIRA_DIRECT_ANSWER_MODE", "") not in ("", "0", "false", "False")
+
 # Stage 0 (2026-05-04) action-request fast-path. Catches imperative
 # work-order requests BEFORE `route_intent`, which currently sends them
 # into RAG (CRITICAL RULE 3 prefers continue_current mid-flow). Without
@@ -1986,7 +1994,9 @@ class Supervisor:
         # explicitly says "create a work order", "log this", etc.
         # We still run recurring-fault annotation on RESOLVED so persistent
         # issues are flagged, but we do not push the WO preview.
-        if state["state"] == "RESOLVED":
+        # Skip in direct-answer/kiosk mode: the annotation appends a "log a work
+        # order?" question the kiosk operator can't act on (single-shot turn).
+        if state["state"] == "RESOLVED" and not _DIRECT_ANSWER_MODE:
             try:
                 _annotated, _pushed = await check_recurring_and_annotate(
                     self.db_path, state, parsed["reply"]
@@ -2016,6 +2026,7 @@ class Supervisor:
         # say "yes" to actually create the WO; the prompt just arms cmms_pending.
         if (
             state["state"] == "RESOLVED"
+            and not _DIRECT_ANSWER_MODE  # kiosk is single-shot: no WO prompt, don't arm cmms_pending
             and state.get("asset_identified")
             and (state.get("fault_category") or state.get("exchange_count", 0) >= 3)
             and not ctx.get("cmms_pending")


### PR DESCRIPTION
## Problem
After direct-answer mode (#1685) shipped, the kiosk stopped asking Socratic questions — but the live `/ask` answer still ended with **two interactive follow-ups** the kiosk operator can't act on:
1. **Auto work-order prompt** — *"Would you like to log a work order? (yes/no)"* + a UNS Work Order Preview. Worse, it armed `cmms_pending`, which would hijack the **next** single-shot kiosk turn into the WO yes/no flow.
2. **Recurring-fault annotation** — *"⚠ Recurring fault detected… log a work order?"* (also had a cosmetic triple-date bug).

Both fire on `next_state=RESOLVED`, which the direct-answer prompt always returns → they appeared on every kiosk answer.

## Fix
Gate both engine blocks (`engine.py` RESOLVED hook ~L1999 and auto-WO prompt ~L2029) on a new module-level `_DIRECT_ANSWER_MODE`, read from the **same `MIRA_DIRECT_ANSWER_MODE` env the kiosk container already sets** (#1685). One file, no compose change. Scoped per-container: Telegram/Slack leave it unset → full interactive WO flow unchanged.

## Verify post-deploy
`/ask` photo-eye diagnostic should return the complete cited answer (rearm via Start/DI_04) with **no** WO prompt and **no** recurring-fault block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
