### PR TITLE
fix(eval): record last response in offline scorecard failures (#1583)

### DIFF
--- a/tests/eval/offline_run.py
+++ b/tests/eval/offline_run.py
@@ -412,6 +412,13 @@ def write_offline_scorecard(
                     lines.append(f"- **{cp.name}** FAILED: {cp.reason}")
             if g.error:
                 lines.append(f"- Photo extraction: {g.error}")
+            # Record what MIRA actually said so the eval watchdog's
+            # last_response_snippet (parsed from this line) is populated —
+            # otherwise failures are diagnosed blind (#1583). Mirrors
+            # run_eval.py's scorecard writer.
+            if g.last_response:
+                preview = g.last_response[:200].replace("\n", " ")
+                lines.append(f"- Last response: `{preview}...`")
             lines.append("")
 
     # Judge summary

--- a/tests/eval/test_offline_scorecard.py
+++ b/tests/eval/test_offline_scorecard.py
@@ -1,0 +1,58 @@
+"""Tests for the offline eval scorecard writer.
+
+Regression guard for the "diagnosing blind" gap (#1583): the offline scorecard
+must record each failing scenario's last MIRA response, so the eval watchdog's
+`last_response_snippet` (parsed from the `- Last response:` line) is populated
+and humans/agents can see what the bot actually said. `run_eval.py` already
+emits this line; `offline_run.py` did not.
+"""
+
+from __future__ import annotations
+
+from tests.eval import offline_run
+from tests.eval.grader import CheckpointResult, ScenarioGrade
+
+
+def _failing_grade(last_response: str) -> ScenarioGrade:
+    return ScenarioGrade(
+        scenario_id="demo_fixture_01",
+        checkpoints=[CheckpointResult(name="cp_keyword_match", passed=False, reason="missing danfoss.com")],
+        final_fsm_state="IDLE",
+        total_turns=1,
+        last_response=last_response,
+    )
+
+
+def test_offline_scorecard_records_last_response_for_failures(tmp_path, monkeypatch):
+    monkeypatch.setattr(offline_run, "_RUNS_DIR", tmp_path)
+    grade = _failing_grade("I have the Danfoss AQUA Drive manual indexed.")
+
+    path = offline_run.write_offline_scorecard(
+        grades=[grade],
+        judge_results=[None],
+        total_seconds=1.0,
+        suite="text",
+        prev_path=None,
+    )
+
+    text = path.read_text()
+    assert "## Failures" in text
+    assert "- Last response:" in text
+    assert "Danfoss AQUA Drive manual indexed" in text
+
+
+def test_offline_scorecard_truncates_and_flattens_response(tmp_path, monkeypatch):
+    monkeypatch.setattr(offline_run, "_RUNS_DIR", tmp_path)
+    long_multiline = "line one\nline two " + ("x" * 300)
+    grade = _failing_grade(long_multiline)
+
+    text = offline_run.write_offline_scorecard(
+        grades=[grade], judge_results=[None], total_seconds=1.0, suite="text", prev_path=None
+    ).read_text()
+
+    # Find the Last response line and verify it's single-line and capped.
+    resp_line = next(ln for ln in text.splitlines() if ln.startswith("- Last response:"))
+    assert "\n" not in resp_line  # newlines flattened
+    assert "line one line two" in resp_line  # newline became a space
+    # 200-char preview cap (well under the 300-x run we fed in)
+    assert "x" * 300 not in resp_line


### PR DESCRIPTION
## Problem
The offline scorecard writer `write_offline_scorecard` in `tests/eval/offline_run.py` — which produces the `*-offline-text.md` scorecards the **eval watchdog / eval-fixer agent** now consume — omitted the per-failure `- Last response:` line that `run_eval.py` already emits. So `eval_watchdog.py`'s `last_response_snippet` (parsed via regex from that line) was **always empty for offline runs**, and failures were diagnosed blind. This was flagged in #1583 ("the offline runner is not capturing the final response text. Fix that first — diagnosing blind is the real blocker") and still bites the keyword-cluster triage in #1720.

## Fix
The reply text is already captured on `ScenarioGrade.last_response` (grader.py:75/394). This change just writes it into the Failures section — a 200-char preview with newlines flattened — **mirroring `run_eval.py:479` exactly**. Single file, no behavior change beyond the added scorecard line.

```python
if g.last_response:
    preview = g.last_response[:200].replace("\n", " ")
    lines.append(f"- Last response: `{preview}...`")
```

## Why it matters now
Unblocks the **#1720 PR-2 stale-fixture decision**: to decide whether `vfd_danfoss_02` / `vfd_siemens_02` are stale fixtures (expecting a vendor URL the doc-intent handler deliberately drops on a KB-hit) or a real bug, a reviewer needs to *see what the handler actually replied*. With this, the scorecard shows it.

## Tests
`tests/eval/test_offline_scorecard.py` (2): asserts the `- Last response:` line is written for failures, and that the preview is single-line + capped at 200 chars.

```
2 passed
```
`ruff check` clean.

## Scope
- `tests/eval/` only — no engine/product code, no collision with the active FSM/conversational-engine branches.
- Pure observability fix for the eval harness; does not change pass/fail grading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)