### PR TITLE
fix(ci): kg-write-guard ignores string-literal mentions (unbreak main)

### DIFF
--- a/scripts/kg_write_guard.py
+++ b/scripts/kg_write_guard.py
@@ -36,6 +36,14 @@ from pathlib import Path
 # and case. The table name + INSERT INTO sit on one line in every real site.
 _INSERT_RE = re.compile(r"insert\s+into\s+kg_relationships\b", re.IGNORECASE)
 
+# A real INSERT continues with a column list / VALUES / SELECT after the table
+# name. When the phrase is instead immediately closed by a string terminator,
+# it's a complete quoted string literal — a *mention* of the phrase, not a
+# write (e.g. a test asserting `not.toContain("INSERT INTO kg_relationships")`,
+# #1729/#1734). Skipping those can never miss a genuine insert, because a real
+# insert never closes a quote right after the table name.
+_STRING_TERMINATORS = ("'", '"', "`")
+
 _SCAN_SUFFIXES = {".py", ".ts", ".tsx", ".sql"}
 _SKIP_DIRS = {
     "node_modules", ".git", ".next", "dist", "build", ".venv", "venv",
@@ -64,7 +72,13 @@ def _scan_file(p: Path) -> bool:
         text = p.read_text(errors="ignore")
     except OSError:
         return False
-    return bool(_INSERT_RE.search(text))
+    for m in _INSERT_RE.finditer(text):
+        # Skip the phrase when it's a complete quoted string literal (the next
+        # non-whitespace char closes a quote) — a mention, not a real write.
+        if text[m.end():].lstrip()[:1] in _STRING_TERMINATORS:
+            continue
+        return True
+    return False
 
 
 def find_insert_sites(root: Path = REPO_ROOT) -> list[str]:

--- a/tests/test_kg_write_guard.py
+++ b/tests/test_kg_write_guard.py
@@ -37,6 +37,27 @@ def test_match_is_case_and_whitespace_insensitive(tmp_path):
     assert "x.py" in g.find_violations(root=tmp_path, allowlist=set())
 
 
+def test_string_literal_mention_is_not_flagged(tmp_path):
+    """The phrase as a COMPLETE quoted string (e.g. a test asserting its
+    absence) is not a real insert and must not trip the guard. Regression for
+    the #1729/#1734 false positive: `not.toContain("INSERT INTO kg_relationships")`."""
+    (tmp_path / "writer.test.ts").write_text(
+        'expect(blob()).not.toContain("INSERT INTO kg_relationships");\n'
+    )
+    assert g.find_insert_sites(root=tmp_path) == []
+
+
+def test_real_insert_flagged_even_with_string_mention_present(tmp_path):
+    """A real insert is still caught even when the same file also mentions the
+    phrase as a quoted string — the relaxation only skips string-literal-only
+    occurrences, never a genuine write."""
+    (tmp_path / "mixed.ts").write_text(
+        "const sql = `INSERT INTO kg_relationships (id) VALUES ($1)`;\n"
+        'expect(x).not.toContain("INSERT INTO kg_relationships");\n'
+    )
+    assert "mixed.ts" in g.find_insert_sites(root=tmp_path)
+
+
 def test_skips_node_modules_and_non_source(tmp_path):
     nm = tmp_path / "node_modules" / "pkg"
     nm.mkdir(parents=True)


### PR DESCRIPTION
**Unbreaks `main`.** Forward-fix chosen over reverting #1729/#1734 (both are needed ADR-0017 propose-by-default doctrine).

## What broke main
`#1729` (schematic writer proposes-by-default, merged 21:59) and `#1734` (kg-write-guard, merged 22:12) landed **13 minutes apart**. `#1734`'s guard does a substring scan for `INSERT INTO kg_relationships` and flagged two of `#1729`'s **test files**:

```ts
expect(blob()).not.toContain("INSERT INTO kg_relationships");
```

Those tests *assert the invariant* — the phrase is a quoted string literal, not a write. `#1734`'s allowlist (verified on Bravo before `#1729`'s tests existed) didn't cover them. This failed **two** main checks with one root cause:
- `kg-write-guard` workflow
- `tests/test_kg_write_guard.py::test_repo_is_clean_against_committed_allowlist` (run by **Eval Offline** via `pytest tests/`)

## Fix
`_scan_file` now skips a match when the phrase is immediately closed by a string terminator (`'` `"` `` ` ``). A real `INSERT INTO kg_relationships` always continues with a column list / `VALUES` / `SELECT`, so **this can never miss a genuine write** — it only drops string-literal *mentions* (test assertions, the guard's own regex, doc comments).

## Verification (TDD)
- Added `test_string_literal_mention_is_not_flagged` (the #1729/#1734 regression) and `test_real_insert_flagged_even_with_string_mention_present`. Watched the first **fail** against the unpatched guard, then pass.
- `7/7` guard tests pass.
- `python3 scripts/kg_write_guard.py` → **clean** (`11 insert site(s), all allowlisted`; the 2 false positives gone). Was: `❌ … 2 file(s)`.
- Rogue real insert still flagged (`True`); string mention not (`False`).
- `ruff check` clean.

## Allowlist hygiene (noted, not swept — separate follow-up)
With the false-positive class removed, 3 allowlist entries no longer match a detected insert (harmless to CI — the guard passes):
- `mira-hub/src/lib/knowledge-graph/relationship-extractor.ts` (migrated to propose in #1729 — no longer inserts)
- `mira-hub/src/app/api/proposals/[id]/decide/__tests__/route.test.ts` (test, string mention)
- `scripts/kg_write_guard.py` (the guard's own regex)

Pruning them is `#1734`/`#1729` allowlist maintenance, out of scope here. Flagging so the owner can tidy.

## Scope
One-purpose fix to `scripts/kg_write_guard.py` + its tests. No engine/eval/guardrail logic, no revert, no prod-disruptive change. The separate **Eval Offline xdist flake** (a run hanging ~21% on an overlong adversarial input, distinct from the guard test) is filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)