### PR TITLE
fix(engine): general/instructional handlers reset FSM to IDLE via target_state

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -3581,7 +3581,9 @@ class Supervisor:
         """
         # Don't wipe an active session photo for a general question — a
         # clarifying ask mid-diagnostic shouldn't break the photo flow.
-        state = self._clear_diagnostic_carryover(chat_id, state, clear_photo=False)
+        # target_state="IDLE": general questions must leave the FSM at IDLE so
+        # callers that return state.get("state") don't surface ASSET_IDENTIFIED.
+        state = self._clear_diagnostic_carryover(chat_id, state, clear_photo=False, target_state="IDLE")
 
         ctx = state.get("context") or {}
         history = ctx.get("history", [])
@@ -4408,7 +4410,9 @@ class Supervisor:
         Bypasses the doc-crawl path and the Q1/Q2/Q3 diagnosis FSM. Injects
         the known asset context so the answer is equipment-specific when available.
         """
-        state = self._clear_diagnostic_carryover(chat_id, state, clear_photo=True)
+        # target_state="IDLE": instructional answers are background responses;
+        # the FSM must return IDLE so state.get("state") doesn't surface ASSET_IDENTIFIED.
+        state = self._clear_diagnostic_carryover(chat_id, state, clear_photo=True, target_state="IDLE")
         asset = state.get("asset_identified", "")
         ctx = state.get("context") or {}
         history = ctx.get("history", [])

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -3583,7 +3583,9 @@ class Supervisor:
         # clarifying ask mid-diagnostic shouldn't break the photo flow.
         # target_state="IDLE": general questions must leave the FSM at IDLE so
         # callers that return state.get("state") don't surface ASSET_IDENTIFIED.
-        state = self._clear_diagnostic_carryover(chat_id, state, clear_photo=False, target_state="IDLE")
+        state = self._clear_diagnostic_carryover(
+            chat_id, state, clear_photo=False, target_state="IDLE"
+        )
 
         ctx = state.get("context") or {}
         history = ctx.get("history", [])
@@ -4412,7 +4414,9 @@ class Supervisor:
         """
         # target_state="IDLE": instructional answers are background responses;
         # the FSM must return IDLE so state.get("state") doesn't surface ASSET_IDENTIFIED.
-        state = self._clear_diagnostic_carryover(chat_id, state, clear_photo=True, target_state="IDLE")
+        state = self._clear_diagnostic_carryover(
+            chat_id, state, clear_photo=True, target_state="IDLE"
+        )
         asset = state.get("asset_identified", "")
         ctx = state.get("context") or {}
         history = ctx.get("history", [])

--- a/mira-bots/tests/test_engine.py
+++ b/mira-bots/tests/test_engine.py
@@ -477,10 +477,10 @@ class TestSessionPivotRouting:
             result = asyncio.run(supervisor.process_full(chat_id, "do they have a website"))
 
         assert followup.await_count == 0
-        assert result["next_state"] == "ASSET_IDENTIFIED"
+        assert result["next_state"] == "IDLE"
 
         loaded = supervisor._load_state(chat_id)
-        assert loaded["state"] == "ASSET_IDENTIFIED"
+        assert loaded["state"] == "IDLE"
         assert loaded["fault_category"] is None
         assert loaded["final_state"] is None
         assert loaded["context"]["session_context"]["last_question"] is None


### PR DESCRIPTION
## Summary

- `_handle_general_question` and `_handle_instructional_question` both called `_clear_diagnostic_carryover` without `target_state`
- When `asset_identified` was populated (confidence ≥ 0.7 auto-set at line 1392), the carryover set `state["state"] = "ASSET_IDENTIFIED"` via `_background_state_for`
- Their return paths used `state.get("state", "IDLE")` which then surfaced `ASSET_IDENTIFIED` to the caller
- Fix: pass `target_state="IDLE"` in both handlers — these are background-answer functions that should always leave the FSM ready for the next turn

## Root Cause Trace

`vfd_mitsu_02_fr_e700_find_datasheet` fixture: "looking for the FR-E700 datasheet"
1. Resolver: Mitsubishi/FR-E700, confidence ≥ 0.7 → auto-sets `asset_identified` at line 1392
2. Route to `_handle_general_question` (LLM classified as general, not pure doc-intent)
3. `_clear_diagnostic_carryover` → `state["state"] = "ASSET_IDENTIFIED"` (via `_background_state_for`)
4. RAG path returns `state.get("state", "IDLE")` → ASSET_IDENTIFIED instead of IDLE

This is the **residual Cluster E** fix — PR #1714 fixed the KB pre-check HIT path in `_do_documentation_lookup`, but the same ASSET_IDENTIFIED propagation existed in the general and instructional handlers.

## Test Plan

- [ ] `vfd_mitsu_02_fr_e700_find_datasheet` returns IDLE in offline eval
- [ ] No new regressions in existing passing fixtures
- [ ] All CI checks pass

Part of issue #1678