### PR TITLE
docs: FlowFuse/Node-RED/Ignition alignment audit + 5 deliverables

### DIFF
--- a/docs/architecture/mira-flowfuse-ignition-application.md
+++ b/docs/architecture/mira-flowfuse-ignition-application.md
@@ -1,0 +1,68 @@
+# How FlowFuse / Node-RED / Ignition apply to MIRA's business
+
+**Purpose:** state the product boundaries — what MIRA *is* in this stack, what it must not try to become, and how the layers serve MIRA's maintenance-intelligence use case.
+**Grounded in:** `docs/THEORY_OF_OPERATIONS.md`, `docs/adr/0021-ignition-module-first-edge.md`, `docs/adr/0016-mira-bridge-flowfuse.md`, `.claude/skills/mira-saas-scope-guard/SKILL.md`, `docs/specs/maintenance-namespace-builder-spec.md`.
+
+---
+
+## The one-sentence positioning
+
+**MIRA = Maintenance Intelligence Resource Agent: a maintenance-reasoning layer that consumes trusted, structured industrial context and turns it into cited, technician-facing troubleshooting — using chat as the interface, not as the product.**
+
+## What MIRA must NOT become
+
+These are scope walls, not preferences (`mira-saas-scope-guard`):
+
+- **MIRA is not a Node-RED management platform.** It does not compete with FlowFuse. `mira-bridge` (Node-RED) is internal plumbing; if we ever need fleet flow management we adopt FlowFuse, we don't rebuild it (ADR-0016).
+- **MIRA does not replace Ignition.** No SCADA, no HMI replacement, no historian replacement. The customer keeps Ignition; MIRA rides on top as an Ignition Module (ADR-0021).
+- **MIRA does not host the customer's MQTT broker.** Making ourselves the broker competes with Mosquitto/HiveMQ/Cirrus Link and adds plant-side ops we don't want (ADR-0021, rejected alternatives).
+- **MIRA does not write to the plant.** Read-only toward equipment; no PLC/VFD writes ship.
+- **MIRA is not a generic chatbot.** Every answer is grounded and UNS-located, or it asks first.
+
+## What each layer does *for* MIRA
+
+| Layer | Role for MIRA | Why MIRA leans on it instead of building it |
+|---|---|---|
+| **Ignition** | Plant-trusted source of live tags, alarms, history; the distribution channel (Exchange/Module) | The customer already paid for it and already trusts it; it already speaks every fieldbus. Building a parallel SCADA would be slower, less trusted, and a fight with Inductive Automation. |
+| **Node-RED** (optionally **FlowFuse**) | Edge protocol-conversion + light data movement where Ignition isn't present or isn't enough | Mature, low-code, ubiquitous. FlowFuse adds ops/multi-tenancy *if/when* we need it — deferred today (ADR-0016). |
+| **MQTT / UNS** | The shared, business-addressable data structure that ties tags ↔ manuals ↔ work orders ↔ KG | A common namespace is what lets MIRA *know what the technician means*. We model the UNS (`uns.py`, `uns_resolver.py`); we don't need to own the transport. |
+| **Sparkplug B** | The production-grade, stateful framing for that bus (birth/death, quality, timestamp) | Adopt when a customer's UNS requires it (#1627). Spec-only today — don't overbuild. |
+| **MIRA** | Reasoning + troubleshooting + citations + UNS confirmation + traceability | This is the part nobody else builds. It is where our IP and margin live. |
+
+## How a question becomes a grounded answer (the value chain)
+
+This is the existing flow, with real components named:
+
+```
+technician chat (Slack / Ignition HMI / Telegram)
+   → intent classification + safety keywords        (mira-bots/shared/guardrails.py, engine.py)
+   → UNS asset/component resolution                 (mira-bots/shared/uns_resolver.py)
+   → UNS CONFIRMATION GATE — confirm before troubleshooting   (engine.py; non-negotiable)
+   → live tag snapshot (where available)            (ask_api/app.py today; see gap below)
+   → document + KG retrieval (manuals, wiring, WOs)  (rag_worker.py, neon_recall.py)
+   → cited answer                                    (citation_compliance.py)
+   → trace log for auditability
+```
+
+**Where the layers plug in:** Ignition/Node-RED/MQTT feed the *live tag snapshot* step. Everything else (the reasoning, retrieval, citations) is MIRA's own and is the most mature part of the system. The honest gap (see the audit): the live-snapshot step is only wired for the single-machine `ask_api` kiosk today, and it injects tags as a text block *before* the gate rather than as a UNS-keyed snapshot attached *after* confirmation.
+
+## The trust-boundary promise (the commercial moat)
+
+The reason this architecture is sellable into brownfield plants is the boundary itself (ADR-0021):
+
+- The customer opens **only outbound 443** to `*.factorylm.com`. No inbound, no VPN, no reverse tunnel, no MIRA agent polling their PLC.
+- Tag reads are **allowlist-first, read-by-default**; an un-allowlisted tag is invisible to MIRA.
+- **No write path ships.** "The cloud reasons; the gateway carries."
+
+This is what lets a customer's IT say yes. It is also why MIRA must resist scope creep toward "just let us write one little setpoint" — that single feature would re-open the firewall conversation that the whole architecture exists to avoid.
+
+## Business implications
+
+- **Land via Ignition.** The Ignition Module + Exchange listing (`docs/specs/ignition-exchange-spec.md`, #1625) is the lowest-friction way into shops that already run Ignition.
+- **Don't force a stack.** Customers without Ignition can be served by the `mira-connect` MQTT/Sparkplug edge (#1627) over the *same* HMAC contract — but that's a later tier, not the wedge.
+- **FlowFuse stays optional.** Adopting it is an internal ops decision triggered by multi-tenant scale, never a customer dependency (ADR-0016).
+- **The compounding asset is the reasoning + the UNS/KG**, not the plumbing. Invest there.
+
+## Bottom line
+
+MIRA should be the **smart, grounded, read-only maintenance brain** that sits on top of whatever industrial nervous system the customer already trusts — Ignition first, plain MQTT/UNS as the bus, Node-RED as an edge bridge when needed, Sparkplug and FlowFuse only when the customer or scale demands them. The product is the reasoning and the citations; everything below is interchangeable plumbing we consume, not own.

--- a/docs/architecture/node-red-ignition-bidirectional-patterns.md
+++ b/docs/architecture/node-red-ignition-bidirectional-patterns.md
@@ -1,0 +1,105 @@
+# Node-RED ↔ Ignition integration patterns
+
+**Purpose:** compare the realistic ways Node-RED and Ignition can exchange data, and state which MIRA should use **now** vs. defer. Grounded in the decisions already made: `docs/adr/0021-ignition-module-first-edge.md` (Ignition-module-first, outbound-only, read-only), `docs/adr/0016-mira-bridge-flowfuse.md` (FlowFuse deferred), `.claude/rules/fieldbus-readonly.md`.
+
+**Non-negotiables that constrain every pattern below:**
+- MIRA is **read-only toward the plant**. No PLC/VFD writes ship (ADR-0021 §"What we now forbid"; `plc_worker.py` is a stub).
+- **No cloud→plant inbound.** The customer opens only `outbound 443`.
+- MIRA **does not replace Ignition** and **does not host the customer's broker**.
+- MIRA's **UNS confirmation gate** and **citation/traceability** requirements survive intact.
+
+---
+
+## Quick comparison
+
+| # | Pattern | Direction | Read | Write to plant | Reliability | Security risk | Demo | Production | MIRA use now? |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | Node-RED → Ignition (Node-RED feeds tags) | edge→SCADA | ✓ | (Ignition writes, not MIRA) | Med-High | Med | ✓ | ✓ (if Node-RED is trusted) | **Not via MIRA** |
+| 2 | Ignition → Node-RED (Ignition publishes) | SCADA→edge | ✓ | n/a | High | Low | ✓ | ✓ | Indirect |
+| 3 | Both share MQTT (plain) | bus | ✓ | n/a | Med-High | Med (broker auth) | ✓ | ✓ | **Yes — bench/edge** |
+| 4 | Sparkplug B / Cirrus Link style | bus (stateful) | ✓ | n/a | High | Med | ◑ | ✓✓ | **Defer (#1627)** |
+| 5 | REST bridge (HTTP both ways) | either | ✓ | gated | High | Low (outbound) | ✓ | ✓ | **Yes — the shipping path** |
+| 6 | Database as exchange | either | ✓ | n/a | Med | Med | ✓ | ◑ | Already used (relay→DB) |
+| 7 | Direct device reads (Node-RED/Ignition → PLC) | edge→device | ✓ | ✗ for MIRA | Med | High on serial | ✓ | bench-only | **Bench-only** |
+| 8 | Command / write path | cloud→plant | — | ✗ | — | **Highest** | ✗ | ✗ | **Forbidden** |
+
+Legend: ✓ good / ◑ partial / ✗ no.
+
+---
+
+## Pattern 1 — Node-RED feeds Ignition
+
+**How:** Node-RED reads devices (Modbus/OPC UA) at the edge and pushes values into Ignition — via MQTT (Ignition's MQTT Engine subscribes) or by writing to an Ignition tag provider.
+**Read/write:** Node-RED reads the device; *Ignition* owns any write-back, not MIRA.
+**Reliability:** good if MQTT-brokered; brittle if it's a bespoke HTTP push.
+**Security:** Node-RED becomes a data source Ignition trusts — needs broker auth + topic ACLs.
+**Demo/Prod:** fine for both **where the customer accepts Node-RED on their edge**. Many Ignition shops do not.
+**MIRA now?** Not MIRA's concern directly. If a customer already does this, MIRA still reads the resulting *Ignition tags*, keeping the trust boundary clean.
+
+## Pattern 2 — Ignition feeds Node-RED
+
+**How:** Ignition publishes tag changes / alarms to MQTT (via its MQTT Transmission module) or to an HTTP endpoint; Node-RED subscribes and does downstream automation (enrich, forward, call APIs).
+**Read/write:** read/event only; no plant write.
+**Reliability:** high — Ignition is the stable producer.
+**Security:** low risk (Ignition → broker → Node-RED, all internal/outbound).
+**Demo/Prod:** good for both, and especially attractive when the customer **already trusts Ignition** and wants event-driven workflows downstream.
+**MIRA now?** Indirectly useful: this is the natural way a customer's Ignition could feed a UNS/MQTT bus that MIRA's future `mira-connect` (#1627) subscribes to. Today MIRA gets the same data more simply via Pattern 5.
+
+## Pattern 3 — Both share a plain MQTT bus (UNS)
+
+**How:** Ignition and Node-RED both publish/subscribe to one broker, addressed by UNS topics. The classic Unified Namespace.
+**Read/write:** read/stream; no plant write.
+**Reliability:** good with retained messages + last-will; **plain MQTT has no birth/death**, so consumers can't always tell "stale vs. offline" — that's what Sparkplug adds.
+**Security:** broker auth + per-topic ACLs are mandatory; a shared broker is a juicy target.
+**Demo/Prod:** demo today (bench: `docker-compose.fault-detective.yml` + `plc/live-plc-bridge/bridge.py` → Mosquitto → `mira-fault-detective/engine.py`). Production-capable, but in the customer architecture MIRA does **not** host the broker (ADR-0021).
+**MIRA now?** **Yes, as the bench/edge bus.** Prefer plain MQTT before Sparkplug. Carry `value, ts, quality, source` in every payload so timestamp/quality survive.
+
+## Pattern 4 — Sparkplug B / Cirrus Link style
+
+**How:** Ignition's Cirrus Link **MQTT Transmission** publishes Sparkplug B (birth/death certs, typed metrics) and **MQTT Engine** subscribes; a Node-RED Sparkplug node or `mira-connect` consumes.
+**Read/write:** read/stream; stateful (knows device online/offline via NBIRTH/NDEATH).
+**Reliability:** the highest of the bus options — quality, timestamp, and liveness are first-class.
+**Security:** broker auth; Sparkplug doesn't add security by itself.
+**Demo/Prod:** the production-grade UNS answer; more moving parts than plain MQTT.
+**MIRA now?** **Defer.** Sparkplug is **spec-only** in this repo (`docs/specs/uns-kg-standards-compliance.md §6`; no publisher/subscriber in code). Implement only when a customer's UNS requires it. `mira-connect` is tracked at #1627.
+
+## Pattern 5 — REST bridge (HTTP both ways)
+
+**How:** Ignition gateway scripts POST to MIRA cloud endpoints; MIRA responds. No inbound to the plant.
+**Read/write:** read + chat round-trips; any "write" is a cloud→gateway *response the gateway chooses to act on*, never a forced command.
+**Reliability:** high; simple to reason about and audit.
+**Security:** lowest — outbound-443-only, HMAC-SHA256 per tenant (ADR-0021 §Decision-3).
+**Demo/Prod:** both. **This is the shipping path today:** `ignition/gateway-scripts/tag-stream.py` → `mira-relay/relay_server.py` (ingest), and the Ignition HMI → `mira-bots/ask_api/app.py` (chat with live tags).
+**MIRA now?** **Yes — this is the spine.** It satisfies the trust boundary by construction.
+
+## Pattern 6 — Database as the exchange layer
+
+**How:** one side writes rows; the other reads them. MIRA already does a version of this: the relay upserts `equipment_status`/`faults`, and the engine reads them.
+**Read/write:** read; no plant write.
+**Reliability:** good for state caches; not ideal for high-rate streaming.
+**Security:** medium — depends on DB access scoping.
+**Demo/Prod:** demo/light-prod. Fine as a **landing table for snapshots**, which is exactly how the proposed snapshot adapter (see next-steps) should persist for traceability.
+**MIRA now?** Already used for ingested status; reuse it as the snapshot/trace store.
+
+## Pattern 7 — Direct device reads
+
+**How:** Node-RED or Ignition (or a bench script) opens a Modbus/OPC UA socket straight to the PLC/VFD.
+**Read/write:** read for monitoring; **MIRA never writes**.
+**Reliability:** medium; RS-485 is single-master and a second master can fault-stop a motor (`.claude/rules/fieldbus-readonly.md`).
+**Security:** high risk if a *cloud* component does it — ADR-0021 forbids any customer-shipped fieldbus socket.
+**Demo/Prod:** **bench-only** (`plc/live-plc-bridge/bridge.py`, `plc/live_monitor.py` carry BENCH-ONLY headers and never ship).
+**MIRA now?** Bench experiments only; never in a customer package.
+
+## Pattern 8 — Command / write path
+
+**How:** cloud or MIRA writes a tag/register to change plant behavior.
+**Everything:** **forbidden.** ADR-0021 §"What we now forbid" #6, scope guard = DEFER tier. If ever built, it requires explicit per-tag admin approval **and** per-prompt cloud approval, RBAC, audit logging, and a safe command boundary (design sketch only, `docs/mira-ignition-secure-architecture.md §4.2`). **Out of scope.**
+
+---
+
+## Recommendation
+
+- **Use now:** Pattern 5 (REST bridge, outbound-only) as the production spine + Pattern 3 (plain MQTT) on the bench/edge + Pattern 6 (DB) as the snapshot/trace store.
+- **Defer:** Pattern 4 (Sparkplug B / `mira-connect`, #1627) until a customer UNS demands it.
+- **Keep out of MIRA:** Pattern 1 write-back, Pattern 7 in customer packages, and Pattern 8 entirely.
+- **Bi-directional, honestly:** MIRA's "bi-directional" is *data up (tags) + answers down (chat)* over HTTPS — **not** control down to the plant. That distinction is the product's safety promise.

--- a/docs/audits/2026-06-04-flowfuse-ignition-alignment.md
+++ b/docs/audits/2026-06-04-flowfuse-ignition-alignment.md
@@ -1,0 +1,112 @@
+# Audit — FlowFuse / Node-RED / Ignition alignment (2026-06-04)
+
+**Auditor stance:** outside reviewer, repo-grounded.
+**Scope:** verify an alignment audit that compared the repo against a FlowFuse / Node-RED / Ignition / MQTT / Sparkplug B / UNS research-and-design prompt.
+**Method:** every claim below was checked against files on `origin/main` (worktree at `1b535a76`). File paths and line counts are real as of this commit. Where something is simulated, spec-only, or deferred, it is labelled as such.
+
+---
+
+## 1. The original research-prompt goal
+
+Investigate FlowFuse, Node-RED, Ignition, MQTT, Sparkplug B and Unified Namespace, then determine how Node-RED could feed Ignition, how Ignition could feed Node-RED, and how both could communicate bi-directionally inside a MIRA / FactoryLM architecture — and produce five durable docs (one overview, one bidirectional-patterns comparison, one MIRA-application doc, one conveyor demo plan, one next-steps plan). MIRA = **Maintenance Intelligence Resource Agent**: a maintenance-reasoning layer that uses chat as its interface, confirms the technician's exact UNS/asset context before troubleshooting, and answers with citations grounded in manuals, wiring, work history, live tag snapshots, and the knowledge graph.
+
+## 2. The five requested deliverables — all were missing
+
+Checked `main`, the working tree, and **every remote branch**. None existed:
+
+| Requested file | Status before this audit |
+|---|---|
+| `docs/research/flowfuse-node-red-ignition-overview.md` | missing |
+| `docs/architecture/node-red-ignition-bidirectional-patterns.md` | missing |
+| `docs/architecture/mira-flowfuse-ignition-application.md` | missing |
+| `docs/plans/conveyor-demo-node-red-ignition-plan.md` | missing |
+| `docs/plans/flowfuse-node-red-next-steps.md` | missing |
+
+These are now created alongside this audit (see §11).
+
+## 3. What the repo already has (verified)
+
+| Area | Real file(s) | Note |
+|---|---|---|
+| Ignition-module-first architecture | `docs/adr/0021-ignition-module-first-edge.md` (Accepted 2026-06-01), `docs/mira-ignition-secure-architecture.md` (33 KB) | The durable decision: customer surface is an Ignition Module; all plant I/O stays in Ignition; outbound-HTTPS-only; allowlist read-only. |
+| Ignition edge code | `ignition/gateway-scripts/tag-stream.py` (161 lines), `ignition/webdev/…`, `ignition/deploy_ignition.ps1`, `ignition/project/…` (Perspective) | Gateway script POSTs tag JSON to the cloud relay over HTTP. |
+| Cloud relay (ingest) | `mira-relay/relay_server.py` (341 lines) | HTTP/WebSocket ingest, HMAC verify, upsert into `equipment_status`/`faults`. Cloud-side only; **no plant write path**. |
+| UNS path model | `mira-crawler/ingest/uns.py` (350 lines), `docs/specs/uns-kg-standards-compliance.md` (519 lines) | ISA-95-derived 6–7 segment paths; ISA-95/ISO-14224/Sparkplug-B compliance audit. |
+| UNS message resolution + confirmation gate | `mira-bots/shared/uns_resolver.py` (975 lines), `mira-bots/shared/engine.py` (4774 lines) | The non-negotiable location-confirmation gate lives in the engine. |
+| Retrieval + citations | `mira-bots/shared/workers/rag_worker.py` (1060), `mira-bots/shared/neon_recall.py` (959), `mira-bots/shared/citation_compliance.py` (96) | Hybrid pgvector + BM25 + RRF; observational citation gate. |
+| Live-tag chat front door | `mira-bots/ask_api/app.py` (171), `mira-bots/ask_api/machine_context.py` | Ignition HMI POSTs `{question, tags}`; decodes GS10/Micro820 tags into a `[LIVE CONVEYOR STATUS]` block, calls `engine.process()`. |
+| Node-RED orchestration | `mira-bridge/` (Node-RED 4.1.7), `mira-bridge/flows/fault-detective.json` (2865 lines) | Message routing + demo HMI flow + Modbus poll stub. |
+| Conveyor demo (bench) | `docker-compose.fault-detective.yml`, `mira-fault-detective/engine.py` (289), `mira-fault-sim/`, `docs/conveyor-fault-detective-demo/README.md`, `docs/superpowers/plans/2026-05-13-mira-conveyor-demo-mvp.md` | Working rule-engine demo driven by a simulator. |
+| Honest gap record | `docs/runbooks/2026-05-15_physical-conveyor-readiness.md` (254 lines) | States "the PLC → MIRA data path is half-built"; lays out Options A/B/C. |
+| FlowFuse decision | `docs/adr/0016-mira-bridge-flowfuse.md` (175 lines) | **Defer**; stay on stock Node-RED; revisit at 500 paying tenants. |
+| PLC bench tools | `plc/live-plc-bridge/bridge.py` (196), `plc/live_monitor.py`, `plc/discover.py` | Read-only / bench-only; never shipped to customers (ADR-0021 §"What we now forbid"). |
+| Read-only safety rules | `.claude/rules/fieldbus-readonly.md` (100), `.claude/skills/mira-saas-scope-guard/SKILL.md` (91) | Discovery is read-only; arbitrary PLC writes are DEFER-tier. |
+| PLC worker | `mira-bots/shared/workers/plc_worker.py` (22) | A **stub** that returns "Live PLC data is not connected yet." |
+
+## 4. What is real working code
+
+- The **reasoning layer**: UNS resolver + confirmation gate, hybrid retrieval, citation compliance, the Supervisor FSM (not LangGraph — PRD §4 bans framework abstraction).
+- The **Ignition → cloud ingest path**: `tag-stream.py` (HTTP POST) → `mira-relay` (HMAC + upsert).
+- The **live-tag chat front door** for the garage conveyor kiosk: `ask_api/app.py` decodes real GS10/Micro820 tags and grounds the answer in `machine_context.py`.
+- The **bench fault-detective demo**: rule engine + simulator + MQTT broker, all running.
+
+## 5. What is simulated (not live machine data)
+
+- `docker-compose.fault-detective.yml` is headed **"BENCH HARNESS — NOT a customer architecture."** Its `fault-sim` service publishes fake PE/PX/fuse/vision values to MQTT. The diagnoses the demo shows are computed from **simulated** signals unless a real PLC is attached via the bench-only bridge.
+- `plc/live-plc-bridge/bridge.py` can poll a real Micro820 at `192.168.1.100:502`, but it is **bench-only** (ADR-0021 §"What we now forbid") and never ships to a customer.
+
+## 6. What is spec-only
+
+- **Sparkplug B.** `docs/specs/uns-kg-standards-compliance.md §6` describes the UNS↔Sparkplug mapping (NBIRTH/DBIRTH/NDATA/…, `spBv1.0/{group}/{type}/{node}/{device}`) in detail and calls it a "future MIRA Layer 4 (event stream)" with "a 10-line transform" to bridge `.`↔`/`. **There is no Sparkplug publisher or subscriber in the codebase** (`uns.py` has no topic builders). Sparkplug is intent + schema mapping, not runtime.
+- **`mira-connect`** (the non-Ignition MQTT/Sparkplug edge subscriber) is referenced by ADR-0021 §"What this decision enables" and tracked at issue **#1627** — spec, not shipped.
+
+## 7. What is deferred (by ADR or design)
+
+- **FlowFuse** — deferred per ADR-0016 (revisit at 500 tenants; conditional triggers documented).
+- **Cloud→plant inbound / writes** — forbidden by ADR-0021 (outbound-HTTPS-only; "Writing to tags from the MVP. The code path does not ship.").
+- **Sparkplug B runtime + `mira-connect`** — deferred to #1627.
+- **Live PLC→NeonDB UNS path** (Option B in the readiness runbook) — deferred post-expo.
+
+## 8. Safety posture today
+
+Strong and enforced, not aspirational:
+- **Read-only by construction.** No PLC/VFD write path ships; `plc_worker.py` is a stub; relay only ingests; ADR-0021 forbids writes and cloud-initiated connections.
+- **Allowlist-first tag reads** (ADR-0021 §Decision-4; `ignition/webdev/.../tags/doGet.py` fail-closed).
+- **Fieldbus discovery is read-only** (`.claude/rules/fieldbus-readonly.md`); the RS-485 sweep refuses to run on a live PLC-mastered bus without `--serial-bus-idle`.
+- **Scope guard** classifies arbitrary PLC control as DEFER-tier.
+- **UNS confirmation gate** must pass before troubleshooting (`engine.py`).
+
+## 9. Alignment with the hybrid architecture
+
+The repo has independently converged on the hybrid shape the prompt points toward:
+- **Ignition = trusted SCADA/HMI/source-of-truth** (ADR-0021).
+- **Node-RED = edge/protocol-conversion + routing** (mira-bridge), with FlowFuse explicitly *not* a dependency (ADR-0016).
+- **MQTT/UNS = shared nervous system** — UNS modelled and ISA-95/Sparkplug-mapped; MQTT used on the bench; Sparkplug runtime deferred.
+- **MIRA = reasoning/troubleshooting layer** — the strongest, most complete part.
+- **Read-only from cloud toward plant** — enforced.
+
+Estimated alignment: **deliverables ≈ 0/5 (now remediated); architectural substance ≈ 60–70%.** The brain is real; the live nervous system is the weak link.
+
+## 10. Biggest gaps
+
+1. **Live machine data rarely reaches the reasoning workflow.** Only the single-machine `ask_api` kiosk injects live tags, and it prepends them as a text block rather than attaching a UNS-keyed snapshot *after* the confirmation gate. `plc_worker.py` is a stub; the Telegram path has no live context.
+2. **No general, UNS-keyed, logged live-tag snapshot adapter** that any front door can reuse.
+3. **Sparkplug B is spec-only** — fine for now, but the docs imply more than exists.
+4. **The conveyor demo's live path is half-built** (readiness runbook), and the bench compose is explicitly not a customer architecture.
+
+## 11. Recommended next move
+
+Consolidate the documentation (done — see the five new files) and then make **one boring, reliable, read-only live data path** real: a small **read-only live-tag snapshot adapter** that normalizes whatever source is easiest today (the Ignition `tag-stream`/`ask_api` tags, or the bench MQTT bridge) into a UNS-keyed structure, attaches it to the conversation **after** the UNS confirmation gate, and logs each snapshot for traceability. Keep plain MQTT before Sparkplug B; keep FlowFuse out until the business case changes; never add a write path.
+
+### Bottom line
+
+> **MIRA's reasoning brain is ahead of the live industrial nervous system. The next hard push should be getting real conveyor/PLC/VFD data into the reasoning workflow in a boring, reliable, read-only way.**
+
+---
+
+**Companion documents created with this audit:**
+- `docs/research/flowfuse-node-red-ignition-overview.md`
+- `docs/architecture/node-red-ignition-bidirectional-patterns.md`
+- `docs/architecture/mira-flowfuse-ignition-application.md`
+- `docs/plans/conveyor-demo-node-red-ignition-plan.md`
+- `docs/plans/flowfuse-node-red-next-steps.md`

--- a/docs/plans/conveyor-demo-node-red-ignition-plan.md
+++ b/docs/plans/conveyor-demo-node-red-ignition-plan.md
@@ -1,0 +1,98 @@
+# Conveyor demo — Node-RED / Ignition / MQTT data-path plan
+
+**Purpose:** a practical plan for getting **real** conveyor data into MIRA's reasoning workflow, read-only, building on what already exists. Grounded in `mira-bots/ask_api/`, `docker-compose.fault-detective.yml`, `plc/live-plc-bridge/bridge.py`, `docs/conveyor-fault-detective-demo/README.md`, `docs/runbooks/2026-05-15_physical-conveyor-readiness.md`, `docs/superpowers/plans/2026-05-13-mira-conveyor-demo-mvp.md`, `docs/adr/0021-ignition-module-first-edge.md`.
+
+**Hard constraints:** read-only toward the plant; no PLC/VFD writes; no cloud→plant inbound; don't present simulator data as live; preserve the UNS confirmation gate and citations.
+
+---
+
+## 1. Hardware (the real iron, per `machine_context.py`)
+
+- **PLC:** Allen-Bradley **Micro820** `2080-LC20-20QBB` @ `192.168.1.100` (EtherNet/IP :44818; **Modbus TCP slave :502 unit 1**).
+- **VFD:** AutomationDirect **GS10** (DURApulse) driving the belt motor. PLC↔VFD = RS-485 Modbus RTU, PLC=master, GS10=slave 1, 9600 8N1.
+- **I/O of interest:** e-stop (dual-channel DI_02/DI_03), photo-eye DI_05 (latching soft-stop), main contactor DO_02, start DI_04, direction DI_00/DI_01.
+- **Key VFD tags + scaling:** `vfd_comm_ok` (master trust gate), `vfd_frequency` (Hz×100), `vfd_current` (A×100), `vfd_dc_bus` (V×10), `vfd_cmd_word` (1/18/20), `vfd_status_word` (low 2 bits = stopped/decel/standby/running), `vfd_fault_code` (0=none; 21=oL overload; 58=CE10 modbus timeout; …).
+
+> If the lab VFD is a **GS11** rather than a GS10, the command/status/fault model is the same DURApulse family; verify register addresses and the `vfd_fault_code` table on the bench before trusting decoded values. The decode tables live in `mira-bots/ask_api/app.py` and `machine_context.py` — update both together.
+
+## 2. Current state (what works today)
+
+- **Bench fault-detective demo** (`docker-compose.fault-detective.yml`, headed **BENCH HARNESS — NOT a customer architecture**): Mosquitto + `mira-fault-sim` (publishes **fake** PE/PX/fuse/vision) + `mira-fault-detective/engine.py` (rule engine) + `mira-bridge` HMI. Diagnoses are computed from **simulated** signals.
+- **Live read path (bench-only):** `plc/live-plc-bridge/bridge.py` polls the Micro820 over Modbus TCP and republishes to MQTT. Read-only; bench-only header; never ships (ADR-0021).
+- **Live-tag chat (single machine):** `mira-bots/ask_api/app.py` accepts `{question, tags, session_id}` from the Ignition HMI, decodes the GS10 tags into a `[LIVE CONVEYOR STATUS]` block, prepends `machine_context.py`, and calls the same `Supervisor.process()` the bots use.
+
+## 3. Live-data gaps (per the readiness runbook)
+
+- The **PLC → MIRA path is "half-built."** Tag-name casing mismatches between the PLC manifest and the relay; no broker running on the production node; no `equipment_telemetry`/`live_signal_cache` table; demo CMMS asset name mismatch (`Conv-001` ≠ garage hardware).
+- Live tags reach MIRA **only** through the `ask_api` kiosk, as a text block injected *before* the UNS gate — not as a UNS-keyed snapshot attached *after* confirmation, and **not logged** as a discrete snapshot for traceability.
+- `mira-bots/shared/workers/plc_worker.py` is a **stub** ("Live PLC data is not connected yet").
+
+## 4. Recommended first live path (boring + read-only)
+
+Adopt the readiness runbook's **Option A / C** spirit — the smallest path that puts *real* values in front of MIRA — and standardize how the snapshot enters the conversation.
+
+```
+Micro820 (Modbus TCP :502, read-only)
+  → [easiest available source]
+        • Bench:    plc/live-plc-bridge/bridge.py  → Mosquitto (UNS topics)   [Pattern 3]
+        • Customer: Ignition gateway tag-stream.py → mira-relay over HTTPS     [Pattern 5, ADR-0021]
+  → normalize to a UNS-keyed snapshot {uns_path, datapoint, value, quality, ts, source}
+  → attach to the MIRA conversation AFTER the UNS confirmation gate
+  → engine retrieves manuals/KG, answers with citations
+  → snapshot logged (DB row) for traceability
+```
+
+- **Bench vs. customer:** the bench uses MQTT (Pattern 3); the customer uses the outbound-HTTPS relay (Pattern 5). The **adapter normalizes both into the same UNS-keyed snapshot** so the engine never cares which source produced it.
+- **Plain MQTT, not Sparkplug**, for now (Sparkplug is spec-only, #1627). Carry `value, ts, quality, source` explicitly so quality/timestamp survive even without birth/death certs.
+- **No writes.** The adapter only reads/receives. `vfd_comm_ok=false` ⇒ mark all VFD values **stale**, never silently trust them (this rule already lives in `machine_context.py`).
+
+## 5. UNS path + MQTT topic shape (demo)
+
+Use the existing UNS builders (`mira-crawler/ingest/uns.py`); do not hand-format paths. Illustrative demo addressing:
+
+```
+UNS path (persisted):  enterprise.garage.line1.conveyor1.gs10_vfd.vfd_frequency
+MQTT topic (bench):    factorylm/garage/line1/conveyor1/gs10_vfd/vfd_frequency
+Payload:               {"value": 6000, "scaled": 60.0, "unit": "Hz", "quality": "good", "ts": "<iso8601>", "source": "live-plc-bridge"}
+```
+
+(`.` for the persisted UNS, `/` for MQTT — the documented 10-line transform in `uns-kg-standards-compliance.md §6`.)
+
+## 6. FactoryLM Hub / MIRA consumption
+
+- The snapshot lands in a small **read-only landing/trace table** (reuse the `equipment_status` pattern in `mira-relay`), keyed by `uns_path` + `ts`.
+- After the technician confirms the asset (UNS gate), the engine pulls the *latest snapshot for that confirmed `uns_path`* and attaches it to context — so live data is scoped to the confirmed machine, not a global blob.
+- Retrieval (`rag_worker.py`/`neon_recall.py`) adds the GS10 manual fault-code section, the wiring rung for the photo-eye, and prior work orders; `citation_compliance.py` ensures the answer cites them.
+
+## 7. What the technician can ask (and how MIRA answers)
+
+| Question | Live tags used | Grounding |
+|---|---|---|
+| "Why won't Conveyor 1 start?" | `vfd_run_permit`, e-stop, `pe_latched`, `vfd_status_word` | run-permit logic in machine card + cited manual |
+| "What fault is active on the GS10/GS11?" | `vfd_fault_code`, `vfd_comm_ok` | decoded fault table + manual section |
+| "Is the photo-eye made / latched?" | `DI_05`/`pe_beam`, `pe_latched` | machine card soft-stop logic |
+| "Is the motor commanded on?" | `vfd_cmd_word`, `vfd_status_word` | command-word decode |
+| "Is the VFD ready?" | `vfd_comm_ok`, `vfd_status_word`, `vfd_fault_code` | trust gate + status |
+| "What changed before the fault?" | snapshot history (trace log) | snapshot DB rows |
+| "What manual section / wiring diagram applies?" | (asset context) | KG + retrieval citation |
+| "What did the last technician do?" | (asset context) | work-order history |
+
+## 8. How citations + live snapshots should appear
+
+- **Live data is labelled and timestamped:** e.g. `Live (2026-06-04 14:03:11, source=ignition): VFD fault CE10 modbus timeout (code 58); comms LOST → other VFD values stale.`
+- **Stated separately from cited knowledge:** the manual/wiring/work-order facts carry `[Source: …]` tags (existing `citation_compliance.py` behavior).
+- **Never blended:** simulated values (if the bench sim is running) must be labelled `simulated`, never presented as live.
+
+## 9. What proves the demo works
+
+1. Ask "what fault is active?" with the VFD **healthy** → MIRA says no active fault, cites the status decode.
+2. Inject/trigger a real fault (or, on the bench, clearly-labelled sim) → MIRA names the decoded fault, cites the manual section, recommends the first check, and the snapshot appears in the trace log.
+3. Ask before confirming the asset → MIRA runs the **UNS confirmation gate first** (proves the gate survived).
+4. Pull the trace log → each answer has an associated, timestamped, UNS-keyed snapshot (proves traceability).
+5. Screenshots saved to `docs/promo-screenshots/` per the repo's Screenshot Rule.
+
+## 10. Demo tiers
+
+- **Mike's lab now:** bench MQTT (Pattern 3) + the snapshot adapter, with sim clearly labelled and the live bridge used when the Micro820 is on.
+- **First customer demo:** Ignition Module + relay (Pattern 5), allowlisted read-only tags, outbound-HTTPS (ADR-0021).
+- **Defer:** Sparkplug B framing, `equipment_telemetry` historian table, multi-machine fleet — until a customer needs them.

--- a/docs/plans/flowfuse-node-red-next-steps.md
+++ b/docs/plans/flowfuse-node-red-next-steps.md
@@ -1,0 +1,65 @@
+# FlowFuse / Node-RED / live-data — next steps
+
+**Purpose:** a prioritized, repo-grounded action plan coming out of the 2026-06-04 alignment audit (`docs/audits/2026-06-04-flowfuse-ignition-alignment.md`).
+**Guiding principle:** the reasoning brain is ahead of the live nervous system. Close that gap with **one boring, reliable, read-only data path** — not a big build.
+
+**Standing constraints (do not violate):** no PLC/VFD writes; no cloud→plant inbound; don't remove safety guards; don't replace Ignition; don't make FlowFuse a hard dependency; don't claim Sparkplug B is implemented; don't present sim data as live; preserve the UNS confirmation gate + citations.
+
+---
+
+## Priority order
+
+### P0 — Documentation consolidation  ✅ (this batch)
+- The five missing deliverables + this audit now exist under `docs/research/`, `docs/architecture/`, `docs/plans/`, `docs/audits/`.
+- **Action:** link them from `docs/THEORY_OF_OPERATIONS.md` and the ADR cross-references so they're discoverable. (1 small docs PR.)
+
+### P1 — One boring live data path (read-only)
+The single highest-value engineering move. Build a **read-only live-tag snapshot adapter** (see "Next coding task" below). Plain MQTT / existing relay only — **no Sparkplug yet**.
+- **Done when:** a confirmed UNS asset's latest real snapshot is attached to the conversation *after* the gate, labelled + timestamped, and logged for traceability; tests cover normalize + stale-handling.
+
+### P2 — Normalize tag sources behind one shape
+- Today live tags arrive two ways (bench MQTT via `plc/live-plc-bridge/bridge.py`; customer HTTPS via `ignition/gateway-scripts/tag-stream.py` → `mira-relay`). Make both normalize into the **same** `{uns_path, datapoint, value, quality, ts, source}` snapshot so the engine is source-agnostic.
+- Fix the documented tag-name casing mismatch (readiness runbook) in the adapter's normalize step, not by editing the PLC.
+
+### P3 — Keep Ignition integration customer-friendly
+- Continue on the ADR-0021 path: allowlist-first reads, outbound-HTTPS, HMAC. Land the Exchange listing work (`docs/specs/ignition-exchange-spec.md`, #1625) on its own track.
+- No new fieldbus sockets in any customer-shipped package.
+
+### P4 — Plain MQTT before Sparkplug B
+- Only implement Sparkplug B (`mira-connect`, #1627) when a real customer UNS requires birth/death + typed metrics. Until then, plain MQTT with explicit `quality`/`ts` is enough.
+
+### P5 — FlowFuse: hold
+- Do **not** adopt FlowFuse yet (ADR-0016). Re-evaluate only on its documented triggers: a multi-tenant deal needing per-customer Node-RED isolation, Node-RED 4.x EOL/CVE, or a flow-drift production incident.
+
+### P6 — Retire the stub honestly
+- Once the snapshot adapter exists, decide the fate of `mira-bots/shared/workers/plc_worker.py` (the "not connected yet" stub): either route it to the new adapter (read-only) or delete it. Don't leave a misleading stub once a real path exists.
+
+---
+
+## Phase 4 — Next coding task (task list only this pass)
+
+**Task:** *Create a read-only live-tag snapshot adapter that accepts conveyor/VFD/PLC state from the easiest current source, normalizes it into a UNS-keyed structure, attaches it to the MIRA conversation context after the UNS confirmation gate, and logs the snapshot for traceability.*
+
+**Why this is NOT implemented in this pass:** attaching a snapshot *after the gate* requires touching `mira-bots/shared/engine.py` (4774 lines; flagged in `.claude/rules/codegraph-usage.md` as requiring a `codegraph_impact` pass before edits — high blast radius). That is not a "very small" change, and the constraints say docs/adapters over rewrites. So this is a task list, not a patch.
+
+**Build it read-only, in small pieces, with tests:**
+
+1. **`snapshot.py` (pure, no I/O)** — define `LiveTagSnapshot {uns_path, datapoint, value, quality, ts, source}` and `normalize(raw_tags, uns_path) -> list[LiveTagSnapshot]`. Reuse the decode logic that already exists in `mira-bots/ask_api/app.py::_build_status_block` (extract it; don't duplicate). Honor the `vfd_comm_ok=false ⇒ stale` rule. **Unit-testable with zero infra.**
+2. **Source readers (read-only, behind one interface):**
+   - MQTT reader (bench): subscribe to the UNS topics `plc/live-plc-bridge/bridge.py` already publishes.
+   - Relay reader (customer): read the latest row from the `equipment_status` table `mira-relay` already upserts.
+   - Both return raw tags for `normalize()`. **No writes anywhere.**
+3. **Snapshot store (trace):** append each attached snapshot to a small read-only table (reuse the `equipment_status` pattern), keyed by `uns_path` + `ts` + `session_id`, for "what changed before the fault?" and auditability.
+4. **Engine attach point (the one careful edit):** *after* the UNS confirmation gate succeeds, look up the latest snapshot for the confirmed `uns_path` and attach it to context — mirroring how `ask_api` prepends `[LIVE CONVEYOR STATUS]`, but gate-scoped and logged. Do a `codegraph_impact` on the gate/`process()` path first; keep the diff surgical; add a golden case.
+5. **Tests:** `normalize()` unit tests (good/stale/unknown tags); a snapshot-attach integration test; a golden case proving the gate still fires before any live data is used.
+6. **Safety review:** confirm no write FCs, no inbound, no Sparkplug claim, sim labelled as sim, citations intact. Run `mira-run-hallucination-audit` after the engine edit.
+
+---
+
+## Summary answers
+
+- **FlowFuse now?** No — deferred (ADR-0016).
+- **Direction?** Both share **plain MQTT/UNS**; the customer-shipping spine is the **outbound-HTTPS relay** (Ignition → MIRA). Node-RED feeds the bus at the edge; Ignition stays the source of truth. MIRA never feeds the plant.
+- **Safest first experiment:** the read-only snapshot adapter above, on the bench (`plc/live-plc-bridge` → MQTT) first, then the relay path.
+- **Sparkplug B now?** No — spec-only; defer to #1627.
+- **Next coding task:** the snapshot adapter (Phase 4), built read-only with tests, with only one surgical engine edit guarded by `codegraph_impact`.

--- a/docs/research/flowfuse-node-red-ignition-overview.md
+++ b/docs/research/flowfuse-node-red-ignition-overview.md
@@ -1,0 +1,85 @@
+# FlowFuse / Node-RED / Ignition / MQTT / Sparkplug B / UNS — plain-English overview
+
+**Audience:** anyone on the MIRA / FactoryLM team who needs a shared vocabulary for the industrial-edge stack.
+**Companion:** `docs/audits/2026-06-04-flowfuse-ignition-alignment.md` (what we actually have today), `docs/architecture/node-red-ignition-bidirectional-patterns.md` (how the pieces connect).
+**Rule of thumb:** MIRA is the **maintenance reasoning layer**. Everything below is plumbing that gets *trusted, structured machine context* to MIRA so it can answer a technician with citations. MIRA does not try to own or replace the plumbing.
+
+---
+
+## Node-RED
+
+**What it is:** a flow-based, low-code wiring tool. You drag "nodes" (read Modbus, parse JSON, publish MQTT, call an HTTP endpoint) onto a canvas and connect them. It runs on Node.js and is the de-facto glue layer of the industrial-IoT world for moving and reshaping data.
+
+**Why it matters for brownfield:** old plants have a zoo of protocols (Modbus RTU/TCP, OPC UA, EtherNet/IP, serial, REST). Node-RED is excellent at *protocol conversion and light transformation at the edge* — read a device one way, publish it another way — without writing a service from scratch.
+
+**In MIRA today:** `mira-bridge/` is a self-hosted Node-RED 4.1.7 deployment. It does message routing (Telegram/REST webhooks → services), holds the shared SQLite write lock, and carries the demo HMI flow (`mira-bridge/flows/fault-detective.json`). See `mira-bridge/CLAUDE.md`.
+
+## FlowFuse
+
+**What it is:** a management platform *on top of* Node-RED. It adds multi-tenant project isolation, Git-synced flows, deploy snapshots/rollback, an audit log, role-based access, and a blueprint system (publish a flow, deploy to many tenants). Open-source self-host + a commercial cloud.
+
+**Why it matters:** stock Node-RED's weak spot is operations — flows are edited in a UI and exported by hand, with no audit trail. FlowFuse fixes that and gives you per-customer isolation.
+
+**In MIRA today:** **deferred.** `docs/adr/0016-mira-bridge-flowfuse.md` evaluated it and recommended staying on stock Node-RED for the MVP window (its multi-tenant model is incompatible with our shared-SQLite pattern, and its cloud pricing is margin-negative at our ARPU). Revisit at ~500 paying tenants or if a multi-tenant deal forces per-customer Node-RED isolation. **MIRA should not become "a FlowFuse."**
+
+## Ignition (Inductive Automation)
+
+**What it is:** a full industrial platform — SCADA, HMI, historian, alarming, tag system, and a driver suite (Modbus, OPC UA, EtherNet/IP, etc.). It runs on a "Gateway" (a JVM service) and is the system many plants already trust as their source of truth for live tags.
+
+**Why it matters:** the customer probably already owns Ignition (or is buying it). Ignition already talks to the PLCs. Fighting Ignition is a losing battle; riding on top of it (Ignition Exchange / a Module) is the winning one.
+
+**In MIRA today:** the **customer-deployable surface is an Ignition Module** (Perspective project + WebDev endpoints + gateway scripts), per `docs/adr/0021-ignition-module-first-edge.md` and `docs/mira-ignition-secure-architecture.md`. All plant-side I/O stays inside Ignition; MIRA reads tags by browsing Ignition's tag space, never by opening its own protocol socket. **MIRA does not replace Ignition.**
+
+## MQTT
+
+**What it is:** a lightweight publish/subscribe messaging protocol. Publishers send messages to "topics"; subscribers receive any topic they care about. A central "broker" (Mosquitto, HiveMQ, EMQX) routes everything. It is the standard backbone for the Unified Namespace pattern.
+
+**Why it matters:** decouples producers from consumers. A PLC bridge publishes once; Ignition, Node-RED, a dashboard, and MIRA can all subscribe independently. It is the natural "shared nervous system."
+
+**In MIRA today:** used **on the bench** (`docker-compose.fault-detective.yml` runs Mosquitto; `plc/live-plc-bridge/bridge.py` publishes Modbus reads; `mira-fault-detective/engine.py` subscribes). That compose file is explicitly a **BENCH HARNESS, not a customer architecture**. The customer path (ADR-0021) moves tags over **outbound HTTPS**, not a MIRA-hosted broker.
+
+## Sparkplug B
+
+**What it is:** a *convention on top of MQTT* (Eclipse Tahu, spec 3.0.0) that standardizes the topic structure (`spBv1.0/{group}/{message_type}/{edge_node}/{device}`) and the payload (typed metrics, **birth/death certificates** so consumers know when a device goes online/offline, and aliased metric names for bandwidth). It turns "raw MQTT" into a self-describing, stateful industrial bus.
+
+**Why it matters:** birth/death + typed metrics + quality/timestamp make MQTT trustworthy for SCADA-grade data. It is the clean way to do a real UNS event stream.
+
+**In MIRA today:** **spec-only.** `docs/specs/uns-kg-standards-compliance.md §6` maps MIRA's 7-segment UNS path onto Sparkplug's namespace and notes it is a "future Layer 4 (event stream)" needing "a 10-line transform." **No Sparkplug publisher or subscriber exists in code.** The non-Ignition Sparkplug edge subscriber (`mira-connect`) is tracked at issue #1627, not shipped. Do **not** describe Sparkplug as implemented.
+
+## UNS — Unified Namespace
+
+**What it is:** a single, hierarchical, business-friendly address space for everything in the plant — `enterprise / site / area / line / equipment / component / datapoint` — derived from ISA-95. Every tag, manual chunk, fault code and work order hangs off one path. It is the "single source of structure," whether expressed as MQTT topics (live) or database rows (persisted).
+
+**Why it matters for MIRA:** the UNS is *how MIRA knows what the technician is talking about*. The confirmation gate resolves the technician's words to a UNS path before troubleshooting; retrieval and the knowledge graph are keyed on it.
+
+**In MIRA today:** real and central. `mira-crawler/ingest/uns.py` builds the paths; `mira-bots/shared/uns_resolver.py` resolves free-form messages to a UNS context; the confirmation gate in `mira-bots/shared/engine.py` enforces "no confirmed context, no troubleshooting." Storage uses ltree (`docs/migrations/007_uns_path.sql`). ISA-95/ISO-14224/Sparkplug alignment is audited in `docs/specs/uns-kg-standards-compliance.md`.
+
+## OPC UA
+
+**What it is:** a vendor-neutral industrial protocol with a rich, browsable "address space" (typed nodes, metadata, security). Modern PLCs (Siemens S7, AB Logix, Beckhoff) expose an OPC UA server. It also supports PubSub over MQTT, which can bridge directly to a Sparkplug-style UNS.
+
+**Why it matters:** where it exists, OPC UA gives structure for free — its address space maps almost 1:1 onto the UNS.
+
+**In MIRA today:** **scanned, not consumed.** `plc/discover.py` probes for OPC UA endpoints during read-only discovery, but there is no OPC UA *read driver*. ADR-0001 deferred OPC UA (license/scope). In the customer architecture (ADR-0021) OPC UA is Ignition's job, and MIRA reads the resulting tags from Ignition.
+
+## Modbus
+
+**What it is:** the oldest, simplest, most universal fieldbus. Reads/writes numbered registers (coils, holding registers) over TCP or RS-485 serial (RTU). Ubiquitous on VFDs and small PLCs.
+
+**Why it matters:** it is the lowest common denominator for brownfield devices — the GS10 VFD and Micro820 PLC in the conveyor lab speak it.
+
+**In MIRA today:** the real device path. `mira-connect/.../drivers/modbus_driver.py` (async read), `plc/live-plc-bridge/bridge.py` and `plc/live_monitor.py` (bench tools). **Read-only by rule** (`.claude/rules/fieldbus-readonly.md`); the RS-485 sweep refuses to run on a live PLC-mastered bus without `--serial-bus-idle` (two masters can fault-stop a motor).
+
+## REST APIs
+
+**What it is:** plain HTTP request/response with JSON. The universal integration glue between web services.
+
+**Why it matters for MIRA:** it is how the *trusted edge talks to the cloud* without opening inbound ports — the customer only allows `outbound 443`.
+
+**In MIRA today:** the spine of the customer architecture. The Ignition gateway script `ignition/gateway-scripts/tag-stream.py` POSTs tag JSON to `mira-relay/relay_server.py`; the Ignition HMI POSTs questions to `mira-bots/ask_api/app.py`; both are outbound-HTTPS, HMAC-signed (ADR-0021). The chat engine itself talks to LLM providers over REST (Groq → Cerebras → Gemini cascade).
+
+---
+
+## How they fit together (one paragraph)
+
+In a brownfield plant, **Modbus/OPC UA** are how you reach the iron. **Node-RED** (optionally managed by **FlowFuse**) converts those protocols at the edge. **Ignition** is the trusted SCADA/HMI/historian the customer already runs. **MQTT** (optionally framed as **Sparkplug B**) is the shared bus, addressed by the **UNS**. **REST** carries trusted, signed snapshots outbound to the cloud. **MIRA** sits at the top: it consumes the structured context, confirms the technician's UNS location, and produces cited troubleshooting answers. The deliberate boundary: data flows *up and out* to MIRA; MIRA never reaches *down and in* to write the plant.


### PR DESCRIPTION
Repo-grounded remediation of the 2026-06-04 alignment audit. The five requested FlowFuse/Node-RED/Ignition research deliverables existed on **no branch**; this adds them plus the audit, grounded in real files (ADR-0021, ADR-0016, `ask_api/`, the fault-detective bench harness, `uns.py`/`uns_resolver.py`, Sparkplug spec-only per `uns-kg-standards-compliance.md §6`).

**Docs-only — no code changes.** Honors all hard constraints: read-only, no writes, no cloud→plant inbound, Sparkplug labelled spec-only, sim labelled as sim, UNS gate + citations preserved. The Phase-4 next coding task (read-only live-tag snapshot adapter) is a task list only — it would touch `engine.py` and isn't a small change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)