### PR TITLE
feat(engine): gated read-only live-tag snapshot + ask_api de-dup

### DIFF
--- a/mira-bots/ask_api/app.py
+++ b/mira-bots/ask_api/app.py
@@ -14,12 +14,14 @@ Run: uvicorn ask_api.app:app --host 0.0.0.0 --port 8011
 import logging
 import os
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel
+from shared.engine import Supervisor
+from shared.live_snapshot import normalize, render_status_block
 
 from ask_api.machine_context import MACHINE_CONTEXT
-from shared.engine import Supervisor
 
 logging.basicConfig(
     level=logging.INFO,
@@ -57,79 +59,17 @@ class AskRequest(BaseModel):
     session_id: str | None = None
 
 
-# --- GS10 decode tables (mirror MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md) ---
-# Status word (reg 0x2101) low 2 bits -> run state.
-_STATUS_BITS = {0: "STOPPED", 1: "DECEL", 2: "STANDBY", 3: "RUNNING"}
-# GS10 fault/error codes (vfd_fault_code, low byte of reg 0x2100) -> short name.
-_FAULT_CODES = {
-    0: "no active fault",
-    4: "GFF ground fault",
-    12: "Lvd undervoltage",
-    21: "oL overload",
-    49: "EF external fault",
-    54: "CE1 comm illegal cmd",
-    55: "CE2 comm illegal addr",
-    56: "CE3 comm illegal data",
-    57: "CE4 comm fail",
-    58: "CE10 modbus timeout",
-}
-
-
 def _build_status_block(tags: dict | None) -> str:
-    """Decode known live conveyor/VFD tags into a human-readable status block.
+    """Decode live conveyor/VFD tags into a human-readable status block.
 
-    Unknown keys are passed through raw. Missing/None values are skipped.
-    Returns "" when there is nothing to report.
+    Thin wrapper over ``shared.live_snapshot`` (the single source of the
+    GS10/Micro820 decode tables, mirroring the machine card) so this kiosk and
+    the engine share one decoder. Kept as a function so the /ask call site is
+    unchanged. Adds ``[STALE]`` markers when ``vfd_comm_ok`` is false. Returns
+    "" when there is nothing to report.
     """
-    if not tags:
-        return ""
-
-    lines: list[str] = []
-    cmd_word_map = {1: "STOP", 18: "FWD+RUN", 20: "REV+RUN"}
-
-    for key, value in tags.items():
-        if value is None:
-            continue
-
-        if key == "vfd_frequency":
-            lines.append(f"VFD output: {value / 100:.1f} Hz")
-        elif key == "vfd_freq_sp":
-            lines.append(f"Freq setpoint: {value / 100:.1f} Hz")
-        elif key == "vfd_current":
-            lines.append(f"Current: {value / 100:.1f} A")
-        elif key == "vfd_dc_bus":
-            lines.append(f"DC bus: {value / 10:.1f} V")
-        elif key == "vfd_cmd_word":
-            lines.append(f"Command: {cmd_word_map.get(value, f'cmd {value}')}")
-        elif key == "vfd_status_word":
-            state = _STATUS_BITS.get(value & 0b11, "?")
-            lines.append(f"Drive state: {state} (status word {value})")
-        elif key == "vfd_fault_code":
-            if value == 0:
-                lines.append("no active fault")
-            elif value in _FAULT_CODES:
-                lines.append(f"FAULT: {_FAULT_CODES[value]} (code {value})")
-            else:
-                lines.append(f"FAULT code {value} (unmapped)")
-        elif key == "vfd_comm_ok":
-            lines.append(f"VFD comms {'OK' if value else 'LOST'}")
-        elif key == "pe_latched":
-            lines.append(
-                "PHOTO-EYE JAM LATCHED (soft-stop active)" if value else "photo-eye clear"
-            )
-        elif key in ("DI_02", "e_stop"):
-            lines.append(f"E-stop {'ARMED/OK' if value else 'TRIPPED'}")
-        elif key in ("DI_05", "pe_beam"):
-            lines.append(f"PE-01 beam {'BLOCKED' if value else 'clear'}")
-        elif key in ("DO_02", "mlc"):
-            lines.append(f"Main line contactor {'CLOSED/energized' if value else 'OPEN'}")
-        else:
-            lines.append(f"{key}: {value}")
-
-    if not lines:
-        return ""
-
-    return "[LIVE CONVEYOR STATUS]\n" + "\n".join(lines)
+    snaps = normalize(tags, "", source="ignition", ts=datetime.now(timezone.utc).isoformat())
+    return render_status_block(snaps)
 
 
 @app.get("/health")

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -69,6 +69,8 @@ from .integrations.pm_suggestions import (
     is_pm_acceptance,
     suggest_followup_pm,
 )
+from .live_snapshot import STALE, render_status_block
+from .live_snapshot import normalize as normalize_live_tags
 from .models.work_order import (
     UNSWorkOrder,
     apply_wo_edit,
@@ -885,6 +887,7 @@ class Supervisor:
         mira_user_id: str | None = None,
         uns_source: str | None = None,
         tag_evidence: list | None = None,
+        live_tags: dict | None = None,
     ) -> str:
         """Main entry point. Returns reply string (backward-compatible).
 
@@ -901,6 +904,11 @@ class Supervisor:
         is recorded on ``state["context"]["uns_context"]["source"]`` and surfaced
         in the decision trace; it does NOT by itself alter gate firing (the full
         gate bypass is master-plan Phase 6).
+
+        ``live_tags`` (optional) is a raw read-only PLC/VFD tag dict. It is
+        attached to the message ONLY after the UNS confirmation gate has passed
+        (see ``_maybe_attach_live_snapshot``) — never before — so live data can
+        never bypass the gate. Callers that don't pass it are unaffected.
         """
         # Per-call tenant overrides constructor default. Stash on self so workers
         # can reach the current request's tenant via self._current_tenant_id.
@@ -908,6 +916,9 @@ class Supervisor:
         # from __init__ (set as the fallback below).
         self._current_tenant_id = tenant_id or self.tenant_id
         self._current_mira_user_id = mira_user_id or ""
+
+        # Read-only live-tag snapshot — gated on a confirmed asset (see helper).
+        message = self._maybe_attach_live_snapshot(chat_id, message, live_tags, platform)
 
         t0 = time.monotonic()
         try:
@@ -1025,6 +1036,62 @@ class Supervisor:
             task.add_done_callback(self._decision_trace_tasks.discard)
         except Exception as exc:  # noqa: BLE001
             logger.debug("decision_trace schedule skipped: %s", exc)
+
+    def _maybe_attach_live_snapshot(
+        self,
+        chat_id: str,
+        message: str,
+        live_tags: dict | None,
+        platform: str,
+    ) -> str:
+        """Prefix ``message`` with a read-only live-tag status block, gated.
+
+        Returns ``message`` unchanged unless ALL hold:
+          * ``live_tags`` was provided, and
+          * the conversation has already passed the UNS confirmation gate — the
+            pre-turn FSM state is an active diagnostic state AND an asset is
+            confirmed (``asset_identified``).
+
+        This is the gate-safety guarantee: live machine data is never attached
+        before the technician's asset context is confirmed, so it cannot drive a
+        troubleshooting answer ahead of the gate. Each attached snapshot is
+        logged (``LIVE_SNAPSHOT``) for traceability. Best-effort: any failure
+        falls back to the original message so a snapshot bug never breaks chat.
+        """
+        if not live_tags:
+            return message
+        try:
+            state = self._load_state(chat_id)
+            fsm_state = state.get("state", "IDLE")
+            if fsm_state not in ACTIVE_DIAGNOSTIC_STATES or not state.get("asset_identified"):
+                logger.info(
+                    "LIVE_SNAPSHOT_WITHHELD chat_id=%s reason=gate_not_passed state=%s",
+                    chat_id,
+                    fsm_state,
+                )
+                return message
+            uns_ctx = (state.get("context") or {}).get("uns_context") or {}
+            uns_base = uns_ctx.get("uns_path") or ""
+            ts = datetime.now(timezone.utc).isoformat()
+            snapshots = normalize_live_tags(live_tags, uns_base, source=platform, ts=ts)
+            block = render_status_block(snapshots)
+            if not block:
+                return message
+            n_stale = sum(1 for s in snapshots if s.quality == STALE)
+            logger.info(
+                "LIVE_SNAPSHOT chat_id=%s uns=%s source=%s ts=%s n=%d stale=%d datapoints=%s",
+                chat_id,
+                uns_base or "-",
+                platform,
+                ts,
+                len(snapshots),
+                n_stale,
+                ",".join(s.datapoint for s in snapshots),
+            )
+            return f"{block}\n\n{message}"
+        except Exception as exc:
+            logger.warning("LIVE_SNAPSHOT_ERROR chat_id=%s err=%s", chat_id, exc)
+            return message
 
     async def _apply_quality_gate(
         self,

--- a/mira-bots/tests/test_engine_live_snapshot.py
+++ b/mira-bots/tests/test_engine_live_snapshot.py
@@ -1,0 +1,108 @@
+"""Tests for the gated live-tag snapshot wiring in Supervisor.process().
+
+The safety-critical property: live machine data is attached to the message ONLY
+after the UNS confirmation gate has passed (pre-turn FSM state is an active
+diagnostic state AND an asset is confirmed). Before the gate, live data is
+withheld so it can never drive a troubleshooting answer ahead of confirmation.
+
+We monkeypatch ``_load_state`` (so no DB schema is needed) and patch
+``process_full`` (so no LLM/network is needed), then assert what message
+``process_full`` actually received.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest
+
+LIVE_TAGS = {"vfd_fault_code": 58, "vfd_comm_ok": True, "DI_02": True}
+
+
+def _engine(tmp_db):
+    from shared.engine import Supervisor
+
+    return Supervisor(
+        db_path=tmp_db,
+        openwebui_url="http://stub",
+        api_key="",
+        collection_id="",
+        tenant_id="t",
+    )
+
+
+def _confirmed_state():
+    return {
+        "state": "DIAGNOSIS",
+        "asset_identified": "AutomationDirect GS10",
+        "context": {"uns_context": {"uns_path": "enterprise.garage.line1.conveyor1"}},
+    }
+
+
+def _idle_state():
+    return {"state": "IDLE", "asset_identified": None, "context": {}}
+
+
+@pytest.mark.asyncio
+async def test_snapshot_injected_after_gate(tmp_db):
+    sup = _engine(tmp_db)
+    sup._load_state = lambda chat_id: _confirmed_state()
+    with patch.object(sup, "process_full", new=AsyncMock(return_value={"reply": "ok"})) as pf:
+        await sup.process("c1", "why won't it start?", live_tags=LIVE_TAGS)
+    sent = pf.call_args[0][1]  # process_full(chat_id, message, photo_b64)
+    assert sent.startswith("[LIVE CONVEYOR STATUS]")
+    assert "CE10 modbus timeout" in sent
+    assert "why won't it start?" in sent  # original question preserved
+
+
+@pytest.mark.asyncio
+async def test_snapshot_withheld_before_gate(tmp_db):
+    sup = _engine(tmp_db)
+    sup._load_state = lambda chat_id: _idle_state()
+    with patch.object(sup, "process_full", new=AsyncMock(return_value={"reply": "ok"})) as pf:
+        await sup.process("c1", "why won't it start?", live_tags=LIVE_TAGS)
+    sent = pf.call_args[0][1]
+    assert "LIVE CONVEYOR STATUS" not in sent
+    assert sent == "why won't it start?"  # message untouched before the gate
+
+
+@pytest.mark.asyncio
+async def test_no_live_tags_is_backward_compatible(tmp_db):
+    sup = _engine(tmp_db)
+    # _load_state must not even be needed when live_tags is omitted.
+    sup._load_state = lambda chat_id: (_ for _ in ()).throw(AssertionError("should not load state"))
+    with patch.object(sup, "process_full", new=AsyncMock(return_value={"reply": "ok"})) as pf:
+        result = await sup.process("c1", "hello")
+    assert pf.call_args[0][1] == "hello"
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_failure_is_best_effort(tmp_db):
+    sup = _engine(tmp_db)
+
+    def _boom(chat_id):
+        raise RuntimeError("state load failed")
+
+    sup._load_state = _boom
+    with patch.object(sup, "process_full", new=AsyncMock(return_value={"reply": "ok"})) as pf:
+        result = await sup.process("c1", "why won't it start?", live_tags=LIVE_TAGS)
+    # A snapshot bug must never break chat: message passes through unchanged.
+    assert pf.call_args[0][1] == "why won't it start?"
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_stale_marker_when_comm_lost(tmp_db):
+    sup = _engine(tmp_db)
+    sup._load_state = lambda chat_id: _confirmed_state()
+    tags = {"vfd_comm_ok": False, "vfd_frequency": 6000}
+    with patch.object(sup, "process_full", new=AsyncMock(return_value={"reply": "ok"})) as pf:
+        await sup.process("c1", "status?", live_tags=tags)
+    sent = pf.call_args[0][1]
+    assert "[STALE]" in sent
+    assert "VFD comms LOST" in sent


### PR DESCRIPTION
Wires the live-tag snapshot (#1698) into the reasoning workflow, and does the `ask_api` refactor.

**Wiring (engine):** `Supervisor.process()` gains an optional `live_tags` kwarg. Tags are normalized and prefixed to the message **only after the UNS confirmation gate has passed** (pre-turn FSM state in `ACTIVE_DIAGNOSTIC_STATES` **and** `asset_identified`) — so live data can never bypass the gate. Each attached snapshot is logged (`LIVE_SNAPSHOT`) for traceability; comm-lost values are `[STALE]`. Best-effort (failure ⇒ original message). The kwarg is optional, so dispatcher/Telegram callers are unchanged (blast radius: only `ask_api` + `dispatcher` call `process()`).

**Refactor (ask_api):** `_build_status_block` now delegates to the shared `normalize`/`render_status_block`, deleting ~55 lines of duplicated GS10/Micro820 decode tables. Kiosk behavior preserved.

**Tests:** 5 new engine tests (inject-after-gate, withhold-before-gate, backward-compat, best-effort-on-error, stale-marker) + 13 module tests — all pass locally with full deps; `ruff` clean; existing engine tests green.

**Constraints:** read-only, no writes, no cloud→plant inbound, UNS gate strengthened (not bypassed), citations untouched, Sparkplug not claimed.

**Recommended pre-merge:** `/mira-run-hallucination-audit` (engine-edit gate) + the staging `tests/eval/` regime, per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)