### PR TITLE
feat(shared): read-only live-tag snapshot normalizer (pure, tested)

### DIFF
--- a/mira-bots/shared/live_snapshot.py
+++ b/mira-bots/shared/live_snapshot.py
@@ -1,0 +1,192 @@
+"""Read-only live-tag snapshot normalization (pure, I/O-free).
+
+Turns a raw tag dict — from the Ignition HMI POST (`mira-bots/ask_api/app.py`),
+a `mira-relay` `equipment_status` row, or the bench MQTT bridge
+(`plc/live-plc-bridge/bridge.py`) — into a list of typed, UNS-keyed
+``LiveTagSnapshot`` records. The engine can attach these to the conversation
+*after* the UNS confirmation gate and log them for traceability (see
+``docs/plans/flowfuse-node-red-next-steps.md`` Phase 4).
+
+Hard boundary: this module NEVER writes, NEVER opens a socket, NEVER touches a
+fieldbus. It only reshapes data already received. No clock either — the caller
+passes ``ts`` so normalization stays deterministic and unit-testable.
+
+The GS10/Micro820 decode tables mirror ``mira-bots/ask_api/app.py`` and the
+machine card (``MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md``); keep them in sync.
+Trust rule (from ``ask_api/machine_context.py``): ``vfd_comm_ok`` is the master
+trust gate — when it is false, every VFD-derived value is marked ``stale``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# --- GS10 decode tables (mirror ask_api/app.py) ---
+_STATUS_BITS = {0: "STOPPED", 1: "DECEL", 2: "STANDBY", 3: "RUNNING"}
+_CMD_WORD = {1: "STOP", 18: "FWD+RUN", 20: "REV+RUN"}
+_FAULT_CODES = {
+    0: "no active fault",
+    4: "GFF ground fault",
+    12: "Lvd undervoltage",
+    21: "oL overload",
+    49: "EF external fault",
+    54: "CE1 comm illegal cmd",
+    55: "CE2 comm illegal addr",
+    56: "CE3 comm illegal data",
+    57: "CE4 comm fail",
+    58: "CE10 modbus timeout",
+}
+
+# Quality bands.
+GOOD = "good"
+STALE = "stale"
+UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class LiveTagSnapshot:
+    """One decoded, UNS-keyed live datapoint at a point in time.
+
+    ``value`` is the decoded/scaled value where the tag is known, else the raw
+    value. ``label`` is the human-readable rendering used in a status block.
+    ``quality`` is one of ``good`` / ``stale`` / ``unknown``.
+    """
+
+    uns_path: str
+    datapoint: str
+    value: Any
+    unit: str | None
+    quality: str
+    label: str
+    source: str
+    ts: str
+
+
+def _num(raw: Any) -> float | int | None:
+    """Return raw as a number, or None if it isn't a plain numeric (bools excluded)."""
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        return raw
+    return None
+
+
+def _decode_one(key: str, raw: Any) -> tuple[Any, str | None, str] | None:
+    """Decode a single known tag → (value, unit, label). None ⇒ unknown tag."""
+    if key == "vfd_frequency":
+        n = _num(raw)
+        return None if n is None else (n / 100, "Hz", f"VFD output: {n / 100:.1f} Hz")
+    if key == "vfd_freq_sp":
+        n = _num(raw)
+        return None if n is None else (n / 100, "Hz", f"Freq setpoint: {n / 100:.1f} Hz")
+    if key == "vfd_current":
+        n = _num(raw)
+        return None if n is None else (n / 100, "A", f"Current: {n / 100:.1f} A")
+    if key == "vfd_dc_bus":
+        n = _num(raw)
+        return None if n is None else (n / 10, "V", f"DC bus: {n / 10:.1f} V")
+    if key == "vfd_cmd_word":
+        name = _CMD_WORD.get(raw, f"cmd {raw}")
+        return (name, None, f"Command: {name}")
+    if key == "vfd_status_word":
+        n = _num(raw)
+        if n is None:
+            return None
+        state = _STATUS_BITS.get(int(n) & 0b11, "?")
+        return (state, None, f"Drive state: {state} (status word {raw})")
+    if key == "vfd_fault_code":
+        if raw == 0:
+            return ("no active fault", None, "no active fault")
+        if raw in _FAULT_CODES:
+            return (_FAULT_CODES[raw], None, f"FAULT: {_FAULT_CODES[raw]} (code {raw})")
+        return (f"code {raw}", None, f"FAULT code {raw} (unmapped)")
+    if key == "vfd_comm_ok":
+        return ("OK" if raw else "LOST", None, f"VFD comms {'OK' if raw else 'LOST'}")
+    if key == "pe_latched":
+        return (
+            "latched" if raw else "clear",
+            None,
+            "PHOTO-EYE JAM LATCHED (soft-stop active)" if raw else "photo-eye clear",
+        )
+    if key in ("DI_02", "e_stop"):
+        return (
+            "ARMED/OK" if raw else "TRIPPED",
+            None,
+            f"E-stop {'ARMED/OK' if raw else 'TRIPPED'}",
+        )
+    if key in ("DI_05", "pe_beam"):
+        return ("BLOCKED" if raw else "clear", None, f"PE-01 beam {'BLOCKED' if raw else 'clear'}")
+    if key in ("DO_02", "mlc"):
+        return (
+            "CLOSED/energized" if raw else "OPEN",
+            None,
+            f"Main line contactor {'CLOSED/energized' if raw else 'OPEN'}",
+        )
+    return None
+
+
+def normalize(
+    raw_tags: dict[str, Any] | None,
+    uns_base: str,
+    *,
+    source: str,
+    ts: str,
+) -> list[LiveTagSnapshot]:
+    """Normalize a raw tag dict into UNS-keyed snapshots.
+
+    ``uns_base`` is the CONFIRMED asset UNS path (from the confirmation gate);
+    each snapshot's ``uns_path`` is ``f"{uns_base}.{datapoint}"``. Tags with a
+    ``None`` value are skipped. Unknown tags pass through with ``unknown``
+    quality. When ``vfd_comm_ok`` is present and false, every other ``vfd_*``
+    value is marked ``stale``.
+    """
+    if not raw_tags:
+        return []
+
+    comm_ok = raw_tags.get("vfd_comm_ok")
+    vfd_stale = comm_ok is not None and not comm_ok
+
+    out: list[LiveTagSnapshot] = []
+    for key, raw in raw_tags.items():
+        if raw is None:
+            continue
+
+        decoded = _decode_one(key, raw)
+        quality = GOOD
+        if key != "vfd_comm_ok" and key.startswith("vfd_") and vfd_stale:
+            quality = STALE
+
+        if decoded is None:
+            value, unit, label = raw, None, f"{key}: {raw}"
+            if quality == GOOD:
+                quality = UNKNOWN
+        else:
+            value, unit, label = decoded
+
+        out.append(
+            LiveTagSnapshot(
+                uns_path=f"{uns_base}.{key}" if uns_base else key,
+                datapoint=key,
+                value=value,
+                unit=unit,
+                quality=quality,
+                label=label,
+                source=source,
+                ts=ts,
+            )
+        )
+    return out
+
+
+def render_status_block(snapshots: list[LiveTagSnapshot]) -> str:
+    """Render snapshots as a human-readable ``[LIVE CONVEYOR STATUS]`` block.
+
+    Mirrors ``ask_api/app.py::_build_status_block`` output, with ``[STALE]``
+    markers so the LLM never silently trusts stale VFD values. Returns ``""``
+    when there is nothing to report.
+    """
+    if not snapshots:
+        return ""
+    lines = [s.label + (" [STALE]" if s.quality == STALE else "") for s in snapshots]
+    return "[LIVE CONVEYOR STATUS]\n" + "\n".join(lines)

