### PR TITLE
fix(ci): web-review canary rebases before pushing report to main (push race)

### DIFF
--- a/.github/workflows/web-review-canary.yml
+++ b/.github/workflows/web-review-canary.yml
@@ -150,7 +150,20 @@ jobs:
             exit 0
           fi
           git commit -m "chore(web-review): daily canary $(date -u +%FT%H%MZ)"
-          git push origin HEAD:main
+          # main moves under this scheduled canary (other pushes land while it
+          # runs), so a bare push hits `! [rejected] non-fast-forward`. Rebase
+          # onto latest main before pushing; retry a few times to absorb a
+          # concurrent push that lands mid-rebase. The report is an append-only
+          # new file, so the rebase never conflicts.
+          ok=0
+          for attempt in 1 2 3; do
+            if git pull --rebase origin main && git push origin HEAD:main; then
+              ok=1; break
+            fi
+            echo "::notice::push attempt $attempt raced a moving main; retrying"
+            sleep $((attempt * 3))
+          done
+          [ "$ok" = 1 ] || { echo "::error::web-review canary: push failed after 3 rebase attempts"; exit 1; }
 
       - name: Surface P0/P1 in run summary
         if: always()


### PR DESCRIPTION
## Problem
The daily `web-review canary` runs the site audit, writes `wiki/reviews/<date>-factorylm.com.md`, commits it, and pushes to `main`. While it runs, other commits land on `main`, so the bare `git push origin HEAD:main` fails:
```
! [rejected]          HEAD -> main (non-fast-forward)
error: failed to push some refs
```
That's why the canary was red — **not** a site-quality problem (the audit step ran fine). It's a push race against a moving `main`.

## Fix (minimal, as requested)
Rebase onto latest `main` before pushing, with a small 3-attempt retry to absorb a concurrent push that lands mid-rebase:
```bash
ok=0
for attempt in 1 2 3; do
  if git pull --rebase origin main && git push origin HEAD:main; then ok=1; break; fi
  echo "::notice::push attempt $attempt raced a moving main; retrying"
  sleep $((attempt * 3))
done
[ "$ok" = 1 ] || { echo "::error::… push failed after 3 rebase attempts"; exit 1; }
```
The report is an **append-only new file**, so the rebase never conflicts. Safe under `set -e` (`if/then` form, not a `&&` chain).

## Verification
- `actionlint` structural check: clean.
- `actionlint` (with embedded shellcheck) on the file: no findings on the new run-block.

## Follow-up (kept out to stay minimal — per request)
A cleaner long-term option is to have the canary **open a PR / push to a branch** instead of committing straight to `main` (no race at all, reviewable history). Happy to do that as a separate small PR if you'd prefer it over committing to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)