### PR TITLE
feat(kg): migration 043 — CMMS/tag canonical relationship types + map (#1721)

### DIFF
--- a/mira-hub/db/migrations/043_has_work_order_relationship_type.sql
+++ b/mira-hub/db/migrations/043_has_work_order_relationship_type.sql
@@ -1,0 +1,98 @@
+BEGIN;
+
+-- Migration 043: Add CMMS / tag relationship types to
+-- relationship_proposals.relationship_type (HAS_WORK_ORDER, HAS_PM_SCHEDULE,
+-- HAS_TAG).
+--
+-- Issue : #1721 (hub relationship writers must propose by default)
+-- ADR   : docs/adr/0017-proposal-state-machine-mapping.md
+-- Map   : mira-hub/src/lib/knowledge-graph/proposals-writer.ts
+--         (CANONICAL_PROPOSAL_RELATIONSHIP_TYPES + mapToCanonicalEdge)
+--
+-- Why:
+--   The CMMS-sync + conversation writers (cmms-sync.ts / extractor.ts) emit
+--   equipment→work-order, equipment→PM-schedule, and asset→tag edges. To
+--   migrate them onto the propose path (upsertInferredProposal) these need
+--   canonical types the CHECK accepts, and the team chose DEDICATED types over
+--   reusing near-fits (so the graph distinguishes a work order from a
+--   procedure, and a tag from a generic signal):
+--     - has_work_order → HAS_WORK_ORDER   (vs the too-narrow HAS_PROCEDURE)
+--     - has_pm         → HAS_PM_SCHEDULE   (a recurring PM, distinct from a
+--                                           one-off work-instruction PROCEDURE)
+--     - mentioned_tag  → HAS_TAG           (a PLC/CMMS tag, distinct from the
+--                                           generic HAS_SIGNAL)
+--   The remaining emitted types still map to existing canonical members
+--   (located_at→LOCATED_IN, parent_of→LOCATED_IN [flipped],
+--   exhibited_fault→HAS_FAILURE_MODE, requires_part→HAS_PART) — no new type
+--   needed for those.
+--
+-- Numbering:
+--   037 is the live tail; 038–042 are reserved by #1677 (canonical asset-graph
+--   sign-offs). This takes 043 to stay clear of that range.
+--
+-- Compatibility:
+--   The new CHECK is a strict SUPERSET of migration 032 — every existing row
+--   stays valid. DOWN restores the 032 CHECK exactly (refuses if HAS_WORK_ORDER
+--   rows exist).
+
+ALTER TABLE relationship_proposals
+  DROP CONSTRAINT IF EXISTS relationship_proposals_relationship_type_check;
+
+ALTER TABLE relationship_proposals
+  ADD CONSTRAINT relationship_proposals_relationship_type_check
+  CHECK (relationship_type IN (
+    -- Hierarchy
+    'HAS_COMPONENT', 'INSTANCE_OF', 'LOCATED_IN', 'HAS_PART',
+    -- Documentation
+    'HAS_DOCUMENT', 'HAS_CHUNK', 'REFERENCES', 'HAS_PROCEDURE',
+    -- Wiring & power
+    'WIRED_TO', 'POWERED_BY', 'MAPS_TO', 'PUBLISHED_AS',
+    -- Logic & control
+    'USED_IN_LOGIC', 'TRIGGERS', 'CAUSES', 'DRIVES', 'IS_DRIVEN_BY',
+    -- Faults & resolution
+    'OCCURS_ON', 'RESOLVED_BY', 'HAS_FAILURE_MODE',
+    -- Signals
+    'HAS_SIGNAL', 'HAS_ALIAS',
+    -- Topology
+    'DEPENDS_ON', 'UPSTREAM_OF', 'DOWNSTREAM_OF', 'REPLACES',
+    -- Evidence meta
+    'CONFIRMED_BY', 'CONTRADICTED_BY',
+    -- Inferred / similarity
+    'SAME_MODEL_AS', 'CO_FAILED_WITH', 'SIMILAR_TO',
+    -- CMMS / tags (new in this migration)
+    'HAS_WORK_ORDER', 'HAS_PM_SCHEDULE', 'HAS_TAG'
+  ));
+
+COMMIT;
+
+-- ----------------------------------------------------------------------------
+-- DOWN
+-- ----------------------------------------------------------------------------
+--
+-- BEGIN;
+--
+-- DO $$
+-- BEGIN
+--   IF EXISTS (SELECT 1 FROM relationship_proposals WHERE relationship_type IN ('HAS_WORK_ORDER','HAS_PM_SCHEDULE','HAS_TAG')) THEN
+--     RAISE EXCEPTION 'Cannot down-migrate: HAS_WORK_ORDER/HAS_PM_SCHEDULE/HAS_TAG rows exist. Reject or rewrite them first.';
+--   END IF;
+-- END $$;
+--
+-- ALTER TABLE relationship_proposals
+--   DROP CONSTRAINT IF EXISTS relationship_proposals_relationship_type_check;
+--
+-- ALTER TABLE relationship_proposals
+--   ADD CONSTRAINT relationship_proposals_relationship_type_check
+--   CHECK (relationship_type IN (
+--     'HAS_COMPONENT', 'INSTANCE_OF', 'LOCATED_IN', 'HAS_PART',
+--     'HAS_DOCUMENT', 'HAS_CHUNK', 'REFERENCES', 'HAS_PROCEDURE',
+--     'WIRED_TO', 'POWERED_BY', 'MAPS_TO', 'PUBLISHED_AS',
+--     'USED_IN_LOGIC', 'TRIGGERS', 'CAUSES', 'DRIVES', 'IS_DRIVEN_BY',
+--     'OCCURS_ON', 'RESOLVED_BY', 'HAS_FAILURE_MODE',
+--     'HAS_SIGNAL', 'HAS_ALIAS',
+--     'DEPENDS_ON', 'UPSTREAM_OF', 'DOWNSTREAM_OF', 'REPLACES',
+--     'CONFIRMED_BY', 'CONTRADICTED_BY',
+--     'SAME_MODEL_AS', 'CO_FAILED_WITH', 'SIMILAR_TO'
+--   ));
+--
+-- COMMIT;

