### PR TITLE
feat(connectors): generic connector framework + 5 mock connectors + 67 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,13 @@ jobs:
         # clarification invariants. Hermetic, no LLM, runs in <1s.
         run: pytest tests/bot_regression.py -v
 
+      - name: Connector framework tests
+        # mira-connectors/ is a sys.path root (its conftest injects itself +
+        # mira-crawler). Hermetic mock connectors, no network/DB/LLM, <1s.
+        # Per-module invocation keeps its `cmms` package from colliding with
+        # mira-mcp/cmms. See docs/mira/connector-framework.md §7.
+        run: pytest mira-connectors/tests/ -v
+
   architecture-check:
     name: Architecture Check
     runs-on: ubuntu-latest

--- a/NORTH_STAR.md
+++ b/NORTH_STAR.md
@@ -26,6 +26,41 @@ Infrastructure first. AI second. Every customer engagement starts with **"what d
 
 Everything in the repo — `mira-pipeline`, `mira-mcp`, `mira-bots`, `mira-web`, `mira-cmms`, `mira-crawler` — is supporting infrastructure for delivering and operating that namespace.
 
+## The Canonical Asset Graph (the next evolution)
+
+> Added 2026-06-02. This sharpens — does not replace — the doctrine above. The "Maintenance
+> Intelligence Namespace" and the "canonical asset graph" are the same artifact at two altitudes:
+> the namespace is what we *sell*; the asset graph is what it *is* under the hood.
+
+"AI-ready infrastructure" has a concrete shape: a **canonical industrial asset graph** that is the
+**translation layer between plant-floor OT and enterprise maintenance systems.**
+
+- **In:** semi-structured customer reality from every direction — IBM Maximo, SAP, MaintainX,
+  Fiix, Limble; Ignition, MQTT/Sparkplug B, OPC UA, historians; manuals, wiring diagrams, PLC
+  tags, nameplates, and technician knowledge.
+- **Through:** one canonical graph (`kg_entities` + `kg_relationships`, ISA-95 `uns_path`
+  addressing, `proposed → verified` approval state, confidence on every edge) — with the
+  **original source record preserved**, never normalized-and-discarded.
+- **Out:** the reasoning layer AI agents ground in, *and* a bidirectional bridge — OT signal
+  meaning flows up to enterprise CMMS/ERP; enterprise asset structure flows down to the plant
+  floor — without MIRA replacing either system or ever writing to a PLC.
+
+**The graph IS the product.** The copilot, the connectors, the Hub, the bots are how the graph
+gets built and used. Two architectural commitments make this defensible:
+
+1. **Build the canonical graph first, connectors around it.** No connector owns a shape; each maps
+   *into* the canonical model and keeps its raw record. We never hardcode around one system.
+2. **Read-only for OT by default.** MIRA observes the plant floor; it never controls it.
+
+This reframes the Knowledge Cooperative moat: every plant we structure deepens a *shared canonical
+graph* of OEM components, fault patterns, and tag-mapping heuristics — so each new plant maps onto
+existing canonical nodes instead of starting blank. The asset graph is what compounds.
+
+**Architecture docs:** `docs/mira/canonical-asset-graph.md` (the model),
+`docs/mira/source-record-preservation.md` (raw-record layer),
+`docs/mira/current-repo-inventory.md` (what's built), governed by
+`docs/plans/2026-06-01-mira-master-architecture-plan.md`.
+
 ## The Decision Filter
 
 Before building any feature, ask: **"Does this make the flywheel spin faster?"**

--- a/docs/mira/canonical-asset-graph.md
+++ b/docs/mira/canonical-asset-graph.md
@@ -1,0 +1,248 @@
+# MIRA — Canonical Industrial Asset Graph
+
+**Status:** Phase 1 deliverable of the canonical-asset-graph initiative — **design + additive
+schema proposals (docs-only)**
+**Authored:** 2026-06-02
+**Owner:** Lead architect (MIRA)
+**Builds on:** `docs/mira/current-repo-inventory.md` · `docs/plans/2026-06-01-mira-master-architecture-plan.md` · `docs/specs/uns-kg-unification-spec.md` · `docs/specs/mira-component-intelligence-architecture.md`
+**Pairs with:** `docs/mira/source-record-preservation.md` (the source-identity mechanism is defined there and referenced here)
+
+---
+
+## 0. Thesis and the one rule that shapes everything
+
+MIRA's value is a **canonical industrial asset graph** that is simultaneously:
+
+- the **memory** a grounded copilot reasons over, and
+- the **translation layer** between plant-floor OT (PLC / Ignition / MQTT / OPC UA / historian)
+  and enterprise maintenance systems (Maximo / SAP / MaintainX / Fiix / manuals / tribal knowledge).
+
+**The rule:** build the canonical graph first, connectors around it. A connector never owns a
+shape; it *maps into* the canonical shape and keeps its original record (Phase 2). So this
+document does **not** invent a new store — it confirms `kg_entities` + `kg_relationships` as the
+canonical spine and specifies the **minimal additive** changes that turn today's KG into the full
+graph. Postgres-first; no Neo4j (master-plan Phase 13 trigger gate stands).
+
+---
+
+## 1. The model in one picture
+
+```
+                       ┌──────────────────────────────────────────────┐
+   ENTERPRISE SYSTEMS  │            source_objects  (Phase 2)          │  OT SYSTEMS
+   Maximo / SAP /      │  raw imported record + connector + version    │  Ignition / MQTT /
+   MaintainX / Fiix    │  + mapping_status  (never destroyed)          │  OPC UA / historian / PLC
+        │              └───────────────────┬──────────────────────────┘        │
+        │  connector adapters              │ source_object_id FK                │  tag collector
+        ▼                                  ▼                                    ▼
+   ┌───────────────────────────────────────────────────────────────────────────────┐
+   │  CANONICAL SPINE   kg_entities (node)  ──  kg_relationships (edge)             │
+   │  • uns_path (ltree, ISA-95)     • approval_state (proposed→verified)          │
+   │  • entity_type (discriminator)  • confidence    • source_object_id (NEW)      │
+   └───────────────┬───────────────────────────────────────────────────────────────┘
+                   │ FK / source_chunk_id / equipment_entity_id  (typed projections)
+     ┌─────────────┼───────────────┬──────────────┬───────────────┬────────────────┐
+     ▼             ▼               ▼              ▼               ▼                ▼
+ tag_entities  knowledge_     cmms_equipment  component_    installed_       fault_codes /
+ (signals/    entries        + work orders    templates     component_       tag_events
+  tags)       (manuals/docs) (CMMS assets)    (per-model)   instances        (fault events)
+```
+
+**Spine + typed projections (hybrid).** `kg_entities` is the *addressed, approvable node*; the
+specialized tables carry domain columns and link back. The graph is the index; the projections
+are the detail. This is already how the repo is shaped — we are formalizing it, not rebuilding it.
+
+---
+
+## 2. Entity model — requested vocabulary → existing schema
+
+`kg_entities.entity_type` is **free `TEXT` with no CHECK constraint** (Hub 001; verified). New
+entity types therefore need **no migration** — only a governed vocabulary so writers agree.
+"Spine row" = a `kg_entities` row carrying the canonical address. "Typed projection" = a
+specialized table that holds the columns and links to the spine.
+
+| Requested entity | `entity_type` | Spine row? | Typed projection (detail) | Status |
+|---|---|---|---|---|
+| Enterprise | `enterprise` | ✅ | — (root of `uns_path`) | ✅ exists |
+| Site | `site` | ✅ | `cmms_equipment` (site rows) | ✅ |
+| Area | `area` | ✅ | — | ✅ |
+| Line | `line` | ✅ | — | ✅ |
+| Cell | `cell` | ✅ | — | ⚠️ supported, rarely populated |
+| Asset | `asset` / `equipment` | ✅ | `cmms_equipment` (`equipment_entity_id`) | ✅ |
+| Component | `component` | ✅ | `installed_component_instances` (per-instance) | ✅ |
+| (Component model) | `component_template` | reference | `component_templates` (per-model) | ✅ |
+| Signal / feedback signal | `signal` | ✅ | `tag_entities` | ✅ |
+| PLC tag | `tag` (`tag_kind=plc`) | ✅ | `tag_entities` | ✅ |
+| SCADA tag | `tag` (`tag_kind=scada`) | ✅ | `tag_entities` | ✅ |
+| Historian signal | `tag` (`tag_kind=historian`) | ✅ | `tag_entities` + `live_signal_cache` | ✅ |
+| Alarm | `alarm` | ✅ | `tag_events` (alarm windows) | ⚠️ new entity_type + edge (§3) |
+| Fault event | `fault_event` | ✅ | `tag_events` (`fault_window_open/close`, DT branch) | ✅ stream; node optional |
+| (Fault code catalog) | `fault_code` | ✅ | `fault_codes` (engine 002) | ✅ |
+| Work order | `work_order` | ✅ | CMMS work-order rows (`cmms_*`) | ⚠️ node not always materialized |
+| PM task | `pm_task` | ✅ | `pm_schedules` | ✅ |
+| Failure mode | `failure_mode` | ✅ | `properties` JSONB | ✅ |
+| Root cause | `root_cause` | ✅ | `properties` JSONB | ✅ |
+| Remedy / fix | `remedy` | ✅ | `properties` JSONB | ✅ |
+| Part / spare | `part` | ✅ | `properties` JSONB + `manufacturer_part_number` | ✅ |
+| Manual / document | `document` | ✅ | `knowledge_entries` (`source_chunk_id`) | ✅ |
+| Wiring diagram | `wiring_diagram` | ✅ | `knowledge_entries` + `wiring_connections` (Hub 026) | ✅ |
+| Procedure | `procedure` | ✅ | `knowledge_entries` | ✅ |
+| Technician confirmation | — | ✗ | `approval_state` transition + `CONFIRMED_BY` edge | ✅ not a node |
+| External system | `external_system` | ✅ (registry) | `source_systems` (Phase 2) | ⚠️ Phase 2 |
+| External object | — | ✗ | `source_objects` (Phase 2) — **raw record, not a graph node** | ⚠️ Phase 2 |
+| Relationship | — | edge | `kg_relationships` / `relationship_proposals` | ✅ |
+| Confidence score | — | column | `confidence` on entity/edge/suggestion | ✅ |
+
+**Takeaway:** of 25 requested entity kinds, **all are expressible today** on the spine + existing
+projections. Only `alarm` and a materialized `work_order` node need new `entity_type` *values*
+(free-text, no migration) plus the edges in §3. `external_system` / `external_object` are
+deliberately **not** graph nodes — they live in the Phase 2 source layer and attach via FK.
+
+### 2.1 Governance: an `entity_type` registry (no schema change)
+
+Because `entity_type` is unconstrained TEXT, the failure mode is writer drift (`asset` vs
+`equipment` vs `machine`). Fix is documentation + a shared constant, not a CHECK (a CHECK would
+make the cooperative's open-vocabulary growth a migration every time). Canonical list lives here;
+writers import it. (If we later want enforcement, a `kg_entity_types` reference table + soft FK is
+the additive path — deferred until drift is observed.)
+
+---
+
+## 3. Relationship model — requested vocabulary → existing 28-type set
+
+`relationship_proposals.relationship_type` **has a CHECK** (Hub 028, 28 values; verified).
+`kg_relationships.relationship_type` is free TEXT. To keep the proposal path authoritative
+(master-plan Phase 3), new edge types are added by **extending the Hub 028 CHECK**.
+
+| Requested edge | Existing type (Hub 028) | Action |
+|---|---|---|
+| `is_located_at` | `LOCATED_IN` | ✅ use as-is |
+| `belongs_to` | `LOCATED_IN` / `INSTANCE_OF` (by context) | ✅ |
+| `contains` | `HAS_COMPONENT` (inverse) | ✅ store canonical direction parent→child |
+| `is_part_of` | `HAS_PART` (inverse) | ✅ store HAS_PART parent→child |
+| `is_controlled_by` | `DRIVES` / `IS_DRIVEN_BY` / `USED_IN_LOGIC` | ✅ |
+| `has_feedback_signal` | `HAS_SIGNAL` | ✅ |
+| `has_manual` | `HAS_DOCUMENT` | ✅ |
+| `has_failure_mode` | `HAS_FAILURE_MODE` | ✅ |
+| `caused_by` | `CAUSES` (inverse) | ✅ |
+| `fixed_by` | `RESOLVED_BY` | ✅ |
+| `uses_part` | `HAS_PART` (containment) | ⚠️ propose **`USES_PART`** for *consumption* semantics (a WO consumes a spare ≠ an asset contains a part) |
+| `maps_to_external_object` | `MAPS_TO` | ✅ — but the **canonical** mechanism is `source_object_id` FK (§4), MAPS_TO is the graph-visible mirror |
+| `proposed_match` | (status, not type) | ✅ a `MAPS_TO` edge with `approval_state='proposed'` |
+| `technician_confirmed` | `CONFIRMED_BY` | ✅ + `approval_state='verified'` |
+| `supersedes` | `REPLACES` | ✅ |
+| `conflicts_with` | `CONTRADICTED_BY` | ✅ (or propose symmetric `CONFLICTS_WITH`) |
+| `has_alarm` | — | ⚠️ propose **`HAS_ALARM`** |
+| `has_work_order` | — | ⚠️ propose **`HAS_WORK_ORDER`** |
+| (`has_pm_task`) | — | ⚠️ propose **`HAS_PM_TASK`** (implied by PM-task entity) |
+
+**16 of 18 requested edges map onto the existing 28-type vocabulary as-is.** Only four genuinely
+new types are needed: `HAS_ALARM`, `HAS_WORK_ORDER`, `HAS_PM_TASK`, `USES_PART` (+ optional
+`CONFLICTS_WITH`). Direction convention: store the **canonical** direction (parent→child,
+asset→signal, fault→cause-of) and let queries traverse inverses; don't store both directions.
+
+---
+
+## 4. The seven requirements — how each is met
+
+| # | Requirement | Mechanism | Today | Proposal |
+|---|---|---|---|---|
+| 1 | Preserve **source-system identity** on every node | `kg_entities.source_object_id` FK → `source_objects` (Phase 2) | ⚠️ only `source_chunk_id`/`source_conversation_id` | **add `source_object_id`** (mig 039) |
+| 2 | Reference **≥1 external record** per normalized node | many-to-one via `source_objects` (a node ← N source rows) + `cmms_equipment` external-ID columns (Hub 013) + `ai_suggestions.source_*` | ⚠️ ID columns only, no payload | Phase 2 layer + §4.1 |
+| 3 | **Confidence scoring** | `confidence FLOAT` on `kg_relationships`, `ai_suggestions`; `extraction_confidence` on template sources | ✅ | none |
+| 4 | **Technician confirmation** | `approval_state` (proposed→verified) + `CONFIRMED_BY` edge + `relationship_evidence` | ✅ | enforce `proposed` default (Phase 3 / G4) |
+| 5 | **Uncertain / proposed** relationships | `ai_suggestions` (6 types) + `relationship_proposals` + `approval_state='proposed'` | ✅ | make proposal path the *only* writer (Phase 3) |
+| 6 | **ISA-95 hierarchy without rigid structure** | `uns_path ltree` as a *cached projection* over the `LOCATED_IN`/`parent_of` edge graph (Hub 010) | ✅ | none — graph is source of truth, path is the index |
+| 7 | **Future UNS/MQTT topic generation** | `uns_path` + `cmms_equipment.uns_topic_path` + `uns.py` builders + Sparkplug mapping (`.claude/rules/...`) | ⚠️ column-only | topic generator (post-MVP) |
+
+### 4.1 Source-identity is ONE mechanism (not a parallel scheme)
+
+Requirement 1 (node-level) and the Phase 2 `source_objects` table are **the same thing**. A node
+does not get its own provenance columns; it gets **one FK** (`source_object_id`) into the Phase 2
+raw-record store, plus the graph-visible `MAPS_TO` mirror edge for traversal. The existing
+`cmms_equipment` external-ID columns (Hub 013) and `ai_suggestions.source_kind/source_id` are
+*compatible* with this — they become *derived* views of the source layer, not competing stores.
+The authoritative definition lives in `source-record-preservation.md`; this doc only consumes it.
+
+---
+
+## 5. Additive schema proposals (docs-only — do NOT write migration files)
+
+Slots 032–037 are consumed by the DT branch (`feat/dt2026-gap-closure`). New work starts at
+**038**. These are **proposals for review**, not files to apply — applying crosses the
+dev→staging→prod migration discipline and `apply-migrations.yml` flow. Author the real files only
+after sign-off and after re-checking the live tail of `mira-hub/db/migrations/`.
+
+```sql
+-- 038_relationship_type_asset_graph.sql  (PROPOSAL)
+-- Extend the Hub-028 relationship_type CHECK with the 4 genuinely-new edge types.
+-- Keeps the proposal path (relationship_proposals) authoritative per master-plan Phase 3.
+ALTER TABLE relationship_proposals
+  DROP CONSTRAINT IF EXISTS relationship_proposals_relationship_type_check;
+ALTER TABLE relationship_proposals
+  ADD CONSTRAINT relationship_proposals_relationship_type_check
+  CHECK (relationship_type IN (
+    -- existing 28 (Hub 028) ...
+    'HAS_COMPONENT','INSTANCE_OF','LOCATED_IN','HAS_PART','HAS_DOCUMENT','HAS_CHUNK',
+    'REFERENCES','HAS_PROCEDURE','WIRED_TO','POWERED_BY','MAPS_TO','PUBLISHED_AS',
+    'USED_IN_LOGIC','TRIGGERS','CAUSES','DRIVES','IS_DRIVEN_BY','OCCURS_ON','RESOLVED_BY',
+    'HAS_FAILURE_MODE','HAS_SIGNAL','HAS_ALIAS','DEPENDS_ON','UPSTREAM_OF','DOWNSTREAM_OF',
+    'REPLACES','CONFIRMED_BY','CONTRADICTED_BY',
+    -- NEW for the asset-graph vision:
+    'HAS_ALARM','HAS_WORK_ORDER','HAS_PM_TASK','USES_PART'
+  ));
+-- kg_relationships.relationship_type stays free TEXT (no CHECK); the gate is the proposal table.
+
+-- 039_kg_entities_source_object.sql  (PROPOSAL)
+-- Canonical source-system identity on a node = one FK into the Phase 2 source layer.
+-- Nullable: organic (chat/photo) nodes have no external source object; that's normal.
+ALTER TABLE kg_entities
+  ADD COLUMN IF NOT EXISTS source_object_id UUID;   -- FK-by-convention -> source_objects(id), Phase 2
+CREATE INDEX IF NOT EXISTS idx_kg_entities_source_object
+  ON kg_entities (tenant_id, source_object_id)
+  WHERE source_object_id IS NOT NULL;
+-- A node may derive from N source rows (manual + CMMS + nameplate). source_object_id holds the
+-- PRIMARY/origin row; the full N is the set of source_objects rows whose mapped_entity_id = this
+-- node (reverse FK, defined in Phase 2). One-to-one column + one-to-many reverse index = both.
+```
+
+No other DDL. `entity_type` additions (`alarm`, `work_order` node, etc.) are free-text and need
+no migration. The `entity_type` vocabulary registry (§2.1) is documentation, not schema.
+
+---
+
+## 6. What this explicitly does NOT change
+
+- ❌ No new node/edge store. `kg_entities`/`kg_relationships` remain canonical (no Neo4j —
+  Phase 13 triggers unchanged).
+- ❌ No rename of `source_id`/`target_id`/`relationship_type` (the PR #1443 trap).
+- ❌ No CHECK on `entity_type` (would tax the open cooperative vocabulary).
+- ❌ No second provenance scheme — source identity is the single Phase 2 FK.
+- ❌ No migration files written from this doc — proposals only, slots 038+.
+
+---
+
+## 7. Acceptance (when this model is "real")
+
+1. Every requested entity kind resolves to a documented `entity_type` + projection (§2). ✅ by design.
+2. Every requested edge resolves to an existing or proposed `relationship_type` (§3). ✅ by design.
+3. A node carries `source_object_id` when it originated from a connector import (after mig 039 +
+   Phase 2) — verified by: import a MaintainX asset → `kg_entities` row has `source_object_id`
+   pointing at the preserved raw record.
+4. `uns_path` remains a projection over the edge graph, not a parallel hierarchy (no writer sets
+   `uns_path` without a corresponding `LOCATED_IN` edge).
+5. New edge types only enter via `relationship_proposals` (proposal path authoritative).
+
+---
+
+## 8. Cross-references
+
+- `docs/mira/current-repo-inventory.md` — verified baseline this builds on
+- `docs/mira/source-record-preservation.md` — the source-identity FK target (Phase 2)
+- `docs/plans/2026-06-01-mira-master-architecture-plan.md` — Phase 3 (proposal path), Phase 6
+  (hierarchy gate), Phase 11 (`get_asset_context` bundle), Phase 13 (graph-DB trigger gate)
+- `docs/specs/uns-kg-unification-spec.md` — UNS authority
+- `docs/specs/mira-component-intelligence-architecture.md` — template/instance mechanics
+- `.claude/rules/uns-compliance.md` — path builders, lowercase, reserved labels
+- ADR-0013 (Hub-canonical schema), ADR-0014 (`ai_suggestions` broad queue), ADR-0017 (status
+  transitions through helpers)

--- a/docs/mira/connector-framework.md
+++ b/docs/mira/connector-framework.md
@@ -1,0 +1,258 @@
+# MIRA — Connector Framework
+
+**Status:** Phase 2-aligned deliverable of the canonical-asset-graph initiative —
+**framework + mock connectors (no live source I/O, no DB writes)**
+**Authored:** 2026-06-04
+**Builds on:** `docs/mira/canonical-asset-graph.md` · `docs/mira/source-record-preservation.md` · `docs/mira/current-repo-inventory.md`
+**Code:** `mira-connectors/`
+
+---
+
+## 0. What this is
+
+A **connector** is the translation layer between an external system and MIRA's
+canonical industrial asset graph. The canonical graph is built first; connectors
+map *into* it and never own a shape (canonical-asset-graph.md §0, "the one rule").
+
+Two families:
+
+- **Enterprise (CMMS / EAM):** IBM Maximo, SAP PM, MaintainX, Fiix, Limble, Atlas.
+- **Plant-floor (OT):** Ignition / SCADA, MQTT/Sparkplug, OPC UA, AVEVA PI historian.
+
+This module ships **mock** connectors for five of them (Maximo, Ignition, SAP,
+MaintainX, AVEVA PI) that read realistic fixtures instead of calling live APIs,
+so the full normalize → validate → propose → export pipeline runs with zero
+credentials. The live path swaps the fixture read for the real API client; the
+mapping code is unchanged.
+
+```
+mira-connectors/
+├── base.py            # Connector ABC + Capability/RawRecord/ExportResult
+├── canonical.py       # in-memory mirror of kg_entities/kg_relationships/
+│                      #   ai_suggestions/source_objects (live column names)
+├── uns_bridge.py      # re-exports mira-crawler/ingest/uns.py builders (reuse, never reimplement)
+├── demo.py            # runnable end-to-end OT↔enterprise join
+├── cmms/              # maximo_mock.py · sap_mock.py · maintainx_mock.py (+ fixtures/)
+├── scada/             # ignition_mock.py (+ fixtures/)
+├── historian/         # pi_mock.py (+ fixtures/)
+└── tests/             # per-connector + canonical + base + e2e (67 tests)
+```
+
+---
+
+## 1. The pipeline
+
+```
+  EXTERNAL SYSTEM                          MIRA
+  ┌────────────┐   discover()   ┌──────────────────────────────────────┐
+  │ Maximo /   │ ─────────────▶ │ Capability (schema, object types,     │
+  │ SAP /      │                │            supports_export, read_only) │
+  │ MaintainX /│   import_records(config)                                │
+  │ Ignition / │ ─────────────▶ │ list[RawRecord]  (raw, untouched)      │
+  │ PI         │                │        │                               │
+  └────────────┘                │        ▼ normalize()  (pure, no I/O)   │
+                                │ NormalizedGraph:                       │
+                                │   • CanonicalEntity   (kg_entities)    │
+                                │   • CanonicalRelationship (kg_rels)    │
+                                │   • Proposal          (ai_suggestions) │
+                                │   • SourceObject      (source_objects) │
+                                │        │                               │
+                                │        ▼ validate()                    │
+                                │ ValidationReport (errors block, warns) │
+                                │        │                               │
+                                │        ▼ [a writer persists — Phase 2/3]│
+                                │   kg_entities + kg_relationships        │
+                                │        │                               │
+                  export_enriched(ctx)   ▼                               │
+  ┌────────────┐ ◀───────────── │ enriched payload in SOURCE format      │
+  │ source     │   (only when    │ (e.g. Maximo WO + MIRA_UNS_PATH)       │
+  │ (writable) │   read_only=    └──────────────────────────────────────┘
+  └────────────┘    False & not dry_run)
+```
+
+Each stage is a method on `Connector` (`base.py`):
+
+| Method | Sync/async | Returns | Notes |
+|---|---|---|---|
+| `discover()` | async | `Capability` | schema + capabilities, no records |
+| `import_records(config)` | async | `list[RawRecord]` | read-only pull; `config` filters |
+| `normalize(raw)` | sync | `NormalizedGraph` | pure transform; preserves payloads |
+| `validate(graph)` | sync | `ValidationReport` | errors block, warnings inform |
+| `export_enriched(ctx)` | async | `ExportResult` | source-format write-back |
+| `get_config_schema()` | sync | `dict` | expected config (secrets flagged) |
+
+`run(config)` is a convenience that chains import → normalize → validate.
+
+---
+
+## 2. The canonical model (what connectors emit)
+
+`canonical.py` mirrors the **live** NeonDB schema (column names verified in
+`current-repo-inventory.md` §2.1 — `source_id`/`target_id`/`relationship_type`,
+**not** the engine-005 `source_entity`/`relation_type` names — the PR #1443 trap).
+
+| Canonical class | Live table | Key fields |
+|---|---|---|
+| `CanonicalEntity` | `kg_entities` | `entity_type`, `name` (natural key), `uns_path`, `properties`, `approval_state`, `confidence`, `source_payload` |
+| `CanonicalRelationship` | `kg_relationships` | `source_key`, `target_key`, `relationship_type`, `confidence`, `approval_state` |
+| `Proposal` | `ai_suggestions` | one of 6 `suggestion_type`, `extracted_data`, `confidence`, `risk_level`, `proposed_by` |
+| `SourceObject` | `source_objects` (proposed mig 042) | `raw_payload`, `content_hash`, `mapping_status`, `mapped_entity_key` |
+
+**Vocabulary is governed, not free-for-all.** `ENTITY_TYPES`, `REL_TYPES` (the
+Hub-028 28 + the 4 new edges `HAS_ALARM`/`HAS_WORK_ORDER`/`HAS_PM_TASK`/`USES_PART`
+from canonical-asset-graph.md §3), and the 6 `SUGGESTION_TYPES` are constants; a
+typo raises at construction time, not at Hub render time.
+
+**UNS paths come only from `uns.py`** (`uns_bridge.py` re-exports it). Connectors
+call `uns.site_path`, `uns.assigned_equipment_path`, `uns.equipment_subnode_path`,
+`uns.fault_code_path`, `uns.work_order_path`, etc. — never hand-formatted strings
+(`.claude/rules/uns-compliance.md` rule #1).
+
+### Natural keys
+
+Entities are keyed by `(entity_type, name)` where `name` is the source system's
+**unique ID** (Maximo `ASSETNUM`, SAP `EQUNR`, PI tag, Ignition tag path) — never
+the free-text description (two motors both named "MOTOR" would silently merge).
+Relationships reference entities by the in-memory `key` (`entity_type:name`),
+which a writer resolves to real `kg_entities.id` UUIDs.
+
+---
+
+## 3. The confirmation gate (proposed → verified)
+
+**Nothing a connector produces is `verified`.** Every `CanonicalEntity` and
+`CanonicalRelationship` defaults to `approval_state="proposed"`; every `Proposal`
+starts `status="pending"`. Promotion to `verified` is a **human/admin action**
+(canonical-asset-graph.md req 4/5; `.claude/CLAUDE.md` "Knowledge graph
+proposals"). A connector that auto-verifies is a bug — `validate()` flags any
+non-`proposed` entity/edge as an `error`.
+
+Two kinds of uncertainty surface as `ai_suggestions` (`Proposal`):
+
+- **Mapping ambiguity** → `uns_confirmation`. Example: Maximo's location depth is
+  `PLANT → AREA → LINE → CELL` (4 levels) but ISA-95 below a site is
+  `area → line → work_cell` (3). The connector folds `PLANT-*` into the site and
+  emits a `uns_confirmation` proposal rather than silently forcing a mapping.
+- **Cross-system links** → `kg_edge`. The Ignition connector matches SCADA tags
+  to CMMS assets (`propose_asset_links`) and proposes `HAS_SIGNAL` edges with
+  calibrated confidence (exact tag↔ASSETNUM = 0.9; fuzzy folder keyword =
+  0.55–0.8). The technician confirms before these become trusted.
+
+**Safety proposals are `risk_level="safety_critical"`.** Anything touching
+E-stop / interlock / LOTO (a Maximo failure path, an Ignition `EStop` tag, a PI
+"Safety Event" frame) is flagged so the Hub gates it for review (migration 027
+writer responsibility). The authoritative keyword list is
+`mira-bots/shared/guardrails.py SAFETY_KEYWORDS`; connectors carry a small local
+hint set only for risk-tagging proposals, not for user-facing STOP behavior.
+
+---
+
+## 4. Source-record preservation
+
+Every connector preserves the **complete original record** twice:
+
+1. on the entity, in `CanonicalEntity.source_payload` (convenience), and
+2. as a `SourceObject` (`raw_payload` + `content_hash` + `mapping_status`), which
+   is the canonical raw store from `source-record-preservation.md`.
+
+Custom fields are **not junk** — Maximo's `MIRA_UNS_PATH` / `MIRA_CONFIDENCE`
+survive verbatim and round-trip back out through `export_enriched`. `content_hash`
+(sha256 of the canonicalized payload) is the re-import dedup key. Because the raw
+record is kept, a mapping change is a **re-run of `normalize` over stored
+payloads** — no second call to the customer's system.
+
+---
+
+## 5. Read-only and dry-run (two distinct axes)
+
+| Flag | Guards | Default |
+|---|---|---|
+| `read_only` | the **source system** — never write back to Maximo/PI/Ignition | `True` |
+| `dry_run` | **MIRA's** stores — don't persist into kg_entities/source_objects | `True` |
+
+`export_enriched` pushes to the source only when `read_only=False` **and**
+`dry_run=False` (`_may_write_source()`). A mock/read-only/dry-run connector still
+*builds* the enriched payload and returns it with `written=False`, so a caller
+can inspect exactly what would be sent. SCADA and historian connectors return
+`ExportResult(supported=False)` — you don't write enriched payloads back to a tag
+provider or a read-only historian.
+
+---
+
+## 6. Mock vs live connectors
+
+The mocks are **shape-faithful**: real field names (`ASSETNUM`, `EQUNR`,
+`TPLNR`, `WONUM`, PI point names, Ignition `[provider]Folder/Tag` paths) and real
+API response envelopes (MaintainX `workOrders`/`assets`). Only the *transport*
+differs.
+
+To go live, keep `normalize`/`validate`/`export_enriched` exactly as-is and
+replace `_load()`/`import_records` with the real client:
+
+- **Maximo** → Manage REST (`oslc/os/mxapiasset`, `mxapiwodetail`, `mxapipm`).
+- **SAP PM** → S/4HANA OData (`API_FUNCTIONALLOCATION`, `API_EQUIPMENT`, …).
+- **MaintainX** → `https://api.getmaintainx.com/v1/...` (reuse the existing
+  `mira-mcp/cmms/maintainx.py` `MaintainXCMMS._get`).
+- **Ignition** → tag browse (`system.tag.browse`) + WebDev/Web API.
+- **AVEVA PI** → PI Web API (`/piwebapi/...`) or AF SDK.
+
+Secrets stay **Doppler-managed** (`factorylm/dev|stg|prd`) and are referenced by
+`get_config_schema()` fields marked `"secret": True` — never placed in
+`source_systems.config` (security-boundaries.md).
+
+---
+
+## 7. How to add a new connector
+
+1. Pick the family dir (`cmms/`, `scada/`, `historian/`, or a new one).
+2. Add a fixture under `fixtures/<system>_demo.json` using **real source field
+   names** and the real response shape.
+3. Subclass `Connector`; set `name`, `system_kind` (must be one of the
+   source-record-preservation `system_kind` values), `connector_version`.
+4. Implement the six methods. In `normalize`:
+   - build UNS paths **only** via `uns.*` builders;
+   - key entities by the source's unique ID;
+   - set `source_payload` to the full record and emit a `SourceObject`;
+   - leave everything `approval_state="proposed"`;
+   - raise ambiguities as `Proposal`s (`uns_confirmation` / `kg_edge` / …), and
+     tag safety-relevant ones `risk_level="safety_critical"`.
+5. `validate` should check valid UNS paths, no orphan edges, preserved payloads,
+   and that nothing is auto-verified.
+6. Add a test file `tests/test_<system>_mock.py` covering the seven behaviors
+   (import, normalize, payload preservation, UNS paths, proposals-not-facts,
+   dry_run, export). Run from inside the module: `cd mira-connectors && pytest`.
+
+> **Import note:** `mira-connectors/` is a `sys.path` root (like `mira-mcp/`),
+> not an installable package — its `cmms/` subpackage shares a name with
+> `mira-mcp/cmms`, so the two are never put on `sys.path` together. Tests run
+> per-module (`conftest.py` injects `mira-connectors/` + `mira-crawler/`). All
+> modules use `from __future__ import annotations` so they import cleanly under
+> the CHARLIE system Python (3.9) as well as the 3.12 target.
+
+---
+
+## 8. Run the demo
+
+```bash
+python mira-connectors/demo.py
+# imports Maximo + Ignition mocks, normalizes both, cross-references SCADA→CMMS,
+# prints the proposed unified graph + the technician confirmation queue, and
+# builds (dry-run) an enriched Maximo work-order payload.
+```
+
+```bash
+cd mira-connectors && pytest tests/ -q     # 67 tests
+```
+
+---
+
+## 9. Cross-references
+
+- `docs/mira/canonical-asset-graph.md` — the node/edge model + entity/edge vocabulary
+- `docs/mira/source-record-preservation.md` — `source_objects` raw-record store
+- `docs/mira/current-repo-inventory.md` — verified live schema (column names)
+- `.claude/rules/uns-compliance.md` — path builders, slugs, reserved labels
+- `.claude/rules/direct-connection-uns-certified.md` — SCADA/OT surfaces carry UNS by construction
+- `mira-mcp/cmms/` — the existing live CMMS adapter pattern this framework generalizes
+- `mira-crawler/ingest/uns.py` — the one source of UNS path builders
+- ADR-0013 (Hub-canonical schema), ADR-0014 (`ai_suggestions`), ADR-0017 (status transitions)

--- a/docs/mira/current-repo-inventory.md
+++ b/docs/mira/current-repo-inventory.md
@@ -1,0 +1,264 @@
+# MIRA — Current Repo Inventory (Asset-Graph Lens)
+
+**Status:** Phase 0 deliverable of the canonical-asset-graph initiative
+**Authored:** 2026-06-02
+**Owner:** Lead architect (MIRA)
+**Companion to:** `docs/plans/2026-06-01-mira-master-architecture-plan.md` §1 ("What already exists")
+
+---
+
+## 0. What this document is (and is not)
+
+The master plan's §1 already enumerates the engine, MCP tools, schema, ingestion, tag
+collector, Ignition and Hub surfaces. **This inventory does not restate that.** It adds the
+three things §1 does not carry, framed through the question that now governs the build:
+*does MIRA hold a **canonical industrial asset graph** that is the translation layer between
+plant-floor OT data (PLC / Ignition / MQTT / OPC UA / historian) and enterprise maintenance
+systems (Maximo / SAP / MaintainX / Fiix / manuals / tribal knowledge)?*
+
+The three deltas:
+
+1. **The OT↔enterprise asset-graph lens** over each existing piece — what role it plays in a
+   canonical graph, and where it stops short.
+2. **As-built reconciliation of the DT gap-closure branch** (`feat/dt2026-gap-closure`), which
+   shipped Hub migrations 032–037 and the tag-event layer — and **diverged from the master
+   plan's proposed 036/037**. The record below matches the branch, not the plan's intent.
+3. **The two architectural gaps** for the full vision: (a) no canonical *source-system identity*
+   on a graph node, (b) no *raw imported-record preservation* layer. These are the subjects of
+   the two sibling docs (`canonical-asset-graph.md`, `source-record-preservation.md`).
+
+Everything below was verified against the working tree on 2026-06-02, not inherited from §1.
+
+---
+
+## 1. Verification preflight (2026-06-02)
+
+```
+branch:        feat/hub-command-center
+origin/main:   ahead — includes #1634 (master plan → North Star), #1593 umbrella
+               (Command Center + Ignition secure edge), #1641 (garage-conveyor KB seed)
+DT branch:     feat/dt2026-gap-closure present locally AND on origin
+               (24 files, +3736 / −204 vs feat/hub-command-center)
+```
+
+Verified code anchors (CodeGraph + grep, not inherited):
+
+| Claim (master plan §1) | Verified |
+|---|---|
+| `Supervisor` class | ✅ `mira-bots/shared/engine.py:467` |
+| `_should_fire_uns_gate` | ✅ `engine.py:4541` |
+| `Supervisor.process` / `process_full` | ✅ `engine.py:838` / `engine.py:1103` |
+| `resolve_uns_path` / `_multi` | ✅ `mira-bots/shared/uns_resolver.py:717` / `:808` |
+| "26 MCP tools" | ✅ exactly 26 `@mcp.tool` in `mira-mcp/server.py` |
+
+---
+
+## 2. The canonical-graph spine — what exists
+
+### 2.1 `kg_entities` / `kg_relationships` (the node + edge tables)
+
+**Authoritative DDL is the Hub line, not the engine line.** `docs/migrations/004_kg_entities.sql`
+and `005_kg_relationships.sql` are headed *"PLANNED — do not run / NOT YET CREATED"* and are
+**not** the live schema (ADR-0013). The live tables are created by Hub
+`001_knowledge_graph.sql` and mutated by 010/024/025/026/028/029 (+ engine 007/008 add the same
+columns idempotently). **True column set as of 2026-06-02:**
+
+`kg_entities`
+| Column | Source migration | Notes |
+|---|---|---|
+| `id UUID PK` | Hub 001 | |
+| `tenant_id UUID` | Hub 001 | RLS policy `app.current_tenant_id` |
+| `entity_type TEXT` | Hub 001 | the type discriminator — see §canonical doc |
+| `entity_id TEXT` (nullable) | Hub 001 → 025 | legacy aux; natural key moved off it |
+| `name TEXT` | Hub 001 | |
+| `properties JSONB` | Hub 001 | |
+| `uns_path ltree` | Hub 010 | GIST + compound `(tenant_id, uns_path)` GIST |
+| `source_chunk_id UUID` | Hub 024 | FK-by-convention → `knowledge_entries.id` |
+| `approval_state TEXT` | Hub 029 | `proposed`\|`verified`\|`rejected`\|`needs_review`\|`deprecated` |
+| `proposed_by`, `evidence_summary` | engine 008 / Hub 029 | |
+| `created_at`, `updated_at` | Hub 001 | |
+| natural key | Hub 025 | `UNIQUE (tenant_id, entity_type, name)` |
+
+`kg_relationships`
+| Column | Source migration | Notes |
+|---|---|---|
+| `id UUID PK` | Hub 001 | |
+| `tenant_id UUID` | Hub 001 | RLS |
+| `source_id UUID` FK→`kg_entities(id)` | Hub 001 | **`source_id` / `target_id`, NOT `source_entity`** |
+| `target_id UUID` FK→`kg_entities(id)` | Hub 001 | `no_self_loop` CHECK |
+| `relationship_type TEXT` | Hub 001 | |
+| `properties JSONB`, `confidence FLOAT` | Hub 001 | confidence already present |
+| `source_conversation_id UUID` | Hub 001 | |
+| `source_chunk_id UUID` | Hub 024 | |
+| `approval_state TEXT` | Hub 029 | `proposed`\|`verified`\|`rejected`\|`needs_review` |
+
+> ⚠️ **Naming trap (do not re-introduce):** the engine `005` file names columns
+> `source_entity / target_entity / relation_type`. The **live** columns are
+> `source_id / target_id / relationship_type`. `kg_writer.py` once wrote the wrong names →
+> fixed in PR #1443. Any new code or schema doc **must** use the live names.
+
+> ⚠️ **approval_state default drift:** Hub 029 defaults new rows to **`proposed`**
+> (human-in-the-loop, correct per TOO Invariant #4). Engine 008 defaults to **`verified`**
+> (legacy auto-insert). Where both ran, last-writer-wins on the column default. The flywheel
+> requires `proposed` to be the default; treat any `verified`-default path as a bug to close
+> (master-plan Phase 3).
+
+**Asset-graph lens:** this *is* the canonical node+edge spine. `entity_type` + `uns_path` +
+`approval_state` + `confidence` already deliver requirements 3 (confidence), 4 (technician
+confirmation via approval_state), 5 (proposed/uncertain), and 6 (ISA-95 ltree). **What it lacks
+for the OT↔enterprise vision:** a *source-system identity* on the node (today provenance is only
+`source_chunk_id` → a manual chunk, or `source_conversation_id` → a chat turn; there is no pointer
+to "row 4471 of the customer's Maximo asset export"). That is the Phase 1/2 gap.
+
+`kg_triples_log` (Hub 001) is the raw extraction log (subject/predicate/object + source) — a
+provenance breadcrumb, not the graph itself.
+
+### 2.2 The proposal / confirmation layer (the "MIRA proposes, human confirms" wedge)
+
+| Surface | Where | Role in the graph |
+|---|---|---|
+| `relationship_proposals` + `relationship_evidence` | Hub 018 | edge-with-evidence staging before `kg_relationships` |
+| **28-value `relationship_type` vocabulary** | Hub 028 (CHECK on `relationship_proposals`) | see §canonical doc — already covers most of the requested edge types |
+| `ai_suggestions` | Hub 027 | 6-type Hub work queue; `kg_edge` rows header onto a proposal; carries `source_kind`/`source_id`/`source_document_id`/`source_page` provenance + `confidence` |
+| `approval_state` on `kg_*` | Hub 029 | `proposed → verified` is the human gate |
+
+**Asset-graph lens:** the uncertain/proposed-match machinery the vision calls for (req 4/5) is
+**already built** — `ai_suggestions` even has a polymorphic source-provenance pointer. The gap is
+that the proposal path is not yet the *only* write path (`kg_writer` still inserts directly;
+master-plan Phase 3 closes this).
+
+### 2.3 Component intelligence (reusable per-model vs per-instance)
+
+| Table | Migration | Layer |
+|---|---|---|
+| `component_templates` | Hub 016 | per-model reusable asset (the Knowledge Cooperative unit) |
+| `component_template_sources` | Hub 016 | template provenance (doc id, page, excerpt, `extracted_by`) — **pointer, not raw payload** |
+| `installed_component_instances` | Hub 017 | per-tenant per-instance, `uns_path`-addressed |
+
+---
+
+## 3. UNS address layer
+
+| Piece | Where | Status |
+|---|---|---|
+| Path builders (`slug`, `*_path`, `RESERVED_LABELS`, `is_valid_path`) | `mira-crawler/ingest/uns.py` | ✅ canonical builders (UNS-001) |
+| Message → UNS resolver (`resolve_uns_path`, `_multi`, `UNSContext`) | `mira-bots/shared/uns_resolver.py:717/808` | ✅ vendor/model/fault scope; hierarchy (site→component) is the master-plan Phase 6 extension |
+| Location-confirmation gate (`_should_fire_uns_gate`) | `engine.py:4541` | ✅ chat scope; direct-connection `source="direct_connection"` wiring is the Phase 6 gap |
+| `uns_path` storage | `kg_entities.uns_path` (Hub 010), engine 007 format CHECK | ✅ ltree, GIST-indexed, lowercase CHECK |
+| MQTT/UNS topic projection | `cmms_equipment.uns_topic_path` (Hub 013) + `uns.py` | ⚠️ column exists; generation path is post-MVP |
+
+**Asset-graph lens:** the ISA-95 address space (req 6) and future UNS/MQTT topic generation
+(req 7) are in place at the column + builder level. Requirement 6's "without rigid structure" is
+satisfied: `uns_path` is a *cached projection* over the `parent_of`/`LOCATED_IN` edge graph (Hub
+010 comment), so the hierarchy is graph-driven, not a fixed-depth column scheme.
+
+---
+
+## 4. Tag / signal / OT-live layer
+
+| Piece | Where | Status |
+|---|---|---|
+| `tag_entities` (first-class PLC/Sparkplug/OPC UA tag) | Hub 025 | ✅ |
+| `live_signal_cache` + diagnostic trend tables | Hub 020 | ✅ latest-value snapshot |
+| `live_signal_events` (per-session) | Hub 019 | ✅ session-bound |
+| Read-only Modbus poller + diff pattern | `tools/demo_plc_poller.py` (`detect_events`) | 🟦 bench reference |
+| Mock Modbus server | `tools/demo_plc_simulator.py` | 🟦 bench |
+| Relay cloud ingest (HMAC `/ingest`, WS) | `mira-relay/relay_server.py` | ✅ |
+
+**DT gap-closure branch (`feat/dt2026-gap-closure`) — as-built, NOT yet on main:**
+
+| Shipped on the branch | File | Reconciliation note |
+|---|---|---|
+| `032_decision_traces.sql` | Hub migrations | matches plan |
+| `033_tag_events.sql` | Hub migrations | append-only meaningful-change stream |
+| `034_flaky_input_signals.sql` | Hub migrations | matches plan |
+| `035_approved_tags.sql` | Hub migrations | allowlist as a table |
+| **`036_current_tag_state_freshness.sql`** | Hub migrations | ⚠️ **supersedes** plan's proposed `036_decision_trace_session_link` |
+| **`037_tag_event_diffs.sql`** | Hub migrations | ⚠️ **supersedes** plan's proposed `037_kg_relationships_evidence_ref` |
+| `tag_ingest.py`, `tag_diff_logger.py` (+ tests) | `mira-relay/` | Phase 5 diff-logger, already built here |
+| `POST /api/v1/tags/ingest` | `mira-relay/relay_server.py` | |
+| Ignition HMAC collector | `ignition/webdev/FactoryLM/api/tags/collector.py`, `ignition/gateway-scripts/tag-stream.py` | |
+| Command Center freshness | `mira-hub/src/lib/command-center-freshness.ts` (+ test) | |
+| ADR-0022 (decision-trace + tag-stream storage) | `docs/adr/0022-decision-trace-and-tag-stream-storage.md` | |
+
+> **Numbering reality:** migration slots **032–037 are consumed** by the DT branch. Any new
+> schema (including the proposals in the two sibling docs) must start at **038+**, and the
+> master plan's §3.D2 first-pass 036/037 are now historical.
+
+---
+
+## 5. Enterprise-system connectors (the "OT↔enterprise" half)
+
+| Connector | Where | Preserves original fields? |
+|---|---|---|
+| Atlas CMMS (sync) | `mira-mcp/cmms/atlas.py` + `cmms_sync_state`/`cmms_sync_conflicts` (Hub 007) | ⚠️ **only on conflict** — `cmms_sync_conflicts.atlas_payload JSONB`. Happy path normalizes into `cmms_equipment` and discards the raw record. |
+| MaintainX | `mira-mcp/cmms/maintainx.py` | via factory; same normalize-and-discard shape |
+| Limble | `mira-mcp/cmms/limble.py` | same |
+| Fiix | `mira-mcp/cmms/fiix.py` | same |
+| Adapter base + factory | `mira-mcp/cmms/base.py`, `factory.py` | unified interface |
+| External-ID cross-reference | `cmms_equipment` columns (Hub 013): `cmms_id`, `plc_tag`, `scada_path`, `manufacturer_part_number`, `uns_topic_path`, `erp_asset_id`, `drawing_reference` | ✅ **ID mapping** (req 2, partial) — but flat TEXT columns on one table, no payload, CMMS-asset-shaped only |
+
+**Asset-graph lens:** the connector *adapters* exist and the i3X external-ID columns (Hub 013)
+give a real "this MIRA asset = that Maximo asset" mapping. **The gap is structural:** there is no
+connector-agnostic place that stores the *original imported record* (Maximo asset row, SAP
+functional location, MaintainX work order, OPC UA browse node) with its raw payload, the
+connector version that produced it, and a remappable mapping status. Today raw payload survives
+**only** in `cmms_sync_conflicts.atlas_payload`, **only on conflict, only for Atlas.** This is the
+single sharpest gap for the vision — addressed in `source-record-preservation.md`.
+
+---
+
+## 6. Knowledge / evidence layer
+
+| Piece | Where | Status |
+|---|---|---|
+| `knowledge_entries` (text + `embedding` + `metadata` JSONB + `equipment_entity_id` FK) | engine 001 + 006_kg_bridge | ✅ ~25K+ chunks; **chunk-level** source metadata only |
+| PDF → chunk → embed → dedup → store + KG side-effect | `mira-crawler/ingest/` (`converter`/`chunker`/`embedder`/`dedup`/`store`/`kg_writer`) | ✅ works; first-class ingest API is master-plan Phase 2 |
+| `fault_codes` | engine 002 | ✅ |
+| `namespace_direct_uploads` | Hub 027 | ✅ upload metadata (filename/mime/size), no payload preservation |
+| Open WebUI (chunk/embed/retrieve backend) | container `mira-core` | ✅ service-sunset, still the embed/retrieve engine |
+| MiraDrop watcher | `tools/mira-drop-watcher/` | ✅ drop-folder → Hub → OW path |
+
+---
+
+## 7. MCP tool surface (26 verified)
+
+26 `@mcp.tool` across 7 domains (equipment/live-signal, diagnostic-case, CMMS, asset/nameplate,
+agent-control, knowledge-graph, namespace/UNS, schematic-vision) — full list in master plan §1.2.
+**Asset-graph lens:** there is no single `get_asset_context(uns_path)` that returns the unified
+asset+component+tag+document+WO+edge bundle an agent needs — the graph is queryable in pieces, not
+as one node-centric view. Master-plan Phase 11 adds it; the canonical-graph doc specifies the
+bundle shape that tool should return.
+
+---
+
+## 8. The gap list for the full asset-graph vision
+
+| # | Gap | Severity | Where it's solved |
+|---|---|---|---|
+| G1 | No canonical **source-system identity** on a graph node (provenance is chunk/chat only) | High | `canonical-asset-graph.md` §node-identity → FK into G2 |
+| G2 | No **raw imported-record preservation** layer; raw payload survives only in `cmms_sync_conflicts` (conflict-only, Atlas-only) | **Highest** | `source-record-preservation.md` |
+| G3 | Proposal path is not the *only* KG write path (`kg_writer` still direct-inserts) | Medium | master-plan Phase 3 |
+| G4 | `approval_state` default drift (`proposed` vs `verified`) | Medium | master-plan Phase 3 |
+| G5 | No node-centric `get_asset_context` agent bundle | Medium | master-plan Phase 11 + `canonical-asset-graph.md` |
+| G6 | Hierarchy resolution (site→component) + direct-connection gate wiring | Medium | master-plan Phase 6 |
+| G7 | UNS/MQTT topic generation from `uns_path` is column-only, no generator | Low | post-MVP |
+
+**Not gaps (already built, do not rebuild):** the node/edge spine, the 28-type relationship
+vocabulary, confidence scoring, approval-state machine, `ai_suggestions` work queue with
+polymorphic provenance, component template/instance split, ltree addressing, tag_entities, the
+tag-event stream (DT branch), CMMS adapters, external-ID mapping columns, KB ingest.
+
+---
+
+## 9. Cross-references
+
+- `docs/plans/2026-06-01-mira-master-architecture-plan.md` — phase 0–13 execution (this doc is the
+  asset-graph lens over its §1)
+- `docs/mira/canonical-asset-graph.md` — the canonical node/edge model + additive schema proposals
+- `docs/mira/source-record-preservation.md` — the raw-record preservation layer (G2)
+- `docs/THEORY_OF_OPERATIONS.md` — primary doctrine
+- `docs/adr/0013-...` — Hub-canonical schema lineage
+- `docs/adr/0017-...` — status transitions through helpers
+- `docs/adr/0022-decision-trace-and-tag-stream-storage.md` — DT branch ADR
+- `.claude/rules/uns-compliance.md`, `.claude/rules/direct-connection-uns-certified.md`

--- a/docs/mira/source-record-preservation.md
+++ b/docs/mira/source-record-preservation.md
@@ -1,0 +1,286 @@
+# MIRA — Source-Record Preservation Layer
+
+**Status:** Phase 2 deliverable of the canonical-asset-graph initiative — **design + additive
+schema proposals (docs-only)**
+**Authored:** 2026-06-02
+**Owner:** Lead architect (MIRA)
+**Builds on:** `docs/mira/current-repo-inventory.md` · `docs/mira/canonical-asset-graph.md`
+**Defines:** the FK target (`source_objects`) that `kg_entities.source_object_id` points at
+
+---
+
+## 0. The problem in one sentence
+
+Today, raw imported records survive in exactly one place — **`cmms_sync_conflicts.atlas_payload`**
+(Hub 007) — and only **on conflict**, only for **Atlas**. Every successful import normalizes
+straight into `cmms_equipment` and **discards the original record.** That violates the rule
+"never destroy original customer fields" and makes "remap if the schema changes" impossible:
+once normalized, the source row is gone.
+
+This layer fixes that for **every connector** (Maximo, SAP, MaintainX, Fiix, Ignition, MQTT/
+Sparkplug, OPC UA, historian, manuals, CSV exports) by storing the **raw record before
+normalization**, immutably enough to remap, with full connector provenance.
+
+---
+
+## 1. Design principles
+
+1. **Store raw, then map — never map-and-discard.** The connector's job is to *land* the record;
+   normalization is a separate, re-runnable step that reads from the stored raw record.
+2. **One mechanism, all connectors.** `cmms_sync_conflicts.atlas_payload` is the right idea at the
+   wrong scope. Generalize it: any source, any object type, happy path *and* conflict.
+3. **The graph references the source, not vice-versa.** `kg_entities.source_object_id` →
+   `source_objects.id` (the FK proposed in `canonical-asset-graph.md` mig 039). The source layer
+   is upstream; the graph is downstream and re-derivable.
+4. **Remapping is re-reading, not re-fetching.** A schema/mapping change re-runs the mapper over
+   stored `raw_payload` — no second call to the customer's Maximo. `content_hash` dedups re-imports.
+5. **Tenant-isolated, RLS-enabled** — same posture as `kg_entities` (Hub 001 RLS), *unlike*
+   `hub_uploads` (which has no RLS — a known footgun; don't repeat it here).
+
+---
+
+## 2. The three tables
+
+```
+source_systems       1 ──< source_import_runs       1 ──< source_objects >── 1  kg_entities
+(connected external      (one connector execution)       (one raw record)       (mapped node)
+ system per tenant)                                        mapped_entity_id ─────────┘
+```
+
+### 2.1 `source_systems` — registry of connected external systems
+
+The FK target for `entity_type='external_system'` (canonical-graph §2). One row per
+tenant×connected-system (a specific Maximo instance, a MaintainX account, an Ignition gateway, an
+OPC UA endpoint). Supersedes the implicit single-CMMS assumption in `tenant_cmms_config`.
+
+### 2.2 `source_import_runs` — one row per connector execution
+
+Generalizes `cmms_sync_state` (which is just a cursor) into a full run record: connector name +
+**version**, window, counts, status, errors. This is where requirement 2 (import timestamp,
+connector version, errors/warnings) lives at batch granularity; `source_objects` carries it at
+record granularity.
+
+### 2.3 `source_objects` — the raw imported record (the core)
+
+Generalizes `cmms_sync_conflicts` to all sources and the happy path. **This is the table that
+"never destroys original customer fields."**
+
+---
+
+## 3. Additive schema proposals (docs-only — do NOT write migration files)
+
+Slots 032–037 consumed by the DT branch; `canonical-asset-graph.md` proposes 038/039. This doc
+proposes **040–042**. Proposals for review — author real files only after sign-off and after
+re-checking the live migration tail (`ls mira-hub/db/migrations/ | tail`).
+
+```sql
+-- 040_source_systems.sql  (PROPOSAL)
+CREATE TABLE IF NOT EXISTS source_systems (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id       UUID NOT NULL,
+  system_kind     TEXT NOT NULL,          -- 'maximo'|'sap'|'maintainx'|'fiix'|'limble'|'atlas'
+                                          -- |'ignition'|'mqtt_sparkplug'|'opcua'|'historian'
+                                          -- |'manual_upload'|'csv_export'|'plc_bridge'
+  display_name    TEXT NOT NULL,          -- "Plant 2 Maximo", "MaintainX (East)"
+  external_base   TEXT,                   -- base URL / broker / gateway id (no secrets here)
+  config          JSONB DEFAULT '{}',     -- non-secret connector config; secrets stay in Doppler
+  uns_root        ltree,                  -- optional: where this system's objects attach by default
+  status          TEXT NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active','paused','disconnected','error')),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, system_kind, display_name)
+);
+CREATE INDEX IF NOT EXISTS idx_source_systems_tenant ON source_systems (tenant_id);
+ALTER TABLE source_systems ENABLE ROW LEVEL SECURITY;
+CREATE POLICY source_systems_tenant ON source_systems
+  USING (tenant_id = current_setting('app.current_tenant_id')::UUID);
+
+-- 041_source_import_runs.sql  (PROPOSAL)
+CREATE TABLE IF NOT EXISTS source_import_runs (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id         UUID NOT NULL,
+  source_system_id  UUID NOT NULL REFERENCES source_systems(id) ON DELETE CASCADE,
+  connector_name    TEXT NOT NULL,        -- 'mira-mcp/cmms/maintainx.py' etc.
+  connector_version TEXT NOT NULL,        -- semver/git-sha of the adapter that produced this run
+  object_type       TEXT,                 -- NULL = mixed/full sync; else the resource swept
+  started_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  finished_at       TIMESTAMPTZ,
+  status            TEXT NOT NULL DEFAULT 'running'
+                      CHECK (status IN ('running','succeeded','partial','failed')),
+  cursor_before     JSONB,                -- replaces cmms_sync_state.last_poll_at, generalized
+  cursor_after      JSONB,
+  objects_seen      INT NOT NULL DEFAULT 0,
+  objects_new       INT NOT NULL DEFAULT 0,
+  objects_updated   INT NOT NULL DEFAULT 0,
+  errors            JSONB DEFAULT '[]',   -- [{external_object_id, stage, message}]
+  warnings          JSONB DEFAULT '[]'
+);
+CREATE INDEX IF NOT EXISTS idx_import_runs_system ON source_import_runs (source_system_id, started_at DESC);
+ALTER TABLE source_import_runs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY source_import_runs_tenant ON source_import_runs
+  USING (tenant_id = current_setting('app.current_tenant_id')::UUID);
+
+-- 042_source_objects.sql  (PROPOSAL) — the raw record store
+CREATE TABLE IF NOT EXISTS source_objects (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id         UUID NOT NULL,
+  source_system_id  UUID NOT NULL REFERENCES source_systems(id) ON DELETE CASCADE,
+  object_type       TEXT NOT NULL,        -- 'asset'|'work_order'|'pm'|'location'|'part'
+                                          -- |'tag'|'opcua_node'|'manual'|'fault'...
+  external_object_id TEXT NOT NULL,       -- the source system's own ID for this record
+  raw_payload       JSONB NOT NULL,       -- ORIGINAL record, unmodified. requirement 4.
+  content_hash      TEXT NOT NULL,        -- sha256 of canonicalized raw_payload (re-import dedup)
+  first_import_run_id UUID REFERENCES source_import_runs(id) ON DELETE SET NULL,
+  last_import_run_id  UUID REFERENCES source_import_runs(id) ON DELETE SET NULL,
+  first_seen_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_seen_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  connector_version TEXT NOT NULL,        -- version that last wrote raw_payload
+  mapping_status    TEXT NOT NULL DEFAULT 'unmapped'
+                      CHECK (mapping_status IN
+                        ('unmapped','mapped','conflict','stale','superseded','error')),
+  mapped_entity_id  UUID,                 -- -> kg_entities(id) when normalized; reverse of
+                                          --    kg_entities.source_object_id (canonical-graph mig 039)
+  mapping_errors    JSONB DEFAULT '[]',   -- requirement 2: per-record warnings/errors
+  mapped_at         TIMESTAMPTZ,
+  mapped_by         TEXT,                 -- 'llm'|'rule'|'human'|connector name
+  UNIQUE (tenant_id, source_system_id, object_type, external_object_id)
+);
+CREATE INDEX IF NOT EXISTS idx_source_objects_lookup
+  ON source_objects (tenant_id, source_system_id, object_type, external_object_id);
+CREATE INDEX IF NOT EXISTS idx_source_objects_mapped
+  ON source_objects (tenant_id, mapped_entity_id) WHERE mapped_entity_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_source_objects_status
+  ON source_objects (tenant_id, mapping_status) WHERE mapping_status IN ('unmapped','conflict','error');
+ALTER TABLE source_objects ENABLE ROW LEVEL SECURITY;
+CREATE POLICY source_objects_tenant ON source_objects
+  USING (tenant_id = current_setting('app.current_tenant_id')::UUID);
+
+-- 042b_ai_suggestions_source_object.sql  (PROPOSAL — ships with 042)
+-- ai_suggestions.source_kind has a CHECK (Hub 027). To let a suggestion cite a raw source
+-- record (§5), extend it — same DROP/ADD pattern as the relationship_type CHECK in
+-- canonical-asset-graph.md proposal 038. Without this, source_kind='source_object' fails the CHECK.
+ALTER TABLE ai_suggestions DROP CONSTRAINT IF EXISTS ai_suggestions_source_kind_check;
+ALTER TABLE ai_suggestions
+  ADD CONSTRAINT ai_suggestions_source_kind_check
+  CHECK (source_kind IS NULL OR source_kind IN (
+    -- existing 9 (Hub 027) ...
+    'knowledge_entry','work_order','tag_entity','photo','session',
+    'manifest_row','technician_note','live_event','manual_entry',
+    -- NEW: a suggestion can cite the preserved raw record it was derived from
+    'source_object'
+  ));
+
+-- OPTIONAL 043_source_object_versions.sql  (PROPOSAL, defer until drift auditing is needed)
+-- Append-only history when raw_payload changes between imports, for true immutability /
+-- schema-drift forensics. Until requested, the upsert in §4 just refreshes raw_payload +
+-- last_seen_at; content_hash tells you whether it changed.
+```
+
+---
+
+## 4. Lifecycle (how the four requirements are satisfied)
+
+```
+CONNECTOR RUN
+  source_import_runs row opened (connector_name + version, cursor_before)         [req 2: batch]
+        │
+        ▼  for each external record:
+  compute content_hash(raw_payload)
+  UPSERT source_objects ON (tenant_id, source_system_id, object_type, external_object_id):
+     - new            → INSERT raw_payload, mapping_status='unmapped'              [req 1,4]
+     - unchanged hash → bump last_seen_at, last_import_run_id (raw kept)           [req 4]
+     - changed hash   → refresh raw_payload + connector_version, mapping_status='stale'
+                        (+ optional source_object_versions append)                 [req 3,4]
+        │
+        ▼  NORMALIZE (separate, re-runnable step — reads raw_payload only)         [req 3]
+  mapper(raw_payload, connector_version) → upsert kg_entities (+ typed projection)
+     - set kg_entities.source_object_id = this row        (canonical-graph mig 039)
+     - set source_objects.mapped_entity_id = node id, mapping_status='mapped'
+     - parse failure → mapping_status='error', mapping_errors=[...]               [req 2]
+     - newer-than-graph → mapping_status='conflict' (replaces cmms_sync_conflicts) [req 2]
+        │
+        ▼  REMAP (schema/mapping change, NO re-fetch)                             [req 3]
+  re-run mapper over stored raw_payload for all rows where
+     connector_version < current OR mapping_status IN ('stale','error')
+  → new/updated kg_entities, mapping_status back to 'mapped'
+        │
+        ▼
+  source_import_runs row closed (status, counts, cursor_after)                    [req 2]
+```
+
+- **Requirement 1 (source system, object type, object ID, payload):** `source_objects`
+  (`source_system_id` → `source_systems.system_kind`, `object_type`, `external_object_id`,
+  `raw_payload`).
+- **Requirement 2 (timestamp, connector version, mapping status, errors/warnings):**
+  `source_import_runs` (batch) + `source_objects.{connector_version, mapping_status,
+  mapping_errors, first/last_seen_at}` (record).
+- **Requirement 3 (remap on schema change):** the REMAP step re-reads `raw_payload`; no re-fetch.
+  Triggered by `connector_version` drift or `mapping_status IN ('stale','error')`.
+- **Requirement 4 (never destroy originals):** `raw_payload` is the unmodified record; normalize
+  reads from it and never overwrites it with normalized data. Optional
+  `source_object_versions` adds full immutability when drift forensics are needed.
+
+---
+
+## 5. Relationship to what already exists (subsume, don't duplicate)
+
+| Existing | New role |
+|---|---|
+| `cmms_sync_conflicts.atlas_payload` (Hub 007) | special case → `source_objects` rows with `mapping_status='conflict'`. Migrate Atlas conflicts into the general table; keep the view name for back-compat if callers read it. |
+| `cmms_sync_state` (Hub 007) | cursor bookkeeping → `source_import_runs.cursor_before/after`. |
+| `cmms_equipment` external-ID columns (Hub 013) | **derived** from `source_objects` (a node's external IDs = the `external_object_id`s of its mapped source rows). Keep columns as a denormalized read cache; source layer is authoritative. |
+| `ai_suggestions.source_kind/source_id` (Hub 027) | add `source_kind='source_object'` so a suggestion can cite the raw record it came from — **requires extending the Hub-027 `source_kind` CHECK** (proposal 042b in §3). |
+| `tenant_cmms_config` (Hub 008) | folds into `source_systems` (one CMMS = one `source_systems` row of the matching `system_kind`). |
+| `component_template_sources` (Hub 016) | unchanged — it cites *documents*; orthogonal to connector records. |
+
+---
+
+## 6. What this explicitly does NOT do
+
+- ❌ Does not change any connector adapter's external API calls (Phase 2 of the master plan owns
+  the ingest API; this is the storage shape it writes into).
+- ❌ Does not write migration files — proposals only, slots 040–042 (043 deferred).
+- ❌ Does not make `source_objects` a graph node — it is upstream raw data; the graph references
+  it by FK.
+- ❌ Does not store secrets in `source_systems.config` — secrets remain Doppler-managed.
+- ❌ Does not add a parallel provenance scheme — this *is* the single mechanism
+  `canonical-asset-graph.md` §4.1 points `kg_entities.source_object_id` at.
+
+---
+
+## 7. Acceptance (when this layer is "real")
+
+1. Import a MaintainX asset → a `source_objects` row holds the unmodified MaintainX JSON; a
+   `kg_entities` row has `source_object_id` pointing at it; `cmms_equipment` external IDs match.
+2. Re-run the same import → no duplicate row (content_hash dedup); `last_seen_at` bumped.
+3. Change the mapper, run REMAP → graph node updates from stored `raw_payload` with **zero**
+   calls to the customer's MaintainX.
+4. A parse failure lands `mapping_status='error'` + `mapping_errors`, and the raw record is still
+   present and retryable.
+5. RLS: a query without `app.current_tenant_id` set returns zero rows from all three tables.
+
+---
+
+## 8. Open questions (decide before authoring migrations)
+
+1. **`source_object_versions` now or deferred?** Proposal: defer until a connector's schema
+   actually drifts in production (YAGNI; content_hash already detects change).
+2. **`raw_payload` size ceiling.** Maximo/SAP records can be large; cap + offload oversized
+   payloads (e.g. full manuals) to blob storage with a pointer? Manuals already go to
+   `knowledge_entries`, so `source_objects` should hold *structured* records, not document bodies.
+3. **Conflict resolution UX.** `mapping_status='conflict'` should surface in Hub `/proposals` as
+   an `ai_suggestions` row — confirm the reviewer flow before wiring.
+4. **Backfill of existing `cmms_sync_conflicts`.** One-time migration into `source_objects`, or
+   leave historical conflicts in place and start fresh? (Lean: start fresh, document the cutover.)
+
+---
+
+## 9. Cross-references
+
+- `docs/mira/canonical-asset-graph.md` §4.1 — the `source_object_id` FK this table backs
+- `docs/mira/current-repo-inventory.md` §5 — the connector + sync-state inventory this generalizes
+- `docs/plans/2026-06-01-mira-master-architecture-plan.md` — Phase 2 (ingest API), Phase 3 (proposal path)
+- ADR-0013 (Hub-canonical schema), ADR-0014 (`ai_suggestions`), ADR-0017 (status transitions)
+- `.claude/rules/security-boundaries.md` — RLS / Doppler / no-secrets-in-config posture
+- Memory: `project_hub_uploads_no_rls` — why these tables MUST enable RLS

--- a/marketing/comic-pipeline/scripts/phase5-video-16-photo-to-plant-v2.yaml
+++ b/marketing/comic-pipeline/scripts/phase5-video-16-photo-to-plant-v2.yaml
@@ -1,0 +1,46 @@
+# Phase 5 — Video 16 v2 (2026-06-02): "One Conveyor → A Located, Structured Asset"
+# Rebuild of phase5-video-16-photo-to-plant with the new live Command Center
+# captures Mike walked this morning. Per Mike: drop the old referenced images;
+# keep ONLY the angled conveyor render as the anchor (open + bookend close).
+# Pace is intentionally a touch SLOWER and SMOOTHER than v1: 5 frames (was 6),
+# calmer narration (~10s/frame), transition 0.8s (was 0.4) for gentler crossfades,
+# gentle 0.012 zoom. V16's identity stays STRUCTURE/placement (distinct from V2's
+# "it's live" build story and the standalone Ask-MIRA short).
+# Original v1 (video-16-photo-to-plant/) left intact for comparison.
+slug: phase5-video-16-photo-to-plant-v2
+output_dir: marketing/videos/2026-05-31-phase5-demos/video-16-photo-to-plant-v2
+width: 1920
+height: 1080
+zoom_amount: 0.012          # gentle Ken Burns — UI text stays sharp
+transition_duration: 0.8    # slower v1 used 0.4; longer crossfade = smoother
+fit_mode: letterbox
+tts_provider: groq
+tts_voice: austin
+tts_model: canopylabs/orpheus-v1-english
+tts_format: wav
+voiceover_style: |
+  Adult male, 40s, calm and direct. Sounds like a senior field engineer who
+  has worked in heavy manufacturing for 15 years — knowledgeable without
+  being academic, confident without being aggressive. Does not perform
+  enthusiasm. States facts and lets the listener draw conclusions.
+
+  Pacing: slow and deliberate, 120–130 words per minute. Steady. A real pause
+  after each short sentence. Let the images breathe. No acceleration on product
+  names or feature callouts.
+
+  Tone: neutral American accent, no regional markers. Clean consonants.
+  Comfortable with industrial vocabulary. Does not soften or inflate language.
+
+  Avoid: upward inflection on statements, marketing superlatives, breathless
+  pacing on product reveals, hesitation fillers, reading the style brief aloud.
+frames:
+  - image: docs/promo-screenshots/2026-05-30_conveyor-reference-stock-render_input.png
+    narration: "Start with one conveyor. Just a render — no tags, no namespace, no place in the plant yet. Watch where it goes."
+  - image: docs/promo-screenshots/2026-06-02_command-center-conveyor-running-30hz_desktop.png
+    narration: "It comes up as a live screen. The same conveyor, now running — thirty hertz forward, every value read straight off a real Micro 820."
+  - image: docs/promo-screenshots/2026-06-02_command-center-pmc-panel-running-30hz-fwd_desktop.png
+    narration: "Underneath sit its real parts. The GS10 drive. The main line contactor. The Micro 820 controller. Each one bound to a live tag over CIP."
+  - image: docs/promo-screenshots/2026-06-02_command-center-conveyor-stopped-tree_desktop.png
+    narration: "And it has a place now. Plant, area, line, asset — a real spot in your namespace. Located and live, not a file on a laptop."
+  - image: docs/promo-screenshots/2026-05-30_conveyor-reference-stock-render_input.png
+    narration: "One render became a located, living asset — and every fault scoped to it. Request a demo at factorylm.com."

--- a/mira-connectors/README.md
+++ b/mira-connectors/README.md
@@ -1,0 +1,40 @@
+# mira-connectors
+
+Translation layer between external systems and MIRA's canonical industrial asset
+graph. Ships **mock** connectors (realistic fixtures, no credentials) for IBM
+Maximo, Ignition/SCADA, SAP PM, MaintainX, and AVEVA PI.
+
+**Full docs:** [`docs/mira/connector-framework.md`](../docs/mira/connector-framework.md)
+
+## Quick start
+
+```bash
+python mira-connectors/demo.py          # end-to-end OT↔enterprise join demo
+cd mira-connectors && pytest tests/ -q  # 67 tests (run from inside the module)
+```
+
+## Layout
+
+| Path | What |
+|---|---|
+| `base.py` | `Connector` ABC: discover / import_records / normalize / validate / export_enriched / get_config_schema. `read_only` (guards source) + `dry_run` (guards MIRA) default `True`. |
+| `canonical.py` | In-memory mirror of the live `kg_entities` / `kg_relationships` / `ai_suggestions` / `source_objects` schema. Everything connector-produced is `approval_state="proposed"`. |
+| `uns_bridge.py` | Re-exports `mira-crawler/ingest/uns.py` path builders (reuse, never reimplement). |
+| `cmms/` | `maximo_mock.py`, `sap_mock.py`, `maintainx_mock.py` (+ `fixtures/`). |
+| `scada/` | `ignition_mock.py` — tag tree → signals + SCADA↔CMMS cross-reference (+ `fixtures/`). |
+| `historian/` | `pi_mock.py` — AF hierarchy + PI points + event frames (+ `fixtures/`). |
+| `demo.py` | Runnable pipeline. |
+| `tests/` | Per-connector + canonical-model + base + e2e. |
+
+## Invariants
+
+- **Proposed, not verified.** Connectors never auto-verify; `proposed → verified`
+  is a human action.
+- **Preserve every source field** in `source_payload` + a `SourceObject` (custom
+  fields included).
+- **Read-only by default** — connectors don't write to source systems.
+- **UNS paths only via `uns.py`** builders.
+- **Safety proposals** (E-stop / LOTO / interlock) are `risk_level="safety_critical"`.
+
+`mira-connectors/` is a `sys.path` root (like `mira-mcp/`); run tests from inside
+the module so its `cmms/` subpackage doesn't collide with `mira-mcp/cmms`.

--- a/mira-connectors/base.py
+++ b/mira-connectors/base.py
@@ -1,0 +1,172 @@
+"""Abstract base class for all MIRA connectors.
+
+A *connector* is the translation layer between an external system (enterprise
+CMMS/EAM — Maximo, SAP, MaintainX, Fiix — or plant-floor OT — Ignition, MQTT,
+OPC UA, AVEVA PI) and MIRA's canonical asset graph (``canonical.py``).
+
+The pipeline every connector implements is the one from
+``docs/mira/connector-framework.md``::
+
+    discover() ─▶ import_records() ─▶ normalize() ─▶ validate() ─▶ [graph]
+                                                                      │
+                                                       export_enriched() ─▶ source format
+
+Design rules (from ``.claude/CLAUDE.md`` and the canonical docs):
+
+* **Read-only by default.** ``read_only=True`` — a connector never writes back
+  to the *source* system unless explicitly constructed with ``read_only=False``
+  (and even then only ``export_enriched`` may do so, never import/normalize).
+* **Dry-run by default.** ``dry_run=True`` — ``normalize()`` produces an
+  in-memory :class:`~canonical.NormalizedGraph` but nothing is persisted into
+  *MIRA's* stores (kg_entities / source_objects). The two flags are independent
+  axes: ``read_only`` guards the source system, ``dry_run`` guards MIRA.
+* **Never auto-verify.** Everything produced is ``approval_state="proposed"``.
+* **Preserve every original field** in ``source_payload`` / ``SourceObject``.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from canonical import NormalizedGraph, ValidationReport
+
+logger = logging.getLogger("mira-connectors")
+
+
+@dataclass
+class Capability:
+    """What :meth:`Connector.discover` returns — the source system's schema and
+    what this connector can do with it."""
+
+    system_kind: str  # 'maximo'|'sap'|'maintainx'|'ignition'|'historian'
+    display_name: str
+    object_types: list[str]  # resource kinds this connector can import
+    supports_export: bool  # can enriched payloads be written back?
+    read_only: bool
+    # Per-object-type field inventory the source exposes (schema discovery).
+    schema: dict[str, list[str]] = field(default_factory=dict)
+    notes: str = ""
+
+
+@dataclass
+class RawRecord:
+    """One record as pulled from the source, before normalization. Carries the
+    untouched payload plus enough provenance to build a :class:`SourceObject`."""
+
+    object_type: str
+    external_object_id: str
+    payload: dict[str, Any]
+
+
+@dataclass
+class ExportResult:
+    """What :meth:`Connector.export_enriched` returns. ``written`` is True only
+    when a live (``read_only=False``, non-dry-run) connector actually pushed to
+    the source; mock/read-only/dry-run connectors return the payload with
+    ``written=False`` so a caller can inspect what *would* be sent."""
+
+    supported: bool
+    written: bool
+    payloads: list[dict[str, Any]] = field(default_factory=list)
+    note: str = ""
+
+
+class Connector(ABC):
+    """Base interface for every MIRA connector."""
+
+    #: stable connector identity, e.g. 'maximo_mock'
+    name: str = "connector"
+    #: source system family, one of the source-record-preservation system kinds
+    system_kind: str = "unknown"
+    #: semver/sha of the adapter — recorded on every SourceObject + import run
+    connector_version: str = "0.1.0"
+
+    def __init__(self, dry_run: bool = True, read_only: bool = True) -> None:
+        # read_only → never mutate the SOURCE system (Maximo/PI/...).
+        self.read_only = read_only
+        # dry_run → never persist into MIRA's stores (kg_entities/source_objects).
+        self.dry_run = dry_run
+
+    # ── the pipeline ────────────────────────────────────────────────
+
+    @abstractmethod
+    async def discover(self) -> Capability:
+        """Return the source system's schema/capabilities (no records)."""
+
+    @abstractmethod
+    async def import_records(self, config: Optional[dict[str, Any]] = None) -> list[RawRecord]:
+        """Pull raw records from the source (or, for a mock, from fixtures).
+
+        Read-only operation: importing never mutates the source. ``config`` may
+        filter object types / windows; see :meth:`get_config_schema`.
+        """
+
+    @abstractmethod
+    def normalize(self, raw_records: list[RawRecord]) -> NormalizedGraph:
+        """Map raw records into the MIRA canonical model.
+
+        Pure transformation (no I/O): reads ``RawRecord.payload``, emits
+        :class:`CanonicalEntity` / :class:`CanonicalRelationship` (all
+        ``proposed``), preserves the full payload in ``source_payload`` and a
+        :class:`SourceObject`, and raises ambiguous mappings as
+        :class:`Proposal` rows rather than asserting them as fact.
+        """
+
+    @abstractmethod
+    def validate(self, graph: NormalizedGraph) -> ValidationReport:
+        """Check the normalized graph: valid UNS paths, no orphan edges,
+        preserved payloads, flagged ambiguities. Warnings don't block; errors do.
+        """
+
+    @abstractmethod
+    async def export_enriched(self, graph_context: dict[str, Any]) -> ExportResult:
+        """Generate enriched payloads back in the source system's format
+        (e.g. a Maximo work order annotated with MIRA's diagnosis + UNS path).
+
+        Honors both flags: if ``read_only`` or ``dry_run`` it returns the payload
+        with ``written=False`` (the connector built it but did not push it).
+        Sources that have no meaningful write-back (SCADA/historian) return
+        ``ExportResult(supported=False, ...)``.
+        """
+
+    @abstractmethod
+    def get_config_schema(self) -> dict[str, Any]:
+        """Return the configuration this connector expects (JSON-schema-ish:
+        field name → {type, required, description, default})."""
+
+    # ── shared helpers ──────────────────────────────────────────────
+
+    def _may_write_source(self) -> bool:
+        """True only when this connector is allowed to push to the source."""
+        if self.read_only:
+            logger.info("%s: read_only — refusing to write back to source", self.name)
+            return False
+        if self.dry_run:
+            logger.info("%s: dry_run — not pushing to source (would write)", self.name)
+            return False
+        return True
+
+    async def run(self, config: Optional[dict[str, Any]] = None) -> NormalizedGraph:
+        """Convenience: import → normalize → validate, logging the dry-run
+        decision. Returns the graph; persistence is a caller/writer concern."""
+        raw = await self.import_records(config)
+        graph = self.normalize(raw)
+        report = self.validate(graph)
+        if not report.ok:
+            for err in report.errors:
+                logger.warning("%s validation error [%s]: %s", self.name, err.code, err.message)
+        if self.dry_run:
+            s = graph.summary()
+            logger.info(
+                "%s: dry_run — would persist %d entities, %d relationships, "
+                "%d proposals, %d source_objects (nothing written to MIRA)",
+                self.name,
+                s["entities"],
+                s["relationships"],
+                s["proposals"],
+                s["source_objects"],
+            )
+        return graph

--- a/mira-connectors/canonical.py
+++ b/mira-connectors/canonical.py
@@ -284,9 +284,7 @@ class ValidationIssue:
 class ValidationReport:
     issues: list[ValidationIssue] = field(default_factory=list)
 
-    def add(
-        self, severity: str, code: str, message: str, entity_key: Optional[str] = None
-    ) -> None:
+    def add(self, severity: str, code: str, message: str, entity_key: Optional[str] = None) -> None:
         self.issues.append(ValidationIssue(severity, code, message, entity_key))
 
     @property
@@ -362,9 +360,7 @@ class NormalizedGraph:
         self.source_objects.extend(other.source_objects)
 
     def summary(self) -> dict[str, int]:
-        proposed_edges = sum(
-            1 for r in self.relationships if r.approval_state == APPROVAL_PROPOSED
-        )
+        proposed_edges = sum(1 for r in self.relationships if r.approval_state == APPROVAL_PROPOSED)
         return {
             "entities": len(self.entities),
             "relationships": len(self.relationships),

--- a/mira-connectors/canonical.py
+++ b/mira-connectors/canonical.py
@@ -1,0 +1,374 @@
+"""The MIRA canonical asset-graph model that every connector normalizes into.
+
+This module is a faithful **in-memory mirror** of the live NeonDB schema
+described in ``docs/mira/canonical-asset-graph.md`` and
+``docs/mira/source-record-preservation.md``. It deliberately uses the *live*
+column names (verified in ``docs/mira/current-repo-inventory.md`` §2.1):
+
+* ``kg_entities``        → :class:`CanonicalEntity`
+* ``kg_relationships``   → :class:`CanonicalRelationship`
+  (``source_id`` / ``target_id`` / ``relationship_type`` — **NOT**
+  ``source_entity`` / ``target_entity`` / ``relation_type``; the PR #1443 trap)
+* ``ai_suggestions``     → :class:`Proposal`  (the six ``suggestion_type`` values)
+* ``source_objects``     → :class:`SourceObject`  (raw record, never destroyed)
+
+Connectors produce a :class:`NormalizedGraph` of these objects. They do **not**
+write to NeonDB — a future writer (master-plan Phase 2/3) maps these straight
+onto rows. Keeping the shape identical means that writer is a thin translation,
+not a redesign.
+
+Two hard rules baked in here, both from ``.claude/CLAUDE.md`` and the canonical
+docs:
+
+1. **Nothing a connector emits is ``verified``.** Every entity and relationship
+   defaults to ``approval_state="proposed"``. Promotion to ``verified`` is a
+   human/admin action. Auto-verifying is a bug.
+2. **The raw record is never destroyed.** Every normalized entity carries its
+   complete original payload in ``source_payload``; the matching
+   :class:`SourceObject` is the canonical raw store (``raw_payload``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Governed vocabulary (canonical-asset-graph.md §2 entity types, §3 edge types)
+# ---------------------------------------------------------------------------
+
+# `kg_entities.entity_type` is free TEXT (no CHECK) — these constants are the
+# governed vocabulary writers agree on, not a schema constraint (§2.1).
+ENTITY_TYPES: frozenset[str] = frozenset(
+    {
+        "enterprise",
+        "site",
+        "area",
+        "line",
+        "cell",
+        "asset",  # canonical doc allows asset|equipment; we use `asset` consistently
+        "equipment",
+        "component",
+        "component_template",
+        "signal",
+        "tag",
+        "alarm",
+        "fault_event",
+        "fault_code",
+        "work_order",
+        "pm_task",
+        "failure_mode",
+        "root_cause",
+        "remedy",
+        "part",
+        "document",
+        "wiring_diagram",
+        "procedure",
+        "external_system",
+    }
+)
+
+# `relationship_proposals.relationship_type` has a CHECK (Hub 028, 28 values);
+# `kg_relationships.relationship_type` is free TEXT. The four NEW_* entries are
+# the genuinely-new edge types proposed in canonical-asset-graph.md mig 038.
+REL_TYPES: frozenset[str] = frozenset(
+    {
+        # Hub 028 (28 existing)
+        "HAS_COMPONENT",
+        "INSTANCE_OF",
+        "LOCATED_IN",
+        "HAS_PART",
+        "HAS_DOCUMENT",
+        "HAS_CHUNK",
+        "REFERENCES",
+        "HAS_PROCEDURE",
+        "WIRED_TO",
+        "POWERED_BY",
+        "MAPS_TO",
+        "PUBLISHED_AS",
+        "USED_IN_LOGIC",
+        "TRIGGERS",
+        "CAUSES",
+        "DRIVES",
+        "IS_DRIVEN_BY",
+        "OCCURS_ON",
+        "RESOLVED_BY",
+        "HAS_FAILURE_MODE",
+        "HAS_SIGNAL",
+        "HAS_ALIAS",
+        "DEPENDS_ON",
+        "UPSTREAM_OF",
+        "DOWNSTREAM_OF",
+        "REPLACES",
+        "CONFIRMED_BY",
+        "CONTRADICTED_BY",
+        # NEW for the asset-graph vision (canonical-asset-graph.md mig 038 proposal)
+        "HAS_ALARM",
+        "HAS_WORK_ORDER",
+        "HAS_PM_TASK",
+        "USES_PART",
+    }
+)
+
+# `ai_suggestions.suggestion_type` CHECK (Hub 027) — exactly these six.
+SUGGESTION_TYPES: frozenset[str] = frozenset(
+    {
+        "kg_edge",  # header on a relationship_proposals row
+        "kg_entity",  # new entity (component instance, tag, location, asset)
+        "tag_mapping",  # a tag_entities row proposed by ingestion
+        "component_profile",  # a component_templates row proposed by extraction
+        "uns_confirmation",  # the UNS Gate "is this the right asset?" prompt
+        "namespace_move",  # a drag-drop / rename on the namespace tree
+    }
+)
+
+# `ai_suggestions.status` / approval states.
+APPROVAL_PROPOSED = "proposed"
+APPROVAL_VERIFIED = "verified"
+APPROVAL_REJECTED = "rejected"
+APPROVAL_NEEDS_REVIEW = "needs_review"
+
+# `ai_suggestions.risk_level` CHECK (Hub 027).
+RISK_LEVELS: frozenset[str] = frozenset({"low", "medium", "high", "safety_critical"})
+
+
+def content_hash(payload: Any) -> str:
+    """SHA-256 of the canonicalized payload — the ``source_objects.content_hash``
+    used for re-import dedup (source-record-preservation.md §4)."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def confidence_band(confidence: float) -> str:
+    """The Hub UI bands (migration 027): low <0.5, medium 0.5-0.8, high >0.8."""
+    if confidence < 0.5:
+        return "low"
+    if confidence <= 0.8:
+        return "medium"
+    return "high"
+
+
+# ---------------------------------------------------------------------------
+# Source-record preservation layer (source-record-preservation.md §2.3)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SourceObject:
+    """One raw imported record — the ``source_objects`` row that "never destroys
+    original customer fields". ``raw_payload`` is the unmodified source record.
+    """
+
+    system_kind: str  # 'maximo'|'sap'|'maintainx'|'ignition'|'historian'...
+    object_type: str  # 'asset'|'work_order'|'pm'|'location'|'part'|'tag'|'fault'...
+    external_object_id: str  # the source system's own ID (ASSETNUM, EQUNR, PI tag)
+    raw_payload: dict[str, Any]  # ORIGINAL record, unmodified (requirement 4)
+    connector_version: str
+    content_hash: str = ""
+    mapping_status: str = "unmapped"  # unmapped|mapped|conflict|stale|error
+    mapped_entity_key: Optional[str] = None  # → CanonicalEntity.key once normalized
+    mapping_errors: list[dict[str, Any]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.content_hash:
+            self.content_hash = content_hash(self.raw_payload)
+
+
+# ---------------------------------------------------------------------------
+# Canonical spine: nodes + edges (kg_entities / kg_relationships)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CanonicalEntity:
+    """A ``kg_entities`` row.
+
+    ``name`` is the natural-key component (UNIQUE ``(tenant_id, entity_type,
+    name)``) and is keyed off the source system's **unique ID** (ASSETNUM /
+    EQUNR / PI tag) — never the free-text description, which is not unique. The
+    human label lives in ``properties['description']``.
+    """
+
+    entity_type: str
+    name: str
+    uns_path: Optional[str] = None
+    properties: dict[str, Any] = field(default_factory=dict)
+    confidence: float = 0.7
+    approval_state: str = APPROVAL_PROPOSED  # rule #1: connectors never auto-verify
+    # Source-system identity (canonical-asset-graph.md §4 req 1).
+    source_system: Optional[str] = None
+    object_type: Optional[str] = None
+    external_object_id: Optional[str] = None
+    source_payload: dict[str, Any] = field(default_factory=dict)  # ALL original fields
+    content_hash: str = ""
+
+    def __post_init__(self) -> None:
+        if self.entity_type not in ENTITY_TYPES:
+            raise ValueError(f"unknown entity_type {self.entity_type!r}")
+        if self.source_payload and not self.content_hash:
+            self.content_hash = content_hash(self.source_payload)
+
+    @property
+    def key(self) -> str:
+        """Stable in-memory join key mirroring the natural key
+        ``(entity_type, name)``. Relationships reference entities by this."""
+        return f"{self.entity_type}:{self.name}"
+
+
+@dataclass
+class CanonicalRelationship:
+    """A ``kg_relationships`` row. Uses the **live** column names
+    (``source_id``/``target_id``/``relationship_type``). ``source_key`` /
+    ``target_key`` hold the in-memory :attr:`CanonicalEntity.key`; a writer
+    resolves them to the real ``kg_entities.id`` UUIDs."""
+
+    source_key: str  # → CanonicalEntity.key  (becomes source_id UUID)
+    target_key: str  # → CanonicalEntity.key  (becomes target_id UUID)
+    relationship_type: str
+    confidence: float = 0.6
+    approval_state: str = APPROVAL_PROPOSED  # rule #1
+    properties: dict[str, Any] = field(default_factory=dict)
+    # relationship_evidence rows (Hub 018): {kind, ref, detail}
+    evidence: list[dict[str, Any]] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if self.relationship_type not in REL_TYPES:
+            raise ValueError(f"unknown relationship_type {self.relationship_type!r}")
+
+
+@dataclass
+class Proposal:
+    """An ``ai_suggestions`` row — the Hub ``/proposals`` work-queue unit for an
+    ambiguous or cross-system mapping that needs a human decision.
+
+    ``proposed_by`` follows the migration-027 actor vocabulary; connector
+    imports use ``import:<connector>``.
+    """
+
+    suggestion_type: str  # one of SUGGESTION_TYPES
+    title: str
+    body: str
+    extracted_data: dict[str, Any] = field(default_factory=dict)
+    confidence: float = 0.5
+    risk_level: str = "low"
+    status: str = "pending"  # ai_suggestions lifecycle starts at pending
+    proposed_by: str = "import:unknown"
+    source_kind: Optional[str] = None  # ai_suggestions.source_kind (Hub 027 CHECK)
+    source_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.suggestion_type not in SUGGESTION_TYPES:
+            raise ValueError(f"unknown suggestion_type {self.suggestion_type!r}")
+        if self.risk_level not in RISK_LEVELS:
+            raise ValueError(f"unknown risk_level {self.risk_level!r}")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be in [0.0, 1.0]")
+
+
+# ---------------------------------------------------------------------------
+# Validation report (Connector.validate)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ValidationIssue:
+    severity: str  # 'error' | 'warning' | 'info'
+    code: str  # machine-readable, e.g. 'invalid_uns_path', 'orphan_relationship'
+    message: str
+    entity_key: Optional[str] = None
+
+
+@dataclass
+class ValidationReport:
+    issues: list[ValidationIssue] = field(default_factory=list)
+
+    def add(
+        self, severity: str, code: str, message: str, entity_key: Optional[str] = None
+    ) -> None:
+        self.issues.append(ValidationIssue(severity, code, message, entity_key))
+
+    @property
+    def ok(self) -> bool:
+        """True when there are no ``error``-severity issues (warnings are fine —
+        they typically become proposals, not blockers)."""
+        return not any(i.severity == "error" for i in self.issues)
+
+    @property
+    def errors(self) -> list[ValidationIssue]:
+        return [i for i in self.issues if i.severity == "error"]
+
+    @property
+    def warnings(self) -> list[ValidationIssue]:
+        return [i for i in self.issues if i.severity == "warning"]
+
+
+# ---------------------------------------------------------------------------
+# The normalized graph a connector produces
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NormalizedGraph:
+    """Everything a connector's ``normalize()`` produces for one import: the
+    canonical entities + relationships, the proposals for ambiguous mappings,
+    and the preserved raw source records."""
+
+    entities: dict[str, CanonicalEntity] = field(default_factory=dict)  # keyed by .key
+    relationships: list[CanonicalRelationship] = field(default_factory=list)
+    proposals: list[Proposal] = field(default_factory=list)
+    source_objects: list[SourceObject] = field(default_factory=list)
+
+    def add_entity(self, entity: CanonicalEntity) -> CanonicalEntity:
+        """Upsert by natural key. On collision, merge properties/source_payload
+        (last write wins per field) and keep the higher confidence — mirrors the
+        ``ON CONFLICT (tenant_id, entity_type, name)`` upsert a writer would do."""
+        existing = self.entities.get(entity.key)
+        if existing is None:
+            self.entities[entity.key] = entity
+            return entity
+        existing.properties.update(entity.properties)
+        existing.source_payload.update(entity.source_payload)
+        existing.confidence = max(existing.confidence, entity.confidence)
+        if entity.uns_path and not existing.uns_path:
+            existing.uns_path = entity.uns_path
+        return existing
+
+    def add_relationship(self, rel: CanonicalRelationship) -> CanonicalRelationship:
+        self.relationships.append(rel)
+        return rel
+
+    def add_proposal(self, proposal: Proposal) -> Proposal:
+        self.proposals.append(proposal)
+        return proposal
+
+    def add_source_object(self, obj: SourceObject) -> SourceObject:
+        self.source_objects.append(obj)
+        return obj
+
+    def by_type(self, entity_type: str) -> list[CanonicalEntity]:
+        return [e for e in self.entities.values() if e.entity_type == entity_type]
+
+    def get(self, key: str) -> Optional[CanonicalEntity]:
+        return self.entities.get(key)
+
+    def merge(self, other: NormalizedGraph) -> None:
+        """Fold another graph into this one (used by the cross-reference demo)."""
+        for e in other.entities.values():
+            self.add_entity(e)
+        self.relationships.extend(other.relationships)
+        self.proposals.extend(other.proposals)
+        self.source_objects.extend(other.source_objects)
+
+    def summary(self) -> dict[str, int]:
+        proposed_edges = sum(
+            1 for r in self.relationships if r.approval_state == APPROVAL_PROPOSED
+        )
+        return {
+            "entities": len(self.entities),
+            "relationships": len(self.relationships),
+            "proposed_relationships": proposed_edges,
+            "proposals": len(self.proposals),
+            "source_objects": len(self.source_objects),
+        }

--- a/mira-connectors/cmms/__init__.py
+++ b/mira-connectors/cmms/__init__.py
@@ -1,0 +1,1 @@
+"""MIRA CMMS/EAM connectors (Maximo, SAP, MaintainX)."""

--- a/mira-connectors/cmms/fixtures/maintainx_demo.json
+++ b/mira-connectors/cmms/fixtures/maintainx_demo.json
@@ -1,0 +1,25 @@
+{
+  "_meta": {
+    "source": "MaintainX",
+    "api_hint": "GET https://api.getmaintainx.com/v1/{assets,workorders,locations,parts} (Bearer)",
+    "note": "Mock fixture in MaintainX REST response shape. IDs are numeric; assets carry locationId + parentId; work orders carry assetId + categories[]."
+  },
+  "company": "Acme Manufacturing",
+  "locations": [
+    { "id": 5001, "name": "Bedford Plant", "parentId": null, "description": "Bedford site" },
+    { "id": 5002, "name": "Packaging", "parentId": 5001, "description": "Packaging area" },
+    { "id": 5003, "name": "Line 1", "parentId": 5002, "description": "Bottling line 1" }
+  ],
+  "assets": [
+    { "id": 8001, "name": "CONV-001", "description": "Infeed Belt Conveyor", "locationId": 5003, "parentId": null, "serialNumber": "CNV-2021-4471", "manufacturer": "Dorner", "model": "2200", "status": "ONLINE" },
+    { "id": 8002, "name": "MOTOR-001", "description": "Conveyor Drive Motor 2HP", "locationId": 5003, "parentId": 8001, "serialNumber": "WEG-9931", "manufacturer": "WEG", "model": "W22", "status": "ONLINE" },
+    { "id": 8003, "name": "VFD-001", "description": "VFD GS10", "locationId": 5003, "parentId": 8001, "serialNumber": "GS10-55120", "manufacturer": "AutomationDirect", "model": "GS10", "status": "ONLINE" }
+  ],
+  "workOrders": [
+    { "id": 91001, "title": "Conveyor VFD fault F0004", "description": "Drive tripped, cleared and restarted", "priority": "HIGH", "status": "DONE", "categories": ["REACTIVE"], "assetId": 8001, "createdAt": "2026-05-18T06:30:00Z", "completedAt": "2026-05-18T08:10:00Z" },
+    { "id": 91002, "title": "Monthly motor lubrication", "description": "Lubricate drive motor bearings", "priority": "MEDIUM", "status": "OPEN", "categories": ["PREVENTIVE"], "assetId": 8002, "createdAt": "2026-06-01T05:00:00Z", "completedAt": null }
+  ],
+  "parts": [
+    { "id": 7001, "name": "10A class CC fuse", "partNumber": "FUSE-10A-CC", "quantityInStock": 24, "assetIds": [8003] }
+  ]
+}

--- a/mira-connectors/cmms/fixtures/maximo_demo_plant.json
+++ b/mira-connectors/cmms/fixtures/maximo_demo_plant.json
@@ -1,0 +1,157 @@
+{
+  "_meta": {
+    "source": "IBM Maximo EAM",
+    "api_hint": "MAS Maximo Manage REST (oslc/os/mxapiasset, mxapiwodetail, mxapipm, ...)",
+    "note": "Mock fixture. Real Maximo field names (ASSETNUM, SITEID, LOCATION, PARENT, ...). The two MIRA_* fields on assets show how MIRA-written custom fields survive a round-trip.",
+    "orgid": "ACME"
+  },
+  "orgs": [
+    { "ORGID": "ACME", "DESCRIPTION": "Acme Manufacturing", "BASECURRENCY1": "USD", "ACTIVE": true }
+  ],
+  "sites": [
+    { "SITEID": "BEDFORD", "ORGID": "ACME", "DESCRIPTION": "Bedford Plant", "ACTIVE": true, "CONTACT": "J. Reyes" },
+    { "SITEID": "NASHUA", "ORGID": "ACME", "DESCRIPTION": "Nashua Plant", "ACTIVE": true, "CONTACT": "K. Owens" }
+  ],
+  "locations": [
+    { "LOCATION": "PLANT-A", "DESCRIPTION": "Bedford Plant Building A", "SITEID": "BEDFORD", "ORGID": "ACME", "PARENT": null, "TYPE": "OPERATING", "STATUS": "OPERATING", "LOCHIERARCHY": "PLANT-A", "CHANGEDATE": "2025-11-03T08:12:00Z" },
+    { "LOCATION": "AREA-1", "DESCRIPTION": "Packaging Area", "SITEID": "BEDFORD", "ORGID": "ACME", "PARENT": "PLANT-A", "TYPE": "OPERATING", "STATUS": "OPERATING", "LOCHIERARCHY": "PLANT-A \\ AREA-1", "CHANGEDATE": "2025-11-03T08:14:00Z" },
+    { "LOCATION": "LINE-1", "DESCRIPTION": "Bottling Line 1", "SITEID": "BEDFORD", "ORGID": "ACME", "PARENT": "AREA-1", "TYPE": "OPERATING", "STATUS": "OPERATING", "LOCHIERARCHY": "PLANT-A \\ AREA-1 \\ LINE-1", "CHANGEDATE": "2025-11-03T08:15:00Z" },
+    { "LOCATION": "CELL-1", "DESCRIPTION": "Infeed Conveyor Cell", "SITEID": "BEDFORD", "ORGID": "ACME", "PARENT": "LINE-1", "TYPE": "OPERATING", "STATUS": "OPERATING", "LOCHIERARCHY": "PLANT-A \\ AREA-1 \\ LINE-1 \\ CELL-1", "CHANGEDATE": "2025-11-03T08:16:00Z" },
+    { "LOCATION": "PLANT-B", "DESCRIPTION": "Nashua Plant Building B", "SITEID": "NASHUA", "ORGID": "ACME", "PARENT": null, "TYPE": "OPERATING", "STATUS": "OPERATING", "LOCHIERARCHY": "PLANT-B", "CHANGEDATE": "2025-11-04T09:00:00Z" },
+    { "LOCATION": "AREA-7", "DESCRIPTION": "Receiving Area", "SITEID": "NASHUA", "ORGID": "ACME", "PARENT": "PLANT-B", "TYPE": "OPERATING", "STATUS": "OPERATING", "LOCHIERARCHY": "PLANT-B \\ AREA-7", "CHANGEDATE": "2025-11-04T09:02:00Z" }
+  ],
+  "assets": [
+    {
+      "ASSETNUM": "CONV-001", "SITEID": "BEDFORD", "ORGID": "ACME", "LOCATION": "CELL-1",
+      "PARENT": null, "DESCRIPTION": "Infeed Belt Conveyor", "STATUS": "OPERATING",
+      "ASSETTYPE": "PRODUCTION", "SERIALNUM": "CNV-2021-4471", "MANUFACTURER": "Dorner",
+      "VENDOR": "Dorner", "INSTALLDATE": "2021-06-15", "PRIORITY": 2,
+      "CHANGEDATE": "2026-05-20T14:03:00Z", "CHANGEBY": "MAXADMIN",
+      "MIRA_UNS_PATH": "enterprise.acme.site.bedford.area.area_1.line.line_1.work_cell.cell_1.equipment.conv_001",
+      "MIRA_CONFIDENCE": "high"
+    },
+    {
+      "ASSETNUM": "MOTOR-001", "SITEID": "BEDFORD", "ORGID": "ACME", "LOCATION": "CELL-1",
+      "PARENT": "CONV-001", "DESCRIPTION": "Conveyor Drive Motor 2HP", "STATUS": "OPERATING",
+      "ASSETTYPE": "ROTATING", "SERIALNUM": "WEG-9931", "MANUFACTURER": "WEG", "VENDOR": "WEG",
+      "INSTALLDATE": "2021-06-15", "PRIORITY": 2, "CHANGEDATE": "2026-05-20T14:03:10Z", "CHANGEBY": "MAXADMIN",
+      "MIRA_UNS_PATH": null, "MIRA_CONFIDENCE": null
+    },
+    {
+      "ASSETNUM": "VFD-001", "SITEID": "BEDFORD", "ORGID": "ACME", "LOCATION": "CELL-1",
+      "PARENT": "CONV-001", "DESCRIPTION": "Variable Frequency Drive GS10 1HP", "STATUS": "OPERATING",
+      "ASSETTYPE": "ELECTRICAL", "SERIALNUM": "GS10-55120", "MANUFACTURER": "AutomationDirect", "VENDOR": "AutomationDirect",
+      "INSTALLDATE": "2021-06-15", "PRIORITY": 1, "CHANGEDATE": "2026-05-21T11:20:00Z", "CHANGEBY": "MAXADMIN",
+      "MIRA_UNS_PATH": null, "MIRA_CONFIDENCE": null
+    },
+    {
+      "ASSETNUM": "PE-101", "SITEID": "BEDFORD", "ORGID": "ACME", "LOCATION": "CELL-1",
+      "PARENT": "CONV-001", "DESCRIPTION": "Photoeye Infeed Present", "STATUS": "OPERATING",
+      "ASSETTYPE": "INSTRUMENT", "SERIALNUM": "BJ-PE101", "MANUFACTURER": "Banner", "VENDOR": "Banner",
+      "INSTALLDATE": "2021-06-15", "PRIORITY": 3, "CHANGEDATE": "2026-05-19T07:45:00Z", "CHANGEBY": "MAXADMIN",
+      "MIRA_UNS_PATH": null, "MIRA_CONFIDENCE": null
+    },
+    {
+      "ASSETNUM": "PE-102", "SITEID": "BEDFORD", "ORGID": "ACME", "LOCATION": "CELL-1",
+      "PARENT": "CONV-001", "DESCRIPTION": "Photoeye Discharge Clear", "STATUS": "OPERATING",
+      "ASSETTYPE": "INSTRUMENT", "SERIALNUM": "BJ-PE102", "MANUFACTURER": "Banner", "VENDOR": "Banner",
+      "INSTALLDATE": "2021-06-15", "PRIORITY": 3, "CHANGEDATE": "2026-05-19T07:46:00Z", "CHANGEBY": "MAXADMIN",
+      "MIRA_UNS_PATH": null, "MIRA_CONFIDENCE": null
+    },
+    {
+      "ASSETNUM": "PX-101", "SITEID": "BEDFORD", "ORGID": "ACME", "LOCATION": "CELL-1",
+      "PARENT": "CONV-001", "DESCRIPTION": "Proximity Switch Belt Index", "STATUS": "OPERATING",
+      "ASSETTYPE": "INSTRUMENT", "SERIALNUM": "IFM-PX101", "MANUFACTURER": "ifm", "VENDOR": "ifm",
+      "INSTALLDATE": "2021-06-15", "PRIORITY": 3, "CHANGEDATE": "2026-05-19T07:47:00Z", "CHANGEBY": "MAXADMIN",
+      "MIRA_UNS_PATH": null, "MIRA_CONFIDENCE": null
+    },
+    {
+      "ASSETNUM": "PUMP-220", "SITEID": "NASHUA", "ORGID": "ACME", "LOCATION": "AREA-7",
+      "PARENT": null, "DESCRIPTION": "Transfer Pump", "STATUS": "OPERATING",
+      "ASSETTYPE": "ROTATING", "SERIALNUM": "GRF-220-77", "MANUFACTURER": "Grundfos", "VENDOR": "Grundfos",
+      "INSTALLDATE": "2022-02-01", "PRIORITY": 2, "CHANGEDATE": "2026-05-10T10:00:00Z", "CHANGEBY": "MAXADMIN",
+      "MIRA_UNS_PATH": null, "MIRA_CONFIDENCE": null
+    }
+  ],
+  "failurecodes": [
+    {
+      "FAILURECODE": "CONVEYOR", "DESCRIPTION": "Conveyor System Failures", "ORGID": "ACME",
+      "children": [
+        {
+          "PROBLEMCODE": "NORUN", "DESCRIPTION": "Conveyor will not run",
+          "children": [
+            {
+              "CAUSECODE": "VFDFAULT", "DESCRIPTION": "VFD in fault state",
+              "children": [
+                { "REMEDYCODE": "RSTVFD", "DESCRIPTION": "Clear fault and restart VFD" },
+                { "REMEDYCODE": "RPLVFD", "DESCRIPTION": "Replace VFD module" }
+              ]
+            },
+            {
+              "CAUSECODE": "ESTOP", "DESCRIPTION": "E-stop engaged",
+              "children": [
+                { "REMEDYCODE": "RSTEST", "DESCRIPTION": "Reset E-stop and verify safety circuit" }
+              ]
+            }
+          ]
+        },
+        {
+          "PROBLEMCODE": "BELTSLIP", "DESCRIPTION": "Belt slipping / mistracking",
+          "children": [
+            {
+              "CAUSECODE": "TENSION", "DESCRIPTION": "Improper belt tension",
+              "children": [
+                { "REMEDYCODE": "ADJTEN", "DESCRIPTION": "Adjust take-up tension" }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "workorders": [
+    {
+      "WONUM": "WO-10231", "DESCRIPTION": "Conveyor tripped on VFD fault F0004", "SITEID": "BEDFORD", "ORGID": "ACME",
+      "ASSETNUM": "CONV-001", "LOCATION": "CELL-1", "STATUS": "COMP", "WORKTYPE": "CM",
+      "REPORTDATE": "2026-05-18T06:30:00Z", "ACTFINISH": "2026-05-18T08:10:00Z",
+      "FAILURECODE": "CONVEYOR", "PROBLEMCODE": "NORUN", "CAUSECODE": "VFDFAULT", "REMEDYCODE": "RSTVFD",
+      "ACTLABHRS": 1.5, "LEADCRAFT": "ELECT", "REPORTEDBY": "operator_lopez",
+      "matusetrans": [
+        { "ITEMNUM": "FUSE-10A", "DESCRIPTION": "10A class CC fuse", "QTY": 2, "UNITCOST": 4.25 }
+      ],
+      "CHANGEDATE": "2026-05-18T08:11:00Z"
+    },
+    {
+      "WONUM": "WO-10198", "DESCRIPTION": "Belt mistracking on infeed", "SITEID": "BEDFORD", "ORGID": "ACME",
+      "ASSETNUM": "CONV-001", "LOCATION": "CELL-1", "STATUS": "COMP", "WORKTYPE": "CM",
+      "REPORTDATE": "2026-04-29T13:00:00Z", "ACTFINISH": "2026-04-29T14:20:00Z",
+      "FAILURECODE": "CONVEYOR", "PROBLEMCODE": "BELTSLIP", "CAUSECODE": "TENSION", "REMEDYCODE": "ADJTEN",
+      "ACTLABHRS": 1.0, "LEADCRAFT": "MECH", "REPORTEDBY": "operator_lopez",
+      "matusetrans": [],
+      "CHANGEDATE": "2026-04-29T14:21:00Z"
+    },
+    {
+      "WONUM": "WO-10302", "DESCRIPTION": "Monthly motor lubrication", "SITEID": "BEDFORD", "ORGID": "ACME",
+      "ASSETNUM": "MOTOR-001", "LOCATION": "CELL-1", "STATUS": "WAPPR", "WORKTYPE": "PM",
+      "REPORTDATE": "2026-06-01T05:00:00Z", "ACTFINISH": null,
+      "FAILURECODE": null, "PROBLEMCODE": null, "CAUSECODE": null, "REMEDYCODE": null,
+      "ACTLABHRS": 0.0, "LEADCRAFT": "MECH", "REPORTEDBY": "pm_scheduler", "PMNUM": "PM-MOTOR-LUBE",
+      "matusetrans": [],
+      "CHANGEDATE": "2026-06-01T05:00:00Z"
+    }
+  ],
+  "pmschedules": [
+    { "PMNUM": "PM-MOTOR-LUBE", "DESCRIPTION": "Motor bearing lubrication", "ASSETNUM": "MOTOR-001", "SITEID": "BEDFORD", "ORGID": "ACME", "FREQUENCY": 1, "FREQUNIT": "MONTHS", "LEADCRAFT": "MECH", "STATUS": "ACTIVE", "CHANGEDATE": "2026-01-05T00:00:00Z" },
+    { "PMNUM": "PM-BELT-INSPECT", "DESCRIPTION": "Belt tension & tracking inspection", "ASSETNUM": "CONV-001", "SITEID": "BEDFORD", "ORGID": "ACME", "FREQUENCY": 2, "FREQUNIT": "WEEKS", "LEADCRAFT": "MECH", "STATUS": "ACTIVE", "CHANGEDATE": "2026-01-05T00:00:00Z" },
+    { "PMNUM": "PM-VFD-ANNUAL", "DESCRIPTION": "VFD annual inspection & firmware check", "ASSETNUM": "VFD-001", "SITEID": "BEDFORD", "ORGID": "ACME", "FREQUENCY": 12, "FREQUNIT": "MONTHS", "LEADCRAFT": "ELECT", "STATUS": "ACTIVE", "CHANGEDATE": "2026-01-05T00:00:00Z" }
+  ],
+  "meters": [
+    { "ASSETNUM": "MOTOR-001", "METERNAME": "MOTOR_HOURS", "METERTYPE": "CONTINUOUS", "UOM": "HOURS", "LASTREADING": 8421.5, "MEASUREDATE": "2026-06-02T23:00:00Z" },
+    { "ASSETNUM": "MOTOR-001", "METERNAME": "VIBRATION_LEVEL", "METERTYPE": "GAUGE", "UOM": "MM/S", "LASTREADING": 2.8, "MEASUREDATE": "2026-06-02T23:00:00Z" }
+  ],
+  "doclinks": [
+    { "DOCINFOID": 90011, "DOCUMENT": "GS10_user_manual_v3.pdf", "DESCRIPTION": "AutomationDirect GS10 VFD User Manual", "URLTYPE": "FILE", "URLNAME": "doclinks/GS10_user_manual_v3.pdf", "ADDINFO": "MANUAL", "ASSETNUM": "VFD-001", "SITEID": "BEDFORD" },
+    { "DOCINFOID": 90012, "DOCUMENT": "CONV-001_wiring.pdf", "DESCRIPTION": "Infeed conveyor wiring diagram rev B", "URLTYPE": "FILE", "URLNAME": "doclinks/CONV-001_wiring.pdf", "ADDINFO": "WIRING", "ASSETNUM": "CONV-001", "SITEID": "BEDFORD" },
+    { "DOCINFOID": 90013, "DOCUMENT": "WEG_motor_datasheet.pdf", "DESCRIPTION": "WEG W22 motor datasheet", "URLTYPE": "FILE", "URLNAME": "doclinks/WEG_motor_datasheet.pdf", "ADDINFO": "MANUAL", "ASSETNUM": "MOTOR-001", "SITEID": "BEDFORD" }
+  ]
+}

--- a/mira-connectors/cmms/fixtures/sap_demo_plant.json
+++ b/mira-connectors/cmms/fixtures/sap_demo_plant.json
@@ -1,0 +1,31 @@
+{
+  "_meta": {
+    "source": "SAP Plant Maintenance (PM)",
+    "api_hint": "S/4HANA OData (API_FUNCTIONALLOCATION, API_EQUIPMENT, API_MAINTENANCEORDER) or BAPI_EQUI_GETDETAIL",
+    "note": "Mock fixture. Real SAP PM field names (EQUNR, TPLNR, AUFNR, MATNR, HERST, ...). Functional-location TPLNR is the SAP hierarchy; '-' separates structure levels.",
+    "client": "100"
+  },
+  "functional_locations": [
+    { "TPLNR": "ACME-BED", "PLTXT": "Bedford Plant", "TPLMA": null, "FLTYP": "PLANT", "SWERK": "BED1", "STORT": "BED" },
+    { "TPLNR": "ACME-BED-PKG", "PLTXT": "Packaging Area", "TPLMA": "ACME-BED", "FLTYP": "AREA", "SWERK": "BED1", "STORT": "BED" },
+    { "TPLNR": "ACME-BED-PKG-L1", "PLTXT": "Bottling Line 1", "TPLMA": "ACME-BED-PKG", "FLTYP": "LINE", "SWERK": "BED1", "STORT": "BED" },
+    { "TPLNR": "ACME-BED-PKG-L1-C1", "PLTXT": "Infeed Conveyor Cell", "TPLMA": "ACME-BED-PKG-L1", "FLTYP": "CELL", "SWERK": "BED1", "STORT": "BED" }
+  ],
+  "equipment": [
+    { "EQUNR": "10000455", "EQKTX": "Infeed Belt Conveyor", "TPLNR": "ACME-BED-PKG-L1-C1", "HEQUI": null, "EQTYP": "M", "HERST": "Dorner", "TYPBZ": "2200-Series", "SERGE": "CNV-2021-4471", "SWERK": "BED1", "DATAB": "2021-06-15", "ELIEF": "Dorner" },
+    { "EQUNR": "10000456", "EQKTX": "Conveyor Drive Motor 2HP", "TPLNR": "ACME-BED-PKG-L1-C1", "HEQUI": "10000455", "EQTYP": "M", "HERST": "WEG", "TYPBZ": "W22", "SERGE": "WEG-9931", "SWERK": "BED1", "DATAB": "2021-06-15", "ELIEF": "WEG" },
+    { "EQUNR": "10000457", "EQKTX": "VFD GS10 1HP", "TPLNR": "ACME-BED-PKG-L1-C1", "HEQUI": "10000455", "EQTYP": "E", "HERST": "AutomationDirect", "TYPBZ": "GS10-11P5", "SERGE": "GS10-55120", "SWERK": "BED1", "DATAB": "2021-06-15", "ELIEF": "AutomationDirect" }
+  ],
+  "maintenance_orders": [
+    { "AUFNR": "4000123", "KTEXT": "Conveyor VFD fault investigation", "EQUNR": "10000455", "TPLNR": "ACME-BED-PKG-L1-C1", "AUART": "PM02", "GSTRP": "2026-05-18", "GLTRP": "2026-05-18", "IWERK": "BED1", "PRIOK": "2", "ANLZU": "completed" },
+    { "AUFNR": "4000130", "KTEXT": "Motor lubrication (preventive)", "EQUNR": "10000456", "TPLNR": "ACME-BED-PKG-L1-C1", "AUART": "PM01", "GSTRP": "2026-06-05", "GLTRP": "2026-06-05", "IWERK": "BED1", "PRIOK": "3", "ANLZU": "released" }
+  ],
+  "task_lists": [
+    { "PLNNR": "TL-MOTOR-LUBE", "PLNAL": "01", "KTEXT": "Motor bearing lubrication", "EQUNR": "10000456", "STRAT": "MONTHLY", "WERKS": "BED1" },
+    { "PLNNR": "TL-VFD-INSP", "PLNAL": "01", "KTEXT": "VFD annual inspection", "EQUNR": "10000457", "STRAT": "ANNUAL", "WERKS": "BED1" }
+  ],
+  "bom": [
+    { "EQUNR": "10000457", "MATNR": "FUSE-10A-CC", "MAKTX": "10A class CC fuse", "MENGE": 3, "MEINS": "EA", "POSNR": "0010" },
+    { "EQUNR": "10000456", "MATNR": "BRG-6204-2RS", "MAKTX": "Bearing 6204-2RS", "MENGE": 2, "MEINS": "EA", "POSNR": "0010" }
+  ]
+}

--- a/mira-connectors/cmms/maintainx_mock.py
+++ b/mira-connectors/cmms/maintainx_mock.py
@@ -1,0 +1,308 @@
+"""MaintainX mock connector.
+
+Extends the MaintainX adapter pattern already in the repo
+(``mira-mcp/cmms/maintainx.py`` — REST + Bearer key, ``workOrders`` / ``assets``
+response envelopes) into the connector framework. The mock reads the same REST
+response shape from ``fixtures/maintainx_demo.json`` so the mapping is exercised
+without an API key; a live connector would swap ``_load`` for the existing
+``MaintainXCMMS._get`` calls.
+
+Mapping:
+
+* Location tree → ``site``/``area``/``line`` by depth from the root location.
+* Asset (``parentId`` null) → ``asset``; child asset → ``component``.
+* Work order → ``work_order`` + ``HAS_WORK_ORDER`` (PREVENTIVE category → a PM-
+  flavored note in properties); parts referencing the asset → ``part`` + ``HAS_PART``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from base import Capability, Connector, ExportResult, RawRecord
+from canonical import (
+    CanonicalEntity,
+    CanonicalRelationship,
+    NormalizedGraph,
+    SourceObject,
+    ValidationReport,
+)
+from uns_bridge import uns
+
+logger = logging.getLogger("mira-connectors.maintainx")
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "maintainx_demo.json"
+
+
+class MaintainXMockConnector(Connector):
+    name = "maintainx_mock"
+    system_kind = "maintainx"
+    connector_version = "0.1.0"
+
+    def __init__(
+        self,
+        fixture_path: Optional[Path] = None,
+        company: str = "acme",
+        dry_run: bool = True,
+        read_only: bool = True,
+    ) -> None:
+        super().__init__(dry_run=dry_run, read_only=read_only)
+        self._fixture_path = Path(fixture_path) if fixture_path else _FIXTURE
+        self._company = company
+        self._data: dict[str, Any] = {}
+
+    def _load(self) -> dict[str, Any]:
+        if not self._data:
+            self._data = json.loads(self._fixture_path.read_text())
+        return self._data
+
+    async def discover(self) -> Capability:
+        data = self._load()
+        schema = {}
+        for ot, key in (("asset", "assets"), ("work_order", "workOrders"), ("location", "locations"), ("part", "parts")):
+            rows = data.get(key, [])
+            if rows:
+                schema[ot] = sorted({k for r in rows for k in r.keys()})
+        return Capability(
+            system_kind=self.system_kind,
+            display_name="MaintainX (mock)",
+            object_types=list(schema.keys()),
+            supports_export=True,
+            read_only=self.read_only,
+            schema=schema,
+            notes="REST response shape mirrors mira-mcp/cmms/maintainx.py. Flat location tree (parentId).",
+        )
+
+    async def import_records(
+        self, config: Optional[dict[str, Any]] = None
+    ) -> list[RawRecord]:
+        data = self._load()
+        out: list[RawRecord] = []
+        for loc in data.get("locations", []):
+            out.append(RawRecord("location", str(loc["id"]), loc))
+        for a in data.get("assets", []):
+            out.append(RawRecord("asset", str(a["id"]), a))
+        for wo in data.get("workOrders", []):
+            out.append(RawRecord("work_order", str(wo["id"]), wo))
+        for p in data.get("parts", []):
+            out.append(RawRecord("part", str(p["id"]), p))
+        return out
+
+    def normalize(self, raw_records: list[RawRecord]) -> NormalizedGraph:
+        g = NormalizedGraph()
+        by_type: dict[str, list[RawRecord]] = {}
+        for r in raw_records:
+            by_type.setdefault(r.object_type, []).append(r)
+
+        company = uns.slug(self._load().get("company") or self._company)
+        locs = {r.payload["id"]: r.payload for r in by_type.get("location", [])}
+        self._normalize_locations(g, company, locs)
+        self._normalize_assets(g, by_type.get("asset", []), locs)
+        self._normalize_work_orders(g, by_type.get("work_order", []))
+        self._normalize_parts(g, by_type.get("part", []))
+        return g
+
+    @staticmethod
+    def _depth(loc_id: Any, locs: dict[Any, dict]) -> int:
+        depth, cur, guard = 0, locs.get(loc_id), 0
+        while cur and cur.get("parentId") is not None and guard < 12:
+            guard += 1
+            depth += 1
+            cur = locs.get(cur["parentId"])
+        return depth
+
+    def _normalize_locations(
+        self, g: NormalizedGraph, company: str, locs: dict[Any, dict]
+    ) -> dict[Any, str]:
+        """Map the flat parentId tree to site/area/line by depth. Returns a
+        location-id → {site,area,line} context for assets to resolve against."""
+        ctx: dict[Any, str] = {}
+        # site = the root location
+        site_label = None
+        for lid, loc in locs.items():
+            if loc.get("parentId") is None:
+                site_label = uns.slug(loc["name"])
+                self._emit(g, "site", site_label, "location", str(lid), {"description": loc.get("description")}, uns.site_path(company, site_label), 0.9, raw=loc)
+        site_label = site_label or "site"
+        for lid, loc in locs.items():
+            d = self._depth(lid, locs)
+            if d == 0:
+                ctx[lid] = site_label
+                continue
+            chain = self._loc_chain(lid, locs)
+            label = uns.slug(loc["name"])
+            if d == 1:
+                path, parent, etype = uns.area_path(company, site_label, label), f"site:{site_label}", "area"
+            elif d == 2:
+                path = uns.line_path(company, site_label, chain.get("area", "area"), label)
+                parent, etype = f"area:{chain.get('area')}", "line"
+            else:
+                path = uns.work_cell_path(company, site_label, chain.get("area", "area"), chain.get("line", "line"), label)
+                parent, etype = f"line:{chain.get('line')}", "cell"
+            ent = self._emit(g, etype, label, "location", str(lid), {"description": loc.get("description")}, path, 0.88, raw=loc)
+            g.add_relationship(CanonicalRelationship(source_key=ent.key, target_key=parent, relationship_type="LOCATED_IN", confidence=0.88))
+            ctx[lid] = label
+        return ctx
+
+    def _loc_chain(self, loc_id: Any, locs: dict[Any, dict]) -> dict[str, str]:
+        out: dict[str, str] = {}
+        cur, guard = locs.get(loc_id), 0
+        while cur and guard < 12:
+            guard += 1
+            d = self._depth(cur["id"], locs)
+            level = {1: "area", 2: "line", 3: "work_cell"}.get(d)
+            if level:
+                out.setdefault(level, uns.slug(cur["name"]))
+            cur = locs.get(cur.get("parentId"))
+        return out
+
+    def _normalize_assets(
+        self, g: NormalizedGraph, rows: list[RawRecord], locs: dict[Any, dict]
+    ) -> dict[Any, str]:
+        company = uns.slug(self._load().get("company") or self._company)
+        site_label = next((uns.slug(loc["name"]) for loc in locs.values() if loc.get("parentId") is None), "site")
+        eq_path: dict[Any, str] = {}
+        for r in rows:
+            a = r.payload
+            if a.get("parentId"):
+                continue
+            chain = self._loc_chain(a.get("locationId"), locs)
+            path = uns.assigned_equipment_path(
+                company, site_label, chain.get("area", "unassigned"), a["name"],
+                line=chain.get("line"), work_cell=chain.get("work_cell"),
+            )
+            eq_path[a["id"]] = path
+            self._emit_asset(g, a, "asset", path)
+        for r in rows:
+            a = r.payload
+            parent = a.get("parentId")
+            if not parent:
+                continue
+            ppath = eq_path.get(parent)
+            path = uns.equipment_subnode_path(ppath, "component", a["name"]) if ppath else None
+            ent = self._emit_asset(g, a, "component", path)
+            if ppath:
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=f"asset:{self._asset_name(rows, parent)}", target_key=ent.key,
+                        relationship_type="HAS_COMPONENT", confidence=0.95,
+                        evidence=[{"kind": "maintainx_parent", "ref": a["name"], "detail": parent}],
+                    )
+                )
+        return eq_path
+
+    @staticmethod
+    def _asset_name(rows: list[RawRecord], asset_id: Any) -> str:
+        for r in rows:
+            if r.payload["id"] == asset_id:
+                return r.payload["name"]
+        return str(asset_id)
+
+    def _emit_asset(self, g: NormalizedGraph, a: dict, etype: str, path: Optional[str]) -> CanonicalEntity:
+        return self._emit(
+            g, etype, a["name"], "asset", str(a["id"]),
+            {"description": a.get("description"), "manufacturer": a.get("manufacturer"), "model": a.get("model"), "serial": a.get("serialNumber"), "maintainx_id": a["id"], "status": a.get("status")},
+            path, 0.9, raw=a,
+        )
+
+    def _normalize_work_orders(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
+        # need asset id → name; build from the asset entities already in graph
+        id_to_name = {e.properties.get("maintainx_id"): e.name for e in g.entities.values() if e.properties.get("maintainx_id")}
+        for r in rows:
+            wo = r.payload
+            cats = wo.get("categories", [])
+            ent = self._emit(
+                g, "work_order", str(wo["id"]), "work_order", str(wo["id"]),
+                {"title": wo.get("title"), "status": wo.get("status"), "priority": wo.get("priority"), "categories": cats, "is_preventive": "PREVENTIVE" in cats},
+                uns.work_order_path(str(wo["id"])), 0.9, raw=wo,
+            )
+            aid = wo.get("assetId")
+            aname = id_to_name.get(aid)
+            if aname:
+                src = f"component:{aname}" if g.get(f"component:{aname}") else f"asset:{aname}"
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=src, target_key=ent.key, relationship_type="HAS_WORK_ORDER",
+                        confidence=0.95, evidence=[{"kind": "maintainx_wo", "ref": str(wo["id"]), "detail": aid}],
+                    )
+                )
+
+    def _normalize_parts(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
+        id_to_name = {e.properties.get("maintainx_id"): e.name for e in g.entities.values() if e.properties.get("maintainx_id")}
+        for r in rows:
+            p = r.payload
+            part = self._emit(
+                g, "part", p.get("partNumber") or str(p["id"]), "part", str(p["id"]),
+                {"description": p.get("name"), "manufacturer_part_number": p.get("partNumber"), "qty_in_stock": p.get("quantityInStock")},
+                None, 0.85, raw=p,
+            )
+            for aid in p.get("assetIds", []):
+                aname = id_to_name.get(aid)
+                if aname:
+                    src = f"component:{aname}" if g.get(f"component:{aname}") else f"asset:{aname}"
+                    g.add_relationship(
+                        CanonicalRelationship(
+                            source_key=src, target_key=part.key, relationship_type="HAS_PART",
+                            confidence=0.8, evidence=[{"kind": "maintainx_part", "ref": str(p["id"]), "detail": aid}],
+                        )
+                    )
+
+    def _emit(
+        self, g: NormalizedGraph, entity_type: str, name: str, object_type: str, external_id: str,
+        properties: dict[str, Any], uns_path: Optional[str], confidence: float, raw: dict[str, Any],
+    ) -> CanonicalEntity:
+        ent = g.add_entity(
+            CanonicalEntity(
+                entity_type=entity_type, name=name, uns_path=uns_path, properties=properties,
+                confidence=confidence, source_system=self.system_kind, object_type=object_type,
+                external_object_id=external_id, source_payload=dict(raw),
+            )
+        )
+        g.add_source_object(
+            SourceObject(
+                system_kind=self.system_kind, object_type=object_type, external_object_id=external_id,
+                raw_payload=dict(raw), connector_version=self.connector_version,
+                mapping_status="mapped", mapped_entity_key=ent.key,
+            )
+        )
+        return ent
+
+    def validate(self, graph: NormalizedGraph) -> ValidationReport:
+        report = ValidationReport()
+        keys = set(graph.entities.keys())
+        for ent in graph.entities.values():
+            if ent.uns_path and not uns.is_valid_path(ent.uns_path):
+                report.add("error", "invalid_uns_path", f"{ent.key}: {ent.uns_path!r}", ent.key)
+            if ent.approval_state != "proposed":
+                report.add("error", "auto_verified", ent.key, ent.key)
+            if not ent.source_payload:
+                report.add("error", "missing_source_payload", ent.key, ent.key)
+        for rel in graph.relationships:
+            for endpoint in (rel.source_key, rel.target_key):
+                if endpoint not in keys:
+                    report.add("warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}")
+        return report
+
+    async def export_enriched(self, graph_context: dict[str, Any]) -> ExportResult:
+        wo_id = graph_context.get("work_order_id", "91001")
+        payload = {
+            "_resource": "workorders",
+            "id": wo_id,
+            "completionComment": f"[MIRA] {graph_context.get('diagnosis', '')}",
+            "customFields": {"mira_uns_path": graph_context.get("uns_path", "")},
+        }
+        written = self._may_write_source()
+        return ExportResult(
+            supported=True, written=written, payloads=[payload],
+            note="patched MaintainX work order" if written else "read_only/dry_run — payload built but NOT pushed",
+        )
+
+    def get_config_schema(self) -> dict[str, Any]:
+        return {
+            "api_key": {"type": "string", "required": True, "secret": True, "description": "MAINTAINX_API_KEY (Doppler-managed)"},
+            "company": {"type": "string", "required": False, "default": "acme", "description": "Company/enterprise UNS root"},
+            "fixture_path": {"type": "string", "required": False, "description": "Mock only: path to fixture JSON"},
+        }

--- a/mira-connectors/cmms/maintainx_mock.py
+++ b/mira-connectors/cmms/maintainx_mock.py
@@ -62,7 +62,12 @@ class MaintainXMockConnector(Connector):
     async def discover(self) -> Capability:
         data = self._load()
         schema = {}
-        for ot, key in (("asset", "assets"), ("work_order", "workOrders"), ("location", "locations"), ("part", "parts")):
+        for ot, key in (
+            ("asset", "assets"),
+            ("work_order", "workOrders"),
+            ("location", "locations"),
+            ("part", "parts"),
+        ):
             rows = data.get(key, [])
             if rows:
                 schema[ot] = sorted({k for r in rows for k in r.keys()})
@@ -76,9 +81,7 @@ class MaintainXMockConnector(Connector):
             notes="REST response shape mirrors mira-mcp/cmms/maintainx.py. Flat location tree (parentId).",
         )
 
-    async def import_records(
-        self, config: Optional[dict[str, Any]] = None
-    ) -> list[RawRecord]:
+    async def import_records(self, config: Optional[dict[str, Any]] = None) -> list[RawRecord]:
         data = self._load()
         out: list[RawRecord] = []
         for loc in data.get("locations", []):
@@ -125,7 +128,17 @@ class MaintainXMockConnector(Connector):
         for lid, loc in locs.items():
             if loc.get("parentId") is None:
                 site_label = uns.slug(loc["name"])
-                self._emit(g, "site", site_label, "location", str(lid), {"description": loc.get("description")}, uns.site_path(company, site_label), 0.9, raw=loc)
+                self._emit(
+                    g,
+                    "site",
+                    site_label,
+                    "location",
+                    str(lid),
+                    {"description": loc.get("description")},
+                    uns.site_path(company, site_label),
+                    0.9,
+                    raw=loc,
+                )
         site_label = site_label or "site"
         for lid, loc in locs.items():
             d = self._depth(lid, locs)
@@ -135,15 +148,38 @@ class MaintainXMockConnector(Connector):
             chain = self._loc_chain(lid, locs)
             label = uns.slug(loc["name"])
             if d == 1:
-                path, parent, etype = uns.area_path(company, site_label, label), f"site:{site_label}", "area"
+                path, parent, etype = (
+                    uns.area_path(company, site_label, label),
+                    f"site:{site_label}",
+                    "area",
+                )
             elif d == 2:
                 path = uns.line_path(company, site_label, chain.get("area", "area"), label)
                 parent, etype = f"area:{chain.get('area')}", "line"
             else:
-                path = uns.work_cell_path(company, site_label, chain.get("area", "area"), chain.get("line", "line"), label)
+                path = uns.work_cell_path(
+                    company, site_label, chain.get("area", "area"), chain.get("line", "line"), label
+                )
                 parent, etype = f"line:{chain.get('line')}", "cell"
-            ent = self._emit(g, etype, label, "location", str(lid), {"description": loc.get("description")}, path, 0.88, raw=loc)
-            g.add_relationship(CanonicalRelationship(source_key=ent.key, target_key=parent, relationship_type="LOCATED_IN", confidence=0.88))
+            ent = self._emit(
+                g,
+                etype,
+                label,
+                "location",
+                str(lid),
+                {"description": loc.get("description")},
+                path,
+                0.88,
+                raw=loc,
+            )
+            g.add_relationship(
+                CanonicalRelationship(
+                    source_key=ent.key,
+                    target_key=parent,
+                    relationship_type="LOCATED_IN",
+                    confidence=0.88,
+                )
+            )
             ctx[lid] = label
         return ctx
 
@@ -163,7 +199,9 @@ class MaintainXMockConnector(Connector):
         self, g: NormalizedGraph, rows: list[RawRecord], locs: dict[Any, dict]
     ) -> dict[Any, str]:
         company = uns.slug(self._load().get("company") or self._company)
-        site_label = next((uns.slug(loc["name"]) for loc in locs.values() if loc.get("parentId") is None), "site")
+        site_label = next(
+            (uns.slug(loc["name"]) for loc in locs.values() if loc.get("parentId") is None), "site"
+        )
         eq_path: dict[Any, str] = {}
         for r in rows:
             a = r.payload
@@ -171,8 +209,12 @@ class MaintainXMockConnector(Connector):
                 continue
             chain = self._loc_chain(a.get("locationId"), locs)
             path = uns.assigned_equipment_path(
-                company, site_label, chain.get("area", "unassigned"), a["name"],
-                line=chain.get("line"), work_cell=chain.get("work_cell"),
+                company,
+                site_label,
+                chain.get("area", "unassigned"),
+                a["name"],
+                line=chain.get("line"),
+                work_cell=chain.get("work_cell"),
             )
             eq_path[a["id"]] = path
             self._emit_asset(g, a, "asset", path)
@@ -187,8 +229,10 @@ class MaintainXMockConnector(Connector):
             if ppath:
                 g.add_relationship(
                     CanonicalRelationship(
-                        source_key=f"asset:{self._asset_name(rows, parent)}", target_key=ent.key,
-                        relationship_type="HAS_COMPONENT", confidence=0.95,
+                        source_key=f"asset:{self._asset_name(rows, parent)}",
+                        target_key=ent.key,
+                        relationship_type="HAS_COMPONENT",
+                        confidence=0.95,
                         evidence=[{"kind": "maintainx_parent", "ref": a["name"], "detail": parent}],
                     )
                 )
@@ -201,23 +245,54 @@ class MaintainXMockConnector(Connector):
                 return r.payload["name"]
         return str(asset_id)
 
-    def _emit_asset(self, g: NormalizedGraph, a: dict, etype: str, path: Optional[str]) -> CanonicalEntity:
+    def _emit_asset(
+        self, g: NormalizedGraph, a: dict, etype: str, path: Optional[str]
+    ) -> CanonicalEntity:
         return self._emit(
-            g, etype, a["name"], "asset", str(a["id"]),
-            {"description": a.get("description"), "manufacturer": a.get("manufacturer"), "model": a.get("model"), "serial": a.get("serialNumber"), "maintainx_id": a["id"], "status": a.get("status")},
-            path, 0.9, raw=a,
+            g,
+            etype,
+            a["name"],
+            "asset",
+            str(a["id"]),
+            {
+                "description": a.get("description"),
+                "manufacturer": a.get("manufacturer"),
+                "model": a.get("model"),
+                "serial": a.get("serialNumber"),
+                "maintainx_id": a["id"],
+                "status": a.get("status"),
+            },
+            path,
+            0.9,
+            raw=a,
         )
 
     def _normalize_work_orders(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
         # need asset id → name; build from the asset entities already in graph
-        id_to_name = {e.properties.get("maintainx_id"): e.name for e in g.entities.values() if e.properties.get("maintainx_id")}
+        id_to_name = {
+            e.properties.get("maintainx_id"): e.name
+            for e in g.entities.values()
+            if e.properties.get("maintainx_id")
+        }
         for r in rows:
             wo = r.payload
             cats = wo.get("categories", [])
             ent = self._emit(
-                g, "work_order", str(wo["id"]), "work_order", str(wo["id"]),
-                {"title": wo.get("title"), "status": wo.get("status"), "priority": wo.get("priority"), "categories": cats, "is_preventive": "PREVENTIVE" in cats},
-                uns.work_order_path(str(wo["id"])), 0.9, raw=wo,
+                g,
+                "work_order",
+                str(wo["id"]),
+                "work_order",
+                str(wo["id"]),
+                {
+                    "title": wo.get("title"),
+                    "status": wo.get("status"),
+                    "priority": wo.get("priority"),
+                    "categories": cats,
+                    "is_preventive": "PREVENTIVE" in cats,
+                },
+                uns.work_order_path(str(wo["id"])),
+                0.9,
+                raw=wo,
             )
             aid = wo.get("assetId")
             aname = id_to_name.get(aid)
@@ -225,19 +300,36 @@ class MaintainXMockConnector(Connector):
                 src = f"component:{aname}" if g.get(f"component:{aname}") else f"asset:{aname}"
                 g.add_relationship(
                     CanonicalRelationship(
-                        source_key=src, target_key=ent.key, relationship_type="HAS_WORK_ORDER",
-                        confidence=0.95, evidence=[{"kind": "maintainx_wo", "ref": str(wo["id"]), "detail": aid}],
+                        source_key=src,
+                        target_key=ent.key,
+                        relationship_type="HAS_WORK_ORDER",
+                        confidence=0.95,
+                        evidence=[{"kind": "maintainx_wo", "ref": str(wo["id"]), "detail": aid}],
                     )
                 )
 
     def _normalize_parts(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
-        id_to_name = {e.properties.get("maintainx_id"): e.name for e in g.entities.values() if e.properties.get("maintainx_id")}
+        id_to_name = {
+            e.properties.get("maintainx_id"): e.name
+            for e in g.entities.values()
+            if e.properties.get("maintainx_id")
+        }
         for r in rows:
             p = r.payload
             part = self._emit(
-                g, "part", p.get("partNumber") or str(p["id"]), "part", str(p["id"]),
-                {"description": p.get("name"), "manufacturer_part_number": p.get("partNumber"), "qty_in_stock": p.get("quantityInStock")},
-                None, 0.85, raw=p,
+                g,
+                "part",
+                p.get("partNumber") or str(p["id"]),
+                "part",
+                str(p["id"]),
+                {
+                    "description": p.get("name"),
+                    "manufacturer_part_number": p.get("partNumber"),
+                    "qty_in_stock": p.get("quantityInStock"),
+                },
+                None,
+                0.85,
+                raw=p,
             )
             for aid in p.get("assetIds", []):
                 aname = id_to_name.get(aid)
@@ -245,27 +337,50 @@ class MaintainXMockConnector(Connector):
                     src = f"component:{aname}" if g.get(f"component:{aname}") else f"asset:{aname}"
                     g.add_relationship(
                         CanonicalRelationship(
-                            source_key=src, target_key=part.key, relationship_type="HAS_PART",
-                            confidence=0.8, evidence=[{"kind": "maintainx_part", "ref": str(p["id"]), "detail": aid}],
+                            source_key=src,
+                            target_key=part.key,
+                            relationship_type="HAS_PART",
+                            confidence=0.8,
+                            evidence=[
+                                {"kind": "maintainx_part", "ref": str(p["id"]), "detail": aid}
+                            ],
                         )
                     )
 
     def _emit(
-        self, g: NormalizedGraph, entity_type: str, name: str, object_type: str, external_id: str,
-        properties: dict[str, Any], uns_path: Optional[str], confidence: float, raw: dict[str, Any],
+        self,
+        g: NormalizedGraph,
+        entity_type: str,
+        name: str,
+        object_type: str,
+        external_id: str,
+        properties: dict[str, Any],
+        uns_path: Optional[str],
+        confidence: float,
+        raw: dict[str, Any],
     ) -> CanonicalEntity:
         ent = g.add_entity(
             CanonicalEntity(
-                entity_type=entity_type, name=name, uns_path=uns_path, properties=properties,
-                confidence=confidence, source_system=self.system_kind, object_type=object_type,
-                external_object_id=external_id, source_payload=dict(raw),
+                entity_type=entity_type,
+                name=name,
+                uns_path=uns_path,
+                properties=properties,
+                confidence=confidence,
+                source_system=self.system_kind,
+                object_type=object_type,
+                external_object_id=external_id,
+                source_payload=dict(raw),
             )
         )
         g.add_source_object(
             SourceObject(
-                system_kind=self.system_kind, object_type=object_type, external_object_id=external_id,
-                raw_payload=dict(raw), connector_version=self.connector_version,
-                mapping_status="mapped", mapped_entity_key=ent.key,
+                system_kind=self.system_kind,
+                object_type=object_type,
+                external_object_id=external_id,
+                raw_payload=dict(raw),
+                connector_version=self.connector_version,
+                mapping_status="mapped",
+                mapped_entity_key=ent.key,
             )
         )
         return ent
@@ -283,7 +398,9 @@ class MaintainXMockConnector(Connector):
         for rel in graph.relationships:
             for endpoint in (rel.source_key, rel.target_key):
                 if endpoint not in keys:
-                    report.add("warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}")
+                    report.add(
+                        "warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}"
+                    )
         return report
 
     async def export_enriched(self, graph_context: dict[str, Any]) -> ExportResult:
@@ -296,13 +413,31 @@ class MaintainXMockConnector(Connector):
         }
         written = self._may_write_source()
         return ExportResult(
-            supported=True, written=written, payloads=[payload],
-            note="patched MaintainX work order" if written else "read_only/dry_run — payload built but NOT pushed",
+            supported=True,
+            written=written,
+            payloads=[payload],
+            note="patched MaintainX work order"
+            if written
+            else "read_only/dry_run — payload built but NOT pushed",
         )
 
     def get_config_schema(self) -> dict[str, Any]:
         return {
-            "api_key": {"type": "string", "required": True, "secret": True, "description": "MAINTAINX_API_KEY (Doppler-managed)"},
-            "company": {"type": "string", "required": False, "default": "acme", "description": "Company/enterprise UNS root"},
-            "fixture_path": {"type": "string", "required": False, "description": "Mock only: path to fixture JSON"},
+            "api_key": {
+                "type": "string",
+                "required": True,
+                "secret": True,
+                "description": "MAINTAINX_API_KEY (Doppler-managed)",
+            },
+            "company": {
+                "type": "string",
+                "required": False,
+                "default": "acme",
+                "description": "Company/enterprise UNS root",
+            },
+            "fixture_path": {
+                "type": "string",
+                "required": False,
+                "description": "Mock only: path to fixture JSON",
+            },
         }

--- a/mira-connectors/cmms/maximo_mock.py
+++ b/mira-connectors/cmms/maximo_mock.py
@@ -110,9 +110,7 @@ class MaximoMockConnector(Connector):
 
     # ── import ──────────────────────────────────────────────────────
 
-    async def import_records(
-        self, config: Optional[dict[str, Any]] = None
-    ) -> list[RawRecord]:
+    async def import_records(self, config: Optional[dict[str, Any]] = None) -> list[RawRecord]:
         """Read-only pull. ``config`` may carry ``site`` (SITEID filter) and
         ``object_types`` (subset). Importing never mutates Maximo."""
         config = config or {}
@@ -144,9 +142,7 @@ class MaximoMockConnector(Connector):
         # meters/doclinks have no single natural id → synthesize a stable one
         if not wanted or "meter" in wanted:
             for m in data.get("meters", []):
-                records.append(
-                    RawRecord("meter", f"{m['ASSETNUM']}.{m['METERNAME']}", m)
-                )
+                records.append(RawRecord("meter", f"{m['ASSETNUM']}.{m['METERNAME']}", m))
         if not wanted or "doclink" in wanted:
             for d in data.get("doclinks", []):
                 records.append(RawRecord("doclink", str(d["DOCINFOID"]), d))
@@ -248,9 +244,7 @@ class MaximoMockConnector(Connector):
             return "work_cell"
         return "area"  # default: treat unknown intermediate as an area
 
-    def _normalize_locations(
-        self, g: NormalizedGraph, company: str, rows: list[RawRecord]
-    ) -> None:
+    def _normalize_locations(self, g: NormalizedGraph, company: str, rows: list[RawRecord]) -> None:
         # sites first (so site entities exist before areas reference them)
         seen_sites: set[str] = set()
         for r in rows:
@@ -311,9 +305,7 @@ class MaximoMockConnector(Connector):
                 uns_path = uns.line_path(company, site, area or "area", name)
                 parent_key = f"area:{area}" if area else f"site:{site}"
             else:  # work_cell
-                uns_path = uns.work_cell_path(
-                    company, site, area or "area", line or "line", name
-                )
+                uns_path = uns.work_cell_path(company, site, area or "area", line or "line", name)
                 parent_key = f"line:{line}" if line else f"site:{site}"
 
             entity_type = {"area": "area", "line": "line", "work_cell": "cell"}[level]
@@ -334,7 +326,9 @@ class MaximoMockConnector(Connector):
                     target_key=parent_key,
                     relationship_type="LOCATED_IN",
                     confidence=0.9,
-                    evidence=[{"kind": "maximo_location", "ref": name, "detail": loc.get("PARENT")}],
+                    evidence=[
+                        {"kind": "maximo_location", "ref": name, "detail": loc.get("PARENT")}
+                    ],
                 )
             )
 
@@ -380,9 +374,7 @@ class MaximoMockConnector(Connector):
             site = a["SITEID"]
             loc_name = a.get("LOCATION")
             area, line, cell = (
-                self._location_isa95_chain(loc_name, loc_rows)
-                if loc_name
-                else (None, None, None)
+                self._location_isa95_chain(loc_name, loc_rows) if loc_name else (None, None, None)
             )
             eq_path = uns.assigned_equipment_path(
                 company, site, area or "unassigned", a["ASSETNUM"], line=line, work_cell=cell
@@ -409,7 +401,9 @@ class MaximoMockConnector(Connector):
                         target_key=ent.key,
                         relationship_type="HAS_COMPONENT",  # parent→child canonical
                         confidence=0.95,
-                        evidence=[{"kind": "maximo_parent", "ref": a["ASSETNUM"], "detail": parent}],
+                        evidence=[
+                            {"kind": "maximo_parent", "ref": a["ASSETNUM"], "detail": parent}
+                        ],
                     )
                 )
 
@@ -447,7 +441,11 @@ class MaximoMockConnector(Connector):
                         f"Maximo custom field MIRA_UNS_PATH='{stored}' differs from "
                         f"the connector-generated path '{uns_path}'. Confirm which is correct."
                     ),
-                    extracted_data={"assetnum": a["ASSETNUM"], "stored": stored, "generated": uns_path},
+                    extracted_data={
+                        "assetnum": a["ASSETNUM"],
+                        "stored": stored,
+                        "generated": uns_path,
+                    },
                     confidence=0.5,
                     proposed_by=f"import:{self.name}",
                     source_kind="manual_entry",
@@ -619,7 +617,10 @@ class MaximoMockConnector(Connector):
                     raw=mat,
                     uns_path=None,
                     confidence=0.85,
-                    properties={"description": mat.get("DESCRIPTION"), "manufacturer_part_number": mat["ITEMNUM"]},
+                    properties={
+                        "description": mat.get("DESCRIPTION"),
+                        "manufacturer_part_number": mat["ITEMNUM"],
+                    },
                 )
                 g.add_relationship(
                     CanonicalRelationship(
@@ -716,7 +717,9 @@ class MaximoMockConnector(Connector):
             anchor = g.get(self._anchor_key(g, assetnum)) if assetnum else None
             subfolder = "schematics" if is_wiring else "manuals"
             uns_path = (
-                uns.equipment_subnode_path(anchor.uns_path, "documentation", subfolder, d["DOCUMENT"])
+                uns.equipment_subnode_path(
+                    anchor.uns_path, "documentation", subfolder, d["DOCUMENT"]
+                )
                 if anchor and anchor.uns_path
                 else None
             )
@@ -742,7 +745,13 @@ class MaximoMockConnector(Connector):
                         target_key=ent.key,
                         relationship_type="HAS_DOCUMENT",
                         confidence=0.85,
-                        evidence=[{"kind": "maximo_doclink", "ref": str(d["DOCINFOID"]), "detail": assetnum}],
+                        evidence=[
+                            {
+                                "kind": "maximo_doclink",
+                                "ref": str(d["DOCINFOID"]),
+                                "detail": assetnum,
+                            }
+                        ],
                     )
                 )
 
@@ -756,11 +765,17 @@ class MaximoMockConnector(Connector):
             if ent.approval_state != "proposed":
                 report.add("error", "auto_verified", f"{ent.key} is {ent.approval_state}", ent.key)
             if not ent.source_payload:
-                report.add("error", "missing_source_payload", f"{ent.key} lost its raw record", ent.key)
+                report.add(
+                    "error", "missing_source_payload", f"{ent.key} lost its raw record", ent.key
+                )
         keys = set(graph.entities.keys())
         for rel in graph.relationships:
             if rel.approval_state != "proposed":
-                report.add("error", "auto_verified_edge", f"{rel.relationship_type} {rel.source_key}->{rel.target_key}")
+                report.add(
+                    "error",
+                    "auto_verified_edge",
+                    f"{rel.relationship_type} {rel.source_key}->{rel.target_key}",
+                )
             for endpoint in (rel.source_key, rel.target_key):
                 if endpoint not in keys:
                     report.add(
@@ -795,17 +810,37 @@ class MaximoMockConnector(Connector):
             supported=True,
             written=written,
             payloads=[payload],
-            note="pushed to Maximo" if written else "read_only/dry_run — payload built but NOT pushed",
+            note="pushed to Maximo"
+            if written
+            else "read_only/dry_run — payload built but NOT pushed",
         )
 
     # ── config ──────────────────────────────────────────────────────
 
     def get_config_schema(self) -> dict[str, Any]:
         return {
-            "base_url": {"type": "string", "required": True, "description": "Maximo Manage REST base, e.g. https://maximo.example.com/maximo"},
-            "api_key": {"type": "string", "required": True, "secret": True, "description": "maxauth/apikey (Doppler-managed; never in config)"},
+            "base_url": {
+                "type": "string",
+                "required": True,
+                "description": "Maximo Manage REST base, e.g. https://maximo.example.com/maximo",
+            },
+            "api_key": {
+                "type": "string",
+                "required": True,
+                "secret": True,
+                "description": "maxauth/apikey (Doppler-managed; never in config)",
+            },
             "orgid": {"type": "string", "required": False, "description": "Org filter (ORGID)"},
             "site": {"type": "string", "required": False, "description": "SITEID filter"},
-            "object_types": {"type": "array", "required": False, "description": "Subset to import", "default": []},
-            "fixture_path": {"type": "string", "required": False, "description": "Mock only: path to fixture JSON"},
+            "object_types": {
+                "type": "array",
+                "required": False,
+                "description": "Subset to import",
+                "default": [],
+            },
+            "fixture_path": {
+                "type": "string",
+                "required": False,
+                "description": "Mock only: path to fixture JSON",
+            },
         }

--- a/mira-connectors/cmms/maximo_mock.py
+++ b/mira-connectors/cmms/maximo_mock.py
@@ -1,0 +1,811 @@
+"""IBM Maximo EAM mock connector.
+
+Maps a realistic IBM Maximo asset/work-order/PM export into MIRA's canonical
+asset graph. Uses real Maximo field names (``ASSETNUM``, ``SITEID``,
+``LOCATION``, ``PARENT``, ``WONUM``, ``FAILURECODE`` …) and the native Maximo
+org hierarchy ``ORGID > SITEID > LOCATION``.
+
+Why a mock: the live path would hit the Maximo Manage REST API
+(``oslc/os/mxapiasset`` etc.) with OAuth/apikey auth. The mock reads the same
+*shape* from ``fixtures/maximo_demo_plant.json`` so the normalize / validate /
+proposal logic is exercised end-to-end with zero credentials.
+
+Mapping summary (see ``docs/mira/connector-framework.md``):
+
+* ORGID → ``company`` segment, SITEID → ``site`` entity.
+* Location chain ``PLANT-A → AREA-1 → LINE-1 → CELL-1`` → ISA-95
+  ``area / line / work_cell`` by name prefix. **PLANT-\\* has no ISA-95 slot**
+  (4 Maximo levels vs 3 ISA-95) → that's a genuine ambiguity, emitted as a
+  ``uns_confirmation`` proposal rather than silently forced.
+* Top-level asset (``PARENT`` null) → ``asset``; child asset → ``component``.
+* Failure tree ``FAILURECODE→PROBLEMCODE→CAUSECODE→REMEDYCODE`` →
+  ``fault_code / failure_mode / root_cause / remedy`` entities + edges.
+* Work order → ``work_order`` entity; parts used → ``USES_PART``.
+* PM → ``pm_task``; meter → ``signal``; doclink → ``document``/``wiring_diagram``.
+* Every original field is preserved in ``source_payload`` + a ``SourceObject``;
+  the two ``MIRA_*`` custom fields demonstrate a MIRA-written round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from base import Capability, Connector, ExportResult, RawRecord
+from canonical import (
+    CanonicalEntity,
+    CanonicalRelationship,
+    NormalizedGraph,
+    Proposal,
+    SourceObject,
+    ValidationReport,
+)
+from uns_bridge import uns
+
+logger = logging.getLogger("mira-connectors.maximo")
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "maximo_demo_plant.json"
+
+# Local hint list for tagging proposal risk. The AUTHORITATIVE safety-keyword
+# set is mira-bots/shared/guardrails.py SAFETY_KEYWORDS — importing it would
+# drag the engine in, and this is only used to set ai_suggestions.risk_level on
+# import proposals, not to drive a user-facing STOP. Keep in spirit with that.
+_SAFETY_HINTS = ("e-stop", "estop", "e stop", "lockout", "loto", "arc flash", "confined space")
+
+
+def _is_safety(*texts: Optional[str]) -> bool:
+    blob = " ".join(t for t in texts if t).lower()
+    return any(h in blob for h in _SAFETY_HINTS)
+
+
+class MaximoMockConnector(Connector):
+    name = "maximo_mock"
+    system_kind = "maximo"
+    connector_version = "0.1.0"
+
+    def __init__(
+        self,
+        fixture_path: Optional[Path] = None,
+        dry_run: bool = True,
+        read_only: bool = True,
+    ) -> None:
+        super().__init__(dry_run=dry_run, read_only=read_only)
+        self._fixture_path = Path(fixture_path) if fixture_path else _FIXTURE
+        self._data: dict[str, Any] = {}
+
+    def _load(self) -> dict[str, Any]:
+        if not self._data:
+            self._data = json.loads(self._fixture_path.read_text())
+        return self._data
+
+    # ── discover ────────────────────────────────────────────────────
+
+    async def discover(self) -> Capability:
+        data = self._load()
+        schema: dict[str, list[str]] = {}
+        for object_type, key in (
+            ("asset", "assets"),
+            ("location", "locations"),
+            ("workorder", "workorders"),
+            ("pm", "pmschedules"),
+            ("meter", "meters"),
+            ("doclink", "doclinks"),
+            ("site", "sites"),
+        ):
+            rows = data.get(key, [])
+            if rows:
+                schema[object_type] = sorted({k for r in rows for k in r.keys()})
+        return Capability(
+            system_kind=self.system_kind,
+            display_name="IBM Maximo EAM (mock)",
+            object_types=list(schema.keys()) + ["failurecode"],
+            supports_export=True,  # work orders + asset custom fields are writable
+            read_only=self.read_only,
+            schema=schema,
+            notes="Native hierarchy ORGID > SITEID > LOCATION. Custom fields "
+            "(MIRA_UNS_PATH, MIRA_CONFIDENCE) round-trip via export_enriched.",
+        )
+
+    # ── import ──────────────────────────────────────────────────────
+
+    async def import_records(
+        self, config: Optional[dict[str, Any]] = None
+    ) -> list[RawRecord]:
+        """Read-only pull. ``config`` may carry ``site`` (SITEID filter) and
+        ``object_types`` (subset). Importing never mutates Maximo."""
+        config = config or {}
+        site_filter = config.get("site")
+        wanted = set(config.get("object_types") or [])
+        data = self._load()
+
+        records: list[RawRecord] = []
+
+        def emit(object_type: str, key_field: str, rows: list[dict]) -> None:
+            if wanted and object_type not in wanted:
+                return
+            for row in rows:
+                if site_filter and row.get("SITEID") not in (site_filter, None):
+                    continue
+                records.append(
+                    RawRecord(
+                        object_type=object_type,
+                        external_object_id=str(row.get(key_field)),
+                        payload=row,
+                    )
+                )
+
+        emit("site", "SITEID", data.get("sites", []))
+        emit("location", "LOCATION", data.get("locations", []))
+        emit("asset", "ASSETNUM", data.get("assets", []))
+        emit("workorder", "WONUM", data.get("workorders", []))
+        emit("pm", "PMNUM", data.get("pmschedules", []))
+        # meters/doclinks have no single natural id → synthesize a stable one
+        if not wanted or "meter" in wanted:
+            for m in data.get("meters", []):
+                records.append(
+                    RawRecord("meter", f"{m['ASSETNUM']}.{m['METERNAME']}", m)
+                )
+        if not wanted or "doclink" in wanted:
+            for d in data.get("doclinks", []):
+                records.append(RawRecord("doclink", str(d["DOCINFOID"]), d))
+        if not wanted or "failurecode" in wanted:
+            for fc in data.get("failurecodes", []):
+                records.append(RawRecord("failurecode", fc["FAILURECODE"], fc))
+        return records
+
+    # ── normalize ───────────────────────────────────────────────────
+
+    def normalize(self, raw_records: list[RawRecord]) -> NormalizedGraph:
+        g = NormalizedGraph()
+        by_type: dict[str, list[RawRecord]] = {}
+        for r in raw_records:
+            by_type.setdefault(r.object_type, []).append(r)
+
+        data = self._load()
+        company = uns.slug(self._org_id(data))
+        loc_index = {r.payload["LOCATION"]: r.payload for r in by_type.get("location", [])}
+
+        self._normalize_locations(g, company, by_type.get("location", []))
+        self._normalize_assets(g, company, by_type.get("asset", []), loc_index)
+        self._normalize_failure_catalog(g, by_type.get("failurecode", []))
+        self._normalize_workorders(g, by_type.get("workorder", []))
+        self._normalize_pms(g, by_type.get("pm", []))
+        self._normalize_meters(g, by_type.get("meter", []))
+        self._normalize_doclinks(g, by_type.get("doclink", []))
+        return g
+
+    # -- helpers --
+
+    @staticmethod
+    def _org_id(data: dict[str, Any]) -> str:
+        orgs = data.get("orgs") or []
+        return orgs[0]["ORGID"] if orgs else "acme"
+
+    def _emit_entity(
+        self,
+        g: NormalizedGraph,
+        *,
+        entity_type: str,
+        name: str,
+        object_type: str,
+        external_id: str,
+        raw: dict[str, Any],
+        uns_path: Optional[str],
+        confidence: float,
+        properties: Optional[dict[str, Any]] = None,
+    ) -> CanonicalEntity:
+        """Build a canonical entity + its preserved SourceObject and link them.
+
+        ``source_payload`` is the COMPLETE original record (requirement 4)."""
+        entity = CanonicalEntity(
+            entity_type=entity_type,
+            name=name,
+            uns_path=uns_path,
+            properties=properties or {},
+            confidence=confidence,
+            source_system=self.system_kind,
+            object_type=object_type,
+            external_object_id=external_id,
+            source_payload=dict(raw),  # every field, unmodified
+        )
+        entity = g.add_entity(entity)
+        g.add_source_object(
+            SourceObject(
+                system_kind=self.system_kind,
+                object_type=object_type,
+                external_object_id=external_id,
+                raw_payload=dict(raw),
+                connector_version=self.connector_version,
+                mapping_status="mapped",
+                mapped_entity_key=entity.key,
+            )
+        )
+        return entity
+
+    @staticmethod
+    def _anchor_key(g: NormalizedGraph, assetnum: str) -> str:
+        """An ASSETNUM may have normalized to either an ``asset`` (top-level) or
+        a ``component`` (has PARENT). Return whichever key exists, defaulting to
+        ``asset:`` so a genuinely-missing endpoint surfaces as an orphan warning."""
+        if g.get(f"component:{assetnum}"):
+            return f"component:{assetnum}"
+        return f"asset:{assetnum}"
+
+    @staticmethod
+    def _isa95_level(location_name: str) -> str:
+        """Infer the ISA-95 level of a Maximo location from its name prefix.
+        PLANT-* has no slot below ``site`` → 'plant' (the flagged case)."""
+        up = location_name.upper()
+        if up.startswith("PLANT"):
+            return "plant"
+        if up.startswith("AREA"):
+            return "area"
+        if up.startswith("LINE"):
+            return "line"
+        if up.startswith("CELL") or up.startswith("WORKCELL"):
+            return "work_cell"
+        return "area"  # default: treat unknown intermediate as an area
+
+    def _normalize_locations(
+        self, g: NormalizedGraph, company: str, rows: list[RawRecord]
+    ) -> None:
+        # sites first (so site entities exist before areas reference them)
+        seen_sites: set[str] = set()
+        for r in rows:
+            loc = r.payload
+            site = loc["SITEID"]
+            if site not in seen_sites:
+                seen_sites.add(site)
+                self._emit_entity(
+                    g,
+                    entity_type="site",
+                    name=site,
+                    object_type="site",
+                    external_id=site,
+                    raw={"SITEID": site, "ORGID": loc.get("ORGID")},
+                    uns_path=uns.site_path(company, site),
+                    confidence=0.95,
+                )
+
+        for r in rows:
+            loc = r.payload
+            site = loc["SITEID"]
+            name = loc["LOCATION"]
+            level = self._isa95_level(name)
+            if level == "plant":
+                # 4-vs-3 depth mismatch: no ISA-95 slot below site. Don't force
+                # it — fold into site and ask a human (uns_confirmation).
+                g.add_proposal(
+                    Proposal(
+                        suggestion_type="uns_confirmation",
+                        title=f"Maximo location {name} has no ISA-95 slot",
+                        body=(
+                            f"Maximo location hierarchy is 4 levels deep "
+                            f"(PLANT→AREA→LINE→CELL) but ISA-95 below a site is "
+                            f"area→line→work_cell (3). '{name}' (TYPE="
+                            f"{loc.get('TYPE')}) was folded into site '{site}'. "
+                            f"Confirm or remap."
+                        ),
+                        extracted_data={
+                            "location": name,
+                            "site": site,
+                            "chosen_mapping": "fold_into_site",
+                            "candidate_paths": [uns.site_path(company, site)],
+                            "lochierarchy": loc.get("LOCHIERARCHY"),
+                        },
+                        confidence=0.6,
+                        proposed_by=f"import:{self.name}",
+                        source_kind="manual_entry",
+                    )
+                )
+                continue
+
+            # Build the area/line/work_cell path by walking up to find ancestors.
+            area, line, _cell = self._location_isa95_chain(name, rows)
+            if level == "area":
+                uns_path = uns.area_path(company, site, name)
+                parent_key = f"site:{site}"
+            elif level == "line":
+                uns_path = uns.line_path(company, site, area or "area", name)
+                parent_key = f"area:{area}" if area else f"site:{site}"
+            else:  # work_cell
+                uns_path = uns.work_cell_path(
+                    company, site, area or "area", line or "line", name
+                )
+                parent_key = f"line:{line}" if line else f"site:{site}"
+
+            entity_type = {"area": "area", "line": "line", "work_cell": "cell"}[level]
+            ent = self._emit_entity(
+                g,
+                entity_type=entity_type,
+                name=name,
+                object_type="location",
+                external_id=name,
+                raw=loc,
+                uns_path=uns_path,
+                confidence=0.9,
+            )
+            # child LOCATED_IN parent (is_located_at) — store child→parent.
+            g.add_relationship(
+                CanonicalRelationship(
+                    source_key=ent.key,
+                    target_key=parent_key,
+                    relationship_type="LOCATED_IN",
+                    confidence=0.9,
+                    evidence=[{"kind": "maximo_location", "ref": name, "detail": loc.get("PARENT")}],
+                )
+            )
+
+    def _location_isa95_chain(
+        self,
+        location_name: str,
+        rows: list[RawRecord],
+    ) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """Walk PARENT links to find the AREA/LINE/CELL names at/above a location."""
+        index = {r.payload["LOCATION"]: r.payload for r in rows}
+        area = line = cell = None
+        cur: Optional[str] = location_name
+        guard = 0
+        while cur and guard < 12:
+            guard += 1
+            loc = index.get(cur)
+            if not loc:
+                break
+            lvl = self._isa95_level(cur)
+            if lvl == "area":
+                area = cur
+            elif lvl == "line":
+                line = cur
+            elif lvl == "work_cell":
+                cell = cur
+            cur = loc.get("PARENT")
+        return area, line, cell
+
+    def _normalize_assets(
+        self,
+        g: NormalizedGraph,
+        company: str,
+        rows: list[RawRecord],
+        loc_index: dict[str, dict],
+    ) -> None:
+        loc_rows = [RawRecord("location", k, v) for k, v in loc_index.items()]
+        # First pass: top-level assets (PARENT null) → equipment nodes.
+        eq_path_by_assetnum: dict[str, str] = {}
+        for r in rows:
+            a = r.payload
+            if a.get("PARENT"):
+                continue
+            site = a["SITEID"]
+            loc_name = a.get("LOCATION")
+            area, line, cell = (
+                self._location_isa95_chain(loc_name, loc_rows)
+                if loc_name
+                else (None, None, None)
+            )
+            eq_path = uns.assigned_equipment_path(
+                company, site, area or "unassigned", a["ASSETNUM"], line=line, work_cell=cell
+            )
+            eq_path_by_assetnum[a["ASSETNUM"]] = eq_path
+            self._emit_asset(g, a, "asset", eq_path)
+
+        # Second pass: child assets → component nodes under their parent.
+        for r in rows:
+            a = r.payload
+            parent = a.get("PARENT")
+            if not parent:
+                continue
+            parent_path = eq_path_by_assetnum.get(parent)
+            if parent_path:
+                uns_path = uns.equipment_subnode_path(parent_path, "component", a["ASSETNUM"])
+            else:
+                uns_path = None  # orphan — validate() will flag it
+            ent = self._emit_asset(g, a, "component", uns_path)
+            if parent_path:
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=f"asset:{parent}",
+                        target_key=ent.key,
+                        relationship_type="HAS_COMPONENT",  # parent→child canonical
+                        confidence=0.95,
+                        evidence=[{"kind": "maximo_parent", "ref": a["ASSETNUM"], "detail": parent}],
+                    )
+                )
+
+    def _emit_asset(
+        self, g: NormalizedGraph, a: dict, entity_type: str, uns_path: Optional[str]
+    ) -> CanonicalEntity:
+        props = {
+            "description": a.get("DESCRIPTION"),
+            "manufacturer": a.get("MANUFACTURER"),
+            "serial": a.get("SERIALNUM"),
+            "status": a.get("STATUS"),
+            "asset_type": a.get("ASSETTYPE"),
+            "location": a.get("LOCATION"),
+        }
+        ent = self._emit_entity(
+            g,
+            entity_type=entity_type,
+            name=a["ASSETNUM"],
+            object_type="asset",
+            external_id=a["ASSETNUM"],
+            raw=a,
+            uns_path=uns_path,
+            confidence=0.9,
+            properties=props,
+        )
+        # Custom-field round-trip check: if Maximo already carries a
+        # MIRA_UNS_PATH and it disagrees with what we'd generate, flag drift.
+        stored = a.get("MIRA_UNS_PATH")
+        if stored and uns_path and stored != uns_path:
+            g.add_proposal(
+                Proposal(
+                    suggestion_type="uns_confirmation",
+                    title=f"UNS path drift on {a['ASSETNUM']}",
+                    body=(
+                        f"Maximo custom field MIRA_UNS_PATH='{stored}' differs from "
+                        f"the connector-generated path '{uns_path}'. Confirm which is correct."
+                    ),
+                    extracted_data={"assetnum": a["ASSETNUM"], "stored": stored, "generated": uns_path},
+                    confidence=0.5,
+                    proposed_by=f"import:{self.name}",
+                    source_kind="manual_entry",
+                )
+            )
+        return ent
+
+    def _normalize_failure_catalog(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
+        for r in rows:
+            fc = r.payload
+            code = fc["FAILURECODE"]
+            fault = self._emit_entity(
+                g,
+                entity_type="fault_code",
+                name=code,
+                object_type="failurecode",
+                external_id=code,
+                raw=fc,
+                uns_path=uns.fault_code_path(None, code),
+                confidence=0.85,
+                properties={"description": fc.get("DESCRIPTION")},
+            )
+            for problem in fc.get("children", []):
+                pm = self._emit_entity(
+                    g,
+                    entity_type="failure_mode",
+                    name=problem["PROBLEMCODE"],
+                    object_type="failurecode",
+                    external_id=f"{code}.{problem['PROBLEMCODE']}",
+                    raw=problem,
+                    uns_path=None,  # catalog concept; site-binding comes from work orders
+                    confidence=0.8,
+                    properties={"description": problem.get("DESCRIPTION"), "failure_class": code},
+                )
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=fault.key,
+                        target_key=pm.key,
+                        relationship_type="HAS_FAILURE_MODE",
+                        confidence=0.8,
+                    )
+                )
+                for cause in problem.get("children", []):
+                    rc = self._emit_entity(
+                        g,
+                        entity_type="root_cause",
+                        name=cause["CAUSECODE"],
+                        object_type="failurecode",
+                        external_id=f"{code}.{problem['PROBLEMCODE']}.{cause['CAUSECODE']}",
+                        raw=cause,
+                        uns_path=None,
+                        confidence=0.78,
+                        properties={"description": cause.get("DESCRIPTION")},
+                    )
+                    # cause → problem  (caused_by → CAUSES, cause is the source)
+                    g.add_relationship(
+                        CanonicalRelationship(
+                            source_key=rc.key,
+                            target_key=pm.key,
+                            relationship_type="CAUSES",
+                            confidence=0.78,
+                        )
+                    )
+                    safety = _is_safety(cause.get("DESCRIPTION"), problem.get("DESCRIPTION"))
+                    if safety:
+                        g.add_proposal(
+                            Proposal(
+                                suggestion_type="kg_entity",
+                                title=f"Safety review: failure path {problem['PROBLEMCODE']}/{cause['CAUSECODE']}",
+                                body=(
+                                    "This Maximo failure path references a safety system "
+                                    f"({cause.get('DESCRIPTION')}). Review before MIRA surfaces "
+                                    "remediation steps to a technician."
+                                ),
+                                extracted_data={"failure_class": code, "cause": cause["CAUSECODE"]},
+                                confidence=0.7,
+                                risk_level="safety_critical",
+                                proposed_by=f"import:{self.name}",
+                                source_kind="manual_entry",
+                            )
+                        )
+                    for remedy in cause.get("children", []):
+                        rm = self._emit_entity(
+                            g,
+                            entity_type="remedy",
+                            name=remedy["REMEDYCODE"],
+                            object_type="failurecode",
+                            external_id=(
+                                f"{code}.{problem['PROBLEMCODE']}."
+                                f"{cause['CAUSECODE']}.{remedy['REMEDYCODE']}"
+                            ),
+                            raw=remedy,
+                            uns_path=None,
+                            confidence=0.78,
+                            properties={"description": remedy.get("DESCRIPTION")},
+                        )
+                        # problem → remedy  (fixed_by → RESOLVED_BY)
+                        g.add_relationship(
+                            CanonicalRelationship(
+                                source_key=pm.key,
+                                target_key=rm.key,
+                                relationship_type="RESOLVED_BY",
+                                confidence=0.75,
+                            )
+                        )
+
+    def _normalize_workorders(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
+        for r in rows:
+            wo = r.payload
+            wonum = wo["WONUM"]
+            ent = self._emit_entity(
+                g,
+                entity_type="work_order",
+                name=wonum,
+                object_type="work_order",
+                external_id=wonum,
+                raw=wo,
+                uns_path=uns.work_order_path(wonum),
+                confidence=0.9,
+                properties={
+                    "description": wo.get("DESCRIPTION"),
+                    "status": wo.get("STATUS"),
+                    "worktype": wo.get("WORKTYPE"),
+                    "actlabhrs": wo.get("ACTLABHRS"),
+                    "reportdate": wo.get("REPORTDATE"),
+                },
+            )
+            assetnum = wo.get("ASSETNUM")
+            if assetnum:
+                anchor_key = self._anchor_key(g, assetnum)
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=anchor_key,
+                        target_key=ent.key,
+                        relationship_type="HAS_WORK_ORDER",  # asset→wo
+                        confidence=0.95,
+                        evidence=[{"kind": "maximo_wo", "ref": wonum, "detail": assetnum}],
+                    )
+                )
+                # Bind the generic failure mode to this asset, with the WO as evidence.
+                if wo.get("PROBLEMCODE"):
+                    g.add_relationship(
+                        CanonicalRelationship(
+                            source_key=anchor_key,
+                            target_key=f"failure_mode:{wo['PROBLEMCODE']}",
+                            relationship_type="HAS_FAILURE_MODE",
+                            confidence=0.6,  # inferred from history, not asserted
+                            evidence=[{"kind": "work_order", "ref": wonum}],
+                        )
+                    )
+                if wo.get("REMEDYCODE"):
+                    g.add_relationship(
+                        CanonicalRelationship(
+                            source_key=ent.key,
+                            target_key=f"remedy:{wo['REMEDYCODE']}",
+                            relationship_type="RESOLVED_BY",
+                            confidence=0.7,
+                            evidence=[{"kind": "work_order", "ref": wonum}],
+                        )
+                    )
+            # parts used → part entities + USES_PART (consumption, not containment)
+            for mat in wo.get("matusetrans", []):
+                part = self._emit_entity(
+                    g,
+                    entity_type="part",
+                    name=mat["ITEMNUM"],
+                    object_type="part",
+                    external_id=mat["ITEMNUM"],
+                    raw=mat,
+                    uns_path=None,
+                    confidence=0.85,
+                    properties={"description": mat.get("DESCRIPTION"), "manufacturer_part_number": mat["ITEMNUM"]},
+                )
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=ent.key,
+                        target_key=part.key,
+                        relationship_type="USES_PART",  # WO consumes a spare
+                        confidence=0.85,
+                        properties={"qty": mat.get("QTY")},
+                        evidence=[{"kind": "matusetrans", "ref": wonum}],
+                    )
+                )
+
+    def _normalize_pms(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
+        for r in rows:
+            pm = r.payload
+            pmnum = pm["PMNUM"]
+            assetnum = pm.get("ASSETNUM")
+            uns_path = None
+            anchor = g.get(self._anchor_key(g, assetnum)) if assetnum else None
+            if anchor and anchor.uns_path:
+                uns_path = uns.equipment_subnode_path(
+                    anchor.uns_path, "maintenance", "pm_schedule", pmnum
+                )
+            ent = self._emit_entity(
+                g,
+                entity_type="pm_task",
+                name=pmnum,
+                object_type="pm",
+                external_id=pmnum,
+                raw=pm,
+                uns_path=uns_path,
+                confidence=0.88,
+                properties={
+                    "description": pm.get("DESCRIPTION"),
+                    "frequency": pm.get("FREQUENCY"),
+                    "frequnit": pm.get("FREQUNIT"),
+                },
+            )
+            if assetnum:
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=self._anchor_key(g, assetnum),
+                        target_key=ent.key,
+                        relationship_type="HAS_PM_TASK",
+                        confidence=0.9,
+                        evidence=[{"kind": "maximo_pm", "ref": pmnum, "detail": assetnum}],
+                    )
+                )
+
+    def _normalize_meters(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
+        for r in rows:
+            m = r.payload
+            assetnum = m["ASSETNUM"]
+            metername = m["METERNAME"]
+            anchor_key = self._anchor_key(g, assetnum)
+            anchor = g.get(anchor_key)
+            uns_path = (
+                uns.equipment_subnode_path(anchor.uns_path, "datapoint", metername)
+                if anchor and anchor.uns_path
+                else None
+            )
+            ent = self._emit_entity(
+                g,
+                entity_type="signal",
+                name=f"{assetnum}.{metername}",
+                object_type="meter",
+                external_id=f"{assetnum}.{metername}",
+                raw=m,
+                uns_path=uns_path,
+                confidence=0.82,
+                properties={
+                    "metername": metername,
+                    "uom": m.get("UOM"),
+                    "last_reading": m.get("LASTREADING"),
+                    "measure_date": m.get("MEASUREDATE"),
+                },
+            )
+            g.add_relationship(
+                CanonicalRelationship(
+                    source_key=anchor_key,
+                    target_key=ent.key,
+                    relationship_type="HAS_SIGNAL",
+                    confidence=0.82,
+                    evidence=[{"kind": "maximo_meter", "ref": metername, "detail": assetnum}],
+                )
+            )
+
+    def _normalize_doclinks(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
+        for r in rows:
+            d = r.payload
+            assetnum = d.get("ASSETNUM")
+            is_wiring = (d.get("ADDINFO") or "").upper() == "WIRING"
+            entity_type = "wiring_diagram" if is_wiring else "document"
+            anchor = g.get(self._anchor_key(g, assetnum)) if assetnum else None
+            subfolder = "schematics" if is_wiring else "manuals"
+            uns_path = (
+                uns.equipment_subnode_path(anchor.uns_path, "documentation", subfolder, d["DOCUMENT"])
+                if anchor and anchor.uns_path
+                else None
+            )
+            ent = self._emit_entity(
+                g,
+                entity_type=entity_type,
+                name=str(d["DOCINFOID"]),
+                object_type="doclink",
+                external_id=str(d["DOCINFOID"]),
+                raw=d,
+                uns_path=uns_path,
+                confidence=0.85,
+                properties={
+                    "document": d.get("DOCUMENT"),
+                    "description": d.get("DESCRIPTION"),
+                    "urlname": d.get("URLNAME"),
+                },
+            )
+            if assetnum:
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=self._anchor_key(g, assetnum),
+                        target_key=ent.key,
+                        relationship_type="HAS_DOCUMENT",
+                        confidence=0.85,
+                        evidence=[{"kind": "maximo_doclink", "ref": str(d["DOCINFOID"]), "detail": assetnum}],
+                    )
+                )
+
+    # ── validate ────────────────────────────────────────────────────
+
+    def validate(self, graph: NormalizedGraph) -> ValidationReport:
+        report = ValidationReport()
+        for ent in graph.entities.values():
+            if ent.uns_path and not uns.is_valid_path(ent.uns_path):
+                report.add("error", "invalid_uns_path", f"{ent.key}: {ent.uns_path!r}", ent.key)
+            if ent.approval_state != "proposed":
+                report.add("error", "auto_verified", f"{ent.key} is {ent.approval_state}", ent.key)
+            if not ent.source_payload:
+                report.add("error", "missing_source_payload", f"{ent.key} lost its raw record", ent.key)
+        keys = set(graph.entities.keys())
+        for rel in graph.relationships:
+            if rel.approval_state != "proposed":
+                report.add("error", "auto_verified_edge", f"{rel.relationship_type} {rel.source_key}->{rel.target_key}")
+            for endpoint in (rel.source_key, rel.target_key):
+                if endpoint not in keys:
+                    report.add(
+                        "warning",
+                        "orphan_relationship",
+                        f"{rel.relationship_type}: endpoint {endpoint} not in graph",
+                    )
+        return report
+
+    # ── export ──────────────────────────────────────────────────────
+
+    async def export_enriched(self, graph_context: dict[str, Any]) -> ExportResult:
+        """Build a Maximo-shaped enrichment payload for a work order: MIRA's
+        diagnosis + the generated UNS path written back into the customer's own
+        custom fields (MIRA_UNS_PATH, MIRA_CONFIDENCE). Demonstrates that custom
+        fields survive the round-trip. Only pushed when this connector is live
+        (``read_only=False`` and not ``dry_run``)."""
+        wonum = graph_context.get("wonum", "WO-10231")
+        uns_path = graph_context.get("uns_path", "")
+        diagnosis = graph_context.get("diagnosis", "")
+        confidence = graph_context.get("confidence", "medium")
+        payload = {
+            "_resource": "mxapiwodetail",
+            "WONUM": wonum,
+            "DESCRIPTION_LONGDESCRIPTION": f"[MIRA] {diagnosis}",
+            "MIRA_UNS_PATH": uns_path,  # custom field — preserved/round-tripped
+            "MIRA_CONFIDENCE": confidence,
+            "WORKLOG": [{"LOGTYPE": "CLIENTNOTE", "DESCRIPTION": diagnosis}],
+        }
+        written = self._may_write_source()
+        return ExportResult(
+            supported=True,
+            written=written,
+            payloads=[payload],
+            note="pushed to Maximo" if written else "read_only/dry_run — payload built but NOT pushed",
+        )
+
+    # ── config ──────────────────────────────────────────────────────
+
+    def get_config_schema(self) -> dict[str, Any]:
+        return {
+            "base_url": {"type": "string", "required": True, "description": "Maximo Manage REST base, e.g. https://maximo.example.com/maximo"},
+            "api_key": {"type": "string", "required": True, "secret": True, "description": "maxauth/apikey (Doppler-managed; never in config)"},
+            "orgid": {"type": "string", "required": False, "description": "Org filter (ORGID)"},
+            "site": {"type": "string", "required": False, "description": "SITEID filter"},
+            "object_types": {"type": "array", "required": False, "description": "Subset to import", "default": []},
+            "fixture_path": {"type": "string", "required": False, "description": "Mock only: path to fixture JSON"},
+        }

--- a/mira-connectors/cmms/sap_mock.py
+++ b/mira-connectors/cmms/sap_mock.py
@@ -1,0 +1,376 @@
+"""SAP Plant Maintenance (PM) mock connector.
+
+Maps a lightweight SAP PM export into the MIRA canonical model using real SAP
+field names: ``TPLNR`` (functional location), ``EQUNR`` (equipment master),
+``AUFNR`` (maintenance order), ``MATNR`` (material/spare), ``PLNNR`` (task
+list). SAP's hierarchy is the functional-location tree (``TPLNR``), with ``-``
+separating structure levels and ``TPLMA`` pointing at the superior FL.
+
+Mapping:
+
+* Functional location → ``site``/``area``/``line``/``cell`` by FLTYP + depth.
+* Equipment master (``HEQUI`` null) → ``asset``; child equipment → ``component``.
+* Maintenance order → ``work_order`` + ``HAS_WORK_ORDER``.
+* Task list → ``pm_task`` + ``HAS_PM_TASK``.
+* BOM line → ``part`` + ``HAS_PART`` (containment — a BOM is what an asset is
+  *made of*, distinct from a work order's ``USES_PART`` consumption).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from base import Capability, Connector, ExportResult, RawRecord
+from canonical import (
+    CanonicalEntity,
+    CanonicalRelationship,
+    NormalizedGraph,
+    Proposal,
+    SourceObject,
+    ValidationReport,
+)
+from uns_bridge import uns
+
+logger = logging.getLogger("mira-connectors.sap")
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "sap_demo_plant.json"
+_FLTYP_LEVEL = {"PLANT": "plant", "AREA": "area", "LINE": "line", "CELL": "work_cell"}
+
+
+class SAPMockConnector(Connector):
+    name = "sap_mock"
+    system_kind = "sap"
+    connector_version = "0.1.0"
+
+    def __init__(
+        self,
+        fixture_path: Optional[Path] = None,
+        dry_run: bool = True,
+        read_only: bool = True,
+    ) -> None:
+        super().__init__(dry_run=dry_run, read_only=read_only)
+        self._fixture_path = Path(fixture_path) if fixture_path else _FIXTURE
+        self._data: dict[str, Any] = {}
+
+    def _load(self) -> dict[str, Any]:
+        if not self._data:
+            self._data = json.loads(self._fixture_path.read_text())
+        return self._data
+
+    async def discover(self) -> Capability:
+        data = self._load()
+        schema = {}
+        for ot, key in (
+            ("functional_location", "functional_locations"),
+            ("equipment", "equipment"),
+            ("maintenance_order", "maintenance_orders"),
+            ("task_list", "task_lists"),
+            ("bom", "bom"),
+        ):
+            rows = data.get(key, [])
+            if rows:
+                schema[ot] = sorted({k for r in rows for k in r.keys()})
+        return Capability(
+            system_kind=self.system_kind,
+            display_name="SAP Plant Maintenance (mock)",
+            object_types=list(schema.keys()),
+            supports_export=True,
+            read_only=self.read_only,
+            schema=schema,
+            notes="Hierarchy = functional-location TPLNR tree (TPLMA = superior FL).",
+        )
+
+    async def import_records(
+        self, config: Optional[dict[str, Any]] = None
+    ) -> list[RawRecord]:
+        data = self._load()
+        out: list[RawRecord] = []
+        for fl in data.get("functional_locations", []):
+            out.append(RawRecord("functional_location", fl["TPLNR"], fl))
+        for eq in data.get("equipment", []):
+            out.append(RawRecord("equipment", eq["EQUNR"], eq))
+        for mo in data.get("maintenance_orders", []):
+            out.append(RawRecord("maintenance_order", mo["AUFNR"], mo))
+        for tl in data.get("task_lists", []):
+            out.append(RawRecord("task_list", f"{tl['PLNNR']}.{tl['PLNAL']}", tl))
+        for b in data.get("bom", []):
+            out.append(RawRecord("bom", f"{b['EQUNR']}.{b['MATNR']}", b))
+        return out
+
+    def normalize(self, raw_records: list[RawRecord]) -> NormalizedGraph:
+        g = NormalizedGraph()
+        by_type: dict[str, list[RawRecord]] = {}
+        for r in raw_records:
+            by_type.setdefault(r.object_type, []).append(r)
+
+        fls = {r.payload["TPLNR"]: r.payload for r in by_type.get("functional_location", [])}
+        company = uns.slug(self._company(fls))
+        self._normalize_fls(g, company, by_type.get("functional_location", []), fls)
+        self._normalize_equipment(g, company, by_type.get("equipment", []), fls)
+        self._normalize_orders(g, by_type.get("maintenance_order", []))
+        self._normalize_task_lists(g, by_type.get("task_list", []))
+        self._normalize_bom(g, by_type.get("bom", []))
+        return g
+
+    @staticmethod
+    def _company(fls: dict[str, dict]) -> str:
+        # The first segment of the top functional location is the company.
+        for tplnr, fl in fls.items():
+            if fl.get("TPLMA") is None:
+                return tplnr.split("-")[0]
+        return "acme"
+
+    def _fl_chain(self, tplnr: str, fls: dict[str, dict]) -> dict[str, str]:
+        """Resolve the {site, area, line, work_cell} names above/at a FL."""
+        out: dict[str, str] = {}
+        cur: Optional[str] = tplnr
+        guard = 0
+        while cur and guard < 12:
+            guard += 1
+            fl = fls.get(cur)
+            if not fl:
+                break
+            level = _FLTYP_LEVEL.get(fl.get("FLTYP", ""))
+            if level == "plant":
+                pass  # no ISA-95 slot — folded into site
+            elif level:
+                out.setdefault(level, self._fl_label(cur))
+            cur = fl.get("TPLMA")
+        return out
+
+    @staticmethod
+    def _fl_label(tplnr: str) -> str:
+        """The instance label of a FL = its last '-'-separated segment."""
+        return tplnr.split("-")[-1]
+
+    def _normalize_fls(
+        self, g: NormalizedGraph, company: str, rows: list[RawRecord], fls: dict[str, dict]
+    ) -> None:
+        seen_site: set[str] = set()
+        for r in rows:
+            fl = r.payload
+            level = _FLTYP_LEVEL.get(fl.get("FLTYP", ""))
+            chain = self._fl_chain(fl["TPLNR"], fls)
+            site = fl.get("STORT") or fl.get("SWERK") or "site"
+            site = uns.slug(site)
+            if site not in seen_site:
+                seen_site.add(site)
+                self._emit(
+                    g, "site", site, "functional_location", site, {"derived_from": fl["TPLNR"]},
+                    uns.site_path(company, site), 0.9,
+                )
+            if level == "plant":
+                g.add_proposal(
+                    Proposal(
+                        suggestion_type="uns_confirmation",
+                        title=f"SAP functional location {fl['TPLNR']} (PLANT) has no ISA-95 slot",
+                        body=f"PLANT-level FL '{fl['TPLNR']}' folded into site '{site}'. Confirm or remap.",
+                        extracted_data={"tplnr": fl["TPLNR"], "site": site},
+                        confidence=0.6,
+                        proposed_by=f"import:{self.name}",
+                        source_kind="manual_entry",
+                    )
+                )
+                continue
+            label = self._fl_label(fl["TPLNR"])
+            if level == "area":
+                path, parent = uns.area_path(company, site, label), f"site:{site}"
+                etype = "area"
+            elif level == "line":
+                path = uns.line_path(company, site, chain.get("area", "area"), label)
+                parent, etype = f"area:{chain.get('area')}", "line"
+            else:  # work_cell
+                path = uns.work_cell_path(
+                    company, site, chain.get("area", "area"), chain.get("line", "line"), label
+                )
+                parent, etype = f"line:{chain.get('line')}", "cell"
+            ent = self._emit(
+                g, etype, label, "functional_location", fl["TPLNR"],
+                {"description": fl.get("PLTXT"), "tplnr": fl["TPLNR"]}, path, 0.9, raw=fl,
+            )
+            g.add_relationship(
+                CanonicalRelationship(
+                    source_key=ent.key, target_key=parent, relationship_type="LOCATED_IN", confidence=0.9
+                )
+            )
+
+    def _normalize_equipment(
+        self, g: NormalizedGraph, company: str, rows: list[RawRecord], fls: dict[str, dict]
+    ) -> dict[str, str]:
+        eq_path_by_equnr: dict[str, str] = {}
+        # top-level equipment first
+        for r in rows:
+            eq = r.payload
+            if eq.get("HEQUI"):
+                continue
+            chain = self._fl_chain(eq.get("TPLNR", ""), fls)
+            site = uns.slug(fls.get(eq.get("TPLNR", ""), {}).get("STORT") or "site")
+            path = uns.assigned_equipment_path(
+                company, site, chain.get("area", "unassigned"), eq["EQUNR"],
+                line=chain.get("line"), work_cell=chain.get("work_cell"),
+            )
+            eq_path_by_equnr[eq["EQUNR"]] = path
+            self._emit_eq(g, eq, "asset", path)
+        # child equipment → components
+        for r in rows:
+            eq = r.payload
+            parent = eq.get("HEQUI")
+            if not parent:
+                continue
+            ppath = eq_path_by_equnr.get(parent)
+            path = uns.equipment_subnode_path(ppath, "component", eq["EQUNR"]) if ppath else None
+            ent = self._emit_eq(g, eq, "component", path)
+            if ppath:
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=f"asset:{parent}", target_key=ent.key,
+                        relationship_type="HAS_COMPONENT", confidence=0.95,
+                        evidence=[{"kind": "sap_hequi", "ref": eq["EQUNR"], "detail": parent}],
+                    )
+                )
+        return eq_path_by_equnr
+
+    def _emit_eq(self, g: NormalizedGraph, eq: dict, etype: str, path: Optional[str]) -> CanonicalEntity:
+        return self._emit(
+            g, etype, eq["EQUNR"], "equipment", eq["EQUNR"],
+            {
+                "description": eq.get("EQKTX"),
+                "manufacturer": eq.get("HERST"),
+                "model": eq.get("TYPBZ"),
+                "serial": eq.get("SERGE"),
+                "tplnr": eq.get("TPLNR"),
+            },
+            path, 0.9, raw=eq,
+        )
+
+    def _normalize_orders(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
+        for r in rows:
+            mo = r.payload
+            ent = self._emit(
+                g, "work_order", mo["AUFNR"], "work_order", mo["AUFNR"],
+                {"description": mo.get("KTEXT"), "order_type": mo.get("AUART"), "status": mo.get("ANLZU")},
+                uns.work_order_path(mo["AUFNR"]), 0.9, raw=mo,
+            )
+            equnr = mo.get("EQUNR")
+            if equnr:
+                src = f"component:{equnr}" if g.get(f"component:{equnr}") else f"asset:{equnr}"
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=src, target_key=ent.key, relationship_type="HAS_WORK_ORDER",
+                        confidence=0.95, evidence=[{"kind": "sap_order", "ref": mo["AUFNR"], "detail": equnr}],
+                    )
+                )
+
+    def _normalize_task_lists(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
+        for r in rows:
+            tl = r.payload
+            tlid = f"{tl['PLNNR']}.{tl['PLNAL']}"
+            equnr = tl.get("EQUNR")
+            anchor = g.get(f"component:{equnr}") or g.get(f"asset:{equnr}")
+            path = (
+                uns.equipment_subnode_path(anchor.uns_path, "maintenance", "pm_schedule", tl["PLNNR"])
+                if anchor and anchor.uns_path
+                else None
+            )
+            ent = self._emit(
+                g, "pm_task", tlid, "task_list", tlid,
+                {"description": tl.get("KTEXT"), "strategy": tl.get("STRAT")}, path, 0.88, raw=tl,
+            )
+            if equnr and anchor:
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=anchor.key, target_key=ent.key, relationship_type="HAS_PM_TASK",
+                        confidence=0.9, evidence=[{"kind": "sap_tasklist", "ref": tlid, "detail": equnr}],
+                    )
+                )
+
+    def _normalize_bom(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
+        for r in rows:
+            b = r.payload
+            part = self._emit(
+                g, "part", b["MATNR"], "bom", b["MATNR"],
+                {"description": b.get("MAKTX"), "manufacturer_part_number": b["MATNR"], "uom": b.get("MEINS")},
+                None, 0.85, raw=b,
+            )
+            equnr = b.get("EQUNR")
+            if equnr:
+                anchor = g.get(f"component:{equnr}") or g.get(f"asset:{equnr}")
+                if anchor:
+                    g.add_relationship(
+                        CanonicalRelationship(
+                            source_key=anchor.key, target_key=part.key, relationship_type="HAS_PART",
+                            confidence=0.85, properties={"qty": b.get("MENGE")},
+                            evidence=[{"kind": "sap_bom", "ref": b["MATNR"], "detail": equnr}],
+                        )
+                    )
+
+    def _emit(
+        self,
+        g: NormalizedGraph,
+        entity_type: str,
+        name: str,
+        object_type: str,
+        external_id: str,
+        properties: dict[str, Any],
+        uns_path: Optional[str],
+        confidence: float,
+        raw: Optional[dict[str, Any]] = None,
+    ) -> CanonicalEntity:
+        payload = dict(raw) if raw is not None else dict(properties)
+        ent = g.add_entity(
+            CanonicalEntity(
+                entity_type=entity_type, name=name, uns_path=uns_path, properties=properties,
+                confidence=confidence, source_system=self.system_kind, object_type=object_type,
+                external_object_id=external_id, source_payload=payload,
+            )
+        )
+        g.add_source_object(
+            SourceObject(
+                system_kind=self.system_kind, object_type=object_type, external_object_id=external_id,
+                raw_payload=payload, connector_version=self.connector_version,
+                mapping_status="mapped", mapped_entity_key=ent.key,
+            )
+        )
+        return ent
+
+    def validate(self, graph: NormalizedGraph) -> ValidationReport:
+        report = ValidationReport()
+        keys = set(graph.entities.keys())
+        for ent in graph.entities.values():
+            if ent.uns_path and not uns.is_valid_path(ent.uns_path):
+                report.add("error", "invalid_uns_path", f"{ent.key}: {ent.uns_path!r}", ent.key)
+            if ent.approval_state != "proposed":
+                report.add("error", "auto_verified", ent.key, ent.key)
+            if not ent.source_payload:
+                report.add("error", "missing_source_payload", ent.key, ent.key)
+        for rel in graph.relationships:
+            for endpoint in (rel.source_key, rel.target_key):
+                if endpoint not in keys:
+                    report.add("warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}")
+        return report
+
+    async def export_enriched(self, graph_context: dict[str, Any]) -> ExportResult:
+        aufnr = graph_context.get("aufnr", "4000123")
+        payload = {
+            "_resource": "API_MAINTENANCEORDER",
+            "AUFNR": aufnr,
+            "LTXA1": f"[MIRA] {graph_context.get('diagnosis', '')}",
+            "ZZ_MIRA_UNS_PATH": graph_context.get("uns_path", ""),  # customer Z-field
+        }
+        written = self._may_write_source()
+        return ExportResult(
+            supported=True, written=written, payloads=[payload],
+            note="pushed to SAP" if written else "read_only/dry_run — payload built but NOT pushed",
+        )
+
+    def get_config_schema(self) -> dict[str, Any]:
+        return {
+            "odata_url": {"type": "string", "required": True, "description": "S/4HANA OData base URL"},
+            "client": {"type": "string", "required": False, "default": "100", "description": "SAP client (MANDT)"},
+            "username": {"type": "string", "required": True, "description": "SAP service user"},
+            "password": {"type": "string", "required": True, "secret": True, "description": "Doppler-managed"},
+            "fixture_path": {"type": "string", "required": False, "description": "Mock only: path to fixture JSON"},
+        }

--- a/mira-connectors/cmms/sap_mock.py
+++ b/mira-connectors/cmms/sap_mock.py
@@ -83,9 +83,7 @@ class SAPMockConnector(Connector):
             notes="Hierarchy = functional-location TPLNR tree (TPLMA = superior FL).",
         )
 
-    async def import_records(
-        self, config: Optional[dict[str, Any]] = None
-    ) -> list[RawRecord]:
+    async def import_records(self, config: Optional[dict[str, Any]] = None) -> list[RawRecord]:
         data = self._load()
         out: list[RawRecord] = []
         for fl in data.get("functional_locations", []):
@@ -159,8 +157,14 @@ class SAPMockConnector(Connector):
             if site not in seen_site:
                 seen_site.add(site)
                 self._emit(
-                    g, "site", site, "functional_location", site, {"derived_from": fl["TPLNR"]},
-                    uns.site_path(company, site), 0.9,
+                    g,
+                    "site",
+                    site,
+                    "functional_location",
+                    site,
+                    {"derived_from": fl["TPLNR"]},
+                    uns.site_path(company, site),
+                    0.9,
                 )
             if level == "plant":
                 g.add_proposal(
@@ -188,12 +192,22 @@ class SAPMockConnector(Connector):
                 )
                 parent, etype = f"line:{chain.get('line')}", "cell"
             ent = self._emit(
-                g, etype, label, "functional_location", fl["TPLNR"],
-                {"description": fl.get("PLTXT"), "tplnr": fl["TPLNR"]}, path, 0.9, raw=fl,
+                g,
+                etype,
+                label,
+                "functional_location",
+                fl["TPLNR"],
+                {"description": fl.get("PLTXT"), "tplnr": fl["TPLNR"]},
+                path,
+                0.9,
+                raw=fl,
             )
             g.add_relationship(
                 CanonicalRelationship(
-                    source_key=ent.key, target_key=parent, relationship_type="LOCATED_IN", confidence=0.9
+                    source_key=ent.key,
+                    target_key=parent,
+                    relationship_type="LOCATED_IN",
+                    confidence=0.9,
                 )
             )
 
@@ -209,8 +223,12 @@ class SAPMockConnector(Connector):
             chain = self._fl_chain(eq.get("TPLNR", ""), fls)
             site = uns.slug(fls.get(eq.get("TPLNR", ""), {}).get("STORT") or "site")
             path = uns.assigned_equipment_path(
-                company, site, chain.get("area", "unassigned"), eq["EQUNR"],
-                line=chain.get("line"), work_cell=chain.get("work_cell"),
+                company,
+                site,
+                chain.get("area", "unassigned"),
+                eq["EQUNR"],
+                line=chain.get("line"),
+                work_cell=chain.get("work_cell"),
             )
             eq_path_by_equnr[eq["EQUNR"]] = path
             self._emit_eq(g, eq, "asset", path)
@@ -226,16 +244,24 @@ class SAPMockConnector(Connector):
             if ppath:
                 g.add_relationship(
                     CanonicalRelationship(
-                        source_key=f"asset:{parent}", target_key=ent.key,
-                        relationship_type="HAS_COMPONENT", confidence=0.95,
+                        source_key=f"asset:{parent}",
+                        target_key=ent.key,
+                        relationship_type="HAS_COMPONENT",
+                        confidence=0.95,
                         evidence=[{"kind": "sap_hequi", "ref": eq["EQUNR"], "detail": parent}],
                     )
                 )
         return eq_path_by_equnr
 
-    def _emit_eq(self, g: NormalizedGraph, eq: dict, etype: str, path: Optional[str]) -> CanonicalEntity:
+    def _emit_eq(
+        self, g: NormalizedGraph, eq: dict, etype: str, path: Optional[str]
+    ) -> CanonicalEntity:
         return self._emit(
-            g, etype, eq["EQUNR"], "equipment", eq["EQUNR"],
+            g,
+            etype,
+            eq["EQUNR"],
+            "equipment",
+            eq["EQUNR"],
             {
                 "description": eq.get("EQKTX"),
                 "manufacturer": eq.get("HERST"),
@@ -243,24 +269,39 @@ class SAPMockConnector(Connector):
                 "serial": eq.get("SERGE"),
                 "tplnr": eq.get("TPLNR"),
             },
-            path, 0.9, raw=eq,
+            path,
+            0.9,
+            raw=eq,
         )
 
     def _normalize_orders(self, g: NormalizedGraph, rows: list[RawRecord]) -> None:
         for r in rows:
             mo = r.payload
             ent = self._emit(
-                g, "work_order", mo["AUFNR"], "work_order", mo["AUFNR"],
-                {"description": mo.get("KTEXT"), "order_type": mo.get("AUART"), "status": mo.get("ANLZU")},
-                uns.work_order_path(mo["AUFNR"]), 0.9, raw=mo,
+                g,
+                "work_order",
+                mo["AUFNR"],
+                "work_order",
+                mo["AUFNR"],
+                {
+                    "description": mo.get("KTEXT"),
+                    "order_type": mo.get("AUART"),
+                    "status": mo.get("ANLZU"),
+                },
+                uns.work_order_path(mo["AUFNR"]),
+                0.9,
+                raw=mo,
             )
             equnr = mo.get("EQUNR")
             if equnr:
                 src = f"component:{equnr}" if g.get(f"component:{equnr}") else f"asset:{equnr}"
                 g.add_relationship(
                     CanonicalRelationship(
-                        source_key=src, target_key=ent.key, relationship_type="HAS_WORK_ORDER",
-                        confidence=0.95, evidence=[{"kind": "sap_order", "ref": mo["AUFNR"], "detail": equnr}],
+                        source_key=src,
+                        target_key=ent.key,
+                        relationship_type="HAS_WORK_ORDER",
+                        confidence=0.95,
+                        evidence=[{"kind": "sap_order", "ref": mo["AUFNR"], "detail": equnr}],
                     )
                 )
 
@@ -271,19 +312,31 @@ class SAPMockConnector(Connector):
             equnr = tl.get("EQUNR")
             anchor = g.get(f"component:{equnr}") or g.get(f"asset:{equnr}")
             path = (
-                uns.equipment_subnode_path(anchor.uns_path, "maintenance", "pm_schedule", tl["PLNNR"])
+                uns.equipment_subnode_path(
+                    anchor.uns_path, "maintenance", "pm_schedule", tl["PLNNR"]
+                )
                 if anchor and anchor.uns_path
                 else None
             )
             ent = self._emit(
-                g, "pm_task", tlid, "task_list", tlid,
-                {"description": tl.get("KTEXT"), "strategy": tl.get("STRAT")}, path, 0.88, raw=tl,
+                g,
+                "pm_task",
+                tlid,
+                "task_list",
+                tlid,
+                {"description": tl.get("KTEXT"), "strategy": tl.get("STRAT")},
+                path,
+                0.88,
+                raw=tl,
             )
             if equnr and anchor:
                 g.add_relationship(
                     CanonicalRelationship(
-                        source_key=anchor.key, target_key=ent.key, relationship_type="HAS_PM_TASK",
-                        confidence=0.9, evidence=[{"kind": "sap_tasklist", "ref": tlid, "detail": equnr}],
+                        source_key=anchor.key,
+                        target_key=ent.key,
+                        relationship_type="HAS_PM_TASK",
+                        confidence=0.9,
+                        evidence=[{"kind": "sap_tasklist", "ref": tlid, "detail": equnr}],
                     )
                 )
 
@@ -291,9 +344,19 @@ class SAPMockConnector(Connector):
         for r in rows:
             b = r.payload
             part = self._emit(
-                g, "part", b["MATNR"], "bom", b["MATNR"],
-                {"description": b.get("MAKTX"), "manufacturer_part_number": b["MATNR"], "uom": b.get("MEINS")},
-                None, 0.85, raw=b,
+                g,
+                "part",
+                b["MATNR"],
+                "bom",
+                b["MATNR"],
+                {
+                    "description": b.get("MAKTX"),
+                    "manufacturer_part_number": b["MATNR"],
+                    "uom": b.get("MEINS"),
+                },
+                None,
+                0.85,
+                raw=b,
             )
             equnr = b.get("EQUNR")
             if equnr:
@@ -301,8 +364,11 @@ class SAPMockConnector(Connector):
                 if anchor:
                     g.add_relationship(
                         CanonicalRelationship(
-                            source_key=anchor.key, target_key=part.key, relationship_type="HAS_PART",
-                            confidence=0.85, properties={"qty": b.get("MENGE")},
+                            source_key=anchor.key,
+                            target_key=part.key,
+                            relationship_type="HAS_PART",
+                            confidence=0.85,
+                            properties={"qty": b.get("MENGE")},
                             evidence=[{"kind": "sap_bom", "ref": b["MATNR"], "detail": equnr}],
                         )
                     )
@@ -322,16 +388,26 @@ class SAPMockConnector(Connector):
         payload = dict(raw) if raw is not None else dict(properties)
         ent = g.add_entity(
             CanonicalEntity(
-                entity_type=entity_type, name=name, uns_path=uns_path, properties=properties,
-                confidence=confidence, source_system=self.system_kind, object_type=object_type,
-                external_object_id=external_id, source_payload=payload,
+                entity_type=entity_type,
+                name=name,
+                uns_path=uns_path,
+                properties=properties,
+                confidence=confidence,
+                source_system=self.system_kind,
+                object_type=object_type,
+                external_object_id=external_id,
+                source_payload=payload,
             )
         )
         g.add_source_object(
             SourceObject(
-                system_kind=self.system_kind, object_type=object_type, external_object_id=external_id,
-                raw_payload=payload, connector_version=self.connector_version,
-                mapping_status="mapped", mapped_entity_key=ent.key,
+                system_kind=self.system_kind,
+                object_type=object_type,
+                external_object_id=external_id,
+                raw_payload=payload,
+                connector_version=self.connector_version,
+                mapping_status="mapped",
+                mapped_entity_key=ent.key,
             )
         )
         return ent
@@ -349,7 +425,9 @@ class SAPMockConnector(Connector):
         for rel in graph.relationships:
             for endpoint in (rel.source_key, rel.target_key):
                 if endpoint not in keys:
-                    report.add("warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}")
+                    report.add(
+                        "warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}"
+                    )
         return report
 
     async def export_enriched(self, graph_context: dict[str, Any]) -> ExportResult:
@@ -362,15 +440,35 @@ class SAPMockConnector(Connector):
         }
         written = self._may_write_source()
         return ExportResult(
-            supported=True, written=written, payloads=[payload],
+            supported=True,
+            written=written,
+            payloads=[payload],
             note="pushed to SAP" if written else "read_only/dry_run — payload built but NOT pushed",
         )
 
     def get_config_schema(self) -> dict[str, Any]:
         return {
-            "odata_url": {"type": "string", "required": True, "description": "S/4HANA OData base URL"},
-            "client": {"type": "string", "required": False, "default": "100", "description": "SAP client (MANDT)"},
+            "odata_url": {
+                "type": "string",
+                "required": True,
+                "description": "S/4HANA OData base URL",
+            },
+            "client": {
+                "type": "string",
+                "required": False,
+                "default": "100",
+                "description": "SAP client (MANDT)",
+            },
             "username": {"type": "string", "required": True, "description": "SAP service user"},
-            "password": {"type": "string", "required": True, "secret": True, "description": "Doppler-managed"},
-            "fixture_path": {"type": "string", "required": False, "description": "Mock only: path to fixture JSON"},
+            "password": {
+                "type": "string",
+                "required": True,
+                "secret": True,
+                "description": "Doppler-managed",
+            },
+            "fixture_path": {
+                "type": "string",
+                "required": False,
+                "description": "Mock only: path to fixture JSON",
+            },
         }

--- a/mira-connectors/conftest.py
+++ b/mira-connectors/conftest.py
@@ -1,0 +1,28 @@
+"""pytest configuration for the connector framework.
+
+Mirrors the per-module convention used across the repo (e.g.
+``mira-crawler/conftest.py``, ``mira-relay/tests/conftest.py``): tests are run
+from inside this module (``pytest mira-connectors/tests`` or ``cd
+mira-connectors && pytest``), and this conftest puts the two roots the imports
+need onto ``sys.path``:
+
+* ``mira-connectors/`` itself  → ``from base import ...``, ``from cmms.maximo_mock import ...``
+* ``mira-crawler/``            → ``from ingest.uns import ...`` (the UNS builders)
+
+NOTE: this module defines a ``cmms`` subpackage whose name collides with
+``mira-mcp/cmms``. Under the repo's per-module test invocation they are never on
+``sys.path`` together, so the collision is benign. Do not add ``mira-mcp`` to
+``sys.path`` in the same session.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent  # mira-connectors/
+_CRAWLER = _HERE.parent / "mira-crawler"
+
+for p in (_HERE, _CRAWLER):
+    if p.is_dir() and str(p) not in sys.path:
+        sys.path.insert(0, str(p))

--- a/mira-connectors/demo.py
+++ b/mira-connectors/demo.py
@@ -1,0 +1,166 @@
+"""End-to-end connector-framework demo.
+
+Run it::
+
+    python mira-connectors/demo.py
+    # or, from inside the module dir:
+    cd mira-connectors && python demo.py
+
+It walks the full pipeline from ``docs/mira/connector-framework.md``:
+
+1. Import IBM Maximo mock data (enterprise CMMS/EAM).
+2. Import Ignition mock tag tree (plant-floor SCADA).
+3. Normalize both into the MIRA canonical asset graph.
+4. Cross-reference: propose tag→asset links (the OT↔enterprise join).
+5. Print the proposed graph with confidence bands.
+6. Show what a technician would confirm (the proposal queue).
+7. Export an enriched Maximo work-order payload (dry-run → not pushed).
+
+Nothing here writes to a source system or to NeonDB — everything is
+``proposed`` and ``dry_run``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Bootstrap sys.path so the demo runs standalone (no install / PYTHONPATH).
+_HERE = Path(__file__).resolve().parent  # mira-connectors/
+for _p in (_HERE, _HERE.parent / "mira-crawler"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from canonical import NormalizedGraph, Proposal, confidence_band  # noqa: E402
+from cmms.maximo_mock import MaximoMockConnector  # noqa: E402
+from scada.ignition_mock import IgnitionMockConnector  # noqa: E402
+
+RULE = "─" * 72
+
+
+def _h(title: str) -> None:
+    print(f"\n{RULE}\n  {title}\n{RULE}")
+
+
+def _print_graph(name: str, g: NormalizedGraph) -> None:
+    s = g.summary()
+    print(
+        f"{name}: {s['entities']} entities · {s['relationships']} edges "
+        f"(all proposed) · {s['proposals']} proposals · {s['source_objects']} raw records preserved"
+    )
+    from collections import Counter
+
+    types = Counter(e.entity_type for e in g.entities.values())
+    print("  entity types:", ", ".join(f"{k}×{v}" for k, v in sorted(types.items())))
+    edges = Counter(r.relationship_type for r in g.relationships)
+    print("  edge types:  ", ", ".join(f"{k}×{v}" for k, v in sorted(edges.items())))
+
+
+def _print_proposals(proposals: list[Proposal]) -> None:
+    if not proposals:
+        print("  (none)")
+        return
+    for p in sorted(proposals, key=lambda x: -x.confidence):
+        flag = "  ⚠ SAFETY" if p.risk_level == "safety_critical" else ""
+        print(
+            f"  [{p.confidence:.2f} {confidence_band(p.confidence):>6}] {p.suggestion_type:16}{flag}"
+        )
+        print(f"           {p.title}")
+
+
+async def main() -> None:
+    print("MIRA connector framework — end-to-end demo")
+    print("source systems → raw import → normalize → cross-reference → propose → export")
+
+    # 1+2. Import (read-only) from both a CMMS and a SCADA source.
+    maximo = MaximoMockConnector()  # dry_run=True, read_only=True by default
+    ignition = IgnitionMockConnector()
+
+    _h("1. DISCOVER + IMPORT (read-only)")
+    mx_cap = await maximo.discover()
+    ig_cap = await ignition.discover()
+    print(f"Maximo:   {mx_cap.display_name} — object types: {mx_cap.object_types}")
+    print(f"Ignition: {ig_cap.display_name} — object types: {ig_cap.object_types}")
+    mx_raw = await maximo.import_records()
+    ig_raw = await ignition.import_records()
+    print(f"imported: {len(mx_raw)} Maximo records, {len(ig_raw)} Ignition tags")
+
+    # 3. Normalize each into the canonical model.
+    _h("2. NORMALIZE into the canonical asset graph")
+    mx_graph = maximo.normalize(mx_raw)
+    ig_graph = ignition.normalize(ig_raw)
+    _print_graph("Maximo  ", mx_graph)
+    _print_graph("Ignition", ig_graph)
+    for conn, g in ((maximo, mx_graph), (ignition, ig_graph)):
+        rep = conn.validate(g)
+        print(
+            f"  validate {conn.name}: ok={rep.ok} errors={len(rep.errors)} warnings={len(rep.warnings)}"
+        )
+
+    # 4. Cross-reference: join OT (SCADA tags) to enterprise (CMMS assets).
+    _h("3. CROSS-REFERENCE  (propose SCADA tag → CMMS asset links)")
+    link_proposals = ignition.propose_asset_links(ig_graph, mx_graph)
+    for p in sorted(link_proposals, key=lambda x: -x.confidence):
+        tags = p.extracted_data["scada_tags"]
+        flag = " ⚠SAFETY" if p.risk_level == "safety_critical" else ""
+        print(
+            f"  [{p.confidence:.2f} {confidence_band(p.confidence):>6}]{flag} "
+            f"{len(tags)} tag(s) → {p.extracted_data['cmms_target_key']}"
+        )
+        print(f"           basis: {p.extracted_data['match_basis']}")
+        print(f"           target UNS: {p.extracted_data['cmms_uns_path']}")
+
+    # 5. The unified proposed graph.
+    _h("4. PROPOSED UNIFIED GRAPH (merged, with confidence)")
+    unified = NormalizedGraph()
+    unified.merge(mx_graph)
+    unified.merge(ig_graph)
+    for p in link_proposals:
+        unified.add_proposal(p)
+    _print_graph("Unified ", unified)
+    print("\n  Sample asset, its UNS address, and a few proposed edges:")
+    conv = unified.get("asset:CONV-001")
+    print(f"    {conv.key}  [{confidence_band(conv.confidence)} conf]  {conv.uns_path}")
+    shown = 0
+    for r in unified.relationships:
+        if r.source_key == conv.key and shown < 5:
+            shown += 1
+            print(
+                f"      └─{r.relationship_type}→ {r.target_key}  ({confidence_band(r.confidence)})"
+            )
+
+    # 6. What a technician confirms (the proposal queue).
+    _h("5. TECHNICIAN CONFIRMATION QUEUE  (proposed → verified is a human action)")
+    all_proposals = list(unified.proposals)
+    print(f"{len(all_proposals)} pending proposal(s). MIRA proposes; a technician confirms:")
+    _print_proposals(all_proposals)
+    print(
+        "\n  Until confirmed, every entity and edge stays approval_state='proposed'. "
+        "\n  Nothing the connectors produced is auto-verified."
+    )
+
+    # 7. Export an enriched work-order payload (dry-run — not pushed).
+    _h("6. EXPORT enriched work order back to Maximo (dry-run)")
+    result = await maximo.export_enriched(
+        {
+            "wonum": "WO-10231",
+            "uns_path": conv.uns_path,
+            "diagnosis": "VFD GS10 tripped on F0004 (DC bus OK at 325V); fault cleared, "
+            "fuses replaced. Recommend PM-VFD-ANNUAL firmware check.",
+            "confidence": "high",
+        }
+    )
+    print(f"supported={result.supported}  written={result.written}  ({result.note})")
+    print("  payload that WOULD be written to Maximo (custom fields preserved):")
+    for k, v in result.payloads[0].items():
+        if k.startswith("MIRA_") or k == "WONUM":
+            print(f"    {k} = {v}")
+
+    _h("done")
+    print("Run the connectors live by constructing with dry_run=False, read_only=False")
+    print("and pointing get_config_schema() fields at real endpoints (secrets via Doppler).")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/mira-connectors/historian/__init__.py
+++ b/mira-connectors/historian/__init__.py
@@ -1,0 +1,1 @@
+"""MIRA historian connectors (AVEVA PI / OSIsoft)."""

--- a/mira-connectors/historian/fixtures/pi_demo_points.json
+++ b/mira-connectors/historian/fixtures/pi_demo_points.json
@@ -1,0 +1,30 @@
+{
+  "_meta": {
+    "source": "AVEVA PI / OSIsoft PI System",
+    "api_hint": "PI Web API (/piwebapi/assetdatabases, /elements, /points, /streams, /eventframes) or AF SDK",
+    "note": "Mock fixture. PI Point names use the \\\\server\\tag convention; AF element Paths use backslash separators. Archived values are time-series; event frames are time windows of events (faults, downtime)."
+  },
+  "af_database": "Acme-Garage",
+  "af_elements": [
+    { "Path": "Bedford", "Name": "Bedford", "Template": "Site", "Parent": null },
+    { "Path": "Bedford\\Packaging", "Name": "Packaging", "Template": "Area", "Parent": "Bedford" },
+    { "Path": "Bedford\\Packaging\\Conveyor", "Name": "Conveyor", "Template": "Conveyor", "Parent": "Bedford\\Packaging", "attributes": [ {"Name": "Manufacturer", "Value": "Dorner"}, {"Name": "AssetTag", "Value": "CONV-001"} ] },
+    { "Path": "Bedford\\Packaging\\Conveyor\\Motor", "Name": "Motor", "Template": "Motor", "Parent": "Bedford\\Packaging\\Conveyor", "attributes": [ {"Name": "AssetTag", "Value": "MOTOR-001"} ] },
+    { "Path": "Bedford\\Packaging\\Conveyor\\VFD", "Name": "VFD", "Template": "VFD", "Parent": "Bedford\\Packaging\\Conveyor", "attributes": [ {"Name": "AssetTag", "Value": "VFD-001"} ] }
+  ],
+  "pi_points": [
+    { "Name": "\\\\PISRV01\\Conv.Motor.Current", "PointType": "Float32", "EngUnits": "A", "Descriptor": "Motor current", "element_path": "Bedford\\Packaging\\Conveyor\\Motor" },
+    { "Name": "\\\\PISRV01\\Conv.Motor.Speed", "PointType": "Float32", "EngUnits": "RPM", "Descriptor": "Motor speed", "element_path": "Bedford\\Packaging\\Conveyor\\Motor" },
+    { "Name": "\\\\PISRV01\\Conv.VFD.DcBus", "PointType": "Float32", "EngUnits": "V", "Descriptor": "VFD DC bus voltage", "element_path": "Bedford\\Packaging\\Conveyor\\VFD" },
+    { "Name": "\\\\PISRV01\\Conv.VFD.FaultCode", "PointType": "Int32", "EngUnits": "", "Descriptor": "VFD fault code", "element_path": "Bedford\\Packaging\\Conveyor\\VFD" }
+  ],
+  "archived_values": [
+    { "pi_point": "\\\\PISRV01\\Conv.Motor.Current", "values": [ {"Timestamp": "2026-06-03T22:45:00Z", "Value": 0.0, "Good": true}, {"Timestamp": "2026-06-03T22:50:00Z", "Value": 3.6, "Good": true}, {"Timestamp": "2026-06-03T22:59:00Z", "Value": 3.4, "Good": true} ] },
+    { "pi_point": "\\\\PISRV01\\Conv.VFD.DcBus", "values": [ {"Timestamp": "2026-06-03T22:50:00Z", "Value": 324.0, "Good": true}, {"Timestamp": "2026-06-03T22:59:00Z", "Value": 325.0, "Good": true} ] },
+    { "pi_point": "\\\\PISRV01\\Conv.VFD.FaultCode", "values": [ {"Timestamp": "2026-05-18T06:29:00Z", "Value": 4, "Good": true}, {"Timestamp": "2026-05-18T06:31:00Z", "Value": 0, "Good": true} ] }
+  ],
+  "event_frames": [
+    { "Name": "VFD Fault F0004", "Template": "Equipment Downtime", "element_path": "Bedford\\Packaging\\Conveyor\\VFD", "StartTime": "2026-05-18T06:29:00Z", "EndTime": "2026-05-18T06:31:00Z", "attributes": [ {"Name": "FaultCode", "Value": "F0004"}, {"Name": "Severity", "Value": "Trip"} ] },
+    { "Name": "Infeed E-Stop Pressed", "Template": "Safety Event", "element_path": "Bedford\\Packaging\\Conveyor", "StartTime": "2026-04-12T11:02:00Z", "EndTime": "2026-04-12T11:09:00Z", "attributes": [ {"Name": "Cause", "Value": "Operator E-stop"} ] }
+  ]
+}

--- a/mira-connectors/historian/pi_mock.py
+++ b/mira-connectors/historian/pi_mock.py
@@ -1,0 +1,305 @@
+"""AVEVA PI / OSIsoft PI System mock connector (historian).
+
+Maps a PI System export into the canonical model:
+
+* **AF element hierarchy** → ``site``/``area``/``asset``/``component`` by depth
+  in the element ``Path`` (AF database name → company). The AF→ISA-95 mapping is
+  a heuristic, so the hierarchy is ``proposed``, not asserted.
+* **PI points** → ``tag`` entities (``tag_kind=historian``) attached to their AF
+  element via ``HAS_SIGNAL``; archived values ride along as samples.
+* **Event frames** → ``fault_event`` entities + ``OCCURS_ON`` the element.
+  A safety-template event frame (E-stop) is flagged ``safety_critical``.
+
+PI is read-only telemetry; ``export_enriched`` is unsupported.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from base import Capability, Connector, ExportResult, RawRecord
+from canonical import (
+    CanonicalEntity,
+    CanonicalRelationship,
+    NormalizedGraph,
+    Proposal,
+    SourceObject,
+    ValidationReport,
+)
+from uns_bridge import uns
+
+logger = logging.getLogger("mira-connectors.pi")
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "pi_demo_points.json"
+_SAFETY_TEMPLATES = ("safety event", "safety", "estop", "e-stop", "lockout")
+
+
+class PIMockConnector(Connector):
+    name = "pi_mock"
+    system_kind = "historian"
+    connector_version = "0.1.0"
+
+    def __init__(
+        self,
+        fixture_path: Optional[Path] = None,
+        dry_run: bool = True,
+        read_only: bool = True,
+    ) -> None:
+        super().__init__(dry_run=dry_run, read_only=read_only)
+        self._fixture_path = Path(fixture_path) if fixture_path else _FIXTURE
+        self._data: dict[str, Any] = {}
+
+    def _load(self) -> dict[str, Any]:
+        if not self._data:
+            self._data = json.loads(self._fixture_path.read_text())
+        return self._data
+
+    async def discover(self) -> Capability:
+        data = self._load()
+        schema = {}
+        for ot, key in (("af_element", "af_elements"), ("pi_point", "pi_points"), ("event_frame", "event_frames")):
+            rows = data.get(key, [])
+            if rows:
+                schema[ot] = sorted({k for r in rows for k in r.keys()})
+        return Capability(
+            system_kind=self.system_kind,
+            display_name="AVEVA PI System (mock)",
+            object_types=list(schema.keys()),
+            supports_export=False,
+            read_only=self.read_only,
+            schema=schema,
+            notes=f"AF database '{data.get('af_database')}'. AF element Path → ISA-95 by depth (heuristic).",
+        )
+
+    async def import_records(
+        self, config: Optional[dict[str, Any]] = None
+    ) -> list[RawRecord]:
+        data = self._load()
+        out: list[RawRecord] = []
+        for el in data.get("af_elements", []):
+            out.append(RawRecord("af_element", el["Path"], el))
+        for pt in data.get("pi_points", []):
+            out.append(RawRecord("pi_point", pt["Name"], pt))
+        for ef in data.get("event_frames", []):
+            out.append(RawRecord("event_frame", ef["Name"], ef))
+        return out
+
+    def normalize(self, raw_records: list[RawRecord]) -> NormalizedGraph:
+        g = NormalizedGraph()
+        by_type: dict[str, list[RawRecord]] = {}
+        for r in raw_records:
+            by_type.setdefault(r.object_type, []).append(r)
+
+        company = uns.slug(self._load().get("af_database") or "historian")
+        archived = {a["pi_point"]: a.get("values", []) for a in self._load().get("archived_values", [])}
+
+        elem_uns = self._normalize_elements(g, company, by_type.get("af_element", []))
+        self._normalize_points(g, by_type.get("pi_point", []), elem_uns, archived)
+        self._normalize_event_frames(g, by_type.get("event_frame", []), elem_uns)
+        return g
+
+    @staticmethod
+    def _depth(path: str) -> int:
+        return path.count("\\")
+
+    def _normalize_elements(
+        self, g: NormalizedGraph, company: str, rows: list[RawRecord]
+    ) -> dict[str, str]:
+        """Map AF elements to the canonical hierarchy. Returns element_path → entity.key."""
+        elem_key: dict[str, str] = {}
+        # build a path→element index and resolve site/area chain by depth
+        elems = {r.payload["Path"]: r.payload for r in rows}
+
+        def chain(path: str) -> dict[str, str]:
+            out: dict[str, str] = {}
+            cur: Optional[str] = path
+            guard = 0
+            while cur and guard < 12:
+                guard += 1
+                el = elems.get(cur)
+                if not el:
+                    break
+                d = self._depth(cur)
+                level = {0: "site", 1: "area", 2: "asset", 3: "component"}.get(d)
+                if level in ("area", "site"):
+                    out.setdefault(level, uns.slug(el["Name"]))
+                cur = el.get("Parent")
+            return out
+
+        # ordered by depth so parents exist (in elem_key) before children
+        for r in sorted(rows, key=lambda x: self._depth(x.payload["Path"])):
+            el = r.payload
+            d = self._depth(el["Path"])
+            name = el["Name"]
+            ctx = chain(el["Path"])
+            site = ctx.get("site", "site")
+            parent_key = elem_key.get(el.get("Parent") or "")
+            if d == 0:
+                etype, path = "site", uns.site_path(company, name)
+            elif d == 1:
+                etype, path = "area", uns.area_path(company, site, name)
+            elif d == 2:
+                etype = "asset"
+                path = uns.assigned_equipment_path(company, site, ctx.get("area", "unassigned"), name)
+            else:
+                etype = "component"
+                parent_path = g.get(parent_key).uns_path if parent_key and g.get(parent_key) else None
+                path = uns.equipment_subnode_path(parent_path, "component", name) if parent_path else None
+            ent = self._emit(
+                g, etype, f"af:{el['Path']}", "af_element", el["Path"],
+                {"af_name": name, "template": el.get("Template"), "af_path": el["Path"], "attributes": el.get("attributes", [])},
+                path, 0.6, raw=el,  # AF→ISA-95 is a heuristic → modest confidence
+            )
+            elem_key[el["Path"]] = ent.key
+            if parent_key:
+                if etype == "component":
+                    # parent asset HAS_COMPONENT child (canonical parent→child)
+                    g.add_relationship(
+                        CanonicalRelationship(
+                            source_key=parent_key, target_key=ent.key,
+                            relationship_type="HAS_COMPONENT", confidence=0.6,
+                            evidence=[{"kind": "af_element", "ref": el["Path"]}],
+                        )
+                    )
+                else:
+                    # area/asset LOCATED_IN its parent (child→parent)
+                    g.add_relationship(
+                        CanonicalRelationship(
+                            source_key=ent.key, target_key=parent_key,
+                            relationship_type="LOCATED_IN", confidence=0.6,
+                            evidence=[{"kind": "af_element", "ref": el["Path"]}],
+                        )
+                    )
+        return elem_key
+
+    def _normalize_points(
+        self, g: NormalizedGraph, rows: list[RawRecord], elem_uns: dict[str, str], archived: dict[str, list]
+    ) -> None:
+        for r in rows:
+            pt = r.payload
+            elem_path = pt.get("element_path", "")
+            anchor_key = elem_uns.get(elem_path)
+            anchor = g.get(anchor_key) if anchor_key else None
+            uns_path = (
+                uns.equipment_subnode_path(anchor.uns_path, "datapoint", pt["Name"].split("\\")[-1])
+                if anchor and anchor.uns_path
+                else None
+            )
+            samples = archived.get(pt["Name"], [])
+            ent = self._emit(
+                g, "tag", pt["Name"], "pi_point", pt["Name"],
+                {
+                    "tag_kind": "historian",
+                    "pi_point": pt["Name"],
+                    "point_type": pt.get("PointType"),
+                    "eng_unit": pt.get("EngUnits"),
+                    "descriptor": pt.get("Descriptor"),
+                    "sample_count": len(samples),
+                    "last_value": samples[-1]["Value"] if samples else None,
+                },
+                uns_path, 0.7, raw={**pt, "_archived_values": samples},
+            )
+            if anchor:
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=anchor.key, target_key=ent.key, relationship_type="HAS_SIGNAL",
+                        confidence=0.7, evidence=[{"kind": "pi_point", "ref": pt["Name"], "detail": elem_path}],
+                    )
+                )
+
+    def _normalize_event_frames(
+        self, g: NormalizedGraph, rows: list[RawRecord], elem_uns: dict[str, str]
+    ) -> None:
+        for r in rows:
+            ef = r.payload
+            template = (ef.get("Template") or "").lower()
+            is_safety = any(s in template or s in ef.get("Name", "").lower() for s in _SAFETY_TEMPLATES)
+            ent = self._emit(
+                g, "fault_event", ef["Name"], "event_frame", ef["Name"],
+                {
+                    "template": ef.get("Template"),
+                    "start": ef.get("StartTime"),
+                    "end": ef.get("EndTime"),
+                    "attributes": ef.get("attributes", []),
+                    "is_safety": is_safety,
+                },
+                None, 0.75, raw=ef,
+            )
+            anchor_key = elem_uns.get(ef.get("element_path", ""))
+            anchor = g.get(anchor_key) if anchor_key else None
+            if anchor:
+                g.add_relationship(
+                    CanonicalRelationship(
+                        source_key=ent.key, target_key=anchor.key, relationship_type="OCCURS_ON",
+                        confidence=0.75, evidence=[{"kind": "event_frame", "ref": ef["Name"]}],
+                    )
+                )
+            if is_safety:
+                g.add_proposal(
+                    Proposal(
+                        suggestion_type="kg_entity",
+                        title=f"Safety review: PI event frame '{ef['Name']}'",
+                        body=(
+                            f"Event frame '{ef['Name']}' (template {ef.get('Template')}) is a safety "
+                            "event. Review before MIRA reasons over it in a technician-facing answer."
+                        ),
+                        extracted_data={"event_frame": ef["Name"], "element_path": ef.get("element_path")},
+                        confidence=0.7,
+                        risk_level="safety_critical",
+                        proposed_by=f"import:{self.name}",
+                        source_kind="live_event",
+                    )
+                )
+
+    def _emit(
+        self, g: NormalizedGraph, entity_type: str, name: str, object_type: str, external_id: str,
+        properties: dict[str, Any], uns_path: Optional[str], confidence: float, raw: dict[str, Any],
+    ) -> CanonicalEntity:
+        ent = g.add_entity(
+            CanonicalEntity(
+                entity_type=entity_type, name=name, uns_path=uns_path, properties=properties,
+                confidence=confidence, source_system=self.system_kind, object_type=object_type,
+                external_object_id=external_id, source_payload=dict(raw),
+            )
+        )
+        g.add_source_object(
+            SourceObject(
+                system_kind=self.system_kind, object_type=object_type, external_object_id=external_id,
+                raw_payload=dict(raw), connector_version=self.connector_version,
+                mapping_status="mapped", mapped_entity_key=ent.key,
+            )
+        )
+        return ent
+
+    def validate(self, graph: NormalizedGraph) -> ValidationReport:
+        report = ValidationReport()
+        keys = set(graph.entities.keys())
+        for ent in graph.entities.values():
+            if ent.uns_path and not uns.is_valid_path(ent.uns_path):
+                report.add("error", "invalid_uns_path", f"{ent.key}: {ent.uns_path!r}", ent.key)
+            if ent.approval_state != "proposed":
+                report.add("error", "auto_verified", ent.key, ent.key)
+            if not ent.source_payload:
+                report.add("error", "missing_source_payload", ent.key, ent.key)
+        for rel in graph.relationships:
+            for endpoint in (rel.source_key, rel.target_key):
+                if endpoint not in keys:
+                    report.add("warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}")
+        return report
+
+    async def export_enriched(self, graph_context: dict[str, Any]) -> ExportResult:
+        return ExportResult(
+            supported=False, written=False, payloads=[],
+            note="PI is read-only telemetry; MIRA does not write enriched payloads back to a historian.",
+        )
+
+    def get_config_schema(self) -> dict[str, Any]:
+        return {
+            "piwebapi_url": {"type": "string", "required": True, "description": "PI Web API base URL"},
+            "af_database": {"type": "string", "required": True, "description": "AF database name (→ company UNS root)"},
+            "auth": {"type": "string", "required": True, "secret": True, "description": "Kerberos/Basic token (Doppler-managed)"},
+            "fixture_path": {"type": "string", "required": False, "description": "Mock only: path to fixture JSON"},
+        }

--- a/mira-connectors/historian/pi_mock.py
+++ b/mira-connectors/historian/pi_mock.py
@@ -60,7 +60,11 @@ class PIMockConnector(Connector):
     async def discover(self) -> Capability:
         data = self._load()
         schema = {}
-        for ot, key in (("af_element", "af_elements"), ("pi_point", "pi_points"), ("event_frame", "event_frames")):
+        for ot, key in (
+            ("af_element", "af_elements"),
+            ("pi_point", "pi_points"),
+            ("event_frame", "event_frames"),
+        ):
             rows = data.get(key, [])
             if rows:
                 schema[ot] = sorted({k for r in rows for k in r.keys()})
@@ -74,9 +78,7 @@ class PIMockConnector(Connector):
             notes=f"AF database '{data.get('af_database')}'. AF element Path → ISA-95 by depth (heuristic).",
         )
 
-    async def import_records(
-        self, config: Optional[dict[str, Any]] = None
-    ) -> list[RawRecord]:
+    async def import_records(self, config: Optional[dict[str, Any]] = None) -> list[RawRecord]:
         data = self._load()
         out: list[RawRecord] = []
         for el in data.get("af_elements", []):
@@ -94,7 +96,9 @@ class PIMockConnector(Connector):
             by_type.setdefault(r.object_type, []).append(r)
 
         company = uns.slug(self._load().get("af_database") or "historian")
-        archived = {a["pi_point"]: a.get("values", []) for a in self._load().get("archived_values", [])}
+        archived = {
+            a["pi_point"]: a.get("values", []) for a in self._load().get("archived_values", [])
+        }
 
         elem_uns = self._normalize_elements(g, company, by_type.get("af_element", []))
         self._normalize_points(g, by_type.get("pi_point", []), elem_uns, archived)
@@ -143,15 +147,34 @@ class PIMockConnector(Connector):
                 etype, path = "area", uns.area_path(company, site, name)
             elif d == 2:
                 etype = "asset"
-                path = uns.assigned_equipment_path(company, site, ctx.get("area", "unassigned"), name)
+                path = uns.assigned_equipment_path(
+                    company, site, ctx.get("area", "unassigned"), name
+                )
             else:
                 etype = "component"
-                parent_path = g.get(parent_key).uns_path if parent_key and g.get(parent_key) else None
-                path = uns.equipment_subnode_path(parent_path, "component", name) if parent_path else None
+                parent_path = (
+                    g.get(parent_key).uns_path if parent_key and g.get(parent_key) else None
+                )
+                path = (
+                    uns.equipment_subnode_path(parent_path, "component", name)
+                    if parent_path
+                    else None
+                )
             ent = self._emit(
-                g, etype, f"af:{el['Path']}", "af_element", el["Path"],
-                {"af_name": name, "template": el.get("Template"), "af_path": el["Path"], "attributes": el.get("attributes", [])},
-                path, 0.6, raw=el,  # AF→ISA-95 is a heuristic → modest confidence
+                g,
+                etype,
+                f"af:{el['Path']}",
+                "af_element",
+                el["Path"],
+                {
+                    "af_name": name,
+                    "template": el.get("Template"),
+                    "af_path": el["Path"],
+                    "attributes": el.get("attributes", []),
+                },
+                path,
+                0.6,
+                raw=el,  # AF→ISA-95 is a heuristic → modest confidence
             )
             elem_key[el["Path"]] = ent.key
             if parent_key:
@@ -159,8 +182,10 @@ class PIMockConnector(Connector):
                     # parent asset HAS_COMPONENT child (canonical parent→child)
                     g.add_relationship(
                         CanonicalRelationship(
-                            source_key=parent_key, target_key=ent.key,
-                            relationship_type="HAS_COMPONENT", confidence=0.6,
+                            source_key=parent_key,
+                            target_key=ent.key,
+                            relationship_type="HAS_COMPONENT",
+                            confidence=0.6,
                             evidence=[{"kind": "af_element", "ref": el["Path"]}],
                         )
                     )
@@ -168,15 +193,21 @@ class PIMockConnector(Connector):
                     # area/asset LOCATED_IN its parent (child→parent)
                     g.add_relationship(
                         CanonicalRelationship(
-                            source_key=ent.key, target_key=parent_key,
-                            relationship_type="LOCATED_IN", confidence=0.6,
+                            source_key=ent.key,
+                            target_key=parent_key,
+                            relationship_type="LOCATED_IN",
+                            confidence=0.6,
                             evidence=[{"kind": "af_element", "ref": el["Path"]}],
                         )
                     )
         return elem_key
 
     def _normalize_points(
-        self, g: NormalizedGraph, rows: list[RawRecord], elem_uns: dict[str, str], archived: dict[str, list]
+        self,
+        g: NormalizedGraph,
+        rows: list[RawRecord],
+        elem_uns: dict[str, str],
+        archived: dict[str, list],
     ) -> None:
         for r in rows:
             pt = r.payload
@@ -190,7 +221,11 @@ class PIMockConnector(Connector):
             )
             samples = archived.get(pt["Name"], [])
             ent = self._emit(
-                g, "tag", pt["Name"], "pi_point", pt["Name"],
+                g,
+                "tag",
+                pt["Name"],
+                "pi_point",
+                pt["Name"],
                 {
                     "tag_kind": "historian",
                     "pi_point": pt["Name"],
@@ -200,13 +235,18 @@ class PIMockConnector(Connector):
                     "sample_count": len(samples),
                     "last_value": samples[-1]["Value"] if samples else None,
                 },
-                uns_path, 0.7, raw={**pt, "_archived_values": samples},
+                uns_path,
+                0.7,
+                raw={**pt, "_archived_values": samples},
             )
             if anchor:
                 g.add_relationship(
                     CanonicalRelationship(
-                        source_key=anchor.key, target_key=ent.key, relationship_type="HAS_SIGNAL",
-                        confidence=0.7, evidence=[{"kind": "pi_point", "ref": pt["Name"], "detail": elem_path}],
+                        source_key=anchor.key,
+                        target_key=ent.key,
+                        relationship_type="HAS_SIGNAL",
+                        confidence=0.7,
+                        evidence=[{"kind": "pi_point", "ref": pt["Name"], "detail": elem_path}],
                     )
                 )
 
@@ -216,9 +256,15 @@ class PIMockConnector(Connector):
         for r in rows:
             ef = r.payload
             template = (ef.get("Template") or "").lower()
-            is_safety = any(s in template or s in ef.get("Name", "").lower() for s in _SAFETY_TEMPLATES)
+            is_safety = any(
+                s in template or s in ef.get("Name", "").lower() for s in _SAFETY_TEMPLATES
+            )
             ent = self._emit(
-                g, "fault_event", ef["Name"], "event_frame", ef["Name"],
+                g,
+                "fault_event",
+                ef["Name"],
+                "event_frame",
+                ef["Name"],
                 {
                     "template": ef.get("Template"),
                     "start": ef.get("StartTime"),
@@ -226,15 +272,20 @@ class PIMockConnector(Connector):
                     "attributes": ef.get("attributes", []),
                     "is_safety": is_safety,
                 },
-                None, 0.75, raw=ef,
+                None,
+                0.75,
+                raw=ef,
             )
             anchor_key = elem_uns.get(ef.get("element_path", ""))
             anchor = g.get(anchor_key) if anchor_key else None
             if anchor:
                 g.add_relationship(
                     CanonicalRelationship(
-                        source_key=ent.key, target_key=anchor.key, relationship_type="OCCURS_ON",
-                        confidence=0.75, evidence=[{"kind": "event_frame", "ref": ef["Name"]}],
+                        source_key=ent.key,
+                        target_key=anchor.key,
+                        relationship_type="OCCURS_ON",
+                        confidence=0.75,
+                        evidence=[{"kind": "event_frame", "ref": ef["Name"]}],
                     )
                 )
             if is_safety:
@@ -246,7 +297,10 @@ class PIMockConnector(Connector):
                             f"Event frame '{ef['Name']}' (template {ef.get('Template')}) is a safety "
                             "event. Review before MIRA reasons over it in a technician-facing answer."
                         ),
-                        extracted_data={"event_frame": ef["Name"], "element_path": ef.get("element_path")},
+                        extracted_data={
+                            "event_frame": ef["Name"],
+                            "element_path": ef.get("element_path"),
+                        },
                         confidence=0.7,
                         risk_level="safety_critical",
                         proposed_by=f"import:{self.name}",
@@ -255,21 +309,39 @@ class PIMockConnector(Connector):
                 )
 
     def _emit(
-        self, g: NormalizedGraph, entity_type: str, name: str, object_type: str, external_id: str,
-        properties: dict[str, Any], uns_path: Optional[str], confidence: float, raw: dict[str, Any],
+        self,
+        g: NormalizedGraph,
+        entity_type: str,
+        name: str,
+        object_type: str,
+        external_id: str,
+        properties: dict[str, Any],
+        uns_path: Optional[str],
+        confidence: float,
+        raw: dict[str, Any],
     ) -> CanonicalEntity:
         ent = g.add_entity(
             CanonicalEntity(
-                entity_type=entity_type, name=name, uns_path=uns_path, properties=properties,
-                confidence=confidence, source_system=self.system_kind, object_type=object_type,
-                external_object_id=external_id, source_payload=dict(raw),
+                entity_type=entity_type,
+                name=name,
+                uns_path=uns_path,
+                properties=properties,
+                confidence=confidence,
+                source_system=self.system_kind,
+                object_type=object_type,
+                external_object_id=external_id,
+                source_payload=dict(raw),
             )
         )
         g.add_source_object(
             SourceObject(
-                system_kind=self.system_kind, object_type=object_type, external_object_id=external_id,
-                raw_payload=dict(raw), connector_version=self.connector_version,
-                mapping_status="mapped", mapped_entity_key=ent.key,
+                system_kind=self.system_kind,
+                object_type=object_type,
+                external_object_id=external_id,
+                raw_payload=dict(raw),
+                connector_version=self.connector_version,
+                mapping_status="mapped",
+                mapped_entity_key=ent.key,
             )
         )
         return ent
@@ -287,19 +359,40 @@ class PIMockConnector(Connector):
         for rel in graph.relationships:
             for endpoint in (rel.source_key, rel.target_key):
                 if endpoint not in keys:
-                    report.add("warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}")
+                    report.add(
+                        "warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}"
+                    )
         return report
 
     async def export_enriched(self, graph_context: dict[str, Any]) -> ExportResult:
         return ExportResult(
-            supported=False, written=False, payloads=[],
+            supported=False,
+            written=False,
+            payloads=[],
             note="PI is read-only telemetry; MIRA does not write enriched payloads back to a historian.",
         )
 
     def get_config_schema(self) -> dict[str, Any]:
         return {
-            "piwebapi_url": {"type": "string", "required": True, "description": "PI Web API base URL"},
-            "af_database": {"type": "string", "required": True, "description": "AF database name (→ company UNS root)"},
-            "auth": {"type": "string", "required": True, "secret": True, "description": "Kerberos/Basic token (Doppler-managed)"},
-            "fixture_path": {"type": "string", "required": False, "description": "Mock only: path to fixture JSON"},
+            "piwebapi_url": {
+                "type": "string",
+                "required": True,
+                "description": "PI Web API base URL",
+            },
+            "af_database": {
+                "type": "string",
+                "required": True,
+                "description": "AF database name (→ company UNS root)",
+            },
+            "auth": {
+                "type": "string",
+                "required": True,
+                "secret": True,
+                "description": "Kerberos/Basic token (Doppler-managed)",
+            },
+            "fixture_path": {
+                "type": "string",
+                "required": False,
+                "description": "Mock only: path to fixture JSON",
+            },
         }

--- a/mira-connectors/scada/__init__.py
+++ b/mira-connectors/scada/__init__.py
@@ -1,0 +1,1 @@
+"""MIRA SCADA connectors (Ignition tag trees)."""

--- a/mira-connectors/scada/fixtures/ignition_demo_tags.json
+++ b/mira-connectors/scada/fixtures/ignition_demo_tags.json
@@ -1,0 +1,32 @@
+{
+  "_meta": {
+    "source": "Inductive Automation Ignition",
+    "api_hint": "Tag browse via system.tag.browse / WebDev; values via system.tag.readBlocking",
+    "gateway": "ignition-edge-garage",
+    "provider": "default",
+    "note": "Mock fixture. Ignition tag paths use [provider]Folder/Sub/Tag. Sample values cover the last hour. SCADA tags do not carry a UNS site path until linked to a CMMS asset — that link is a proposal a technician confirms.",
+    "window_start": "2026-06-03T22:00:00Z",
+    "window_end": "2026-06-03T23:00:00Z"
+  },
+  "tags": [
+    { "path": "[default]Conv_Simple/Motor/RunCmd", "folder": "Conv_Simple/Motor", "name": "RunCmd", "dataType": "Boolean", "engUnit": "", "quality": "Good", "value": true, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:30:00Z", "v": false, "q": "Good"}, {"t": "2026-06-03T22:45:00Z", "v": true, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/Motor/RunFbk", "folder": "Conv_Simple/Motor", "name": "RunFbk", "dataType": "Boolean", "engUnit": "", "quality": "Good", "value": true, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:45:02Z", "v": true, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/Motor/FaultBit", "folder": "Conv_Simple/Motor", "name": "FaultBit", "dataType": "Boolean", "engUnit": "", "quality": "Good", "value": false, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:10:00Z", "v": true, "q": "Good"}, {"t": "2026-06-03T22:12:00Z", "v": false, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/Motor/Current", "folder": "Conv_Simple/Motor", "name": "Current", "dataType": "Float4", "engUnit": "A", "quality": "Good", "value": 3.4, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:45:00Z", "v": 0.0, "q": "Good"}, {"t": "2026-06-03T22:50:00Z", "v": 3.6, "q": "Good"}, {"t": "2026-06-03T22:59:00Z", "v": 3.4, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/Motor/Speed", "folder": "Conv_Simple/Motor", "name": "Speed", "dataType": "Float4", "engUnit": "RPM", "quality": "Good", "value": 1725.0, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:50:00Z", "v": 1725.0, "q": "Good"} ] },
+
+    { "path": "[default]Conv_Simple/VFD_GS10/FreqCmd", "folder": "Conv_Simple/VFD_GS10", "name": "FreqCmd", "dataType": "Float4", "engUnit": "Hz", "quality": "Good", "value": 60.0, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:45:00Z", "v": 60.0, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/VFD_GS10/FreqFbk", "folder": "Conv_Simple/VFD_GS10", "name": "FreqFbk", "dataType": "Float4", "engUnit": "Hz", "quality": "Good", "value": 59.9, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:50:00Z", "v": 59.9, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/VFD_GS10/DcBusVoltage", "folder": "Conv_Simple/VFD_GS10", "name": "DcBusVoltage", "dataType": "Float4", "engUnit": "V", "quality": "Good", "value": 325.0, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:50:00Z", "v": 324.0, "q": "Good"}, {"t": "2026-06-03T22:59:00Z", "v": 325.0, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/VFD_GS10/OutputCurrent", "folder": "Conv_Simple/VFD_GS10", "name": "OutputCurrent", "dataType": "Float4", "engUnit": "A", "quality": "Good", "value": 3.5, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:59:00Z", "v": 3.5, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/VFD_GS10/FaultCode", "folder": "Conv_Simple/VFD_GS10", "name": "FaultCode", "dataType": "Int4", "engUnit": "", "quality": "Good", "value": 0, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:10:00Z", "v": 4, "q": "Good"}, {"t": "2026-06-03T22:12:00Z", "v": 0, "q": "Good"} ] },
+
+    { "path": "[default]Conv_Simple/Sensors/PE_101", "folder": "Conv_Simple/Sensors", "name": "PE_101", "dataType": "Boolean", "engUnit": "", "quality": "Good", "value": true, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:59:50Z", "v": true, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/Sensors/PE_102", "folder": "Conv_Simple/Sensors", "name": "PE_102", "dataType": "Boolean", "engUnit": "", "quality": "Good", "value": false, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:59:50Z", "v": false, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/Sensors/PX_101", "folder": "Conv_Simple/Sensors", "name": "PX_101", "dataType": "Boolean", "engUnit": "", "quality": "Uncertain", "value": true, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:58:00Z", "v": true, "q": "Uncertain"} ] },
+
+    { "path": "[default]Conv_Simple/Conveyor/ConvState", "folder": "Conv_Simple/Conveyor", "name": "ConvState", "dataType": "Int4", "engUnit": "", "quality": "Good", "value": 2, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:10:00Z", "v": 9, "q": "Good"}, {"t": "2026-06-03T22:45:00Z", "v": 2, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/Conveyor/EStop", "folder": "Conv_Simple/Conveyor", "name": "EStop", "dataType": "Boolean", "engUnit": "", "quality": "Good", "value": false, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:59:50Z", "v": false, "q": "Good"} ] },
+    { "path": "[default]Conv_Simple/Conveyor/StartBtn", "folder": "Conv_Simple/Conveyor", "name": "StartBtn", "dataType": "Boolean", "engUnit": "", "quality": "Good", "value": false, "timestamp": "2026-06-03T22:59:55Z", "samples": [ {"t": "2026-06-03T22:44:58Z", "v": true, "q": "Good"}, {"t": "2026-06-03T22:45:00Z", "v": false, "q": "Good"} ] }
+  ]
+}

--- a/mira-connectors/scada/ignition_mock.py
+++ b/mira-connectors/scada/ignition_mock.py
@@ -90,9 +90,7 @@ class IgnitionMockConnector(Connector):
 
     # ── import ──────────────────────────────────────────────────────
 
-    async def import_records(
-        self, config: Optional[dict[str, Any]] = None
-    ) -> list[RawRecord]:
+    async def import_records(self, config: Optional[dict[str, Any]] = None) -> list[RawRecord]:
         config = config or {}
         folder_filter = config.get("folder")
         data = self._load()
@@ -125,7 +123,10 @@ class IgnitionMockConnector(Connector):
                     name=f"scada:{equipment_name}",
                     object_type="folder",
                     external_id=equipment_name,
-                    raw={"folder": equipment_name, "gateway": self._load().get("_meta", {}).get("gateway")},
+                    raw={
+                        "folder": equipment_name,
+                        "gateway": self._load().get("_meta", {}).get("gateway"),
+                    },
                     confidence=0.5,
                     properties={"scada_root": equipment_name, "provisional": True},
                 )
@@ -272,7 +273,9 @@ class IgnitionMockConnector(Connector):
         for tag in all_tags:
             if tag.key in matched_tag_keys:
                 continue
-            folders.setdefault(tag.properties.get("scada_path", "").rsplit("/", 1)[0], []).append(tag)
+            folders.setdefault(tag.properties.get("scada_path", "").rsplit("/", 1)[0], []).append(
+                tag
+            )
 
         for folder, tags in folders.items():
             device_leaf = folder.rsplit("/", 1)[-1]
@@ -286,8 +289,10 @@ class IgnitionMockConnector(Connector):
         self, target: CanonicalEntity, tags: list[CanonicalEntity], *, basis: str, score: float
     ) -> Proposal:
         is_safety = any(t.properties.get("is_safety") for t in tags)
-        label = tags[0].properties.get("tag_name") if len(tags) == 1 else (
-            tags[0].properties.get("scada_path", "").rsplit("/", 1)[0].rsplit("/", 1)[-1]
+        label = (
+            tags[0].properties.get("tag_name")
+            if len(tags) == 1
+            else (tags[0].properties.get("scada_path", "").rsplit("/", 1)[0].rsplit("/", 1)[-1])
         )
         return Proposal(
             suggestion_type="kg_edge",
@@ -349,7 +354,9 @@ class IgnitionMockConnector(Connector):
             if ent.approval_state != "proposed":
                 report.add("error", "auto_verified", f"{ent.key} is {ent.approval_state}", ent.key)
             if not ent.source_payload:
-                report.add("error", "missing_source_payload", f"{ent.key} lost its raw record", ent.key)
+                report.add(
+                    "error", "missing_source_payload", f"{ent.key} lost its raw record", ent.key
+                )
             if ent.entity_type == "tag" and ent.uns_path is not None:
                 report.add(
                     "warning",
@@ -360,7 +367,9 @@ class IgnitionMockConnector(Connector):
         for rel in graph.relationships:
             for endpoint in (rel.source_key, rel.target_key):
                 if endpoint not in keys:
-                    report.add("warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}")
+                    report.add(
+                        "warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}"
+                    )
         return report
 
     # ── export (unsupported for SCADA) ──────────────────────────────
@@ -378,11 +387,33 @@ class IgnitionMockConnector(Connector):
 
     def get_config_schema(self) -> dict[str, Any]:
         return {
-            "gateway_url": {"type": "string", "required": True, "description": "Ignition gateway base URL"},
-            "provider": {"type": "string", "required": False, "default": "default", "description": "Tag provider"},
-            "folder": {"type": "string", "required": False, "description": "Browse root folder filter"},
-            "api_key": {"type": "string", "required": True, "secret": True, "description": "WebDev/API key (Doppler-managed)"},
-            "fixture_path": {"type": "string", "required": False, "description": "Mock only: path to fixture JSON"},
+            "gateway_url": {
+                "type": "string",
+                "required": True,
+                "description": "Ignition gateway base URL",
+            },
+            "provider": {
+                "type": "string",
+                "required": False,
+                "default": "default",
+                "description": "Tag provider",
+            },
+            "folder": {
+                "type": "string",
+                "required": False,
+                "description": "Browse root folder filter",
+            },
+            "api_key": {
+                "type": "string",
+                "required": True,
+                "secret": True,
+                "description": "WebDev/API key (Doppler-managed)",
+            },
+            "fixture_path": {
+                "type": "string",
+                "required": False,
+                "description": "Mock only: path to fixture JSON",
+            },
         }
 
 

--- a/mira-connectors/scada/ignition_mock.py
+++ b/mira-connectors/scada/ignition_mock.py
@@ -1,0 +1,394 @@
+"""Ignition (Inductive Automation) SCADA mock connector.
+
+Maps an Ignition tag tree into MIRA ``tag`` (signal) entities and proposes
+links between those tags and CMMS assets imported by another connector.
+
+Key semantic, straight from ``.claude/rules/direct-connection-uns-certified.md``
+and the canonical model: **a SCADA tag does not carry a UNS site path on its
+own.** The tag tree gives a *provisional* folder structure (``Conv_Simple /
+Motor / Current``) but which physical asset that maps to is a *proposal* a
+technician confirms — never an asserted fact. So:
+
+* ``normalize()`` emits ``tag`` entities (``uns_path=None``) plus a provisional
+  ``asset``/``component`` skeleton from the folder hierarchy, all at LOW
+  confidence and ``approval_state="proposed"``.
+* :meth:`propose_asset_links` cross-references the SCADA graph against a CMMS
+  graph and emits ``kg_edge`` ``ai_suggestions`` (HAS_SIGNAL) with calibrated
+  confidence and the match basis. Nothing is auto-verified.
+
+``export_enriched`` is intentionally unsupported — you don't write enriched
+payloads back to a SCADA tag provider.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+from base import Capability, Connector, ExportResult, RawRecord
+from canonical import (
+    CanonicalEntity,
+    CanonicalRelationship,
+    NormalizedGraph,
+    Proposal,
+    SourceObject,
+    ValidationReport,
+)
+
+logger = logging.getLogger("mira-connectors.ignition")
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "ignition_demo_tags.json"
+
+_SAFETY_TAGS = ("estop", "e_stop", "estp", "lockout", "interlock", "lightcurtain", "guard")
+
+
+def _norm(s: str) -> str:
+    """Normalize an identifier for fuzzy matching: lowercase, strip separators."""
+    return "".join(ch for ch in s.lower() if ch.isalnum())
+
+
+class IgnitionMockConnector(Connector):
+    name = "ignition_mock"
+    system_kind = "ignition"
+    connector_version = "0.1.0"
+
+    def __init__(
+        self,
+        fixture_path: Optional[Path] = None,
+        dry_run: bool = True,
+        read_only: bool = True,
+    ) -> None:
+        super().__init__(dry_run=dry_run, read_only=read_only)
+        self._fixture_path = Path(fixture_path) if fixture_path else _FIXTURE
+        self._data: dict[str, Any] = {}
+
+    def _load(self) -> dict[str, Any]:
+        if not self._data:
+            self._data = json.loads(self._fixture_path.read_text())
+        return self._data
+
+    # ── discover ────────────────────────────────────────────────────
+
+    async def discover(self) -> Capability:
+        data = self._load()
+        tags = data.get("tags", [])
+        return Capability(
+            system_kind=self.system_kind,
+            display_name="Ignition SCADA (mock)",
+            object_types=["tag"],
+            supports_export=False,  # no enriched write-back to a tag provider
+            read_only=self.read_only,
+            schema={"tag": sorted({k for t in tags for k in t.keys()})},
+            notes=(
+                f"gateway={data.get('_meta', {}).get('gateway')} "
+                f"provider={data.get('_meta', {}).get('provider')}. SCADA tags "
+                "have no UNS site path until linked to a CMMS asset (a proposal)."
+            ),
+        )
+
+    # ── import ──────────────────────────────────────────────────────
+
+    async def import_records(
+        self, config: Optional[dict[str, Any]] = None
+    ) -> list[RawRecord]:
+        config = config or {}
+        folder_filter = config.get("folder")
+        data = self._load()
+        out: list[RawRecord] = []
+        for tag in data.get("tags", []):
+            if folder_filter and not tag["folder"].startswith(folder_filter):
+                continue
+            out.append(RawRecord(object_type="tag", external_object_id=tag["path"], payload=tag))
+        return out
+
+    # ── normalize ───────────────────────────────────────────────────
+
+    def normalize(self, raw_records: list[RawRecord]) -> NormalizedGraph:
+        g = NormalizedGraph()
+        # equipment root = the top folder segment (e.g. "Conv_Simple").
+        roots: dict[str, str] = {}  # equipment_name -> entity.key
+
+        for r in raw_records:
+            tag = r.payload
+            folder = tag["folder"]  # e.g. "Conv_Simple/Motor"
+            segs = folder.split("/")
+            equipment_name = segs[0]
+            device_folder = segs[1] if len(segs) > 1 else None
+
+            # provisional equipment node (low confidence — folder-derived, not asserted)
+            if equipment_name not in roots:
+                eq = self._emit(
+                    g,
+                    entity_type="asset",
+                    name=f"scada:{equipment_name}",
+                    object_type="folder",
+                    external_id=equipment_name,
+                    raw={"folder": equipment_name, "gateway": self._load().get("_meta", {}).get("gateway")},
+                    confidence=0.5,
+                    properties={"scada_root": equipment_name, "provisional": True},
+                )
+                roots[equipment_name] = eq.key
+
+            anchor_key = roots[equipment_name]
+            # provisional component node per device sub-folder (Motor, VFD_GS10, ...)
+            if device_folder:
+                comp_key = f"component:scada:{equipment_name}/{device_folder}"
+                if not g.get(comp_key):
+                    comp = self._emit(
+                        g,
+                        entity_type="component",
+                        name=f"scada:{equipment_name}/{device_folder}",
+                        object_type="folder",
+                        external_id=f"{equipment_name}/{device_folder}",
+                        raw={"folder": folder, "provisional": True},
+                        confidence=0.45,
+                        properties={"scada_folder": folder, "provisional": True},
+                    )
+                    g.add_relationship(
+                        CanonicalRelationship(
+                            source_key=anchor_key,
+                            target_key=comp.key,
+                            relationship_type="HAS_COMPONENT",
+                            confidence=0.45,  # folder grouping is a heuristic
+                            evidence=[{"kind": "scada_folder", "ref": folder}],
+                        )
+                    )
+                anchor_key = comp_key
+
+            # the tag itself → a `tag` entity (tag_kind=scada). No UNS path yet.
+            tag_ent = self._emit(
+                g,
+                entity_type="tag",
+                name=tag["path"],
+                object_type="tag",
+                external_id=tag["path"],
+                raw=tag,
+                confidence=0.7,
+                properties={
+                    "tag_kind": "scada",
+                    "scada_path": tag["path"],
+                    "tag_name": tag["name"],
+                    "datatype": tag.get("dataType"),
+                    "eng_unit": tag.get("engUnit"),
+                    "quality": tag.get("quality"),
+                    "value": tag.get("value"),
+                    "sample_count": len(tag.get("samples", [])),
+                    "is_safety": _norm(tag["name"]) in {_norm(s) for s in _SAFETY_TAGS}
+                    or any(s in _norm(tag["name"]) for s in ("estop", "lockout")),
+                },
+            )
+            g.add_relationship(
+                CanonicalRelationship(
+                    source_key=anchor_key,
+                    target_key=tag_ent.key,
+                    relationship_type="HAS_SIGNAL",
+                    confidence=0.7,
+                    evidence=[{"kind": "scada_tag", "ref": tag["path"]}],
+                )
+            )
+        return g
+
+    def _emit(
+        self,
+        g: NormalizedGraph,
+        *,
+        entity_type: str,
+        name: str,
+        object_type: str,
+        external_id: str,
+        raw: dict[str, Any],
+        confidence: float,
+        properties: Optional[dict[str, Any]] = None,
+    ) -> CanonicalEntity:
+        ent = g.add_entity(
+            CanonicalEntity(
+                entity_type=entity_type,
+                name=name,
+                uns_path=None,  # SCADA carries no UNS site path until linked
+                properties=properties or {},
+                confidence=confidence,
+                source_system=self.system_kind,
+                object_type=object_type,
+                external_object_id=external_id,
+                source_payload=dict(raw),
+            )
+        )
+        g.add_source_object(
+            SourceObject(
+                system_kind=self.system_kind,
+                object_type=object_type,
+                external_object_id=external_id,
+                raw_payload=dict(raw),
+                connector_version=self.connector_version,
+                mapping_status="mapped",
+                mapped_entity_key=ent.key,
+            )
+        )
+        return ent
+
+    # ── cross-reference SCADA tags ↔ CMMS assets ────────────────────
+
+    def propose_asset_links(
+        self, scada_graph: NormalizedGraph, cmms_graph: NormalizedGraph
+    ) -> list[Proposal]:
+        """Propose HAS_SIGNAL links between SCADA tags and CMMS assets/components.
+
+        Matching is fuzzy and NEVER auto-verified — each match becomes a
+        ``kg_edge`` ``ai_suggestion`` (status pending) a technician confirms.
+        Confidence reflects the match basis:
+
+        * tag name == CMMS ASSETNUM (PE_101 ↔ PE-101)        → 0.9 (exact)
+        * folder/device keyword in CMMS DESCRIPTION/ASSETNUM → 0.55–0.8
+        """
+        cmms_targets = [
+            e for e in cmms_graph.entities.values() if e.entity_type in ("asset", "component")
+        ]
+        by_assetnum = {_norm(c.name): c for c in cmms_targets}
+        proposals: list[Proposal] = []
+        all_tags = scada_graph.by_type("tag")
+        matched_tag_keys: set[str] = set()
+
+        # 1) Precise per-tag links: a tag whose name exactly matches a CMMS
+        #    ASSETNUM (PE_101 ↔ PE-101) — high confidence, one proposal each.
+        for tag in all_tags:
+            cand = by_assetnum.get(_norm(tag.properties.get("tag_name", "")))
+            if not cand:
+                continue
+            matched_tag_keys.add(tag.key)
+            proposals.append(
+                self._edge_proposal(
+                    cand,
+                    [tag],
+                    basis=f"tag name '{tag.properties.get('tag_name')}' == ASSETNUM {cand.name}",
+                    score=0.9,
+                )
+            )
+
+        # 2) Folder-level fuzzy links for the remaining tags (device folders
+        #    like Motor / VFD_GS10 that map to one asset, not per-tag).
+        folders: dict[str, list[CanonicalEntity]] = {}
+        for tag in all_tags:
+            if tag.key in matched_tag_keys:
+                continue
+            folders.setdefault(tag.properties.get("scada_path", "").rsplit("/", 1)[0], []).append(tag)
+
+        for folder, tags in folders.items():
+            device_leaf = folder.rsplit("/", 1)[-1]
+            best, basis, score = self._best_cmms_match(device_leaf, tags, cmms_targets)
+            if not best:
+                continue
+            proposals.append(self._edge_proposal(best, tags, basis=basis, score=score))
+        return proposals
+
+    def _edge_proposal(
+        self, target: CanonicalEntity, tags: list[CanonicalEntity], *, basis: str, score: float
+    ) -> Proposal:
+        is_safety = any(t.properties.get("is_safety") for t in tags)
+        label = tags[0].properties.get("tag_name") if len(tags) == 1 else (
+            tags[0].properties.get("scada_path", "").rsplit("/", 1)[0].rsplit("/", 1)[-1]
+        )
+        return Proposal(
+            suggestion_type="kg_edge",
+            title=f"Link SCADA '{label}' → {target.name} (HAS_SIGNAL)",
+            body=(
+                f"{len(tags)} Ignition tag(s) look like signals of CMMS "
+                f"{target.entity_type} '{target.name}' "
+                f"({target.properties.get('description')}). Match basis: {basis}. "
+                "Confirm to attach these live signals to the asset."
+            ),
+            extracted_data={
+                "relationship_type": "HAS_SIGNAL",
+                "cmms_target_key": target.key,
+                "cmms_uns_path": target.uns_path,
+                "scada_tags": [t.properties.get("scada_path") for t in tags],
+                "match_basis": basis,
+            },
+            confidence=score,
+            risk_level="safety_critical" if is_safety else "low",
+            proposed_by=f"import:{self.name}",
+            source_kind="tag_entity",
+        )
+
+    @staticmethod
+    def _best_cmms_match(
+        device_leaf: str, tags: list[CanonicalEntity], cmms_targets: list[CanonicalEntity]
+    ) -> tuple[Optional[CanonicalEntity], str, float]:
+        leaf_n = _norm(device_leaf)
+        tag_names_n = {_norm(t.properties.get("tag_name", "")) for t in tags}
+        best: Optional[CanonicalEntity] = None
+        best_basis = ""
+        best_score = 0.0
+        for cand in cmms_targets:
+            assetnum_n = _norm(cand.name)
+            desc_n = _norm(cand.properties.get("description") or "")
+            score = 0.0
+            basis = ""
+            # 1) a tag name equals the CMMS asset number (PE_101 ↔ PE-101)
+            if assetnum_n in tag_names_n or leaf_n == assetnum_n:
+                score, basis = 0.9, f"tag/folder name == ASSETNUM {cand.name}"
+            # 2) device keyword present in the asset number
+            elif leaf_n and leaf_n in assetnum_n:
+                score, basis = 0.7, f"'{device_leaf}' in ASSETNUM {cand.name}"
+            # 3) device keyword present in the description (motor → "Drive Motor")
+            elif leaf_n and any(tok and tok in desc_n for tok in _split_leaf(leaf_n)):
+                hits = [tok for tok in _split_leaf(leaf_n) if tok in desc_n]
+                score = 0.55 + 0.1 * (len(hits) - 1)
+                basis = f"keyword(s) {hits} in DESCRIPTION of {cand.name}"
+            if score > best_score:
+                best, best_basis, best_score = cand, basis, min(score, 0.85)
+        return best, best_basis, best_score
+
+    # ── validate ────────────────────────────────────────────────────
+
+    def validate(self, graph: NormalizedGraph) -> ValidationReport:
+        report = ValidationReport()
+        keys = set(graph.entities.keys())
+        for ent in graph.entities.values():
+            if ent.approval_state != "proposed":
+                report.add("error", "auto_verified", f"{ent.key} is {ent.approval_state}", ent.key)
+            if not ent.source_payload:
+                report.add("error", "missing_source_payload", f"{ent.key} lost its raw record", ent.key)
+            if ent.entity_type == "tag" and ent.uns_path is not None:
+                report.add(
+                    "warning",
+                    "scada_tag_has_uns",
+                    f"{ent.key} has a UNS path before being linked to an asset",
+                    ent.key,
+                )
+        for rel in graph.relationships:
+            for endpoint in (rel.source_key, rel.target_key):
+                if endpoint not in keys:
+                    report.add("warning", "orphan_relationship", f"{rel.relationship_type}: {endpoint}")
+        return report
+
+    # ── export (unsupported for SCADA) ──────────────────────────────
+
+    async def export_enriched(self, graph_context: dict[str, Any]) -> ExportResult:
+        return ExportResult(
+            supported=False,
+            written=False,
+            payloads=[],
+            note="Ignition tag providers are not an enriched-write-back target; "
+            "MIRA reads SCADA, it does not push enriched payloads to a tag tree.",
+        )
+
+    # ── config ──────────────────────────────────────────────────────
+
+    def get_config_schema(self) -> dict[str, Any]:
+        return {
+            "gateway_url": {"type": "string", "required": True, "description": "Ignition gateway base URL"},
+            "provider": {"type": "string", "required": False, "default": "default", "description": "Tag provider"},
+            "folder": {"type": "string", "required": False, "description": "Browse root folder filter"},
+            "api_key": {"type": "string", "required": True, "secret": True, "description": "WebDev/API key (Doppler-managed)"},
+            "fixture_path": {"type": "string", "required": False, "description": "Mock only: path to fixture JSON"},
+        }
+
+
+def _split_leaf(leaf_n: str) -> list[str]:
+    """Break a normalized device leaf into candidate keyword tokens.
+    'vfdgs10' → ['vfd', 'gs10']; 'motor' → ['motor']."""
+    known = ["motor", "vfd", "gs10", "pump", "sensor", "conveyor", "drive", "valve"]
+    found = [k for k in known if k in leaf_n]
+    return found or [leaf_n]

--- a/mira-connectors/tests/test_base.py
+++ b/mira-connectors/tests/test_base.py
@@ -1,0 +1,48 @@
+"""Base-interface contract: read_only vs dry_run are distinct axes, and the
+write-guard only opens when a connector is explicitly live."""
+
+from __future__ import annotations
+
+import asyncio
+
+from cmms.maximo_mock import MaximoMockConnector
+
+
+def test_defaults_are_safe():
+    c = MaximoMockConnector()
+    assert c.dry_run is True
+    assert c.read_only is True
+    assert c._may_write_source() is False
+
+
+def test_read_only_blocks_source_write_even_when_not_dry_run():
+    c = MaximoMockConnector(dry_run=False, read_only=True)
+    assert c._may_write_source() is False  # read_only guards the SOURCE
+
+
+def test_dry_run_blocks_source_write_even_when_writable():
+    c = MaximoMockConnector(dry_run=True, read_only=False)
+    assert c._may_write_source() is False  # dry_run guards persistence
+
+
+def test_live_connector_may_write():
+    c = MaximoMockConnector(dry_run=False, read_only=False)
+    assert c._may_write_source() is True
+
+
+def test_dry_run_run_helper_returns_graph_without_persisting():
+    c = MaximoMockConnector()  # dry_run
+    graph = asyncio.run(c.run())
+    # run() returns the in-memory graph; nothing is persisted (no DB at all here)
+    assert graph.summary()["entities"] > 0
+    assert all(e.approval_state == "proposed" for e in graph.entities.values())
+
+
+def test_export_respects_dry_run():
+    dry = MaximoMockConnector()
+    res = asyncio.run(dry.export_enriched({"wonum": "WO-1"}))
+    assert res.supported and res.written is False
+
+    live = MaximoMockConnector(dry_run=False, read_only=False)
+    res2 = asyncio.run(live.export_enriched({"wonum": "WO-1"}))
+    assert res2.written is True

--- a/mira-connectors/tests/test_canonical.py
+++ b/mira-connectors/tests/test_canonical.py
@@ -1,0 +1,96 @@
+"""Canonical-model invariants: proposed-by-default, payload preservation,
+content hashing, governed vocabulary, and the validation report."""
+
+from __future__ import annotations
+
+import pytest
+
+from canonical import (
+    APPROVAL_PROPOSED,
+    CanonicalEntity,
+    CanonicalRelationship,
+    NormalizedGraph,
+    Proposal,
+    SourceObject,
+    ValidationReport,
+    confidence_band,
+    content_hash,
+)
+
+
+def test_entity_defaults_to_proposed():
+    e = CanonicalEntity(entity_type="asset", name="A-1")
+    assert e.approval_state == APPROVAL_PROPOSED
+    assert e.key == "asset:A-1"
+
+
+def test_relationship_defaults_to_proposed():
+    r = CanonicalRelationship("asset:A", "component:B", "HAS_COMPONENT")
+    assert r.approval_state == APPROVAL_PROPOSED
+
+
+def test_unknown_entity_type_rejected():
+    with pytest.raises(ValueError):
+        CanonicalEntity(entity_type="gadget", name="x")
+
+
+def test_unknown_relationship_type_rejected():
+    with pytest.raises(ValueError):
+        CanonicalRelationship("a", "b", "FROBS")
+
+
+def test_unknown_suggestion_type_rejected():
+    with pytest.raises(ValueError):
+        Proposal(suggestion_type="nonsense", title="t", body="b")
+
+
+def test_proposal_confidence_bounds():
+    with pytest.raises(ValueError):
+        Proposal(suggestion_type="kg_edge", title="t", body="b", confidence=1.5)
+
+
+def test_content_hash_stable_and_order_independent():
+    a = {"x": 1, "y": 2}
+    b = {"y": 2, "x": 1}
+    assert content_hash(a) == content_hash(b)
+    assert content_hash({"x": 1}) != content_hash({"x": 2})
+
+
+def test_source_object_autocomputes_hash():
+    so = SourceObject("maximo", "asset", "A-1", {"ASSETNUM": "A-1"}, "0.1.0")
+    assert so.content_hash and len(so.content_hash) == 64
+
+
+def test_entity_autocomputes_hash_from_payload():
+    e = CanonicalEntity(entity_type="asset", name="A-1", source_payload={"ASSETNUM": "A-1"})
+    assert e.content_hash
+
+
+def test_confidence_bands():
+    assert confidence_band(0.4) == "low"
+    assert confidence_band(0.5) == "medium"
+    assert confidence_band(0.8) == "medium"
+    assert confidence_band(0.81) == "high"
+
+
+def test_graph_add_entity_upserts_by_key():
+    g = NormalizedGraph()
+    g.add_entity(
+        CanonicalEntity(entity_type="asset", name="A", confidence=0.5, properties={"a": 1})
+    )
+    g.add_entity(
+        CanonicalEntity(entity_type="asset", name="A", confidence=0.9, properties={"b": 2})
+    )
+    assert len(g.entities) == 1
+    merged = g.get("asset:A")
+    assert merged.properties == {"a": 1, "b": 2}
+    assert merged.confidence == 0.9  # max kept
+
+
+def test_validation_report_ok_and_buckets():
+    rep = ValidationReport()
+    assert rep.ok
+    rep.add("warning", "w", "a warning")
+    assert rep.ok and len(rep.warnings) == 1
+    rep.add("error", "e", "an error")
+    assert not rep.ok and len(rep.errors) == 1

--- a/mira-connectors/tests/test_demo.py
+++ b/mira-connectors/tests/test_demo.py
@@ -1,0 +1,47 @@
+"""Smoke test: the end-to-end demo runs cleanly and produces the expected join.
+
+This also exercises the cross-connector merge + cross-reference path that the
+demo narrates, asserting the OT↔enterprise link actually forms."""
+
+from __future__ import annotations
+
+import asyncio
+
+from cmms.maximo_mock import MaximoMockConnector
+from canonical import NormalizedGraph
+from scada.ignition_mock import IgnitionMockConnector
+
+
+def test_end_to_end_join_produces_unified_proposed_graph():
+    maximo = MaximoMockConnector()
+    ignition = IgnitionMockConnector()
+
+    mx = maximo.normalize(asyncio.run(maximo.import_records()))
+    ig = ignition.normalize(asyncio.run(ignition.import_records()))
+
+    # both validate clean
+    assert maximo.validate(mx).ok
+    assert ignition.validate(ig).ok
+
+    links = ignition.propose_asset_links(ig, mx)
+    assert links, "cross-reference should propose SCADA↔CMMS links"
+
+    unified = NormalizedGraph()
+    unified.merge(mx)
+    unified.merge(ig)
+    for p in links:
+        unified.add_proposal(p)
+
+    s = unified.summary()
+    assert s["entities"] > len(mx.entities)  # SCADA entities folded in
+    # every edge in the unified graph is still proposed (no auto-verify)
+    assert s["proposed_relationships"] == s["relationships"]
+    # raw records from BOTH systems are preserved
+    systems = {so.system_kind for so in unified.source_objects}
+    assert {"maximo", "ignition"} <= systems
+
+
+def test_demo_main_runs():
+    import demo
+
+    asyncio.run(demo.main())  # raises if anything in the flow breaks

--- a/mira-connectors/tests/test_ignition_mock.py
+++ b/mira-connectors/tests/test_ignition_mock.py
@@ -1,0 +1,92 @@
+"""Ignition SCADA connector tests — tag normalization + cross-reference."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cmms.maximo_mock import MaximoMockConnector
+from scada.ignition_mock import IgnitionMockConnector
+
+
+@pytest.fixture()
+def scada():
+    c = IgnitionMockConnector()
+    return c, c.normalize(asyncio.run(c.import_records()))
+
+
+def test_discover_no_export():
+    cap = asyncio.run(IgnitionMockConnector().discover())
+    assert cap.system_kind == "ignition"
+    assert cap.supports_export is False  # no write-back to a tag provider
+
+
+def test_import_returns_valid_tags():
+    raw = asyncio.run(IgnitionMockConnector().import_records())
+    assert raw and all(
+        r.object_type == "tag" and r.external_object_id.startswith("[default]") for r in raw
+    )
+
+
+def test_tags_have_no_uns_until_linked(scada):
+    _, g = scada
+    tags = g.by_type("tag")
+    assert tags
+    assert all(t.uns_path is None for t in tags), (
+        "SCADA tags carry no UNS path until linked to an asset"
+    )
+
+
+def test_tag_payload_preserved_with_samples(scada):
+    _, g = scada
+    t = g.by_type("tag")[0]
+    assert "path" in t.source_payload and "samples" in t.source_payload
+    assert t.properties["tag_kind"] == "scada"
+
+
+def test_folder_structure_detected(scada):
+    _, g = scada
+    # provisional equipment + device-folder components from the tag tree
+    assert any(e.entity_type == "asset" and "Conv_Simple" in e.name for e in g.entities.values())
+    assert any(e.entity_type == "component" for e in g.entities.values())
+    assert any(r.relationship_type == "HAS_SIGNAL" for r in g.relationships)
+
+
+def test_cross_reference_exact_and_fuzzy_matches(scada):
+    ig, sg = scada
+    mx = MaximoMockConnector()
+    mxg = mx.normalize(asyncio.run(mx.import_records()))
+    props = ig.propose_asset_links(sg, mxg)
+    assert props
+    # all cross-ref proposals are kg_edge, pending, never auto-verified
+    assert all(p.suggestion_type == "kg_edge" and p.status == "pending" for p in props)
+    by_target = {p.extracted_data["cmms_target_key"]: p for p in props}
+    # exact tag↔ASSETNUM match (PE_101 ↔ PE-101) scores high
+    assert by_target["component:PE-101"].confidence >= 0.9
+    # fuzzy folder match scores lower
+    assert by_target["component:MOTOR-001"].confidence < 0.9
+    # every proposed link names the relationship and the target UNS path
+    for p in props:
+        assert p.extracted_data["relationship_type"] == "HAS_SIGNAL"
+        assert p.extracted_data["cmms_uns_path"]
+
+
+def test_safety_tag_link_flagged(scada):
+    ig, sg = scada
+    mx = MaximoMockConnector()
+    mxg = mx.normalize(asyncio.run(mx.import_records()))
+    props = ig.propose_asset_links(sg, mxg)
+    conv = [p for p in props if p.extracted_data["cmms_target_key"] == "asset:CONV-001"]
+    assert conv and conv[0].risk_level == "safety_critical"  # EStop tag present
+
+
+def test_validate_clean(scada):
+    c, g = scada
+    rep = c.validate(g)
+    assert rep.ok and not rep.warnings
+
+
+def test_export_unsupported():
+    res = asyncio.run(IgnitionMockConnector().export_enriched({}))
+    assert res.supported is False and res.written is False

--- a/mira-connectors/tests/test_maintainx_mock.py
+++ b/mira-connectors/tests/test_maintainx_mock.py
@@ -1,0 +1,72 @@
+"""MaintainX connector tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from uns_bridge import uns
+from cmms.maintainx_mock import MaintainXMockConnector
+
+
+@pytest.fixture()
+def graph():
+    c = MaintainXMockConnector()
+    return c, c.normalize(asyncio.run(c.import_records()))
+
+
+def test_discover_rest_shape():
+    cap = asyncio.run(MaintainXMockConnector().discover())
+    assert cap.system_kind == "maintainx"
+    assert "asset" in cap.object_types and "work_order" in cap.object_types
+
+
+def test_import_records_valid():
+    raw = asyncio.run(MaintainXMockConnector().import_records())
+    assert raw and {r.object_type for r in raw} >= {"location", "asset", "work_order", "part"}
+
+
+def test_hierarchy_and_uns(graph):
+    _, g = graph
+    conv = g.get("asset:CONV-001")
+    motor = g.get("component:MOTOR-001")
+    assert conv and motor
+    assert uns.is_valid_path(conv.uns_path)
+    assert motor.uns_path.startswith(conv.uns_path + ".component.")
+
+
+def test_payload_preserved_incl_numeric_id(graph):
+    _, g = graph
+    conv = g.get("asset:CONV-001")
+    assert conv.source_payload["id"] == 8001
+    assert conv.source_payload["manufacturer"] == "Dorner"
+
+
+def test_edges(graph):
+    _, g = graph
+    types = {r.relationship_type for r in g.relationships}
+    assert {"LOCATED_IN", "HAS_COMPONENT", "HAS_WORK_ORDER", "HAS_PART"} <= types
+
+
+def test_preventive_category_flagged(graph):
+    _, g = graph
+    pms = [e for e in g.by_type("work_order") if e.properties.get("is_preventive")]
+    assert pms, "PREVENTIVE-category work order should be flagged"
+
+
+def test_all_proposed_and_validate(graph):
+    c, g = graph
+    assert all(e.approval_state == "proposed" for e in g.entities.values())
+    rep = c.validate(g)
+    assert rep.ok and not rep.warnings
+
+
+def test_export_dry_run():
+    res = asyncio.run(
+        MaintainXMockConnector().export_enriched(
+            {"work_order_id": "91001", "uns_path": "enterprise.acme"}
+        )
+    )
+    assert res.supported and res.written is False
+    assert res.payloads[0]["customFields"]["mira_uns_path"] == "enterprise.acme"

--- a/mira-connectors/tests/test_maximo_mock.py
+++ b/mira-connectors/tests/test_maximo_mock.py
@@ -1,0 +1,158 @@
+"""Maximo connector tests — covers the 7 required behaviors:
+import, normalize, payload preservation, UNS paths, proposals (not facts),
+dry_run, and export."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from uns_bridge import uns
+from cmms.maximo_mock import MaximoMockConnector
+
+
+@pytest.fixture()
+def graph():
+    c = MaximoMockConnector()
+    return c, c.normalize(asyncio.run(c.import_records()))
+
+
+def test_discover_reports_schema_and_export():
+    c = MaximoMockConnector()
+    cap = asyncio.run(c.discover())
+    assert cap.system_kind == "maximo"
+    assert cap.supports_export is True
+    assert "asset" in cap.object_types
+    assert "ASSETNUM" in cap.schema["asset"]  # real Maximo field name surfaced
+
+
+def test_import_returns_valid_raw_records():
+    c = MaximoMockConnector()
+    raw = asyncio.run(c.import_records())
+    assert raw, "expected records"
+    assert all(r.object_type and r.external_object_id and r.payload for r in raw)
+    assert {r.object_type for r in raw} >= {
+        "asset",
+        "location",
+        "workorder",
+        "pm",
+        "meter",
+        "doclink",
+        "failurecode",
+    }
+
+
+def test_import_site_filter():
+    c = MaximoMockConnector()
+    raw = asyncio.run(c.import_records({"site": "NASHUA", "object_types": ["asset"]}))
+    assert raw and all(r.payload["SITEID"] == "NASHUA" for r in raw)
+
+
+def test_normalize_asset_and_component_types(graph):
+    _, g = graph
+    assert g.get("asset:CONV-001").entity_type == "asset"
+    # children (PARENT set) normalize to components
+    assert g.get("component:MOTOR-001").entity_type == "component"
+    assert g.get("component:VFD-001").entity_type == "component"
+
+
+def test_uns_paths_are_valid_and_nested(graph):
+    _, g = graph
+    conv = g.get("asset:CONV-001")
+    motor = g.get("component:MOTOR-001")
+    assert conv.uns_path == uns.assigned_equipment_path(
+        "acme", "bedford", "area_1", "CONV-001", line="line_1", work_cell="cell_1"
+    )
+    assert motor.uns_path.startswith(conv.uns_path + ".component.")
+    for e in g.entities.values():
+        if e.uns_path:
+            assert uns.is_valid_path(e.uns_path), e.uns_path
+
+
+def test_all_source_fields_preserved(graph):
+    _, g = graph
+    conv = g.get("asset:CONV-001")
+    # the original Maximo record — including custom fields — survives verbatim
+    assert conv.source_payload["ASSETNUM"] == "CONV-001"
+    assert conv.source_payload["SERIALNUM"] == "CNV-2021-4471"
+    assert "MIRA_UNS_PATH" in conv.source_payload  # custom field not dropped
+    assert "MIRA_CONFIDENCE" in conv.source_payload
+    # a matching SourceObject preserves the raw record too
+    so = [s for s in g.source_objects if s.external_object_id == "CONV-001"][0]
+    assert so.raw_payload == conv.source_payload
+    assert so.mapping_status == "mapped"
+
+
+def test_failure_code_tree_normalized(graph):
+    _, g = graph
+    assert g.get("fault_code:CONVEYOR")
+    assert g.get("failure_mode:NORUN")
+    assert g.get("root_cause:VFDFAULT")
+    assert g.get("remedy:RSTVFD")
+    rels = {(r.source_key, r.relationship_type, r.target_key) for r in g.relationships}
+    assert ("root_cause:VFDFAULT", "CAUSES", "failure_mode:NORUN") in rels
+    assert ("failure_mode:NORUN", "RESOLVED_BY", "remedy:RSTVFD") in rels
+
+
+def test_workorder_edges_and_parts(graph):
+    _, g = graph
+    rels = {(r.source_key, r.relationship_type, r.target_key) for r in g.relationships}
+    assert ("asset:CONV-001", "HAS_WORK_ORDER", "work_order:WO-10231") in rels
+    # WO against a component (MOTOR-001) resolves to the component, not a phantom asset
+    assert ("component:MOTOR-001", "HAS_WORK_ORDER", "work_order:WO-10302") in rels
+    assert any(r.relationship_type == "USES_PART" for r in g.relationships)
+
+
+def test_pm_and_meter_and_doclink_edges(graph):
+    _, g = graph
+    types = {r.relationship_type for r in g.relationships}
+    assert {"HAS_PM_TASK", "HAS_SIGNAL", "HAS_DOCUMENT"} <= types
+    # a wiring doclink becomes a wiring_diagram entity
+    assert any(e.entity_type == "wiring_diagram" for e in g.entities.values())
+
+
+def test_ambiguous_mappings_are_proposals_not_facts(graph):
+    _, g = graph
+    # the 4-vs-3 ISA-95 depth mismatch is a uns_confirmation proposal
+    assert any(p.suggestion_type == "uns_confirmation" for p in g.proposals)
+    # nothing the connector produced is auto-verified
+    assert all(e.approval_state == "proposed" for e in g.entities.values())
+    assert all(r.approval_state == "proposed" for r in g.relationships)
+
+
+def test_safety_failure_path_flagged(graph):
+    _, g = graph
+    safety = [p for p in g.proposals if p.risk_level == "safety_critical"]
+    assert safety, "E-stop failure path should be flagged safety_critical"
+
+
+def test_validate_clean(graph):
+    c, g = graph
+    rep = c.validate(g)
+    assert rep.ok, [e.message for e in rep.errors]
+    assert not rep.warnings, [w.message for w in rep.warnings]
+
+
+def test_export_dry_run_builds_but_does_not_write():
+    c = MaximoMockConnector()
+    res = asyncio.run(
+        c.export_enriched(
+            {
+                "wonum": "WO-10231",
+                "uns_path": "enterprise.acme",
+                "diagnosis": "x",
+                "confidence": "high",
+            }
+        )
+    )
+    assert res.supported and res.written is False
+    payload = res.payloads[0]
+    assert payload["WONUM"] == "WO-10231"
+    assert payload["MIRA_UNS_PATH"] == "enterprise.acme"  # custom field round-trips
+
+
+def test_config_schema_marks_secret():
+    c = MaximoMockConnector()
+    schema = c.get_config_schema()
+    assert schema["api_key"]["secret"] is True

--- a/mira-connectors/tests/test_pi_mock.py
+++ b/mira-connectors/tests/test_pi_mock.py
@@ -1,0 +1,72 @@
+"""AVEVA PI historian connector tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from uns_bridge import uns
+from historian.pi_mock import PIMockConnector
+
+
+@pytest.fixture()
+def graph():
+    c = PIMockConnector()
+    return c, c.normalize(asyncio.run(c.import_records()))
+
+
+def test_discover():
+    cap = asyncio.run(PIMockConnector().discover())
+    assert cap.system_kind == "historian"
+    assert cap.supports_export is False
+    assert "pi_point" in cap.object_types
+
+
+def test_import_records_valid():
+    raw = asyncio.run(PIMockConnector().import_records())
+    assert raw and {r.object_type for r in raw} >= {"af_element", "pi_point", "event_frame"}
+
+
+def test_af_hierarchy_to_canonical(graph):
+    _, g = graph
+    site = [e for e in g.by_type("site")]
+    assert site
+    asset = g.get("asset:af:Bedford\\Packaging\\Conveyor")
+    assert asset and uns.is_valid_path(asset.uns_path)
+    motor = g.get("component:af:Bedford\\Packaging\\Conveyor\\Motor")
+    assert motor.uns_path.startswith(asset.uns_path + ".component.")
+
+
+def test_pi_points_become_historian_tags(graph):
+    _, g = graph
+    tags = g.by_type("tag")
+    assert tags and all(t.properties["tag_kind"] == "historian" for t in tags)
+    # archived values ride along as samples, preserved in the payload
+    cur = [t for t in tags if t.name.endswith("Conv.Motor.Current")][0]
+    assert cur.properties["sample_count"] == 3
+    assert "_archived_values" in cur.source_payload
+
+
+def test_event_frames_become_fault_events(graph):
+    _, g = graph
+    fe = g.by_type("fault_event")
+    assert fe
+    assert any(r.relationship_type == "OCCURS_ON" for r in g.relationships)
+
+
+def test_safety_event_frame_flagged(graph):
+    _, g = graph
+    assert any(p.risk_level == "safety_critical" for p in g.proposals)
+
+
+def test_all_proposed_and_validate(graph):
+    c, g = graph
+    assert all(e.approval_state == "proposed" for e in g.entities.values())
+    rep = c.validate(g)
+    assert rep.ok and not rep.warnings
+
+
+def test_export_unsupported():
+    res = asyncio.run(PIMockConnector().export_enriched({}))
+    assert res.supported is False

--- a/mira-connectors/tests/test_sap_mock.py
+++ b/mira-connectors/tests/test_sap_mock.py
@@ -1,0 +1,76 @@
+"""SAP PM connector tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from uns_bridge import uns
+from cmms.sap_mock import SAPMockConnector
+
+
+@pytest.fixture()
+def graph():
+    c = SAPMockConnector()
+    return c, c.normalize(asyncio.run(c.import_records()))
+
+
+def test_discover_real_field_names():
+    cap = asyncio.run(SAPMockConnector().discover())
+    assert cap.system_kind == "sap"
+    assert "EQUNR" in cap.schema["equipment"]
+    assert "TPLNR" in cap.schema["functional_location"]
+
+
+def test_import_records_valid():
+    raw = asyncio.run(SAPMockConnector().import_records())
+    assert raw and {r.object_type for r in raw} >= {
+        "functional_location",
+        "equipment",
+        "maintenance_order",
+        "task_list",
+        "bom",
+    }
+
+
+def test_equipment_hierarchy_and_uns(graph):
+    _, g = graph
+    conv = g.get("asset:10000455")
+    motor = g.get("component:10000456")
+    assert conv and motor
+    assert uns.is_valid_path(conv.uns_path)
+    assert motor.uns_path.startswith(conv.uns_path + ".component.")
+
+
+def test_payload_preserved(graph):
+    _, g = graph
+    conv = g.get("asset:10000455")
+    assert conv.source_payload["EQUNR"] == "10000455"
+    assert conv.source_payload["HERST"] == "Dorner"
+
+
+def test_edges(graph):
+    _, g = graph
+    types = {r.relationship_type for r in g.relationships}
+    assert {"LOCATED_IN", "HAS_COMPONENT", "HAS_WORK_ORDER", "HAS_PM_TASK", "HAS_PART"} <= types
+
+
+def test_plant_level_is_proposal(graph):
+    _, g = graph
+    assert any(p.suggestion_type == "uns_confirmation" for p in g.proposals)
+    assert all(e.approval_state == "proposed" for e in g.entities.values())
+
+
+def test_validate_clean(graph):
+    c, g = graph
+    rep = c.validate(g)
+    assert rep.ok and not rep.warnings
+
+
+def test_export_dry_run():
+    res = asyncio.run(
+        SAPMockConnector().export_enriched({"aufnr": "4000123", "uns_path": "enterprise.acme"})
+    )
+    assert res.supported and res.written is False
+    assert res.payloads[0]["ZZ_MIRA_UNS_PATH"] == "enterprise.acme"

--- a/mira-connectors/uns_bridge.py
+++ b/mira-connectors/uns_bridge.py
@@ -1,0 +1,32 @@
+"""Bridge to the canonical UNS path builders in ``mira-crawler/ingest/uns.py``.
+
+The connector framework MUST NOT reinvent UNS path construction
+(``.claude/rules/uns-compliance.md`` rule #1). All ``enterprise.*`` paths are
+built by the functions in ``mira-crawler/ingest/uns.py`` — ``slug``,
+``site_path``, ``area_path``, ``line_path``, ``work_cell_path``,
+``assigned_equipment_path``, ``equipment_subnode_path``, ``fault_code_path``,
+``model_path``, ``manual_path``, ``work_order_path``, etc.
+
+``mira-crawler`` is a sibling module, not an installed package, so we inject it
+onto ``sys.path`` the same way the repo's backfill scripts and conftests do
+(e.g. ``tools/migrations/backfill_equipment_entities.py`` → ``from ingest.uns
+import ...``). Importing this module re-exports the live ``uns`` module so
+connectors can ``from uns_bridge import uns`` and call ``uns.site_path(...)``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# mira-connectors/ -> repo root -> mira-crawler/ (where the `ingest` package lives)
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CRAWLER = _REPO_ROOT / "mira-crawler"
+
+if _CRAWLER.is_dir() and str(_CRAWLER) not in sys.path:
+    sys.path.insert(0, str(_CRAWLER))
+
+# The single source of truth for UNS path grammar. Re-exported, never copied.
+from ingest import uns  # noqa: E402  (sys.path injection must precede import)
+
+__all__ = ["uns"]

--- a/tools/youtube_uploader.py
+++ b/tools/youtube_uploader.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Minimal YouTube uploader for MIRA promo/demo renders.
+
+Auth: refresh-token OAuth from Doppler `factorylm/prd`
+(`YOUTUBE_CLIENT_ID`, `YOUTUBE_CLIENT_SECRET`, `YOUTUBE_REFRESH_TOKEN`).
+
+Usage:
+  doppler run -p factorylm -c prd -- python tools/youtube_uploader.py --jobs jobs.json
+  doppler run -p factorylm -c prd -- python tools/youtube_uploader.py \
+      --file path.mp4 --title "T" --description "D" --privacy private
+
+`jobs.json` is a list of {file, title, description}. Privacy defaults to
+`private` (override per-job with a "privacy" key or globally with --privacy).
+Prints a JSON summary of {file, video_id, url, privacy} per upload.
+
+Quota: each insert costs ~1600 units of the 10K/day default → ~6 uploads/day.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaFileUpload
+
+TOKEN_URI = "https://oauth2.googleapis.com/token"
+SCOPES = ["https://www.googleapis.com/auth/youtube.upload"]
+
+
+def build_client():
+    cid = os.environ.get("YOUTUBE_CLIENT_ID")
+    csec = os.environ.get("YOUTUBE_CLIENT_SECRET")
+    rtok = os.environ.get("YOUTUBE_REFRESH_TOKEN")
+    missing = [k for k, v in
+               {"YOUTUBE_CLIENT_ID": cid, "YOUTUBE_CLIENT_SECRET": csec,
+                "YOUTUBE_REFRESH_TOKEN": rtok}.items() if not v]
+    if missing:
+        sys.exit(f"Missing env (run via Doppler factorylm/prd): {', '.join(missing)}")
+    creds = Credentials(
+        token=None, refresh_token=rtok, token_uri=TOKEN_URI,
+        client_id=cid, client_secret=csec, scopes=SCOPES,
+    )
+    return build("youtube", "v3", credentials=creds, cache_discovery=False)
+
+
+def upload_one(youtube, path: str, title: str, description: str, privacy: str) -> dict:
+    if not os.path.isfile(path):
+        return {"file": path, "error": "file not found"}
+    body = {
+        "snippet": {
+            "title": title[:100],
+            "description": description,
+            "categoryId": "28",  # Science & Technology
+        },
+        "status": {
+            "privacyStatus": privacy,
+            "selfDeclaredMadeForKids": False,
+            "embeddable": True,
+        },
+    }
+    media = MediaFileUpload(path, mimetype="video/mp4", chunksize=-1, resumable=True)
+    req = youtube.videos().insert(part="snippet,status", body=body, media_body=media)
+    resp = None
+    while resp is None:
+        _, resp = req.next_chunk()
+    vid = resp["id"]
+    return {
+        "file": os.path.basename(path),
+        "video_id": vid,
+        "url": f"https://youtu.be/{vid}",
+        "studio": f"https://studio.youtube.com/video/{vid}/edit",
+        "privacy": resp["status"]["privacyStatus"],
+        "title": resp["snippet"]["title"],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--jobs", help="JSON list of {file,title,description[,privacy]}")
+    ap.add_argument("--file")
+    ap.add_argument("--title")
+    ap.add_argument("--description", default="")
+    ap.add_argument("--privacy", default="private",
+                    choices=["private", "unlisted", "public"])
+    args = ap.parse_args()
+
+    if args.jobs:
+        with open(args.jobs) as f:
+            jobs = json.load(f)
+    elif args.file and args.title:
+        jobs = [{"file": args.file, "title": args.title,
+                 "description": args.description}]
+    else:
+        sys.exit("Provide --jobs FILE or --file + --title")
+
+    youtube = build_client()
+    results = []
+    for j in jobs:
+        try:
+            r = upload_one(youtube, j["file"], j["title"],
+                           j.get("description", ""),
+                           j.get("privacy", args.privacy))
+        except HttpError as e:
+            r = {"file": j.get("file"), "error": f"HttpError {e.resp.status}: {e}"}
+        results.append(r)
+        print(json.dumps(r, indent=2), flush=True)
+
+    print("\n=== SUMMARY ===")
+    for r in results:
+        if "error" in r:
+            print(f"  FAIL  {r.get('file')}: {r['error']}")
+        else:
+            print(f"  OK    [{r['privacy']}] {r['url']}  {r['title']}")
+    return 0 if all("error" not in r for r in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -562,3 +562,13 @@ Mitsubishi Electric: 16 chunks (NULL model)
 - Scorecard: 30/57 passing (53%) — new low in the FSM/UNS-gate band
 - Action: issue-filed (commented on tracker #1583, not a duplicate)
 - 27 patchable failures but both autopatch hard-stops tripped (>15 failures; 3 file clusters). Same clusters A–E as #1583. `last_response_snippet` still empty for all — transcript capture remains the #1 blocker.
+
+## eval-fixer run — 2026-06-02
+- Scorecard: 35/57 passing (61%)
+- Action: issue-filed (#1640)
+- 22 failures, all autopatch-blocked (>15 patchable AND 3 file clusters). Systemic FSM/UNS-gate regression — 21/22 point at engine.py. Clusters: gate stuck in AWAITING_UNS_CONFIRMATION, docs-requests landing in ASSET_IDENTIFIED instead of IDLE, over-qualifying (stuck Q1/Q2 vs DIAGNOSIS), CMMS WO not created, PowerFlex leaking on GS20. Needs human bisect.
+
+## eval-fixer run — 2026-06-03
+- Scorecard: 35/57 passing (61%) — runs/2026-06-03T0109-offline-text.md
+- Action: issue-filed (#1678)
+- 22 patchable failures but BOTH hard-stops tripped (>15 failures AND 3 file clusters: engine.py, guardrails.py, active.yaml). Broad FSM-routing regression — fixtures stuck in AWAITING_UNS_CONFIRMATION/Q1/IDLE or over-advancing to ASSET_IDENTIFIED. Needs human bisect of recent engine.py state-machine edits.


### PR DESCRIPTION
## Summary

Generic connector framework for ingesting external CMMS/SCADA/historian context into MIRA's knowledge graph, with mock connectors for the major systems and a full test suite.

**Commits (5):**
- `a264251e` connector framework base + Maximo mock connector
- `5964f37e` Ignition SCADA, SAP PM, MaintainX, AVEVA PI mock connectors
- `01d48b47` end-to-end demo + test suite (67 tests)
- `be8231cf` connector-framework.md + module README
- `dd6d1228` run mira-connectors test suite in the Python test job (CI)

## Scope / safety
- No safety-critical files touched (`engine.py`, `guardrails.py`, `uns_resolver.py`, `citation_compliance.py` all untouched).
- Connectors are mock/framework-level — they feed proposals through the existing technician-confirmation gate, not auto-verify.
- 67 tests included; CI job wired.

## Stacking
Based on `feat/hub-command-center` (the 4 shared base commits: YouTube uploader + asset-graph docs + eval-fixer + promo). Retarget to `main` once that base lands, or merge base first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
