### PR TITLE
fix(ci): oauth-redirect canary tests the real signin flow (no secret, correct exit codes)

### DIFF
--- a/.github/workflows/oauth-redirect-canary.yml
+++ b/.github/workflows/oauth-redirect-canary.yml
@@ -10,10 +10,17 @@ name: oauth-redirect canary
 # sign-in. The canonical list lives in
 # mira-hub/docs/auth/oauth-redirect-uris.md.
 #
-# This workflow runs the probe script, which hits Google's authorize
-# endpoint with our exact redirect_uri and fails on a 302 → /signin/oauth/error
-# carrying redirect_uri_mismatch. Failure means: re-add the URI in
-# Google Cloud Console; see the script's stderr for the exact value.
+# This workflow runs the probe script, which drives the app's REAL signin
+# flow (GET csrf → POST signin/google) to obtain the exact Google authorize
+# URL the app sends, then follows it to Google. No secret needed — client_id
+# and redirect_uri are public values the app already emits. Exit codes are
+# distinct so the failure is never mislabelled:
+#   1 = redirect_uri_mismatch (REAL — re-add the URI in Google Cloud Console)
+#   2 = probe could not run (app unreachable / signin shape changed) — NOT a
+#       Google rejection; investigate the probe/deploy, not the Console
+#   3 = inconclusive. The script emits the matching ::error::/::warning::
+# annotation itself, so there is no separate (and previously misleading)
+# "on failure" step. Canonical URI list: mira-hub/docs/auth/oauth-redirect-uris.md.
 
 on:
   schedule:
@@ -46,20 +53,10 @@ jobs:
 
       - name: Run canary
         env:
-          HUB_AUTH_GOOGLE_CLIENT_ID: ${{ secrets.HUB_AUTH_GOOGLE_CLIENT_ID }}
-          # Override-able so the same script can verify per-env URIs
-          # (preview / staging) by passing OAUTH_REDIRECT_URI_TO_VERIFY.
+          # No secret needed — the probe derives the public client_id from the
+          # live signin flow. HUB_URL selects which deployment to verify;
+          # OAUTH_REDIRECT_URI_TO_VERIFY is the documented URI to assert against
+          # (override both to check preview / staging).
+          HUB_URL: "https://app.factorylm.com"
           OAUTH_REDIRECT_URI_TO_VERIFY: "https://app.factorylm.com/api/auth/callback/google"
         run: bun run mira-hub/scripts/verify-google-oauth-redirect.ts
-
-      - name: On failure, point reader at the fix
-        if: failure()
-        run: |
-          echo "::error title=Google OAuth redirect URI not authorized::"
-          echo "Google rejected mira-hub's redirect_uri. Fix:"
-          echo "  1. Open Google Cloud Console → APIs & Services → Credentials"
-          echo "  2. Edit OAuth 2.0 Client ID 246891599587-…"
-          echo "  3. Under 'Authorized redirect URIs' add the URI from the"
-          echo "     stderr above (or the canonical list in"
-          echo "     mira-hub/docs/auth/oauth-redirect-uris.md)"
-          echo "  4. Save. Wait ~30s. Re-run this workflow."

--- a/mira-hub/scripts/verify-google-oauth-redirect.ts
+++ b/mira-hub/scripts/verify-google-oauth-redirect.ts
@@ -1,98 +1,182 @@
 #!/usr/bin/env bun
-// Canary: probe Google's OAuth authorize endpoint with our exact
-// redirect_uri and fail loudly if Google returns redirect_uri_mismatch.
+// Canary: verify Google sign-in works end-to-end against a running deployment,
+// and fail loudly if Google returns `redirect_uri_mismatch`.
 //
-// Why this exists: there is no public API to read the redirect URIs
-// registered on a Google OAuth 2.0 Client ID, so drift between what we
-// send (NEXTAUTH_URL + NextAuth basePath) and what's registered in
-// Google Cloud Console can only be detected by trying. This script does
+// Why this exists: there is no public API to read the redirect URIs registered
+// on a Google OAuth 2.0 Client ID, so drift between what the app sends
+// (NEXTAUTH_URL + NextAuth basePath → /callback/google) and what's registered
+// in Google Cloud Console can only be detected by trying. This script does
 // that, on a schedule, before the next end user does.
 //
