### PR TITLE
feat(hub): schematic relationship writer proposes by default (#1721 slice)

### DIFF
--- a/mira-hub/docs/audits/2026-06-05-hub-relationship-writers-1721.md
+++ b/mira-hub/docs/audits/2026-06-05-hub-relationship-writers-1721.md
@@ -1,0 +1,41 @@
+# Hub relationship-writer audit (issue #1721)
+
+**Date:** 2026-06-05 · **Parent:** #1662 · **EPIC:** #1666 · companion to the Python-side `docs/audits/2026-06-04-ingest-edge-write-paths-1662.md` (note: that file lives in the repo root `docs/`; this one is hub-local).
+
+Follow-up to #1716 (Python ingest now proposes). This classifies the **mira-hub TypeScript** writers that touch `kg_relationships` and migrates the first one to propose-by-default.
+
+## Policy (the Iron Rule, stricter than Python)
+
+Per `.claude/skills/managing-the-knowledge-graph` + ADR-0017: **no MIRA-inferred edge is ever written directly to `kg_relationships`.** It lands as a `relationship_proposals` row (via `upsertInferredProposal`); the verified edge is written only on human approval (`proposals/[id]/decide/route.ts`).
+
+Unlike the Python ingest path, the hub has **no `autoverify` escape hatch** for inferred edges — determinism/high-confidence sets *confidence*, never *verified*. The human confirm IS the product. (`MIRA_KG_INGEST_AUTOVERIFY` is a Python-ingest-only migration concession; it does not exist on the hub.)
+
+**Central enforcement (this PR):** `upsertInferredProposal` now guards on `CANONICAL_PROPOSAL_RELATIONSHIP_TYPES` (the `relationship_proposals.relationship_type` CHECK vocabulary, migrations 018→028→032). A non-canonical type is skipped with a warning instead of throwing a CHECK violation that would silently drop the edge.
+
+## Writer classification
+
+| Writer | Class | Status |
+|---|---|---|
+| `queries.ts::upsertSchematicComponents` | **inferred** (schematic intelligence extracts components + wiring) | ✅ **migrated** (this PR) → proposes via `upsertInferredProposal`. Entity nodes still upserted; edges propose. |
+| `proposals/[id]/decide/route.ts` | **safe** | Human-approval verified write — the one legitimate door. Unchanged. |
+| `relationship-extractor.ts` (LLM, `confidence ≥ HIGH_CONFIDENCE_THRESHOLD → INSERT`) | **inferred** — the literal "confidence > X → verify" anti-pattern | ⛔ TODO: route through `upsertInferredProposal`. Predicates already validated by `isRelationshipType`; map/validate to canonical. |
+| `extractor.ts::upsertRelationship` (conversation extraction, conf 1.0) | **inferred** | ⛔ TODO: propose. |
+| `cmms-sync.ts::upsertRelationship` (conf 1.0) | **inferred** (mirrors CMMS structural data — still a proposal per Iron Rule) | ⛔ TODO + **blocker**: emits `has_work_order` (lowercase) which is **not in the proposals CHECK**. Needs a CHECK migration (`HAS_WORK_ORDER`) or a canonical map first. |
+| `hierarchy-backfill.ts::createParentOf` | **decision → inferred** | ⛔ TODO + **blocker**: it's a *heuristic* location-string match (`entity_id = $2 OR name = $2`), so it is **inferred, not deliberate structure → must propose**. Blocker: `parent_of` is **not** in the proposals CHECK; map to `LOCATED_IN` (equipment → area/line) or add to the CHECK. Decision recorded: **propose**, not auto-verify. |
+| `queries.ts::createRelationship` | **dead code** (0 callers in `src/`) | Leave as-is; remove in a follow-up (out of scope here — surgical). |
+
+## Vocabulary note (load-bearing)
+
+Staging ground truth: `kg_relationships` holds a **mix** — lowercase legacy from Python ingest (`has_manual`, `documented_in`, `has_fault_code`, `has_work_order`) + uppercase canonical from hub/schematic paths (`WIRED_TO`, `POWERED_BY`, `MAPS_TO`, `USED_IN_LOGIC`, `CAUSES`, `DRIVES`, `LOCATED_IN`, `HAS_COMPONENT`, `HAS_DOCUMENT`). `relationship_proposals` is **entirely** canonical uppercase (+ `SAME_MODEL_AS`/`CO_FAILED_WITH`/`SIMILAR_TO`).
+
+Implication: schematic edges were already canonical (clean migration, no remap). But `cmms-sync` (`has_work_order`) and `hierarchy-backfill` (`parent_of`) use types **absent from the proposals CHECK** — those migrations are blocked on either a CHECK extension (dev→staging→prod) or a canonical map, and must be sequenced accordingly. `types.ts::RELATIONSHIP_TYPES` (lowercase) is also out of step with the proposals CHECK (uppercase) — reconciling them is a separate cleanup.
+
+## Verification (this PR)
+
+- `vitest` — 4 new tests (`queries-schematic.test.ts`): canonical edge → proposal not `kg_relationships`; non-canonical skipped; missing-endpoint skipped; entities still upserted. 35/35 in the affected suites.
+- `eslint` clean on changed files; `tsc` clean on changed files (pre-existing unrelated typecheck errors in `namespace/tree`, `rls-deny`, `command-center-freshness` are not touched here).
+- Staging smoke on `factorylm/stg`: `proposals=1 evidence=1 kg_relationships=0`, idempotent, guard skips non-canonical.
+
+## Remaining for #1721
+
+`relationship-extractor.ts`, `extractor.ts`, then `cmms-sync.ts` + `hierarchy-backfill.ts` (after the CHECK/mapping decision). #1721 stays open until all are propose-by-default or explicitly justified. CI guard for unguarded inserts = #1722; canary = #1723.

--- a/mira-hub/docs/audits/2026-06-05-hub-relationship-writers-1721.md
+++ b/mira-hub/docs/audits/2026-06-05-hub-relationship-writers-1721.md
@@ -12,13 +12,15 @@ Unlike the Python ingest path, the hub has **no `autoverify` escape hatch** for 
 
 **Central enforcement (this PR):** `upsertInferredProposal` now guards on `CANONICAL_PROPOSAL_RELATIONSHIP_TYPES` (the `relationship_proposals.relationship_type` CHECK vocabulary, migrations 018→028→032). A non-canonical type is skipped with a warning instead of throwing a CHECK violation that would silently drop the edge.
 
+**Shared vocabulary map (this PR):** `mapToCanonicalEdge(rawType)` (proposals-writer.ts) maps the hub's lowercase `kg_relationships` vocabulary → canonical, returning `{type, flip}` (`flip` = the canonical edge runs the opposite direction, e.g. `caused_by` → `CAUSES` reversed). The TS analogue of Python's `_CANONICAL_RELATION_TYPE`. Unmapped types (`has_work_order`, `controls`, `protects`, `maintained_by`) return null → caller skips. This is the foundation every remaining writer migrates onto.
+
 ## Writer classification
 
 | Writer | Class | Status |
 |---|---|---|
 | `queries.ts::upsertSchematicComponents` | **inferred** (schematic intelligence extracts components + wiring) | ✅ **migrated** (this PR) → proposes via `upsertInferredProposal`. Entity nodes still upserted; edges propose. |
 | `proposals/[id]/decide/route.ts` | **safe** | Human-approval verified write — the one legitimate door. Unchanged. |
-| `relationship-extractor.ts` (LLM, `confidence ≥ HIGH_CONFIDENCE_THRESHOLD → INSERT`) | **inferred** — the literal "confidence > X → verify" anti-pattern | ⛔ TODO: route through `upsertInferredProposal`. Predicates already validated by `isRelationshipType`; map/validate to canonical. |
+| `relationship-extractor.ts` (LLM, `confidence ≥ HIGH_CONFIDENCE_THRESHOLD → INSERT`) | **inferred** — the literal "confidence > X → verify" anti-pattern | ✅ **migrated** (this PR) → above-threshold edges propose via `upsertInferredProposal` (predicate mapped through `mapToCanonicalEdge`, incl. `caused_by`→`CAUSES` flip); below-threshold stays triple-only. |
 | `extractor.ts::upsertRelationship` (conversation extraction, conf 1.0) | **inferred** | ⛔ TODO: propose. |
 | `cmms-sync.ts::upsertRelationship` (conf 1.0) | **inferred** (mirrors CMMS structural data — still a proposal per Iron Rule) | ⛔ TODO + **blocker**: emits `has_work_order` (lowercase) which is **not in the proposals CHECK**. Needs a CHECK migration (`HAS_WORK_ORDER`) or a canonical map first. |
 | `hierarchy-backfill.ts::createParentOf` | **decision → inferred** | ⛔ TODO + **blocker**: it's a *heuristic* location-string match (`entity_id = $2 OR name = $2`), so it is **inferred, not deliberate structure → must propose**. Blocker: `parent_of` is **not** in the proposals CHECK; map to `LOCATED_IN` (equipment → area/line) or add to the CHECK. Decision recorded: **propose**, not auto-verify. |

--- a/mira-hub/src/lib/knowledge-graph/__tests__/proposals-writer.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/proposals-writer.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  isCanonicalProposalRelationshipType,
+  mapToCanonicalEdge,
+} from "../proposals-writer";
+
+describe("isCanonicalProposalRelationshipType", () => {
+  test("accepts canonical CHECK vocabulary", () => {
+    for (const t of ["WIRED_TO", "HAS_COMPONENT", "SAME_MODEL_AS", "HAS_FAILURE_MODE"]) {
+      expect(isCanonicalProposalRelationshipType(t)).toBe(true);
+    }
+  });
+  test("rejects lowercase / unknown types", () => {
+    for (const t of ["feeds", "has_work_order", "frobnicate", ""]) {
+      expect(isCanonicalProposalRelationshipType(t)).toBe(false);
+    }
+  });
+});
+
+describe("mapToCanonicalEdge", () => {
+  test("canonical types pass through unflipped", () => {
+    expect(mapToCanonicalEdge("WIRED_TO")).toEqual({ type: "WIRED_TO", flip: false });
+    expect(mapToCanonicalEdge("SAME_MODEL_AS")).toEqual({ type: "SAME_MODEL_AS", flip: false });
+  });
+
+  test("direction-preserving lowercase mappings", () => {
+    expect(mapToCanonicalEdge("feeds")).toEqual({ type: "UPSTREAM_OF", flip: false });
+    expect(mapToCanonicalEdge("requires_part")).toEqual({ type: "HAS_PART", flip: false });
+    expect(mapToCanonicalEdge("had_fault")).toEqual({ type: "HAS_FAILURE_MODE", flip: false });
+    expect(mapToCanonicalEdge("resolved_by")).toEqual({ type: "RESOLVED_BY", flip: false });
+    expect(mapToCanonicalEdge("triggered_pm")).toEqual({ type: "TRIGGERS", flip: false });
+    expect(mapToCanonicalEdge("located_at")).toEqual({ type: "LOCATED_IN", flip: false });
+    expect(mapToCanonicalEdge("parent_of")).toEqual({ type: "HAS_COMPONENT", flip: false });
+    expect(mapToCanonicalEdge("electrically_connected")).toEqual({ type: "WIRED_TO", flip: false });
+    expect(mapToCanonicalEdge("mentioned_tag")).toEqual({ type: "HAS_SIGNAL", flip: false });
+  });
+
+  test("caused_by flips direction (A caused_by B → B CAUSES A)", () => {
+    expect(mapToCanonicalEdge("caused_by")).toEqual({ type: "CAUSES", flip: true });
+  });
+
+  test("types with no clean canonical equivalent return null (caller skips)", () => {
+    for (const t of ["has_work_order", "controls", "protects", "maintained_by", "frobnicate"]) {
+      expect(mapToCanonicalEdge(t)).toBeNull();
+    }
+  });
+
+  test("every mapped target is itself canonical (round-trip safety)", () => {
+    for (const raw of [
+      "caused_by", "resolved_by", "feeds", "requires_part", "triggered_pm", "had_fault",
+      "mentioned_tag", "exhibited_fault", "located_at", "has_pm", "parent_of",
+      "has_component", "electrically_connected", "references_drawing", "similar_to",
+    ]) {
+      const edge = mapToCanonicalEdge(raw);
+      expect(edge).not.toBeNull();
+      expect(isCanonicalProposalRelationshipType(edge!.type)).toBe(true);
+    }
+  });
+});

