### PR TITLE
fix(engine): doc-intent KB hit returns IDLE not ASSET_IDENTIFIED (Cluster E, #1678)

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -4550,7 +4550,7 @@ class Supervisor:
                 mfr,
                 kb_reason,
             )
-            state["state"] = self._background_state_for(state)
+            state["state"] = "IDLE"
             self._record_exchange(chat_id, state, message, reply)
             tl_flush()
             return self._make_result(reply, "medium", trace_id, state["state"])


### PR DESCRIPTION
## Summary

- Documentation-intent turns with a recognized vendor/model (confidence ≥ 0.7) were landing the FSM in `ASSET_IDENTIFIED` instead of `IDLE` — violating the contract that doc-intent responses never start a diagnostic session.
- Root cause: `_background_state_for(state)` at the KB pre-check HIT terminal return was returning `"ASSET_IDENTIFIED"` whenever `asset_identified` was auto-set (line 1392) before intent routing.
- Fix: explicit `state["state"] = "IDLE"` at that return site. The KB-miss path (line 4601) was already correct.

## Test plan

- [ ] Fixtures in `tests/eval/fixtures/vfd_ab_04_pf70_find_manual.yaml` and siblings confirm `expected_final_state: IDLE` for doc-intent turns — this is the Cluster E fixture group from issue #1678.
- [ ] Run `tests/eval/run_eval.py` offline to confirm Cluster E failures are resolved.
- [ ] No change to diagnostic troubleshooting path (gate, Q-states, DIAGNOSIS/FIX_STEP flows are untouched).

Closes #1678 (Cluster E — 5 fixtures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)