### PR TITLE
fix(ingest): #1596 carve-outs — AB→Rockwell decision + mira-core/mira-hub normalizers + consistency guard

### DIFF
--- a/mira-core/mira-ingest/db/manufacturer_normalize.py
+++ b/mira-core/mira-ingest/db/manufacturer_normalize.py
@@ -1,0 +1,73 @@
+"""Ingest-side manufacturer name normalization (issue #1596).
+
+This module mirrors ``mira-crawler/ingest/manufacturer_normalize.py`` so the
+``mira-core/mira-ingest`` service applies the SAME OCR/variant collapse at its
+own DB write boundary (``db/neon.py`` ``insert_knowledge_entry`` /
+``insert_knowledge_entries_batch``). The Hub KB manufacturer catalog is
+computed by ``GROUP BY knowledge_entries.manufacturer``; without this, OCR /
+extraction variants ("Alien-Bradley", "Cofemo", "Orldndo Rigging",
+"Deshaco") each mint their own catalog row and fragment one real vendor.
+
+The ``OCR_VARIANT_ALIASES`` map MUST stay identical to the crawler's: a
+cross-service consistency test asserts the two maps match, so a vendor groups
+the same way no matter which service ingested the chunk. This module is the
+deterministic seed-map layer only; the crawler's fuzzy *proposer* is not
+needed here (the ingest write boundary applies the seed map, nothing more).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Curated manufacturer-variant -> canonical map. Keys are matched
+# case-insensitively with internal whitespace collapsed (see ``normalize_
+# manufacturer``). MUST stay identical to the crawler's copy in
+# ``mira-crawler/ingest/manufacturer_normalize.py`` (guarded by a
+# cross-service consistency test). Seeded from issue #1596.
+OCR_VARIANT_ALIASES: dict[str, str] = {
+    "allen-bradley": "Rockwell Automation",
+    "allen bradley": "Rockwell Automation",
+    "alien-bradley": "Rockwell Automation",
+    "alien bradley": "Rockwell Automation",
+    "cofemo": "Coffing",
+    "cofing": "Coffing",
+    "cottins": "Coffing",
+    "orldndo rigging": "Orlando Rigging",
+    "deshaco": "Deshazo",
+    "desha": "Deshazo",
+    "deshao": "Deshazo",
+    "deshazzo": "Deshazo",
+}
+
+
+@dataclass(frozen=True)
+class NormalizedManufacturer:
+    """Result of normalizing a raw manufacturer string."""
+
+    canonical: str  # the string to store / build the catalog row from
+    method: str  # "alias" | "identity"
+    confidence: float  # 1.0 for deterministic alias/identity
+    raw: str  # the original input
+
+
+def normalize_manufacturer(raw: str | None) -> NormalizedManufacturer:
+    """Collapse an OCR/extraction manufacturer variant to its canonical
+    spelling, or pass an unknown vendor through unchanged.
+
+    Whitespace is always trimmed and internally collapsed. None / blank input
+    yields an empty canonical (the ``manufacturer`` column is nullable; the
+    write boundary stores ``None`` for an empty canonical).
+    """
+    if not raw or not raw.strip():
+        return NormalizedManufacturer(
+            canonical="", method="identity", confidence=1.0, raw=raw or ""
+        )
+
+    key = " ".join(raw.lower().split())
+    canonical = OCR_VARIANT_ALIASES.get(key)
+    if canonical is not None:
+        return NormalizedManufacturer(canonical=canonical, method="alias", confidence=1.0, raw=raw)
+
+    # Unknown vendor — pass through with whitespace cleaned only.
+    cleaned = " ".join(raw.split())
+    return NormalizedManufacturer(canonical=cleaned, method="identity", confidence=1.0, raw=raw)

--- a/mira-core/mira-ingest/db/neon.py
+++ b/mira-core/mira-ingest/db/neon.py
@@ -15,6 +15,7 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.pool import NullPool
 
 from . import data_types as _data_types
+from .manufacturer_normalize import normalize_manufacturer
 
 
 def _engine():
@@ -361,6 +362,9 @@ def insert_knowledge_entry(
 ) -> str:
     """Insert one chunk into knowledge_entries. Returns the new row id."""
     _data_types.validate(data_type)
+    # Collapse OCR/extraction manufacturer variants to the catalog canonical
+    # (#1596). Column is nullable — preserve None for an empty canonical.
+    manufacturer = normalize_manufacturer(manufacturer).canonical or None
     entry_id = str(uuid.uuid4())
     meta = {
         "source_url": source_url,
@@ -425,6 +429,7 @@ def insert_knowledge_entries_batch(entries: list[dict]) -> int:
         prepared.append(
             {
                 **e,
+                "manufacturer": normalize_manufacturer(e.get("manufacturer")).canonical or None,
                 "isa95_path": e.get("isa95_path"),
                 "equipment_id": e.get("equipment_id"),
                 "data_type": dt,

--- a/mira-core/mira-ingest/db/test_manufacturer_normalize.py
+++ b/mira-core/mira-ingest/db/test_manufacturer_normalize.py
@@ -1,0 +1,155 @@
+"""Tests for ingest-side manufacturer OCR/variant normalization (issue #1596).
+
+mira-core/mira-ingest mirrors the crawler's normalizer at its own DB write
+boundary so the Hub KB manufacturer catalog (GROUP BY
+knowledge_entries.manufacturer) doesn't fragment one real vendor into several
+rows when chunks arrive through this service.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+from db.manufacturer_normalize import NormalizedManufacturer, normalize_manufacturer
+
+
+class TestNormalizeManufacturerAliases:
+    """The curated OCR-variant seed map collapses the issue's named cases."""
+
+    def test_allen_bradley_ocr_variant(self):
+        r = normalize_manufacturer("Alien-Bradley")
+        assert r.canonical == "Rockwell Automation"
+        assert r.method == "alias"
+        assert r.confidence == 1.0
+
+    def test_coffing_ocr_variant(self):
+        assert normalize_manufacturer("Cofemo").canonical == "Coffing"
+
+    def test_orlando_rigging_ocr_variant(self):
+        assert normalize_manufacturer("Orldndo Rigging").canonical == "Orlando Rigging"
+
+    def test_deshazo_ocr_variant(self):
+        assert normalize_manufacturer("Deshaco").canonical == "Deshazo"
+
+    def test_alias_lookup_is_case_insensitive(self):
+        assert normalize_manufacturer("ALIEN-BRADLEY").canonical == "Rockwell Automation"
+
+
+class TestNormalizeManufacturerIdentity:
+    """Unknown vendors pass through unchanged; blank yields empty canonical."""
+
+    def test_unknown_clean_vendor_passes_through(self):
+        r = normalize_manufacturer("Acme Hoist")
+        assert isinstance(r, NormalizedManufacturer)
+        assert r.canonical == "Acme Hoist"
+        assert r.method == "identity"
+        assert r.confidence == 1.0
+        assert r.raw == "Acme Hoist"
+
+    def test_empty_input_yields_empty_canonical(self):
+        for blank in ("", "   ", None):
+            r = normalize_manufacturer(blank)
+            assert r.canonical == ""
+            assert r.method == "identity"
+
+
+def _stub_sqlalchemy(monkeypatch):
+    """Inject a fake sqlalchemy into sys.modules before neon.py imports it.
+
+    neon.py does ``from sqlalchemy import create_engine, text`` and
+    ``from sqlalchemy.pool import NullPool`` at module top, so both the
+    package and its ``pool`` submodule must be present.
+    """
+    fake_sa = types.ModuleType("sqlalchemy")
+    fake_sa.create_engine = lambda *a, **k: None
+    fake_sa.text = lambda s: s
+    fake_pool = types.ModuleType("sqlalchemy.pool")
+    fake_pool.NullPool = object
+    fake_sa.pool = fake_pool
+    monkeypatch.setitem(sys.modules, "sqlalchemy", fake_sa)
+    monkeypatch.setitem(sys.modules, "sqlalchemy.pool", fake_pool)
+
+
+class _FakeConn:
+    def __init__(self, captured):
+        self._captured = captured
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, _stmt, params):
+        self._captured.append(dict(params))
+
+    def commit(self):
+        pass
+
+
+class _FakeEngine:
+    def __init__(self, captured):
+        self._captured = captured
+
+    def connect(self):
+        return _FakeConn(self._captured)
+
+
+class TestInsertKnowledgeEntryWiring:
+    """insert_knowledge_entry normalizes manufacturer before binding the SQL
+    params — hermetic via a stubbed sqlalchemy boundary."""
+
+    def test_insert_knowledge_entry_normalizes_manufacturer(self, monkeypatch):
+        _stub_sqlalchemy(monkeypatch)
+        from db import neon
+
+        captured: list[dict] = []
+        monkeypatch.setattr(neon, "_engine", lambda: _FakeEngine(captured))
+
+        entry_id = neon.insert_knowledge_entry(
+            tenant_id="t1",
+            content="x",
+            embedding=[0.1],
+            manufacturer="Alien-Bradley",
+            model_number="MR-2000",
+            source_url="u",
+            chunk_index=0,
+            page_num=None,
+            section=None,
+        )
+
+        assert entry_id
+        assert captured[0]["manufacturer"] == "Rockwell Automation"
+
+
+class TestInsertKnowledgeEntriesBatchWiring:
+    """insert_knowledge_entries_batch normalizes each entry's manufacturer."""
+
+    def test_batch_insert_normalizes_manufacturer(self, monkeypatch):
+        _stub_sqlalchemy(monkeypatch)
+        from db import neon
+
+        captured: list[dict] = []
+        monkeypatch.setattr(neon, "_engine", lambda: _FakeEngine(captured))
+
+        count = neon.insert_knowledge_entries_batch(
+            [
+                {
+                    "id": "x",
+                    "tenant_id": "t1",
+                    "source_type": "manual",
+                    "manufacturer": "Cofemo",
+                    "model_number": "MR-2000",
+                    "content": "c",
+                    "embedding": "[0.1]",
+                    "source_url": "s",
+                    "source_page": 0,
+                    "metadata": "{}",
+                    "chunk_type": "text",
+                }
+            ]
+        )
+
+        assert count == 1
+        assert captured[0]["manufacturer"] == "Coffing"

