### PR TITLE
fix(recall): clean retrieval query for /ask — eliminate the ~10s Neon recall floor (#1766)

### DIFF
--- a/mira-bots/ask_api/app.py
+++ b/mira-bots/ask_api/app.py
@@ -91,6 +91,21 @@ async def ask(req: AskRequest, x_mira_key: str = Header(None)):
         parts.append("[QUESTION]\n" + req.question)
         enriched = "\n\n".join(parts)
 
+        # Clean retrieval query (#1766 follow-up): keyword/BM25/fault-code/product
+        # extraction must key off the QUESTION + decoded live-status block, NOT the
+        # static ~440-token MACHINE_CONTEXT card. Otherwise every token of the card
+        # feeds _extract_fault_codes / _extract_product_names / _recall_bm25 — the
+        # card alone yields ~12 fault codes + 3 product names, firing ~9 sequential
+        # NeonDB round-trips per /ask (the ~10s recall block). The embedding still
+        # uses the full enriched text (semantic context); only the lexical streams
+        # use this trimmed query. The fault code lives in the status block
+        # (vfd_fault_code → CExx), so it MUST be included here, not just the question.
+        retrieval_parts = []
+        if status_block:
+            retrieval_parts.append(status_block)
+        retrieval_parts.append(req.question)
+        retrieval_query = "\n".join(retrieval_parts)
+
         chat_id = req.session_id or ("ignition:" + uuid.uuid4().hex)
 
         # platform="ignition": process() accepts platform as a plain str and only
@@ -103,6 +118,7 @@ async def ask(req: AskRequest, x_mira_key: str = Header(None)):
             platform="ignition",
             tenant_id=engine.tenant_id or os.getenv("MIRA_TENANT_ID", ""),
             mira_user_id="ignition:kiosk",
+            retrieval_query=retrieval_query,
         )
         return {"answer": reply}
     except Exception as e:  # always return 200 so the HMI shows something

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -1083,6 +1083,7 @@ class Supervisor:
         uns_source: str | None = None,
         tag_evidence: list | None = None,
         live_tags: dict | None = None,
+        retrieval_query: str | None = None,
     ) -> str:
         """Main entry point. Returns reply string (backward-compatible).
 
@@ -1104,6 +1105,14 @@ class Supervisor:
         attached to the message ONLY after the UNS confirmation gate has passed
         (see ``_maybe_attach_live_snapshot``) — never before — so live data can
         never bypass the gate. Callers that don't pass it are unaffected.
+
+        ``retrieval_query`` (optional) overrides the text used for LEXICAL recall
+        only — BM25, fault-code extraction, product-name extraction. Direct-
+        connection surfaces (the Ignition /ask kiosk) prepend a large static
+        context card to ``message``; passing the trimmed question+status here
+        keeps the lexical streams from keying off that boilerplate (#1766). The
+        EMBEDDING still uses the full ``message`` for semantic context. Default
+        None = use ``message`` (chat surfaces unchanged).
         """
         # Per-call tenant overrides constructor default. Stash on self so workers
         # can reach the current request's tenant via self._current_tenant_id.
@@ -1118,7 +1127,13 @@ class Supervisor:
         t0 = time.monotonic()
         try:
             result = await asyncio.wait_for(
-                self.process_full(chat_id, message, photo_b64, uns_source=uns_source),
+                self.process_full(
+                    chat_id,
+                    message,
+                    photo_b64,
+                    uns_source=uns_source,
+                    retrieval_query=retrieval_query,
+                ),
                 timeout=_PROCESS_TIMEOUT,
             )
         except asyncio.TimeoutError:
@@ -1525,6 +1540,7 @@ class Supervisor:
         photo_b64: str = None,
         *,
         uns_source: str | None = None,