-// Exits 0 if Google accepts the redirect_uri (302 → consent / chooser).
-// Exits 1 with a human-readable explanation if Google rejects it.
+// It needs NO secret. client_id and redirect_uri are *public* values the app
+// already puts in its Google authorize redirect, so we drive the real signin
+// flow (GET csrf → POST signin/google) to obtain the exact authorize URL the
+// app would send a user to, then follow it to Google. This tests the real flow
+// rather than a reconstruction of it — and removes the dependency on the
+// HUB_AUTH_GOOGLE_CLIENT_ID GitHub secret that previously made the canary
+// exit 2 ("not set") without ever probing Google.
+//
+// Exit codes (each maps to a distinct CI annotation):
+//   0  OK          — Google accepted the redirect_uri (consent / chooser).
+//   1  MISMATCH    — Google rejected it (redirect_uri_mismatch). REAL incident:
+//                    the redirect URI is not registered in Google Cloud Console.
+//   2  CANT_RUN    — probe could not run (app unreachable, signin flow shape
+//                    changed, no authorize redirect). NOT a Google rejection.
+//   3  INCONCLUSIVE — unexpected response from Google; inspect manually.
 //
 // Run locally:  bun run scripts/verify-google-oauth-redirect.ts
+//               HUB_URL=https://staging… bun run scripts/verify-google-oauth-redirect.ts
 // Run in CI:    same, see .github/workflows/oauth-redirect-canary.yml
 
