### PR TITLE
docs(ignition): 8.3 alignment foundation + bench tag allowlist

### DIFF
--- a/.claude/skills/ignition-webdev/SKILL.md
+++ b/.claude/skills/ignition-webdev/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: ignition-webdev
+description: Use when adding or editing MIRA's Ignition WebDev endpoints, gateway scripts, Perspective views, tag allowlist, or any file under ignition/ in the MIRA monorepo — covers the config-as-files deploy procedure, the tag allowlist, secrets, and validation.
+---
+
+# Ignition WebDev / resource development (MIRA monorepo)
+
+Use this when touching anything under `ignition/` in MIRA-monorepo. Full context:
+`docs/agent-workflows/ignition-resource-development.md` and `docs/ignition-8.3-alignment-plan.md`.
+
+## When this applies
+- Editing `ignition/webdev/FactoryLM/api/<name>/{doGet,doPost}.py` (Jython 2.7 HTTP handlers)
+- Editing `ignition/gateway-scripts/*.py` (Jython tag-change / timer scripts)
+- Editing Perspective `view.json` / `resource.json` under `ignition/project/...perspective/views/`
+- Editing `ignition/project/approved_tags.json` (the read allowlist) or `ignition/tags/*.json`
+
+## Hard rules (do not violate)
+1. **Never deploy via the Gateway web-UI Project Import** — it corrupts 8.3.x projects. Deploy is
+   stop-service → write files → start-service. (See `MIRA_PLC/.claude/skills/ignition-dashboard`.)
+2. **Reads are allowlisted, fail-closed.** A tag MIRA reads must be in `approved_tags.json` or the
+   WebDev tags endpoint returns 503. The allowlist loader is `ignition/webdev/FactoryLM/api/tags/allowlist.py`;
+   its repo-dev fallback path is `ignition/project/approved_tags.json`.
+3. **No secrets in files.** Never commit a literal or empty key (e.g. `X-Mira-Key:""`) in a view or
+   script. Use `system.secret.get('MIRA_IGNITION_HMAC_KEY')` with a `factorylm.properties` fallback.
+4. **Jython 2.7, not Python 3.** WebDev/gateway scripts run in Jython — no f-strings beyond 2.7, no
+   `httpx`; prefer `system.net.httpGet/httpPost` and `system.util.jsonEncode/jsonDecode`.
+5. **HMAC-sign cloud-bound POSTs** using `ignition/webdev/FactoryLM/api/chat/signing.py` (matches the
+   verifier in `mira-pipeline/ignition_chat.py`).
+
+## Validate before you finish (checklist)
+- [ ] `python -m json.tool <each changed .json>` exits 0
+- [ ] Perspective view: both `resource.json` (metadata) and `view.json` (content) present + valid
+- [ ] Allowlist still resolves: `allowlist.resolve_allowlist_path()` returns a real path
+- [ ] If a handler/script changed: `tests/regime7_ignition/` and `tests/ignition/` pass
+- [ ] No secret literals; no web-UI-Import instructions added to docs
+
+## Common gotchas
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Tags endpoint returns 503 | tag not in `approved_tags.json` | add the exact `[provider]path` |
+| AskMira reads return null quality | script provider/folder ≠ deployed tag folder (e.g. `MIRA_IOCheck` vs `[MIRA_PLC]`) | match the folder name or parameterize it |
+| View edit doesn't show after copy | `resource.json` timestamp not bumped | update `attributes.lastModification.timestamp`, restart service |
+| Project corrupted (files→dirs) | used web-UI Project Import | restore from `_import_stage` / `RESTORE_PROJECT.ps1`; never import via web UI |

