### PR TITLE
test(canary): ADR-0017 proposal-state drift canary (#1723)

### DIFF
--- a/.github/workflows/proposal-state-canary.yml
+++ b/.github/workflows/proposal-state-canary.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+      - run: pip install pytest
       - run: python3 -m pytest tests/canary/test_proposal_canary.py -q
 
   # Drift check against staging — needs the staging DB secret.

--- a/.github/workflows/proposal-state-canary.yml
+++ b/.github/workflows/proposal-state-canary.yml
@@ -27,8 +27,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install pytest
-      - run: python3 -m pytest tests/canary/test_proposal_canary.py -q
+      # Run as a plain script — no pytest/conftest deps needed for this pure test.
+      - run: python3 tests/canary/test_proposal_canary.py
 
   # Drift check against staging — needs the staging DB secret.
   drift:

--- a/.github/workflows/proposal-state-canary.yml
+++ b/.github/workflows/proposal-state-canary.yml
@@ -1,0 +1,45 @@
+name: Proposal State Canary
+
+# ADR-0017 nightly drift canary (#1723). Read-only queries against STAGING:
+# fails if any proposal / suggestion / kg_relationships status triple is
+# inconsistent. A failed scheduled run notifies via GitHub's workflow-failure
+# email. Static counterpart: scripts/kg_write_guard.py (#1722, CI-time writes).
+
+on:
+  schedule:
+    - cron: "0 7 * * *" # nightly 07:00 UTC
+  workflow_dispatch: {}
+  pull_request:
+    branches: [main, develop, dev]
+    paths:
+      - "tests/canary/**"
+      - ".github/workflows/proposal-state-canary.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  # Pure unit test of the runner (no DB) — always runs.
+  parse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: python3 -m pytest tests/canary/test_proposal_canary.py -q
+
+  # Drift check against staging — needs the staging DB secret.
+  drift:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install "psycopg2-binary>=2.9"
+      - name: Proposal-state drift canary (staging)
+        env:
+          NEON_DATABASE_URL: ${{ secrets.NEON_STG_DATABASE_URL }}
+        run: python3 tests/canary/run_proposal_canary.py

--- a/scripts/kg_write_guard_allowlist.txt
+++ b/scripts/kg_write_guard_allowlist.txt
@@ -32,4 +32,6 @@ tests/test_kg_write_guard.py                               # the guard's own fix
 # --- Seeds + tests (not runtime inference) ---
 mira-hub/scripts/seed-synthetic-users.ts                   # synthetic seed data
 mira-hub/src/app/api/proposals/[id]/decide/__tests__/route.test.ts  # asserts the decide route's insert
+mira-hub/src/lib/knowledge-graph/__tests__/queries-schematic.test.ts        # asserts schematic writer does NOT insert kg_relationships (#1729)
+mira-hub/src/lib/knowledge-graph/__tests__/relationship-extractor-store.test.ts  # asserts extractor does NOT insert kg_relationships (#1729)
 tools/seeds/demo-conveyor-001.sql                          # demo seed (commented inserts)

--- a/tests/canary/README.md
+++ b/tests/canary/README.md
@@ -1,0 +1,44 @@
+# Proposal-state drift canary (ADR-0017, #1723)
+
+Runtime safety net for the "MIRA proposes, a human verifies" invariant
+(ADR-0017, `.claude/skills/managing-the-knowledge-graph`). The three status
+projections must stay consistent:
+
+| Table | Column | Vocabulary |
+|---|---|---|
+| `ai_suggestions` | `status` | pending / accepted / rejected / deferred / superseded |
+| `relationship_proposals` | `status` | proposed / reviewed / verified / rejected / deprecated / contradicted |
+| `kg_relationships` | `approval_state` | proposed / verified / rejected / needs_review |
+
+## Files
+- `proposal_state_drift.sql` — one `-- @check:` query per invariant; each returns the **offending rows** (zero = healthy).
+- `run_proposal_canary.py` — runs every check against `NEON_DATABASE_URL`, exits 1 on any drift.
+- `test_proposal_canary.py` — pure unit test of the runner (no DB).
+- `../../.github/workflows/proposal-state-canary.yml` — nightly (07:00 UTC) + on-demand; the `drift` job runs against staging.
+
+## Run it
+```bash
+doppler run --project factorylm --config stg -- python3.12 tests/canary/run_proposal_canary.py
+```
+
+## The two checks (and why they're legacy-safe)
+1. **accepted_suggestion_pairs_unverified_proposal** — an `ai_suggestions(kg_edge)` a human *accepted* must point at a `verified` proposal.
+2. **verified_edge_links_unverified_proposal** — a `kg_relationships` row that records `relationship_proposal_id` must link to a `verified` proposal.
+
+Both key off an explicit proposal link, so the ~300 pre-#1716/#1729
+auto-verified edges (which have `relationship_proposal_id IS NULL`, no paired
+suggestion) are **never** flagged. A naïve "any verified edge without a
+proposal" check would false-positive on all of them — these don't. Verified on
+staging: PASS clean; FAILS correctly when an accepted-suggestion→unverified-proposal
+pair is injected.
+
+## Companion
+- **Static** (CI-time, blocks new unguarded *writes*): `scripts/kg_write_guard.py` (#1722).
+- **Positive** ("fresh ingest proposes, zero new verified edges"): `mira-crawler/tools/smoke_proposal_writer.py`.
+
+## Known gap / next
+The Hub decide route (`mira-hub/.../proposals/[id]/decide/route.ts`) does not
+yet populate `kg_relationships.relationship_proposal_id` when it writes the
+verified edge, so Check 2 is currently vacuous (no edges carry the link).
+Wiring the decide route to set `relationship_proposal_id` makes Check 2
+load-bearing — recommended follow-up.

--- a/tests/canary/proposal_state_drift.sql
+++ b/tests/canary/proposal_state_drift.sql
@@ -1,0 +1,51 @@
+-- ADR-0017 proposal-state-drift canary (#1723)
+--
+-- Each query below returns the OFFENDING rows for one cross-table invariant.
+-- A healthy database returns ZERO rows for every check. The nightly workflow
+-- (.github/workflows/proposal-state-canary.yml) runs these against STAGING and
+-- fails on any non-zero result.
+--
+-- Doctrine: MIRA proposes, a human verifies (ADR-0017,
+-- .claude/skills/managing-the-knowledge-graph). The three status projections
+-- (ai_suggestions.status / relationship_proposals.status /
+-- kg_relationships.approval_state) must stay consistent.
+--
+-- LEGACY-SAFE BY DESIGN: both checks key off an explicit proposal link, so the
+-- ~300 pre-#1716/#1729 auto-verified edges (which have
+-- kg_relationships.relationship_proposal_id IS NULL and no paired suggestion)
+-- are never flagged. A naive "any verified edge without a proposal" check would
+-- false-positive on all of them — these don't.
+
+-- @check: accepted_suggestion_pairs_unverified_proposal
+-- An ai_suggestions(kg_edge) the human ACCEPTED must point at a
+-- relationship_proposals row that is now 'verified'. If the suggestion is
+-- accepted but its paired proposal is not verified, the accept→verify
+-- transition (ADR-0017) broke.
+SELECT
+  s.id              AS suggestion_id,
+  s.status          AS suggestion_status,
+  p.id              AS proposal_id,
+  p.status          AS proposal_status
+FROM ai_suggestions s
+JOIN relationship_proposals p
+  ON p.id = NULLIF(s.extracted_data ->> 'relationship_proposal_id', '')::uuid
+WHERE s.suggestion_type = 'kg_edge'
+  AND s.status = 'accepted'
+  AND p.status <> 'verified';
+
+-- @check: verified_edge_links_unverified_proposal
+-- A kg_relationships row that records which proposal it came from
+-- (relationship_proposal_id) must link to a 'verified' proposal — the edge is
+-- only supposed to exist because a human verified that proposal. A link to a
+-- non-verified proposal means an edge was written ahead of (or without) its
+-- human approval.
+SELECT
+  k.id                       AS relationship_id,
+  k.approval_state,
+  k.relationship_proposal_id,
+  p.status                   AS proposal_status
+FROM kg_relationships k
+JOIN relationship_proposals p
+  ON p.id = k.relationship_proposal_id
+WHERE k.relationship_proposal_id IS NOT NULL
+  AND p.status <> 'verified';

--- a/tests/canary/run_proposal_canary.py
+++ b/tests/canary/run_proposal_canary.py
@@ -25,8 +25,6 @@ import re
 import sys
 from pathlib import Path
 
-import psycopg2
-
 SQL_PATH = Path(__file__).resolve().parent / "proposal_state_drift.sql"
 _CHECK_RE = re.compile(r"--\s*@check:\s*(\S+)\s*\n(.*?)(?=\n--\s*@check:|\Z)", re.DOTALL)
 
@@ -46,6 +44,8 @@ def parse_checks(sql_text: str) -> list[tuple[str, str]]:
 
 
 def main() -> int:
+    import psycopg2  # lazy — the pure parse path (and its unit test) needs no DB driver
+
     url = os.environ.get("NEON_DATABASE_URL")
     if not url:
         print("NEON_DATABASE_URL not set", file=sys.stderr)

--- a/tests/canary/run_proposal_canary.py
+++ b/tests/canary/run_proposal_canary.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3.12
+"""ADR-0017 proposal-state-drift canary runner (#1723).
+
+Runs every `-- @check:` query in proposal_state_drift.sql against
+NEON_DATABASE_URL and fails (exit 1) if any returns rows. A healthy database
+returns zero rows for every check.
+
+Run against STAGING (never prod — the queries are read-only, but keep prod
+out of canary loops):
+
+    doppler run --project factorylm --config stg -- \
+        python3.12 tests/canary/run_proposal_canary.py
+
+Pairs with the static guard (scripts/kg_write_guard.py, #1722): the guard stops
+new unguarded WRITES at CI time; this canary catches state DRIFT in the data at
+runtime. The positive "fresh ingest proposes, zero new verified edges"
+assertion lives in mira-crawler/tools/smoke_proposal_writer.py (run alongside
+this in the nightly workflow).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+import psycopg2
+
+SQL_PATH = Path(__file__).resolve().parent / "proposal_state_drift.sql"
+_CHECK_RE = re.compile(r"--\s*@check:\s*(\S+)\s*\n(.*?)(?=\n--\s*@check:|\Z)", re.DOTALL)
+
+
+def parse_checks(sql_text: str) -> list[tuple[str, str]]:
+    """Return [(name, query)] for each `-- @check:` block."""
+    out: list[tuple[str, str]] = []
+    for m in _CHECK_RE.finditer(sql_text):
+        name = m.group(1)
+        # strip remaining comment lines + trailing semicolon/whitespace
+        body = "\n".join(
+            ln for ln in m.group(2).splitlines() if not ln.strip().startswith("--")
+        ).strip().rstrip(";").strip()
+        if body:
+            out.append((name, body))
+    return out
+
+
+def main() -> int:
+    url = os.environ.get("NEON_DATABASE_URL")
+    if not url:
+        print("NEON_DATABASE_URL not set", file=sys.stderr)
+        return 2
+
+    checks = parse_checks(SQL_PATH.read_text())
+    if not checks:
+        print(f"no @check blocks found in {SQL_PATH}", file=sys.stderr)
+        return 2
+
+    conn = psycopg2.connect(url)
+    drift = 0
+    try:
+        with conn.cursor() as cur:
+            for name, query in checks:
+                cur.execute(query)
+                rows = cur.fetchall()
+                if rows:
+                    drift += 1
+                    print(f"❌ DRIFT [{name}]: {len(rows)} offending row(s)")
+                    for r in rows[:10]:
+                        print(f"     {r}")
+                else:
+                    print(f"✅ ok    [{name}]")
+    finally:
+        conn.close()
+
+    if drift:
+        print(
+            f"\nproposal-state canary FAILED: {drift} check(s) drifted. "
+            "A proposal/suggestion/edge status triple is inconsistent (ADR-0017).",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"\nproposal-state canary PASSED: {len(checks)} checks, no drift.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/canary/test_proposal_canary.py
+++ b/tests/canary/test_proposal_canary.py
@@ -1,0 +1,34 @@
+"""Pure unit tests for the ADR-0017 canary runner (#1723) — no DB."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from run_proposal_canary import SQL_PATH, parse_checks  # noqa: E402
+
+EXPECTED = [
+    "accepted_suggestion_pairs_unverified_proposal",
+    "verified_edge_links_unverified_proposal",
+]
+
+
+def test_parses_every_check_block():
+    checks = parse_checks(SQL_PATH.read_text())
+    assert [name for name, _ in checks] == EXPECTED
+
+
+def test_each_query_is_a_clean_select():
+    for name, query in parse_checks(SQL_PATH.read_text()):
+        upper = query.upper()
+        assert upper.startswith("SELECT"), name
+        assert "FROM" in upper, name
+        # comment lines stripped, no trailing semicolon
+        assert not any(ln.strip().startswith("--") for ln in query.splitlines()), name
+        assert not query.rstrip().endswith(";"), name
+
+
+def test_parse_checks_handles_no_blocks():
+    assert parse_checks("-- just a comment, no @check markers\n") == []

--- a/tests/canary/test_proposal_canary.py
+++ b/tests/canary/test_proposal_canary.py
@@ -32,3 +32,12 @@ def test_each_query_is_a_clean_select():
 
 def test_parse_checks_handles_no_blocks():
     assert parse_checks("-- just a comment, no @check markers\n") == []
+
+
+if __name__ == "__main__":
+    # Runnable without pytest (the canary workflow has no pytest/conftest deps).
+    fns = [v for k, v in sorted(globals().items()) if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"ok  {fn.__name__}")
+    print(f"\n{len(fns)} checks passed")


### PR DESCRIPTION
Closes #1723. The **runtime** complement to the static write-guard (#1722): a nightly drift canary that catches inconsistent proposal/suggestion/edge status triples (ADR-0017). Built + verified on **BRAVO**, zero collision (new files).

## Checks (legacy-safe by design)
Each `-- @check:` query returns offending rows; zero = healthy.
1. **accepted_suggestion_pairs_unverified_proposal** — an `ai_suggestions(kg_edge)` a human *accepted* must point at a `verified` proposal.
2. **verified_edge_links_unverified_proposal** — a `kg_relationships` row carrying `relationship_proposal_id` must link to a `verified` proposal.

Both key off an explicit proposal link, so the **~300 pre-#1716/#1729 auto-verified edges** (`relationship_proposal_id IS NULL`, no paired suggestion) are **never flagged** — the false-positive trap I called out last turn. Verified against staging: PASS clean; **FAILS correctly** when an accepted→unverified pair is injected; PASS again after cleanup.

## Files
- `tests/canary/proposal_state_drift.sql` — the checks
- `tests/canary/run_proposal_canary.py` — runner (exit 1 on drift)
- `tests/canary/test_proposal_canary.py` — pure unit test (no DB)
- `tests/canary/README.md` — docs + legacy-safety rationale + known gap
- `.github/workflows/proposal-state-canary.yml` — nightly 07:00 UTC + dispatch (`parse` unit job + `drift` staging job)

## Also: kg-write-guard hotfix (#1722)
After #1729 + #1734 both merged, the two #1729 **test files** (which assert ON the string `INSERT INTO kg_relationships`) trip the guard — its allowlist was written before those files merged, so **the guard is currently red on `main`**. This PR allowlists them with a reason → guard green (15 sites). ⚠️ Worth a quick look since it un-breaks `main`'s guard.

## Known gap (follow-up, in README)
The Hub decide route doesn't yet set `kg_relationships.relationship_proposal_id`, so Check 2 is currently vacuous. Wiring it makes Check 2 load-bearing.

## Verification
Unit tests pass; ruff clean; canary PASS on `factorylm/stg` (0 drift) + proven to fail on injected drift.

Related: #1662, #1716, #1729, #1734, EPIC #1666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)