### PR TITLE
fix(engine): only gate-re-confirm on switch_asset when prior asset is confirmed

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -3866,14 +3866,14 @@ class Supervisor:
         state["context"] = ctx
         self._clear_session_photo(chat_id)
 
-        # UNS gate: a deliberate switch must re-confirm the NEW asset before any
-        # troubleshooting. Don't silently adopt a freshly-resolved-but-unconfirmed
-        # asset -- the pre-gate behavior let a mis-resolved switch sail straight
-        # into diagnosis. When the gate is on and there is something to confirm,
-        # drop the stale asset and route through the same confirmation handler the
-        # diagnose path uses; the user's "yes" promotes the candidate to
-        # asset_identified via _handle_uns_confirmation_response.
-        if _UNS_GATE_ENABLED and getattr(new_ctx, "confidence", 0.0) > 0:
+        # UNS gate: a deliberate switch FROM a confirmed asset must re-confirm the NEW
+        # asset before troubleshooting. Guard: only clear + re-gate when there was
+        # already a confirmed asset to switch away from. If no prior asset_identified
+        # (LLM mis-routed a first-mention as switch_asset), adopt directly so the
+        # session doesn't get trapped in AWAITING_UNS_CONFIRMATION — the normal
+        # diagnose_equipment gate handles first-mention confirmation via line 1392+gate.
+        current_asset = state.get("asset_identified") or ""
+        if _UNS_GATE_ENABLED and current_asset and getattr(new_ctx, "confidence", 0.0) > 0:
             state["asset_identified"] = None
             self._save_state(chat_id, state)
             return await self._handle_uns_confirmation_request(


### PR DESCRIPTION
## Summary

- Fixes FSM regression where LLM misclassification of a first-mention message as `switch_asset` trapped the session in `AWAITING_UNS_CONFIRMATION` indefinitely
- Guard: only clear `asset_identified` and re-fire the UNS gate when there was already a confirmed asset to switch away from (`current_asset = state.get("asset_identified") or ""`)
- Fixes `pf40_undervoltage_21` regression introduced by `ae510ce7` (part of issue #1678)

## Root Cause

`ae510ce7` changed `_handle_asset_switch` to always route through the UNS gate when `confidence > 0`. But the LLM classifier (`route_intent`) occasionally misroutes a first-mention message like "PowerFlex 40 keeps tripping F4" as `switch_asset`. Without a prior `asset_identified`, this path cleared the candidate and fired the gate → `AWAITING_UNS_CONFIRMATION` with nothing to confirm.

The normal `diagnose_equipment` gate already handles first-mention confirmation via the auto-set at line 1392 + `_should_fire_uns_gate`. The switch_asset gate should only activate when there's a real asset to switch FROM.

## Test Plan

- [ ] `pf40_undervoltage_21` passes in offline eval
- [ ] Eval pass rate recovers from 28/57 toward 33/57+ (with cluster-e fix in #1714)
- [ ] All existing CI checks pass

Closes part of #1678