--- a/mira-core/mira-ingest/tests/test_manufacturer_normalize.py
+++ b/mira-core/mira-ingest/tests/test_manufacturer_normalize.py
@@ -4,14 +4,34 @@ mira-core/mira-ingest mirrors the crawler's normalizer at its own DB write
 boundary so the Hub KB manufacturer catalog (GROUP BY
 knowledge_entries.manufacturer) doesn't fragment one real vendor into several
 rows when chunks arrive through this service.
+
+Lives under tests/ (not db/) so the CI step `pytest mira-core/mira-ingest/tests/`
+actually collects it. Adds mira-ingest/ to sys.path the same way the sibling
+tests do (see test_ingest.py) so `db.*` imports resolve.
 """
 
 from __future__ import annotations
 
+import os
 import sys
 import types
 
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
 from db.manufacturer_normalize import NormalizedManufacturer, normalize_manufacturer
+
+
+@pytest.fixture
+def _isolate_neon():
+    """Drop any cached ``db.neon`` before and after, so the sqlalchemy-stubbed
+    import in the wiring tests below can't leak a stub-bound module to sibling
+    tests (e.g. test_ingest.py) that import the same module under the real
+    sqlalchemy — and vice-versa — when pytest-xdist co-schedules them."""
+    sys.modules.pop("db.neon", None)
+    yield
+    sys.modules.pop("db.neon", None)
 
 
 class TestNormalizeManufacturerAliases:
@@ -100,7 +120,7 @@ class TestInsertKnowledgeEntryWiring:
     """insert_knowledge_entry normalizes manufacturer before binding the SQL
     params — hermetic via a stubbed sqlalchemy boundary."""
 
-    def test_insert_knowledge_entry_normalizes_manufacturer(self, monkeypatch):
+    def test_insert_knowledge_entry_normalizes_manufacturer(self, monkeypatch, _isolate_neon):
         _stub_sqlalchemy(monkeypatch)
         from db import neon
 
@@ -126,7 +146,7 @@ class TestInsertKnowledgeEntryWiring:
 class TestInsertKnowledgeEntriesBatchWiring:
     """insert_knowledge_entries_batch normalizes each entry's manufacturer."""
 
-    def test_batch_insert_normalizes_manufacturer(self, monkeypatch):
+    def test_batch_insert_normalizes_manufacturer(self, monkeypatch, _isolate_neon):
         _stub_sqlalchemy(monkeypatch)
         from db import neon
 

--- a/mira-crawler/ingest/manufacturer_normalize.py
+++ b/mira-crawler/ingest/manufacturer_normalize.py
@@ -10,16 +10,17 @@ Each variant mints its own ``enterprise.knowledge_base.<slug>`` node, which
 inflates the manufacturer count and scatters chunks/manuals across spurious
 vendors, hurting retrieval grouping.
 
