### PR TITLE
feat(connectors): SAP PM, MaintainX, AVEVA PI mock connectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,13 @@ jobs:
         # clarification invariants. Hermetic, no LLM, runs in <1s.
         run: pytest tests/bot_regression.py -v
 
+      - name: Connector framework tests
+        # mira-connectors/ is its own package (pyproject pythonpath=["."]) — run from
+        # inside it. Hermetic mock connectors (Maximo/Ignition/SAP/MaintainX/PI), no
+        # network/DB/LLM, <1s. Guards the whole framework, not just the new connectors.
+        working-directory: mira-connectors
+        run: pytest tests/ -v
+
   architecture-check:
     name: Architecture Check
     runs-on: ubuntu-latest

--- a/docs/mira/connector-framework.md
+++ b/docs/mira/connector-framework.md
@@ -161,6 +161,37 @@ folder hierarchy, OPC tags bound to a Modbus device (`Mira_PLC`, register map mi
 `CanonicalTag` rows; derives `HAS_SIGNAL` (asset folder → tags) and `LOCATED_IN` (folder
 hierarchy). Read-only — `export_records` refuses.
 
+### `SAPMockConnector` — `mocks/sap_mock.py` + `fixtures/sap.json`
+
+A second CMMS provider (`provider="sap"`). Native SAP PM field names: functional locations
+`TPLNR` (with `TPLMA` = superior FL, `FLTYP`), equipment masters `EQUNR` (`EQKTX`, `HERST`,
+`TYPBZ`, `SERGE`, `HEQUI` parent, `ABCKZ` criticality), maintenance orders `AUFNR`
+(`AUART`→work_type, `ANLZU`→status), task lists `PLNNR`/`PLNAL`→PM, and BOM lines `MATNR`.
+Hierarchy walks the `TPLNR` functional-location tree. Derived edges: `HAS_COMPONENT`
+(`HEQUI`), `LOCATED_IN` (`TPLNR`), `HAS_PART` (BOM/STPO). Write-back (maintenance orders)
+targets the SAP API, gated read-only by default.
+
+### `MaintainXMockConnector` — `mocks/maintainx_mock.py` + `fixtures/maintainx.json`
+
+`provider="maintainx"`, in MaintainX's REST response shape — the same `assets` /
+`workOrders` / `locations` / `parts` envelopes the live `mira-mcp/cmms/maintainx.py` adapter
+already parses. Numeric ids, `parentId`/`locationId`, `categories[]` (REACTIVE→corrective,
+PREVENTIVE→preventive), `status` (DONE→COMPLETE). The factory registry comments anticipate a
+real `MaintainXConnector` that simply wraps `MaintainXCMMS`. Derived edges: `HAS_COMPONENT`,
+`LOCATED_IN`, `HAS_PART` (`part.assetIds`).
+
+### `PIMockConnector` — `mocks/pi_mock.py` + `fixtures/pi.json`
+
+Reference **historian** connector (`provider="pi"`, `ConnectorKind.HISTORIAN`). AVEVA PI / AF
+data: AF element hierarchy (`Path`/`Parent`/`Template`) → `CanonicalAsset`; PI points
+(`\\server\tag`, `PointType`, `EngUnits`) → `CanonicalTag` (`history_enabled=True`,
+archived-value summary in `attributes`); archived values roll up into `CanonicalMeter`. Event
+frames are preserved on the owning element's `attributes` and surfaced in `discover()`; a
+safety-template event frame (E-stop) flags the element `criticality="safety_critical"`.
+Derived edges: `HAS_COMPONENT` (AF hierarchy), `HAS_SIGNAL` (element → point). **Read-only by
+construction** — historian `export_records` refuses regardless of mode (the high-frequency
+sample firehose belongs to the relay/event-stream layer, Phase 5 — not this connector).
+
 ---
 
 ## 7. Adding a real connector
@@ -180,15 +211,16 @@ hierarchy). Read-only — `export_records` refuses.
 
 ## 8. Testing
 
-`mira-connectors/tests/` — 37 tests, offline (in-memory, no DB, no network):
+`mira-connectors/tests/` — 79 tests, offline (in-memory, no DB, no network):
 
 - `test_canonical.py` — relationship/evidence validation (self-loop with kind-awareness,
   unknown type, missing evidence, confidence bounds).
 - `test_base_connector.py` — read-only refusal, dry-run planning, READ_WRITE export,
   SCADA refusal even in READ_WRITE, `sync()` structured result, validation errors/warnings.
-- `test_maximo_mock.py` / `test_ignition_mock.py` — full import→normalize→derive→export
-  lifecycle per connector.
-- `test_factory.py` — provider registry.
+- `test_maximo_mock.py` / `test_ignition_mock.py` / `test_sap_mock.py` /
+  `test_maintainx_mock.py` / `test_pi_mock.py` — full import→normalize→derive→export
+  lifecycle per connector (CMMS write-back gating; historian/SCADA read-only by construction).
+- `test_factory.py` — provider registry (all five mock providers).
 
 Run: `cd mira-connectors && pytest` (asyncio auto-mode from `pyproject.toml`).
 

--- a/mira-connectors/README.md
+++ b/mira-connectors/README.md
@@ -16,7 +16,7 @@ mira_connectors/
 ├── base.py               # Connector ABC + BaseConnector (the 10 capabilities)
 ├── factory.py            # create_connector(provider, config)
 ├── types/                # CMMS / SCADA / Historian / Document / MQTT type bases
-├── mocks/                # MaximoMockConnector + IgnitionMockConnector + fixtures
+├── mocks/                # Maximo + Ignition + SAP + MaintainX + PI mock connectors + fixtures
 ├── store.py              # ProposalStore (InMemory + Postgres) — existing tables only
 ├── confirmation_gate.py  # ConnectorConfirmationGate — propose/confirm/correct/reject (ADR-0017)
 └── service.py            # import_and_propose(connector, gate, ...) — one-call wiring
@@ -30,6 +30,6 @@ mira_connectors/
 ## Test
 
 ```bash
-cd mira-connectors && pytest        # 53 offline tests, no DB / network
+cd mira-connectors && pytest        # 79 offline tests, no DB / network
 ruff check mira_connectors tests
 ```

--- a/mira-connectors/mira_connectors/factory.py
+++ b/mira-connectors/mira_connectors/factory.py
@@ -12,7 +12,10 @@ from typing import Callable
 
 from mira_connectors.base import Connector, ConnectorConfig
 from mira_connectors.mocks.ignition_mock import IgnitionMockConnector
+from mira_connectors.mocks.maintainx_mock import MaintainXMockConnector
 from mira_connectors.mocks.maximo_mock import MaximoMockConnector
+from mira_connectors.mocks.pi_mock import PIMockConnector
+from mira_connectors.mocks.sap_mock import SAPMockConnector
 
 logger = logging.getLogger("mira-connectors")
 
@@ -20,10 +23,14 @@ logger = logging.getLogger("mira-connectors")
 _REGISTRY: dict[str, Callable[[ConnectorConfig], Connector]] = {
     "maximo_mock": MaximoMockConnector,
     "ignition_mock": IgnitionMockConnector,
-    # Real connectors (future):
+    "sap_mock": SAPMockConnector,
+    "maintainx_mock": MaintainXMockConnector,
+    "pi_mock": PIMockConnector,
+    # Real connectors (future) — swap _load() for the live client, keep normalize():
     # "maximo": MaximoConnector,
     # "ignition": IgnitionConnector,
-    # "pi": PIHistorianConnector,
+    # "sap": SAPConnector,
+    # "pi": PIConnector,
     # "maintainx": MaintainXConnector,  # wraps mira-mcp/cmms/maintainx.py
 }
 