+        retrieval_query: str | None = None,
     ) -> dict:
         """Full entry point. Returns {"reply", "confidence", "trace_id", "next_state"}.
 
@@ -1559,6 +1575,13 @@ class Supervisor:
             return self._make_result(reply, "none", trace_id, "IDLE")
 
         state = self._load_state(chat_id)
+
+        # Per-turn clean lexical-recall query (#1766). Stashed on state so the
+        # RAGWorker uses it for BM25/fault/product extraction without threading a
+        # new arg through the two self.rag.process() call sites. Set every turn
+        # (incl. None) so a value never persists stale across turns. The embedding
+        # path still uses the full message; only lexical recall reads this.
+        state["retrieval_query"] = retrieval_query
 
         if _PROCEED_RE.match(_msg_stripped) and not photo_b64:
             ctx_p = state.get("context") or {}

--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -421,6 +421,15 @@ class RAGWorker:
                         if photo_b64 and state.get("asset_identified"):
                             embed_query = f"{state['asset_identified']} {message}"
 
+                        # Clean lexical-recall query (#1766). The engine stashes a
+                        # trimmed question+status string on state for direct-
+                        # connection surfaces (the /ask kiosk) whose `message` is a
+                        # large static context card. BM25 / fault-code / product-name
+                        # extraction key off this; the EMBEDDING still uses
+                        # embed_query (full semantic context). Falls back to message
+                        # for chat surfaces that don't set it.
+                        recall_query = state.get("retrieval_query") or message
+
                         sub_queries: list[str] = [embed_query]
                         if is_decompose_enabled():
                             try:
@@ -449,16 +458,32 @@ class RAGWorker:
                                 len(neon_chunks),
                             )
                         else:
+                            _t_emb = time.monotonic()
                             embedding = await self._embed_ollama(embed_query)
+                            _embed_ms = int((time.monotonic() - _t_emb) * 1000)
                             # Call recall_knowledge unconditionally — it now
                             # falls through to lexical streams when embedding
                             # is None (Ollama sidecar down). Pre-fix this gate
                             # short-circuited BM25 and produced NO_KB_COVERAGE
                             # despite KB rows being lexically retrievable.
+                            # query_text = recall_query (clean) so fault/product/
+                            # BM25 extraction doesn't key off the static context
+                            # card (#1766); embedding still uses embed_query.
+                            _t_rec = time.monotonic()
                             neon_chunks = _neon_recall.recall_knowledge(
                                 embedding,
                                 effective_tenant,
-                                query_text=embed_query,
+                                query_text=recall_query,
+                            )
+                            _recall_ms = int((time.monotonic() - _t_rec) * 1000)
+                            logger.info(
+                                "RAG_STAGE_TIMING embed_ms=%d recall_ms=%d embed_chars=%d "
+                                "recall_chars=%d n_chunks=%d",
+                                _embed_ms,
+                                _recall_ms,
+                                len(embed_query),
+                                len(recall_query),
+                                len(neon_chunks),
                             )
 
                         if is_self_eval_enabled() and neon_chunks:


### PR DESCRIPTION
## Context
Follow-up to #1775. That PR bounded the BM25 tsquery and took grounded `/ask` from **37–50s → ~9s**, but a stable ~10s recall floor remained. This PR targets that floor.

## Attribution (prod logs, read-only)
One request (`why is the drive faulted?`, total 13s):
```
17:03:48.182 ROUTER intent=diagnose_equipment            (intent-classify LLM)
17:03:58.515 NEON_RECALL ... products=[GS10,Micro820,DURApulse]   <-- 10.3s gap, nothing between
             fault_codes=[CE1,LOW-2,CE2,CE10,GS10,P00,FC06,CE3,CE4,RS-485,BE-34,LC20]
17:03:59.472 LLM_CALL groq latency_ms=954               (final generation — fast)
```
The 12 fault codes + 3 product names were extracted from the **440-token MACHINE_CONTEXT card**, not the question. `_extract_fault_codes` / `_extract_product_names` were still keying off the enriched blob (#1775 only fixed BM25), firing **~9 sequential NeonDB round-trips** (3 structured fault lookups + ILIKE + 3 product CTEs + main vector + bm25). That's the ~10s — not the embed, not the LLM (0.95s).

## Fix — the goal's preferred "root fix"
Thread a clean `retrieval_query` (question **+ decoded live-status block**, minus the static card) through `ask_api → engine.process → process_full → state["retrieval_query"] → RAGWorker`, and use it for the **lexical** streams (BM25 / fault / product). The **embedding still uses the full enriched message** (semantic context).

- The fault code lives in the status block (`vfd_fault_code` → CExx), so the status block is part of the clean query → **CE10/FC14 grounding preserved**.
- **Backward-compatible:** `retrieval_query` defaults to `None` → `recall_query` falls back to `message`; Telegram/Slack/web chat unchanged.
- Stashed on `state` to avoid touching the two `self.rag.process()` call sites.
- Adds a `RAG_STAGE_TIMING` log (embed_ms / recall_ms / recall_chars) for a definitive per-stage split post-deploy.

## Gate
- Offline: `test_recall_no_embedding_fallthrough` + `test_engine_no_embedding_gs11` + `test_hybrid_retrieval` (24) + `test_quality_gate_stream_aware` (12) — **all pass**.
- Post-deploy (in this sweep): 3 warm latency samples + Q1/Q4/Q11 live confirming GS10/AutomationDirect/CE10 still cited, and `RAG_STAGE_TIMING` confirming the recall drop.

## Sequencing note
Mike chose "do both" (code + HNSW index). This is the code half and should be the bigger win (it removes ~3 of the ~4 vector queries + the fault/ILIKE fan-out). The HNSW index migration is step 2; if this clears <5s, the prod-DB migration may be unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)