### PR TITLE
fix(kg): guard GraphCanvas painters against non-finite node coords (map page crash)

### DIFF
--- a/mira-hub/src/components/kg/GraphCanvas.tsx
+++ b/mira-hub/src/components/kg/GraphCanvas.tsx
@@ -83,6 +83,10 @@ export function GraphCanvas({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       nodeCanvasObject={(node: any, ctx: CanvasRenderingContext2D, scale: number) => {
         const n = node as GraphNode & { x: number; y: number };
+        // d3-force can emit a non-finite x/y on the first tick before positions
+        // settle; createRadialGradient throws on NaN/Infinity and crashes the
+        // whole page (React error boundary). Skip painting until coords are real.
+        if (!Number.isFinite(n.x) || !Number.isFinite(n.y)) return;
         const r = nodeRadius(n.degree ?? 0);
         const isHi = hasHighlight && highlightNodeIds!.has(n.id);
         const dim = hasHighlight && !isHi;
@@ -126,6 +130,7 @@ export function GraphCanvas({
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       nodePointerAreaPaint={(node: any, color: string, ctx: CanvasRenderingContext2D) => {
         const n = node as GraphNode & { x: number; y: number };
+        if (!Number.isFinite(n.x) || !Number.isFinite(n.y)) return;
         ctx.fillStyle = color;
         ctx.beginPath();
         ctx.arc(n.x, n.y, nodeRadius(n.degree ?? 0) + 2, 0, 2 * Math.PI);


### PR DESCRIPTION
## Symptom

`app.factorylm.com/knowledge/map` (the relationship graph) **opens, then crashes** to the Next.js `This page couldn't load` error boundary. Reproduced live on prod 2026-06-06.

## Root cause

The custom `nodeCanvasObject` painter in `GraphCanvas.tsx` calls:

```js
ctx.createRadialGradient(n.x, n.y, 0, n.x, n.y, r * 2.6)
```

`react-force-graph-2d`'s d3-force simulation emits a **non-finite `n.x`/`n.y`** on the first `tickFrame`, which runs **synchronously inside the kapsule `init`** (not in a `requestAnimationFrame`). `createRadialGradient` throws `The provided double value is non-finite` on NaN/Infinity. Because the throw happens during React's synchronous commit, it propagates to the error boundary and blanks the entire page.

Confirmed via the live browser console:

```
TypeError: Failed to execute 'createRadialGradient' on 'CanvasRenderingContext2D':
The provided double value is non-finite.
    at Object.nodeCanvasObject
    at g.tickFrame → g.init
```

The data is clean and tiny (16 nodes / 8 edges, no dangling links, no duplicate IDs, API 200) — this is **not** a data problem. The NaN is **transient**: d3 assigns finite positions within a frame or two. `react-force-graph`'s built-in node renderer guards against non-finite coords; this custom painter did not.

Likely surfaced by the recent **Next 16 / React 19** bump shifting first-paint timing so the painter runs before d3 seeds coordinates (prod image rebuilt today).

## Fix

Skip painting a node on any frame where its coordinates aren't finite — in both `nodeCanvasObject` and `nodePointerAreaPaint`. Guarded nodes render normally once d3 settles. 5-line change, no behavior change for finite coords.

## Verification (live prod)

Monkeypatched `createRadialGradient` on prod with the same finite-guard, then SPA-navigated to the Map tab:
- **Before:** error boundary, page dead.
- **After patch:** full graph renders — 16/16 nodes laid out, verified edge cluster drawn, **zero console errors**.

This PR ports that guard into the source. No ops/data/config change required.

## Scope

`GraphCanvas` is imported only by the `/knowledge/map` page — no blast radius elsewhere.