### PR TITLE
fix(hub): unauth /api/* returns 401 JSON (#1764)

### DIFF
--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## v2.1.3 — 2026-06-07
+- fix(hub): unauth /api/* returns 401 JSON instead of 308→/login HTML (#1764)
+
 ## v2.1.2 — 2026-06-07
 - fix(hub): /scan 412px mobile overflow (#1763)
 

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/middleware.ts
+++ b/mira-hub/src/middleware.ts
@@ -145,7 +145,15 @@ export default async function middleware(req: NextRequest, _ev: NextFetchEvent) 
   const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
 
   // No cookie or no secret configured → bounce to /login with callback.
+  // EXCEPT for /api/* which must return 401 JSON (matches sessionOr401() in
+  // lib/session.ts) so non-browser consumers (curl, SDK, canary) don't get
+  // an HTML redirect they can't interpret. See #1764.
   if (!cookieValue || !secret) {
+    if (pathname.startsWith("/api/")) {
+      const resp = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      resp.headers.set("Content-Security-Policy", csp);
+      return resp;
+    }
     const url = req.nextUrl.clone();
     url.pathname = "/login";
     url.search = "";
@@ -157,6 +165,11 @@ export default async function middleware(req: NextRequest, _ev: NextFetchEvent) 
 
   const token = await decodeSessionJwt(cookieValue, secret);
   if (!token) {
+    if (pathname.startsWith("/api/")) {
+      const resp = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      resp.headers.set("Content-Security-Policy", csp);
+      return resp;
+    }
     const url = req.nextUrl.clone();
     url.pathname = "/login";
     url.search = "";

--- a/mira-hub/tests/e2e/api-unauth-returns-401.spec.ts
+++ b/mira-hub/tests/e2e/api-unauth-returns-401.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Regression test for #1764 — unauthenticated /api/* requests must return
+ * 401 application/json {"error":"Unauthorized"}, NOT a 307/308 redirect to
+ * the /login HTML page.
+ *
+ * Before the fix in mira-hub/src/middleware.ts, curl-style consumers
+ * (canary, future SDK, third-party automation) hitting /api/usage with no
+ * session cookie got a redirect to /login and an HTML body — surfaces as
+ * a silent failure in any non-browser consumer.
+ *
+ * The middleware now mirrors the shape of `sessionOr401()` in
+ * mira-hub/src/lib/session.ts:85-91, while page paths keep the existing
+ * /login redirect behavior.
+ *
+ * Run locally:
+ *   cd mira-hub
+ *   npx playwright test tests/e2e/api-unauth-returns-401.spec.ts
+ *
+ * Override target URL:
+ *   HUB_URL=https://staging.app.factorylm.com \
+ *   npx playwright test tests/e2e/api-unauth-returns-401.spec.ts
+ */
+
+import { test, expect } from "@playwright/test";
+
+const HUB = (process.env.HUB_URL ?? "https://app.factorylm.com").replace(/\/$/, "");
+
+test.describe("#1764 — unauthenticated /api/* returns 401 JSON", () => {
+  test("GET /api/usage without cookie returns 401 JSON, not a redirect", async ({ request }) => {
+    const res = await request.get(HUB + "/api/usage", {
+      maxRedirects: 0,
+      // Strip any baggage that could be interpreted as a session
+      headers: { cookie: "" },
+    });
+
+    // 1. Status is 401, not a 307/308 redirect.
+    expect(res.status()).toBe(401);
+
+    // 2. Content-Type is JSON.
+    const contentType = res.headers()["content-type"] ?? "";
+    expect(contentType.toLowerCase()).toContain("application/json");
+
+    // 3. Body matches sessionOr401() shape from lib/session.ts:85-91.
+    const body = await res.json();
+    expect(body).toEqual({ error: "Unauthorized" });
+
+    // 4. No Location header — this is NOT a redirect.
+    expect(res.headers()["location"]).toBeUndefined();
+
+    // 5. CSP header preserved on the 401 response (security headers must not
+    //    regress just because the response shape changed).
+    const csp = res.headers()["content-security-policy"];
+    expect(csp).toBeDefined();
+    expect(csp).toContain("default-src");
+  });
+
+  test("page paths still redirect unauthenticated users to /login", async ({ request }) => {
+    // Sanity check: the fix is scoped to /api/* — page paths must keep the
+    // existing /login redirect behavior so the browser flow is unchanged.
+    const res = await request.get(HUB + "/feed", {
+      maxRedirects: 0,
+      headers: { cookie: "" },
+    });
+
+    // 307 or 308 — both are valid Next.js middleware redirect codes.
+    expect([307, 308]).toContain(res.status());
+
+    const location = res.headers()["location"] ?? "";
+    expect(location).toContain("/login");
+  });
+});


### PR DESCRIPTION
## Summary
- Middleware now distinguishes `/api/*` unauth from page unauth.
- `/api/*` → `401 application/json {"error":"Unauthorized"}` (matches `sessionOr401()` shape from `lib/session.ts`).
- Page paths → unchanged (`/login` redirect).
- CSP header preserved on both branches.
- Adds e2e spec asserting status + content-type + body + no Location header.

## Why
Closes #1764. API clients (curl, the cowork canary, future SDK) expect 401 JSON. Today they get 308 to `/login` HTML — surfaces as silent failure in any non-browser consumer.

## Test plan
- [ ] `curl -sIL https://app.factorylm.com/api/usage` returns `HTTP/2 401` (was 308).
- [ ] `curl -s https://app.factorylm.com/api/usage` returns `{"error":"Unauthorized"}` (was HTML).
- [ ] Page paths still redirect: `curl -sIL https://app.factorylm.com/feed` returns 307→`/login`.
- [ ] e2e spec passes.

Closes #1764.