### PR TITLE
fix(hub): /api/usage KB Chunks reads untenanted knowledge_entries (#1761)

### DIFF
--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## v2.1.1 — 2026-06-06
+- fix(hub): /api/usage KB Chunks tile now returns total knowledge_entries (#1761)
+
 ## [1.9.1] - 2026-05-22
 ### Fixed
 - `/hub/namespace` — clicking `+` on a synthesized parent row (kind=`namespace`, id prefixed `synthetic:`) returned `400 parentId required (uuid)` with no way to recover, because POST `/api/namespace/node` requires a UUID and synthesized nodes have no kg_entities row. Hide the `+` button on synthesized rows and show a short hint ("run onboarding to add") so the user is steered to the wizard that materializes a real parent. Inline-create remains available on every real (UUID-id) row.

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "1.9.1",
+  "version": "2.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/app/api/usage/route.ts
+++ b/mira-hub/src/app/api/usage/route.ts
@@ -56,13 +56,9 @@ export async function GET() {
         ORDER BY count DESC LIMIT 10`,
         [ctx.tenantId],
       );
-      // UNS+KG unification (spec §4.3, Phase 1): the legacy `kb_chunks`
-      // table is empty in production; the real vector store is
-      // `knowledge_entries` (74K+ rows). Reading from the wrong table
-      // is what made the Hub "Total KB Chunks" tile show 0 forever.
+      // Untenanted: OEM manuals in `knowledge_entries` are a universal corpus shared across all tenants (see `knowledge/route.ts:14-18`).
       const { rows: kbRows } = await c.query(
-        `SELECT COUNT(*) as total_chunks FROM knowledge_entries WHERE tenant_id = $1`,
-        [ctx.tenantId],
+        `SELECT COUNT(*) as total_chunks FROM knowledge_entries`,
       );
       return { monthRows, allTimeRows, dailyRows, bySourceRows, byTechRows, kbRows };
     });


### PR DESCRIPTION
## Summary
- Drops `WHERE tenant_id = $1` from the `knowledge_entries` count in `/api/usage`.
- Mirrors the existing untenanted pattern in `/api/knowledge` (which already counts the same table this way — see lines 9-18 of `knowledge/route.ts`).

## Why
Closes #1761. KB Chunks tile read `kb_chunks` for years; the recent UNS+KG unification re-pointed it at `knowledge_entries`, but kept the tenant filter, so the tile still showed 0. Rows in `knowledge_entries` carry `tenant_id='mike'` (env-baked legacy ingest), session tenantId is a UUID — never match.

## Test plan
- [ ] `curl -sL -b $JAR https://app.factorylm.com/api/usage | jq '.allTime.totalKbChunks'` returns ~83553 (was 0).
- [ ] Work-order queries still scoped by tenant (no regression on `thisMonth.totalActions` etc).
- [ ] Verified by web-review skill after deploy.

Closes #1761.