--- a/mira-connectors/mira_connectors/mocks/__init__.py
+++ b/mira-connectors/mira_connectors/mocks/__init__.py
@@ -6,6 +6,15 @@ serve as the reference implementation of each connector type.
 """
 
 from mira_connectors.mocks.ignition_mock import IgnitionMockConnector
+from mira_connectors.mocks.maintainx_mock import MaintainXMockConnector
 from mira_connectors.mocks.maximo_mock import MaximoMockConnector
+from mira_connectors.mocks.pi_mock import PIMockConnector
+from mira_connectors.mocks.sap_mock import SAPMockConnector
 
-__all__ = ["IgnitionMockConnector", "MaximoMockConnector"]
+__all__ = [
+    "IgnitionMockConnector",
+    "MaintainXMockConnector",
+    "MaximoMockConnector",
+    "PIMockConnector",
+    "SAPMockConnector",
+]

--- a/mira-connectors/mira_connectors/mocks/fixtures/maintainx.json
+++ b/mira-connectors/mira_connectors/mocks/fixtures/maintainx.json
@@ -1,0 +1,24 @@
+{
+  "_meta": {
+    "source": "MaintainX",
+    "api_hint": "GET https://api.getmaintainx.com/v1/{assets,workorders,locations,parts} (Bearer)",
+    "note": "Mock fixture in MaintainX REST response shape. Mirrors mira-mcp/cmms/maintainx.py envelopes. IDs numeric; assets carry locationId + parentId; work orders carry assetId + categories[]."
+  },
+  "locations": [
+    { "id": 5001, "name": "Bedford Plant", "parentId": null, "description": "Bedford site" },
+    { "id": 5002, "name": "Packaging", "parentId": 5001, "description": "Packaging area" },
+    { "id": 5003, "name": "Line 1", "parentId": 5002, "description": "Bottling line 1" }
+  ],
+  "assets": [
+    { "id": 8001, "name": "CONV-001", "description": "Infeed Belt Conveyor", "locationId": 5003, "parentId": null, "serialNumber": "CNV-2021-4471", "manufacturer": "Dorner", "model": "2200", "status": "ONLINE" },
+    { "id": 8002, "name": "MOTOR-001", "description": "Conveyor Drive Motor 2HP", "locationId": 5003, "parentId": 8001, "serialNumber": "WEG-9931", "manufacturer": "WEG", "model": "W22", "status": "ONLINE" },
+    { "id": 8003, "name": "VFD-001", "description": "VFD GS10", "locationId": 5003, "parentId": 8001, "serialNumber": "GS10-55120", "manufacturer": "AutomationDirect", "model": "GS10", "status": "ONLINE" }
+  ],
+  "workOrders": [
+    { "id": 91001, "title": "Conveyor VFD fault F0004", "description": "Drive tripped, cleared and restarted", "priority": "HIGH", "status": "DONE", "categories": ["REACTIVE"], "assetId": 8001, "createdAt": "2026-05-18T06:30:00Z", "completedAt": "2026-05-18T08:10:00Z" },
+    { "id": 91002, "title": "Monthly motor lubrication", "description": "Lubricate drive motor bearings", "priority": "MEDIUM", "status": "OPEN", "categories": ["PREVENTIVE"], "assetId": 8002, "createdAt": "2026-06-01T05:00:00Z", "completedAt": null }
+  ],
+  "parts": [
+    { "id": 7001, "name": "10A class CC fuse", "partNumber": "FUSE-10A-CC", "quantityInStock": 24, "assetIds": [8003] }
+  ]
+}

--- a/mira-connectors/mira_connectors/mocks/fixtures/pi.json
+++ b/mira-connectors/mira_connectors/mocks/fixtures/pi.json
@@ -1,0 +1,30 @@
+{
+  "_meta": {
+    "source": "AVEVA PI / OSIsoft PI System",
+    "api_hint": "PI Web API (/piwebapi/assetdatabases, /elements, /points, /streams, /eventframes) or AF SDK",
+    "note": "Mock fixture. PI Point names use the \\\\server\\tag convention; AF element Paths use backslash separators. Archived values roll up into CanonicalMeter; event frames are preserved on the AF element (the raw firehose belongs to the relay/event-stream layer, not the historian connector)."
+  },
+  "af_database": "Acme-Garage",
+  "af_elements": [
+    { "Path": "Bedford", "Name": "Bedford", "Template": "Site", "Parent": null },
+    { "Path": "Bedford\\Packaging", "Name": "Packaging", "Template": "Area", "Parent": "Bedford" },
+    { "Path": "Bedford\\Packaging\\Conveyor", "Name": "Conveyor", "Template": "Conveyor", "Parent": "Bedford\\Packaging", "attributes": [ {"Name": "Manufacturer", "Value": "Dorner"}, {"Name": "AssetTag", "Value": "CONV-001"} ] },
+    { "Path": "Bedford\\Packaging\\Conveyor\\Motor", "Name": "Motor", "Template": "Motor", "Parent": "Bedford\\Packaging\\Conveyor", "attributes": [ {"Name": "AssetTag", "Value": "MOTOR-001"} ] },
+    { "Path": "Bedford\\Packaging\\Conveyor\\VFD", "Name": "VFD", "Template": "VFD", "Parent": "Bedford\\Packaging\\Conveyor", "attributes": [ {"Name": "AssetTag", "Value": "VFD-001"} ] }
+  ],
+  "pi_points": [
+    { "Name": "\\\\PISRV01\\Conv.Motor.Current", "PointType": "Float32", "EngUnits": "A", "Descriptor": "Motor current", "element_path": "Bedford\\Packaging\\Conveyor\\Motor" },
+    { "Name": "\\\\PISRV01\\Conv.Motor.Speed", "PointType": "Float32", "EngUnits": "RPM", "Descriptor": "Motor speed", "element_path": "Bedford\\Packaging\\Conveyor\\Motor" },
+    { "Name": "\\\\PISRV01\\Conv.VFD.DcBus", "PointType": "Float32", "EngUnits": "V", "Descriptor": "VFD DC bus voltage", "element_path": "Bedford\\Packaging\\Conveyor\\VFD" },
+    { "Name": "\\\\PISRV01\\Conv.VFD.FaultCode", "PointType": "Int32", "EngUnits": "", "Descriptor": "VFD fault code", "element_path": "Bedford\\Packaging\\Conveyor\\VFD" }
+  ],
+  "archived_values": [
+    { "pi_point": "\\\\PISRV01\\Conv.Motor.Current", "values": [ {"Timestamp": "2026-06-03T22:45:00Z", "Value": 0.0, "Good": true}, {"Timestamp": "2026-06-03T22:50:00Z", "Value": 3.6, "Good": true}, {"Timestamp": "2026-06-03T22:59:00Z", "Value": 3.4, "Good": true} ] },
+    { "pi_point": "\\\\PISRV01\\Conv.VFD.DcBus", "values": [ {"Timestamp": "2026-06-03T22:50:00Z", "Value": 324.0, "Good": true}, {"Timestamp": "2026-06-03T22:59:00Z", "Value": 325.0, "Good": true} ] },
+    { "pi_point": "\\\\PISRV01\\Conv.VFD.FaultCode", "values": [ {"Timestamp": "2026-05-18T06:29:00Z", "Value": 4, "Good": true}, {"Timestamp": "2026-05-18T06:31:00Z", "Value": 0, "Good": true} ] }
+  ],
+  "event_frames": [
+    { "Name": "VFD Fault F0004", "Template": "Equipment Downtime", "element_path": "Bedford\\Packaging\\Conveyor\\VFD", "StartTime": "2026-05-18T06:29:00Z", "EndTime": "2026-05-18T06:31:00Z", "attributes": [ {"Name": "FaultCode", "Value": "F0004"}, {"Name": "Severity", "Value": "Trip"} ] },
+    { "Name": "Infeed E-Stop Pressed", "Template": "Safety Event", "element_path": "Bedford\\Packaging\\Conveyor", "StartTime": "2026-04-12T11:02:00Z", "EndTime": "2026-04-12T11:09:00Z", "attributes": [ {"Name": "Cause", "Value": "Operator E-stop"} ] }
+  ]
+}

--- a/mira-connectors/mira_connectors/mocks/fixtures/sap.json
+++ b/mira-connectors/mira_connectors/mocks/fixtures/sap.json
@@ -1,0 +1,31 @@
+{
+  "_meta": {
+    "source": "SAP Plant Maintenance (PM)",
+    "api_hint": "S/4HANA OData (API_FUNCTIONALLOCATION, API_EQUIPMENT, API_MAINTENANCEORDER) or BAPI_EQUI_GETDETAIL",
+    "note": "Mock fixture. Real SAP PM field names (EQUNR, TPLNR, AUFNR, MATNR, HERST, ...). Functional-location TPLNR is the SAP hierarchy; TPLMA points at the superior FL.",
+    "client": "100"
+  },
+  "functional_locations": [
+    { "TPLNR": "ACME-BED", "PLTXT": "Bedford Plant", "TPLMA": null, "FLTYP": "PLANT", "SWERK": "BED1", "STORT": "BED" },
+    { "TPLNR": "ACME-BED-PKG", "PLTXT": "Packaging Area", "TPLMA": "ACME-BED", "FLTYP": "AREA", "SWERK": "BED1", "STORT": "BED" },
+    { "TPLNR": "ACME-BED-PKG-L1", "PLTXT": "Bottling Line 1", "TPLMA": "ACME-BED-PKG", "FLTYP": "LINE", "SWERK": "BED1", "STORT": "BED" },
+    { "TPLNR": "ACME-BED-PKG-L1-C1", "PLTXT": "Infeed Conveyor Cell", "TPLMA": "ACME-BED-PKG-L1", "FLTYP": "CELL", "SWERK": "BED1", "STORT": "BED" }
+  ],
+  "equipment": [
+    { "EQUNR": "10000455", "EQKTX": "Infeed Belt Conveyor", "TPLNR": "ACME-BED-PKG-L1-C1", "HEQUI": null, "EQTYP": "M", "HERST": "Dorner", "TYPBZ": "2200-Series", "SERGE": "CNV-2021-4471", "SWERK": "BED1", "DATAB": "2021-06-15", "ELIEF": "Dorner", "ABCKZ": "A" },
+    { "EQUNR": "10000456", "EQKTX": "Conveyor Drive Motor 2HP", "TPLNR": "ACME-BED-PKG-L1-C1", "HEQUI": "10000455", "EQTYP": "M", "HERST": "WEG", "TYPBZ": "W22", "SERGE": "WEG-9931", "SWERK": "BED1", "DATAB": "2021-06-15", "ELIEF": "WEG", "ABCKZ": "B" },
+    { "EQUNR": "10000457", "EQKTX": "VFD GS10 1HP", "TPLNR": "ACME-BED-PKG-L1-C1", "HEQUI": "10000455", "EQTYP": "E", "HERST": "AutomationDirect", "TYPBZ": "GS10-11P5", "SERGE": "GS10-55120", "SWERK": "BED1", "DATAB": "2021-06-15", "ELIEF": "AutomationDirect", "ABCKZ": "A" }
+  ],
+  "maintenance_orders": [
+    { "AUFNR": "4000123", "KTEXT": "Conveyor VFD fault investigation", "EQUNR": "10000455", "TPLNR": "ACME-BED-PKG-L1-C1", "AUART": "PM02", "GSTRP": "2026-05-18", "GLTRP": "2026-05-18", "IWERK": "BED1", "PRIOK": "2", "ANLZU": "TECO", "QMNUM": "10004521" },
+    { "AUFNR": "4000130", "KTEXT": "Motor lubrication (preventive)", "EQUNR": "10000456", "TPLNR": "ACME-BED-PKG-L1-C1", "AUART": "PM01", "GSTRP": "2026-06-05", "GLTRP": "2026-06-05", "IWERK": "BED1", "PRIOK": "3", "ANLZU": "REL", "QMNUM": null }
+  ],
+  "task_lists": [
+    { "PLNNR": "TL-MOTOR-LUBE", "PLNAL": "01", "KTEXT": "Motor bearing lubrication", "EQUNR": "10000456", "STRAT": "MONTHLY", "ZYKL1": 1, "ZEIEH": "MON", "WERKS": "BED1" },
+    { "PLNNR": "TL-VFD-INSP", "PLNAL": "01", "KTEXT": "VFD annual inspection", "EQUNR": "10000457", "STRAT": "ANNUAL", "ZYKL1": 12, "ZEIEH": "MON", "WERKS": "BED1" }
+  ],
+  "bom": [
+    { "EQUNR": "10000457", "MATNR": "FUSE-10A-CC", "MAKTX": "10A class CC fuse", "MENGE": 3, "MEINS": "EA", "POSNR": "0010", "LGORT": "0001" },
+    { "EQUNR": "10000456", "MATNR": "BRG-6204-2RS", "MAKTX": "Bearing 6204-2RS", "MENGE": 2, "MEINS": "EA", "POSNR": "0010", "LGORT": "0001" }
+  ]
+}

--- a/mira-connectors/mira_connectors/mocks/maintainx_mock.py
+++ b/mira-connectors/mira_connectors/mocks/maintainx_mock.py
@@ -1,0 +1,313 @@
+"""MaintainXMockConnector — fixture-backed MaintainX (CMMS) connector.
+
+Reads ``fixtures/maintainx.json`` in MaintainX's REST response shape (the same
+envelopes the live ``mira-mcp/cmms/maintainx.py`` adapter parses — ``assets`` /
+``workOrders`` / ``locations`` / ``parts``). ``is_mock = True``.
+
+A real ``MaintainXConnector`` would wrap the already-working
+``mira-mcp/cmms/maintainx.py:MaintainXCMMS`` HTTP client (Bearer key from Doppler) in
+``import_records`` / ``_do_export`` and keep ``normalize`` / ``derive_relationships``
+verbatim — exactly the future entry the factory registry comments anticipate.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+from mira_connectors._uns import candidate_uns_path
+from mira_connectors.base import (
+    ConnectorCapabilities,
+    ConnectorConfig,
+    ConnectorKind,
+    ExportResult,
+)
+from mira_connectors.canonical import (
+    CanonicalAsset,
+    CanonicalLocation,
+    CanonicalPart,
+    CanonicalRecord,
+    CanonicalRelationship,
+    CanonicalWorkOrder,
+    EvidenceRef,
+    RawRecord,
+    RecordType,
+)
+from mira_connectors.types.cmms import CMMSConnector
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "maintainx.json"
+
+# MaintainX status → MIRA work-order status.
+_WO_STATUS = {
+    "OPEN": "OPEN",
+    "IN_PROGRESS": "IN_PROGRESS",
+    "ON_HOLD": "IN_PROGRESS",
+    "DONE": "COMPLETE",
+}
+# MaintainX category → MIRA work_type (first category wins).
+_WORKTYPE = {"REACTIVE": "corrective", "PREVENTIVE": "preventive", "INSPECTION": "preventive"}
+
+MAINTAINX_RECORD_TYPES = [
+    RecordType.LOCATION,
+    RecordType.ASSET,
+    RecordType.WORK_ORDER,
+    RecordType.PART,
+]
+
+
+class MaintainXMockConnector(CMMSConnector):
+    provider = "maintainx"
+    is_mock = True
+
+    def __init__(self, config: ConnectorConfig) -> None:
+        super().__init__(config)
+        self._data: dict[str, Any] = {}
+
+    @property
+    def configured(self) -> bool:
+        return True
+
+    def _load(self) -> dict[str, Any]:
+        if not self._data:
+            self._data = json.loads(_FIXTURE.read_text())
+        return self._data
+
+    async def health_check(self) -> dict[str, Any]:
+        data = self._load()
+        return {
+            "ok": True,
+            "provider": self.provider,
+            "mock": True,
+            "assets": len(data.get("assets", [])),
+        }
+
+    async def discover(self) -> ConnectorCapabilities:
+        return ConnectorCapabilities(
+            kind=ConnectorKind.CMMS,
+            provider=self.provider,
+            record_types=MAINTAINX_RECORD_TYPES,
+            supports_export=True,  # work-order patch (CMMS API, not the plant)
+            supports_incremental=True,
+            schema={
+                "asset_endpoint": "GET /v1/assets",
+                "asset_fields": [
+                    "id",
+                    "name",
+                    "description",
+                    "locationId",
+                    "parentId",
+                    "manufacturer",
+                    "model",
+                    "serialNumber",
+                    "status",
+                ],
+                "workorder_endpoint": "GET /v1/workorders",
+                "workorder_fields": ["id", "title", "priority", "status", "categories", "assetId"],
+                "location_endpoint": "GET /v1/locations (flat tree via parentId)",
+            },
+            notes="Mock MaintainX. Real connector wraps mira-mcp/cmms/maintainx.py MaintainXCMMS.",
+        )
+
+    async def import_records(
+        self, record_type: RecordType, *, since: Optional[str] = None, limit: int = 500
+    ) -> list[RawRecord]:
+        data = self._load()
+        section_for = {
+            RecordType.LOCATION: "locations",
+            RecordType.ASSET: "assets",
+            RecordType.WORK_ORDER: "workOrders",
+            RecordType.PART: "parts",
+        }
+        section = section_for.get(record_type)
+        if not section:
+            return []
+        rows = data.get(section, [])[:limit]
+        return [RawRecord(self.provider, record_type, str(row["id"]), row) for row in rows]
+
+    # --- normalize -----------------------------------------------------------
+
+    def _loc_index(self) -> dict[Any, dict[str, Any]]:
+        return {loc["id"]: loc for loc in self._load().get("locations", [])}
+
+    def _loc_chain(self, location_id: Any) -> list[str]:
+        """Walk parentId root→leaf, returning location names (the candidate path source)."""
+        index = self._loc_index()
+        chain: list[str] = []
+        cur, seen = location_id, set()
+        while cur is not None and cur in index and cur not in seen:
+            seen.add(cur)
+            chain.append(index[cur]["name"])
+            cur = index[cur].get("parentId")
+        return list(reversed(chain))
+
+    def normalize(self, raw: list[RawRecord]) -> list[CanonicalRecord]:
+        out: list[CanonicalRecord] = []
+        for r in raw:
+            f = r.fields
+            if r.record_type is RecordType.LOCATION:
+                out.append(self._loc(f))
+            elif r.record_type is RecordType.ASSET:
+                out.append(self._asset(f))
+            elif r.record_type is RecordType.WORK_ORDER:
+                out.append(self._workorder(f))
+            elif r.record_type is RecordType.PART:
+                out.append(self._part(f))
+        return out
+
+    def _loc(self, f: dict[str, Any]) -> CanonicalLocation:
+        index = self._loc_index()
+        depth, cur = 0, f
+        while cur.get("parentId") is not None and cur["parentId"] in index:
+            depth += 1
+            cur = index[cur["parentId"]]
+        type_map = {0: "site", 1: "area", 2: "line", 3: "cell"}
+        return CanonicalLocation(
+            source_system=self.provider,
+            source_record_id=str(f["id"]),
+            name=f.get("name", str(f["id"])),
+            location_type=type_map.get(depth, "cell"),
+            parent_source_id=str(f["parentId"]) if f.get("parentId") is not None else None,
+            proposed_uns_path=candidate_uns_path(*self._loc_chain(f["id"])),
+            confidence=0.75,
+            raw=f,
+        )
+
+    def _asset(self, f: dict[str, Any]) -> CanonicalAsset:
+        loc_chain = self._loc_chain(f.get("locationId"))
+        path = candidate_uns_path(*loc_chain, f["name"]) if loc_chain else None
+        return CanonicalAsset(
+            source_system=self.provider,
+            source_record_id=str(f["id"]),
+            name=f.get("name", str(f["id"])),
+            manufacturer=f.get("manufacturer"),
+            model=f.get("model"),
+            serial=f.get("serialNumber"),
+            asset_type=f.get("status"),
+            parent_source_id=str(f["parentId"]) if f.get("parentId") is not None else None,
+            location_path=".".join(loc_chain) if loc_chain else None,
+            proposed_uns_path=path,
+            attributes={"description": f.get("description")},
+            confidence=0.6,
+            raw=f,
+        )
+
+    def _workorder(self, f: dict[str, Any]) -> CanonicalWorkOrder:
+        cats = f.get("categories", []) or []
+        work_type = _WORKTYPE.get(cats[0], None) if cats else None
+        return CanonicalWorkOrder(
+            source_system=self.provider,
+            source_record_id=str(f["id"]),
+            wo_number=str(f["id"]),
+            title=f.get("title", ""),
+            description=f.get("description", ""),
+            status=_WO_STATUS.get(f.get("status", ""), f.get("status")),
+            work_type=work_type,
+            priority=f.get("priority"),
+            asset_source_id=str(f["assetId"]) if f.get("assetId") is not None else None,
+            reported_at=f.get("createdAt"),
+            completed_at=f.get("completedAt"),
+            confidence=0.9,
+            raw=f,
+        )
+
+    def _part(self, f: dict[str, Any]) -> CanonicalPart:
+        return CanonicalPart(
+            source_system=self.provider,
+            source_record_id=str(f.get("partNumber") or f["id"]),
+            item_number=str(f.get("partNumber") or f["id"]),
+            description=f.get("name", ""),
+            qty_on_hand=f.get("quantityInStock"),
+            confidence=0.85,
+            raw=f,
+        )
+
+    # --- derive relationships ------------------------------------------------
+
+    def derive_relationships(self, records: list[CanonicalRecord]) -> list[CanonicalRelationship]:
+        rels: list[CanonicalRelationship] = []
+        for rec in records:
+            if isinstance(rec, CanonicalAsset):
+                if rec.parent_source_id:
+                    rels.append(
+                        self._rel(
+                            "HAS_COMPONENT",
+                            rec.parent_source_id,
+                            "asset",
+                            rec.source_record_id,
+                            "asset",
+                            EvidenceRef(
+                                "manifest",
+                                f"MaintainX asset.parentId on {rec.source_record_id}",
+                                page_or_location="asset.parentId",
+                                confidence_contribution=0.8,
+                            ),
+                            confidence=0.7,
+                        )
+                    )
+                loc_id = rec.raw.get("locationId")
+                if loc_id is not None:
+                    rels.append(
+                        self._rel(
+                            "LOCATED_IN",
+                            rec.source_record_id,
+                            "asset",
+                            str(loc_id),
+                            "location",
+                            EvidenceRef(
+                                "manifest",
+                                f"MaintainX asset.locationId on {rec.source_record_id}",
+                                page_or_location="asset.locationId",
+                                confidence_contribution=0.7,
+                            ),
+                            confidence=0.7,
+                        )
+                    )
+            elif isinstance(rec, CanonicalPart):
+                for aid in rec.raw.get("assetIds", []):
+                    rels.append(
+                        self._rel(
+                            "HAS_PART",
+                            str(aid),
+                            "asset",
+                            rec.source_record_id,
+                            "part",
+                            EvidenceRef(
+                                "manifest",
+                                f"MaintainX part.assetIds links {rec.item_number} to {aid}",
+                                page_or_location="part.assetIds",
+                                confidence_contribution=0.7,
+                            ),
+                            confidence=0.65,
+                        )
+                    )
+        return rels
+
+    def _rel(
+        self,
+        rel_type: str,
+        source_ref: str,
+        source_kind: str,
+        target_ref: str,
+        target_kind: str,
+        evidence: EvidenceRef,
+        *,
+        confidence: float,
+    ) -> CanonicalRelationship:
+        return CanonicalRelationship(
+            source_system=self.provider,
+            source_record_id=f"{rel_type}:{source_kind}:{source_ref}->{target_kind}:{target_ref}",
+            relationship_type=rel_type,
+            source_ref=source_ref,
+            source_ref_kind=source_kind,
+            target_ref=target_ref,
+            target_ref_kind=target_kind,
+            confidence=confidence,
+            reasoning=f"Derived from MaintainX {rel_type} link",
+            evidence=[evidence],
+        )
+
+    async def _do_export(self, enriched: list[CanonicalRecord]) -> ExportResult:
+        # Mock write-back: PATCH /v1/workorders/{id}. CMMS-API target, not the plant.
+        writable = [r for r in enriched if isinstance(r, CanonicalWorkOrder)]
+        return ExportResult(exported=len(writable), refused=len(enriched) - len(writable))