--- a/docs/agent-workflows/ignition-resource-development.md
+++ b/docs/agent-workflows/ignition-resource-development.md
@@ -1,0 +1,92 @@
+# Agent Workflow — Developing & PR-ing Ignition Resources
+
+**Status:** ACTIVE · **Authored:** 2026-06-04 · Pairs with
+[`../ignition-8.3-alignment-plan.md`](../ignition-8.3-alignment-plan.md).
+
+How an agent (or human) safely inspects, generates, validates, and PRs Ignition 8.3 resources in this
+repo. Ignition 8.3 stores Gateway resources as files, so they version-control and review like code —
+**if** you follow the layout and deploy rules below.
+
+---
+
+## Where Ignition resources live
+
+| Resource | Path | Format |
+|----------|------|--------|
+| Perspective views | `ignition/project/com.inductiveautomation.perspective/views/<View>/` | `resource.json` (metadata) **+** `view.json` (content) |
+| Page routes | `ignition/project/com.inductiveautomation.perspective/page-config/config.json` | JSON URL→view map |
+| WebDev endpoints | `ignition/webdev/FactoryLM/api/<name>/{doGet,doPost}.py` | Jython 2.7 |
+| Gateway event scripts | `ignition/gateway-scripts/*.py` | Jython 2.7 |
+| Tag definitions | `ignition/tags/*.json`, `MIRA_PLC/ignition/**/tag-definition/**/tags.json` | JSON tag arrays |
+| Tag read allowlist | `ignition/project/approved_tags.json` | JSON `{version, description, tags:[...]}` |
+| Config template | `ignition/config/factorylm.properties.template` | properties |
+| Deploy scripts | `ignition/deploy_ignition.ps1`, `MIRA_PLC/ignition/ConvSimpleLive/APPLY*.ps1` | PowerShell |
+
+**Correct view layout (8.3):** `resource.json` holds *metadata only*
+(`{scope, version, restricted, overridable, files:["view.json"], attributes.lastModification}`);
+`view.json` holds the component tree. The `MIRA_PLC/ignition/ConvSimpleLive/views/AskMira/` pair is the
+reference. (Several monorepo views still embed content in `resource.json` — a Phase 1 cleanup.)
+
+---
+
+## The golden rules
+
+1. **Never use the Gateway web-UI "Project Import."** On 8.3.x it corrupts the project (resource files
+   become directories). Deploy by **stop service → write files → start service** (see below). This is
+   codified in `MIRA_PLC/.claude/skills/ignition-dashboard/SKILL.md`.
+2. **Read-only by default.** Reads go through the fail-closed allowlist (`approved_tags.json`). Adding a
+   write (`system.tag.writeBlocking`) requires an explicit Security Level gate and a reviewer.
+3. **No secrets in resources.** Never put a literal or empty credential in `view.json`, a script, or a
+   doc. Use `system.secret.get('MIRA_IGNITION_HMAC_KEY')`.
+4. **Validate before deploy.** `python -m json.tool <file>.json` must pass for every `view.json` /
+   `resource.json` / `tags.json` you touch. (Phase 2 makes this a CI gate.)
+5. **One render per change.** Keep a `rollbacks/` snapshot + PNG per significant view version (the
+   `MIRA_PLC/ignition/ConvSimpleLive/rollbacks/` pattern) so a regression is one copy away from undone.
+
+---
+
+## The deploy procedure (existing Perspective view edits)
+
+```powershell
+# Reference: MIRA_PLC/ignition/ConvSimpleLive/APPLY_ASKMIRA.ps1
+Stop-Service Ignition
+Copy-Item <repo>\ignition\...\view.json  <gateway>\data\projects\<proj>\...\view.json
+# bump resource.json attributes.lastModification.timestamp so the gateway reloads it
+Start-Service Ignition
+# verify: open /data/perspective/client/<proj>, confirm the change rendered
+```
+
+Config-only resources (tags, properties) can be hot-applied without a service stop; **Perspective views
+cannot** — they require the stop-write-start cycle.
+
+---
+
+## How an agent should open an Ignition PR
+
+1. **Branch** off `main`: `feat/ignition-<short-topic>` (resources) or `docs/ignition-<topic>` (docs).
+2. **Separate generated from hand-edited.** Agent-generated resources (e.g. a synthesized view) go in
+   `ignition/starter-project/` or a clearly-labeled generated path; never silently overwrite a
+   hand-tuned bench view. Hand edits to live bench views (`MIRA_PLC/ignition/ConvSimpleLive/`) are
+   explicit and reviewed.
+3. **Validate locally:** `python -m json.tool` on every JSON touched; if a WebDev/script changed, run
+   `tests/regime7_ignition/` and `tests/ignition/`.
+4. **Keep PRs small + foundational.** Docs/scaffold PRs don't touch live gateways. A view-changing PR
+   should land *after* the JSON-lint CI gate exists (Phase 2) and carry a `RESTORE_PROJECT.ps1` rollback note.
+5. **PR description must state:** which gateway (bench `100.72.2.99` vs customer), whether it was deployed
+   + verified or is file-only, and that no secrets/no web-UI-Import were used.
+6. **Resource changes that touch a running gateway are proposals**, not direct writes, once the Phase 5
+   approval pipeline exists — route through `mira-hub` /proposals.
+
+---
+
+## Quick reference — validate everything an agent touched
+
+```bash
+# JSON syntax (run on every changed .json under ignition/)
+git diff --name-only --diff-filter=d main... | grep -E 'ignition/.*\.(json)$' \
+  | while read f; do python -m json.tool "$f" >/dev/null && echo "ok  $f" || echo "BAD $f"; done
+
+# allowlist still loads
+python -c "import sys; sys.path.insert(0,'ignition/webdev/FactoryLM/api/tags'); \
+  import allowlist; print('allowlist path:', allowlist.resolve_allowlist_path())"
+```

