### PR TITLE
feat(hub): decide route links verified edge to its proposal (#1739)

### DIFF
--- a/mira-hub/src/app/api/proposals/[id]/decide/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/proposals/[id]/decide/__tests__/route.test.ts
@@ -124,6 +124,7 @@ describe("POST /api/proposals/[id]/decide", () => {
     vi.mocked(sessionOr401).mockResolvedValue(goodSession);
     let updateProposalArgs: unknown[] = [];
     let insertSql = "";
+    let insertArgs: unknown[] = [];
     let insertCalls = 0;
     let updateKgCalls = 0;
 
@@ -142,6 +143,7 @@ describe("POST /api/proposals/[id]/decide", () => {
           }
           if (sql.includes("INSERT INTO kg_relationships")) {
             insertSql = sql;
+            insertArgs = args;
             insertCalls++;
             return { rows: [] };
           }
@@ -171,6 +173,9 @@ describe("POST /api/proposals/[id]/decide", () => {
     expect(updateKgCalls).toBe(0);
     expect(insertSql).toContain("INSERT INTO kg_relationships");
     expect(insertSql).toContain("'verified'");
+    // Provenance: the verified edge records which proposal verified it (#1723).
+    expect(insertSql).toContain("relationship_proposal_id");
+    expect(insertArgs).toContain(VALID_UUID);
   });
 
   it("verify when kg_relationships row already exists → UPDATE not INSERT, confidence GREATEST", async () => {
@@ -214,6 +219,8 @@ describe("POST /api/proposals/[id]/decide", () => {
     expect(updateKgConfidence).toBe(baseProposal.confidence);
     expect(updateKgSql).toContain("approval_state = 'verified'");
     expect(updateKgSql).toContain("GREATEST(confidence");
+    // Provenance: link the existing edge to the verifying proposal, keep first (#1723).
+    expect(updateKgSql).toContain("relationship_proposal_id = COALESCE");
   });
 
   it("reject → flips status to 'rejected' with no kg_relationships write", async () => {

--- a/mira-hub/src/app/api/proposals/[id]/decide/route.ts
+++ b/mira-hub/src/app/api/proposals/[id]/decide/route.ts
@@ -114,8 +114,9 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
           await c.query(
             `INSERT INTO kg_relationships
                (tenant_id, source_id, target_id, relationship_type,
-                confidence, approval_state, proposed_by, evidence_summary)
-             VALUES ($1, $2, $3, $4, $5, 'verified', $6, $7)`,
+                confidence, approval_state, proposed_by, evidence_summary,
+                relationship_proposal_id)
+             VALUES ($1, $2, $3, $4, $5, 'verified', $6, $7, $8)`,
             [
               ctx.tenantId,
               p.source_entity_id,
@@ -124,17 +125,22 @@ export async function POST(req: Request, { params }: { params: Promise<{ id: str
               p.confidence,
               p.created_by,
               p.reasoning,
+              id,
             ],
           );
         } else {
+          // Provenance link: record which proposal verified this edge (keep the
+          // first link if one already exists). Makes the edge traceable back to
+          // the human approval and the ADR-0017 canary's Check 2 load-bearing.
           await c.query(
             `UPDATE kg_relationships
                 SET approval_state = 'verified',
                     confidence = GREATEST(confidence, $1),
                     proposed_by = COALESCE(proposed_by, $2),
-                    evidence_summary = COALESCE(evidence_summary, $3)
+                    evidence_summary = COALESCE(evidence_summary, $3),
+                    relationship_proposal_id = COALESCE(relationship_proposal_id, $5)
               WHERE id = $4`,
-            [p.confidence, p.created_by, p.reasoning, existingRes.rows[0].id],
+            [p.confidence, p.created_by, p.reasoning, existingRes.rows[0].id, id],
           );
         }
       }


### PR DESCRIPTION
Closes #1739. Closes the edge↔proposal **provenance gap** surfaced while building the ADR-0017 canary (#1723). Built + verified on **BRAVO**.

## Problem
The Hub verify path (`proposals/[id]/decide/route.ts`) writes the verified `kg_relationships` edge but leaves `relationship_proposal_id` (a real FK to `relationship_proposals`) unset. So verified edges had no traceable link back to the human-approved proposal, and the canary's Check 2 (`verified_edge_links_unverified_proposal`) was **vacuous** (no edges carried the link).

## Change
- **INSERT** (new edge): `relationship_proposal_id = <verifying proposal id>`.
- **UPDATE** (existing edge): `relationship_proposal_id = COALESCE(existing, <proposal id>)` — record provenance, keep the first link.

## Verification
- 10/10 decide-route vitest pass (added assertions: INSERT carries `relationship_proposal_id` + the proposal id; UPDATE sets it via COALESCE). eslint + tsc clean on changed files.
- **Staging smoke** (`factorylm/stg`, real entities + FK-valid proposal): the linked edge lands; **canary Check 2 = 0** when the proposal is verified, **= 1** when un-verified → Check 2 is now **load-bearing** (closes the known gap noted in `tests/canary/README.md`).

## Why it matters (foundation)
Every verified edge now traces to the human approval that created it, and the runtime canary actually detects edge↔proposal drift. Pairs with the static write-guard (#1722) and the propose-by-default writers (#1716/#1729).

Related: #1723, #1662, EPIC #1666.

🤖 Generated with [Claude Code](https://claude.com/claude-code)