-Scope (deliberately narrow)
----------------------------
-This module does **OCR/typo collapse only** — it maps misspellings toward
-the cleanest observed spelling. It does NOT do brand→corporate-parent
-canonicalization (e.g. ``Allen-Bradley`` → ``Rockwell Automation``). That
-brand-vs-parent question is a *separate, pre-existing* split between the KB
-catalog (which stores ``Allen-Bradley``) and the query-side resolver
-(``mira-bots/shared/uns_resolver.py`` ``VENDOR_ALIASES``, which maps to
-``Rockwell Automation``). Resolving it changes both surfaces and is carved
-out of #1596 as an open product decision — see the issue.
+Scope
+-----
+This module maps a raw manufacturer string to its canonical catalog name:
+- **Known vendors** (those the query-side resolver's ``VENDOR_ALIASES`` in
+  ``mira-bots/shared/uns_resolver.py`` recognizes) use the resolver's
+  canonical so the catalog and the query side group identically.
+  ``Allen-Bradley`` → ``Rockwell Automation`` (the corporate parent), per
+  the #1596 brand-vs-parent decision. A cross-surface consistency test
+  guards this agreement against drift.
+- **Long-tail vendors** the resolver has no opinion on (rigging / hoist
+  OEMs) get OCR/typo collapse toward the cleanest observed spelling.
 
 Divergence safety
 -----------------
@@ -60,16 +61,30 @@ logger = logging.getLogger("mira-crawler.manufacturer_normalize")
 # (Deshazoo/Deshazo ~0.93) clear it.
 FUZZY_THRESHOLD = 0.88
 
-# Curated OCR / extraction-variant → cleanest-observed-spelling map.
+# Curated manufacturer-variant → canonical map.
 # Keys are matched case-insensitively with internal whitespace collapsed
 # (see ``_norm_key``). Seeded from the cases named in issue #1596; extend as
-# new variants surface in QA. NOTE: keep canonical *brands* here, never
-# corporate parents (see module docstring "Scope").
+# new variants surface in QA.
+#
+# Canonical rule:
+#   - For a vendor the query-side resolver KNOWS (VENDOR_ALIASES in
+#     mira-bots/shared/uns_resolver.py), use the resolver's canonical so the
+#     catalog and the query side group the same way. Allen-Bradley → the
+#     corporate parent "Rockwell Automation" per the #1596 brand-vs-parent
+#     decision. A consistency test guards this agreement against drift.
+#   - For a vendor the resolver has NO opinion on (the long-tail rigging /
+#     hoist OEMs), collapse OCR/typo variants toward the cleanest observed
+#     spelling. The resolver passes these through to uns.slug() unchanged, so
+#     this stays divergence-free.
 OCR_VARIANT_ALIASES: dict[str, str] = {
-    # Allen-Bradley (the brand spelling — NOT "Rockwell Automation")
-    "alien-bradley": "Allen-Bradley",
-    "alien bradley": "Allen-Bradley",
-    # Coffing (hoists)
+    # Allen-Bradley → Rockwell Automation (corporate parent; matches the
+    # resolver's VENDOR_ALIASES). Clean brand spelling AND OCR variants
+    # collapse to the single catalog node.
+    "allen-bradley": "Rockwell Automation",
+    "allen bradley": "Rockwell Automation",
+    "alien-bradley": "Rockwell Automation",
+    "alien bradley": "Rockwell Automation",
+    # Coffing (hoists) — no resolver opinion; collapse to cleanest spelling
     "cofemo": "Coffing",
     "cofing": "Coffing",
     "cottins": "Coffing",

--- a/mira-crawler/tests/test_manufacturer_normalize.py
+++ b/mira-crawler/tests/test_manufacturer_normalize.py
@@ -23,8 +23,9 @@ class TestNormalizeManufacturerAliases:
     """The curated OCR-variant seed map collapses the issue's named cases."""
 
     def test_allen_bradley_ocr_variant(self):
+        # AB → corporate parent per the #1596 brand-vs-parent decision.
         r = normalize_manufacturer("Alien-Bradley")
-        assert r.canonical == "Allen-Bradley"
+        assert r.canonical == "Rockwell Automation"
         assert r.method == "alias"
         assert r.confidence == 1.0
 
@@ -40,7 +41,7 @@ class TestNormalizeManufacturerAliases:
             assert normalize_manufacturer(variant).canonical == "Deshazo", variant
 
     def test_alias_lookup_is_case_insensitive(self):
-        assert normalize_manufacturer("alien-bradley").canonical == "Allen-Bradley"
+        assert normalize_manufacturer("alien-bradley").canonical == "Rockwell Automation"
         assert normalize_manufacturer("DESHACO").canonical == "Deshazo"
 
 
@@ -66,15 +67,15 @@ class TestNormalizeManufacturerIdentity:
             assert r.method == "identity"
 
 
-class TestBrandParentCarveOut:
-    """#1596 carve-out: do NOT collapse the AB brand to its corporate parent.
-    The resolver maps query-side 'allen-bradley'→'Rockwell Automation'; that
-    split is pre-existing and out of scope for this OCR-cleanup pass."""
+class TestBrandParentReconciled:
+    """#1596 decision: AB canonicalizes to the corporate parent 'Rockwell
+    Automation', matching the query-side resolver's VENDOR_ALIASES so the
+    catalog and the query side group identically."""
 
-    def test_clean_allen_bradley_is_not_rebranded(self):
-        assert normalize_manufacturer("Allen-Bradley").canonical == "Allen-Bradley"
+    def test_clean_allen_bradley_maps_to_parent(self):
+        assert normalize_manufacturer("Allen-Bradley").canonical == "Rockwell Automation"
 
-    def test_rockwell_is_not_rewritten(self):
+    def test_rockwell_is_idempotent(self):
         assert normalize_manufacturer("Rockwell Automation").canonical == "Rockwell Automation"
 
 
@@ -133,8 +134,8 @@ class TestKgWriterWiring:
         )
         equipment = calls[0]
         assert equipment["entity_type"] == "equipment"
-        assert equipment["properties"]["manufacturer"] == "Allen-Bradley"
-        assert "allen_bradley" in equipment["uns_path"]
+        assert equipment["properties"]["manufacturer"] == "Rockwell Automation"
+        assert "rockwell_automation" in equipment["uns_path"]
         assert "alien" not in equipment["uns_path"]
 
     def test_register_fault_code_normalizes_manufacturer(self, monkeypatch):
