### PR TITLE
ci(kg): audit guard for unguarded kg_relationships inserts (#1722)

### DIFF
--- a/.github/workflows/kg-write-guard.yml
+++ b/.github/workflows/kg-write-guard.yml
@@ -1,0 +1,31 @@
+name: KG Write Guard
+
+# Fails when a NEW unguarded `INSERT INTO kg_relationships` is introduced.
+# MIRA-inferred edges must PROPOSE (ADR-0017); the allowlist
+# (scripts/kg_write_guard_allowlist.txt) holds the known/legitimate sites.
+
+on:
+  pull_request:
+    branches: [main, develop, dev]
+    paths:
+      - "**/*.py"
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.sql"
+      - "scripts/kg_write_guard.py"
+      - "scripts/kg_write_guard_allowlist.txt"
+      - ".github/workflows/kg-write-guard.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  kg-write-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: No unguarded kg_relationships inserts
+        run: python3 scripts/kg_write_guard.py --list

--- a/scripts/kg_write_guard.py
+++ b/scripts/kg_write_guard.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""CI guard — no NEW unguarded `INSERT INTO kg_relationships`.
+
+The doctrine (`.claude/CLAUDE.md` § "Knowledge graph proposals", ADR-0017,
+`.claude/skills/managing-the-knowledge-graph`): MIRA proposes, a human
+verifies. A MIRA-inferred edge must NOT be written straight to
+`kg_relationships` — it goes through the propose path
+(`mira-crawler/ingest/proposal_writer.py` /
+`mira-hub/.../proposals-writer.ts::upsertInferredProposal`). The only
+verified write is the human-approval decide route.
+
+This guard scans the tree for direct `kg_relationships` inserts and fails if
+any appear in a file NOT on the allowlist
+(`scripts/kg_write_guard_allowlist.txt`). The allowlist is the baseline of
+known/legitimate sites: the decide route, the flag-gated ingest branches,
+the not-yet-migrated hub writers (#1721), seeds, and tests. A NEW writer must
+either propose, or be added to the allowlist with a justification reviewers
+can see in the diff.
+
+Match is case-insensitive and whitespace-normalized, so reformatting an
+existing line doesn't trip it. Pure stdlib; runnable locally:
+
+    python3 scripts/kg_write_guard.py            # scan, exit 1 on violations
+    python3 scripts/kg_write_guard.py --list     # print every insert site + status
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+# `insert into kg_relationships`, tolerant of run-together whitespace/newlines
+# and case. The table name + INSERT INTO sit on one line in every real site.
+_INSERT_RE = re.compile(r"insert\s+into\s+kg_relationships\b", re.IGNORECASE)
+
+_SCAN_SUFFIXES = {".py", ".ts", ".tsx", ".sql"}
+_SKIP_DIRS = {
+    "node_modules", ".git", ".next", "dist", "build", ".venv", "venv",
+    "__pycache__", ".turbo", "coverage", ".pytest_cache",
+}
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ALLOWLIST_PATH = REPO_ROOT / "scripts" / "kg_write_guard_allowlist.txt"
+
+
+def load_allowlist(path: Path = ALLOWLIST_PATH) -> set[str]:
+    """Repo-relative paths permitted to contain a direct kg_relationships
+    insert. Blank lines and `#` comments are ignored."""
+    allow: set[str] = set()
+    if not path.exists():
+        return allow
+    for line in path.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line:
+            allow.add(line)
+    return allow
+
+
+def _scan_file(p: Path) -> bool:
+    try:
+        text = p.read_text(errors="ignore")
+    except OSError:
+        return False
+    return bool(_INSERT_RE.search(text))
+
+
+def find_insert_sites(root: Path = REPO_ROOT) -> list[str]:
+    """All repo-relative paths (sorted) containing a direct kg_relationships
+    insert."""
+    hits: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS]
+        for name in filenames:
+            p = Path(dirpath) / name
+            if p.suffix not in _SCAN_SUFFIXES:
+                continue
+            if _scan_file(p):
+                hits.append(p.relative_to(root).as_posix())
+    return sorted(hits)
+
+
+def find_violations(root: Path = REPO_ROOT, allowlist: set[str] | None = None) -> list[str]:
+    """Insert sites that are NOT on the allowlist."""
+    allow = load_allowlist() if allowlist is None else allowlist
+    return [s for s in find_insert_sites(root) if s not in allow]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--list", action="store_true", help="print every insert site + allow/VIOLATION status")
+    args = ap.parse_args(argv)
+
+    allow = load_allowlist()
+    sites = find_insert_sites()
+    violations = [s for s in sites if s not in allow]
+
+    if args.list:
+        for s in sites:
+            print(f"  {'allow' if s in allow else 'VIOLATION'}  {s}")
+
+    if violations:
+        print(
+            "\n❌ kg-write-guard: new unguarded `INSERT INTO kg_relationships` "
+            f"in {len(violations)} file(s):",
+            file=sys.stderr,
+        )
+        for v in violations:
+            print(f"   - {v}", file=sys.stderr)
+        print(
+            "\nMIRA-inferred edges must PROPOSE (proposal_writer.py / "
+            "upsertInferredProposal), not write kg_relationships directly "
+            "(ADR-0017). If this write is the human-approval path or a "
+            "flag-gated/seed/test site, add it to "
+            "scripts/kg_write_guard_allowlist.txt with a one-line reason.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"✅ kg-write-guard: {len(sites)} insert site(s), all allowlisted.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/kg_write_guard_allowlist.txt
+++ b/scripts/kg_write_guard_allowlist.txt
@@ -1,0 +1,35 @@
+# kg-write-guard allowlist — repo-relative paths permitted to contain a direct
+# `INSERT INTO kg_relationships`. Everything else must PROPOSE (ADR-0017).
+# A new entry needs a one-line reason reviewers can see in the diff.
+#
+# Baseline captured 2026-06-05 (#1722). As writers migrate to the propose
+# path (#1721), their inserts disappear — leaving an allowlisted file with no
+# insert is harmless; prune opportunistically.
+
+# --- The one legitimate verified write: human approval on the Hub ---
+mira-hub/src/app/api/proposals/[id]/decide/route.ts        # admin "verify" decision writes the verified edge
+
+# --- Flag-gated legacy auto-verify (default OFF, MIRA_KG_INGEST_AUTOVERIFY) ---
+mira-crawler/ingest/kg_writer.py                            # _autoverify_relationship — gated opt-in (#1716)
+mira-crawler/tasks/full_ingest_pipeline.py                 # _write_kg_edge — gated opt-in (#1716)
+
+# --- Technician-confirmation path (human-gated, mira-connect) ---
+mira-connectors/mira_connectors/store.py                   # confirmation_gate verified write on technician confirm
+
+# --- Not-yet-migrated hub writers (tracked by #1721; migrate → remove) ---
+mira-hub/src/lib/knowledge-graph/cmms-sync.ts              # TODO #1721 (blocked: has_work_order not in CHECK)
+mira-hub/src/lib/knowledge-graph/extractor.ts              # TODO #1721 (conversation extractor)
+mira-hub/src/lib/knowledge-graph/hierarchy-backfill.ts     # TODO #1721 (parent_of → LOCATED_IN decision)
+
+# --- Migrated in #1729; inserts removed once merged (allow until then) ---
+mira-hub/src/lib/knowledge-graph/queries.ts                # upsertSchematicComponents now proposes (#1729)
+mira-hub/src/lib/knowledge-graph/relationship-extractor.ts # now proposes (#1729)
+
+# --- The guard itself (contains the pattern as a regex / fixtures) ---
+scripts/kg_write_guard.py                                  # the guard's own matcher
+tests/test_kg_write_guard.py                               # the guard's own fixtures
+
+# --- Seeds + tests (not runtime inference) ---
+mira-hub/scripts/seed-synthetic-users.ts                   # synthetic seed data
+mira-hub/src/app/api/proposals/[id]/decide/__tests__/route.test.ts  # asserts the decide route's insert
+tools/seeds/demo-conveyor-001.sql                          # demo seed (commented inserts)

--- a/tests/test_kg_write_guard.py
+++ b/tests/test_kg_write_guard.py
@@ -1,0 +1,45 @@
+"""Tests for the kg-write-guard CI check (#1722)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import kg_write_guard as g  # noqa: E402
+
+
+def test_repo_is_clean_against_committed_allowlist():
+    """Every direct kg_relationships insert in the tree is allowlisted."""
+    violations = g.find_violations()
+    assert violations == [], (
+        "Unguarded kg_relationships inserts found — propose instead, or "
+        f"allowlist with a reason: {violations}"
+    )
+
+
+def test_detects_new_unguarded_insert(tmp_path):
+    (tmp_path / "rogue_worker.ts").write_text(
+        "await client.query(`INSERT INTO kg_relationships (a) VALUES (1)`);\n"
+    )
+    violations = g.find_violations(root=tmp_path, allowlist=set())
+    assert "rogue_worker.ts" in violations
+
+
+def test_allowlisted_file_is_not_flagged(tmp_path):
+    (tmp_path / "ok.ts").write_text("INSERT INTO kg_relationships ...\n")
+    assert g.find_violations(root=tmp_path, allowlist={"ok.ts"}) == []
+
+
+def test_match_is_case_and_whitespace_insensitive(tmp_path):
+    (tmp_path / "x.py").write_text("cur.execute('Insert    INTO     kg_relationships ...')\n")
+    assert "x.py" in g.find_violations(root=tmp_path, allowlist=set())
+
+
+def test_skips_node_modules_and_non_source(tmp_path):
+    nm = tmp_path / "node_modules" / "pkg"
+    nm.mkdir(parents=True)
+    (nm / "index.ts").write_text("INSERT INTO kg_relationships ...\n")
+    (tmp_path / "notes.md").write_text("INSERT INTO kg_relationships ...\n")
+    assert g.find_insert_sites(root=tmp_path) == []


### PR DESCRIPTION
Closes #1722. The **keystone** that locks the propose-by-default invariant from #1716 (Python ingest) + #1729 (hub writers): a NEW direct `INSERT INTO kg_relationships` fails CI unless allowlisted. Built + verified on **BRAVO**, zero collision (new files only).

## Why
MIRA-inferred edges must **propose** (ADR-0017, managing-the-knowledge-graph Iron Rule); the only verified write is the human-approval decide route. Without a guard, a future writer can silently re-introduce auto-verify — undoing #1716/#1729.

## What
- **`scripts/kg_write_guard.py`** — stdlib-only scanner. Case-insensitive, whitespace-normalized match; prunes `node_modules`/build dirs; scans `.py/.ts/.tsx/.sql`. Importable core + `--list` CLI.
- **`scripts/kg_write_guard_allowlist.txt`** — baseline of known/legitimate sites, each with a one-line reason (decide route, flag-gated ingest branches, technician-confirmation path, not-yet-migrated hub writers #1721, seeds, tests). New entries show up in the diff for reviewers.
- **`.github/workflows/kg-write-guard.yml`** — runs on PRs touching source.
- **`tests/test_kg_write_guard.py`** — 5 tests: repo clean vs allowlist; new insert flagged; allowlisted passes; case/whitespace-insensitive; node_modules/non-source skipped.

## Verification
```
$ python3 scripts/kg_write_guard.py
✅ kg-write-guard: 14 insert site(s), all allowlisted.   (exit 0)
# injected rogue insert →  ❌ ... 1 file(s)   (exit 1)
5/5 tests pass; ruff clean.
```

## Maintenance
As #1721 migrates writers to propose, prune their allowlist entries — the guard then prevents backsliding. Static counterpart to the runtime ADR-0017 canary (#1723).

Related: #1662, #1716, #1729, EPIC #1666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)