### PR TITLE
feat(eval): SimLab machine-behavior scenario eval framework

### DIFF
--- a/tests/simlab/README.md
+++ b/tests/simlab/README.md
@@ -1,0 +1,83 @@
+# SimLab — Machine Behavior Scenario Evaluation
+
+SimLab tests **cross-component diagnostic reasoning** — whether MIRA correctly isolates
+a fault across a multi-component machine, not just whether it knows a device's fault codes.
+
+## Architecture
+
+```
+tests/simlab/
+├── scenarios/            # YAML scenario files
+│   ├── conveyor_jam_01.yaml
+│   ├── motor_no_motion_01.yaml
+│   ├── pump_no_flow_01.yaml
+│   ├── vfd_thermal_cascade_01.yaml
+│   └── sensor_stuck_high_01.yaml
+├── ingestion/
+│   └── ai4i.py          # AI4I 2020 dataset → scenario YAML seeds
+├── schema.py            # SimLabScenario dataclasses
+├── checkpoints.py       # Behavior checkpoint evaluators
+├── runner.py            # In-process Supervisor runner
+└── runs/                # Scorecard output (YYYY-MM-DDTHHMM-simlab.md)
+```
+
+## Scenario Tiers
+
+| Tier | Use case | Examples |
+|------|----------|---------|
+| 1 | Full eval — complex stateful device, multi-component fault | conveyor jam, VFD thermal, pump no-flow |
+| 2 | Lightweight — binary component, single failure mode | sensor stuck, tool wear |
+| 3 | Knowledge-card — passive hardware, no FSM required | (future) |
+
+## Running
+
+```bash
+# Load Doppler secrets first
+doppler run --project factorylm --config prd -- \
+    python3 tests/simlab/runner.py
+
+# Run single scenario
+python3 tests/simlab/runner.py --scenario conveyor_jam_01
+
+# Schema-only dry run (no LLM calls)
+python3 tests/simlab/runner.py --dry-run
+```
+
+## Behavior Checkpoints
+
+Checkpoints that can't be evaluated per-turn — they look across the whole conversation:
+
+| Checkpoint | What it checks |
+|-----------|---------------|
+| `cp_no_premature_blame` | MIRA didn't name red-herring components before isolation |
+| `cp_isolation_evidence` | MIRA cited measurements/tags before concluding root cause |
+| `cp_subsystem_identified` | MIRA named the correct faulty subsystem |
+| `cp_no_cross_component_confusion` | MIRA didn't direct action on unrelated components |
+
+## AI4I 2020 Seed Ingestion
+
+The [AI4I 2020 Predictive Maintenance Dataset](https://archive.ics.uci.edu/dataset/601/ai4i+2020+predictive+maintenance+dataset)
+(UCI, 10k rows) provides realistic sensor values (air/process temp, RPM, torque, tool wear)
+to seed scenario tag states. Failure modes map to:
+
+| AI4I failure | Machine scenario |
+|-------------|-----------------|
+| HDF (heat dissipation) | Clogged coolant filter |
+| PWF (power failure) | Worn tooling excessive load |
+| TWF (tool wear) | Tool life expiration |
+| OSF (overstrain) | Worn tool + heavy cut |
+| RNF | Excluded — no mechanical root cause |
+
+```bash
+# Generate AI4I-seeded scenarios (downloads dataset on first run)
+python3 tests/simlab/ingestion/ai4i.py --out tests/simlab/scenarios/
+
+# Dry run
+python3 tests/simlab/ingestion/ai4i.py --dry-run
+```
+
+## Pre-seeding Machine Context
+
+The runner pre-seeds Supervisor state with `source="direct_connection"` so the UNS
+confirmation gate is bypassed. The SimLab runner IS the machine context — scenarios
+run from the perspective of a tech already standing at the machine.

--- a/tests/simlab/__init__.py
+++ b/tests/simlab/__init__.py
@@ -1,0 +1,5 @@
+"""SimLab — MIRA machine-behavior scenario evaluation.
+
+Tests how MIRA reasons across multiple components in a machine sequence,
+not just whether it knows a specific device's fault codes.
+"""

--- a/tests/simlab/checkpoints.py
+++ b/tests/simlab/checkpoints.py
@@ -112,7 +112,14 @@ def cp_no_cross_component_confusion(
     the tech to replace the VFD.
     """
     combined = " ".join(replies).lower()
-    confused = [c for c in forbidden_blame if re.search(rf"\breplace\b.*\b{re.escape(c.lower())}\b|\bfaulty\b.*\b{re.escape(c.lower())}\b", combined)]
+    confused = [
+        c
+        for c in forbidden_blame
+        if re.search(
+            rf"\breplace\b.*\b{re.escape(c.lower())}\b|\bfaulty\b.*\b{re.escape(c.lower())}\b",
+            combined,
+        )
+    ]
     if confused:
         return BehaviorCheckResult(
             name="cp_no_cross_component_confusion",
@@ -137,25 +144,33 @@ def evaluate_behavior_checkpoints(
     results = []
     for cp in scenario.behavior_checkpoints:
         if cp.name == "cp_no_premature_blame":
-            results.append(cp_no_premature_blame(
-                replies=bot_replies,
-                forbidden_components=cp.params.get("forbidden_components", []),
-                until_turn=cp.params.get("until_turn", 99),
-            ))
+            results.append(
+                cp_no_premature_blame(
+                    replies=bot_replies,
+                    forbidden_components=cp.params.get("forbidden_components", []),
+                    until_turn=cp.params.get("until_turn", 99),
+                )
+            )
         elif cp.name == "cp_isolation_evidence":
-            results.append(cp_isolation_evidence(
-                replies=bot_replies,
-                required_measurements=cp.params.get("required_measurements", []),
-            ))
+            results.append(
+                cp_isolation_evidence(
+                    replies=bot_replies,
+                    required_measurements=cp.params.get("required_measurements", []),
+                )
+            )
         elif cp.name == "cp_subsystem_identified":
-            results.append(cp_subsystem_identified(
-                replies=bot_replies,
-                expected_subsystem=cp.params.get("expected_subsystem", ""),
-                aliases=cp.params.get("aliases", []),
-            ))
+            results.append(
+                cp_subsystem_identified(
+                    replies=bot_replies,
+                    expected_subsystem=cp.params.get("expected_subsystem", ""),
+                    aliases=cp.params.get("aliases", []),
+                )
+            )
         elif cp.name == "cp_no_cross_component_confusion":
-            results.append(cp_no_cross_component_confusion(
-                replies=bot_replies,
-                forbidden_blame=cp.params.get("forbidden_blame", []),
-            ))
+            results.append(
+                cp_no_cross_component_confusion(
+                    replies=bot_replies,
+                    forbidden_blame=cp.params.get("forbidden_blame", []),
+                )
+            )
     return results

--- a/tests/simlab/checkpoints.py
+++ b/tests/simlab/checkpoints.py
@@ -1,0 +1,161 @@
+"""Machine-behavior checkpoints for SimLab scenarios.
+
+These extend the standard grader.py checkpoints with cross-component reasoning
+checks that can't be evaluated per-turn — they look across the entire conversation.
+
+Standard checkpoints (from grader.py):
+  cp_reached_state, cp_keyword_match, cp_no_5xx, cp_turn_budget, cp_citation_groundedness
+
+New machine-behavior checkpoints (this module):
+  cp_no_premature_blame   — MIRA didn't blame a red-herring component before isolation
+  cp_isolation_evidence   — MIRA cited measurements/tags before concluding
+  cp_subsystem_identified — MIRA named the correct faulty subsystem
+  cp_safety_respected     — MIRA did not recommend unsafe actions for this scenario
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from tests.simlab.schema import SimLabScenario
+
+
+@dataclass
+class BehaviorCheckResult:
+    name: str
+    passed: bool
+    reason: str
+
+
+# ── Checkpoint implementations ────────────────────────────────────────────────
+
+
+def cp_no_premature_blame(
+    replies: list[str],
+    forbidden_components: list[str],
+    until_turn: int = 99,
+) -> BehaviorCheckResult:
+    """MIRA must not name forbidden (red-herring) components as the fault before isolation.
+
+    Example: for a product jam, blaming the photoeye sensors in the first two turns
+    before checking the belt physically is premature blame.
+    """
+    checked_replies = replies[:until_turn]
+    combined = " ".join(checked_replies).lower()
+    for component in forbidden_components:
+        if re.search(rf"\b{re.escape(component.lower())}\b", combined):
+            return BehaviorCheckResult(
+                name="cp_no_premature_blame",
+                passed=False,
+                reason=f"Prematurely blamed '{component}' before isolation (turn ≤{until_turn})",
+            )
+    return BehaviorCheckResult(
+        name="cp_no_premature_blame",
+        passed=True,
+        reason="No premature blame of red-herring components",
+    )
+
+
+def cp_isolation_evidence(
+    replies: list[str],
+    required_measurements: list[str],
+) -> BehaviorCheckResult:
+    """MIRA must reference measurement/tag evidence before concluding root cause.
+
+    Prevents "replace the motor" answers without citing any measurement evidence.
+    """
+    combined = " ".join(replies).lower()
+    found = [m for m in required_measurements if m.lower() in combined]
+    if not found:
+        return BehaviorCheckResult(
+            name="cp_isolation_evidence",
+            passed=False,
+            reason=f"No measurement evidence cited. Expected at least one of: {required_measurements}",
+        )
+    return BehaviorCheckResult(
+        name="cp_isolation_evidence",
+        passed=True,
+        reason=f"Evidence cited: {found}",
+    )
+
+
+def cp_subsystem_identified(
+    replies: list[str],
+    expected_subsystem: str,
+    aliases: list[str] | None = None,
+) -> BehaviorCheckResult:
+    """MIRA must identify the correct subsystem in its response."""
+    all_terms = [expected_subsystem] + (aliases or [])
+    combined = " ".join(replies).lower()
+    for term in all_terms:
+        if term.lower() in combined:
+            return BehaviorCheckResult(
+                name="cp_subsystem_identified",
+                passed=True,
+                reason=f"Subsystem '{term}' identified",
+            )
+    return BehaviorCheckResult(
+        name="cp_subsystem_identified",
+        passed=False,
+        reason=f"Expected subsystem '{expected_subsystem}' not identified in any reply",
+    )
+
+
+def cp_no_cross_component_confusion(
+    replies: list[str],
+    forbidden_blame: list[str],
+) -> BehaviorCheckResult:
+    """MIRA must not blame a component type that is not involved in the fault path.
+
+    Example: for a sensor stuck fault causing a conveyor stop, MIRA should not tell
+    the tech to replace the VFD.
+    """
+    combined = " ".join(replies).lower()
+    confused = [c for c in forbidden_blame if re.search(rf"\breplace\b.*\b{re.escape(c.lower())}\b|\bfaulty\b.*\b{re.escape(c.lower())}\b", combined)]
+    if confused:
+        return BehaviorCheckResult(
+            name="cp_no_cross_component_confusion",
+            passed=False,
+            reason=f"Incorrectly directed action on unrelated components: {confused}",
+        )
+    return BehaviorCheckResult(
+        name="cp_no_cross_component_confusion",
+        passed=True,
+        reason="No cross-component confusion detected",
+    )
+
+
+# ── Dispatcher — applies behavior_checkpoints from scenario spec ──────────────
+
+
+def evaluate_behavior_checkpoints(
+    scenario: SimLabScenario,
+    bot_replies: list[str],
+) -> list[BehaviorCheckResult]:
+    """Run all behavior_checkpoints defined in the scenario spec."""
+    results = []
+    for cp in scenario.behavior_checkpoints:
+        if cp.name == "cp_no_premature_blame":
+            results.append(cp_no_premature_blame(
+                replies=bot_replies,
+                forbidden_components=cp.params.get("forbidden_components", []),
+                until_turn=cp.params.get("until_turn", 99),
+            ))
+        elif cp.name == "cp_isolation_evidence":
+            results.append(cp_isolation_evidence(
+                replies=bot_replies,
+                required_measurements=cp.params.get("required_measurements", []),
+            ))
+        elif cp.name == "cp_subsystem_identified":
+            results.append(cp_subsystem_identified(
+                replies=bot_replies,
+                expected_subsystem=cp.params.get("expected_subsystem", ""),
+                aliases=cp.params.get("aliases", []),
+            ))
+        elif cp.name == "cp_no_cross_component_confusion":
+            results.append(cp_no_cross_component_confusion(
+                replies=bot_replies,
+                forbidden_blame=cp.params.get("forbidden_blame", []),
+            ))
+    return results

--- a/tests/simlab/ingestion/__init__.py
+++ b/tests/simlab/ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""Open-source dataset ingestion — converts fault data into SimLab scenario YAML."""

--- a/tests/simlab/ingestion/ai4i.py
+++ b/tests/simlab/ingestion/ai4i.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""AI4I 2020 Predictive Maintenance dataset ingestion.
+
+Downloads the UCI AI4I 2020 Predictive Maintenance Dataset and generates
+SimLab scenario YAML seeds. The dataset has 10k rows with 5 failure modes:
+  TWF  — Tool Wear Failure
+  HDF  — Heat Dissipation Failure
+  PWF  — Power Failure
+  OSF  — Overstrain Failure
+  RNF  — Random Failure (excluded — no mechanical root cause pattern)
+
+Each failure mode maps to an industrial machine fault scenario template.
+The ingestion picks representative rows (p25/p50/p75 of the failure-mode
+distribution) to seed realistic tag values.
+
+Usage:
+    python3 tests/simlab/ingestion/ai4i.py --out tests/simlab/scenarios/
+    python3 tests/simlab/ingestion/ai4i.py --out tests/simlab/scenarios/ --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import logging
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger("simlab-ai4i")
+
+_DATASET_URL = "https://archive.ics.uci.edu/static/public/601/ai4i2020.csv"
+_CACHE_PATH = Path(__file__).parent / "_ai4i2020_cache.csv"
+
+
+# ── Data loading ──────────────────────────────────────────────────────────────
+
+
+def _fetch_dataset(use_cache: bool = True) -> list[dict[str, str]]:
+    """Download or load cached AI4I 2020 dataset. Returns rows as dicts."""
+    if use_cache and _CACHE_PATH.exists():
+        logger.info("Loading cached dataset from %s", _CACHE_PATH)
+        with open(_CACHE_PATH, newline="") as f:
+            return list(csv.DictReader(f))
+
+    logger.info("Downloading AI4I 2020 dataset from %s", _DATASET_URL)
+    try:
+        with urllib.request.urlopen(_DATASET_URL, timeout=30) as resp:
+            content = resp.read().decode("utf-8")
+    except Exception as e:
+        raise RuntimeError(f"Failed to download AI4I dataset: {e}") from e
+
+    _CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _CACHE_PATH.write_text(content)
+    return list(csv.DictReader(io.StringIO(content)))
+
+
+def _rows_for_failure(rows: list[dict], failure_col: str) -> list[dict]:
+    """Return only rows where the given failure column is 1."""
+    return [r for r in rows if r.get(failure_col, "0").strip() == "1"]
+
+
+def _percentile_row(rows: list[dict], feature: str, pct: float) -> dict | None:
+    """Return the row closest to the given percentile of a numeric feature."""
+    if not rows:
+        return None
+    try:
+        values = [float(r[feature]) for r in rows]
+    except (KeyError, ValueError):
+        return None
+    target = sorted(values)[int(len(values) * pct)]
+    closest = min(rows, key=lambda r: abs(float(r[feature]) - target))
+    return closest
+
+
+# ── Tag-value extraction ──────────────────────────────────────────────────────
+
+
+def _extract_tags(row: dict) -> dict[str, Any]:
+    """Build a realistic tag_state dict from an AI4I dataset row."""
+    def fval(col: str, default: float = 0.0) -> float:
+        try:
+            return round(float(row.get(col, default)), 2)
+        except ValueError:
+            return default
+
+    air_k = fval("Air temperature [K]")
+    proc_k = fval("Process temperature [K]")
+    rpm = fval("Rotational speed [rpm]")
+    torque = fval("Torque [Nm]")
+    wear = fval("Tool wear [min]")
+
+    # Convert Kelvin to Celsius for display
+    air_c = round(air_k - 273.15, 1) if air_k > 200 else air_k
+    proc_c = round(proc_k - 273.15, 1) if proc_k > 200 else proc_k
+
+    return {
+        "motor.air_temp_c": air_c,
+        "motor.process_temp_c": proc_c,
+        "motor.rpm": int(rpm),
+        "motor.torque_nm": torque,
+        "motor.tool_wear_min": int(wear),
+        "ai4i.dataset_row": row.get("UDI", ""),
+        "ai4i.machine_type": row.get("Type", ""),
+    }
+
+
+# ── Scenario templates per failure mode ──────────────────────────────────────
+
+
+@dataclass
+class ScenarioTemplate:
+    failure_mode: str
+    tier: int
+    machine_type: str
+    fault_root_cause: str
+    fault_component: str
+    red_herrings: list[str]
+    isolation_steps: list[str]
+    behavior_checkpoints: dict[str, Any]
+    expected_keywords: list[str]
+    forbidden_keywords: list[str]
+    turns: list[dict[str, str]]
+    description: str
+    tags: list[str] = field(default_factory=list)
+
+
+_TEMPLATES: dict[str, ScenarioTemplate] = {
+    "HDF": ScenarioTemplate(
+        failure_mode="HDF",
+        tier=1,
+        machine_type="cnc_machine",
+        description=(
+            "Heat dissipation failure — process temperature rise exceeds air temp differential. "
+            "Root cause is clogged coolant filter reducing heat transfer. "
+            "MIRA must cite temperature differential before recommending action."
+        ),
+        fault_root_cause="clogged_coolant_filter",
+        fault_component="coolant_system",
+        red_herrings=["spindle_motor", "vfd"],
+        isolation_steps=[
+            "Process temp minus air temp > 8.6K — heat dissipation is impaired",
+            "RPM is at setpoint — motor not overloaded",
+            "Check coolant flow rate and filter condition",
+        ],
+        behavior_checkpoints={
+            "cp_isolation_evidence": {
+                "params": {
+                    "required_measurements": ["temperature", "temp", "differential", "coolant"]
+                },
+                "reason": "Must cite temp differential before recommending action",
+            },
+            "cp_no_cross_component_confusion": {
+                "params": {"forbidden_blame": ["motor", "vfd", "spindle"]},
+                "reason": "Motor and VFD are not at fault in HDF failure mode",
+            },
+        },
+        expected_keywords=["temperature", "coolant", "heat", "differential"],
+        forbidden_keywords=[],
+        tags=["thermal", "coolant", "cnc", "heat-dissipation"],
+        turns=[
+            {"role": "user", "content": "Machine stopped on thermal fault. Air temp is 25C, process temp showing 35C on the display."},
+            {"role": "user", "content": "RPM was at setpoint before the fault. VFD shows no fault code."},
+            {"role": "user", "content": "Coolant filter was completely plugged. Replaced it and machine is running normally."},
+        ],
+    ),
+    "PWF": ScenarioTemplate(
+        failure_mode="PWF",
+        tier=1,
+        machine_type="industrial_motor",
+        description=(
+            "Power failure — torque times RPM outside operating power range. "
+            "Root cause is worn tooling increasing cutting forces. "
+            "MIRA must identify that power = torque × RPM is the fault indicator."
+        ),
+        fault_root_cause="worn_tool_excessive_load",
+        fault_component="cutting_tool",
+        red_herrings=["power_supply", "vfd", "motor"],
+        isolation_steps=[
+            "Power = torque × RPM / 9549 — calculate actual power draw",
+            "Torque is elevated above normal range for this RPM",
+            "Tool wear counter is at or near maximum — inspect/replace tooling",
+        ],
+        behavior_checkpoints={
+            "cp_isolation_evidence": {
+                "params": {
+                    "required_measurements": ["torque", "rpm", "power", "load", "tool"]
+                },
+                "reason": "Power fault requires citing torque and RPM measurements",
+            },
+            "cp_subsystem_identified": {
+                "params": {
+                    "expected_subsystem": "tool",
+                    "aliases": ["tooling", "cutting", "wear", "load"],
+                },
+                "reason": "Root cause is worn tooling increasing cutting load",
+            },
+        },
+        expected_keywords=["torque", "power", "tool", "load", "wear"],
+        forbidden_keywords=[],
+        tags=["power", "torque", "tooling", "cnc"],
+        turns=[
+            {"role": "user", "content": "Machine faulted mid-cycle. Torque reading was high — around 65 Nm. RPM was 1400."},
+            {"role": "user", "content": "This is the third time this week. Tool wear counter shows 210 minutes on this insert."},
+            {"role": "user", "content": "Replaced the cutting insert. Torque back to normal range (40 Nm)."},
+        ],
+    ),
+    "TWF": ScenarioTemplate(
+        failure_mode="TWF",
+        tier=2,
+        machine_type="cnc_machine",
+        description=(
+            "Tool wear failure — tool wear counter exceeds threshold (200-240 min). "
+            "Root cause is tool life expiration. Lightweight scenario — binary check "
+            "on wear counter value. MIRA must cite wear counter before directing action."
+        ),
+        fault_root_cause="tool_life_expiration",
+        fault_component="cutting_tool",
+        red_herrings=["motor", "coolant"],
+        isolation_steps=[
+            "Tool wear counter at or above 200 min threshold",
+            "No other fault indicators (temp, torque, power all normal)",
+            "Replace cutting insert per PM schedule",
+        ],
+        behavior_checkpoints={
+            "cp_isolation_evidence": {
+                "params": {"required_measurements": ["wear", "tool", "counter", "minutes"]},
+                "reason": "Tool wear counter value must be cited",
+            },
+        },
+        expected_keywords=["tool", "wear", "replace", "insert"],
+        forbidden_keywords=[],
+        tags=["tool-wear", "pm", "cnc"],
+        turns=[
+            {"role": "user", "content": "Machine stopped with a tool wear alarm. Wear counter shows 224 minutes."},
+            {"role": "user", "content": "Temperatures and torque all look normal. Just the wear counter."},
+            {"role": "user", "content": "Replaced the insert. Counter reset to zero and machine running normally."},
+        ],
+    ),
+    "OSF": ScenarioTemplate(
+        failure_mode="OSF",
+        tier=1,
+        machine_type="cnc_machine",
+        description=(
+            "Overstrain failure — product of tool wear and torque exceeds safety limit. "
+            "Root cause is worn tool combined with heavy cut parameters, causing spindle overload. "
+            "MIRA must not blame motor or VFD before identifying the wear+torque interaction."
+        ),
+        fault_root_cause="worn_tool_heavy_cut_overstrain",
+        fault_component="spindle_toolholder",
+        red_herrings=["motor", "vfd", "power_supply"],
+        isolation_steps=[
+            "Overstrain fault = torque × wear product exceeds limit",
+            "Check both tool wear counter AND current torque reading",
+            "Reduce depth of cut or replace worn tool",
+        ],
+        behavior_checkpoints={
+            "cp_isolation_evidence": {
+                "params": {
+                    "required_measurements": ["torque", "wear", "overstrain", "strain", "tool"]
+                },
+                "reason": "Both torque and wear measurements needed to diagnose OSF",
+            },
+            "cp_no_cross_component_confusion": {
+                "params": {"forbidden_blame": ["motor", "vfd"]},
+                "reason": "OSF is mechanical overload, not electrical component fault",
+            },
+            "cp_subsystem_identified": {
+                "params": {
+                    "expected_subsystem": "tool",
+                    "aliases": ["tooling", "wear", "cut", "spindle", "overstrain"],
+                },
+                "reason": "Root cause is tool wear + heavy cut combination",
+            },
+        },
+        expected_keywords=["overstrain", "torque", "wear", "tool", "cut"],
+        forbidden_keywords=[],
+        tags=["overstrain", "torque", "tool-wear", "cnc"],
+        turns=[
+            {"role": "user", "content": "Machine tripped on overstrain fault. Torque was 72 Nm at the time. Tool wear counter at 185 min."},
+            {"role": "user", "content": "This is a roughing pass on steel. No motor faults or drive faults, just the overstrain."},
+            {"role": "user", "content": "Reduced depth of cut and replaced the tool. No more overstrain trips."},
+        ],
+    ),
+}
+
+
+# ── YAML scenario generation ──────────────────────────────────────────────────
+
+
+def _build_scenario_yaml(
+    template: ScenarioTemplate,
+    row: dict,
+    percentile_label: str,
+) -> dict:
+    """Build a scenario dict ready for yaml.dump from a template + dataset row."""
+    tags_from_row = _extract_tags(row)
+    uid = row.get("UDI", "0").strip().zfill(5)
+    scenario_id = f"ai4i_{template.failure_mode.lower()}_{uid}"
+
+    return {
+        "id": scenario_id,
+        "name": f"AI4I {template.failure_mode} — {template.fault_root_cause.replace('_', ' ')} ({percentile_label})",
+        "tier": template.tier,
+        "machine_type": template.machine_type,
+        "source": "ai4i_2020",
+        "dataset_reference": f"AI4I 2020 UCI row {uid} ({template.failure_mode})",
+        "tags": template.tags + ["ai4i", template.failure_mode.lower()],
+        "description": template.description,
+        "machine_context": {
+            "site": "enterprise.simlab.ai4i",
+            "uns_path": f"enterprise.simlab.ai4i.{template.machine_type}",
+            "components": [
+                {
+                    "id": "motor_01",
+                    "type": "ac_motor",
+                    "description": f"AI4I machine type: {row.get('Type', 'M')}",
+                }
+            ],
+            "tag_state": tags_from_row,
+        },
+        "fault": {
+            "root_cause": template.fault_root_cause,
+            "root_cause_component": template.fault_component,
+            "red_herrings": template.red_herrings,
+            "correct_isolation_steps": template.isolation_steps,
+        },
+        "behavior_checkpoints": template.behavior_checkpoints,
+        "expected_final_state": "DIAGNOSIS",
+        "max_turns": 5,
+        "expected_keywords": template.expected_keywords,
+        "forbidden_keywords": template.forbidden_keywords,
+        "turns": template.turns,
+    }
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+def _main(args: argparse.Namespace) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    rows = _fetch_dataset(use_cache=not args.no_cache)
+    print(f"Loaded {len(rows)} rows from AI4I 2020 dataset")
+
+    output_dir = Path(args.out)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    generated = 0
+    for failure_col, template in _TEMPLATES.items():
+        failure_rows = _rows_for_failure(rows, failure_col)
+        print(f"  {failure_col}: {len(failure_rows)} failure rows")
+        if not failure_rows:
+            print(f"  [WARN] No rows found for {failure_col}, skipping")
+            continue
+
+        # Produce one scenario per percentile (median by default; p25/p75 for Tier 1)
+        percentiles = [(0.50, "median")] if template.tier == 2 else [
+            (0.25, "p25"), (0.50, "median"), (0.75, "p75")
+        ]
+
+        for pct, label in percentiles:
+            pivot_feature = "Torque [Nm]"
+            row = _percentile_row(failure_rows, pivot_feature, pct)
+            if row is None:
+                continue
+
+            scenario = _build_scenario_yaml(template, row, label)
+            out_path = output_dir / f"{scenario['id']}.yaml"
+
+            if args.dry_run:
+                print(f"  [DRY RUN] Would write {out_path.name}")
+                continue
+
+            with open(out_path, "w") as f:
+                yaml.dump(scenario, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+            print(f"  Wrote {out_path.name}")
+            generated += 1
+
+    if not args.dry_run:
+        print(f"\nGenerated {generated} scenario YAML files in {output_dir}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="AI4I 2020 → SimLab scenario ingestion")
+    parser.add_argument("--out", default="tests/simlab/scenarios/", help="Output directory")
+    parser.add_argument("--no-cache", action="store_true", help="Force re-download")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would be written")
+    args = parser.parse_args()
+    _main(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/simlab/ingestion/ai4i.py
+++ b/tests/simlab/ingestion/ai4i.py
@@ -82,6 +82,7 @@ def _percentile_row(rows: list[dict], feature: str, pct: float) -> dict | None:
 
 def _extract_tags(row: dict) -> dict[str, Any]:
     """Build a realistic tag_state dict from an AI4I dataset row."""
+
     def fval(col: str, default: float = 0.0) -> float:
         try:
             return round(float(row.get(col, default)), 2)
@@ -163,9 +164,18 @@ _TEMPLATES: dict[str, ScenarioTemplate] = {
         forbidden_keywords=[],
         tags=["thermal", "coolant", "cnc", "heat-dissipation"],
         turns=[
-            {"role": "user", "content": "Machine stopped on thermal fault. Air temp is 25C, process temp showing 35C on the display."},
-            {"role": "user", "content": "RPM was at setpoint before the fault. VFD shows no fault code."},
-            {"role": "user", "content": "Coolant filter was completely plugged. Replaced it and machine is running normally."},
+            {
+                "role": "user",
+                "content": "Machine stopped on thermal fault. Air temp is 25C, process temp showing 35C on the display.",
+            },
+            {
+                "role": "user",
+                "content": "RPM was at setpoint before the fault. VFD shows no fault code.",
+            },
+            {
+                "role": "user",
+                "content": "Coolant filter was completely plugged. Replaced it and machine is running normally.",
+            },
         ],
     ),
     "PWF": ScenarioTemplate(
@@ -187,9 +197,7 @@ _TEMPLATES: dict[str, ScenarioTemplate] = {
         ],
         behavior_checkpoints={
             "cp_isolation_evidence": {
-                "params": {
-                    "required_measurements": ["torque", "rpm", "power", "load", "tool"]
-                },
+                "params": {"required_measurements": ["torque", "rpm", "power", "load", "tool"]},
                 "reason": "Power fault requires citing torque and RPM measurements",
             },
             "cp_subsystem_identified": {
@@ -204,9 +212,18 @@ _TEMPLATES: dict[str, ScenarioTemplate] = {
         forbidden_keywords=[],
         tags=["power", "torque", "tooling", "cnc"],
         turns=[
-            {"role": "user", "content": "Machine faulted mid-cycle. Torque reading was high — around 65 Nm. RPM was 1400."},
-            {"role": "user", "content": "This is the third time this week. Tool wear counter shows 210 minutes on this insert."},
-            {"role": "user", "content": "Replaced the cutting insert. Torque back to normal range (40 Nm)."},
+            {
+                "role": "user",
+                "content": "Machine faulted mid-cycle. Torque reading was high — around 65 Nm. RPM was 1400.",
+            },
+            {
+                "role": "user",
+                "content": "This is the third time this week. Tool wear counter shows 210 minutes on this insert.",
+            },
+            {
+                "role": "user",
+                "content": "Replaced the cutting insert. Torque back to normal range (40 Nm).",
+            },
         ],
     ),
     "TWF": ScenarioTemplate(
@@ -236,9 +253,18 @@ _TEMPLATES: dict[str, ScenarioTemplate] = {
         forbidden_keywords=[],
         tags=["tool-wear", "pm", "cnc"],
         turns=[
-            {"role": "user", "content": "Machine stopped with a tool wear alarm. Wear counter shows 224 minutes."},
-            {"role": "user", "content": "Temperatures and torque all look normal. Just the wear counter."},
-            {"role": "user", "content": "Replaced the insert. Counter reset to zero and machine running normally."},
+            {
+                "role": "user",
+                "content": "Machine stopped with a tool wear alarm. Wear counter shows 224 minutes.",
+            },
+            {
+                "role": "user",
+                "content": "Temperatures and torque all look normal. Just the wear counter.",
+            },
+            {
+                "role": "user",
+                "content": "Replaced the insert. Counter reset to zero and machine running normally.",
+            },
         ],
     ),
     "OSF": ScenarioTemplate(
@@ -281,9 +307,18 @@ _TEMPLATES: dict[str, ScenarioTemplate] = {
         forbidden_keywords=[],
         tags=["overstrain", "torque", "tool-wear", "cnc"],
         turns=[
-            {"role": "user", "content": "Machine tripped on overstrain fault. Torque was 72 Nm at the time. Tool wear counter at 185 min."},
-            {"role": "user", "content": "This is a roughing pass on steel. No motor faults or drive faults, just the overstrain."},
-            {"role": "user", "content": "Reduced depth of cut and replaced the tool. No more overstrain trips."},
+            {
+                "role": "user",
+                "content": "Machine tripped on overstrain fault. Torque was 72 Nm at the time. Tool wear counter at 185 min.",
+            },
+            {
+                "role": "user",
+                "content": "This is a roughing pass on steel. No motor faults or drive faults, just the overstrain.",
+            },
+            {
+                "role": "user",
+                "content": "Reduced depth of cut and replaced the tool. No more overstrain trips.",
+            },
         ],
     ),
 }
@@ -359,9 +394,11 @@ def _main(args: argparse.Namespace) -> None:
             continue
 
         # Produce one scenario per percentile (median by default; p25/p75 for Tier 1)
-        percentiles = [(0.50, "median")] if template.tier == 2 else [
-            (0.25, "p25"), (0.50, "median"), (0.75, "p75")
-        ]
+        percentiles = (
+            [(0.50, "median")]
+            if template.tier == 2
+            else [(0.25, "p25"), (0.50, "median"), (0.75, "p75")]
+        )
 
         for pct, label in percentiles:
             pivot_feature = "Torque [Nm]"
@@ -377,7 +414,9 @@ def _main(args: argparse.Namespace) -> None:
                 continue
 
             with open(out_path, "w") as f:
-                yaml.dump(scenario, f, default_flow_style=False, allow_unicode=True, sort_keys=False)
+                yaml.dump(
+                    scenario, f, default_flow_style=False, allow_unicode=True, sort_keys=False
+                )
             print(f"  Wrote {out_path.name}")
             generated += 1
 

--- a/tests/simlab/runner.py
+++ b/tests/simlab/runner.py
@@ -65,12 +65,8 @@ def _build_initial_state(scenario: SimLabScenario) -> dict:
             "confidence": "certified",
             "uns_path": ctx.uns_path,
             "site": ctx.site,
-            "manufacturer": next(
-                (c.manufacturer for c in ctx.components if c.manufacturer), ""
-            ),
-            "model": next(
-                (c.model for c in ctx.components if c.model), ""
-            ),
+            "manufacturer": next((c.manufacturer for c in ctx.components if c.manufacturer), ""),
+            "model": next((c.model for c in ctx.components if c.model), ""),
         },
         "context": {
             "session_context": {
@@ -122,7 +118,7 @@ async def run_scenario(
             "error": None,
         }
 
-    for turn in user_turns[:scenario.max_turns]:
+    for turn in user_turns[: scenario.max_turns]:
         message = turn.get("content", "")
         try:
             result = await supervisor.process_full(chat_id, message, photo_b64=None)
@@ -138,7 +134,11 @@ async def run_scenario(
 
     # ── Standard checkpoints (keyword + state) ────────────────────────────────
     combined_text = " ".join(bot_replies).lower()
-    kw_pass = any(kw.lower() in combined_text for kw in scenario.expected_keywords) if scenario.expected_keywords else True
+    kw_pass = (
+        any(kw.lower() in combined_text for kw in scenario.expected_keywords)
+        if scenario.expected_keywords
+        else True
+    )
     forbidden_hit = [kw for kw in scenario.forbidden_keywords if kw.lower() in combined_text]
     kw_fail_reason = f"Forbidden keywords: {forbidden_hit}" if forbidden_hit else None
     if kw_fail_reason:
@@ -146,7 +146,11 @@ async def run_scenario(
     state_pass = final_state == scenario.expected_final_state
 
     standard_results = {
-        "cp_reached_state": {"passed": state_pass, "actual": final_state, "expected": scenario.expected_final_state},
+        "cp_reached_state": {
+            "passed": state_pass,
+            "actual": final_state,
+            "expected": scenario.expected_final_state,
+        },
         "cp_keyword_match": {"passed": kw_pass, "reason": kw_fail_reason or "OK"},
         "cp_turn_budget": {"passed": len(user_turns) <= scenario.max_turns},
         "cp_no_error": {"passed": error is None, "error": error},
@@ -199,7 +203,7 @@ def _write_scorecard(results: list[dict], output_path: Path) -> None:
     lines = [
         f"# MIRA SimLab — Machine Behavior Eval — {ts}",
         "",
-        f"**Scenarios:** {total}  |  **Pass rate:** {passed}/{total} ({100*passed//total if total else 0}%)",
+        f"**Scenarios:** {total}  |  **Pass rate:** {passed}/{total} ({100 * passed // total if total else 0}%)",
         "",
         "## Results",
         "",
@@ -232,7 +236,9 @@ def _write_scorecard(results: list[dict], output_path: Path) -> None:
             if not sr.get("cp_reached_state", {}).get("passed"):
                 actual = sr["cp_reached_state"]["actual"]
                 expected = sr["cp_reached_state"]["expected"]
-                lines.append(f"- **cp_reached_state** FAILED: State='{actual}', expected='{expected}'")
+                lines.append(
+                    f"- **cp_reached_state** FAILED: State='{actual}', expected='{expected}'"
+                )
             if not sr.get("cp_keyword_match", {}).get("passed"):
                 lines.append(f"- **cp_keyword_match** FAILED: {sr['cp_keyword_match']['reason']}")
             for b in r["behavior_results"]:

--- a/tests/simlab/runner.py
+++ b/tests/simlab/runner.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""SimLab scenario runner — machine-behavior eval harness.
+
+Runs SimLab scenarios in-process against the MIRA Supervisor engine.
+Machine context is pre-seeded as a direct-connection UNS-certified state
+so the UNS confirmation gate is bypassed (the scene is already established).
+
+Usage:
+    # Load Doppler secrets first, then:
+    doppler run --project factorylm --config prd -- \\
+        python3 tests/simlab/runner.py
+
+    # Run a single scenario:
+    python3 tests/simlab/runner.py --scenario conveyor_jam_01
+
+    # Dry run (schema loading only, no LLM calls):
+    python3 tests/simlab/runner.py --dry-run
+
+Output:
+    tests/simlab/runs/YYYY-MM-DDTHHMM-simlab.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "mira-bots"))
+sys.path.insert(0, str(_REPO_ROOT))
+
+from tests.simlab.checkpoints import evaluate_behavior_checkpoints
+from tests.simlab.schema import SimLabScenario, load_all_scenarios, load_scenario
+
+logger = logging.getLogger("mira-simlab")
+logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+
+_RUNS_DIR = Path(__file__).parent / "runs"
+_SCENARIOS_DIR = Path(__file__).parent / "scenarios"
+
+
+# ── State pre-seeding ─────────────────────────────────────────────────────────
+
+
+def _build_initial_state(scenario: SimLabScenario) -> dict:
+    """Build Supervisor state dict pre-seeded with machine context.
+
+    Populates uns_context with source="direct_connection" so the engine
+    skips the UNS confirmation gate — the SimLab runner IS the machine context.
+    """
+    ctx = scenario.machine_context
+    asset_label = ctx.primary_asset_label()
+    return {
+        "state": "Q1",
+        "asset_identified": asset_label,
+        "uns_context": {
+            "source": "direct_connection",
+            "confidence": "certified",
+            "uns_path": ctx.uns_path,
+            "site": ctx.site,
+            "manufacturer": next(
+                (c.manufacturer for c in ctx.components if c.manufacturer), ""
+            ),
+            "model": next(
+                (c.model for c in ctx.components if c.model), ""
+            ),
+        },
+        "context": {
+            "session_context": {
+                "machine_type": scenario.machine_type,
+                "equipment_type": scenario.machine_type,
+                "tag_state": ctx.tag_state,
+                "simlab_scenario_id": scenario.id,
+            }
+        },
+        "exchange_count": 0,
+        "fault_category": None,
+        "final_state": None,
+    }
+
+
+# ── Scenario execution ────────────────────────────────────────────────────────
+
+
+async def run_scenario(
+    supervisor,
+    scenario: SimLabScenario,
+    dry_run: bool = False,
+) -> dict:
+    """Run one SimLab scenario. Returns result dict compatible with scorecard."""
+    chat_id = f"simlab_{scenario.id}_{uuid.uuid4().hex[:8]}"
+
+    # Reset + pre-seed state
+    supervisor.reset(chat_id)
+    initial_state = _build_initial_state(scenario)
+    supervisor._save_state(chat_id, initial_state)
+
+    user_turns = [t for t in scenario.turns if t.get("role") == "user"]
+    bot_replies: list[str] = []
+    final_state = "IDLE"
+    error: str | None = None
+    t_start = time.monotonic()
+
+    if dry_run:
+        return {
+            "id": scenario.id,
+            "name": scenario.name,
+            "passed": True,
+            "dry_run": True,
+            "behavior_results": [],
+            "standard_results": {},
+            "bot_replies": [],
+            "final_state": "N/A",
+            "latency_ms": 0,
+            "error": None,
+        }
+
+    for turn in user_turns[:scenario.max_turns]:
+        message = turn.get("content", "")
+        try:
+            result = await supervisor.process_full(chat_id, message, photo_b64=None)
+            reply = result.get("reply", "")
+            final_state = result.get("next_state") or final_state
+            bot_replies.append(reply)
+        except Exception as e:
+            error = str(e)
+            logger.error("Scenario %s turn error: %s", scenario.id, e)
+            break
+
+    latency_ms = int((time.monotonic() - t_start) * 1000)
+
+    # ── Standard checkpoints (keyword + state) ────────────────────────────────
+    combined_text = " ".join(bot_replies).lower()
+    kw_pass = any(kw.lower() in combined_text for kw in scenario.expected_keywords) if scenario.expected_keywords else True
+    forbidden_hit = [kw for kw in scenario.forbidden_keywords if kw.lower() in combined_text]
+    kw_fail_reason = f"Forbidden keywords: {forbidden_hit}" if forbidden_hit else None
+    if kw_fail_reason:
+        kw_pass = False
+    state_pass = final_state == scenario.expected_final_state
+
+    standard_results = {
+        "cp_reached_state": {"passed": state_pass, "actual": final_state, "expected": scenario.expected_final_state},
+        "cp_keyword_match": {"passed": kw_pass, "reason": kw_fail_reason or "OK"},
+        "cp_turn_budget": {"passed": len(user_turns) <= scenario.max_turns},
+        "cp_no_error": {"passed": error is None, "error": error},
+    }
+
+    # ── Behavior checkpoints ──────────────────────────────────────────────────
+    behavior_results = evaluate_behavior_checkpoints(scenario, bot_replies)
+
+    all_standard_pass = all(v["passed"] for v in standard_results.values())
+    all_behavior_pass = all(r.passed for r in behavior_results)
+    overall_pass = all_standard_pass and all_behavior_pass
+
+    return {
+        "id": scenario.id,
+        "name": scenario.name,
+        "passed": overall_pass,
+        "dry_run": False,
+        "behavior_results": behavior_results,
+        "standard_results": standard_results,
+        "bot_replies": bot_replies,
+        "final_state": final_state,
+        "latency_ms": latency_ms,
+        "error": error,
+    }
+
+
+# ── Supervisor setup ──────────────────────────────────────────────────────────
+
+
+def _build_supervisor():
+    from shared.engine import Supervisor
+
+    db_path = os.getenv("SIMLAB_DB_PATH", "/tmp/mira_simlab.db")
+    return Supervisor(
+        db_path=db_path,
+        openwebui_url=os.getenv("OPENWEBUI_URL", "http://localhost:3000"),
+        api_key=os.getenv("OPENWEBUI_API_KEY", ""),
+        collection_id=os.getenv("OPENWEBUI_COLLECTION_ID", ""),
+    )
+
+
+# ── Scorecard writer ──────────────────────────────────────────────────────────
+
+
+def _write_scorecard(results: list[dict], output_path: Path) -> None:
+    passed = sum(1 for r in results if r["passed"])
+    total = len(results)
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M")
+
+    lines = [
+        f"# MIRA SimLab — Machine Behavior Eval — {ts}",
+        "",
+        f"**Scenarios:** {total}  |  **Pass rate:** {passed}/{total} ({100*passed//total if total else 0}%)",
+        "",
+        "## Results",
+        "",
+        "| Scenario | State | Keywords | Behavior | Score |",
+        "|----------|-------|----------|----------|-------|",
+    ]
+
+    for r in results:
+        sr = r["standard_results"]
+        state_icon = "✓" if sr.get("cp_reached_state", {}).get("passed") else "✗"
+        kw_icon = "✓" if sr.get("cp_keyword_match", {}).get("passed") else "✗"
+        beh_icons = " ".join("✓" if b.passed else "✗" for b in r["behavior_results"])
+        total_checks = 2 + len(r["behavior_results"])
+        check_pass = (
+            (1 if state_icon == "✓" else 0)
+            + (1 if kw_icon == "✓" else 0)
+            + sum(1 for b in r["behavior_results"] if b.passed)
+        )
+        overall = "✓" if r["passed"] else "✗"
+        lines.append(
+            f"| `{r['id']}` {overall} | {state_icon} | {kw_icon} | {beh_icons or '—'} | {check_pass}/{total_checks} |"
+        )
+
+    failures = [r for r in results if not r["passed"]]
+    if failures:
+        lines += ["", "## Failures", ""]
+        for r in failures:
+            lines.append(f"### {r['id']}")
+            sr = r["standard_results"]
+            if not sr.get("cp_reached_state", {}).get("passed"):
+                actual = sr["cp_reached_state"]["actual"]
+                expected = sr["cp_reached_state"]["expected"]
+                lines.append(f"- **cp_reached_state** FAILED: State='{actual}', expected='{expected}'")
+            if not sr.get("cp_keyword_match", {}).get("passed"):
+                lines.append(f"- **cp_keyword_match** FAILED: {sr['cp_keyword_match']['reason']}")
+            for b in r["behavior_results"]:
+                if not b.passed:
+                    lines.append(f"- **{b.name}** FAILED: {b.reason}")
+            if r["bot_replies"]:
+                snippet = r["bot_replies"][-1][:200].replace("\n", " ")
+                lines.append(f"- Last reply: `{snippet}...`")
+            lines.append("")
+
+    lines.append(f"---\n*Generated by SimLab runner at {datetime.now(timezone.utc).isoformat()}*")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(lines))
+    print(f"Scorecard: {output_path}")
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+
+async def _main(args: argparse.Namespace) -> None:
+    scenarios: list[SimLabScenario] = []
+
+    if args.scenario:
+        path = _SCENARIOS_DIR / f"{args.scenario}.yaml"
+        if not path.exists():
+            path = _SCENARIOS_DIR / args.scenario
+        scenarios.append(load_scenario(path))
+    else:
+        scenarios = load_all_scenarios(_SCENARIOS_DIR)
+
+    if not scenarios:
+        print("No scenarios found.")
+        return
+
+    print(f"Loaded {len(scenarios)} scenario(s)")
+
+    if args.dry_run:
+        for s in scenarios:
+            print(f"  [DRY RUN] {s.id} — {s.name}")
+        print("Schema OK — no LLM calls made.")
+        return
+
+    supervisor = _build_supervisor()
+    results = []
+    for scenario in scenarios:
+        print(f"Running: {scenario.id} ...", end=" ", flush=True)
+        result = await run_scenario(supervisor, scenario)
+        icon = "PASS" if result["passed"] else "FAIL"
+        print(f"{icon} ({result['latency_ms']}ms)")
+        results.append(result)
+
+    passed = sum(1 for r in results if r["passed"])
+    print(f"\nRESULT: {passed}/{len(results)} passed")
+
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M")
+    output_path = _RUNS_DIR / f"{ts}-simlab.md"
+    _write_scorecard(results, output_path)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="SimLab machine-behavior scenario runner")
+    parser.add_argument("--scenario", help="Run a single scenario by ID (without .yaml)")
+    parser.add_argument("--dry-run", action="store_true", help="Load schemas only, no LLM calls")
+    args = parser.parse_args()
+    asyncio.run(_main(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/simlab/scenarios/conveyor_jam_01.yaml
+++ b/tests/simlab/scenarios/conveyor_jam_01.yaml
@@ -1,0 +1,88 @@
+id: conveyor_jam_01
+name: "Conveyor stopped — product jam vs dual photoeye fault"
+tier: 1
+machine_type: conveyor
+source: hand_crafted
+tags: [jam, photoeye, sensor, conveyor, multi-component]
+description: >
+  Zone 2 accumulation belt stopped. Both entry and exit photoeyes show blocked.
+  VFD has no fault code. Root cause is a physical product jam on the belt —
+  NOT a dual sensor failure. MIRA must not prematurely blame the photoeyes
+  before ruling out the VFD and directing a physical check.
+
+machine_context:
+  site: "enterprise.plant1.packaging"
+  uns_path: "enterprise.plant1.packaging.line2"
+  components:
+    - id: conv_belt_01
+      type: belt_conveyor
+      description: "Zone 2 accumulation belt, 25ft"
+      manufacturer: ""
+      model: ""
+    - id: vfd_gs20_01
+      type: vfd
+      manufacturer: AutomationDirect
+      model: GS20
+      uns_path: "enterprise.plant1.packaging.line2.vfd_gs20"
+    - id: pe_101
+      type: photoeye
+      description: "Entry photoeye, zone 2"
+    - id: pe_102
+      type: photoeye
+      description: "Exit photoeye, zone 2"
+  tag_state:
+    "conv_belt_01.commanded": true
+    "conv_belt_01.running": false
+    "vfd_gs20_01.output_hz": 0.0
+    "vfd_gs20_01.output_amps": 0.2
+    "vfd_gs20_01.fault_code": null
+    "vfd_gs20_01.dc_bus_voltage": 320
+    "pe_101.blocked": true
+    "pe_102.blocked": true
+
+fault:
+  root_cause: product_jam_physical
+  root_cause_component: conv_belt_01
+  red_herrings:
+    - pe_101
+    - pe_102
+  correct_isolation_steps:
+    - "VFD shows no fault code — rules out drive fault"
+    - "Both photoeyes blocked simultaneously — statistically unlikely for simultaneous sensor failure"
+    - "Low output amps (0.2A) confirms motor never loaded — belt physically blocked before motor loaded"
+    - "Physical inspection of belt zone 2 for obstruction"
+  precursors:
+    - "High product flow rate in prior shift"
+
+behavior_checkpoints:
+  cp_no_premature_blame:
+    params:
+      forbidden_components: ["photoeye", "sensor", "pe_101", "pe_102"]
+      until_turn: 2
+    reason: "Blaming photoeyes before VFD check and physical inspection is premature"
+  cp_isolation_evidence:
+    params:
+      required_measurements: ["vfd", "fault", "amps", "output", "current"]
+    reason: "Must reference VFD state before directing physical check"
+  cp_subsystem_identified:
+    params:
+      expected_subsystem: "jam"
+      aliases: ["obstruction", "blocked", "product", "physical"]
+    reason: "Root cause is physical jam, not electronic fault"
+
+expected_final_state: DIAGNOSIS
+max_turns: 6
+expected_keywords: [jam, blocked, inspect, belt, physical, vfd]
+forbidden_keywords: []
+
+turns:
+  - role: user
+    content: >
+      Zone 2 belt stopped. Both the entry and exit photoeyes are showing blocked.
+      The motor is not running.
+  - role: user
+    content: >
+      The VFD is not showing any fault code. I tried resetting but the belt won't restart.
+  - role: user
+    content: >
+      I found a cardboard box jammed against the side guide halfway down the belt.

--- a/tests/simlab/scenarios/motor_no_motion_01.yaml
+++ b/tests/simlab/scenarios/motor_no_motion_01.yaml
@@ -1,0 +1,93 @@
+id: motor_no_motion_01
+name: "Motor commanded, VFD running, no shaft motion — coupling vs brake vs motor"
+tier: 1
+machine_type: conveyor
+source: hand_crafted
+tags: [motor, coupling, brake, vfd, mechanical-fault, multi-component]
+description: >
+  VFD shows commanded output (30Hz, 8A), motor is energized, but the conveyor
+  belt is not moving. Root cause is a failed jaw coupling between motor and
+  gearbox — NOT the motor or VFD. MIRA must not immediately blame the motor
+  or VFD when current and Hz appear normal, and must direct the tech toward
+  mechanical isolation (listen for motor spin, check coupling).
+
+machine_context:
+  site: "enterprise.plant1.assembly"
+  uns_path: "enterprise.plant1.assembly.line1"
+  components:
+    - id: motor_01
+      type: ac_motor
+      description: "3HP 1800RPM TEFC induction motor"
+      manufacturer: Baldor
+      model: EM3558T
+    - id: vfd_01
+      type: vfd
+      manufacturer: AutomationDirect
+      model: GS20
+      uns_path: "enterprise.plant1.assembly.line1.vfd_gs20"
+    - id: coupling_01
+      type: jaw_coupling
+      description: "Lovejoy L-095 jaw coupling, motor to gearbox"
+    - id: brake_01
+      type: spring_set_brake
+      description: "24VDC spring-set holding brake, mounted on motor shaft"
+    - id: gearbox_01
+      type: gearbox
+      description: "20:1 gear ratio inline reducer"
+  tag_state:
+    "vfd_01.output_hz": 30.0
+    "vfd_01.output_amps": 8.1
+    "vfd_01.dc_bus_voltage": 320
+    "vfd_01.fault_code": null
+    "motor_01.commanded": true
+    "brake_01.release_signal": true
+    "conv_belt.speed_encoder": 0
+    "conv_belt.running": false
+
+fault:
+  root_cause: failed_jaw_coupling_spider
+  root_cause_component: coupling_01
+  red_herrings:
+    - motor_01
+    - vfd_01
+  correct_isolation_steps:
+    - "VFD output Hz and amps are normal — drive is not at fault"
+    - "Listen at motor — audible spin without belt motion means mechanical disconnect"
+    - "Remove guard and inspect jaw coupling for shredded spider insert"
+    - "Brake release signal is present — brake is NOT engaged"
+  precursors:
+    - "High cyclic loading in prior week from product weight increase"
+
+behavior_checkpoints:
+  cp_no_cross_component_confusion:
+    params:
+      forbidden_blame: ["vfd", "motor"]
+    reason: "VFD and motor are electrically normal; blaming them misdirects the tech"
+  cp_isolation_evidence:
+    params:
+      required_measurements: ["hz", "amps", "output", "current", "fault"]
+    reason: "VFD measurements must be cited before directing mechanical inspection"
+  cp_subsystem_identified:
+    params:
+      expected_subsystem: "coupling"
+      aliases: ["mechanical", "spider", "jaw", "disconnect"]
+    reason: "Root cause is mechanical — coupling spider failure"
+
+expected_final_state: DIAGNOSIS
+max_turns: 6
+expected_keywords: [coupling, mechanical, motor, vfd, amps, inspect]
+forbidden_keywords: []
+
+turns:
+  - role: user
+    content: >
+      The conveyor on line 1 isn't moving. The VFD shows it's running at 30Hz
+      and I'm reading about 8 amps. No fault codes on the drive.
+  - role: user
+    content: >
+      I can hear the motor spinning when I put my hand on the housing but
+      the belt isn't moving at all.
+  - role: user
+    content: >
+      I pulled the guard and the coupling spider is completely shredded.
+      The motor shaft is spinning but the gearbox input shaft isn't turning.

--- a/tests/simlab/scenarios/pump_no_flow_01.yaml
+++ b/tests/simlab/scenarios/pump_no_flow_01.yaml
@@ -1,0 +1,96 @@
+id: pump_no_flow_01
+name: "Pump running, no flow — cavitation vs closed valve vs impeller wear"
+tier: 1
+machine_type: centrifugal_pump
+source: hand_crafted
+tags: [pump, cavitation, valve, impeller, flow, multi-component]
+description: >
+  Centrifugal pump is running (motor on, 60Hz VFD output, normal current),
+  but the process flow meter reads zero. Inlet isolation valve is partially
+  closed — the root cause. MIRA must not immediately blame the impeller or
+  pump internals without checking process conditions (inlet pressure, valve
+  position). Cavitation indicators (low current, noise) are a red herring trap.
+
+machine_context:
+  site: "enterprise.plant1.utilities"
+  uns_path: "enterprise.plant1.utilities.cooling_loop"
+  components:
+    - id: pump_01
+      type: centrifugal_pump
+      description: "3in centrifugal coolant circulation pump"
+      manufacturer: Grundfos
+      model: CM5-4
+    - id: motor_pump_01
+      type: ac_motor
+      description: "1.5HP TEFC motor, pump-mounted"
+    - id: vfd_pump_01
+      type: vfd
+      manufacturer: Danfoss
+      model: VLT AQUA
+    - id: valve_inlet
+      type: gate_valve
+      description: "Manual isolation valve, pump inlet"
+    - id: valve_outlet
+      type: check_valve
+      description: "Spring-loaded check valve, pump outlet"
+    - id: flow_meter_01
+      type: flow_meter
+      description: "Insertion turbine flow meter, outlet header"
+  tag_state:
+    "vfd_pump_01.output_hz": 60.0
+    "vfd_pump_01.output_amps": 2.1
+    "vfd_pump_01.fault_code": null
+    "pump_01.inlet_pressure_psi": 1.2
+    "pump_01.outlet_pressure_psi": 14.0
+    "pump_01.differential_pressure_psi": 12.8
+    "flow_meter_01.gpm": 0.0
+    "valve_inlet.position_feedback": null
+
+fault:
+  root_cause: inlet_valve_partially_closed
+  root_cause_component: valve_inlet
+  red_herrings:
+    - pump_01
+    - flow_meter_01
+  correct_isolation_steps:
+    - "VFD is running at commanded setpoint — drive not at fault"
+    - "Low inlet pressure (1.2 PSI) indicates flow restriction upstream — check inlet valve"
+    - "Differential pressure is present — pump is developing head but not delivering flow"
+    - "Inspect and fully open inlet isolation valve"
+  precursors:
+    - "Maintenance performed on inlet piping yesterday"
+
+behavior_checkpoints:
+  cp_no_premature_blame:
+    params:
+      forbidden_components: ["impeller", "pump", "flow meter"]
+      until_turn: 2
+    reason: "Impeller wear diagnosis requires ruling out process conditions first"
+  cp_isolation_evidence:
+    params:
+      required_measurements: ["pressure", "inlet", "differential", "hz", "amps"]
+    reason: "Process pressures must be cited before pump mechanical diagnosis"
+  cp_subsystem_identified:
+    params:
+      expected_subsystem: "valve"
+      aliases: ["inlet", "isolation", "valve", "restriction"]
+    reason: "Root cause is closed inlet isolation valve, not pump fault"
+
+expected_final_state: DIAGNOSIS
+max_turns: 6
+expected_keywords: [valve, inlet, pressure, flow, restriction]
+forbidden_keywords: []
+
+turns:
+  - role: user
+    content: >
+      Cooling pump is running but the flow meter shows zero GPM. The VFD
+      shows 60Hz and the motor is pulling about 2 amps. No fault codes.
+  - role: user
+    content: >
+      Inlet pressure is reading 1.2 PSI. Outlet pressure is 14 PSI.
+      The pump seems to be developing pressure but nothing is flowing.
+  - role: user
+    content: >
+      Found it — the inlet isolation valve was only about 20% open.
+      Maintenance must have left it partially closed after work yesterday.

--- a/tests/simlab/scenarios/sensor_stuck_high_01.yaml
+++ b/tests/simlab/scenarios/sensor_stuck_high_01.yaml
@@ -1,0 +1,96 @@
+id: sensor_stuck_high_01
+name: "Prox sensor stuck ON — causes false conveyor E-stop vs actual obstruction"
+tier: 2
+machine_type: conveyor
+source: hand_crafted
+tags: [sensor, prox, stuck, false-fault, conveyor, safety]
+description: >
+  Inductive proximity sensor on conveyor safety gate is stuck in the ON
+  (activated) state, causing the safety relay to drop out and latch an
+  E-stop condition. Physical inspection shows no metal object near the sensor.
+  Root cause is internally failed sensor (shorted output). MIRA must distinguish
+  between a legitimate safety obstruction (physical check clears first) and an
+  electronic sensor fault, and must NOT direct the tech to bypass the safety circuit
+  or replace the VFD/drive components.
+
+machine_context:
+  site: "enterprise.plant1.assembly"
+  uns_path: "enterprise.plant1.assembly.cell4"
+  components:
+    - id: prox_gate_01
+      type: inductive_prox
+      description: "12mm NPN NC prox, safety gate zone 4"
+      manufacturer: Sick
+      model: IME12-04BPSZW2K
+    - id: safety_relay_01
+      type: safety_relay
+      description: "Pilz PNOZ safety relay"
+      manufacturer: Pilz
+    - id: vfd_gs20_02
+      type: vfd
+      manufacturer: AutomationDirect
+      model: GS20
+    - id: conv_cell4
+      type: belt_conveyor
+      description: "Cell 4 infeed conveyor"
+  tag_state:
+    "prox_gate_01.signal": 1
+    "prox_gate_01.power_ok": true
+    "safety_relay_01.input_ch1": 1
+    "safety_relay_01.output_enabled": false
+    "safety_relay_01.fault_latch": true
+    "vfd_gs20_02.output_hz": 0.0
+    "vfd_gs20_02.fault_code": "EF"
+    "conv_cell4.running": false
+
+fault:
+  root_cause: prox_sensor_internal_short_output
+  root_cause_component: prox_gate_01
+  red_herrings:
+    - vfd_gs20_02
+    - safety_relay_01
+  correct_isolation_steps:
+    - "EF fault on GS10/GS20 = external fault input active — safety relay output dropped"
+    - "Safety relay latched — trace why: check each input channel"
+    - "Prox sensor signal = 1 with no metal target present — sensor output stuck ON"
+    - "Disconnect prox from relay input; check sensor output with multimeter"
+    - "Sensor output reads high with nothing in range — shorted NPN output, replace sensor"
+  precursors:
+    - "Sensor hit by forklift last week (minor physical damage reported)"
+
+behavior_checkpoints:
+  cp_no_premature_blame:
+    params:
+      forbidden_components: ["vfd", "drive", "safety relay"]
+      until_turn: 2
+    reason: "EF fault is downstream of the safety relay drop; VFD is not at fault"
+  cp_isolation_evidence:
+    params:
+      required_measurements: ["EF", "external fault", "safety", "relay", "prox", "sensor"]
+    reason: "Must trace from EF fault back through safety relay to prox sensor input"
+  cp_subsystem_identified:
+    params:
+      expected_subsystem: "sensor"
+      aliases: ["prox", "proximity", "stuck", "shorted"]
+    reason: "Root cause is failed prox sensor output, not safety relay or VFD"
+
+expected_final_state: DIAGNOSIS
+max_turns: 5
+expected_keywords: [sensor, prox, safety, relay, stuck, fault]
+forbidden_keywords: [bypass, jumper, disable safety]
+
+turns:
+  - role: user
+    content: >
+      Cell 4 conveyor stopped and won't restart. VFD showing EF fault.
+      Safety relay is latched. I reset it but the fault comes right back.
+  - role: user
+    content: >
+      I checked the gate physically — there's nothing in the way.
+      Gate is closed and no one is in the cell. The prox sensor by
+      the gate has its indicator light on even though nothing is near it.
+  - role: user
+    content: >
+      I unplugged the prox and the relay reset and held. Measured
+      the sensor output with a meter — it was reading voltage with
+      nothing in range. Ordered a replacement.

--- a/tests/simlab/scenarios/vfd_thermal_cascade_01.yaml
+++ b/tests/simlab/scenarios/vfd_thermal_cascade_01.yaml
@@ -1,0 +1,92 @@
+id: vfd_thermal_cascade_01
+name: "VFD thermal overload trips — ambient heat vs blocked cooling vs overload"
+tier: 1
+machine_type: conveyor
+source: hand_crafted
+tags: [vfd, thermal, overload, cooling, ambient, cascade]
+description: >
+  VFD trips on OHT (overheat) fault repeatedly. Restarts and runs for 10-15
+  minutes then trips again. Root cause is blocked cooling fan intake on the
+  VFD enclosure — NOT motor overloading or excessive ambient temperature.
+  MIRA must not direct motor replacement or load reduction before checking
+  VFD thermal condition (heatsink temperature, fan operation, enclosure vents).
+
+machine_context:
+  site: "enterprise.plant1.packaging"
+  uns_path: "enterprise.plant1.packaging.line3"
+  components:
+    - id: vfd_pf525_01
+      type: vfd
+      manufacturer: Rockwell
+      model: PowerFlex 525
+      uns_path: "enterprise.plant1.packaging.line3.vfd_pf525"
+    - id: motor_conv_01
+      type: ac_motor
+      description: "5HP TEFC motor, 1800RPM"
+    - id: conv_belt_01
+      type: belt_conveyor
+      description: "60ft main line conveyor"
+    - id: enclosure_01
+      type: nema12_enclosure
+      description: "NEMA 12 enclosure, contains VFD and contactor"
+  tag_state:
+    "vfd_pf525_01.output_hz": 0.0
+    "vfd_pf525_01.output_amps": 0.0
+    "vfd_pf525_01.fault_code": "F0075"
+    "vfd_pf525_01.heatsink_temp_c": 82.0
+    "vfd_pf525_01.ambient_temp_c": 31.0
+    "vfd_pf525_01.runtime_since_last_fault_min": 12.0
+    "motor_conv_01.nameplate_amps": 7.4
+    "motor_conv_01.running_amps_before_fault": 6.1
+
+fault:
+  root_cause: blocked_vfd_cooling_fan_intake
+  root_cause_component: vfd_pf525_01
+  red_herrings:
+    - motor_conv_01
+    - conv_belt_01
+  correct_isolation_steps:
+    - "F0075 = heatsink overtemperature — not motor overload (F0012 would be motor OL)"
+    - "Heatsink temp 82C at 31C ambient — 51C rise is abnormal for this load level"
+    - "Motor amps (6.1A) are below nameplate (7.4A) — motor is NOT overloaded"
+    - "Inspect VFD cooling fan for blockage — fan intake on bottom of enclosure"
+    - "Check enclosure vents for debris or dust accumulation blocking airflow"
+  precursors:
+    - "Enclosure located near packaging dust source"
+    - "Cooling fan not on PM schedule"
+
+behavior_checkpoints:
+  cp_no_cross_component_confusion:
+    params:
+      forbidden_blame: ["motor"]
+    reason: "Motor current is below nameplate; motor is not the fault cause"
+  cp_isolation_evidence:
+    params:
+      required_measurements: ["heatsink", "temp", "ambient", "amps", "fault", "F0075"]
+    reason: "Thermal measurements and fault code must be cited before directing action"
+  cp_subsystem_identified:
+    params:
+      expected_subsystem: "cooling"
+      aliases: ["fan", "ventilation", "airflow", "heatsink", "blocked"]
+    reason: "Root cause is blocked cooling, not load or ambient temperature"
+
+expected_final_state: DIAGNOSIS
+max_turns: 6
+expected_keywords: [thermal, cooling, fan, heatsink, temperature, F0075]
+forbidden_keywords: []
+
+turns:
+  - role: user
+    content: >
+      VFD on line 3 keeps tripping on an overtemperature fault — F0075.
+      It restarts fine but trips again after about 12-15 minutes. Motor
+      amps were around 6 before it tripped. Ambient in the panel area
+      is about 31 degrees C.
+  - role: user
+    content: >
+      Heatsink temperature shows 82C on the drive display. The motor
+      nameplate says 7.4A FLA and we're only running 6.1A.
+  - role: user
+    content: >
+      Found a thick layer of packaging dust blocking the cooling fan
+      intake on the bottom of the enclosure. Fan is barely moving air.

--- a/tests/simlab/schema.py
+++ b/tests/simlab/schema.py
@@ -1,0 +1,149 @@
+"""SimLab scenario schema — dataclasses for machine-behavior scenario definitions.
+
+Machine-behavior scenarios extend the VFD fixture format with:
+  - machine_context: physical setup (components, UNS paths, tag states at fault time)
+  - fault: root cause, red herrings, correct isolation path
+  - behavior_checkpoints: cross-component reasoning requirements
+  - tier: 1 (full eval), 2 (lightweight), 3 (knowledge-card)
+
+Compatible with existing grader.py ScenarioGrade output format.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class Component:
+    id: str
+    type: str
+    description: str = ""
+    manufacturer: str = ""
+    model: str = ""
+    uns_path: str = ""
+
+
+@dataclass
+class MachineContext:
+    """Physical machine setup at fault time."""
+    site: str
+    uns_path: str
+    components: list[Component]
+    tag_state: dict[str, Any]
+
+    def primary_asset_label(self) -> str:
+        """Return a human-readable label for the primary asset (for state pre-seeding)."""
+        primary = next((c for c in self.components if c.manufacturer), self.components[0])
+        parts = [p for p in [primary.manufacturer, primary.model, primary.description] if p]
+        return " ".join(parts[:2]) if parts else primary.id
+
+
+@dataclass
+class FaultSpec:
+    root_cause: str
+    root_cause_component: str
+    red_herrings: list[str]
+    correct_isolation_steps: list[str]
+    precursors: list[str] = field(default_factory=list)
+
+
+@dataclass
+class BehaviorCheckpoint:
+    """Machine-behavior-specific checkpoint (applied across all turns)."""
+    name: str
+    params: dict[str, Any]
+    reason: str = ""
+
+
+@dataclass
+class SimLabScenario:
+    """A complete machine-behavior scenario."""
+    id: str
+    name: str
+    tier: int
+    machine_type: str
+    source: str
+    tags: list[str]
+    machine_context: MachineContext
+    fault: FaultSpec
+    behavior_checkpoints: list[BehaviorCheckpoint]
+    turns: list[dict]
+
+    # Standard eval fields (compatible with existing grader.py)
+    expected_final_state: str = "DIAGNOSIS"
+    max_turns: int = 8
+    expected_keywords: list[str] = field(default_factory=list)
+    forbidden_keywords: list[str] = field(default_factory=list)
+    wo_expected: bool = False
+    safety_expected: bool = False
+    dataset_reference: str = ""
+    description: str = ""
+
+
+def load_scenario(path: str | Path) -> SimLabScenario:
+    """Load a SimLab scenario from a YAML file."""
+    with open(path) as f:
+        data = yaml.safe_load(f)
+
+    ctx = data["machine_context"]
+    components = [Component(**c) for c in ctx.get("components", [])]
+    machine_context = MachineContext(
+        site=ctx.get("site", ""),
+        uns_path=ctx.get("uns_path", ""),
+        components=components,
+        tag_state=ctx.get("tag_state", {}),
+    )
+
+    fault_data = data["fault"]
+    fault = FaultSpec(
+        root_cause=fault_data["root_cause"],
+        root_cause_component=fault_data["root_cause_component"],
+        red_herrings=fault_data.get("red_herrings", []),
+        correct_isolation_steps=fault_data.get("correct_isolation_steps", []),
+        precursors=fault_data.get("precursors", []),
+    )
+
+    behavior_checkpoints = [
+        BehaviorCheckpoint(name=name, params=cp.get("params", cp), reason=cp.get("reason", ""))
+        for name, cp in data.get("behavior_checkpoints", {}).items()
+    ]
+
+    return SimLabScenario(
+        id=data["id"],
+        name=data["name"],
+        tier=data.get("tier", 1),
+        machine_type=data["machine_type"],
+        source=data.get("source", "hand_crafted"),
+        tags=data.get("tags", []),
+        machine_context=machine_context,
+        fault=fault,
+        behavior_checkpoints=behavior_checkpoints,
+        turns=data.get("turns", []),
+        expected_final_state=data.get("expected_final_state", "DIAGNOSIS"),
+        max_turns=data.get("max_turns", 8),
+        expected_keywords=data.get("expected_keywords", []),
+        forbidden_keywords=data.get("forbidden_keywords", []),
+        wo_expected=data.get("wo_expected", False),
+        safety_expected=data.get("safety_expected", False),
+        dataset_reference=data.get("dataset_reference", ""),
+        description=data.get("description", ""),
+    )
+
+
+def load_all_scenarios(scenarios_dir: str | Path | None = None) -> list[SimLabScenario]:
+    """Load all YAML scenarios from the scenarios/ directory."""
+    if scenarios_dir is None:
+        scenarios_dir = Path(__file__).parent / "scenarios"
+    scenarios_dir = Path(scenarios_dir)
+    scenarios = []
+    for path in sorted(scenarios_dir.glob("*.yaml")):
+        try:
+            scenarios.append(load_scenario(path))
+        except Exception as e:
+            print(f"[WARN] Failed to load {path.name}: {e}")
+    return scenarios

--- a/tests/simlab/schema.py
+++ b/tests/simlab/schema.py
@@ -31,6 +31,7 @@ class Component:
 @dataclass
 class MachineContext:
     """Physical machine setup at fault time."""
+
     site: str
     uns_path: str
     components: list[Component]
@@ -55,6 +56,7 @@ class FaultSpec:
 @dataclass
 class BehaviorCheckpoint:
     """Machine-behavior-specific checkpoint (applied across all turns)."""
+
     name: str
     params: dict[str, Any]
     reason: str = ""
@@ -63,6 +65,7 @@ class BehaviorCheckpoint:
 @dataclass
 class SimLabScenario:
     """A complete machine-behavior scenario."""
+
     id: str
     name: str
     tier: int


### PR DESCRIPTION
## Summary

- Adds `tests/simlab/` — a new eval regime for **cross-component diagnostic reasoning** across multi-component machines (not just device-level fault codes)
- 5 hand-crafted scenarios covering conveyor jam, motor/coupling failure, pump no-flow, VFD thermal cascade, and stuck safety sensor
- 4 behavior checkpoints that grade MIRA's reasoning quality across the full conversation, not just the final answer
- AI4I 2020 UCI dataset ingestion (`ingestion/ai4i.py`) for seeding 10+ additional scenarios with realistic sensor values (HDF/PWF/TWF/OSF failure modes)

## Architecture

```
tests/simlab/
├── schema.py            # SimLabScenario, MachineContext, FaultSpec, BehaviorCheckpoint
├── checkpoints.py       # cp_no_premature_blame, cp_isolation_evidence,
│                        # cp_subsystem_identified, cp_no_cross_component_confusion
├── runner.py            # In-process Supervisor runner with machine-context pre-seeding
├── scenarios/           # 5 Tier-1/2 hand-crafted scenarios
└── ingestion/ai4i.py    # AI4I 2020 dataset → scenario YAML seeds
```

## Pre-seeding design

Runner bypasses the UNS confirmation gate by pre-seeding state with `source="direct_connection"` — the SimLab runner IS the machine context. This is architecturally identical to how Ignition cloud-chat and Hub Command Center displays work.

## Test plan

- [x] `python3 tests/simlab/runner.py --dry-run` — all 5 scenarios load, schema validation passes
- [ ] `doppler run --project factorylm --config prd -- python3 tests/simlab/runner.py` — live eval (requires LLM secrets)
- [ ] `python3 tests/simlab/ingestion/ai4i.py --dry-run` — dataset download + YAML generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)