--- a/mira-hub/docs/audits/2026-06-05-hub-relationship-writers-1721.md
+++ b/mira-hub/docs/audits/2026-06-05-hub-relationship-writers-1721.md
@@ -40,4 +40,13 @@ Implication: schematic edges were already canonical (clean migration, no remap).
 
 ## Remaining for #1721
 
-`relationship-extractor.ts`, `extractor.ts`, then `cmms-sync.ts` + `hierarchy-backfill.ts` (after the CHECK/mapping decision). #1721 stays open until all are propose-by-default or explicitly justified. CI guard for unguarded inserts = #1722; canary = #1723.
+`relationship-extractor.ts` ✅ migrated. `extractor.ts`, `cmms-sync.ts`, `hierarchy-backfill.ts` remain — now fully **map-ready**:
+
+**Vocabulary decided (migration 043).** The CHECK gains dedicated CMMS/tag types and the map covers every emitted type:
+- `has_work_order` → `HAS_WORK_ORDER` (new), `has_pm` → `HAS_PM_SCHEDULE` (new), `mentioned_tag` → `HAS_TAG` (new)
+- `parent_of` → `LOCATED_IN` **flipped** (equipment LOCATED_IN area)
+- `located_at`→`LOCATED_IN`, `exhibited_fault`→`HAS_FAILURE_MODE`, `requires_part`→`HAS_PART` (existing)
+
+**Ordering constraint:** migration 043 must be applied (dev → staging → prod via `apply-migrations.yml`) **before** the `cmms-sync`/`extractor` writer-migration PRs deploy, or a proposal carrying a new type would fail the prod CHECK. The TS map/CANONICAL set already include the new types, but no migrated writer emits them yet, so landing them ahead of the apply is safe.
+
+The three writer migrations stay deferred until 043 is applied **and** their competing PRs (#1030/#1263/#1710/#642) settle. CI guard for unguarded inserts = #1722 (merged); canary = #1723 (merged).

--- a/mira-hub/src/lib/knowledge-graph/__tests__/proposals-writer.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/proposals-writer.test.ts
@@ -31,17 +31,21 @@ describe("mapToCanonicalEdge", () => {
     expect(mapToCanonicalEdge("resolved_by")).toEqual({ type: "RESOLVED_BY", flip: false });
     expect(mapToCanonicalEdge("triggered_pm")).toEqual({ type: "TRIGGERS", flip: false });
     expect(mapToCanonicalEdge("located_at")).toEqual({ type: "LOCATED_IN", flip: false });
-    expect(mapToCanonicalEdge("parent_of")).toEqual({ type: "HAS_COMPONENT", flip: false });
     expect(mapToCanonicalEdge("electrically_connected")).toEqual({ type: "WIRED_TO", flip: false });
-    expect(mapToCanonicalEdge("mentioned_tag")).toEqual({ type: "HAS_SIGNAL", flip: false });
+    // dedicated CMMS / tag types (migration 043)
+    expect(mapToCanonicalEdge("has_work_order")).toEqual({ type: "HAS_WORK_ORDER", flip: false });
+    expect(mapToCanonicalEdge("has_pm")).toEqual({ type: "HAS_PM_SCHEDULE", flip: false });
+    expect(mapToCanonicalEdge("mentioned_tag")).toEqual({ type: "HAS_TAG", flip: false });
   });
 
-  test("caused_by flips direction (A caused_by B → B CAUSES A)", () => {
+  test("flipped mappings swap source/target", () => {
     expect(mapToCanonicalEdge("caused_by")).toEqual({ type: "CAUSES", flip: true });
+    // parent_of (area → equipment) becomes equipment LOCATED_IN area
+    expect(mapToCanonicalEdge("parent_of")).toEqual({ type: "LOCATED_IN", flip: true });
   });
 
   test("types with no clean canonical equivalent return null (caller skips)", () => {
-    for (const t of ["has_work_order", "controls", "protects", "maintained_by", "frobnicate"]) {
+    for (const t of ["controls", "protects", "maintained_by", "frobnicate"]) {
       expect(mapToCanonicalEdge(t)).toBeNull();
     }
   });
@@ -49,8 +53,8 @@ describe("mapToCanonicalEdge", () => {
   test("every mapped target is itself canonical (round-trip safety)", () => {
     for (const raw of [
       "caused_by", "resolved_by", "feeds", "requires_part", "triggered_pm", "had_fault",
-      "mentioned_tag", "exhibited_fault", "located_at", "has_pm", "parent_of",
-      "has_component", "electrically_connected", "references_drawing", "similar_to",
+      "mentioned_tag", "exhibited_fault", "located_at", "has_pm", "has_work_order",
+      "parent_of", "has_component", "electrically_connected", "references_drawing", "similar_to",
     ]) {
       const edge = mapToCanonicalEdge(raw);
       expect(edge).not.toBeNull();

--- a/mira-hub/src/lib/knowledge-graph/proposals-writer.ts
+++ b/mira-hub/src/lib/knowledge-graph/proposals-writer.ts
@@ -35,6 +35,8 @@ export const CANONICAL_PROPOSAL_RELATIONSHIP_TYPES = new Set<string>([
   "CONFIRMED_BY", "CONTRADICTED_BY",
   // Inferred / similarity
   "SAME_MODEL_AS", "CO_FAILED_WITH", "SIMILAR_TO",
+  // CMMS / tags (migration 043)
+  "HAS_WORK_ORDER", "HAS_PM_SCHEDULE", "HAS_TAG",
 ]);
 
 export function isCanonicalProposalRelationshipType(t: string): boolean {
@@ -63,20 +65,22 @@ const LOWERCASE_TO_CANONICAL_EDGE: Record<string, { type: string; flip: boolean 
   triggered_pm: { type: "TRIGGERS", flip: false },
   had_fault: { type: "HAS_FAILURE_MODE", flip: false },
   // conversation extractor
-  mentioned_tag: { type: "HAS_SIGNAL", flip: false },
+  mentioned_tag: { type: "HAS_TAG", flip: false },
   exhibited_fault: { type: "HAS_FAILURE_MODE", flip: false },
   // CMMS sync
   located_at: { type: "LOCATED_IN", flip: false },
-  has_pm: { type: "HAS_PROCEDURE", flip: false },
-  // hierarchy backfill (area → equipment: the parent HAS_COMPONENT the child)
-  parent_of: { type: "HAS_COMPONENT", flip: false },
+  has_work_order: { type: "HAS_WORK_ORDER", flip: false },
+  has_pm: { type: "HAS_PM_SCHEDULE", flip: false },
+  // hierarchy backfill (area/line → equipment): the equipment is LOCATED_IN
+  // the area, so flip source/target on propose.
+  parent_of: { type: "LOCATED_IN", flip: true },
   // other types.ts vocabulary
   has_component: { type: "HAS_COMPONENT", flip: false },
   electrically_connected: { type: "WIRED_TO", flip: false },
   references_drawing: { type: "REFERENCES", flip: false },
   similar_to: { type: "SIMILAR_TO", flip: false },
   // No clean canonical equivalent yet (skip + warn until added to the CHECK):
-  //   has_work_order, controls, protects, maintained_by
+  //   controls, protects, maintained_by
 };
 
 /**


### PR DESCRIPTION
Unblocks #1721's remaining hub writers (`cmms-sync`, `extractor`, `hierarchy-backfill`) by adding the canonical relationship types their edges need. **Vocabulary decisions made with the team** (not guessed); migration **dry-run-verified on staging**.

## Decisions
Dedicated types over reusing near-fits, so the graph distinguishes work orders / PMs / tags:
| emitted (lowercase) | canonical | note |
|---|---|---|
| `has_work_order` | **`HAS_WORK_ORDER`** (new) | no existing fit |
| `has_pm` | **`HAS_PM_SCHEDULE`** (new) | distinct from one-off `HAS_PROCEDURE` |
| `mentioned_tag` | **`HAS_TAG`** (new) | distinct from generic `HAS_SIGNAL` |
| `parent_of` | `LOCATED_IN` **(flipped)** | equipment LOCATED_IN area (ISA-95) |
| `located_at` / `exhibited_fault` / `requires_part` | `LOCATED_IN` / `HAS_FAILURE_MODE` / `HAS_PART` | existing |

## Changes
- **Migration 043** — adds the 3 types to the `relationship_proposals` CHECK (strict superset of 032; DOWN restores 032, refuses if new-type rows exist). Number **043** stays clear of #1677's reserved 038–042.
- **`proposals-writer.ts`** — extend `CANONICAL_PROPOSAL_RELATIONSHIP_TYPES` + `mapToCanonicalEdge` (incl. the `parent_of`→`LOCATED_IN` flip).
- Tests (9 pass): new mappings, the flip, round-trip safety.

## Verification
- **Staging dry-run** (`factorylm/stg`, txn + rollback): 0 existing rows violate the new CHECK; all 3 new types accepted.
- vitest 9/9; eslint clean; `db:check-order` passes; kg-write-guard green (migration has no inserts).

## ⚠️ Ordering
Apply 043 **dev→staging→prod via `apply-migrations.yml`** before the `cmms-sync`/`extractor` writer-migration PRs deploy. The TS map already includes the new types, but **no migrated writer emits them yet**, so this is safe to land ahead of the apply. The three writer migrations stay **deferred** until 043 applies *and* their competing PRs (#1030/#1263/#1710/#642) settle.

Related: #1721, #1662, EPIC #1666. Audit doc updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)