### PR TITLE
fix(ci): repair compose memory lint workflow parsing

### DIFF
--- a/.github/workflows/compose-mem-lint.yml
+++ b/.github/workflows/compose-mem-lint.yml
@@ -1,11 +1,5 @@
 name: Compose mem_limit Lint
 
-# Auto-cancel superseded runs on the same PR/branch (CI flood guard).
-# cancel-in-progress gated to pull_request so non-PR events are never cancelled.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 # Walks every docker-compose*.yml in the repo and reports services missing
 # `mem_limit:`. Catches the silently-ignored Swarm-syntax footgun
 # (`deploy.resources.limits.memory`) that took the VPS down for 8.7 hours on


### PR DESCRIPTION
## Exact failure observed

`compose-mem-lint.yml` failed on **every** commit to `main` (e.g. run `27013659753` on `7a7250b4`): `conclusion=failure`, **0 jobs scheduled**, and `gh run view --log` returns `log not found`. This is the signature of a **workflow-load (parse-level) failure** — GitHub Actions rejects the workflow before scheduling any job, so there is no job log to retrieve. It had been failing for days across unrelated commits (crawler, engine, ingest), confirming it was independent of any feature change.

## Root cause

The file declared **two top-level `concurrency:` keys** — one inserted after `name:` (line 5) and an identical one after the `on:` block (line 31), both added during the CI-flood concurrency-guard rollout. GitHub Actions' workflow parser **rejects duplicate top-level mapping keys** at load time.

Notably, Python's `yaml.safe_load` *silently* accepts duplicate keys (last-one-wins), which is why this passed any local PyYAML check and shipped.

## Exact fix

Remove the **first** (pre-`on:`) `concurrency:` block (6 lines, including its comment). Keep the second block (after `on:`, which carries the fuller comment) so the file matches the majority sibling-workflow convention (`concurrency:` after `on:`) and the **CI-flood auto-cancel guard is fully preserved**. The two blocks were byte-identical, so **runtime behavior is unchanged** — this is purely a parse repair.

```diff
 name: Compose mem_limit Lint

-# Auto-cancel superseded runs on the same PR/branch (CI flood guard).
-# cancel-in-progress gated to pull_request so non-PR events are never cancelled.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 # Walks every docker-compose*.yml in the repo and reports services missing
```

## Validation performed

- `grep -c '^concurrency:'` → **1** (was 2).
- **Duplicate-key-aware YAML parse** (a strict loader that raises on any repeated mapping key at any nesting level, mimicking the Actions parser) → **STRICT PARSE OK**, top-level keys `[name, on, concurrency, permissions, jobs]`. (Plain `yaml.safe_load` is *not* a valid check here — it hides the bug.)
- Diff is 6 deletions, 0 additions — `permissions`, `jobs`, steps, `on.paths`, and the surviving concurrency guard are untouched.
- `actionlint` is not installed on this node; GitHub will run its own workflow-load validation on push (the very check that was failing).

## Scope / isolation statements

- **Bravo's eval/engine lane was not touched.** No changes to `mira-bots/shared/engine.py`, `guardrails.py`, eval routing, eval expectations/fixtures, state handlers, or the #1720 failure-family work.
- **Namespace inline-create E2E (`wizard:finish` 500) remains a separate pre-existing issue** — out of scope for this PR and not addressed here.
- Single CI failure only; not combined with any other workflow fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)