--- a/mira-connectors/mira_connectors/mocks/pi_mock.py
+++ b/mira-connectors/mira_connectors/mocks/pi_mock.py
@@ -1,0 +1,283 @@
+"""PIMockConnector — fixture-backed AVEVA PI / OSIsoft (Historian) connector.
+
+Reads ``fixtures/pi.json`` and normalizes a PI System export into the canonical
+model. ``is_mock = True``. Read-only by construction (inherited from
+``HistorianConnector`` — MIRA never writes to a plant historian).
+
+What a historian connector imports (per ``types/historian.py``): point metadata and
+rolled-up history, not the raw high-frequency firehose (that belongs to the relay /
+event-stream layer, master plan Phase 5). So:
+
+* AF element hierarchy → ``CanonicalAsset`` (one per element; AF Path is the id).
+* PI points            → ``CanonicalTag`` (``tag_kind`` historian; PI point name is
+  the address; archived-value summary rides in ``attributes``).
+* archived values      → ``CanonicalMeter`` (rolled-up last reading per point).
+* event frames         → preserved on the owning element's ``attributes`` and surfaced
+  in ``discover()``; materializing them as fault events is a gate/Phase-5 concern, not
+  the historian's mandate.
+
+A real ``PIConnector`` swaps ``_load()`` for the PI Web API and keeps
+``normalize`` / ``derive_relationships`` verbatim.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+from mira_connectors._uns import candidate_uns_path
+from mira_connectors.base import ConnectorCapabilities, ConnectorConfig, ConnectorKind
+from mira_connectors.canonical import (
+    CanonicalAsset,
+    CanonicalMeter,
+    CanonicalRecord,
+    CanonicalRelationship,
+    CanonicalTag,
+    EvidenceRef,
+    RawRecord,
+    RecordType,
+)
+from mira_connectors.types.historian import HISTORIAN_RECORD_TYPES, HistorianConnector
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "pi.json"
+
+# PI PointType → MIRA canonical data_type.
+_DT = {
+    "Float16": "float",
+    "Float32": "float",
+    "Float64": "float",
+    "Int16": "int",
+    "Int32": "int",
+    "Digital": "bool",
+    "String": "string",
+}
+_SAFETY_TEMPLATES = ("safety event", "safety", "estop", "e-stop", "lockout")
+
+
+class PIMockConnector(HistorianConnector):
+    provider = "pi"
+    is_mock = True
+
+    def __init__(self, config: ConnectorConfig) -> None:
+        super().__init__(config)
+        self._data: dict[str, Any] = {}
+
+    @property
+    def configured(self) -> bool:
+        return True
+
+    def _load(self) -> dict[str, Any]:
+        if not self._data:
+            self._data = json.loads(_FIXTURE.read_text())
+        return self._data
+
+    async def health_check(self) -> dict[str, Any]:
+        data = self._load()
+        return {
+            "ok": True,
+            "provider": self.provider,
+            "mock": True,
+            "af_database": data.get("af_database"),
+        }
+
+    async def discover(self) -> ConnectorCapabilities:
+        data = self._load()
+        return ConnectorCapabilities(
+            kind=ConnectorKind.HISTORIAN,
+            provider=self.provider,
+            record_types=HISTORIAN_RECORD_TYPES,
+            supports_export=False,  # read-only by construction
+            supports_incremental=True,
+            schema={
+                "af_database": data.get("af_database"),
+                "element_count": len(data.get("af_elements", [])),
+                "point_count": len(data.get("pi_points", [])),
+                "event_frame_count": len(data.get("event_frames", [])),
+                "point_fields": ["Name", "PointType", "EngUnits", "Descriptor", "element_path"],
+            },
+            notes="Mock AVEVA PI. AF element Path → ISA-95 by hierarchy (heuristic). Read-only.",
+        )
+
+    # --- import --------------------------------------------------------------
+
+    async def import_records(
+        self, record_type: RecordType, *, since: Optional[str] = None, limit: int = 500
+    ) -> list[RawRecord]:
+        data = self._load()
+        if record_type is RecordType.ASSET:
+            rows = data.get("af_elements", [])[:limit]
+            return [RawRecord(self.provider, record_type, r["Path"], r) for r in rows]
+        if record_type is RecordType.TAG:
+            rows = data.get("pi_points", [])[:limit]
+            return [RawRecord(self.provider, record_type, r["Name"], r) for r in rows]
+        if record_type is RecordType.METER:
+            # rolled-up history: one meter per point that has archived values
+            archived = {a["pi_point"] for a in data.get("archived_values", [])}
+            pts = [p for p in data.get("pi_points", []) if p["Name"] in archived][:limit]
+            return [RawRecord(self.provider, record_type, p["Name"], p) for p in pts]
+        return []
+
+    # --- normalize -----------------------------------------------------------
+
+    def _archived(self) -> dict[str, list[dict[str, Any]]]:
+        return {a["pi_point"]: a.get("values", []) for a in self._load().get("archived_values", [])}
+
+    def _event_frames_for(self, element_path: str) -> list[dict[str, Any]]:
+        return [
+            {
+                "name": ef["Name"],
+                "template": ef.get("Template"),
+                "start": ef.get("StartTime"),
+                "end": ef.get("EndTime"),
+            }
+            for ef in self._load().get("event_frames", [])
+            if ef.get("element_path") == element_path
+        ]
+
+    def normalize(self, raw: list[RawRecord]) -> list[CanonicalRecord]:
+        out: list[CanonicalRecord] = []
+        archived = self._archived()
+        for r in raw:
+            f = r.fields
+            if r.record_type is RecordType.ASSET:
+                out.append(self._element(f))
+            elif r.record_type is RecordType.TAG:
+                out.append(self._point(f, archived))
+            elif r.record_type is RecordType.METER:
+                out.append(self._meter(f, archived))
+        return out
+
+    def _element(self, f: dict[str, Any]) -> CanonicalAsset:
+        segs = f["Path"].split("\\")
+        events = self._event_frames_for(f["Path"])
+        attrs = {a["Name"]: a.get("Value") for a in f.get("attributes", [])}
+        if events:
+            attrs["event_frames"] = events  # preserve event frames on the element
+        # An element with a safety-template event frame (E-stop/LOTO) is flagged
+        # safety_critical so the confirmation gate gates it for review.
+        is_safety = any(
+            any(
+                s in (ev.get("template") or "").lower() or s in (ev.get("name") or "").lower()
+                for s in _SAFETY_TEMPLATES
+            )
+            for ev in events
+        )
+        return CanonicalAsset(
+            source_system=self.provider,
+            source_record_id=f["Path"],
+            name=f.get("Name", f["Path"]),
+            asset_type=f.get("Template"),
+            parent_source_id=f.get("Parent"),
+            criticality="safety_critical" if is_safety else None,
+            location_path=".".join(segs),
+            proposed_uns_path=candidate_uns_path(*segs),
+            attributes=attrs,
+            confidence=0.6,  # AF→ISA-95 mapping is a heuristic
+            raw=f,
+        )
+
+    def _point(self, f: dict[str, Any], archived: dict[str, list]) -> CanonicalTag:
+        segs = f["element_path"].split("\\")
+        leaf = f["Name"].split("\\")[-1]
+        samples = archived.get(f["Name"], [])
+        return CanonicalTag(
+            source_system=self.provider,
+            source_record_id=f["Name"],
+            tag_id=".".join([*segs, leaf]),
+            data_type=_DT.get(f.get("PointType", ""), "float"),
+            engineering_unit=f.get("EngUnits") or None,
+            scada_path=f["Name"],
+            address=f["Name"],  # PI point id is the address
+            history_enabled=True,  # a historian point always has history
+            asset_source_id=f.get("element_path"),
+            proposed_uns_path=candidate_uns_path(*segs, leaf),
+            attributes={
+                "descriptor": f.get("Descriptor"),
+                "sample_count": len(samples),
+                "last_value": samples[-1]["Value"] if samples else None,
+            },
+            confidence=0.8,
+            raw=f,
+        )
+
+    def _meter(self, f: dict[str, Any], archived: dict[str, list]) -> CanonicalMeter:
+        samples = archived.get(f["Name"], [])
+        return CanonicalMeter(
+            source_system=self.provider,
+            source_record_id=f"meter:{f['Name']}",
+            name=f["Name"].split("\\")[-1],
+            asset_source_id=f.get("element_path"),
+            last_reading=samples[-1]["Value"] if samples else None,
+            unit=f.get("EngUnits") or None,
+            meter_type="continuous",
+            confidence=0.8,
+            raw={**f, "_archived_values": samples},
+        )
+
+    # --- derive relationships ------------------------------------------------
+
+    def derive_relationships(self, records: list[CanonicalRecord]) -> list[CanonicalRelationship]:
+        rels: list[CanonicalRelationship] = []
+        for rec in records:
+            if isinstance(rec, CanonicalAsset) and rec.parent_source_id:
+                # AF element hierarchy: parent element owns child → HAS_COMPONENT
+                rels.append(
+                    self._rel(
+                        "HAS_COMPONENT",
+                        rec.parent_source_id,
+                        "asset",
+                        rec.source_record_id,
+                        "asset",
+                        EvidenceRef(
+                            "manifest",
+                            f"PI AF element parent of {rec.source_record_id}",
+                            page_or_location="AF.Parent",
+                            confidence_contribution=0.7,
+                        ),
+                        confidence=0.65,
+                    )
+                )
+            elif isinstance(rec, CanonicalTag) and rec.asset_source_id:
+                # PI point on an AF element → element HAS_SIGNAL tag
+                rels.append(
+                    self._rel(
+                        "HAS_SIGNAL",
+                        rec.asset_source_id,
+                        "asset",
+                        rec.tag_id,
+                        "tag",
+                        EvidenceRef(
+                            "tag_list",
+                            f"PI point {rec.scada_path} on element {rec.asset_source_id}",
+                            page_or_location=rec.address,
+                            confidence_contribution=0.8,
+                        ),
+                        confidence=0.75,
+                    )
+                )
+        return rels
+
+    def _rel(
+        self,
+        rel_type: str,
+        source_ref: str,
+        source_kind: str,
+        target_ref: str,
+        target_kind: str,
+        evidence: EvidenceRef,
+        *,
+        confidence: float,
+    ) -> CanonicalRelationship:
+        return CanonicalRelationship(
+            source_system=self.provider,
+            source_record_id=f"{rel_type}:{source_kind}:{source_ref}->{target_kind}:{target_ref}",
+            relationship_type=rel_type,
+            source_ref=source_ref,
+            source_ref_kind=source_kind,
+            target_ref=target_ref,
+            target_ref_kind=target_kind,
+            confidence=confidence,
+            reasoning=f"Derived from PI AF {rel_type}",
+            evidence=[evidence],
+        )

--- a/mira-connectors/mira_connectors/mocks/sap_mock.py
+++ b/mira-connectors/mira_connectors/mocks/sap_mock.py
@@ -1,0 +1,341 @@
+"""SAPMockConnector — fixture-backed SAP Plant Maintenance (CMMS/EAM) connector.
+
+Reads ``fixtures/sap.json`` (native SAP PM field names: ``EQUNR``, ``TPLNR``,
+``AUFNR``, ``MATNR``, ``HERST`` …) and exercises the full lifecycle. ``is_mock = True``.
+
+The reference for a second CMMS provider next to Maximo: SAP's hierarchy is the
+functional-location tree (``TPLNR`` with ``TPLMA`` = superior FL); equipment masters
+(``EQUNR``) hang off a functional location and may nest via ``HEQUI``. A real
+``SAPConnector`` would replace ``_load()`` with S/4HANA OData and keep
+``normalize``/``derive_relationships`` verbatim.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Optional
+
+from mira_connectors._uns import candidate_uns_path
+from mira_connectors.base import (
+    ConnectorCapabilities,
+    ConnectorConfig,
+    ConnectorKind,
+    ExportResult,
+)
+from mira_connectors.canonical import (
+    CanonicalAsset,
+    CanonicalLocation,
+    CanonicalPart,
+    CanonicalPMTask,
+    CanonicalRecord,
+    CanonicalRelationship,
+    CanonicalWorkOrder,
+    EvidenceRef,
+    RawRecord,
+    RecordType,
+)
+from mira_connectors.types.cmms import CMMSConnector
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "sap.json"
+
+# SAP order system status (ANLZU) → MIRA work-order status.
+_WO_STATUS = {"CRTD": "OPEN", "REL": "IN_PROGRESS", "TECO": "COMPLETE", "CLSD": "COMPLETE"}
+# SAP order type (AUART) → MIRA work_type.
+_WORKTYPE = {"PM01": "preventive", "PM02": "corrective", "PM03": "corrective", "PM04": "emergency"}
+# SAP ABC indicator (ABCKZ) → MIRA criticality band.
+_CRIT = {"A": "high", "B": "medium", "C": "low"}
+# FLTYP → location_type (PLANT has no ISA-95 slot below site; folds to site).
+_FLTYP = {"PLANT": "site", "AREA": "area", "LINE": "line", "CELL": "cell"}
+
+# SAP exposes the same record families as any CMMS, minus standalone meters/doclinks.
+SAP_RECORD_TYPES = [
+    RecordType.LOCATION,
+    RecordType.ASSET,
+    RecordType.WORK_ORDER,
+    RecordType.PM_TASK,
+    RecordType.PART,
+]
+
+
+class SAPMockConnector(CMMSConnector):
+    provider = "sap"
+    is_mock = True
+
+    def __init__(self, config: ConnectorConfig) -> None:
+        super().__init__(config)
+        self._data: dict[str, Any] = {}
+
+    @property
+    def configured(self) -> bool:
+        return True
+
+    def _load(self) -> dict[str, Any]:
+        if not self._data:
+            self._data = json.loads(_FIXTURE.read_text())
+        return self._data
+
+    async def health_check(self) -> dict[str, Any]:
+        data = self._load()
+        return {
+            "ok": True,
+            "provider": self.provider,
+            "mock": True,
+            "equipment": len(data.get("equipment", [])),
+        }
+
+    async def discover(self) -> ConnectorCapabilities:
+        return ConnectorCapabilities(
+            kind=ConnectorKind.CMMS,
+            provider=self.provider,
+            record_types=SAP_RECORD_TYPES,
+            supports_export=True,  # maintenance-order write-back (CMMS API, not the plant)
+            supports_incremental=True,
+            schema={
+                "equipment_object": "API_EQUIPMENT (EQUI)",
+                "equipment_fields": [
+                    "EQUNR",
+                    "EQKTX",
+                    "TPLNR",
+                    "HEQUI",
+                    "HERST",
+                    "TYPBZ",
+                    "SERGE",
+                    "EQTYP",
+                    "ABCKZ",
+                ],
+                "functional_location_object": "API_FUNCTIONALLOCATION (IFLO)",
+                "functional_location_fields": ["TPLNR", "PLTXT", "TPLMA", "FLTYP"],
+                "order_object": "API_MAINTENANCEORDER (AUFK/AFKO)",
+                "order_fields": ["AUFNR", "KTEXT", "EQUNR", "AUART", "ANLZU"],
+            },
+            notes="Mock SAP PM. Hierarchy = functional-location TPLNR tree (TPLMA = superior FL).",
+        )
+
+    async def import_records(
+        self, record_type: RecordType, *, since: Optional[str] = None, limit: int = 500
+    ) -> list[RawRecord]:
+        data = self._load()
+        section_for = {
+            RecordType.LOCATION: ("functional_locations", "TPLNR"),
+            RecordType.ASSET: ("equipment", "EQUNR"),
+            RecordType.WORK_ORDER: ("maintenance_orders", "AUFNR"),
+            RecordType.PART: ("bom", None),  # composite key
+        }
+        if record_type is RecordType.PM_TASK:
+            rows = data.get("task_lists", [])[:limit]
+            return [
+                RawRecord(self.provider, record_type, f"{r['PLNNR']}.{r['PLNAL']}", r) for r in rows
+            ]
+        if record_type not in section_for:
+            return []
+        section, pk = section_for[record_type]
+        rows = data.get(section, [])[:limit]
+        if pk is None:  # BOM: composite EQUNR.MATNR id
+            return [
+                RawRecord(self.provider, record_type, f"{r['EQUNR']}.{r['MATNR']}", r) for r in rows
+            ]
+        return [RawRecord(self.provider, record_type, str(r[pk]), r) for r in rows]
+
+    # --- normalize -----------------------------------------------------------
+
+    def _fl_index(self) -> dict[str, dict[str, Any]]:
+        return {fl["TPLNR"]: fl for fl in self._load().get("functional_locations", [])}
+
+    def _fl_chain(self, tplnr: Optional[str]) -> list[str]:
+        """Walk TPLMA root→leaf, returning PLTXT descriptions (PLANT folds into site)."""
+        index = self._fl_index()
+        chain: list[str] = []
+        cur, seen = tplnr, set()
+        while cur and cur in index and cur not in seen:
+            seen.add(cur)
+            fl = index[cur]
+            # Every FL contributes a path segment (PLANT becomes the site label —
+            # SAP's PLANT level maps onto the ISA-95 site rather than a 4th tier).
+            chain.append(fl.get("PLTXT", cur))
+            cur = fl.get("TPLMA")
+        return list(reversed(chain))
+
+    def normalize(self, raw: list[RawRecord]) -> list[CanonicalRecord]:
+        out: list[CanonicalRecord] = []
+        for r in raw:
+            f = r.fields
+            if r.record_type is RecordType.LOCATION:
+                out.append(self._loc(f))
+            elif r.record_type is RecordType.ASSET:
+                out.append(self._equipment(f))
+            elif r.record_type is RecordType.WORK_ORDER:
+                out.append(self._order(f))
+            elif r.record_type is RecordType.PM_TASK:
+                out.append(self._task_list(f))
+            elif r.record_type is RecordType.PART:
+                out.append(self._bom(f))
+        return out
+
+    def _loc(self, f: dict[str, Any]) -> CanonicalLocation:
+        chain = self._fl_chain(f["TPLNR"])
+        return CanonicalLocation(
+            source_system=self.provider,
+            source_record_id=str(f["TPLNR"]),
+            name=f.get("PLTXT", f["TPLNR"]),
+            location_type=_FLTYP.get(f.get("FLTYP", ""), "cell"),
+            parent_source_id=f.get("TPLMA"),
+            proposed_uns_path=candidate_uns_path(*chain) if chain else None,
+            confidence=0.7,
+            raw=f,
+        )
+
+    def _equipment(self, f: dict[str, Any]) -> CanonicalAsset:
+        chain = self._fl_chain(f.get("TPLNR"))
+        path = candidate_uns_path(*chain, str(f["EQUNR"])) if chain else None
+        return CanonicalAsset(
+            source_system=self.provider,
+            source_record_id=str(f["EQUNR"]),
+            name=f.get("EQKTX", f["EQUNR"]),
+            manufacturer=f.get("HERST"),
+            model=f.get("TYPBZ"),
+            serial=f.get("SERGE"),
+            asset_type=f.get("EQTYP"),
+            parent_source_id=f.get("HEQUI"),
+            criticality=_CRIT.get(str(f.get("ABCKZ", "")).upper()),
+            location_path=".".join(chain) if chain else None,
+            proposed_uns_path=path,
+            confidence=0.6,
+            raw=f,
+        )
+
+    def _order(self, f: dict[str, Any]) -> CanonicalWorkOrder:
+        return CanonicalWorkOrder(
+            source_system=self.provider,
+            source_record_id=str(f["AUFNR"]),
+            wo_number=str(f["AUFNR"]),
+            title=f.get("KTEXT", ""),
+            description=f.get("KTEXT", ""),
+            status=_WO_STATUS.get(f.get("ANLZU", ""), f.get("ANLZU")),
+            work_type=_WORKTYPE.get(f.get("AUART", ""), f.get("AUART")),
+            priority=str(f.get("PRIOK")) if f.get("PRIOK") is not None else None,
+            asset_source_id=f.get("EQUNR"),
+            failure_code=f.get("QMNUM"),  # notification number stands in for the failure ref
+            reported_at=f.get("GSTRP"),
+            completed_at=f.get("GLTRP") if f.get("ANLZU") == "TECO" else None,
+            confidence=0.9,
+            raw=f,
+        )
+
+    def _task_list(self, f: dict[str, Any]) -> CanonicalPMTask:
+        return CanonicalPMTask(
+            source_system=self.provider,
+            source_record_id=f"{f['PLNNR']}.{f['PLNAL']}",
+            pm_number=str(f["PLNNR"]),
+            description=f.get("KTEXT", ""),
+            asset_source_id=f.get("EQUNR"),
+            frequency=f.get("ZYKL1"),
+            frequency_unit=str(f.get("ZEIEH", "")).lower() or None,
+            job_plan=f.get("STRAT"),
+            confidence=0.88,
+            raw=f,
+        )
+
+    def _bom(self, f: dict[str, Any]) -> CanonicalPart:
+        return CanonicalPart(
+            source_system=self.provider,
+            source_record_id=str(f["MATNR"]),
+            item_number=str(f["MATNR"]),
+            description=f.get("MAKTX", ""),
+            store_location=f.get("LGORT"),
+            issue_unit=f.get("MEINS"),
+            qty_on_hand=f.get("MENGE"),
+            confidence=0.85,
+            raw=f,
+        )
+
+    # --- derive relationships ------------------------------------------------
+
+    def derive_relationships(self, records: list[CanonicalRecord]) -> list[CanonicalRelationship]:
+        rels: list[CanonicalRelationship] = []
+        for rec in records:
+            if isinstance(rec, CanonicalAsset):
+                if rec.parent_source_id:  # HEQUI: superior equipment owns this one
+                    rels.append(
+                        self._rel(
+                            "HAS_COMPONENT",
+                            rec.parent_source_id,
+                            "asset",
+                            rec.source_record_id,
+                            "asset",
+                            EvidenceRef(
+                                "manifest",
+                                f"SAP EQUI.HEQUI on {rec.source_record_id}",
+                                page_or_location="EQUI.HEQUI",
+                                confidence_contribution=0.8,
+                            ),
+                            confidence=0.7,
+                        )
+                    )
+                loc = rec.raw.get("TPLNR")
+                if loc:  # asset installed at a functional location
+                    rels.append(
+                        self._rel(
+                            "LOCATED_IN",
+                            rec.source_record_id,
+                            "asset",
+                            str(loc),
+                            "location",
+                            EvidenceRef(
+                                "manifest",
+                                f"SAP EQUI.TPLNR on {rec.source_record_id}",
+                                page_or_location="EQUI.TPLNR",
+                                confidence_contribution=0.7,
+                            ),
+                            confidence=0.7,
+                        )
+                    )
+            elif isinstance(rec, CanonicalPart) and rec.raw.get("EQUNR"):
+                # BOM line: equipment HAS_PART material (containment, not consumption)
+                rels.append(
+                    self._rel(
+                        "HAS_PART",
+                        str(rec.raw["EQUNR"]),
+                        "asset",
+                        rec.source_record_id,
+                        "part",
+                        EvidenceRef(
+                            "manifest",
+                            f"SAP BOM (STPO) {rec.item_number} on equipment {rec.raw['EQUNR']}",
+                            page_or_location=f"BOM.POSNR {rec.raw.get('POSNR')}",
+                            confidence_contribution=0.8,
+                        ),
+                        confidence=0.75,
+                    )
+                )
+        return rels
+
+    def _rel(
+        self,
+        rel_type: str,
+        source_ref: str,
+        source_kind: str,
+        target_ref: str,
+        target_kind: str,
+        evidence: EvidenceRef,
+        *,
+        confidence: float,
+    ) -> CanonicalRelationship:
+        return CanonicalRelationship(
+            source_system=self.provider,
+            source_record_id=f"{rel_type}:{source_kind}:{source_ref}->{target_kind}:{target_ref}",
+            relationship_type=rel_type,
+            source_ref=source_ref,
+            source_ref_kind=source_kind,
+            target_ref=target_ref,
+            target_ref_kind=target_kind,
+            confidence=confidence,
+            reasoning=f"Derived from SAP {rel_type} link",
+            evidence=[evidence],
+        )
+
+    async def _do_export(self, enriched: list[CanonicalRecord]) -> ExportResult:
+        # Mock write-back: PATCH maintenance orders (API_MAINTENANCEORDER) back to SAP.
+        # CMMS-API target, not the plant — allowed by doctrine. Only orders are writable.
+        writable = [r for r in enriched if isinstance(r, CanonicalWorkOrder)]
+        return ExportResult(exported=len(writable), refused=len(enriched) - len(writable))

