### PR TITLE
fix(hub): /scan no-overflow at 412px (#1763)

### DIFF
--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## v2.1.2 — 2026-06-07
+- fix(hub): /scan 412px mobile overflow (#1763)
+
 ## v2.1.1 — 2026-06-06
 - fix(hub): /api/usage KB Chunks tile now returns total knowledge_entries (#1761)
 

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/app/(hub)/scan/page.tsx
+++ b/mira-hub/src/app/(hub)/scan/page.tsx
@@ -114,7 +114,7 @@ export default function ScanPage() {
   const showCamera = state === "starting" || state === "scanning";
 
   return (
-    <div className="max-w-md mx-auto px-4 py-6">
+    <div className="w-full max-w-md mx-auto px-4 py-6">
       <h1 className="text-2xl font-semibold mb-1" style={{ color: "var(--foreground)" }}>
         Scan an asset
       </h1>

--- a/mira-hub/tests/e2e/scan-mobile-no-overflow.spec.ts
+++ b/mira-hub/tests/e2e/scan-mobile-no-overflow.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test";
+
+test("scan page has no horizontal overflow at 412px", async ({ page }) => {
+  await page.setViewportSize({ width: 412, height: 915 });
+  await page.goto("/scan");
+  const overflow = await page.evaluate(() =>
+    document.documentElement.scrollWidth - document.documentElement.clientWidth
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+});


### PR DESCRIPTION
## Summary
- One-line CSS fix at `mira-hub/src/app/(hub)/scan/page.tsx:117` — adds `w-full` to the outer wrapper so it clamps to viewport on mobile while still capping at 28rem on desktop.
- Closes #1763.

## Why
Inside monday.com's item-view iframe at 412×915 the `max-w-md`-only wrapper overflowed horizontally. `w-full max-w-md` is the standard Tailwind pattern for "fluid up to a cap."

## Test plan
- [ ] Visual: mobile 412×915 — no horizontal scroll, content centered.
- [ ] Visual: desktop 1440×900 — content centered, capped at 28rem.
- [ ] `scan-mobile-no-overflow.spec.ts` Playwright test passes.

## Screenshots
Screenshots skipped — dev server requires Doppler env (AUTH_SECRET, NeonDB, etc.) not available in this session. Before/after will be captured during the live verify step post-merge per the kiosk/AskMira runbook pattern.

Closes #1763.