### PR TITLE
fix(engine): guard DST dispatch against IDLE reset in all active diagnostic states

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -1595,9 +1595,19 @@ class Supervisor:
                     chat_id, message, state, trace_id, _target
                 )
 
-            if _router_intent == "general_question" and _keyword_intent not in (
-                "safety",
-                "documentation",
+            # Guard: when already in an active diagnostic session and the keyword
+            # classifier sees industrial intent, don't pull the turn out to a
+            # generic/instructional handler — fall through to the RAG diagnostic
+            # path instead. This prevents the LLM router from forcing IDLE on
+            # diagnostic follow-ups like "what should I check first?" that lack
+            # explicit session-followup signals ("you said", "earlier", etc.).
+            _in_active_diagnostic = state["state"] in ACTIVE_DIAGNOSTIC_STATES
+            _router_industrial_override = _in_active_diagnostic and _keyword_intent == "industrial"
+
+            if (
+                _router_intent == "general_question"
+                and _keyword_intent not in ("safety", "documentation")
+                and not _router_industrial_override
             ):
                 return await self._handle_general_question(
                     chat_id, message, state, trace_id, tenant_id=resolved_tenant
@@ -1608,7 +1618,10 @@ class Supervisor:
 
             # Procedural how-to questions: answer from knowledge, skip doc crawl.
             # Keyword "instructional" also routes here via the fallback mapping above.
-            if _router_intent == "answer_question" or _keyword_intent == "instructional":
+            # Guard: same override — industrial turns in active sessions fall through to RAG.
+            if (
+                _router_intent == "answer_question" or _keyword_intent == "instructional"
+            ) and not _router_industrial_override:
                 if detect_session_followup(message, sc, state["state"]):
                     return await self._handle_session_followup(
                         message,
@@ -4159,9 +4172,19 @@ class Supervisor:
                 return None
 
         # Priority 6 — questions
+        # Guard: when the FSM is in any active diagnostic state (Q1+), don't pull
+        # the turn out to an instructional/general handler that resets FSM to IDLE.
+        # Fall through to None so the legacy RAG path continues the session.
+        # This mirrors the _router_industrial_override guard in the LLM router
+        # block — DST can intercept before that guard fires when MIRA_USE_DST=1.
+        _dst_in_active = state.get("state") in ACTIVE_DIAGNOSTIC_STATES
         if kind == DISPATCH_ASK_PROCEDURAL:
+            if _dst_in_active:
+                return None
             return await self._handle_instructional_question(chat_id, message, state, trace_id)
         if kind == DISPATCH_ASK_GENERAL:
+            if _dst_in_active:
+                return None
             return await self._handle_general_question(
                 chat_id, message, state, trace_id, tenant_id=resolved_tenant
             )

--- a/mira-bots/tests/test_engine.py
+++ b/mira-bots/tests/test_engine.py
@@ -9,10 +9,14 @@ import sys
 
 sys.path.insert(0, "mira-bots")
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from shared.engine import _FAULT_INFO_RE, _STATE_ALIASES, Supervisor
+from shared.dialogue_tracker import (
+    DISPATCH_ASK_GENERAL,
+    DISPATCH_ASK_PROCEDURAL,
+)
 
 # ---------------------------------------------------------------------------
 # Fixture: minimal Supervisor with mocked workers
@@ -865,3 +869,67 @@ class TestResetWipesAllChatKeys:
         supervisor.reset("legacy_chat_id")
         reloaded = supervisor._load_state("legacy_chat_id")
         assert reloaded.get("asset_identified") in (None, "")
+
+
+# ---------------------------------------------------------------------------
+# DST guard — active-session ASK_PROCEDURAL/GENERAL must not reset FSM
+# ---------------------------------------------------------------------------
+
+
+class TestDSTActiveSessionGuard:
+    """Regression guard for the DST-bypass bug (MIRA_USE_DST=1).
+
+    When DISPATCH_ASK_PROCEDURAL or DISPATCH_ASK_GENERAL fires while the
+    FSM is in {Q2, Q3, DIAGNOSIS, FIX_STEP}, _maybe_dispatch_via_dst must
+    return None so the legacy RAG path continues the in-progress session.
+    Calling _handle_instructional_question/_handle_general_question from
+    those states resets the FSM to IDLE (via _clear_diagnostic_carryover),
+    which caused gs3_ground_fault_14 and self_critique_low_instruction_35
+    to land in IDLE instead of DIAGNOSIS in the eval.
+    """
+
+    def _state(self, fsm_state: str) -> dict:
+        return {
+            "state": fsm_state,
+            "exchange_count": 1,
+            "final_state": None,
+            "fault_category": None,
+            "asset_identified": "AutomationDirect GS3",
+            "context": {"session_context": {"last_question": "Check the insulation?"}},
+        }
+
+    def _mock_plan(self, kind: str):
+        plan = MagicMock()
+        plan.kind = kind
+        return plan
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("fsm_state", ["Q1", "Q2", "Q3", "DIAGNOSIS", "FIX_STEP"])
+    @pytest.mark.parametrize(
+        "dispatch_kind", [DISPATCH_ASK_PROCEDURAL, DISPATCH_ASK_GENERAL]
+    )
+    async def test_active_session_returns_none(
+        self, supervisor, fsm_state, dispatch_kind
+    ):
+        """All active diagnostic states (Q1+) must return None, not call an IDLE-resetting handler."""
+        from shared.dialogue_state import DialogueState
+        from unittest.mock import MagicMock
+
+        state = self._state(fsm_state)
+        ds = MagicMock(spec=DialogueState)
+        new_ds = MagicMock(spec=DialogueState)
+        new_ds.write_to_engine_state = MagicMock()
+        plan = self._mock_plan(dispatch_kind)
+
+        with patch("shared.engine.DialogueState") as mock_ds_cls, patch(
+            "shared.engine.track_turn", new=AsyncMock(return_value=(new_ds, plan))
+        ):
+            mock_ds_cls.from_engine_state.return_value = ds
+            result = await supervisor._maybe_dispatch_via_dst(
+                "chat1", "what should I check?", state, "trace1", {}, None
+            )
+
+        assert result is None, (
+            f"DST returned a non-None result for {dispatch_kind} in {fsm_state} — "
+            "this would reset FSM to IDLE via _handle_instructional_question"
+        )


### PR DESCRIPTION
## Problem

`MIRA_USE_DST=1` causes `_maybe_dispatch_via_dst` to run **before** the LLM router's `_router_industrial_override` guard. When DST classified a turn as `DISPATCH_ASK_PROCEDURAL` or `DISPATCH_ASK_GENERAL` inside an active diagnostic session, it called `_handle_instructional_question` / `_handle_general_question`, both of which call `_clear_diagnostic_carryover(target_state="IDLE")`, resetting the FSM mid-session.

This caused eval failures:
- `self_critique_low_instruction_35`: FSM hit Q2, DST intercepted a "what is X" follow-up, reset to IDLE → landed in IDLE instead of DIAGNOSIS
- `gs3_ground_fault_14` FSM checkpoint: same mechanism at Q1
- `self_critique_low_groundedness_34`, `asset_change_mid_session_08`, `reset_new_session_09`: related session-continuity failures

A narrow guard (Q2+ only) was tried but left Q1 unguarded, causing `self_crit_inst` to regress. Eval confirmed: broad guard gives **45/57**, narrow gives **43/57**.

## Fix

In `_maybe_dispatch_via_dst`, Priority 6 now guards against `ACTIVE_DIAGNOSTIC_STATES` (Q1/Q2/Q3/DIAGNOSIS/FIX_STEP) — returns `None` for both `DISPATCH_ASK_PROCEDURAL` and `DISPATCH_ASK_GENERAL` when the FSM is in any active state, falling through to the legacy RAG path.

## Changes

- `mira-bots/shared/engine.py`: Replace `_DEEP_DIAG_STATES`/`_dst_in_deep` with `ACTIVE_DIAGNOSTIC_STATES`/`_dst_in_active` in `_maybe_dispatch_via_dst` Priority 6 block
- `mira-bots/tests/test_engine.py`: Extend parametrized guard test to include Q1 (5 states × 2 dispatch kinds = 10 cases); remove `test_q1_state_not_guarded` which asserted the wrong behavior

## Test plan

- [x] `pytest tests/test_engine.py -k TestDSTActiveSessionGuard` — 10/10 passed
- [x] `pytest tests/test_engine.py tests/test_guardrails.py -q` — 155 passed, 1 pre-existing unrelated failure (`test_explicit_recap_still_uses_session_followup`)
- [x] Eval run T1339 (broad guard): **45/57** — vs 43/57 baseline (T1426, narrow guard) and 42/57 without any guard

## Known follow-ups (out of scope)

- `vfd_mitsu_03_a700_parameter` Q1 parameter-lookup reset — not a named A1 target; requires separate analysis
- `gs3_ground_fault_14` + `pf40_undervoltage_21` keyword failures — `_build_clarification_request` example list includes "Rockwell"/"PowerFlex"; separate fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)