--- a/mira-connectors/tests/conftest.py
+++ b/mira-connectors/tests/conftest.py
@@ -12,7 +12,13 @@ if str(_PKG_ROOT) not in sys.path:
     sys.path.insert(0, str(_PKG_ROOT))
 
 from mira_connectors.base import ConnectorConfig, ConnectorMode  # noqa: E402
-from mira_connectors.mocks import IgnitionMockConnector, MaximoMockConnector  # noqa: E402
+from mira_connectors.mocks import (  # noqa: E402
+    IgnitionMockConnector,
+    MaintainXMockConnector,
+    MaximoMockConnector,
+    PIMockConnector,
+    SAPMockConnector,
+)
 
 
 @pytest.fixture
@@ -38,3 +44,18 @@ def maximo(ro_config: ConnectorConfig) -> MaximoMockConnector:
 @pytest.fixture
 def ignition(ro_config: ConnectorConfig) -> IgnitionMockConnector:
     return IgnitionMockConnector(ro_config)
+
+
+@pytest.fixture
+def sap(ro_config: ConnectorConfig) -> SAPMockConnector:
+    return SAPMockConnector(ro_config)
+
+
+@pytest.fixture
+def maintainx(ro_config: ConnectorConfig) -> MaintainXMockConnector:
+    return MaintainXMockConnector(ro_config)
+
+
+@pytest.fixture
+def pi(ro_config: ConnectorConfig) -> PIMockConnector:
+    return PIMockConnector(ro_config)

