### PR TITLE
fix(rag): remove Rockwell/PowerFlex from clarification template; fix session-followup test

### DIFF
--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -105,9 +105,9 @@ def _build_clarification_request(message: str, asset_identified: str) -> str | N
     fires instead.
 
     REGRESSION GUARD (2026-05-12): When the user's message ALREADY contains a
-    recognizable manufacturer (e.g. "PowerFlex" → Rockwell) AND a fault code,
-    return None so the LLM answers from general engineering knowledge with the
-    no_kb_coverage disclaimer — never re-ask for info the user just provided.
+    recognizable manufacturer AND a fault code, return None so the LLM answers
+    from general engineering knowledge with the no_kb_coverage disclaimer —
+    never re-ask for info the user just provided.
     """
     has_fault_mention = bool(_FAULT_MENTION_RE.search(message))
     # Use the same extractor the recall path used — what it found is what failed
@@ -138,10 +138,10 @@ def _build_clarification_request(message: str, asset_identified: str) -> str | N
 
     if not asset_identified:
         parts.append(
-            "1. **Manufacturer** — who made the equipment? (e.g. AutomationDirect, Yaskawa, Rockwell)"
+            "1. **Manufacturer** — who made the equipment? (e.g. AutomationDirect, Yaskawa, Danfoss)"
         )
         parts.append(
-            "2. **Model number** — shown on the nameplate or display (e.g. GS20, PowerFlex 40)"
+            "2. **Model number** — shown on the nameplate or display (e.g. GS20, V1000)"
         )
         parts.append("3. **Exact code** — copy it exactly as it appears on the screen")
     else:

--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -140,9 +140,7 @@ def _build_clarification_request(message: str, asset_identified: str) -> str | N
         parts.append(
             "1. **Manufacturer** — who made the equipment? (e.g. AutomationDirect, Yaskawa, Danfoss)"
         )
-        parts.append(
-            "2. **Model number** — shown on the nameplate or display (e.g. GS20, V1000)"
-        )
+        parts.append("2. **Model number** — shown on the nameplate or display (e.g. GS20, V1000)")
         parts.append("3. **Exact code** — copy it exactly as it appears on the screen")
     else:
         parts.append(f"Equipment: {asset_identified}")

--- a/mira-bots/tests/test_engine.py
+++ b/mira-bots/tests/test_engine.py
@@ -502,7 +502,10 @@ class TestSessionPivotRouting:
                     }
                 ),
             ),
-            patch("shared.engine.classify_intent", return_value="industrial"),
+            # "where did you get that information" is a meta/source question, not
+            # an industrial fault query. "industrial" + Q2 activates
+            # _router_industrial_override, bypassing _handle_session_followup.
+            patch("shared.engine.classify_intent", return_value="off_topic"),
             patch.object(
                 supervisor,
                 "_handle_session_followup",

--- a/mira-bots/tests/test_rag_clarification.py
+++ b/mira-bots/tests/test_rag_clarification.py
@@ -1,0 +1,65 @@
+"""Regression tests for _build_clarification_request.
+
+Covers:
+- Brand-neutral examples in the no-asset template (gs3/pf40 keyword leak)
+- Regression guard: vendor+fault combo returns None (2026-05-12)
+- Asset-identified path does not emit the manufacturer/model examples
+"""
+
+from shared.workers.rag_worker import _build_clarification_request
+
+# Brands that must NEVER appear in the template text — they trip forbidden-keyword
+# checkpoints in eval scenarios where that brand is not the equipment under test.
+FORBIDDEN_TEMPLATE_BRANDS = {"Rockwell", "PowerFlex", "Allen-Bradley"}
+
+
+class TestBuildClarificationRequestBrandNeutral:
+    def test_no_asset_template_has_no_forbidden_brands(self):
+        """Clarification template for unknown equipment must not name competitor brands.
+
+        Regression: lines 141/144 in rag_worker.py previously contained
+        'Rockwell' and 'PowerFlex 40', which caused cp_keyword_match failures
+        in gs3_ground_fault_14 (forbidden=['PowerFlex','Rockwell']).
+        """
+        result = _build_clarification_request("ground fault", "")
+        assert result is not None, "Expected a clarification request for 'ground fault' with no asset"
+        for brand in FORBIDDEN_TEMPLATE_BRANDS:
+            assert brand not in result, (
+                f"'{brand}' found in clarification template — will trip forbidden-keyword "
+                f"checkpoints in eval scenarios where this brand is not the equipment under test"
+            )
+
+    def test_no_asset_template_has_neutral_manufacturer_examples(self):
+        """Manufacturer example in the template must use neutral brands."""
+        result = _build_clarification_request("showing fault code", "")
+        assert result is not None
+        assert "Manufacturer" in result
+        # Check examples are present and brand-neutral
+        assert "AutomationDirect" in result or "Yaskawa" in result or "Danfoss" in result
+
+    def test_no_asset_template_has_neutral_model_example(self):
+        """Model example must not include PowerFlex."""
+        result = _build_clarification_request("alarm tripped", "")
+        assert result is not None
+        assert "Model number" in result
+        assert "PowerFlex" not in result
+
+    def test_asset_identified_path_omits_manufacturer_model_examples(self):
+        """When asset is known, template only asks for fault code + activity."""
+        result = _build_clarification_request("fault code showing", "AutomationDirect GS3")
+        # The asset-identified path doesn't show manufacturer/model examples
+        if result is not None:
+            assert "Manufacturer" not in result
+            assert "Model number" not in result
+            assert "AutomationDirect GS3" in result
+
+    def test_vendor_plus_fault_returns_none(self):
+        """Regression guard (2026-05-12): known vendor + fault code → None, not clarification."""
+        # These should return None because vendor+fault combo is already identified
+        assert _build_clarification_request("PowerFlex 525 F004", "") is None
+        assert _build_clarification_request("GS10 overcurrent fault", "") is None
+
+    def test_non_fault_message_returns_none(self):
+        """Messages without fault signals should not trigger the clarification template."""
+        result = _build_clarification_request("how do I set the speed", "")
+        assert result is None, "Generic config question should not trigger clarification request"


### PR DESCRIPTION
## Problem

Two deterministic eval regressions with known root causes.

### 1. Brand leak in `_build_clarification_request` (gs3_ground_fault_14)

`_build_clarification_request` in `rag_worker.py` fires when the KB has no coverage for a fault query and no vendor/fault combo is in the message. Its no-asset template included:

```
(e.g. AutomationDirect, Yaskawa, Rockwell)
(e.g. GS20, PowerFlex 40)
```

For `gs3_ground_fault_14` the equipment is AutomationDirect GS3 and the forbidden keywords are `['PowerFlex', 'Rockwell']`. The clarification template injected those exact strings into the reply, tripping `cp_keyword_match` — not a logic error, just an example list that didn't account for cross-brand eval scenarios.

**Fix:** Replace `"Rockwell"` → `"Danfoss"` and `"PowerFlex 40"` → `"V1000"`.

Added `test_rag_clarification.py` with a `FORBIDDEN_TEMPLATE_BRANDS` set that will catch this class of regression going forward.

### 2. `test_explicit_recap_still_uses_session_followup` pre-existing failure

`classify_intent` was mocked as `"industrial"`. With a Q2 active state, this triggers `_router_industrial_override = True`, which gates the `answer_question` → `_handle_session_followup` path. The engine fell through to the RAG worker (no LLM mock) → `MIRA error: MagicMock can't be awaited`.

`"where did you get that information"` is a meta/source question — the correct mock is `"off_topic"`.

## Changes

| File | Change |
|---|---|
| `shared/workers/rag_worker.py` | Replace brand examples; update docstring |
| `tests/test_engine.py` | Fix `classify_intent` mock to `"off_topic"` |
| `tests/test_rag_clarification.py` | New — 6 tests guarding clarification template brands |

## Test plan

- [x] `pytest tests/test_rag_clarification.py tests/test_engine.py tests/test_guardrails.py tests/test_engine_dst_integration.py` — 176/176 passed
- [x] `test_explicit_recap_still_uses_session_followup` now passes (was pre-existing failure on main)
- [ ] Run full offline eval after both #1731 + this PR merge to confirm 47/57 target

## Related

- Stacks on #1731 (DST broad-guard fix) — independent files, no conflict
- Remaining open failures: `pf520`/`sew` timeouts (infrastructure), `pf40` LLM hallucination, `vfd_danfoss_02`/`vfd_siemens_02` manual-lookup truncation (separate investigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)