--- a/docs/architecture/mira-ignition-module-architecture.md
+++ b/docs/architecture/mira-ignition-module-architecture.md
@@ -1,0 +1,157 @@
+# MIRA × Ignition 8.3 — Integration & Module Architecture
+
+**Status:** ACTIVE · **Authored:** 2026-06-04 · Pairs with
+[`../ignition-8.3-alignment-plan.md`](../ignition-8.3-alignment-plan.md) and
+[ADR-0021 (Ignition module-first edge)](../adr/0021-ignition-module-first-edge.md).
+
+This document defines the *target* architecture for how MIRA integrates with Ignition 8.3. It is a
+plan; where it describes something not yet built, it says so. Verified-present components are cited
+with real paths.
+
+---
+
+## 1. Three-layer module strategy (Jython now → script library → JAR later)
+
+Per ADR-0021, MIRA adopts Ignition capability in **risk-ascending layers**. We are at Layer 1 today.
+
+| Layer | What | Status | Build cost |
+|------:|------|--------|-----------|
+| **L1 — WebDev (Jython)** | HTTP endpoints + gateway scripts as Python files in Git | **PRESENT**: `ignition/webdev/FactoryLM/api/{tags,chat,alerts,status,connect,ingest}/{doGet,doPost}.py`, `ignition/gateway-scripts/*.py` | none (no compile) |
+| **L2 — Project script library** | `system.mira.*` ergonomics that wrap the L1 endpoints | **PLANNED (Phase 6)**: `ignition/project/script-python/mira/{ask,confirmContext,proposeRelationship}.py` | low (Jython, no JAR) |
+| **L3 — Java/Gradle module** | `GatewayHook`, Config page, `ManagedTagProvider`, signed `.modl` | **NOT STARTED** (deliberate — post first paying customer) | high (Gradle + SDK + signing) |
+
+**Why this order:** Layers 1–2 ship value with zero Java toolchain and are fully agent-editable as
+files. Layer 3 is only justified once a customer needs a Gateway-config UI, managed context tags, or
+`system.mira.*` without a project dependency. Do not start L3 before there is a concrete customer pull.
+
+### Target `system.mira.*` surface (L2, then promoted to L3)
+- `system.mira.ask(question, asset=None)` → POST the existing `/ask` backend
+- `system.mira.confirmContext(session_id, confirm: bool, asset=None)` → drive the UNS gate
+- `system.mira.proposeRelationship(source, type, target)` → enqueue a KG proposal (human-verified)
+- `system.mira.ingestTagProvider(provider)` → register provider tags as ingest candidates
+- `system.mira.publishEvent(event_type, payload)` → write an `agent_events` row + MQTT publish
+
+---
+
+## 2. UNS confirmation gate — surfacing the EXISTING backend in Perspective
+
+**The gate already exists and is hardened in the backend.** `mira-bots/shared/engine.py`:
+`_should_fire_uns_gate`, `_handle_uns_confirmation_request` / `_handle_uns_confirmation_response`,
+FSM state `AWAITING_UNS_CONFIRMATION`, flag `MIRA_UNS_GATE_ENABLED` (default on), and a
+`source == "direct_connection"` carve-out. The AskMira view today (`MIRA_PLC/.../views/AskMira/view.json`)
+POSTs `{question, tags, session_id}` to `:8011/ask` and dumps the reply as raw markdown — so the gate
+prompt is indistinguishable from a normal answer. **The only work is the Perspective surface.**
+
+```
+AskMira view.custom:
+  uns_state       : 'idle' | 'awaiting_confirm' | 'confirmed'
+  confirmed_asset : ''          # set after the gate passes
+
+Ask button onActionPerformed:
+  POST /ask  →  response now carries  uns_gate_state ∈ {awaiting_confirmation, answered}
+  if uns_gate_state == 'awaiting_confirmation':
+       uns_state = 'awaiting_confirm'; render ConfirmationPanel(prompt, candidate_asset)
+  else:
+       uns_state = 'confirmed'; confirmed_asset = response.confirmed_asset
+       route response.answer → markdown pane
+
+ConfirmationPanel (visible when uns_state=='awaiting_confirm'):
+  label(prompt)  ·  button "Yes, correct" → POST /ask {uns_confirm:true}
+                 ·  button "No, specify"  → asset picker
+
+LocationBreadcrumb (visible when uns_state=='confirmed'):
+  label showing confirmed_asset   # the technician always sees what MIRA thinks they're on
+```
+
+**Backend change required:** one small addition in `mira-bots/ask_api/app.py` — tag gate-prompt
+responses with `uns_gate_state: "awaiting_confirmation"` in the JSON envelope (the FSM already knows;
+it just isn't exposed to the frontend). No gate logic changes.
+
+---
+
+## 3. API flow — read · propose · approve · sync (Phase 5)
+
+MIRA is **read-only by default**; all writes are proposals routed through human approval.
+
+```
+READ     Gateway tags → system.tag.readBlocking (WebDev/gateway script)
+              → allowlist.py (FAIL-CLOSED, ignition/project/approved_tags.json)
+              → mira-relay ingest → tag_events / live_signal_cache
+
+PROPOSE  agent generates a Perspective view diff
+              → IgnitionGatewayClient.get_resource() reads current view.json   [Phase 5, NOT built]
+              → diff → mira-hub proposals queue (entity_type='ignition_resource', status='pending')
+
+APPROVE  operator reviews in mira-hub /proposals → 'pending' → 'verified'
+
+SYNC     sync job → IgnitionGatewayClient.write_resource()                     [gated OFF by default]
+              → stop-service · atomic file write · start-service · project rescan
+              → ignition_audit_log row (migration 031)
+```
+
+`IgnitionGatewayClient` (~100 lines httpx, **to build in Phase 5**) is the single choke point for all
+Gateway I/O; write methods sit behind `MIRA_IGNITION_WRITE_ENABLED=false` (default).
+
+---
+
+## 4. Event flow (Phase 4)
+
+```
+PLC tag change → Ignition OPC UA → gateway-scripts/tag-change-fsm-monitor.py → mira_anomalies + alert tag
+              → gateway-scripts/tag-stream.py (HMAC POST) → mira-relay/tag_ingest.py → tag_events
+                   → tag_diff_logger (APScheduler 30s, TO SCHEDULE) → tag_event_diffs + fault_window_id
+
+Ignition alarm  → Alarm Pipeline → POST webdev/.../api/alerts/alarm_notify (NEW) → agent_events('alarm_triggered')
+
+AskMira submit  → /ask → engine.process() [gate fires if unconfirmed]
+                   confirm → FSM AWAITING_UNS_CONFIRMATION→IDLE → emit agent_events('uns_context_confirmed')
+                   → diagnosis (live tags + KG + historian) → ignition_audit_log
+```
+
+Canonical MIRA event taxonomy (target): `tag_changed`, `alarm_triggered`, `form_submitted`,
+`uns_context_confirmed`, `doc_ingested`, `relationship_proposed`, `resource_change_proposed`,
+`resource_change_approved`, `troubleshooting_published`.
+
+---
+
+## 5. Secrets model
+
+```
+Source of truth   Doppler  factorylm/{dev,stg,prd}
+Ignition-side     system.secret.get('MIRA_IGNITION_HMAC_KEY')  →  factorylm.properties fallback
+Perspective       read from a write-protected tag; NEVER a literal/empty key in view.json
+Nonce store       Redis SETNX+TTL  (replace the in-process dict in mira-mcp/ignition_auth.py)
+Weak defaults     FLOWER_PASSWORD / GRAFANA_PASSWORD → Doppler only (remove from .env.template)
+```
+
+**Open item this informs:** `AskMira/view.json` currently commits `X-Mira-Key:""`. The end state is no
+credential field in the view at all — the gateway script reads the key from `system.secret.get()`.
+
+---
+
+## 6. Deployment-mode matrix (Phase 3/8)
+
+| Mode | Compose | Ignition | UNS gate | Tags |
+|------|---------|----------|:-------:|------|
+| Local dev | `docker-compose.yml` + `deployment-modes/docker-compose.ignition.yml` (trial) | container | on | sim conveyor |
+| Staging | `docker-compose.staging-vps.yml` | n/a | on | NeonDB staging |
+| Expo/kiosk | `deployment-modes/docker-compose.expo.yml` | PLC laptop | off* | live PLC |
+| Training | `deployment-modes/docker-compose.training.yml` | container | on | seeded fixture |
+| Production | `docker-compose.saas.yml` | customer gateway | on | customer tags |
+
+\* Kiosk disables the gate only because it is a **single-asset** deployment; adding a second asset
+requires re-enabling the gate (documented hard rule).
+
+---
+
+## 7. What is verified-present vs planned (honesty ledger)
+
+**Present (cited):** WebDev Jython endpoints, 4 gateway scripts, `ignition/project/` Perspective views +
+`page-config`, `approved_tags.json`, `tags/`, `config/factorylm.properties.template`, `db/schema.sql`,
+`deploy_ignition.ps1`, `mira-mcp/ignition_auth.py`, `mira-pipeline/ignition_chat.py`, the backend UNS gate,
+`tag_events`/`tag_event_diffs` migrations, `mira-ignition-exchange/` views.
+
+**Planned / NOT yet built:** containerized Ignition gateway, reusable Perspective widget kit (SVG),
+UNS gate Perspective panel, `uns_gate_state` field in `/ask`, `IgnitionGatewayClient`, resource-sync +
+proposal pipeline, alarm→MIRA binding, scheduled `tag_diff_logger`, VFD historian, `system.mira.*`
+script library, Java module, offline/mobile views, deployment-mode compose files.

--- a/docs/ignition-8.3-alignment-plan.md
+++ b/docs/ignition-8.3-alignment-plan.md
@@ -1,0 +1,96 @@
+# MIRA × Ignition 8.3 — Alignment Plan
+
+**Status:** ACTIVE (living document) · **Authored:** 2026-06-04 · **Owner:** Mike Harper
+
+This is the canonical decision record for bringing MIRA into alignment with the Ignition 8.3
+advanced development model, so the platform becomes a strong base for agent-assisted development
+of Ignition modules, Perspective views, Gateway resources, and maintenance-intelligence workflows.
+
+It pairs with [`docs/architecture/mira-ignition-module-architecture.md`](./architecture/mira-ignition-module-architecture.md)
+(target architecture) and [`docs/agent-workflows/ignition-resource-development.md`](./agent-workflows/ignition-resource-development.md)
+(how agents develop + PR Ignition resources). The full 9-sub-agent assessment with per-file evidence
+lives in the PLC repo at `MIRA_PLC/specs/IGNITION_8.3_ALIGNMENT.md` (+ `_REVIEW.md`).
+
+> **Mental model** (see [`docs/THEORY_OF_OPERATIONS.md`](./THEORY_OF_OPERATIONS.md)):
+> Slack/Telegram = front door · MIRA engine = brain · UNS/MQTT = nervous system ·
+> KG + component templates = memory · **Ignition 8.3 = the industrial integration surface.**
+
+---
+
+## What this accomplishes (plain English)
+
+The PLC-bench side of MIRA already manages Ignition as version-controlled files and deploys them
+safely. The product/monorepo side has strong CI, a hardened backend "confirm-before-troubleshoot"
+gate, and a knowledge graph — **but the Ignition integration surface is thin**: no reusable
+Perspective widgets, the confirmation gate is invisible in the HMI, and there is no repeatable
+(containerized) Ignition environment for CI or training. This plan closes those gaps in eight
+incremental phases, reusing what already works rather than rewriting it.
+
+---
+
+## Current-state scorecard (0 = absent · 5 = excellent / agent-ready)
+
+| # | Area | Score | Where the repo sits today |
+|---|------|:----:|---------------------------|
+| 1 | File-based Gateway config in Git | **4** | `MIRA_PLC/ignition/ConvSimpleLive/` (views/tags/rollbacks + deploy scripts), monorepo `ignition/{project,webdev,gateway-scripts,tags,config,db}` |
+| 2 | Agent-friendly Git/CI | **4** | 7 workflows, PR template, dependabot; **gaps:** no CODEOWNERS, no JSON-lint gate for `view.json`/`tags.json` |
+| 3 | Deployment modes | **3** | 10 `docker-compose*.yml`; **gaps:** no sim/expo/training modes, no containerized Ignition, doppler defaults to `prd` |
+| 4 | Ignition REST / OpenAPI integration | **3** | `ignition/webdev/FactoryLM/api/**`, `mira-mcp`, `mira-pipeline/ignition_chat.py`; **gap:** no `IgnitionGatewayClient`, no resource-sync |
+| 5 | Containers / repeatable Ignition env | **3** | All services Dockerized + Trivy-scanned; **gap:** no containerized Ignition gateway for QA/training |
+| 6 | SVG / HMI visualization | **2** | Raster PNG + pixel-positioned label overlays only; **gap:** no SVG mimic, no reusable widget kit |
+| 7 | UNS confirmation gate **in Perspective** | **2** | Backend gate is live (`mira-bots/shared/engine.py`); **gap:** invisible in AskMira (renders as raw markdown) |
+| 8 | Event-driven design / Event Streams | **2** | Gateway scripts + `tag_events`/`tag_event_diffs`; **gap:** no native 8.3 Event Streams, no alarm→MIRA binding |
+| 9 | Secrets management | **3** | Doppler + `.env.template`; **gaps:** empty `X-Mira-Key` committed in AskMira, weak demo passwords in template |
+| 10 | Ignition SDK / custom module | **2** | Jython WebDev + Exchange views; **no Java/Gradle module** (intentional — ADR-0021 = Jython-first, JAR-later) |
+| 11 | Offline / mobile technician | **1** | Viewport meta only; **gap:** no offline capture, no QR entry, silent failure on disconnect |
+| 12 | OPC-UA roles / read-only safety | **3** | Read-only VFD tags + fail-closed allowlist; **gap:** un-gated `system.tag.writeBlocking` in SpeedControl/FaultLog |
+| 13 | Historian / time-series troubleshooting | **3** | Diff logger + anomaly rules exist; **gap:** historian not enabled on VFD tags, no running scheduler |
+
+**Strongest:** file-based config (1) + agent-friendly CI (2). **Weakest:** offline/mobile (1),
+Perspective viz (6), UNS-gate-in-Perspective (7), event streams (8), module SDK (10).
+
+### Verified corrections to the raw audit (checked against real files 2026-06-04)
+The sub-agent report contained a few stale claims; ground-truth:
+- ✅ `ignition/project/approved_tags.json` **EXISTS** and is populated (the audit's "biggest gap:
+  file absent → allowlist 503" was **wrong**). `allowlist.py`'s repo-dev fallback resolves to
+  `ignition/project/approved_tags.json` — confirmed.
+- ✅ `ignition/README.md` and `docs/THEORY_OF_OPERATIONS.md` **already exist** (audit said create them).
+- ✅ VFD tag-definition has **10** tags (not 9): adds `vfd_run_permit`.
+- ⚠️ **Real residual gap:** `MIRA_PLC/ignition/ConvSimpleLive/views/AskMira/view.json` hard-codes
+  12 `[default]MIRA_IOCheck/...` reads that **bypass the allowlist**, and the script's provider/folder
+  `MIRA_IOCheck` differs from the tag-definition's `[MIRA_PLC]` provider → silent null-quality reads
+  if folder names drift. This PR extends the allowlist to cover those paths; fixing the AskMira
+  script to call the allowlisted endpoint is Phase 3.
+
+---
+
+## Phased plan (summary — full tasks/files/acceptance in the architecture doc + PLC specs)
+
+| Phase | Goal | Headline acceptance |
+|-------|------|---------------------|
+| 1 | Repo alignment + starter project + this doc set | All `view.json` JSON-lint clean; starter project + deployment-modes scaffold exist; this doc merged |
+| 2 | Agent-friendly Git/CI + resource validation | CODEOWNERS on `ignition/**`; a malformed `view.json` is caught in CI before merge |
+| 3 | Perspective UI kit + conveyor widgets + **UNS gate panel** | Reusable VFD/sensor/status widgets; AskMira renders the gate as a Yes/No confirmation panel, not raw text |
+| 4 | Event-driven Gateway integration | An Ignition alarm produces an `agent_events` row; `uns_context_confirmed` emitted on confirm |
+| 5 | OpenAPI resource sync + approval gates | `IgnitionGatewayClient` reads resources; proposed view diffs route through `mira-hub` queue; writes gated off by default |
+| 6 | Custom module foundation | `system.mira.ask()` callable via a project script library (no JAR yet, per ADR-0021) |
+| 7 | Historian / anomaly / fault reasoning | VFD historian enabled; diagnosis prompt includes time-series fault evidence |
+| 8 | Marketplace / customer deployment packaging | Clean machine runs the Ignition demo without the physical PLC laptop |
+
+**Sequencing guardrail (from review):** ship Phase 2's JSON-lint CI gate **before** Phase 3 edits
+any `view.json` against a live gateway, so a broken view can't reach the bench without a CI catch.
+
+---
+
+## Hard rules (non-negotiable)
+
+1. **Confirm-before-troubleshoot.** MIRA must resolve + confirm the technician's UNS/asset context
+   before troubleshooting. The backend gate already enforces this (`engine.py` `_should_fire_uns_gate`,
+   `AWAITING_UNS_CONFIRMATION`, `MIRA_UNS_GATE_ENABLED`, plus a direct-connection carve-out). **Do not
+   rebuild it** — Phase 3 only *surfaces* it in Perspective.
+2. **Read-only first.** MIRA starts read-only and only *proposes* writes; control-tag writes require an
+   explicit approval gate (Phase 5) and a Security Level. Never widen write access by default.
+3. **No secrets in resources.** Never commit a literal or empty credential into a `view.json`, Perspective
+   script, gateway script, doc, or module. Secrets come from Doppler → `system.secret.get()` → tag fallback.
+4. **Config-as-files only.** Deploy by stopping the service, writing files, restarting — **never** the
+   Gateway web-UI Project Import (it corrupts 8.3.x projects: files become directories).

--- a/ignition/README.md
+++ b/ignition/README.md
@@ -1,5 +1,11 @@
 # MIRA — Ignition ConveyorMIRA Dashboard
 
+> **Note (2026-06-04):** This page documents the original bench deploy. The platform's Ignition 8.3
+> alignment direction — architecture, deployment modes, the UNS-gate Perspective surface, and the
+> phased plan — lives in [`docs/ignition-8.3-alignment-plan.md`](../docs/ignition-8.3-alignment-plan.md)
+> and [`docs/architecture/mira-ignition-module-architecture.md`](../docs/architecture/mira-ignition-module-architecture.md).
+> The running bench gateway is **8.3.4**; `deploy_ignition.ps1` still references 8.1 paths (Phase 1 cleanup).
+
 **Target:** PLC Laptop (Windows, Ignition 8.1 Standard trial, `http://localhost:8088`)
 **PLC:** Micro820 at `192.168.1.100:502` (Modbus TCP)
 

--- a/ignition/project/approved_tags.json
+++ b/ignition/project/approved_tags.json
@@ -47,6 +47,18 @@
     "[default]Conveyor/VFD_Hz",
     "[default]Conveyor/VFD_Amps",
     "[default]Conveyor/VFD_DCBus_V",
-    "[default]Conveyor/VFD_Setpoint_Hz"
+    "[default]Conveyor/VFD_Setpoint_Hz",
+    "[default]MIRA_IOCheck/Inputs/DI_02",
+    "[default]MIRA_IOCheck/Inputs/DI_05",
+    "[default]MIRA_IOCheck/Outputs/DO_02",
+    "[default]MIRA_IOCheck/VFD/pe_latched",
+    "[default]MIRA_IOCheck/VFD/vfd_cmd_word",
+    "[default]MIRA_IOCheck/VFD/vfd_comm_ok",
+    "[default]MIRA_IOCheck/VFD/vfd_current",
+    "[default]MIRA_IOCheck/VFD/vfd_dc_bus",
+    "[default]MIRA_IOCheck/VFD/vfd_fault_code",
+    "[default]MIRA_IOCheck/VFD/vfd_freq_sp",
+    "[default]MIRA_IOCheck/VFD/vfd_frequency",
+    "[default]MIRA_IOCheck/VFD/vfd_status_word"
   ]
 }