--- a/mira-connectors/tests/test_factory.py
+++ b/mira-connectors/tests/test_factory.py
@@ -4,18 +4,26 @@ from __future__ import annotations
 
 from mira_connectors.base import ConnectorConfig
 from mira_connectors.factory import available_providers, create_connector
-from mira_connectors.mocks import IgnitionMockConnector, MaximoMockConnector
+from mira_connectors.mocks import (
+    IgnitionMockConnector,
+    MaintainXMockConnector,
+    MaximoMockConnector,
+    PIMockConnector,
+    SAPMockConnector,
+)
 
 
 def test_available_providers():
-    providers = available_providers()
-    assert "maximo_mock" in providers
-    assert "ignition_mock" in providers
+    providers = set(available_providers())
+    assert {"maximo_mock", "ignition_mock", "sap_mock", "maintainx_mock", "pi_mock"} <= providers
 
 
 def test_create_known(ro_config: ConnectorConfig):
     assert isinstance(create_connector("maximo_mock", ro_config), MaximoMockConnector)
     assert isinstance(create_connector("ignition_mock", ro_config), IgnitionMockConnector)
+    assert isinstance(create_connector("sap_mock", ro_config), SAPMockConnector)
+    assert isinstance(create_connector("maintainx_mock", ro_config), MaintainXMockConnector)
+    assert isinstance(create_connector("pi_mock", ro_config), PIMockConnector)
 
 
 def test_create_case_insensitive(ro_config: ConnectorConfig):

