### PR TITLE
security(hub): HSTS + XFO + drop X-Powered-By + /scan CSP allowlist (#1762)

### DIFF
--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## v2.1.4 — 2026-06-07
+- security(hub): HSTS + X-Frame-Options + remove X-Powered-By; /scan CSP frame-ancestors *.monday.com (#1762)
+
 ## v2.1.3 — 2026-06-07
 - fix(hub): unauth /api/* returns 401 JSON instead of 308→/login HTML (#1764)
 

--- a/mira-hub/next.config.ts
+++ b/mira-hub/next.config.ts
@@ -9,6 +9,9 @@ const nextConfig: NextConfig = {
   output: "standalone",
   basePath,
   assetPrefix: basePath,
+  // Drop the `X-Powered-By: Next.js` response header — small fingerprint-leak
+  // cleanup (#1762). No functional impact; Next.js never relied on it.
+  poweredByHeader: false,
   // nginx-oracle.conf has `location /hub/` — that block fires nginx's auto-301
   // from /hub → /hub/. Next.js's default `trailingSlash: false` then 308s
   // /hub/ → /hub, producing an infinite redirect loop on the basePath root.

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/middleware.ts
+++ b/mira-hub/src/middleware.ts
@@ -93,7 +93,12 @@ function gateRedirect(req: NextRequest, status: string, trialExpiresAt: unknown)
   return null;
 }
 
-function buildCsp(nonce: string): string {
+function buildCsp(nonce: string, pathname: string): string {
+  // `/scan` is the monday.com marketplace iframe — it must be framable by
+  // monday's marketplace shell. Every other path stays self-only.
+  const frameAncestors = pathname.startsWith("/scan")
+    ? `frame-ancestors 'self' https://*.monday.com`
+    : `frame-ancestors 'self'`;
   return [
     `default-src 'self'`,
     `script-src 'self' 'nonce-${nonce}' https://accounts.google.com https://apis.google.com https://js.stripe.com`,
@@ -114,7 +119,28 @@ function buildCsp(nonce: string): string {
       `frame-src 'self' https://accounts.google.com https://js.stripe.com https://hooks.stripe.com https://mikecranesync.github.io`,
       ...DISPLAY_FRAME_SRC,
     ].join(" "),
+    frameAncestors,
   ].join("; ");
+}
+
+// Apply HSTS + XFO + CSP to every response in one place. `/scan` is the
+// monday.com marketplace iframe — it must NOT have X-Frame-Options: DENY
+// (which would block ALL framing); the CSP `frame-ancestors` directive
+// (set by buildCsp) is the modern equivalent and already allows monday.
+function applySecurityHeaders(
+  resp: NextResponse,
+  pathname: string,
+  csp: string,
+): NextResponse {
+  resp.headers.set("Content-Security-Policy", csp);
+  resp.headers.set(
+    "Strict-Transport-Security",
+    "max-age=63072000; includeSubDomains; preload",
+  );
+  if (!pathname.startsWith("/scan")) {
+    resp.headers.set("X-Frame-Options", "DENY");
+  }
+  return resp;
 }
 
 // btoa is a global in the edge runtime; use it instead of Buffer for nonce encoding.
@@ -125,6 +151,11 @@ function b64Nonce(raw: string): string {
 export default async function middleware(req: NextRequest, _ev: NextFetchEvent) {
   const pathname = req.nextUrl.pathname;
 
+  // Per-request nonce for script-src CSP — removes unsafe-inline/unsafe-eval.
+  // Forwarded as x-nonce request header so RootLayout can attach it to <Script>.
+  const nonce = b64Nonce(crypto.randomUUID());
+  const csp = buildCsp(nonce, pathname);
+
   // Basepath root → /feed. `redirect()` from a Server Component is silently
   // swallowed in Next.js 16.2.4 standalone + basePath (response comes back
   // chunked, 0 bytes, no Location header), so the redirect has to live here.
@@ -132,13 +163,8 @@ export default async function middleware(req: NextRequest, _ev: NextFetchEvent) 
     const url = req.nextUrl.clone();
     url.pathname = "/feed";
     url.search = "";
-    return NextResponse.redirect(url);
+    return applySecurityHeaders(NextResponse.redirect(url), pathname, csp);
   }
-
-  // Per-request nonce for script-src CSP — removes unsafe-inline/unsafe-eval.
-  // Forwarded as x-nonce request header so RootLayout can attach it to <Script>.
-  const nonce = b64Nonce(crypto.randomUUID());
-  const csp = buildCsp(nonce);
 
   const cookieValue =
     req.cookies.get(SECURE_NAME)?.value ?? req.cookies.get(REGULAR_NAME)?.value;
@@ -150,33 +176,33 @@ export default async function middleware(req: NextRequest, _ev: NextFetchEvent) 
   // an HTML redirect they can't interpret. See #1764.
   if (!cookieValue || !secret) {
     if (pathname.startsWith("/api/")) {
-      const resp = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-      resp.headers.set("Content-Security-Policy", csp);
-      return resp;
+      return applySecurityHeaders(
+        NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+        pathname,
+        csp,
+      );
     }
     const url = req.nextUrl.clone();
     url.pathname = "/login";
     url.search = "";
     url.searchParams.set("callbackUrl", pathname);
-    const resp = NextResponse.redirect(url);
-    resp.headers.set("Content-Security-Policy", csp);
-    return resp;
+    return applySecurityHeaders(NextResponse.redirect(url), pathname, csp);
   }
 
   const token = await decodeSessionJwt(cookieValue, secret);
   if (!token) {
     if (pathname.startsWith("/api/")) {
-      const resp = NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-      resp.headers.set("Content-Security-Policy", csp);
-      return resp;
+      return applySecurityHeaders(
+        NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+        pathname,
+        csp,
+      );
     }
     const url = req.nextUrl.clone();
     url.pathname = "/login";
     url.search = "";
     url.searchParams.set("callbackUrl", pathname);
-    const resp = NextResponse.redirect(url);
-    resp.headers.set("Content-Security-Policy", csp);
-    return resp;
+    return applySecurityHeaders(NextResponse.redirect(url), pathname, csp);
   }
 
   // Already on a gate page — let it render so the user can act.
@@ -184,9 +210,11 @@ export default async function middleware(req: NextRequest, _ev: NextFetchEvent) 
     const status = String(token.status ?? "trial");
     const redirectUrl = gateRedirect(req, status, token.trialExpiresAt);
     if (redirectUrl) {
-      const resp = NextResponse.redirect(redirectUrl);
-      resp.headers.set("Content-Security-Policy", csp);
-      return resp;
+      return applySecurityHeaders(
+        NextResponse.redirect(redirectUrl),
+        pathname,
+        csp,
+      );
     }
   }
 
@@ -194,8 +222,7 @@ export default async function middleware(req: NextRequest, _ev: NextFetchEvent) 
   const requestHeaders = new Headers(req.headers);
   requestHeaders.set("x-nonce", nonce);
   const response = NextResponse.next({ request: { headers: requestHeaders } });
-  response.headers.set("Content-Security-Policy", csp);
-  return response;
+  return applySecurityHeaders(response, pathname, csp);
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- Adds HSTS (`max-age=63072000; includeSubDomains; preload`) to every hub response.
- Adds `X-Frame-Options: DENY` to all responses EXCEPT `/scan` (which is the monday.com marketplace iframe).
- Extends CSP with `frame-ancestors` — `'self'` everywhere, plus `https://*.monday.com` on `/scan`.
- Drops `X-Powered-By: Next.js` via `poweredByHeader: false`.

## Why
Closes #1762. Audit showed three missing security-header best practices. `/scan` is the monday.com marketplace embed — must remain framable by monday but blocked elsewhere.

## Test plan
- [ ] `curl -sIL https://app.factorylm.com/ | grep -i strict-transport-security` returns the header.
- [ ] `curl -sIL https://app.factorylm.com/ | grep -i x-frame-options` returns `DENY`.
- [ ] `curl -sIL https://app.factorylm.com/scan | grep -i x-frame-options` returns empty (no XFO on /scan).
- [ ] `curl -sIL https://app.factorylm.com/scan | grep -i content-security-policy` returns CSP containing `frame-ancestors 'self' https://*.monday.com`.
- [ ] `curl -sIL https://app.factorylm.com/ | grep -i x-powered-by` returns empty.

Closes #1762.