### PR TITLE
ci: guard remaining PR-triggered workflows (compose-mem-lint, seed-oem-manuals)

### DIFF
--- a/.github/workflows/compose-mem-lint.yml
+++ b/.github/workflows/compose-mem-lint.yml
@@ -19,6 +19,13 @@ on:
       - ".github/workflows/compose-mem-lint.yml"
   workflow_dispatch:
 
+# Auto-cancel superseded runs on the same PR/branch. cancel-in-progress is gated
+# to pull_request so a redundant PR re-push cancels its prior run (flood guard),
+# while non-PR events are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/seed-oem-manuals.yml
+++ b/.github/workflows/seed-oem-manuals.yml
@@ -27,6 +27,13 @@ on:
       - 'tools/seeds/oem-manuals-knowledge.sql'
       - '.github/workflows/seed-oem-manuals.yml'
 
+# Auto-cancel superseded runs on the same PR/branch. cancel-in-progress is gated
+# to pull_request so a redundant PR re-push cancels its prior run (flood guard),
+# while non-PR events are never cancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up to #1692. Adds the same gated `concurrency` block to the two PR-triggered workflows #1692 missed (`compose-mem-lint.yml`, `seed-oem-manuals.yml`). After this, **every** PR-triggered workflow on main has `cancel-in-progress` gated to pull_request — no PR-triggered workflow can pile up on rapid re-pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)