@@ -199,4 +200,4 @@ class TestInsertChunkWiring:
         )
 
         assert entry_id  # write path completed
-        assert captured["manufacturer"] == "Allen-Bradley"
+        assert captured["manufacturer"] == "Rockwell Automation"

--- a/mira-hub/src/app/api/documents/upload/route.ts
+++ b/mira-hub/src/app/api/documents/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { sessionOrDemo } from "@/lib/demo-auth";
 import { withTenantContext } from "@/lib/tenant-context";
+import { normalizeManufacturer } from "@/lib/manufacturerNormalize";
 
 export const dynamic = "force-dynamic";
 
@@ -57,6 +58,9 @@ export async function POST(req: Request) {
 
   const excerpt = (body.excerpt ?? "").slice(0, 2000);
   const sourceUrl = body.source_url ?? `demo://upload/${encodeURIComponent(body.filename)}`;
+  // Collapse OCR/extraction manufacturer variants to the canonical catalog name
+  // before insert (issue #1596). Empty → null preserves the existing behavior.
+  const manufacturer = normalizeManufacturer(body.manufacturer).canonical || null;
 
   try {
     const id = await withTenantContext<string>(ctx.tenantId, async (c) => {
@@ -68,7 +72,7 @@ export async function POST(req: Request) {
         [
           ctx.tenantId,
           sourceUrl,
-          body.manufacturer ?? null,
+          manufacturer,
           body.model ?? null,
           null,
           excerpt || `[Demo placeholder — ${body.filename}]`,

--- a/mira-hub/src/lib/__tests__/manufacturerNormalize.test.ts
+++ b/mira-hub/src/lib/__tests__/manufacturerNormalize.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { normalizeManufacturer } from "../manufacturerNormalize";
+
+describe("normalizeManufacturer", () => {
+  it("collapses known OCR variants to the canonical name (alias)", () => {
+    expect(normalizeManufacturer("Alien-Bradley")).toEqual({
+      canonical: "Rockwell Automation",
+      method: "alias",
+    });
+    expect(normalizeManufacturer("Cofemo")).toEqual({
+      canonical: "Coffing",
+      method: "alias",
+    });
+    expect(normalizeManufacturer("Orldndo Rigging")).toEqual({
+      canonical: "Orlando Rigging",
+      method: "alias",
+    });
+    expect(normalizeManufacturer("Deshaco")).toEqual({
+      canonical: "Deshazo",
+      method: "alias",
+    });
+  });
+
+  it("matches alias keys case-insensitively", () => {
+    expect(normalizeManufacturer("alien-bradley")).toEqual({
+      canonical: "Rockwell Automation",
+      method: "alias",
+    });
+    expect(normalizeManufacturer("ALIEN-BRADLEY")).toEqual({
+      canonical: "Rockwell Automation",
+      method: "alias",
+    });
+  });
+
+  it("matches alias keys with collapsed internal whitespace", () => {
+    expect(normalizeManufacturer("alien   bradley")).toEqual({
+      canonical: "Rockwell Automation",
+      method: "alias",
+    });
+  });
+
+  it("passes unknown vendors through unchanged (identity), preserving casing", () => {
+    expect(normalizeManufacturer("Acme Hoist")).toEqual({
+      canonical: "Acme Hoist",
+      method: "identity",
+    });
+  });
+
+  it("collapses whitespace on identity passthrough", () => {
+    expect(normalizeManufacturer("  Orlando   Rigging  ")).toEqual({
+      canonical: "Orlando Rigging",
+      method: "identity",
+    });
+  });
+
+  it("returns empty canonical for null/undefined/blank", () => {
+    expect(normalizeManufacturer(null)).toEqual({ canonical: "", method: "identity" });
+    expect(normalizeManufacturer(undefined)).toEqual({ canonical: "", method: "identity" });
+    expect(normalizeManufacturer("")).toEqual({ canonical: "", method: "identity" });
+    expect(normalizeManufacturer("   ")).toEqual({ canonical: "", method: "identity" });
+  });
+});

--- a/mira-hub/src/lib/manufacturer-aliases.json
+++ b/mira-hub/src/lib/manufacturer-aliases.json
@@ -1,0 +1,14 @@
+{
+  "allen-bradley": "Rockwell Automation",
+  "allen bradley": "Rockwell Automation",
+  "alien-bradley": "Rockwell Automation",
+  "alien bradley": "Rockwell Automation",
+  "cofemo": "Coffing",
+  "cofing": "Coffing",
+  "cottins": "Coffing",
+  "orldndo rigging": "Orlando Rigging",
+  "deshaco": "Deshazo",
+  "desha": "Deshazo",
+  "deshao": "Deshazo",
+  "deshazzo": "Deshazo"
+}

--- a/mira-hub/src/lib/manufacturerNormalize.ts
+++ b/mira-hub/src/lib/manufacturerNormalize.ts
@@ -1,0 +1,42 @@
+/**
+ * Manufacturer name normalization at the Hub's KB write boundary (issue #1596).
+ *
+ * OCR / extraction noise fragments one real vendor into several catalog rows —
+ * "Alien-Bradley" vs "Allen-Bradley", "Cofemo"/"Cofing"/"Cottins" vs "Coffing",
+ * "Orldndo Rigging" vs "Orlando Rigging", "Deshaco"/"Desha"/... vs "Deshazo".
+ * Because the Hub manufacturer catalog is `GROUP BY knowledge_entries.manufacturer`,
+ * each variant mints its own catalog row. Collapsing variants at the insert
+ * boundary keeps the catalog (and BM25 grouping) coherent.
+ *
+ * This is the TypeScript mirror of the crawler's
+ * `mira-crawler/ingest/manufacturer_normalize.py::normalize_manufacturer`.
+ * Semantics MUST stay in lockstep — the alias map lives in
+ * `manufacturer-aliases.json` so a cross-surface consistency test can read it.
+ */
+import aliases from "./manufacturer-aliases.json";
+
+const OCR_VARIANT_ALIASES: Record<string, string> = aliases;
+
+/** Lowercase + collapse internal whitespace for stable lookup. Mirrors the
+ * Python `_norm_key`. */
+function normKey(value: string): string {
+  return value.toLowerCase().split(/\s+/).filter(Boolean).join(" ");
+}
+
+export function normalizeManufacturer(
+  raw: string | null | undefined,
+): { canonical: string; method: "alias" | "identity" } {
+  if (!raw || !raw.trim()) {
+    return { canonical: "", method: "identity" };
+  }
+
+  const key = normKey(raw);
+  const canonical = OCR_VARIANT_ALIASES[key];
+  if (canonical !== undefined) {
+    return { canonical, method: "alias" };
+  }
+
+  // Unknown vendor — pass through with whitespace cleaned only. We do NOT
+  // impose a canonical of our own (matches the Python "Divergence safety").
+  return { canonical: raw.trim().split(/\s+/).join(" "), method: "identity" };
+}

--- a/tests/test_manufacturer_alias_consistency.py
+++ b/tests/test_manufacturer_alias_consistency.py
@@ -1,0 +1,104 @@
+"""Cross-service consistency tests for the manufacturer normalizer map (#1596).
+
+The OCR-variant → canonical map is vendored in THREE places because build
+contexts are per-container and the services cannot import across package
+boundaries:
+
+- ``mira-crawler/ingest/manufacturer_normalize.py`` — Python, source of truth.
+- ``mira-core/mira-ingest/db/manufacturer_normalize.py`` — Python copy.
+- ``mira-hub/src/lib/manufacturer-aliases.json`` — JSON copy.
+
+If these drift, the same vendor groups differently depending on which service
+ingested the chunk — re-fragmenting the catalog #1596 set out to consolidate.
+These tests read each copy BY PATH (no cross-package imports) and assert they
+stay byte-equal in meaning, and that the catalog side agrees with the
+query-side resolver's ``VENDOR_ALIASES`` on every shared key.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CRAWLER_MODULE = REPO_ROOT / "mira-crawler" / "ingest" / "manufacturer_normalize.py"
+CORE_MODULE = REPO_ROOT / "mira-core" / "mira-ingest" / "db" / "manufacturer_normalize.py"
+HUB_JSON = REPO_ROOT / "mira-hub" / "src" / "lib" / "manufacturer-aliases.json"
+RESOLVER_MODULE = REPO_ROOT / "mira-bots" / "shared" / "uns_resolver.py"
+
+
+def _parse_dict_assignment(path: Path, name: str) -> dict[str, str]:
+    """Extract a module-level ``name: dict[str, str] = {...}`` literal via AST.
+
+    The assignment is annotated, so it parses as an ``ast.AnnAssign`` (not a
+    plain ``ast.Assign``). ``ast.literal_eval`` ignores comments, so the
+    inline comments in these dict literals are harmless.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in tree.body:
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == name and node.value is not None:
+                value = ast.literal_eval(node.value)
+                if not isinstance(value, dict):
+                    raise TypeError(f"{name} in {path} is not a dict literal")
+                return value
+    raise AssertionError(f"{name!r} (annotated assignment) not found in {path}")
+
+
+def test_three_maps_are_equal() -> None:
+    """Crawler, mira-core, and hub copies must be identical (keys AND values)."""
+    crawler = _parse_dict_assignment(CRAWLER_MODULE, "OCR_VARIANT_ALIASES")
+    core = _parse_dict_assignment(CORE_MODULE, "OCR_VARIANT_ALIASES")
+    with HUB_JSON.open() as f:
+        hub = json.load(f)
+
+    assert crawler == core, (
+        "OCR_VARIANT_ALIASES diverged between the crawler and mira-core copies. "
+        f"crawler-only={set(crawler.items()) - set(core.items())}; "
+        f"core-only={set(core.items()) - set(crawler.items())}. "
+        "Keep both Python copies byte-identical."
+    )
+    assert crawler == hub, (
+        "OCR_VARIANT_ALIASES diverged between the crawler copy and the hub JSON. "
+        f"crawler-only={set(crawler.items()) - set(hub.items())}; "
+        f"hub-only={set(hub.items()) - set(crawler.items())}. "
+        "Regenerate mira-hub/src/lib/manufacturer-aliases.json from the crawler map."
+    )
+    # Transitively core == hub, but assert it explicitly for a clear message.
+    assert core == hub, (
+        "OCR_VARIANT_ALIASES diverged between the mira-core copy and the hub JSON. "
+        f"core-only={set(core.items()) - set(hub.items())}; "
+        f"hub-only={set(hub.items()) - set(core.items())}."
+    )
+
+
+def test_catalog_agrees_with_resolver_on_shared_keys() -> None:
+    """Every key in BOTH the ingest map and the resolver's VENDOR_ALIASES must
+    map to the same canonical, so the catalog and query sides group the same.
+
+    Today the only overlap is ``allen-bradley`` (and its space variant) →
+    "Rockwell Automation". This test makes that agreement permanent.
+    """
+    catalog = _parse_dict_assignment(CRAWLER_MODULE, "OCR_VARIANT_ALIASES")
+    resolver = _parse_dict_assignment(RESOLVER_MODULE, "VENDOR_ALIASES")
+
+    shared_keys = set(catalog) & set(resolver)
+    # Guard against a vacuous pass: if a parse bug emptied either dict, the
+    # intersection would be empty and this test would assert nothing. The
+    # canonical #1596 overlap MUST be present.
+    assert "allen-bradley" in shared_keys, (
+        "Expected 'allen-bradley' in both OCR_VARIANT_ALIASES and the resolver's "
+        f"VENDOR_ALIASES. shared_keys={sorted(shared_keys)}. A parse failure or a "
+        "removed key would make this consistency check vacuous."
+    )
+
+    mismatches = {
+        key: (catalog[key], resolver[key]) for key in shared_keys if catalog[key] != resolver[key]
+    }
+    assert not mismatches, (
+        "Catalog vs resolver canonical disagreement on shared keys "
+        "(key: (catalog, resolver)): "
+        f"{mismatches}. Both sides must group the vendor identically."
+    )

--- a/tools/reconcile_manufacturers.py
+++ b/tools/reconcile_manufacturers.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+"""DRY-RUN manufacturer catalog reconciliation planner (issue #1596).
+
+Plans — and NEVER applies — the cleanup of the existing polluted catalog by
+mapping each distinct ``knowledge_entries.manufacturer`` value to its canonical
+form using the SAME normalizer the ingest write boundary uses
+(``mira-crawler/ingest/manufacturer_normalize.py``).
+
+This is a planner, not a migration. It has NO write path. Applying the plan is
+a separate, gated dev → staging → prod step (see ``docs/environments.md`` and
+``tools/uns_backfill.py`` for the apply-side pattern).
+
+Classification per distinct input name:
+  - ``alias``     — deterministic OCR-variant map hit (raw → canonical).
+  - ``fuzzy``     — a high-threshold fuzzy proposal toward a known canonical
+                    name; flagged NEEDS REVIEW, never auto-applied.
+  - ``unchanged`` — identity; no alias and no fuzzy candidate.
+
+Input sources (offline-friendly, default is file/stdin — NEVER a database):
+  - ``--input <file>`` : one manufacturer per line, OR a JSON array of strings.
+  - stdin              : same formats, when no ``--input`` and no ``--from-db``.
+  - ``--from-db``      : OPTIONAL read-only mode. Runs only
+                         ``SELECT DISTINCT manufacturer FROM knowledge_entries``.
+                         Requires an explicitly-supplied ``--db-url`` (it will
+                         NOT silently read ``NEON_DATABASE_URL``) that matches a
+                         known-safe (non-prod) marker; any unrecognized URL —
+                         including prod — is refused. SELECT only — no writes.
+
+Usage:
+  python3 tools/reconcile_manufacturers.py --input mfrs.txt
+  cat mfrs.txt | python3 tools/reconcile_manufacturers.py
+  python3 tools/reconcile_manufacturers.py --input mfrs.txt --json
+  python3 tools/reconcile_manufacturers.py --from-db --db-url "$NEON_STG_DATABASE_URL"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# Reuse the crawler's normalizer (source of truth) — don't reimplement it.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "mira-crawler"))
+from ingest.manufacturer_normalize import (  # noqa: E402
+    OCR_VARIANT_ALIASES,
+    normalize_manufacturer,
+    propose_fuzzy_canonical,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+log = logging.getLogger("reconcile-manufacturers")
+
+# Fail-safe ALLOWLIST of markers that identify a KNOWN-SAFE (non-prod) database.
+# --from-db proceeds ONLY when the URL contains one of these; anything else
+# (including the prod URL) is refused by default.
+#
+# Why an allowlist, not a prod blocklist: a real Neon connection string uses the
+# *endpoint* hostname (ep-<id>-pooler.<region>.aws.neon.tech), NOT the branch id
+# / VPS IP / website domain. We don't have the prod endpoint id, and even if we
+# blocked it, any new/renamed prod endpoint would slip through. Default-deny is
+# the only design that can't silently connect to prod.
+#
+# Markers: docs/environments.md (staging endpoint ep-polished-hall-ahcqtcxe,
+# staging branch br-small-term-ahtkz61d) + the standard local-DB loopbacks.
+SAFE_URL_MARKERS = (
+    "ep-polished-hall-ahcqtcxe",  # staging Neon endpoint
+    "br-small-term-ahtkz61d",  # staging Neon branch
+    "localhost",  # local Postgres
+    "127.0.0.1",  # local Postgres
+)
+
+# The set of canonical/known names the fuzzy proposer matches against — the
+# clean canonical spellings the alias map already collapses toward. We do NOT
+# add input names here: that would let one dirty input propose another, creating
+# ambiguous merges.
+KNOWN_CANONICALS: set[str] = set(OCR_VARIANT_ALIASES.values())
+
+BANNER = (
+    "=" * 72 + "\nDRY RUN — no database writes. Apply is a separate, gated "
+    "dev→staging→prod step.\n" + "=" * 72
+)
+
+
+@dataclass(frozen=True)
+class Plan:
+    """A single proposed (never applied) reconciliation for one raw name."""
+
+    raw: str
+    canonical: str
+    action: str  # "alias" | "fuzzy" | "unchanged"
+    needs_review: bool
+    score: float | None = None  # fuzzy similarity, when action == "fuzzy"
+
+
+def classify(raw: str) -> Plan:
+    """Classify one raw manufacturer name. Alias precedence first; fuzzy only
+    as a fallback on identity results; otherwise unchanged."""
+    result = normalize_manufacturer(raw)
+    if result.method == "alias":
+        return Plan(raw=raw, canonical=result.canonical, action="alias", needs_review=False)
+
+    # Identity result — try a high-threshold fuzzy proposal toward a canonical.
+    proposal = propose_fuzzy_canonical(result.canonical, KNOWN_CANONICALS)
+    if proposal is not None:
+        return Plan(
+            raw=raw,
+            canonical=proposal.canonical,
+            action="fuzzy",
+            needs_review=True,
+            score=proposal.score,
+        )
+
+    return Plan(raw=raw, canonical=result.canonical, action="unchanged", needs_review=False)
+
+
+def plan_reconciliation(names: list[str]) -> list[Plan]:
+    """Plan over the DISTINCT non-blank input names, order preserved."""
+    seen: set[str] = set()
+    distinct: list[str] = []
+    for name in names:
+        if name is None:
+            continue
+        stripped = name.strip()
+        if not stripped or stripped in seen:
+            continue
+        seen.add(stripped)
+        distinct.append(stripped)
+    return [classify(name) for name in distinct]
+
+
+def summarize(plans: list[Plan]) -> dict[str, int]:
+    counts = {"alias": 0, "fuzzy": 0, "unchanged": 0}
+    for p in plans:
+        counts[p.action] += 1
+    return counts
+
+
+def is_safe_url(url: str) -> bool:
+    """True only if the URL contains a known-safe (non-prod) marker.
+
+    Fail-safe: any URL we don't recognize as safe — including the production
+    URL — returns False and is refused. This cannot silently connect to prod.
+    """
+    lowered = url.lower()
+    return any(marker in lowered for marker in SAFE_URL_MARKERS)
+
+
+# ---------------------------------------------------------------------------
+# Input sources
+# ---------------------------------------------------------------------------
+
+
+def _parse_names(text: str) -> list[str]:
+    """Parse a JSON array of strings, or fall back to one-name-per-line."""
+    text = text.strip()
+    if not text:
+        return []
+    if text.startswith("["):
+        data = json.loads(text)
+        if not isinstance(data, list):
+            raise ValueError("JSON input must be an array of strings")
+        return [str(item) for item in data]
+    return [line for line in text.splitlines() if line.strip()]
+
+
+def read_from_file(path: Path) -> list[str]:
+    return _parse_names(path.read_text())
+
+
+def read_from_stdin() -> list[str]:
+    return _parse_names(sys.stdin.read())
+
+
+def read_from_db(db_url: str) -> list[str]:
+    """Read DISTINCT manufacturers from NeonDB — read-only, non-prod only.
+
+    sqlalchemy is imported LAZILY here so the default file/stdin path never
+    pulls in a DB driver (no DB/network dependency unless --from-db is used).
+    Runs exactly one statement: SELECT DISTINCT manufacturer. No writes.
+    """
+    if not is_safe_url(db_url):
+        log.error(
+            "REFUSING --from-db: URL does not match a known-safe (non-prod) marker. "
+            "Allowed markers: %s. This planner is dry-run and read-only and connects "
+            "ONLY to a recognized staging/local DB — never prod, never an unknown host.",
+            ", ".join(SAFE_URL_MARKERS),
+        )
+        raise SystemExit(2)
+
+    from sqlalchemy import create_engine, text  # lazy: only when --from-db
+    from sqlalchemy.pool import NullPool
+
+    log.info("Connecting read-only to non-prod DB for SELECT DISTINCT manufacturer…")
+    engine = create_engine(
+        db_url,
+        poolclass=NullPool,
+        connect_args={"sslmode": "require"},
+        pool_pre_ping=True,
+    )
+    with engine.connect() as conn:
+        rows = conn.execute(text("SELECT DISTINCT manufacturer FROM knowledge_entries")).fetchall()
+    return [r[0] for r in rows if r[0]]
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def render_text_report(plans: list[Plan]) -> str:
+    counts = summarize(plans)
+    lines = [
+        BANNER,
+        "",
+        f"Distinct manufacturer values planned: {len(plans)}",
+        f"  alias (deterministic):  {counts['alias']}",
+        f"  fuzzy (NEEDS REVIEW):   {counts['fuzzy']}",
+        f"  unchanged (identity):   {counts['unchanged']}",
+        "",
+    ]
+
+    aliases = [p for p in plans if p.action == "alias"]
+    fuzzies = [p for p in plans if p.action == "fuzzy"]
+
+    if aliases:
+        lines.append("Deterministic alias collapses (safe to apply):")
+        for p in sorted(aliases, key=lambda p: p.raw.lower()):
+            lines.append(f"  {p.raw!r} -> {p.canonical!r}")
+        lines.append("")
+
+    if fuzzies:
+        lines.append("Fuzzy proposals (NEEDS REVIEW — do NOT auto-apply):")
+        for p in sorted(fuzzies, key=lambda p: p.raw.lower()):
+            lines.append(f"  {p.raw!r} ~> {p.canonical!r}  (score={p.score:.3f})")
+        lines.append("")
+
+    lines.append(
+        "No writes were made. To apply, route the reviewed mappings through the "
+        "gated dev→staging→prod migration path (see docs/environments.md)."
+    )
+    return "\n".join(lines)
+
+
+def render_json_report(plans: list[Plan]) -> str:
+    payload = {
+        "dry_run": True,
+        "counts": summarize(plans),
+        "plans": [asdict(p) for p in plans],
+    }
+    return json.dumps(payload, indent=2)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--input", type=Path, help="File of manufacturer names (lines or JSON array)"
+    )
+    parser.add_argument(
+        "--from-db",
+        action="store_true",
+        help="Read DISTINCT manufacturers from NeonDB (read-only, non-prod only; requires --db-url)",
+    )
+    parser.add_argument(
+        "--db-url",
+        help="Explicit non-prod DB URL for --from-db (NOT read from NEON_DATABASE_URL env)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON instead of text"
+    )
+    args = parser.parse_args()
+
+    if args.from_db:
+        if not args.db_url:
+            log.error(
+                "--from-db requires an explicit --db-url (a non-prod URL). "
+                "It will not silently use NEON_DATABASE_URL."
+            )
+            return 2
+        names = read_from_db(args.db_url)
+    elif args.input:
+        names = read_from_file(args.input)
+    else:
+        names = read_from_stdin()
+
+    if not names:
+        log.warning("No manufacturer names provided — nothing to plan.")
+        return 0
+
+    plans = plan_reconciliation(names)
+
+    if args.json:
+        print(render_json_report(plans))
+    else:
+        print(render_text_report(plans))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_reconcile_manufacturers.py
+++ b/tools/test_reconcile_manufacturers.py
@@ -1,0 +1,115 @@
+"""Offline tests for the dry-run manufacturer reconciliation planner (#1596).
+
+These tests exercise the classification logic on a fixed sample list and prove
+the planner does NOT touch a database or network in its default (file/stdin)
+mode. The four canonical cases:
+
+- "Alien-Bradley" → deterministic alias hit  → ``alias``
+- "Cofemo"        → deterministic alias hit  → ``alias``
+- "Deshazoo"      → not in the map, fuzzy-matches "Deshazo" → ``fuzzy``
+- "Acme Hoist"    → no alias, no fuzzy hit   → ``unchanged``
+"""
+
+from __future__ import annotations
+
+import sys
+
+import reconcile_manufacturers as rm
+
+SAMPLE = ["Alien-Bradley", "Cofemo", "Deshazoo", "Acme Hoist"]
+
+
+def _by_raw(plans: list[rm.Plan]) -> dict[str, rm.Plan]:
+    return {p.raw: p for p in plans}
+
+
+def test_classification_of_sample_list() -> None:
+    plans = rm.plan_reconciliation(SAMPLE)
+    by_raw = _by_raw(plans)
+
+    assert by_raw["Alien-Bradley"].action == "alias"
+    assert by_raw["Alien-Bradley"].canonical == "Rockwell Automation"
+
+    assert by_raw["Cofemo"].action == "alias"
+    assert by_raw["Cofemo"].canonical == "Coffing"
+
+    assert by_raw["Deshazoo"].action == "fuzzy"
+    assert by_raw["Deshazoo"].canonical == "Deshazo"
+    assert by_raw["Deshazoo"].needs_review is True
+
+    assert by_raw["Acme Hoist"].action == "unchanged"
+    assert by_raw["Acme Hoist"].canonical == "Acme Hoist"
+    assert by_raw["Acme Hoist"].needs_review is False
+
+
+def test_alias_hit_is_never_fuzzed() -> None:
+    """An alias result must classify as ``alias``, never ``fuzzy`` — fuzzy is a
+    fallback only for identity results."""
+    plans = rm.plan_reconciliation(["Alien-Bradley", "Cofemo"])
+    assert all(p.action == "alias" for p in plans)
+    assert all(p.needs_review is False for p in plans)
+
+
+def test_counts_summary() -> None:
+    counts = rm.summarize(rm.plan_reconciliation(SAMPLE))
+    assert counts == {"alias": 2, "fuzzy": 1, "unchanged": 1}
+
+
+def test_default_mode_imports_no_db_driver() -> None:
+    """The default (file/stdin) path must not import sqlalchemy — proves no DB
+    or network call happens unless ``--from-db`` is explicitly requested.
+
+    sqlalchemy must be imported LAZILY inside the --from-db branch. After a
+    plan run, the module must not be present (assuming it was not already
+    imported by the test runner itself — which it is not in this offline
+    suite)."""
+    sys.modules.pop("sqlalchemy", None)
+    rm.plan_reconciliation(SAMPLE)
+    assert "sqlalchemy" not in sys.modules, (
+        "Default file/stdin mode pulled in sqlalchemy — DB access must be lazy "
+        "and gated behind --from-db only."
+    )
+
+
+def test_from_db_refuses_prod_and_unknown_urls() -> None:
+    """Fail-safe: the prod URL AND any unrecognized URL are NOT safe.
+
+    A real Neon prod connection string uses the endpoint hostname
+    (ep-<id>-pooler.<region>.aws.neon.tech), not the branch id / VPS IP /
+    website domain — so a prod blocklist would be hollow. The allowlist
+    refuses everything it doesn't recognize as safe."""
+    unsafe_urls = [
+        # Realistically-shaped prod Neon URL: endpoint host, no safe marker.
+        "postgresql://u:p@ep-prod-endpoint-xyz-pooler.us-east-2.aws.neon.tech/mira",
+        # Even URLs embedding prod metadata are unsafe (and so is anything else).
+        "postgresql://u:p@165.245.138.91:5432/mira",
+        "postgresql://u:p@db.factorylm.com/mira",
+        "postgresql://u:p@ep-unknown-host-pooler.neon.tech/db",
+    ]
+    for url in unsafe_urls:
+        assert rm.is_safe_url(url) is False, f"wrongly allowed unsafe URL: {url}"
+
+
+def test_from_db_allows_known_safe_url() -> None:
+    safe_urls = [
+        "postgresql://u:p@ep-polished-hall-ahcqtcxe-pooler.neon.tech/db",  # staging endpoint
+        "postgresql://u:p@ep-x.br-small-term-ahtkz61d.neon.tech/db",  # staging branch
+        "postgresql://u:p@localhost:5432/mira_dev",
+        "postgresql://u:p@127.0.0.1/mira",
+    ]
+    for url in safe_urls:
+        assert rm.is_safe_url(url) is True, f"wrongly refused safe URL: {url}"
+
+
+def test_read_from_db_blocks_before_connect_on_unsafe_url() -> None:
+    """read_from_db must refuse (SystemExit) on an unsafe URL BEFORE importing
+    sqlalchemy or opening any socket — proving the guard runs pre-connect."""
+    import pytest
+
+    sys.modules.pop("sqlalchemy", None)
+    with pytest.raises(SystemExit):
+        rm.read_from_db("postgresql://u:p@ep-prod-endpoint-pooler.neon.tech/mira")
+    assert "sqlalchemy" not in sys.modules, (
+        "read_from_db imported sqlalchemy before refusing — the prod guard must "
+        "block before any DB driver loads or socket opens."
+    )


### PR DESCRIPTION
Implements the three carve-outs tracked on #1596. **Stacked on #1713** (base = `fix/manufacturer-ocr-normalize-1596`); retarget to `main` once #1713 merges.

## Carve-out (a) — brand-vs-parent decision: **Rockwell Automation (parent)**
Product decision made: Allen-Bradley canonicalizes to the corporate parent **"Rockwell Automation"**, matching the query-side resolver's `VENDOR_ALIASES` so the KB catalog and the query side group identically (ends the catalog-vs-resolver split).
- Crawler `OCR_VARIANT_ALIASES`: clean `Allen-Bradley` + OCR variants → `Rockwell Automation`.
- The resolver (`mira-bots/shared/uns_resolver.py`) is **not touched** — it already maps AB→Rockwell, so this only makes ingest agree (zero collision with active engine work).
- Long-tail rigging/hoist OEMs keep the cleanest-observed-spelling rule (resolver has no opinion → divergence-free).

## Carve-out (b) — the two other writers of `knowledge_entries.manufacturer`
The Hub KB catalog `GROUP BY knowledge_entries.manufacturer` spans every service that writes that column. #1713 covered mira-crawler; this covers the rest:
- **mira-core/mira-ingest** (photo/RAG API, Python): new `db/manufacturer_normalize.py`, wired at **both** write boundaries — `insert_knowledge_entry` and `insert_knowledge_entries_batch`.
- **mira-hub** (document-upload route, TS): new `lib/manufacturer-aliases.json` + `lib/manufacturerNormalize.ts`, wired into `api/documents/upload/route.ts`. (The production `/api/uploads/*` path hands off to the crawler, already normalized; this closes the only in-hub writer.)

## Carve-out (c) + drift guard
- **`tests/test_manufacturer_alias_consistency.py`** — asserts the three vendored maps (crawler Python, mira-core Python, mira-hub JSON) are **byte-identical**, and that any key shared with the resolver's `VENDOR_ALIASES` agrees (locks `allen-bradley → Rockwell Automation` across both surfaces). This is the integrity mechanism for vendoring the map three times (forced by per-container build contexts).
- **`tools/reconcile_manufacturers.py`** — DRY-RUN reconciliation planner for the existing polluted catalog. Classifies distinct manufacturer values as alias / fuzzy-proposed / unchanged. **No write path exists.** Optional `--from-db` is read-only (`SELECT DISTINCT` only) and **default-deny**: refuses any URL not matching a known-safe staging/local marker, so a prod URL can never connect. The actual apply remains a separate, gated dev→staging→prod step (still tracked on #1596).

## Why three copies of the map
Build contexts are per-container (`./mira-core/mira-ingest`, `./mira-hub`) and two languages (Python/TS), so a single shared runtime module is impossible. The map is vendored per service; the consistency test is what keeps the copies from drifting.

## Tests — 42 total, all green in their service contexts
| Suite | Count |
|---|---|
| `mira-crawler/tests/test_manufacturer_normalize.py` | 18 |
| `mira-core/mira-ingest/db/test_manufacturer_normalize.py` | 9 |
| `tests/test_manufacturer_alias_consistency.py` | 2 |
| `tools/test_reconcile_manufacturers.py` | 7 |
| `mira-hub` vitest `manufacturerNormalize.test.ts` | 6 |

`ruff check` clean on all Python; `tsc --noEmit` clean on touched TS; no new deps.

## Still open on #1596 (not in this PR)
- The catalog-wide **apply** backfill (gated data pass; planner here produces the plan).
- Confirm the `--from-db` safe-marker allowlist against the real staging endpoint before using that mode (default-deny means an unconfirmed marker only risks a safe false-refusal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)