### PR TITLE
revert(deps): park major starlette + redis bumps (#1653, #1647) pending watched rollout

### DIFF
--- a/mira-crawler/requirements-celery.txt
+++ b/mira-crawler/requirements-celery.txt
@@ -1,6 +1,6 @@
 # Celery worker dependencies for mira-crawler
 celery==5.6.3
-redis==8.0.0
+redis==5.2.1
 
 # Ingest pipeline
 httpx>=0.28.1

--- a/mira-mcp/requirements.txt
+++ b/mira-mcp/requirements.txt
@@ -1,6 +1,6 @@
 fastmcp==3.3.*
 uvicorn==0.48.0
-starlette==1.2.1
+starlette==0.52.1
 openviking==0.3.20  # pinned: 0.3.16 (PR #1184, dependabot) pulls litellm 1.83.x which pins python-dotenv==1.0.1, conflicting with fastmcp 3.x's python-dotenv>=1.1.0. Revert until openviking ships a litellm bump or we move off the affected transitive.
 pdfplumber==0.11.9
 python-multipart==0.0.30  # CVE-2026-42561 (HIGH) — fixed in 0.0.28 (boundary length cap)


### PR DESCRIPTION
## Summary

Parks the two **major** dependency bumps that merged this session before they can ship to prod unvalidated. Per maintainer decision (2026-06-04): major version jumps that only pass offline `Docker Build Check` (pip-resolves) but aren't runtime-validated should not auto-deploy.

**Reverted:**
- `#1653` starlette `0.52.1 → 1.2.1` in `/mira-mcp` — a 0.x→1.x ASGI break risk; `mira-mcp` is a prod saas service.
- `#1647` redis `5.2.1 → 8.0.0` in `/mira-crawler` — major client bump.

The minor/patch bumps from this session (stripe, python-multipart, deepeval, langfuse, apify, pytest-asyncio, gitleaks-action, github-script, doppler-cli-action) stay on main and ride the next normal gated deploy.

Dependabot will re-open both as PRs; roll them out under a **watched** deploy when ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