### PR DESCRIPTION
## What & why

**Phase 1 foundation** from the 9-sub-agent Ignition 8.3 alignment audit — the canonical "front door" for Ignition development that unblocks every later phase. Docs + scaffolding + one safe data change. **No prod changes, no secrets, no claimed-but-absent resources.**

## Files

| File | New? | What |
|------|------|------|
| `docs/ignition-8.3-alignment-plan.md` | new | Living decision record: corrected 13-area scorecard (0–5), 8-phase summary, hard rules |
| `docs/architecture/mira-ignition-module-architecture.md` | new | 3-layer module strategy (Jython→script-lib→JAR per ADR-0021), **UNS-gate Perspective surface design**, read/propose/approve/sync API flow, event flow, secrets model, honesty ledger |
| `docs/agent-workflows/ignition-resource-development.md` | new | How agents inspect/validate/PR Ignition resources (config-as-files, stop-write-start, never web-UI Import, JSON-lint, generated-vs-handedited) |
| `.claude/skills/ignition-webdev/SKILL.md` | new | Monorepo WebDev/resource skill with gotchas table |
| `ignition/project/approved_tags.json` | edit | **+12** bench `[default]MIRA_IOCheck/*` read-only paths the AskMira view actually reads — closes the allowlist-coverage gap |
| `ignition/README.md` | edit | Banner pointing to the 8.3 plan; flags the 8.1→8.3.4 drift |