--- a/mira-connectors/tests/test_maintainx_mock.py
+++ b/mira-connectors/tests/test_maintainx_mock.py
@@ -1,0 +1,72 @@
+"""MaintainXMockConnector — REST-shape import → normalize → derive → export."""
+
+from __future__ import annotations
+
+from mira_connectors.canonical import CanonicalAsset, CanonicalWorkOrder, RecordType
+from mira_connectors.mocks import MaintainXMockConnector
+
+
+async def test_discover(maintainx: MaintainXMockConnector):
+    caps = await maintainx.discover()
+    assert caps.kind.value == "cmms"
+    assert caps.provider == "maintainx"
+    assert caps.supports_export is True
+    assert "asset_endpoint" in caps.schema
+
+
+async def test_import_assets_rest_shape(maintainx: MaintainXMockConnector):
+    raw = await maintainx.import_records(RecordType.ASSET)
+    assert len(raw) == 3
+    # MaintainX numeric ids preserved as the source record id + native field kept
+    assert {r.source_record_id for r in raw} == {"8001", "8002", "8003"}
+    assert raw[0].fields["id"] == 8001
+
+
+async def test_normalize_hierarchy_and_uns(maintainx: MaintainXMockConnector):
+    recs = {}
+    for rt in (RecordType.LOCATION, RecordType.ASSET):
+        for r in maintainx.normalize(await maintainx.import_records(rt)):
+            recs[r.source_record_id] = r
+    conv, motor = recs["8001"], recs["8002"]
+    assert isinstance(conv, CanonicalAsset)
+    assert conv.manufacturer == "Dorner"
+    assert conv.proposed_uns_path == "enterprise.bedford_plant.packaging.line_1.conv_001"
+    assert motor.parent_source_id == "8001"
+    assert motor.proposed_uns_path.endswith(".motor_001")
+    assert motor.raw["serialNumber"] == "WEG-9931"  # raw preserved
+
+
+async def test_normalize_workorder_category_to_worktype(maintainx: MaintainXMockConnector):
+    recs = {
+        r.source_record_id: r
+        for r in maintainx.normalize(await maintainx.import_records(RecordType.WORK_ORDER))
+    }
+    assert isinstance(recs["91001"], CanonicalWorkOrder)
+    assert recs["91001"].status == "COMPLETE"  # DONE → COMPLETE
+    assert recs["91001"].work_type == "corrective"  # REACTIVE → corrective
+    assert recs["91002"].work_type == "preventive"  # PREVENTIVE → preventive
+
+
+async def test_derive_relationships(maintainx: MaintainXMockConnector):
+    recs = []
+    for rt in (RecordType.ASSET, RecordType.PART):
+        recs += maintainx.normalize(await maintainx.import_records(rt))
+    rels = maintainx.derive_relationships(recs)
+    types = {r.relationship_type for r in rels}
+    assert {"HAS_COMPONENT", "LOCATED_IN", "HAS_PART"} <= types
+    assert all(not r.validate() for r in rels)
+
+
+async def test_validate_clean(maintainx: MaintainXMockConnector):
+    recs = []
+    for rt in (await maintainx.discover()).record_types:
+        recs += maintainx.normalize(await maintainx.import_records(rt))
+    result = maintainx.validate_mappings(recs)
+    assert result.ok and not result.errors
+
+
+async def test_export_gated(maintainx: MaintainXMockConnector, rw_config):
+    recs = maintainx.normalize(await maintainx.import_records(RecordType.WORK_ORDER))
+    assert (await maintainx.export_records(recs)).refused == len(recs)
+    mx_rw = MaintainXMockConnector(rw_config)
+    assert (await mx_rw.export_records(recs)).exported == len(recs)