--- a/mira-hub/src/lib/knowledge-graph/__tests__/queries-schematic.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/queries-schematic.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Record every SQL statement the fake pg client executes, and answer the
+// queries upsertSchematicComponents + upsertInferredProposal issue. Hoisted so
+// the vi.mock factory below can close over it.
+const { executed, reset } = vi.hoisted(() => {
+  const executed: { sql: string; params: unknown[] }[] = [];
+  return { executed, reset: () => (executed.length = 0) };
+});
+
+vi.mock("@/lib/tenant-context", () => ({
+  withTenantContext: async (_tenantId: string, fn: (c: unknown) => unknown) => {
+    const client = {
+      query: async (sql: string, params: unknown[] = []) => {
+        executed.push({ sql, params });
+        if (sql.includes("INSERT INTO kg_entities"))
+          return { rows: [{ id: `ent-${executed.length}` }], rowCount: 1 };
+        if (sql.includes("INSERT INTO relationship_proposals"))
+          return { rows: [{ id: `prop-${executed.length}` }], rowCount: 1 };
+        if (sql.includes("FROM kg_relationships")) return { rows: [], rowCount: 0 };
+        if (sql.includes("FROM relationship_proposals")) return { rows: [], rowCount: 0 };
+        return { rows: [], rowCount: 0 };
+      },
+    };
+    return fn(client);
+  },
+}));
+
+import { upsertSchematicComponents } from "../queries";
+
+const TENANT = "00000000-0000-0000-0000-000000000001";
+
+function blob() {
+  return executed.map((e) => e.sql).join("\n");
+}
+
+describe("upsertSchematicComponents — proposes, never auto-verifies (#1721)", () => {
+  beforeEach(() => reset());
+
+  const twoEntities = [
+    { entity_type: "component", entity_id: "C1", name: "Motor", properties: {} },
+    { entity_type: "component", entity_id: "C2", name: "Drive", properties: {} },
+  ];
+
+  test("a canonical schematic edge lands as a proposal, NOT a kg_relationships insert", async () => {
+    const result = await upsertSchematicComponents(TENANT, {
+      schematic_type: "wiring",
+      entities: twoEntities,
+      relationships: [
+        { source_entity_id: "C2", target_entity_id: "C1", relationship_type: "POWERED_BY" },
+      ],
+    });
+    expect(blob()).toContain("INSERT INTO relationship_proposals");
+    expect(blob()).toContain("INSERT INTO relationship_evidence");
+    expect(blob()).not.toContain("INSERT INTO kg_relationships");
+    expect(result.relationships_proposed).toBe(1);
+    expect(result.relationships_inserted).toBe(0);
+    expect(result.entities_upserted).toBe(2);
+  });
+
+  test("a non-canonical relationship_type is skipped (no proposal, no throw)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await upsertSchematicComponents(TENANT, {
+      schematic_type: "wiring",
+      entities: twoEntities,
+      relationships: [
+        { source_entity_id: "C1", target_entity_id: "C2", relationship_type: "frobnicate" },
+      ],
+    });
+    expect(blob()).not.toContain("INSERT INTO relationship_proposals");
+    expect(blob()).not.toContain("INSERT INTO kg_relationships");
+    expect(result.relationships_proposed).toBe(0);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  test("an edge whose endpoint is not in the entity set is skipped", async () => {
+    const result = await upsertSchematicComponents(TENANT, {
+      entities: twoEntities,
+      relationships: [
+        { source_entity_id: "C1", target_entity_id: "MISSING", relationship_type: "WIRED_TO" },
+      ],
+    });
+    expect(blob()).not.toContain("INSERT INTO relationship_proposals");
+    expect(result.relationships_proposed).toBe(0);
+  });
+
+  test("entities are still upserted (nodes), only edges become proposals", async () => {
+    await upsertSchematicComponents(TENANT, {
+      entities: twoEntities,
+      relationships: [],
+    });
+    const entityInserts = executed.filter((e) => e.sql.includes("INSERT INTO kg_entities"));
+    expect(entityInserts).toHaveLength(2);
+  });
+});