--- a/mira-bots/tests/test_live_snapshot.py
+++ b/mira-bots/tests/test_live_snapshot.py
@@ -1,0 +1,120 @@
+"""Tests for shared.live_snapshot — pure, read-only live-tag normalization.
+
+Covers the GS10/Micro820 decode parity with ask_api/app.py, the vfd_comm_ok
+stale-trust rule, unknown-tag passthrough, None skipping, UNS-path keying, and
+the status-block renderer. No infra: the module is pure.
+"""
+
+from __future__ import annotations
+
+import sys
+
+sys.path.insert(0, "mira-bots")
+
+from shared.live_snapshot import (  # noqa: E402
+    GOOD,
+    STALE,
+    UNKNOWN,
+    LiveTagSnapshot,
+    normalize,
+    render_status_block,
+)
+
+BASE = "enterprise.garage.line1.conveyor1"
+TS = "2026-06-04T04:00:00Z"
+
+
+def _by_dp(snaps: list[LiveTagSnapshot]) -> dict[str, LiveTagSnapshot]:
+    return {s.datapoint: s for s in snaps}
+
+
+def test_empty_or_none_returns_empty():
+    assert normalize(None, BASE, source="bench", ts=TS) == []
+    assert normalize({}, BASE, source="bench", ts=TS) == []
+
+
+def test_none_values_skipped():
+    snaps = normalize({"vfd_frequency": None, "vfd_current": 1234}, BASE, source="bench", ts=TS)
+    dps = _by_dp(snaps)
+    assert "vfd_frequency" not in dps
+    assert "vfd_current" in dps
+
+
+def test_scaled_decode_and_uns_path():
+    snaps = normalize({"vfd_frequency": 6000}, BASE, source="ignition", ts=TS)
+    s = snaps[0]
+    assert s.value == 60.0
+    assert s.unit == "Hz"
+    assert s.quality == GOOD
+    assert s.uns_path == f"{BASE}.vfd_frequency"
+    assert s.datapoint == "vfd_frequency"
+    assert s.source == "ignition"
+    assert s.ts == TS
+    assert "60.0 Hz" in s.label
+
+
+def test_fault_code_mapping():
+    s = _by_dp(normalize({"vfd_fault_code": 58}, BASE, source="bench", ts=TS))["vfd_fault_code"]
+    assert s.value == "CE10 modbus timeout"
+    assert "FAULT" in s.label and "58" in s.label
+
+
+def test_fault_code_zero_is_no_fault():
+    s = _by_dp(normalize({"vfd_fault_code": 0}, BASE, source="bench", ts=TS))["vfd_fault_code"]
+    assert s.value == "no active fault"
+
+
+def test_status_word_low_bits():
+    s = _by_dp(normalize({"vfd_status_word": 0b11}, BASE, source="bench", ts=TS))["vfd_status_word"]
+    assert s.value == "RUNNING"
+
+
+def test_comm_ok_false_marks_vfd_values_stale_but_not_plant_io():
+    raw = {
+        "vfd_comm_ok": False,
+        "vfd_frequency": 6000,
+        "vfd_fault_code": 21,
+        "DI_02": True,  # e-stop, read straight from PLC, not via VFD comms
+    }
+    dps = _by_dp(normalize(raw, BASE, source="bench", ts=TS))
+    assert dps["vfd_frequency"].quality == STALE
+    assert dps["vfd_fault_code"].quality == STALE
+    # the trust gate itself is trustworthy, and plant I/O is unaffected
+    assert dps["vfd_comm_ok"].quality == GOOD
+    assert dps["DI_02"].quality == GOOD
+
+
+def test_comm_ok_true_keeps_vfd_values_good():
+    dps = _by_dp(normalize({"vfd_comm_ok": True, "vfd_current": 350}, BASE, source="bench", ts=TS))
+    assert dps["vfd_current"].quality == GOOD
+
+
+def test_unknown_tag_passthrough():
+    s = _by_dp(normalize({"weird_tag": 7}, BASE, source="bench", ts=TS))["weird_tag"]
+    assert s.value == 7
+    assert s.quality == UNKNOWN
+    assert s.label == "weird_tag: 7"
+
+
+def test_non_numeric_scaled_tag_falls_back_to_passthrough():
+    # a scaled key with a non-numeric value must not raise
+    s = _by_dp(normalize({"vfd_frequency": "n/a"}, BASE, source="bench", ts=TS))["vfd_frequency"]
+    assert s.value == "n/a"
+    assert s.quality == UNKNOWN
+
+
+def test_render_status_block_marks_stale_and_has_header():
+    raw = {"vfd_comm_ok": False, "vfd_frequency": 6000}
+    block = render_status_block(normalize(raw, BASE, source="bench", ts=TS))
+    assert block.startswith("[LIVE CONVEYOR STATUS]")
+    assert "[STALE]" in block
+    assert "VFD comms LOST" in block
+
+
+def test_render_status_block_empty():
+    assert render_status_block([]) == ""
+
+
+def test_no_uns_base_uses_datapoint_only():
+    s = normalize({"vfd_current": 350}, "", source="bench", ts=TS)[0]
+    assert s.uns_path == "vfd_current"


### PR DESCRIPTION
First, smallest slice of the live-data path (`docs/plans/flowfuse-node-red-next-steps.md` Phase 4, step 1). A **pure, read-only** `shared.live_snapshot` module: `normalize(raw_tags, uns_base, *, source, ts) -> list[LiveTagSnapshot]` + `render_status_block()`.

- **No writes, no sockets, no fieldbus, no clock** — fully deterministic + unit-testable.
- Decode tables mirror `ask_api/app.py` + the machine card; honors the `vfd_comm_ok` master-trust rule (comm lost ⇒ `vfd_*` marked `stale`; plant I/O stays `good`).
- **Not wired into `engine.py`** — that attach-after-the-gate edit is high-blast-radius and gated on a `codegraph_impact` pass; this PR is just the safe, tested foundation.
- 13 unit tests, `ruff check` clean, `ruff format` applied.

Preserves all constraints: read-only, no inbound, no Sparkplug claim, UNS gate + citations untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)