--- a/mira-connectors/tests/test_pi_mock.py
+++ b/mira-connectors/tests/test_pi_mock.py
@@ -1,0 +1,87 @@
+"""PIMockConnector — historian import → normalize → derive; read-only by construction."""
+
+from __future__ import annotations
+
+from mira_connectors.canonical import (
+    CanonicalAsset,
+    CanonicalMeter,
+    CanonicalTag,
+    RecordType,
+)
+from mira_connectors.mocks import PIMockConnector
+
+
+async def test_discover(pi: PIMockConnector):
+    caps = await pi.discover()
+    assert caps.kind.value == "historian"
+    assert caps.provider == "pi"
+    assert caps.supports_export is False  # read-only by construction
+    assert caps.schema["event_frame_count"] == 2  # event frames surfaced in discovery
+
+
+async def test_import_points_preserve_native_name(pi: PIMockConnector):
+    raw = await pi.import_records(RecordType.TAG)
+    assert len(raw) == 4
+    assert all(r.source_record_id.startswith("\\\\PISRV01") for r in raw)
+    assert raw[0].fields["PointType"]  # native PI field preserved
+
+
+async def test_af_hierarchy_to_assets_with_uns(pi: PIMockConnector):
+    recs = {r.source_record_id: r for r in pi.normalize(await pi.import_records(RecordType.ASSET))}
+    conv = recs["Bedford\\Packaging\\Conveyor"]
+    assert isinstance(conv, CanonicalAsset)
+    assert conv.proposed_uns_path == "enterprise.bedford.packaging.conveyor"
+    motor = recs["Bedford\\Packaging\\Conveyor\\Motor"]
+    assert motor.parent_source_id == "Bedford\\Packaging\\Conveyor"
+
+
+async def test_points_become_historian_tags(pi: PIMockConnector):
+    recs = pi.normalize(await pi.import_records(RecordType.TAG))
+    assert all(isinstance(r, CanonicalTag) for r in recs)
+    cur = [r for r in recs if r.address.endswith("Conv.Motor.Current")][0]
+    assert cur.history_enabled is True
+    assert cur.attributes["sample_count"] == 3  # archived values summarized
+    assert cur.attributes["last_value"] == 3.4
+    assert "PointType" in cur.raw  # raw point preserved
+
+
+async def test_archived_values_roll_up_to_meters(pi: PIMockConnector):
+    recs = pi.normalize(await pi.import_records(RecordType.METER))
+    assert recs and all(isinstance(r, CanonicalMeter) for r in recs)
+    # only points that have archived values produce a meter (3 of 4 points)
+    assert len(recs) == 3
+    assert any(r.last_reading is not None for r in recs)
+
+
+async def test_event_frames_preserved_and_safety_flagged(pi: PIMockConnector):
+    recs = {r.source_record_id: r for r in pi.normalize(await pi.import_records(RecordType.ASSET))}
+    vfd = recs["Bedford\\Packaging\\Conveyor\\VFD"]
+    assert "event_frames" in vfd.attributes  # VFD downtime event frame preserved
+    conv = recs["Bedford\\Packaging\\Conveyor"]
+    assert conv.criticality == "safety_critical"  # E-stop safety event frame → flagged
+
+
+async def test_derive_relationships(pi: PIMockConnector):
+    recs = []
+    for rt in (RecordType.ASSET, RecordType.TAG):
+        recs += pi.normalize(await pi.import_records(rt))
+    rels = pi.derive_relationships(recs)
+    types = {r.relationship_type for r in rels}
+    assert {"HAS_COMPONENT", "HAS_SIGNAL"} <= types
+    assert all(not r.validate() for r in rels)
+
+
+async def test_export_refused_by_construction(pi: PIMockConnector, rw_config):
+    recs = pi.normalize(await pi.import_records(RecordType.TAG))
+    # even constructed READ_WRITE, a historian refuses to write to the plant
+    pi_rw = PIMockConnector(rw_config)
+    res = await pi_rw.export_records(recs)
+    assert res.exported == 0 and res.refused == len(recs)
+
+
+async def test_validate_clean(pi: PIMockConnector):
+    recs = []
+    for rt in (await pi.discover()).record_types:
+        recs += pi.normalize(await pi.import_records(rt))
+    result = pi.validate_mappings(recs)
+    assert result.ok and not result.errors