-async function main(): Promise<void> {
-  const clientId = process.env.HUB_AUTH_GOOGLE_CLIENT_ID;
-  const redirectUri =
-    process.env.OAUTH_REDIRECT_URI_TO_VERIFY ??
-    "https://app.factorylm.com/api/auth/callback/google";
+const EXIT_OK = 0;
+const EXIT_MISMATCH = 1;
+const EXIT_CANT_RUN = 2;
+const EXIT_INCONCLUSIVE = 3;
 
-  if (!clientId) {
-    console.error(
-      "FAIL: HUB_AUTH_GOOGLE_CLIENT_ID is not set. Run under Doppler:\n" +
-        "  doppler run -p factorylm -c prd -- bun run scripts/verify-google-oauth-redirect.ts",
-    );
-    process.exit(2);
+const HUB = (process.env.HUB_URL ?? "https://app.factorylm.com").replace(/\/$/, "");
+// The redirect_uri we EXPECT the app to send (drift check on the app side too).
+const EXPECTED_REDIRECT_URI =
+  process.env.OAUTH_REDIRECT_URI_TO_VERIFY ?? `${HUB}/api/auth/callback/google`;
+
+/** Collapse a response's Set-Cookie headers into a single Cookie request header. */
+function cookieHeaderFrom(res: Response): string {
+  const jar = res.headers.getSetCookie?.() ?? [];
+  return jar
+    .map((c) => c.split(";", 1)[0]?.trim())
+    .filter((c): c is string => Boolean(c))
+    .join("; ");
+}
+
+/**
+ * Drive the app's real Google signin to obtain the exact Google authorize URL
+ * it would redirect a user to. Returns null if we cannot (→ EXIT_CANT_RUN).
+ */
+async function getLiveAuthorizeUrl(): Promise<string | null> {
+  // 1. CSRF token + cookie. Trailing slash avoids nginx's 308 normalisation.
+  const csrfRes = await fetch(`${HUB}/api/auth/csrf/`, { redirect: "manual" });
+  if (!csrfRes.ok) {
+    console.error(`[probe] GET /api/auth/csrf returned HTTP ${csrfRes.status}`);
+    return null;
+  }
+  const csrfToken = ((await csrfRes.json().catch(() => ({}))) as { csrfToken?: string })
+    .csrfToken;
+  const cookie = cookieHeaderFrom(csrfRes);
+  if (!csrfToken || !cookie) {
+    console.error("[probe] could not obtain csrfToken / csrf cookie from the app");
+    return null;
   }
 
-  const url = new URL("https://accounts.google.com/o/oauth2/v2/auth");
-  url.searchParams.set("client_id", clientId);
-  url.searchParams.set("redirect_uri", redirectUri);
-  url.searchParams.set("response_type", "code");
-  url.searchParams.set("scope", "openid email profile");
-  url.searchParams.set("state", "canary");
-  // PKCE — Google validates `code_challenge` is base64url-encoded BEFORE
-  // checking the redirect_uri, so we must send a real one or we get
-  // `invalid_request: Code Challenge must be base64 encoded` and never
-  // exercise the redirect-URI check. This is the base64url-SHA256 of the
-  // string "canary-code-verifier" (any fixed value works for the probe).
-  const codeVerifier = "canary-code-verifier-fixed-value-for-the-canary-probe";
-  const challengeBytes = await crypto.subtle.digest(
-    "SHA-256",
-    new TextEncoder().encode(codeVerifier),
+  // 2. POST the Google signin. NextAuth replies with the Google authorize URL —
+  //    as a 302 Location, or as JSON {url} when X-Auth-Return-Redirect is honoured.
+  const body = new URLSearchParams({ csrfToken, callbackUrl: `${HUB}/feed` });
+  const signinRes = await fetch(`${HUB}/api/auth/signin/google/`, {
+    method: "POST",
+    redirect: "manual",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      "X-Auth-Return-Redirect": "1",
+      cookie,
+    },
+    body: body.toString(),
+  });
+
+  const loc = signinRes.headers.get("location");
+  if (loc && loc.includes("accounts.google.com")) return loc;
+
+  const json = (await signinRes.json().catch(() => ({}))) as { url?: string };
+  if (json.url && json.url.includes("accounts.google.com")) return json.url;
+
+  console.error(
+    `[probe] signin did not return a Google authorize URL ` +
+      `(HTTP ${signinRes.status}, location=${loc ?? "none"})`,
   );
-  const codeChallenge = Buffer.from(challengeBytes)
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-  url.searchParams.set("code_challenge", codeChallenge);
-  url.searchParams.set("code_challenge_method", "S256");
+  return null;
+}
 
-  const res = await fetch(url.toString(), { redirect: "manual" });
+async function main(): Promise<void> {
+  const authorizeUrl = await getLiveAuthorizeUrl();
+  if (!authorizeUrl) {
+    console.log(
+      "::error title=OAuth canary could not run::Could not obtain the Google " +
+        `authorize URL from ${HUB}'s signin flow — the app may be unreachable or ` +
+        "the NextAuth signin shape changed. This is NOT a Google rejection; " +
+        "investigate the probe / deployment, not Google Cloud Console.",
+    );
+    console.error(`\nCANT_RUN: no authorize URL from ${HUB}. exit ${EXIT_CANT_RUN}`);
+    process.exit(EXIT_CANT_RUN);
+  }
+
+  const parsed = new URL(authorizeUrl);
+  const clientId = parsed.searchParams.get("client_id") ?? "(none)";
+  const sentRedirectUri = parsed.searchParams.get("redirect_uri") ?? "(none)";
+  console.log(`client_id (public)  = ${clientId}`);
+  console.log(`redirect_uri (sent) = ${sentRedirectUri}`);
+  console.log(`redirect_uri (want) = ${EXPECTED_REDIRECT_URI}`);
+  if (sentRedirectUri !== EXPECTED_REDIRECT_URI) {
+    // App-side drift: the deployment sends a redirect_uri other than the
+    // documented one. Warn (not fatal) — we still test what it actually sends.
+    console.log(
+      "::warning title=App redirect_uri drift::The app is sending a redirect_uri " +
+        `(${sentRedirectUri}) that differs from the documented value ` +
+        `(${EXPECTED_REDIRECT_URI}). Check NEXTAUTH_URL / oauth-redirect-uris.md.`,
+    );
+  }
+
+  // Follow the app's real authorize URL to Google (no redirect-follow).
+  const res = await fetch(authorizeUrl, { redirect: "manual" });
   const loc = res.headers.get("location") ?? "";
+  console.log(`Google: HTTP ${res.status} — Location: ${loc.slice(0, 120)}…`);
 
-  console.log(`HTTP ${res.status} — Location: ${loc.slice(0, 200)}`);
-
-  if (res.status === 302 && loc.includes("/signin/oauth/error")) {
-    const errParam = new URL(loc).searchParams.get("authError") ?? "";
+  if (res.status >= 300 && res.status < 400 && loc.includes("/signin/oauth/error")) {
     let decoded = "";
     try {
+      const errParam = new URL(loc).searchParams.get("authError") ?? "";
       decoded = Buffer.from(errParam, "base64url").toString("utf8");
     } catch {
-      decoded = errParam;
+      decoded = "(could not decode authError)";
     }
-    console.error(
-      `\nFAIL: Google rejected our redirect_uri.\n` +
-        `  client_id    = ${clientId}\n` +
-        `  redirect_uri = ${redirectUri}\n` +
-        `  decoded err  = ${decoded}\n\n` +
-        `Fix: add the redirect URI above to Google Cloud Console:\n` +
-        `  APIs & Services → Credentials → OAuth 2.0 Client ID ${clientId.split("-")[0]}-… →\n` +
-        `  Authorized redirect URIs → Save.\n` +
-        `See mira-hub/docs/auth/oauth-redirect-uris.md.\n`,
+    console.log(
+      "::error title=Google OAuth redirect_uri_mismatch (REAL — sign-in is broken)::" +
+        `Google rejected redirect_uri ${sentRedirectUri} for client ${clientId}. ` +
+        "Add it under Google Cloud Console → APIs & Services → Credentials → that " +
+        "OAuth 2.0 Client ID → Authorized redirect URIs. See " +
+        "mira-hub/docs/auth/oauth-redirect-uris.md.",
     );
-    process.exit(1);
+    console.error(
+      `\nMISMATCH: Google rejected our redirect_uri.\n` +
+        `  client_id    = ${clientId}\n` +
+        `  redirect_uri = ${sentRedirectUri}\n` +
+        `  decoded err  = ${decoded.replace(/[^\x20-\x7e]+/g, " ").trim()}\n` +
+        `exit ${EXIT_MISMATCH}`,
+    );
+    process.exit(EXIT_MISMATCH);
   }
 
   if (
-    res.status === 302 &&
+    res.status >= 300 &&
+    res.status < 400 &&
     (loc.startsWith("https://accounts.google.com/") || loc.includes("/signin/oauth/"))
   ) {
     console.log(
-      `OK: Google accepted our redirect_uri (${redirectUri}).\n` +
-        `  Location starts with the consent / chooser flow as expected.`,
+      `OK: Google accepted redirect_uri ${sentRedirectUri} ` +
+        "(consent / account chooser as expected).",
     );
-    process.exit(0);
+    process.exit(EXIT_OK);
   }
 
-  console.error(
-    `INCONCLUSIVE: unexpected response (HTTP ${res.status}). Inspect manually.`,
+  console.log(
+    `::warning title=OAuth canary inconclusive::Unexpected response from Google ` +
+      `(HTTP ${res.status}). Inspect manually.`,
   );
-  process.exit(3);
+  console.error(`\nINCONCLUSIVE: HTTP ${res.status} from Google. exit ${EXIT_INCONCLUSIVE}`);
+  process.exit(EXIT_INCONCLUSIVE);
 }
 
-void main();
+void main().catch((e) => {
+  console.log(
+    "::error title=OAuth canary could not run::Probe threw before reaching a " +
+      `verdict (${e instanceof Error ? e.message : String(e)}). NOT a Google rejection.`,
+  );
+  console.error(e);
+  process.exit(EXIT_CANT_RUN);
+});


### PR DESCRIPTION
Relates to **#1756** (the real Google sign-in incident this canary exists to catch but didn't).

## Problem
The `oauth-redirect canary` was red — but **not** because it detected a problem. It exited **code 2 — `HUB_AUTH_GOOGLE_CLIENT_ID is not set`** (that GitHub Actions secret is missing), so it **never probed Google at all**. Worse, its `if: failure()` step printed *"Google rejected mira-hub's redirect_uri"* for **any** failure — so a missing-secret/CI problem was mislabelled as a Google config problem. (Ironically, a real `redirect_uri_mismatch` **is** happening right now — #1756 — but the canary couldn't see it.)

## Fix
Make the probe need **no secret**: `client_id` and `redirect_uri` are *public* values the app already emits, so drive the app's **real** signin flow to get the exact Google authorize URL, then follow it to Google:
```
GET  /api/auth/csrf            → csrfToken + cookie
POST /api/auth/signin/google   → 302 Location = the live Google authorize URL
follow it → Google             → consent (OK) | /signin/oauth/error (mismatch)
```
This tests the real end-to-end flow instead of reconstructing it from a secret.

**Distinct, self-annotated exit codes** (each emits its own `::error::`/`::warning::`):
| Exit | Meaning | Annotation |
|---|---|---|
| 0 | Google accepted the redirect_uri | — (pass) |
| 1 | **real `redirect_uri_mismatch`** | `Google OAuth redirect_uri_mismatch (REAL — sign-in is broken)` |
| 2 | probe could not run (app unreachable / signin shape changed) | `OAuth canary could not run … NOT a Google rejection` |
| 3 | inconclusive | warning |

The misleading static `if: failure()` step is **removed** (the script annotates correctly per case); the `HUB_AUTH_GOOGLE_CLIENT_ID` secret env is dropped and replaced with `HUB_URL`.

## Verification (ran with bun against prod)
- **Default (prod)** → `exit 1`, derived `client_id=246891599587-…`, `redirect_uri=https://app.factorylm.com/api/auth/callback/google`, Google `302 → /signin/oauth/error` decoded to `redirect_uri_mismatch`, correct `::error::` emitted. *(This is the real #1756 incident — expected to stay red until the GCP Console URI is added.)*
- **`HUB_URL` unreachable** → `exit 2`, `OAuth canary could not run … NOT a Google rejection`.
- `actionlint -shellcheck=` clean on the workflow.

## Note on the canary's red status
This PR does **not** make the canary green — it **correctly** stays red because Google sign-in is genuinely broken (#1756). Per the incident, do not force-green; the canary should flip to exit 0 only after the redirect URI is re-added in Google Cloud Console. After that, I'll re-run the probe and confirm it reaches consent cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)