### PR TITLE
test(e2e): deflake Namespace inline-create — environment-not-ready vs regression

### DIFF
--- a/mira-hub/tests/e2e/namespace-inline-create.spec.ts
+++ b/mira-hub/tests/e2e/namespace-inline-create.spec.ts
@@ -230,10 +230,12 @@ async function fillKindAndName(
 }
 
 // Module-level flag: did beforeAll complete a working auth + seed?
-// When false, scenarios 1-8 (which depend on a logged-in browser session
-// against a non-empty tenant) skip cleanly instead of producing locator
-// timeouts that masquerade as feature failures. Scenario 9 (regression
-// + API tree shape) always runs since it doesn't need auth.
+// When false, the seed-dependent scenarios (1-5, 7, 10, 11 — which need a
+// logged-in browser session against a non-empty tenant) skip cleanly instead
+// of producing locator timeouts that masquerade as feature failures. The
+// always-run regression/auth canaries (6, 8, 9) still run on a NON-transient
+// failure so a real regression fails clearly; they are skipped only when the
+// failure was transient/env-not-ready (see SETUP_ENV_NOT_READY below).
 let SETUP_OK = false;
 
 // True when beforeAll's auth+seed failed *specifically* because the deployed

--- a/mira-hub/tests/e2e/namespace-inline-create.spec.ts
+++ b/mira-hub/tests/e2e/namespace-inline-create.spec.ts
@@ -236,6 +236,16 @@ async function fillKindAndName(
 // + API tree shape) always runs since it doesn't need auth.
 let SETUP_OK = false;
 
+// True when beforeAll's auth+seed failed *specifically* because the deployed
+// environment returned transient 5xx after retries — a readiness/infra failure,
+// NOT a product regression. retry5xx throws "<label> transient <code>" once it
+// exhausts its attempts on 5xx; we match that signature so the whole suite
+// skips (environment-not-ready) instead of emitting locator timeouts / 5xx
+// assertions that masquerade as namespace-feature regressions. A NON-transient
+// setup failure (e.g. a real 4xx, an empty tree after a 2xx finish, DNS) leaves
+// this false so dependent scenarios still run and fail clearly.
+let SETUP_ENV_NOT_READY = false;
+
 test.beforeAll(async ({ request }) => {
   await register({ request });
   try {
@@ -243,15 +253,34 @@ test.beforeAll(async ({ request }) => {
     await seedWizard(request);
     SETUP_OK = true;
   } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    SETUP_ENV_NOT_READY = /transient \d{3}/.test(msg);
     console.warn(
-      "[beforeAll] auth+seed failed — scenarios 1-8 will skip. Scenario 9 still runs.",
-      e instanceof Error ? e.message : e,
+      SETUP_ENV_NOT_READY
+        ? `[beforeAll] ENVIRONMENT NOT READY — auth+seed hit transient 5xx after retries; ` +
+            `the WHOLE suite will SKIP (this is NOT a product regression — investigate the ` +
+            `deploy/readiness if it persists across runs): ${msg}`
+        : `[beforeAll] auth+seed FAILED (non-transient) — seed-dependent scenarios skip; the ` +
+            `always-run regression checks still run and will FAIL clearly (real regression): ${msg}`,
     );
   }
 });
 
 test.describe("Namespace inline create + doc attach", () => {
   test.beforeEach(async ({ page }) => {
+    // Environment-not-ready gate. If beforeAll's auth+seed hit transient 5xx
+    // after retries, NOTHING in this suite can run meaningfully — there's no
+    // session and the tree never renders. Skip the whole describe as
+    // environment-not-ready rather than letting each scenario emit a locator
+    // timeout (Scenario 9), a 5xx assertion (Scenario 6), or an apiSignIn throw
+    // (Scenario 8) that all masquerade as namespace-feature regressions. When
+    // the env was ready (or setup failed for a NON-transient reason) this flag
+    // is false, so every scenario still runs and real regressions fail clearly.
+    test.skip(
+      SETUP_ENV_NOT_READY,
+      "environment not ready — transient 5xx during auth+seed (see beforeAll log)",
+    );
+
     const title = test.info().title;
     // Scenario 6 (no-session auth check) explicitly does NOT log in.
     // Scenario 8 owns its own context+login (mobile viewport).

--- a/mira-hub/tests/e2e/namespace-inline-create.spec.ts
+++ b/mira-hub/tests/e2e/namespace-inline-create.spec.ts
@@ -233,19 +233,28 @@ async function fillKindAndName(
 // When false, the seed-dependent scenarios (1-5, 7, 10, 11 — which need a
 // logged-in browser session against a non-empty tenant) skip cleanly instead
 // of producing locator timeouts that masquerade as feature failures. The
-// always-run regression/auth canaries (6, 8, 9) still run on a NON-transient
-// failure so a real regression fails clearly; they are skipped only when the
-// failure was transient/env-not-ready (see SETUP_ENV_NOT_READY below).
+// always-run regression/auth canaries (6, 8, 9) still run on a NON-5xx setup
+// failure so a real regression fails clearly; they are skipped only on a
+// 5xx-after-retries (env-not-ready) signature — see SETUP_ENV_NOT_READY below
+// for the precise dividing line and its one known blind spot.
 let SETUP_OK = false;
 
-// True when beforeAll's auth+seed failed *specifically* because the deployed
-// environment returned transient 5xx after retries — a readiness/infra failure,
-// NOT a product regression. retry5xx throws "<label> transient <code>" once it
-// exhausts its attempts on 5xx; we match that signature so the whole suite
-// skips (environment-not-ready) instead of emitting locator timeouts / 5xx
-// assertions that masquerade as namespace-feature regressions. A NON-transient
-// setup failure (e.g. a real 4xx, an empty tree after a 2xx finish, DNS) leaves
-// this false so dependent scenarios still run and fail clearly.
+// True when beforeAll's auth+seed failed with a 5xx-after-retries signature —
+// treated as a readiness/infra failure, NOT a product regression. retry5xx
+// throws "<label> transient <code>" once it exhausts its attempts on 5xx; we
+// match that signature so the whole suite skips (environment-not-ready) instead
+// of emitting locator timeouts / 5xx assertions that masquerade as
+// namespace-feature regressions. A NON-5xx setup failure (a real 4xx, an empty
+// tree after a 2xx finish, a DNS/connection error) leaves this false so
+// dependent scenarios still run and fail clearly.
+//
+// Known blind spot (by design): this matches ANY 5xx-after-retries on a SETUP
+// endpoint (csrf / signin / wizard / tree) — including a *persistent* 5xx
+// regression there, not just a transient blip — so a genuine break of those
+// endpoints would skip silently. The guard against that is (a) the loud
+// "ENVIRONMENT NOT READY" beforeAll log below, and (b) a CI alert on the
+// skip-count. A regression in the create flow itself (POST /api/namespace/node,
+// exercised only inside the tests) is NOT in this blind spot and still fails.
 let SETUP_ENV_NOT_READY = false;
 
 test.beforeAll(async ({ request }) => {


### PR DESCRIPTION
Closes #1727.

## Problem
The "Namespace inline-create E2E (post-deploy)" suite runs against **production** after each deploy. It intermittently reported a hard **product-regression failure** when the real cause was the deployed environment not being ready: `beforeAll`'s auth+seed hit transient `5xx`, and an always-run scenario then false-failed (observed: Scenario 9's `expect(search).toBeVisible()` timing out on an unrendered logged-in tree). The same failure appeared across unrelated crawler/engine/ingest deploys — the signature of an environment flake, not a regression.

## Root cause
`SETUP_OK` already makes the seed-dependent scenarios (1–5, 7, 10, 11) skip cleanly when setup fails. But **three canaries run regardless** and false-fail under sustained 5xx:
- **Scenario 6** asserts the create endpoint is `not 500` → a 5xx-ing env fails it.
- **Scenario 8** calls `apiSignIn()` in its own body → throws on sustained 5xx → test errors.
- **Scenario 9** does locator assertions on a tree that never rendered.

(The old `beforeAll` log even claimed "scenarios 1-8 will skip" — inaccurate: 6 and 8 never skipped via `SETUP_OK`.)

## Fix
Distinguish **environment-not-ready** from a **real regression** (the issue's core ask):
1. **Classify** the `beforeAll` failure. `retry5xx` throws `"<label> transient <code>"` once it exhausts attempts on 5xx; match `/transient \d{3}/` → `SETUP_ENV_NOT_READY`.
2. **Gate the whole describe** at the top of `beforeEach`: `test.skip(SETUP_ENV_NOT_READY, …)`. This covers all three canaries (and everything else) in one place. When the flag is **false** — env was ready, *or* setup failed for a **non-transient** reason (real 4xx, empty-tree-after-2xx-finish, DNS) — every scenario still runs so real regressions **fail clearly**.
3. **Loud, accurate logs**: the `beforeAll` warning now unmistakably labels `ENVIRONMENT NOT READY` vs a non-transient real failure, and the skip reason points back to it.

## Acceptance criteria
- [x] Transient setup failures no longer produce misleading product-regression failures (whole suite skips → run is green-with-skips).
- [x] Real wizard regressions still fail clearly (non-transient setup failure leaves the canaries running; a genuinely-missing search box / 500 endpoint still fails).
- [x] Failure logs identify readiness-vs-real (`ENVIRONMENT NOT READY …` vs `auth+seed FAILED (non-transient) …`, plus the skip reason).

## Verification
- `/transient \d{3}/` matches **all** real throw strings (`csrf/signin/tree/wizard:* transient NNN`, incl. the observed `wizard:finish transient 500`) and correctly does **not** match the non-transient `"tree still empty after finish"` or DNS errors (node one-liner).
- Spec compiles; `npx playwright test --list` discovers all **11** scenarios on this branch.
- **Not run here:** the env-not-ready skip branch requires the live prod target + an actual transient 5xx, which can't be reproduced from this box — stated plainly rather than implied.

## Known limitation (documented in code + commit)
A *deterministic* 500-regression in the seed path also exhausts `retry5xx` and would be classified env-not-ready. The loud `beforeAll` log is the safety valve — investigate if it persists across runs. Acceptable given the issue framing (criterion 3 = loud logs).

## Scope / not-in-this-PR
- Pre-existing dead code noticed but **not** swept: `openCreateUnder` (spec line ~216) is declared-but-unused. Out of scope.
- No engine / eval / guardrail changes. Not bundled with the A1 guardrail (#1728) or the actionlint hook (#1726/#1732).

🤖 Generated with [Claude Code](https://claude.com/claude-code)