--- a/mira-connectors/tests/test_sap_mock.py
+++ b/mira-connectors/tests/test_sap_mock.py
@@ -1,0 +1,101 @@
+"""SAPMockConnector — full import → normalize → derive → export lifecycle."""
+
+from __future__ import annotations
+
+from mira_connectors.canonical import (
+    CanonicalAsset,
+    CanonicalPart,
+    CanonicalWorkOrder,
+    RecordType,
+)
+from mira_connectors.mocks import SAPMockConnector
+
+
+async def test_discover(sap: SAPMockConnector):
+    caps = await sap.discover()
+    assert caps.kind.value == "cmms"
+    assert caps.provider == "sap"
+    assert RecordType.ASSET in caps.record_types
+    assert caps.supports_export is True
+    assert "EQUNR" in caps.schema["equipment_fields"]  # real SAP field name surfaced
+
+
+async def test_health_check(sap: SAPMockConnector):
+    h = await sap.health_check()
+    assert h["ok"] is True and h["mock"] is True
+
+
+async def test_import_equipment_preserves_native_fields(sap: SAPMockConnector):
+    raw = await sap.import_records(RecordType.ASSET)
+    assert len(raw) == 3
+    assert {r.source_record_id for r in raw} == {"10000455", "10000456", "10000457"}
+    assert raw[0].fields["EQUNR"] and "HERST" in raw[0].fields  # native fields preserved
+
+
+async def test_normalize_equipment_hierarchy_and_uns(sap: SAPMockConnector):
+    raw = await sap.import_records(RecordType.ASSET)
+    recs = {r.source_record_id: r for r in sap.normalize(raw)}
+    conv, motor = recs["10000455"], recs["10000456"]
+    assert isinstance(conv, CanonicalAsset)
+    assert conv.manufacturer == "Dorner"
+    assert conv.proposed_uns_path == (
+        "enterprise.bedford_plant.packaging_area.bottling_line_1.infeed_conveyor_cell.10000455"
+    )
+    assert motor.parent_source_id == "10000455"
+    assert motor.proposed_uns_path.endswith(".10000456")
+    assert "HERST" in motor.raw  # raw vendor record fully preserved
+
+
+async def test_normalize_order_status_and_worktype(sap: SAPMockConnector):
+    raw = await sap.import_records(RecordType.WORK_ORDER)
+    recs = {r.source_record_id: r for r in sap.normalize(raw)}
+    assert isinstance(recs["4000123"], CanonicalWorkOrder)
+    assert recs["4000123"].status == "COMPLETE"  # TECO → COMPLETE
+    assert recs["4000123"].work_type == "corrective"  # PM02 → corrective
+    assert recs["4000130"].work_type == "preventive"  # PM01 → preventive
+
+
+async def test_normalize_bom_parts(sap: SAPMockConnector):
+    raw = await sap.import_records(RecordType.PART)
+    recs = sap.normalize(raw)
+    assert all(isinstance(r, CanonicalPart) for r in recs)
+    assert {r.item_number for r in recs} == {"FUSE-10A-CC", "BRG-6204-2RS"}
+
+
+async def test_derive_relationships_use_018_vocab(sap: SAPMockConnector):
+    recs = []
+    for rt in (RecordType.LOCATION, RecordType.ASSET, RecordType.PART):
+        recs += sap.normalize(await sap.import_records(rt))
+    rels = sap.derive_relationships(recs)
+    types = {r.relationship_type for r in rels}
+    assert {"HAS_COMPONENT", "LOCATED_IN", "HAS_PART"} <= types
+    # every derived edge validates against the controlled vocabulary + has evidence
+    assert all(not r.validate() for r in rels)
+
+
+async def test_validate_clean(sap: SAPMockConnector):
+    recs = []
+    for rt in (await sap.discover()).record_types:
+        recs += sap.normalize(await sap.import_records(rt))
+    result = sap.validate_mappings(recs)
+    assert result.ok and not result.errors
+
+
+async def test_export_gated_read_only_then_writable(sap: SAPMockConnector, rw_config):
+    recs = sap.normalize(await sap.import_records(RecordType.WORK_ORDER))
+    ro = await sap.export_records(recs)
+    assert ro.refused == len(recs) and ro.exported == 0  # read-only default
+    sap_rw = SAPMockConnector(rw_config)
+    rw = await sap_rw.export_records(recs)
+    assert rw.exported == len(recs)  # work orders writable to the CMMS API
+
+
+async def test_dry_run_export_is_planned_noop(tenant_id):
+    from mira_connectors.base import ConnectorConfig, ConnectorMode
+
+    dry = SAPMockConnector(
+        ConnectorConfig(tenant_id=tenant_id, mode=ConnectorMode.READ_WRITE, dry_run=True)
+    )
+    recs = dry.normalize(await dry.import_records(RecordType.WORK_ORDER))
+    res = await dry.export_records(recs)
+    assert res.planned == len(recs) and res.exported == 0


### PR DESCRIPTION
## What

Adds the three connectors that were missing from the existing `mira_connectors` framework — **SAP Plant Maintenance**, **MaintainX**, and **AVEVA PI** mock connectors — built **on** that framework (base contract + `ConnectorConfig` + factory + confirmation gate + canonical model), not a parallel one. The framework already shipped Maximo + Ignition; the factory registry comments explicitly anticipated `pi` and `maintainx`.

## Connectors

| Connector | Kind | Notes |
|---|---|---|
| `SAPMockConnector` | CMMS | `TPLNR` functional-location hierarchy, `EQUNR` equipment (`HEQUI` parent), `AUFNR` orders, task-list PMs, BOM parts. Derives `HAS_COMPONENT`/`LOCATED_IN`/`HAS_PART`. Order write-back gated read-only. |
| `MaintainXMockConnector` | CMMS | MaintainX REST response shape (the `assets`/`workOrders`/`locations`/`parts` envelopes `mira-mcp/cmms/maintainx.py` already parses). `parentId`/`locationId`/`categories`. |
| `PIMockConnector` | Historian | AF element hierarchy → assets, PI points → historian tags (archived-value summary), archived values → meters. Event frames preserved on the element; a safety event frame flags `criticality="safety_critical"`. **Read-only by construction.** |

Each uses native source field names, real per-record `raw` preservation, `candidate_uns_path` (gate canonicalizes), and the migration-018 `RELATIONSHIP_TYPES` vocabulary. Registered in `factory._REGISTRY`; exported from `mocks/__init__`.

## Tests & CI

- `53 → 79` offline tests (per-connector lifecycle: discover/import/normalize/derive/validate/export-gating). All hermetic — no network/DB/LLM.
- Adds a **Connector framework tests** step to CI's Python test job — the framework + its tests were never wired into CI; this now guards all 79 (existing + new).

## Design notes (diffed against the framework first)

- **Raw-field preservation is already built in** via `CanonicalRecord.raw` — no separate source-record layer needed.
- **No new edge types added.** WO/PM/part are typed records with FK fields (not graph edges) in this design, so the canonical-asset-graph doc's `HAS_WORK_ORDER`/`USES_PART` aren't required here and would violate the migration-018 `RELATIONSHIP_TYPES` CHECK — correctly omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