## Corrections to the raw audit (verified against real files)

The audit had a few stale claims; I checked ground-truth before writing:
- ✅ `ignition/project/approved_tags.json` **already exists** — the audit's "biggest gap: file absent → allowlist 503" was **wrong**. This PR *extends* it, doesn't create it.
- ✅ `ignition/README.md` and `docs/THEORY_OF_OPERATIONS.md` **already exist** (audit said create).
- ✅ VFD tag-definition has **10** tags, not 9 (`vfd_run_permit`).
- ⚠️ Real residual (documented, fixed later): AskMira hardcodes the 12 reads bypassing the allowlist, and its provider `MIRA_IOCheck` ≠ the tag-def's `[MIRA_PLC]` → null-quality risk (Phase 3).

## The one architecture call that matters

The **UNS confirmation gate already exists and is hardened in the backend** (`mira-bots/shared/engine.py`). The architecture doc treats it as *present* and designs only the **Perspective surface** (`view.custom.uns_state` + ConfirmationPanel + a `uns_gate_state` field in `ask_api/app.py`). It does **not** propose rebuilding the gate.

## Validation
- `python -m json.tool ignition/project/approved_tags.json` → clean (58 tags)
- `allowlist.resolve_allowlist_path()` → returns the extended `ignition/project/approved_tags.json`
- All doc cross-links resolve to real files

Full 9-sub-agent assessment + adversarial review: `MIRA_PLC/specs/IGNITION_8.3_ALIGNMENT.md` (+ `_REVIEW.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)