### PR TITLE
fix(ingest): collapse OCR manufacturer variants before UNS path build (#1596)

### DIFF
--- a/mira-crawler/ingest/kg_writer.py
+++ b/mira-crawler/ingest/kg_writer.py
@@ -30,6 +30,7 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from uuid import UUID
 
+from .manufacturer_normalize import normalize_manufacturer
 from .uns import (
     equipment_unassigned_path,
     fault_code_path,
@@ -232,6 +233,11 @@ def register_equipment_and_manual(
     the user assigns the model to a physical location.
     """
 
+    # Collapse OCR/extraction manufacturer variants before any UNS path is
+    # built, so misspellings ("Alien-Bradley", "Cofemo") don't mint
+    # duplicate catalog nodes. See ingest/manufacturer_normalize.py (#1596).
+    manufacturer = normalize_manufacturer(manufacturer).canonical
+
     eq_path = equipment_unassigned_path(manufacturer, model, family=family)
     eq_id = upsert_entity(
         tenant_id=tenant_id,
@@ -306,6 +312,9 @@ def register_fault_code(
     equipment entity that was the carrier of this extraction so the bot
     can ask "what faults exist on PowerFlex 525?" via graph traversal.
     """
+    # Same OCR-variant collapse as register_equipment_and_manual so a fault
+    # node anchors under the canonical manufacturer (#1596).
+    manufacturer = normalize_manufacturer(manufacturer).canonical
     name = f"{manufacturer} / {fault_code}".strip(" /")
     fc_id = upsert_entity(
         tenant_id=tenant_id,

--- a/mira-crawler/ingest/manufacturer_normalize.py
+++ b/mira-crawler/ingest/manufacturer_normalize.py
@@ -1,0 +1,168 @@
+"""Ingest-side manufacturer name normalization (issue #1596).
+
+Problem
+-------
+OCR / extraction noise fragments one real vendor into several catalog
+entries — ``Allen-Bradley`` vs ``Alien-Bradley``, ``Coffing`` vs
+``Cofemo``/``Cofing``/``Cottins``, ``Orlando Rigging`` vs
+``Orldndo Rigging``, ``Deshazo`` vs ``Deshaco``/``Desha``/``Deshazzo``.
+Each variant mints its own ``enterprise.knowledge_base.<slug>`` node, which
+inflates the manufacturer count and scatters chunks/manuals across spurious
+vendors, hurting retrieval grouping.
+
+Scope (deliberately narrow)
+---------------------------
+This module does **OCR/typo collapse only** — it maps misspellings toward
+the cleanest observed spelling. It does NOT do brand→corporate-parent
+canonicalization (e.g. ``Allen-Bradley`` → ``Rockwell Automation``). That
+brand-vs-parent question is a *separate, pre-existing* split between the KB
+catalog (which stores ``Allen-Bradley``) and the query-side resolver
+(``mira-bots/shared/uns_resolver.py`` ``VENDOR_ALIASES``, which maps to
+``Rockwell Automation``). Resolving it changes both surfaces and is carved
+out of #1596 as an open product decision — see the issue.
+
+Divergence safety
+-----------------
+The query-side resolver returns "no opinion" (``_match_vendor`` →
+``(None, None, None)``) for any vendor not in its ~15-vendor VFD-focused
+alias table, so unknown vendors flow straight to ``uns.slug()`` on both the
+ingest and query sides. The long-tail rigging/hoist OEMs this module cleans
+are all in that "no opinion" set, so collapsing their misspellings cannot
+create new ingest-vs-query divergence. We therefore **pass unknown vendors
+through unchanged** rather than imposing any canonical of our own.
+
+Two layers
+----------
+1. ``OCR_VARIANT_ALIASES`` — a curated, deterministic seed map of the
+   variants named in #1596. Applied at ingest time (``confidence=1.0``).
+2. ``propose_fuzzy_canonical`` — a high-threshold fuzzy *proposer* that
+   LOGS a candidate collapse but never merges. Intended for the gated,
+   review-gated catalog backfill, not for silent ingest-time merging
+   (merging two genuinely distinct vendors is the only irreversible failure
+   mode here).
+
+Wired into ``kg_writer`` (the boundary where the manufacturer string becomes
+a UNS path), so every path that mints a manufacturer node — not just the
+chunk-store hot path — benefits.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+
+logger = logging.getLogger("mira-crawler.manufacturer_normalize")
+
+# Minimum token-sorted similarity for the fuzzy proposer to surface a
+# candidate. Tuned high: at 0.88, real-vendor pairs like Banner/Bauer (~0.72)
+# and ABB/ABM (~0.67) stay below it, while single-character OCR typos
+# (Deshazoo/Deshazo ~0.93) clear it.
+FUZZY_THRESHOLD = 0.88
+
+# Curated OCR / extraction-variant → cleanest-observed-spelling map.
+# Keys are matched case-insensitively with internal whitespace collapsed
+# (see ``_norm_key``). Seeded from the cases named in issue #1596; extend as
+# new variants surface in QA. NOTE: keep canonical *brands* here, never
+# corporate parents (see module docstring "Scope").
+OCR_VARIANT_ALIASES: dict[str, str] = {
+    # Allen-Bradley (the brand spelling — NOT "Rockwell Automation")
+    "alien-bradley": "Allen-Bradley",
+    "alien bradley": "Allen-Bradley",
+    # Coffing (hoists)
+    "cofemo": "Coffing",
+    "cofing": "Coffing",
+    "cottins": "Coffing",
+    # Orlando Rigging
+    "orldndo rigging": "Orlando Rigging",
+    # Deshazo
+    "deshaco": "Deshazo",
+    "desha": "Deshazo",
+    "deshao": "Deshazo",
+    "deshazzo": "Deshazo",
+}
+
+
+@dataclass(frozen=True)
+class NormalizedManufacturer:
+    """Result of normalizing a raw manufacturer string."""
+
+    canonical: str  # the string to store / build the UNS path from
+    method: str  # "alias" | "identity"
+    confidence: float  # 1.0 for deterministic alias/identity
+    raw: str  # the original input
+
+
+@dataclass(frozen=True)
+class FuzzyProposal:
+    """A *proposed* (never applied) collapse of ``raw`` onto a known vendor."""
+
+    raw: str
+    canonical: str
+    score: float
+
+
+def _norm_key(value: str) -> str:
+    """Lowercase + collapse internal whitespace for stable lookup/compare."""
+    return " ".join(value.lower().split())
+
+
+def normalize_manufacturer(raw: str) -> NormalizedManufacturer:
+    """Collapse an OCR/extraction manufacturer variant to its canonical
+    spelling, or pass an unknown vendor through unchanged.
+
+    Whitespace is always trimmed and internally collapsed. Empty / blank
+    input yields an empty canonical (downstream callers already guard on a
+    falsy manufacturer and skip the KG write).
+    """
+    if not raw or not raw.strip():
+        return NormalizedManufacturer(canonical="", method="identity", confidence=1.0, raw=raw)
+
+    key = _norm_key(raw)
+    canonical = OCR_VARIANT_ALIASES.get(key)
+    if canonical is not None:
+        return NormalizedManufacturer(canonical=canonical, method="alias", confidence=1.0, raw=raw)
+
+    # Unknown vendor — pass through with whitespace cleaned only. We do NOT
+    # impose a canonical of our own (see module docstring "Divergence safety").
+    cleaned = " ".join(raw.split())
+    return NormalizedManufacturer(canonical=cleaned, method="identity", confidence=1.0, raw=raw)
+
+
+def propose_fuzzy_canonical(
+    raw: str, known: set[str], threshold: float = FUZZY_THRESHOLD
+) -> FuzzyProposal | None:
+    """Propose (and LOG) collapsing ``raw`` onto the most similar name in
+    ``known`` when similarity clears ``threshold``. Never merges.
+
+    Returns ``None`` when ``raw`` is blank, ``known`` is empty, ``raw`` is
+    already an exact (normalized) member of ``known``, or no candidate clears
+    the threshold. Similarity is a token-sorted ``SequenceMatcher`` ratio so
+    word-order noise ("Rigging Orlando") doesn't defeat the match.
+    """
+    if not raw or not raw.strip() or not known:
+        return None
+
+    raw_norm = _norm_key(raw)
+    raw_sorted = " ".join(sorted(raw_norm.split()))
+
+    best: FuzzyProposal | None = None
+    for candidate in known:
+        cand_norm = _norm_key(candidate)
+        if cand_norm == raw_norm:
+            # Already canonical — nothing to propose.
+            return None
+        cand_sorted = " ".join(sorted(cand_norm.split()))
+        score = SequenceMatcher(None, raw_sorted, cand_sorted).ratio()
+        if score >= threshold and (best is None or score > best.score):
+            best = FuzzyProposal(raw=raw, canonical=candidate, score=score)
+
+    if best is not None:
+        logger.info(
+            "manufacturer fuzzy-collapse PROPOSED (not applied): %r → %r (score=%.3f); "
+            "needs gated backfill review",
+            best.raw,
+            best.canonical,
+            best.score,
+        )
+    return best

--- a/mira-crawler/ingest/store.py
+++ b/mira-crawler/ingest/store.py
@@ -78,6 +78,13 @@ def insert_chunk(
     """Insert a single chunk into knowledge_entries. Returns entry ID or empty string."""
     from sqlalchemy import text
 
+    from .manufacturer_normalize import normalize_manufacturer
+
+    # Collapse OCR/extraction manufacturer variants at the write boundary so
+    # the knowledge_entries.manufacturer column (which the Hub KB catalog
+    # GROUPs BY) stays canonical regardless of which caller wrote it (#1596).
+    manufacturer = normalize_manufacturer(manufacturer).canonical
+
     entry_id = str(uuid.uuid4())
     metadata = {
         "chunk_index": chunk_index,
@@ -146,6 +153,11 @@ def store_chunks(
     the equipment via `equipment_entity_id`, and runs the fault-code
     extractor over chunk text to densify the KG. All entity writes are
     idempotent (UNIQUE on tenant_id+entity_type+name).
+
+    Manufacturer normalization (#1596) happens at the write boundaries —
+    `insert_chunk` for the chunk row and `kg_writer.register_*` for the KG
+    entities — so direct callers of those (e.g. tasks/ingest.py) are covered
+    too, not just this orchestrator.
     """
     # Lazy-import KG modules so a misconfigured KG layer cannot break
     # the chunk-insert hot path. Failures degrade to "we still wrote

--- a/mira-crawler/tests/test_manufacturer_normalize.py
+++ b/mira-crawler/tests/test_manufacturer_normalize.py
@@ -147,3 +147,56 @@ class TestKgWriterWiring:
         assert fault["properties"]["manufacturer"] == "Coffing"
         assert fault["name"].startswith("Coffing /")
         assert "coffing" in fault["uns_path"]
+
+
+class TestInsertChunkWiring:
+    """The Hub KB manufacturer catalog GROUPs BY knowledge_entries.manufacturer.
+    That column is written by insert_chunk, which has callers beyond
+    store_chunks (tasks/ingest.py), so normalization lives at this write
+    boundary — not the orchestrator — or those callers still pollute (#1596)."""
+
+    def test_insert_chunk_normalizes_manufacturer_in_sql_params(self, monkeypatch):
+        import sys
+        import types
+
+        from ingest import store
+
+        # Stub the sqlalchemy I/O boundary so the test is hermetic — we only
+        # care that the normalized manufacturer reaches the INSERT params.
+        fake_sa = types.ModuleType("sqlalchemy")
+        fake_sa.text = lambda s: s
+        monkeypatch.setitem(sys.modules, "sqlalchemy", fake_sa)
+
+        captured: dict = {}
+
+        class _FakeConn:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+            def execute(self, _stmt, params):
+                captured.update(params)
+
+            def commit(self):
+                pass
+
+        class _FakeEngine:
+            def connect(self):
+                return _FakeConn()
+
+        monkeypatch.setattr(store, "_engine", lambda: _FakeEngine())
+
+        entry_id = store.insert_chunk(
+            tenant_id="t1",
+            content="x",
+            embedding=[0.1],
+            source_url="u",
+            manufacturer="Alien-Bradley",
+            model_number="MR-2000",
+            chunk_index=0,
+        )
+
+        assert entry_id  # write path completed
+        assert captured["manufacturer"] == "Allen-Bradley"

--- a/mira-crawler/tests/test_manufacturer_normalize.py
+++ b/mira-crawler/tests/test_manufacturer_normalize.py
@@ -1,0 +1,149 @@
+"""Tests for ingest-side manufacturer OCR/typo normalization (issue #1596).
+
+Scope reminder (see module docstring): this collapses OCR/extraction
+*misspellings* toward the cleanest observed spelling. It deliberately does
+NOT do brand→parent canonicalization (e.g. "Allen-Bradley"→"Rockwell
+Automation") — that is a separate, pre-existing catalog/resolver split
+carved out in #1596 and must not be silently resolved here.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ingest.manufacturer_normalize import (
+    FuzzyProposal,
+    NormalizedManufacturer,
+    normalize_manufacturer,
+    propose_fuzzy_canonical,
+)
+
+
+class TestNormalizeManufacturerAliases:
+    """The curated OCR-variant seed map collapses the issue's named cases."""
+
+    def test_allen_bradley_ocr_variant(self):
+        r = normalize_manufacturer("Alien-Bradley")
+        assert r.canonical == "Allen-Bradley"
+        assert r.method == "alias"
+        assert r.confidence == 1.0
+
+    def test_coffing_ocr_variants(self):
+        for variant in ("Cofemo", "Cofing", "Cottins"):
+            assert normalize_manufacturer(variant).canonical == "Coffing", variant
+
+    def test_orlando_rigging_ocr_variant(self):
+        assert normalize_manufacturer("Orldndo Rigging").canonical == "Orlando Rigging"
+
+    def test_deshazo_ocr_variants(self):
+        for variant in ("Deshaco", "Desha", "Deshao", "Deshazzo"):
+            assert normalize_manufacturer(variant).canonical == "Deshazo", variant
+
+    def test_alias_lookup_is_case_insensitive(self):
+        assert normalize_manufacturer("alien-bradley").canonical == "Allen-Bradley"
+        assert normalize_manufacturer("DESHACO").canonical == "Deshazo"
+
+
+class TestNormalizeManufacturerIdentity:
+    """Unknown vendors pass through unchanged — the resolver has no opinion
+    on them, so identity is provably divergence-free."""
+
+    def test_unknown_clean_vendor_passes_through(self):
+        r = normalize_manufacturer("Acme Hoist")
+        assert isinstance(r, NormalizedManufacturer)
+        assert r.canonical == "Acme Hoist"
+        assert r.method == "identity"
+        assert r.confidence == 1.0
+        assert r.raw == "Acme Hoist"
+
+    def test_collapses_internal_whitespace(self):
+        assert normalize_manufacturer("  Orlando   Rigging  ").canonical == "Orlando Rigging"
+
+    def test_empty_input_yields_empty_canonical(self):
+        for blank in ("", "   ", "\t\n"):
+            r = normalize_manufacturer(blank)
+            assert r.canonical == ""
+            assert r.method == "identity"
+
+
+class TestBrandParentCarveOut:
+    """#1596 carve-out: do NOT collapse the AB brand to its corporate parent.
+    The resolver maps query-side 'allen-bradley'→'Rockwell Automation'; that
+    split is pre-existing and out of scope for this OCR-cleanup pass."""
+
+    def test_clean_allen_bradley_is_not_rebranded(self):
+        assert normalize_manufacturer("Allen-Bradley").canonical == "Allen-Bradley"
+
+    def test_rockwell_is_not_rewritten(self):
+        assert normalize_manufacturer("Rockwell Automation").canonical == "Rockwell Automation"
+
+
+class TestFuzzyProposer:
+    """The fuzzy layer PROPOSES (and logs) — it never merges. Intended for the
+    gated catalog-backfill review, not for silent ingest-time merging."""
+
+    def test_high_similarity_typo_is_proposed(self):
+        p = propose_fuzzy_canonical("Deshazoo", known={"Deshazo", "Coffing"})
+        assert isinstance(p, FuzzyProposal)
+        assert p.canonical == "Deshazo"
+        assert p.score >= 0.88
+
+    def test_distinct_vendors_are_not_proposed(self):
+        # Genuinely different vendors must stay below threshold — merging two
+        # real vendors is the only irreversible failure mode here.
+        assert propose_fuzzy_canonical("Banner", known={"Bauer"}) is None
+        assert propose_fuzzy_canonical("ABB", known={"ABM"}) is None
+
+    def test_exact_match_is_not_proposed(self):
+        # Already canonical → nothing to propose.
+        assert propose_fuzzy_canonical("Coffing", known={"Coffing", "Deshazo"}) is None
+
+    def test_empty_or_no_known_returns_none(self):
+        assert propose_fuzzy_canonical("Coffing", known=set()) is None
+        assert propose_fuzzy_canonical("", known={"Coffing"}) is None
+
+    def test_proposal_is_logged_not_applied(self, caplog):
+        with caplog.at_level(logging.INFO, logger="mira-crawler.manufacturer_normalize"):
+            propose_fuzzy_canonical("Deshazoo", known={"Deshazo"})
+        assert any("Deshazoo" in rec.message and "Deshazo" in rec.message for rec in caplog.records)
+
+
+class TestKgWriterWiring:
+    """kg_writer is the boundary where the manufacturer string becomes a UNS
+    path. Normalizing there (not just in store_chunks) covers every caller.
+    We monkeypatch the DB-touching upserts to capture what was minted."""
+
+    def _capture(self, monkeypatch):
+        from ingest import kg_writer
+
+        calls: list[dict] = []
+
+        def fake_upsert_entity(**kwargs):
+            calls.append(kwargs)
+            return f"id-{len(calls)}"
+
+        monkeypatch.setattr(kg_writer, "upsert_entity", fake_upsert_entity)
+        monkeypatch.setattr(kg_writer, "upsert_relationship", lambda **kw: "rel-1")
+        return kg_writer, calls
+
+    def test_register_equipment_normalizes_manufacturer(self, monkeypatch):
+        kg_writer, calls = self._capture(monkeypatch)
+        kg_writer.register_equipment_and_manual(
+            tenant_id="t1", manufacturer="Alien-Bradley", model="MR-2000"
+        )
+        equipment = calls[0]
+        assert equipment["entity_type"] == "equipment"
+        assert equipment["properties"]["manufacturer"] == "Allen-Bradley"
+        assert "allen_bradley" in equipment["uns_path"]
+        assert "alien" not in equipment["uns_path"]
+
+    def test_register_fault_code_normalizes_manufacturer(self, monkeypatch):
+        kg_writer, calls = self._capture(monkeypatch)
+        kg_writer.register_fault_code(
+            tenant_id="t1", equipment_id="eq1", manufacturer="Cofemo", fault_code="E01"
+        )
+        fault = calls[0]
+        assert fault["entity_type"] == "fault_code"
+        assert fault["properties"]["manufacturer"] == "Coffing"
+        assert fault["name"].startswith("Coffing /")
+        assert "coffing" in fault["uns_path"]


### PR DESCRIPTION
Partial fix for #1596 (the **mira-crawler ingest** OCR-collapse slice; see carve-outs).

## Problem
OCR/extraction noise fragments one real vendor into several KB catalog nodes — `Allen-Bradley` vs `Alien-Bradley`, `Coffing` vs `Cofemo`/`Cofing`/`Cottins`, `Orlando Rigging` vs `Orldndo Rigging`, `Deshazo` vs `Deshaco`/`Desha`/`Deshao`/`Deshazzo`. Each variant inflates the manufacturer count and scatters chunks/manuals across spurious vendors, hurting retrieval grouping.

## Change
New `mira-crawler/ingest/manufacturer_normalize.py`:
- **`normalize_manufacturer()`** — a curated, deterministic OCR-variant seed map (the cases named in #1596) + whitespace-clean **identity passthrough** for unknown vendors.
- **`propose_fuzzy_canonical()`** — a high-threshold (0.88) fuzzy proposer that **LOGS** a candidate collapse but **never merges** (`Banner`/`Bauer` ≈0.72, `ABB`/`ABM` ≈0.67 stay below; `Deshazoo`/`Deshazo` ≈0.93 clears). For the gated backfill review — **no production caller yet** (intentional; see carve-out).

Normalization is applied at the two **write boundaries** that carry the manufacturer string (mirroring each other, so direct callers are covered — not just orchestrators):
1. **`store.insert_chunk`** → `knowledge_entries.manufacturer`, the column the **Hub KB manufacturer catalog GROUPs BY** (`api/library/tree`, `api/knowledge/manufacturer`). *This is the surface #1596 names.* `insert_chunk` has callers beyond `store_chunks` (`tasks/ingest.py` writes a manufacturer directly), so normalizing here — not at `store_chunks` — covers them all.
2. **`kg_writer.register_equipment_and_manual` + `register_fault_code`** → the KG-entity `uns_path` + `properties.manufacturer`. Covers other KG callers (photo ingest, backfill CLIs).

> Crawler ingest mints only `equipment`/`manual`/`fault_code` entities — there is no `manufacturer`-typed entity. The catalog is a `GROUP BY` over the denormalized chunk-row column, which is why boundary (1) is the load-bearing one.

## Scope & carve-outs (deliberate — tracked on #1596)
- **OCR-collapse toward the cleanest *observed spelling* only.** Does **not** do brand→corporate-parent canonicalization (`Allen-Bradley` → `Rockwell Automation`). That split between the catalog and the query-side resolver (`VENDOR_ALIASES`) is **pre-existing** and left as an open product decision. `TestBrandParentCarveOut` locks it.
- **Divergence-safe.** The resolver returns "no opinion" for vendors outside its ~15-vendor VFD table, so the long-tail rigging/hoist OEMs cleaned here land on the same `uns.slug()` path on both ingest and query sides.
- **mira-crawler ingest only.** Other services also write `knowledge_entries.manufacturer` — `mira-core/mira-ingest` (photo/RAG API, `db/neon.py`) and the `mira-hub` document-upload route. They are separate containers; sharing the normalizer across them is a **follow-up** (tracked on #1596), so photo/RAG-API and Hub-upload ingests are **not** normalized by this PR.
- **New ingests only.** The existing ~304-vendor catalog stays polluted until a **gated dev→staging→prod backfill** (+ review of fuzzy proposals) runs — not in this PR.

## Tests
18 offline unit tests (`mira-crawler/tests/test_manufacturer_normalize.py`): alias collapse for every named #1596 case, case-insensitivity, identity passthrough, whitespace collapse, brand-parent carve-out, fuzzy propose-not-merge + distinct-vendor safety + logged-not-applied, and both write-boundary wirings (`insert_chunk` chunk-row via a stubbed sqlalchemy boundary; `kg_writer` entities via monkeypatched upserts).

```
18 passed
```
`ruff check` clean on all changed files. No new dependencies (`difflib` stdlib).

## Verification notes
- Confirmed the Hub manufacturer catalog reads `knowledge_entries.manufacturer` (`api/library/tree` `GROUP BY manufacturer…`), not `kg_entities.uns_path` — drove the `insert_chunk` boundary choice.
- Enumerated all `insert_chunk` callers (`store_chunks`, `tasks/ingest.py`, `tasks/_shared.py`) and all `knowledge_entries` writers across services — informs the explicit scope above.
- Pre-existing local crawler-suite failures are missing-dep (`watchdog`/`celery`/`redis`/`sqlalchemy`) environment gaps, verified identical with these changes stashed — not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)