--- a/mira-hub/src/lib/knowledge-graph/__tests__/relationship-extractor-store.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/relationship-extractor-store.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Prove the LLM relationship-extractor PROPOSES (relationship_proposals via
+// upsertInferredProposal), never inserts kg_relationships directly (#1721).
+const { executed, reset } = vi.hoisted(() => {
+  const executed: { sql: string; params: unknown[] }[] = [];
+  return { executed, reset: () => (executed.length = 0) };
+});
+
+vi.mock("@/lib/llm/cascade", () => ({
+  cascadeComplete: async () => ({
+    content: JSON.stringify({
+      relationships: [
+        { source: "motor", predicate: "caused_by", target: "fault1", confidence: 0.9 },
+      ],
+    }),
+    provider: "groq",
+  }),
+}));
+
+vi.mock("@/lib/db", () => {
+  const client = {
+    query: async (sql: string, params: unknown[] = []) => {
+      executed.push({ sql, params });
+      if (sql.includes("FROM kg_entities"))
+        return {
+          rows: [
+            { ref: "motor", id: "id-motor", entity_type: "component" },
+            { ref: "fault1", id: "id-fault1", entity_type: "fault_code" },
+          ],
+          rowCount: 2,
+        };
+      if (sql.includes("INSERT INTO relationship_proposals"))
+        return { rows: [{ id: "prop-1" }], rowCount: 1 };
+      if (sql.includes("FROM kg_relationships")) return { rows: [], rowCount: 0 };
+      if (sql.includes("FROM relationship_proposals")) return { rows: [], rowCount: 0 };
+      return { rows: [], rowCount: 0 };
+    },
+    release: () => {},
+  };
+  return { default: { connect: async () => client } };
+});
+
+import { extractRelationships } from "../relationship-extractor";
+
+const TENANT = "00000000-0000-0000-0000-000000000001";
+const blob = () => executed.map((e) => e.sql).join("\n");
+
+describe("extractRelationships — proposes, never auto-verifies (#1721)", () => {
+  beforeEach(() => reset());
+
+  test("a high-confidence LLM edge becomes a proposal, not a kg_relationships insert", async () => {
+    const stats = await extractRelationships(
+      TENANT,
+      "the motor caused fault1",
+      [
+        { ref: "motor", type: "component" },
+        { ref: "fault1", type: "fault_code" },
+      ],
+      "conv-1",
+    );
+    expect(blob()).toContain("INSERT INTO relationship_proposals");
+    expect(blob()).toContain("INSERT INTO kg_triples_log"); // audit trail kept
+    expect(blob()).not.toContain("INSERT INTO kg_relationships");
+    expect(stats.storedRelationships).toBe(1);
+    expect(stats.storedTriples).toBe(1);
+  });
+
+  test("caused_by is proposed as CAUSES with flipped direction (B CAUSES A)", async () => {
+    await extractRelationships(
+      TENANT,
+      "the motor caused fault1",
+      [
+        { ref: "motor", type: "component" },
+        { ref: "fault1", type: "fault_code" },
+      ],
+      "conv-1",
+    );
+    const prop = executed.find((e) => e.sql.includes("INSERT INTO relationship_proposals"));
+    expect(prop).toBeDefined();
+    // params: [tenant, source_id, source_type, target_id, target_type, rel_type, confidence, reasoning]
+    const p = prop!.params as unknown[];
+    expect(p).toContain("CAUSES");
+    // flip: source becomes fault1 (LLM target), target becomes motor (LLM source)
+    expect(p[1]).toBe("id-fault1");
+    expect(p[3]).toBe("id-motor");
+  });
+});

--- a/mira-hub/src/lib/knowledge-graph/proposals-writer.ts
+++ b/mira-hub/src/lib/knowledge-graph/proposals-writer.ts
@@ -8,6 +8,39 @@
  */
 import type { PoolClient } from "pg";
 
+/**
+ * Canonical relationship-type vocabulary accepted by the
+ * `relationship_proposals.relationship_type` CHECK (migrations 018 → 028 →
+ * 032). Every inferred proposal MUST use one of these; a non-canonical type
+ * would violate the CHECK and throw, dropping the edge. Single source of
+ * truth on the TS side — keep in lockstep with the latest
+ * `*_relationship_type_check` migration.
+ */
+export const CANONICAL_PROPOSAL_RELATIONSHIP_TYPES = new Set<string>([
+  // Hierarchy
+  "HAS_COMPONENT", "INSTANCE_OF", "LOCATED_IN", "HAS_PART",
+  // Documentation
+  "HAS_DOCUMENT", "HAS_CHUNK", "REFERENCES", "HAS_PROCEDURE",
+  // Wiring & power
+  "WIRED_TO", "POWERED_BY", "MAPS_TO", "PUBLISHED_AS",
+  // Logic & control
+  "USED_IN_LOGIC", "TRIGGERS", "CAUSES", "DRIVES", "IS_DRIVEN_BY",
+  // Faults & resolution
+  "OCCURS_ON", "RESOLVED_BY", "HAS_FAILURE_MODE",
+  // Signals
+  "HAS_SIGNAL", "HAS_ALIAS",
+  // Topology
+  "DEPENDS_ON", "UPSTREAM_OF", "DOWNSTREAM_OF", "REPLACES",
+  // Evidence meta
+  "CONFIRMED_BY", "CONTRADICTED_BY",
+  // Inferred / similarity
+  "SAME_MODEL_AS", "CO_FAILED_WITH", "SIMILAR_TO",
+]);
+
+export function isCanonicalProposalRelationshipType(t: string): boolean {
+  return CANONICAL_PROPOSAL_RELATIONSHIP_TYPES.has(t);
+}
+
 export interface InferredEvidence {
   evidenceType: string; // must be in relationship_evidence CHECK (e.g. 'manifest','work_order')
   sourceDescription?: string;
@@ -32,6 +65,19 @@ export async function upsertInferredProposal(
   tenantId: string,
   p: InferredProposalInput,
 ): Promise<string | null> {
+  // Central guard: a non-canonical type would violate the
+  // relationship_proposals CHECK and throw. Skip (don't drop the run) and
+  // warn so the caller's mapping gap is visible. Every existing caller
+  // already passes canonical types.
+  if (!isCanonicalProposalRelationshipType(p.relationshipType)) {
+    console.warn(
+      `upsertInferredProposal: non-canonical relationship_type ${JSON.stringify(
+        p.relationshipType,
+      )} — proposal skipped (${p.sourceEntityId} -> ${p.targetEntityId})`,
+    );
+    return null;
+  }
+
   const relExists = await client.query(
     `SELECT 1 FROM kg_relationships
       WHERE tenant_id = $1 AND relationship_type = $2

--- a/mira-hub/src/lib/knowledge-graph/proposals-writer.ts
+++ b/mira-hub/src/lib/knowledge-graph/proposals-writer.ts
@@ -41,6 +41,56 @@ export function isCanonicalProposalRelationshipType(t: string): boolean {
   return CANONICAL_PROPOSAL_RELATIONSHIP_TYPES.has(t);
 }
 
+/**
+ * Maps the hub's lowercase `kg_relationships` vocabulary (`types.ts`
+ * RELATIONSHIP_TYPES — emitted by the LLM extractor, CMMS sync, hierarchy
+ * backfill, etc.) to the UPPERCASE canonical vocabulary the
+ * `relationship_proposals` CHECK accepts. The TS analogue of the Python
+ * `_CANONICAL_RELATION_TYPE` map (mira-crawler/ingest/proposal_writer.py).
+ *
+ * `flip` means the canonical edge runs the opposite direction from the
+ * lowercase one (e.g. `A caused_by B` → `B CAUSES A`), so the caller must
+ * swap source/target. Types with no clean canonical equivalent are omitted
+ * → `mapToCanonicalEdge` returns null and the caller skips the edge rather
+ * than emit a wrong type. Extend deliberately as the vocabularies converge.
+ */
+const LOWERCASE_TO_CANONICAL_EDGE: Record<string, { type: string; flip: boolean }> = {
+  // LLM relationship-extractor (EXTRACTOR_ALLOWLIST)
+  caused_by: { type: "CAUSES", flip: true },
+  resolved_by: { type: "RESOLVED_BY", flip: false },
+  feeds: { type: "UPSTREAM_OF", flip: false },
+  requires_part: { type: "HAS_PART", flip: false },
+  triggered_pm: { type: "TRIGGERS", flip: false },
+  had_fault: { type: "HAS_FAILURE_MODE", flip: false },
+  // conversation extractor
+  mentioned_tag: { type: "HAS_SIGNAL", flip: false },
+  exhibited_fault: { type: "HAS_FAILURE_MODE", flip: false },
+  // CMMS sync
+  located_at: { type: "LOCATED_IN", flip: false },
+  has_pm: { type: "HAS_PROCEDURE", flip: false },
+  // hierarchy backfill (area → equipment: the parent HAS_COMPONENT the child)
+  parent_of: { type: "HAS_COMPONENT", flip: false },
+  // other types.ts vocabulary
+  has_component: { type: "HAS_COMPONENT", flip: false },
+  electrically_connected: { type: "WIRED_TO", flip: false },
+  references_drawing: { type: "REFERENCES", flip: false },
+  similar_to: { type: "SIMILAR_TO", flip: false },
+  // No clean canonical equivalent yet (skip + warn until added to the CHECK):
+  //   has_work_order, controls, protects, maintained_by
+};
+
+/**
+ * Resolve any relationship type to a canonical proposal edge. Already-canonical
+ * types pass through unflipped; known lowercase types map; everything else
+ * returns null (caller skips).
+ */
+export function mapToCanonicalEdge(
+  rawType: string,
+): { type: string; flip: boolean } | null {
+  if (isCanonicalProposalRelationshipType(rawType)) return { type: rawType, flip: false };
+  return LOWERCASE_TO_CANONICAL_EDGE[rawType] ?? null;
+}
+
 export interface InferredEvidence {
   evidenceType: string; // must be in relationship_evidence CHECK (e.g. 'manifest','work_order')
   sourceDescription?: string;

--- a/mira-hub/src/lib/knowledge-graph/queries.ts
+++ b/mira-hub/src/lib/knowledge-graph/queries.ts
@@ -1,4 +1,5 @@
 import { withTenantContext } from "@/lib/tenant-context";
+import { upsertInferredProposal } from "./proposals-writer";
 import type { KGEntity, KGRelationship, KGTriple } from "./types";
 
 function rowToEntity(row: Record<string, unknown>): KGEntity {
@@ -229,16 +230,24 @@ export interface SchematicUpsertPayload {
 
 export interface SchematicUpsertResult {
   entities_upserted: number;
+  /** Kept for API back-compat. Schematic edges are now proposed, not verified — always 0. See relationships_proposed. */
   relationships_inserted: number;
+  /** Number of inferred relationship_proposals created (pending human review). */
+  relationships_proposed: number;
   parent_equipment_id: string | null;
   schematic_type: string;
 }
 
 /**
- * Bulk-upsert the entities + relationships produced by the schematic
- * intelligence pipeline (mira-mcp/schematic_intelligence.py). Idempotent on
- * entities (ON CONFLICT updates) and best-effort dedup on relationships
- * (skip when an identical source/target/type triple already exists).
+ * Bulk-upsert the entities produced by the schematic intelligence pipeline
+ * (mira-mcp/schematic_intelligence.py), and PROPOSE its relationships.
+ *
+ * Per the Iron Rule (.claude/skills/managing-the-knowledge-graph, ADR-0017),
+ * a schematic-extracted edge is INFERRED by MIRA — it is never written
+ * straight to kg_relationships as a verified fact. Each edge lands as a
+ * `relationship_proposals` row (via upsertInferredProposal) for human review;
+ * the verified edge is written only on admin approval (proposals/[id]/decide).
+ * Entity upserts are unchanged (nodes), and proposal writes are idempotent.
  */
 export async function upsertSchematicComponents(
   tenantId: string,
@@ -246,6 +255,7 @@ export async function upsertSchematicComponents(
 ): Promise<SchematicUpsertResult> {
   return withTenantContext(tenantId, async (client) => {
     const idByEntityId = new Map<string, string>();
+    const typeByEntityId = new Map<string, string>();
     let entitiesUpserted = 0;
 
     for (const ent of payload.entities) {
@@ -268,39 +278,46 @@ export async function upsertSchematicComponents(
       );
       const internalId = (rows[0] as Record<string, unknown>).id as string;
       idByEntityId.set(ent.entity_id, internalId);
+      typeByEntityId.set(ent.entity_id, ent.entity_type);
       entitiesUpserted++;
     }
 
-    let relationshipsInserted = 0;
+    const schematicLabel = payload.schematic_type ?? "schematic";
+    let relationshipsProposed = 0;
     for (const rel of payload.relationships) {
       const sourceInternalId = idByEntityId.get(rel.source_entity_id);
       const targetInternalId = idByEntityId.get(rel.target_entity_id);
       if (!sourceInternalId || !targetInternalId) continue;
-      const { rowCount } = await client.query(
-        `INSERT INTO kg_relationships
-           (tenant_id, source_id, target_id, relationship_type, properties, confidence)
-         SELECT $1, $2, $3, $4, $5, 1.0
-         WHERE NOT EXISTS (
-           SELECT 1 FROM kg_relationships
-           WHERE tenant_id = $1
-             AND source_id = $2
-             AND target_id = $3
-             AND relationship_type = $4
-         )`,
-        [
-          tenantId,
-          sourceInternalId,
-          targetInternalId,
-          rel.relationship_type,
-          JSON.stringify(rel.properties ?? {}),
+
+      const rawConfidence = Number((rel.properties as Record<string, unknown>)?.confidence);
+      const confidence =
+        Number.isFinite(rawConfidence) && rawConfidence > 0 && rawConfidence <= 1
+          ? rawConfidence
+          : 0.8;
+
+      const proposalId = await upsertInferredProposal(client, tenantId, {
+        sourceEntityId: sourceInternalId,
+        sourceEntityType: typeByEntityId.get(rel.source_entity_id) ?? "entity",
+        targetEntityId: targetInternalId,
+        targetEntityType: typeByEntityId.get(rel.target_entity_id) ?? "entity",
+        relationshipType: rel.relationship_type,
+        confidence,
+        reasoning: `Inferred from ${schematicLabel} (schematic intelligence pipeline).`,
+        evidence: [
+          {
+            evidenceType: "document_page",
+            sourceDescription: `${schematicLabel} schematic`,
+            confidenceContribution: confidence,
+          },
         ],
-      );
-      if (rowCount && rowCount > 0) relationshipsInserted++;
+      });
+      if (proposalId) relationshipsProposed++;
     }
 
     return {
       entities_upserted: entitiesUpserted,
-      relationships_inserted: relationshipsInserted,
+      relationships_inserted: 0,
+      relationships_proposed: relationshipsProposed,
       parent_equipment_id: payload.parent_equipment_id ?? null,
       schematic_type: payload.schematic_type ?? "unknown",
     };

--- a/mira-hub/src/lib/knowledge-graph/relationship-extractor.ts
+++ b/mira-hub/src/lib/knowledge-graph/relationship-extractor.ts
@@ -11,8 +11,10 @@
  *  - Endpoints must reference an entity from the supplied list. Any
  *    relationship referencing an unknown entity is dropped.
  *  - confidence < HIGH_CONFIDENCE_THRESHOLD goes to triples log only.
- *  - confidence >= HIGH_CONFIDENCE_THRESHOLD is also written as a structured
- *    relationship (kg_relationships).
+ *  - confidence >= HIGH_CONFIDENCE_THRESHOLD is PROPOSED for human review
+ *    (relationship_proposals via upsertInferredProposal) — never written
+ *    directly to kg_relationships (Iron Rule, ADR-0017). The lowercase
+ *    predicate is mapped to canonical first.
  *
  * Cost: per-conversation, fire-and-forget after the diagnostic conversation
  * closes (resolved decision §12 #5). Uses the same cascade as chat.
@@ -21,6 +23,7 @@
 import pool from "@/lib/db";
 import type { PoolClient } from "pg";
 import { cascadeComplete } from "@/lib/llm/cascade";
+import { mapToCanonicalEdge, upsertInferredProposal } from "./proposals-writer";
 import { isRelationshipType } from "./types";
 
 // Subset of relationship types the LLM is allowed to emit. We deliberately
@@ -263,26 +266,34 @@ export async function extractRelationships(
         );
         storedTriples++;
 
-        // Promote to structured relationship only above the threshold AND
-        // when both endpoints actually exist in the KG.
+        // Above the threshold AND with both endpoints in the KG, PROPOSE the
+        // edge for human review (Iron Rule: an LLM-inferred edge is never an
+        // auto-verified kg_relationships row). The lowercase predicate is
+        // mapped to canonical; unmapped types are skipped (mapToCanonicalEdge
+        // returns null). Below threshold stays triple-only.
         if (v.confidence >= HIGH_CONFIDENCE_THRESHOLD && src && tgt) {
-          await client.query(
-            `INSERT INTO kg_relationships
-               (tenant_id, source_id, target_id, relationship_type,
-                confidence, source_conversation_id, properties)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
-             ON CONFLICT DO NOTHING`,
-            [
-              tenantId,
-              src.id,
-              tgt.id,
-              v.predicate,
-              v.confidence,
-              conversationId,
-              JSON.stringify({ extractor: "llm", llm_provider: result.provider }),
-            ],
-          );
-          storedRelationships++;
+          const edge = mapToCanonicalEdge(v.predicate);
+          if (edge) {
+            const source = edge.flip ? tgt : src;
+            const target = edge.flip ? src : tgt;
+            const proposalId = await upsertInferredProposal(client, tenantId, {
+              sourceEntityId: source.id,
+              sourceEntityType: source.entity_type,
+              targetEntityId: target.id,
+              targetEntityType: target.entity_type,
+              relationshipType: edge.type,
+              confidence: v.confidence,
+              reasoning: `LLM relationship extraction (${result.provider}) from conversation ${conversationId ?? "?"} — original predicate "${v.predicate}".`,
+              evidence: [
+                {
+                  evidenceType: "technician_note",
+                  sourceDescription: `Diagnostic conversation ${conversationId ?? "(none)"}`,
+                  confidenceContribution: v.confidence,
+                },
+              ],
+            });
+            if (proposalId) storedRelationships++;
+          }
         }
       }
     });


### PR DESCRIPTION
First vertical slice of #1721 (hub relationship writers must propose by default) — the TypeScript follow-up to the Python-side #1716. Built + verified on **BRAVO**.

## Doctrine
Per `.claude/skills/managing-the-knowledge-graph` Iron Rule + ADR-0017: **no MIRA-inferred edge is ever written directly to `kg_relationships`.** It lands as a `relationship_proposals` row for human review; the verified edge is written only on admin approval (`proposals/[id]/decide`). The hub is **stricter than Python** — there is no `autoverify` escape hatch for inferred edges.

## What this does
- **`upsertSchematicComponents`** (the issue-named, clearly-inferred writer) — schematic-extracted edges were inserted into `kg_relationships` at confidence 1.0. They now route through the existing **`upsertInferredProposal`** path (proposal + evidence, idempotent). Entity nodes still upserted; only edges become proposals.
- **Central guard in `upsertInferredProposal`** — new `CANONICAL_PROPOSAL_RELATIONSHIP_TYPES` (the `relationship_proposals` CHECK vocabulary, migrations 018→028→032). A non-canonical type is **skipped with a warning** instead of throwing a CHECK violation that silently drops the edge. Single TS source of truth for the propose vocabulary; existing callers unaffected.

## ⚠️ Behavioral change
The schematic intelligence pipeline (`mira-mcp/schematic_intelligence.py`) will now see edges as **proposals** in `/proposals`, not auto-verified `kg_relationships`. The HTTP result field `relationships_inserted` is now always `0`; consumers should read `relationships_proposed`.

## Verification
- **vitest** — 4 new tests (`queries-schematic.test.ts`): canonical edge → proposal not `kg_relationships`; non-canonical skipped; missing-endpoint skipped; entities still upserted. 35/35 in affected suites.
- **eslint** clean on changed files; **tsc** clean on changed files (pre-existing unrelated typecheck errors in `namespace/tree`, `rls-deny`, `command-center-freshness` are not touched).
- **Staging smoke** on `factorylm/stg` (real `upsertInferredProposal` path, throwaway tenant, self-clean): `proposals=1 evidence=1 kg_relationships=0`, idempotent, guard skips non-canonical.

## Scope / deferred (#1721 stays OPEN)
Audit doc `mira-hub/docs/audits/2026-06-05-hub-relationship-writers-1721.md` classifies every hub writer. Remaining:
- `relationship-extractor.ts` (LLM `confidence ≥ threshold → INSERT` anti-pattern) → propose
- `extractor.ts` (conversation) → propose
- `cmms-sync.ts` — **blocked**: emits `has_work_order`, not in the proposals CHECK → needs a CHECK migration or canonical map
- `hierarchy-backfill.ts` — **decision recorded: inferred → propose** (heuristic location match); **blocked**: `parent_of` not in CHECK → map to `LOCATED_IN` or extend CHECK
- `queries.ts::createRelationship` — dead code (0 callers), remove in follow-up

Related: CI audit guard #1722, ADR-0017 canary #1723. Does not depend on #1716 merging (separate service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)