### PR TITLE
feat(hub): migrate final 3 relationship writers to propose-by-default (#1721)

### DIFF
--- a/mira-hub/docs/audits/2026-06-05-hub-relationship-writers-1721.md
+++ b/mira-hub/docs/audits/2026-06-05-hub-relationship-writers-1721.md
@@ -21,9 +21,9 @@ Unlike the Python ingest path, the hub has **no `autoverify` escape hatch** for 
 | `queries.ts::upsertSchematicComponents` | **inferred** (schematic intelligence extracts components + wiring) | ✅ **migrated** (this PR) → proposes via `upsertInferredProposal`. Entity nodes still upserted; edges propose. |
 | `proposals/[id]/decide/route.ts` | **safe** | Human-approval verified write — the one legitimate door. Unchanged. |
 | `relationship-extractor.ts` (LLM, `confidence ≥ HIGH_CONFIDENCE_THRESHOLD → INSERT`) | **inferred** — the literal "confidence > X → verify" anti-pattern | ✅ **migrated** (this PR) → above-threshold edges propose via `upsertInferredProposal` (predicate mapped through `mapToCanonicalEdge`, incl. `caused_by`→`CAUSES` flip); below-threshold stays triple-only. |
-| `extractor.ts::upsertRelationship` (conversation extraction, conf 1.0) | **inferred** | ⛔ TODO: propose. |
-| `cmms-sync.ts::upsertRelationship` (conf 1.0) | **inferred** (mirrors CMMS structural data — still a proposal per Iron Rule) | ⛔ TODO + **blocker**: emits `has_work_order` (lowercase) which is **not in the proposals CHECK**. Needs a CHECK migration (`HAS_WORK_ORDER`) or a canonical map first. |
-| `hierarchy-backfill.ts::createParentOf` | **decision → inferred** | ⛔ TODO + **blocker**: it's a *heuristic* location-string match (`entity_id = $2 OR name = $2`), so it is **inferred, not deliberate structure → must propose**. Blocker: `parent_of` is **not** in the proposals CHECK; map to `LOCATED_IN` (equipment → area/line) or add to the CHECK. Decision recorded: **propose**, not auto-verify. |
+| `extractor.ts::proposeConversationEdge` (conversation extraction) | **inferred** | ✅ **migrated** (#1721 final slice) → mentioned_tag→HAS_TAG, exhibited_fault→HAS_FAILURE_MODE, requires_part→HAS_PART propose via `upsertInferredProposal`. Proposed at a moderate fixed confidence (0.7), not the old auto-verified 1.0. |
+| `cmms-sync.ts::proposeCmmsEdge` | **inferred** (mirrors CMMS structural data — still a proposal per Iron Rule) | ✅ **migrated** (#1721 final slice) → located_at→LOCATED_IN, has_work_order→HAS_WORK_ORDER, has_pm→HAS_PM_SCHEDULE propose (conf 0.9, evidence `work_order`/`manifest`). Unblocked by migration 043. |
+| `hierarchy-backfill.ts::proposeLocatedIn` | **decision → inferred** | ✅ **migrated** (#1721 final slice) → heuristic location match proposes `equipment LOCATED_IN area/line` (parent_of mapped to LOCATED_IN **flipped**). Dropped the dead `parent_of` existence pre-check (nothing writes parent_of post-migration); dedup now via `upsertInferredProposal`. `if (!dryRun)` guard preserved. |
 | `queries.ts::createRelationship` | **dead code** (0 callers in `src/`) | Leave as-is; remove in a follow-up (out of scope here — surgical). |
 
 ## Vocabulary note (load-bearing)
@@ -38,15 +38,21 @@ Implication: schematic edges were already canonical (clean migration, no remap).
 - `eslint` clean on changed files; `tsc` clean on changed files (pre-existing unrelated typecheck errors in `namespace/tree`, `rls-deny`, `command-center-freshness` are not touched here).
 - Staging smoke on `factorylm/stg`: `proposals=1 evidence=1 kg_relationships=0`, idempotent, guard skips non-canonical.
 
-## Remaining for #1721
+## Final slice (2026-06-07) — #1721 closed
 
-`relationship-extractor.ts` ✅ migrated. `extractor.ts`, `cmms-sync.ts`, `hierarchy-backfill.ts` remain — now fully **map-ready**:
+All three remaining writers migrated onto the propose path. Migration 043 was applied to staging + prod ahead of this, and the competing PRs (#1030/#1263/#1710/#642) settled with **no file overlap** with the target writers.
 
-**Vocabulary decided (migration 043).** The CHECK gains dedicated CMMS/tag types and the map covers every emitted type:
-- `has_work_order` → `HAS_WORK_ORDER` (new), `has_pm` → `HAS_PM_SCHEDULE` (new), `mentioned_tag` → `HAS_TAG` (new)
-- `parent_of` → `LOCATED_IN` **flipped** (equipment LOCATED_IN area)
-- `located_at`→`LOCATED_IN`, `exhibited_fault`→`HAS_FAILURE_MODE`, `requires_part`→`HAS_PART` (existing)
+**Migrated this slice:**
+- `extractor.ts` — `upsertRelationship` → `proposeConversationEdge` (regex pass). `mentioned_tag`/`exhibited_fault`/`requires_part` propose; `relationshipsProposed` added to `ExtractionResult` (back-compat `relationships`=0).
+- `cmms-sync.ts` — `upsertRelationship` → `proposeCmmsEdge`. `located_at`/`has_work_order`/`has_pm` propose; `relationshipsProposed` added to `SyncResult` (back-compat `relationships`=0).
+- `hierarchy-backfill.ts` — `createParentOf` → `proposeLocatedIn` (`parent_of`→`LOCATED_IN` flipped). Dropped the dead `parent_of` existence pre-check; dedup via `upsertInferredProposal`; `if (!dryRun)` guard preserved; `relationshipsProposed` added (back-compat `relationshipsCreated`=0).
 
-**Ordering constraint:** migration 043 must be applied (dev → staging → prod via `apply-migrations.yml`) **before** the `cmms-sync`/`extractor` writer-migration PRs deploy, or a proposal carrying a new type would fail the prod CHECK. The TS map/CANONICAL set already include the new types, but no migrated writer emits them yet, so landing them ahead of the apply is safe.
+**Behavioral note (flood):** the extractor regex pass now proposes on every mentioned tag/fault/part for every asset-chat turn — a real jump in proposal volume (the hub analogue of the #1716 Python "behavioral flood" note). `upsertInferredProposal` dedup caps repeats, but the `/proposals` queue will see more rows.
 
-The three writer migrations stay deferred until 043 is applied **and** their competing PRs (#1030/#1263/#1710/#642) settle. CI guard for unguarded inserts = #1722 (merged); canary = #1723 (merged).
+**Verification (this slice):**
+- `vitest` — 8 new propose tests (`cmms-sync-propose`, `extractor-propose`, `hierarchy-backfill-propose`): each writer proposes (relationship_proposals) and does NOT insert `kg_relationships`; canonical types + flip asserted. 35/35 in affected suites.
+- `eslint` + `tsc` clean on changed files (pre-existing unrelated typecheck errors in `namespace/tree`, `rls-deny`, `command-center-freshness` untouched).
+- `kg-write-guard` green (8 sites, all allowlisted; the 3 migrated sources pruned, 3 new test files added).
+- Staging smoke on `factorylm/stg` (throwaway tenant, real CHECK): confirmed 043 live, all six emitted canonical types accepted — `proposals=6 evidence=6 kg_relationships=0`, idempotent, self-cleaned.
+
+`createRelationship` dead code in `queries.ts` remains out of scope (0 callers; separate surgical follow-up). CI guard = #1722 (merged); canary = #1723 (merged).

--- a/mira-hub/src/lib/knowledge-graph/__tests__/cmms-sync-propose.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/cmms-sync-propose.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Prove the CMMS → KG sync PROPOSES (relationship_proposals via
+// upsertInferredProposal), never inserts kg_relationships directly (#1721).
+const { executed, reset } = vi.hoisted(() => {
+  const executed: { sql: string; params: unknown[] }[] = [];
+  return { executed, reset: () => (executed.length = 0) };
+});
+
+vi.mock("@/lib/db", () => {
+  let propCounter = 0;
+  const client = {
+    query: async (sql: string, params: unknown[] = []) => {
+      executed.push({ sql, params });
+      // Entity upserts echo back id/type/entity_id derived from params so the
+      // sync's lookup maps (eqById/woById/...) resolve.
+      if (sql.includes("INSERT INTO kg_entities"))
+        return {
+          rows: [{ id: `kg-${params[2]}`, entity_type: params[1], entity_id: String(params[2]) }],
+          rowCount: 1,
+        };
+      if (sql.includes("INSERT INTO relationship_proposals"))
+        return { rows: [{ id: `prop-${++propCounter}` }], rowCount: 1 };
+      if (sql.includes("FROM kg_relationships")) return { rows: [], rowCount: 0 };
+      if (sql.includes("FROM relationship_proposals")) return { rows: [], rowCount: 0 };
+      // resolveTenantParentPath
+      if (sql.includes("entity_type IN ('site'"))
+        return { rows: [{ uns_path: "enterprise.plant_a.line_1" }], rowCount: 1 };
+      if (sql.includes("FROM cmms_equipment"))
+        return {
+          rows: [
+            { id: "eq-1", equipment_number: "AC-7", manufacturer: null, model_number: null,
+              serial_number: null, equipment_type: null, location: "Bay 3", department: null,
+              criticality: null, description: "Compressor", uns_path: null },
+          ],
+          rowCount: 1,
+        };
+      if (sql.includes("FROM work_orders"))
+        return { rows: [{ id: "wo-1", work_order_number: "WO-1", equipment_id: "eq-1", title: "Fix it", status: null, priority: null, source: null }], rowCount: 1 };
+      if (sql.includes("FROM pm_schedules"))
+        return { rows: [{ id: "pm-1", equipment_id: "eq-1", task: "Lube", interval_value: 30, interval_unit: "days", criticality: null, next_due_at: null }], rowCount: 1 };
+      if (sql.includes("FROM knowledge_entries")) return { rows: [], rowCount: 0 };
+      return { rows: [], rowCount: 0 };
+    },
+    release: () => {},
+  };
+  return { default: { connect: async () => client } };
+});
+
+import { syncCmmsToKg } from "../cmms-sync";
+
+const TENANT = "00000000-0000-0000-0000-000000000001";
+const blob = () => executed.map((e) => e.sql).join("\n");
+
+describe("syncCmmsToKg — proposes, never auto-verifies (#1721)", () => {
+  beforeEach(() => reset());
+
+  test("CMMS edges become proposals, not kg_relationships inserts", async () => {
+    const result = await syncCmmsToKg(TENANT);
+    expect(blob()).toContain("INSERT INTO relationship_proposals");
+    expect(blob()).toContain("INSERT INTO kg_triples_log"); // audit trail kept
+    expect(blob()).not.toContain("INSERT INTO kg_relationships");
+    expect(result.relationships).toBe(0);
+    expect(result.relationshipsProposed).toBe(3); // located_at + work_order + pm
+  });
+
+  test("proposes canonical types: LOCATED_IN, HAS_WORK_ORDER, HAS_PM_SCHEDULE", async () => {
+    await syncCmmsToKg(TENANT);
+    const types = executed
+      .filter((e) => e.sql.includes("INSERT INTO relationship_proposals"))
+      .map((e) => (e.params as unknown[])[5]); // rel_type is the 6th param
+    expect(types).toContain("LOCATED_IN");
+    expect(types).toContain("HAS_WORK_ORDER");
+    expect(types).toContain("HAS_PM_SCHEDULE");
+  });
+
+  test("work-order edge is equipment → HAS_WORK_ORDER → work_order", async () => {
+    await syncCmmsToKg(TENANT);
+    const wo = executed.find(
+      (e) => e.sql.includes("INSERT INTO relationship_proposals") && (e.params as unknown[])[5] === "HAS_WORK_ORDER",
+    );
+    expect(wo).toBeDefined();
+    // params: [tenant, source_id, source_type, target_id, target_type, rel_type, confidence, reasoning]
+    const p = wo!.params as unknown[];
+    expect(p[1]).toBe("kg-eq-1");
+    expect(p[2]).toBe("equipment");
+    expect(p[3]).toBe("kg-wo-1");
+    expect(p[4]).toBe("work_order");
+  });
+});

--- a/mira-hub/src/lib/knowledge-graph/__tests__/cmms-sync.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/cmms-sync.test.ts
@@ -17,14 +17,16 @@ describe("SyncResult shape", () => {
       locations: 2,
       manufacturers: 6,
       models: 9,
-      relationships: 8,
+      relationships: 0,
+      relationshipsProposed: 8,
       triples: 12,
       durationMs: 150,
     };
     expect(result.equipment).toBe(3);
     expect(result.manufacturers).toBe(6);
     expect(result.models).toBe(9);
-    expect(result.relationships).toBe(8);
+    expect(result.relationships).toBe(0);
+    expect(result.relationshipsProposed).toBe(8);
     expect(result.triples).toBe(12);
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
   });

--- a/mira-hub/src/lib/knowledge-graph/__tests__/extractor-propose.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/extractor-propose.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Prove the conversation entity extractor PROPOSES (relationship_proposals via
+// upsertInferredProposal), never inserts kg_relationships directly (#1721).
+const { executed, reset } = vi.hoisted(() => {
+  const executed: { sql: string; params: unknown[] }[] = [];
+  return { executed, reset: () => (executed.length = 0) };
+});
+
+vi.mock("@/lib/db", () => {
+  let propCounter = 0;
+  const client = {
+    query: async (sql: string, params: unknown[] = []) => {
+      executed.push({ sql, params });
+      if (sql.includes("INSERT INTO kg_entities"))
+        return { rows: [{ id: `kg-${params[2]}` }], rowCount: 1 };
+      if (sql.includes("INSERT INTO relationship_proposals"))
+        return { rows: [{ id: `prop-${++propCounter}` }], rowCount: 1 };
+      if (sql.includes("FROM kg_relationships")) return { rows: [], rowCount: 0 };
+      if (sql.includes("FROM relationship_proposals")) return { rows: [], rowCount: 0 };
+      return { rows: [], rowCount: 0 };
+    },
+    release: () => {},
+  };
+  return { default: { connect: async () => client } };
+});
+
+import { extractAndStore } from "../extractor";
+
+const TENANT = "00000000-0000-0000-0000-000000000001";
+const blob = () => executed.map((e) => e.sql).join("\n");
+
+describe("extractAndStore — proposes, never auto-verifies (#1721)", () => {
+  beforeEach(() => reset());
+
+  test("regex-extracted edges become proposals, not kg_relationships inserts", async () => {
+    const result = await extractAndStore(
+      TENANT,
+      "AC-7",
+      "VFD-07 had fault F005, replaced part IR-39868252",
+      "conv-1",
+      { llmRelationships: false }, // skip LLM Pass 2 — regex pass only
+    );
+    expect(blob()).toContain("INSERT INTO relationship_proposals");
+    expect(blob()).toContain("INSERT INTO kg_triples_log"); // audit trail kept
+    expect(blob()).not.toContain("INSERT INTO kg_relationships");
+    expect(result.relationships).toBe(0);
+    // mentioned_tag (VFD-07) + exhibited_fault (F005) + requires_part (IR-39868252)
+    expect(result.relationshipsProposed).toBe(3);
+  });
+
+  test("proposes canonical types: HAS_TAG, HAS_FAILURE_MODE, HAS_PART", async () => {
+    await extractAndStore(
+      TENANT,
+      "AC-7",
+      "VFD-07 had fault F005, replaced part IR-39868252",
+      "conv-1",
+      { llmRelationships: false },
+    );
+    const types = executed
+      .filter((e) => e.sql.includes("INSERT INTO relationship_proposals"))
+      .map((e) => (e.params as unknown[])[5]);
+    expect(types).toContain("HAS_TAG");
+    expect(types).toContain("HAS_FAILURE_MODE");
+    expect(types).toContain("HAS_PART");
+  });
+});

--- a/mira-hub/src/lib/knowledge-graph/__tests__/hierarchy-backfill-propose.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/hierarchy-backfill-propose.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// Prove the hierarchy backfill PROPOSES equipment LOCATED_IN area/line
+// (relationship_proposals via upsertInferredProposal), never inserts a
+// parent_of kg_relationships edge directly (#1721).
+const { executed, reset } = vi.hoisted(() => {
+  const executed: { sql: string; params: unknown[] }[] = [];
+  return { executed, reset: () => (executed.length = 0) };
+});
+
+vi.mock("@/lib/db", () => {
+  let propCounter = 0;
+  const client = {
+    query: async (sql: string, params: unknown[] = []) => {
+      executed.push({ sql, params });
+      // findEquipmentWithLocation
+      if (sql.includes("properties ? 'location'"))
+        return { rows: [{ id: "kg-eq-1", entity_id: "AC-7", name: "Compressor", location: "Line 1" }], rowCount: 1 };
+      // findParentByLocation
+      if (sql.includes("entity_type IN ('area','line')"))
+        return { rows: [{ id: "kg-line-1", entity_id: "line_1", name: "Line 1", entity_type: "line" }], rowCount: 1 };
+      if (sql.includes("INSERT INTO relationship_proposals"))
+        return { rows: [{ id: `prop-${++propCounter}` }], rowCount: 1 };
+      if (sql.includes("FROM kg_relationships")) return { rows: [], rowCount: 0 };
+      if (sql.includes("FROM relationship_proposals")) return { rows: [], rowCount: 0 };
+      return { rows: [], rowCount: 0 };
+    },
+    release: () => {},
+  };
+  return { default: { connect: async () => client } };
+});
+
+import { runHierarchyBackfill } from "../hierarchy-backfill";
+
+const TENANT = "00000000-0000-0000-0000-000000000001";
+const blob = () => executed.map((e) => e.sql).join("\n");
+
+describe("runHierarchyBackfill — proposes, never auto-verifies (#1721)", () => {
+  beforeEach(() => reset());
+
+  test("a location match becomes a LOCATED_IN proposal, not a parent_of insert", async () => {
+    const result = await runHierarchyBackfill(TENANT, false);
+    expect(blob()).toContain("INSERT INTO relationship_proposals");
+    expect(blob()).not.toContain("INSERT INTO kg_relationships");
+    expect(result.relationshipsCreated).toBe(0);
+    expect(result.relationshipsProposed).toBe(1);
+    expect(result.matchesFound).toBe(1);
+  });
+
+  test("proposes equipment LOCATED_IN line (parent_of flipped)", async () => {
+    await runHierarchyBackfill(TENANT, false);
+    const prop = executed.find((e) => e.sql.includes("INSERT INTO relationship_proposals"));
+    expect(prop).toBeDefined();
+    // params: [tenant, source_id, source_type, target_id, target_type, rel_type, confidence, reasoning]
+    const p = prop!.params as unknown[];
+    expect(p[5]).toBe("LOCATED_IN");
+    // flip: equipment is the source, the line is the target
+    expect(p[1]).toBe("kg-eq-1");
+    expect(p[2]).toBe("equipment");
+    expect(p[3]).toBe("kg-line-1");
+    expect(p[4]).toBe("line");
+  });
+
+  test("dry-run proposes nothing but still reports matches", async () => {
+    const result = await runHierarchyBackfill(TENANT, true);
+    expect(blob()).not.toContain("INSERT INTO relationship_proposals");
+    expect(result.matchesFound).toBe(1);
+    expect(result.relationshipsProposed).toBe(0);
+  });
+});

--- a/mira-hub/src/lib/knowledge-graph/cmms-sync.ts
+++ b/mira-hub/src/lib/knowledge-graph/cmms-sync.ts
@@ -12,6 +12,13 @@
 import pool from "@/lib/db";
 import type { PoolClient } from "pg";
 import { equipmentPath, manufacturerPath, modelPath } from "@/lib/uns";
+import { mapToCanonicalEdge, upsertInferredProposal } from "./proposals-writer";
+
+// CMMS-sync edges mirror real CMMS records (a work order, a PM schedule, a
+// location) so they carry high confidence — but per the Iron Rule (ADR-0017)
+// they are still PROPOSED for human review, never auto-verified into
+// kg_relationships. The hub has no autoverify escape hatch.
+const CMMS_RELATIONSHIP_CONFIDENCE = 0.9;
 
 export interface SyncResult {
   tenantId: string;
@@ -22,7 +29,14 @@ export interface SyncResult {
   locations: number;
   manufacturers: number;
   models: number;
+  /**
+   * Kept for API back-compat. CMMS edges are now PROPOSED for human review
+   * (Iron Rule, ADR-0017), never written directly to kg_relationships —
+   * always 0. See relationshipsProposed.
+   */
   relationships: number;
+  /** New (#1721): edges proposed this sync (located_at / work-order / PM). */
+  relationshipsProposed: number;
   triples: number;
   durationMs: number;
 }
@@ -263,21 +277,41 @@ async function mirrorKnowledgeEntities(
   return { manufacturers: mfrSet.size, models: modelEntries.length };
 }
 
-async function upsertRelationship(
+/**
+ * Propose a CMMS-sync edge for human review instead of writing it straight to
+ * kg_relationships (Iron Rule, ADR-0017). The lowercase predicate is mapped to
+ * canonical via mapToCanonicalEdge; unmapped types are skipped. Returns true
+ * when a new proposal was written (false = unmapped or deduped).
+ */
+async function proposeCmmsEdge(
   client: PoolClient,
   tenantId: string,
-  sourceId: string,
-  targetId: string,
-  relType: string,
-  convId?: string,
-): Promise<void> {
-  await client.query(
-    `INSERT INTO kg_relationships
-       (tenant_id, source_id, target_id, relationship_type, confidence, source_conversation_id)
-     VALUES ($1, $2, $3, $4, 1.0, $5)
-     ON CONFLICT DO NOTHING`,
-    [tenantId, sourceId, targetId, relType, convId ?? null],
-  );
+  src: { id: string; type: string },
+  tgt: { id: string; type: string },
+  rawType: string,
+  evidenceType: string,
+): Promise<boolean> {
+  const edge = mapToCanonicalEdge(rawType);
+  if (!edge) return false;
+  const source = edge.flip ? tgt : src;
+  const target = edge.flip ? src : tgt;
+  const proposalId = await upsertInferredProposal(client, tenantId, {
+    sourceEntityId: source.id,
+    sourceEntityType: source.type,
+    targetEntityId: target.id,
+    targetEntityType: target.type,
+    relationshipType: edge.type,
+    confidence: CMMS_RELATIONSHIP_CONFIDENCE,
+    reasoning: `CMMS → KG batch sync — original predicate "${rawType}".`,
+    evidence: [
+      {
+        evidenceType,
+        sourceDescription: "CMMS batch sync (cmms-sync)",
+        confidenceContribution: CMMS_RELATIONSHIP_CONFIDENCE,
+      },
+    ],
+  });
+  return proposalId !== null;
 }
 
 async function logTriple(
@@ -422,7 +456,7 @@ export async function syncCmmsToKg(tenantId: string): Promise<SyncResult> {
     const pmById = new Map(pmInserted.map((r) => [r.entity_id, r.id]));
     const locByName = new Map(locRows.map((r) => [r.entity_id, r.id]));
 
-    // equipment → located_at → location
+    // equipment → located_at → location  (proposes LOCATED_IN)
     for (const r of equipmentRows) {
       const locRaw = String(r.location ?? "");
       if (!locRaw) continue;
@@ -430,35 +464,47 @@ export async function syncCmmsToKg(tenantId: string): Promise<SyncResult> {
       const eqKgId = eqById.get(String(r.id));
       const locKgId = locByName.get(locSlug);
       if (eqKgId && locKgId) {
-        await upsertRelationship(client, tenantId, eqKgId, locKgId, "located_at");
+        const proposed = await proposeCmmsEdge(
+          client, tenantId, { id: eqKgId, type: "equipment" }, { id: locKgId, type: "location" },
+          "located_at", "manifest",
+        );
         await logTriple(client, tenantId, String(r.description || r.id), "located_at", locRaw);
-        relCount++; tripleCount++;
+        if (proposed) relCount++;
+        tripleCount++;
       }
     }
 
-    // equipment → has_work_order → work_order
+    // equipment → has_work_order → work_order  (proposes HAS_WORK_ORDER)
     for (const r of workOrderRows) {
       const eqId = String(r.equipment_id ?? "");
       if (!eqId) continue;
       const eqKgId = eqById.get(eqId);
       const woKgId = woById.get(String(r.id));
       if (eqKgId && woKgId) {
-        await upsertRelationship(client, tenantId, eqKgId, woKgId, "has_work_order");
+        const proposed = await proposeCmmsEdge(
+          client, tenantId, { id: eqKgId, type: "equipment" }, { id: woKgId, type: "work_order" },
+          "has_work_order", "work_order",
+        );
         await logTriple(client, tenantId, String(r.equipment_id), "has_work_order", String(r.title || r.id));
-        relCount++; tripleCount++;
+        if (proposed) relCount++;
+        tripleCount++;
       }
     }
 
-    // equipment → has_pm → pm_schedule
+    // equipment → has_pm → pm_schedule  (proposes HAS_PM_SCHEDULE)
     for (const r of pmRows) {
       const eqId = String(r.equipment_id ?? "");
       if (!eqId) continue;
       const eqKgId = eqById.get(eqId);
       const pmKgId = pmById.get(String(r.id));
       if (eqKgId && pmKgId) {
-        await upsertRelationship(client, tenantId, eqKgId, pmKgId, "has_pm");
+        const proposed = await proposeCmmsEdge(
+          client, tenantId, { id: eqKgId, type: "equipment" }, { id: pmKgId, type: "pm_schedule" },
+          "has_pm", "manifest",
+        );
         await logTriple(client, tenantId, String(r.equipment_id), "has_pm", String(r.task || r.id));
-        relCount++; tripleCount++;
+        if (proposed) relCount++;
+        tripleCount++;
       }
     }
 
@@ -500,7 +546,8 @@ export async function syncCmmsToKg(tenantId: string): Promise<SyncResult> {
     locations: locationEntities.length,
     manufacturers: mirrorCounts.manufacturers,
     models: mirrorCounts.models,
-    relationships: relCount,
+    relationships: 0,
+    relationshipsProposed: relCount,
     triples: tripleCount,
     durationMs: Date.now() - t0,
   };

--- a/mira-hub/src/lib/knowledge-graph/extractor.ts
+++ b/mira-hub/src/lib/knowledge-graph/extractor.ts
@@ -8,6 +8,12 @@
 import pool from "@/lib/db";
 import type { PoolClient } from "pg";
 import { extractRelationships, type EntityRef, type ExtractionStats } from "./relationship-extractor";
+import { mapToCanonicalEdge, upsertInferredProposal } from "./proposals-writer";
+
+// Regex-extracted conversation edges are co-occurrence inferences (the asset
+// and the tag/fault/part appeared together), not certainties. Propose them at
+// a moderate fixed confidence rather than the old auto-verified 1.0.
+const REGEX_RELATIONSHIP_CONFIDENCE = 0.7;
 
 // ── Regex patterns ─────────────────────────────────────────────────────────
 
@@ -129,21 +135,41 @@ async function upsertEntity(
   return rows[0]!.id;
 }
 
-async function upsertRelationship(
+/**
+ * Propose a conversation-extracted edge for human review instead of writing it
+ * straight to kg_relationships (Iron Rule, ADR-0017). The lowercase predicate
+ * is mapped to canonical via mapToCanonicalEdge; unmapped types are skipped.
+ * Returns true when a new proposal was written (false = unmapped or deduped).
+ */
+async function proposeConversationEdge(
   client: PoolClient,
   tenantId: string,
-  sourceId: string,
-  targetId: string,
-  relType: string,
-  convId: string | null,
-): Promise<void> {
-  await client.query(
-    `INSERT INTO kg_relationships
-       (tenant_id, source_id, target_id, relationship_type, confidence, source_conversation_id)
-     VALUES ($1, $2, $3, $4, 1.0, $5)
-     ON CONFLICT DO NOTHING`,
-    [tenantId, sourceId, targetId, relType, convId],
-  );
+  src: { id: string; type: string },
+  tgt: { id: string; type: string },
+  rawType: string,
+  conversationId: string | null,
+): Promise<boolean> {
+  const edge = mapToCanonicalEdge(rawType);
+  if (!edge) return false;
+  const source = edge.flip ? tgt : src;
+  const target = edge.flip ? src : tgt;
+  const proposalId = await upsertInferredProposal(client, tenantId, {
+    sourceEntityId: source.id,
+    sourceEntityType: source.type,
+    targetEntityId: target.id,
+    targetEntityType: target.type,
+    relationshipType: edge.type,
+    confidence: REGEX_RELATIONSHIP_CONFIDENCE,
+    reasoning: `Conversation entity extraction (regex) from conversation ${conversationId ?? "?"} — original predicate "${rawType}".`,
+    evidence: [
+      {
+        evidenceType: "technician_note",
+        sourceDescription: `Diagnostic conversation ${conversationId ?? "(none)"}`,
+        confidenceContribution: REGEX_RELATIONSHIP_CONFIDENCE,
+      },
+    ],
+  });
+  return proposalId !== null;
 }
 
 async function logTriple(
@@ -169,7 +195,14 @@ export interface ExtractionResult {
   faultCodes: number;
   parts: number;
   actions: number;
+  /**
+   * Kept for API back-compat. Conversation edges are now PROPOSED for human
+   * review (Iron Rule, ADR-0017), never written directly to kg_relationships —
+   * always 0. See relationshipsProposed.
+   */
   relationships: number;
+  /** New (#1721): edges proposed this pass (regex + LLM Pass 2 combined). */
+  relationshipsProposed: number;
   triples: number;
   /** Phase 3: stats from the LLM relationship extractor pass. null if disabled. */
   llmRelationships: ExtractionStats | null;
@@ -202,28 +235,39 @@ export async function extractAndStore(
       client, tenantId, "equipment", assetId, `Asset ${assetId}`, { asset_id: assetId },
     );
 
+    const asset = { id: assetKgId, type: "equipment" };
+
     // Equipment tags mentioned in conversation
     for (const tag of extracted.equipment) {
       const tagKgId = await upsertEntity(client, tenantId, "equipment_tag", tag, tag, { source: "conversation" });
-      await upsertRelationship(client, tenantId, assetKgId, tagKgId, "mentioned_tag", conversationId);
+      const proposed = await proposeConversationEdge(
+        client, tenantId, asset, { id: tagKgId, type: "equipment_tag" }, "mentioned_tag", conversationId,
+      );
       await logTriple(client, tenantId, conversationId, `Asset ${assetId}`, "mentioned_tag", tag);
-      relCount++; tripleCount++;
+      if (proposed) relCount++;
+      tripleCount++;
     }
 
     // Fault codes
     for (const code of extracted.faultCodes) {
       const codeKgId = await upsertEntity(client, tenantId, "fault_code", code, code, { source: "conversation" });
-      await upsertRelationship(client, tenantId, assetKgId, codeKgId, "exhibited_fault", conversationId);
+      const proposed = await proposeConversationEdge(
+        client, tenantId, asset, { id: codeKgId, type: "fault_code" }, "exhibited_fault", conversationId,
+      );
       await logTriple(client, tenantId, conversationId, `Asset ${assetId}`, "exhibited_fault", code);
-      relCount++; tripleCount++;
+      if (proposed) relCount++;
+      tripleCount++;
     }
 
     // Parts
     for (const pn of extracted.parts) {
       const partKgId = await upsertEntity(client, tenantId, "part", pn, pn, { source: "conversation" });
-      await upsertRelationship(client, tenantId, assetKgId, partKgId, "requires_part", conversationId);
+      const proposed = await proposeConversationEdge(
+        client, tenantId, asset, { id: partKgId, type: "part" }, "requires_part", conversationId,
+      );
       await logTriple(client, tenantId, conversationId, `Asset ${assetId}`, "requires_part", pn);
-      relCount++; tripleCount++;
+      if (proposed) relCount++;
+      tripleCount++;
     }
 
     // Actions — logged as triples only (verbs don't need entity nodes)
@@ -259,7 +303,8 @@ export async function extractAndStore(
     faultCodes: extracted.faultCodes.length,
     parts: extracted.parts.length,
     actions: extracted.actions.length,
-    relationships: relCount + (llmStats?.storedRelationships ?? 0),
+    relationships: 0,
+    relationshipsProposed: relCount + (llmStats?.storedRelationships ?? 0),
     triples: tripleCount + (llmStats?.storedTriples ?? 0),
     llmRelationships: llmStats,
   };

--- a/mira-hub/src/lib/knowledge-graph/hierarchy-backfill.ts
+++ b/mira-hub/src/lib/knowledge-graph/hierarchy-backfill.ts
@@ -12,12 +12,28 @@
 
 import pool from "@/lib/db";
 import type { PoolClient } from "pg";
+import { mapToCanonicalEdge, upsertInferredProposal } from "./proposals-writer";
+
+// The parent match is a heuristic location-string compare, so the edge is
+// INFERRED, not deliberate structure — it is PROPOSED for human review (Iron
+// Rule, ADR-0017), never auto-verified. `parent_of` maps to LOCATED_IN flipped
+// (equipment LOCATED_IN area/line). Moderate confidence: an exact id/name
+// match is reliable but still a string heuristic.
+const HIERARCHY_RELATIONSHIP_CONFIDENCE = 0.7;
 
 export interface HierarchyBackfillResult {
   tenantId: string;
   equipmentScanned: number;
   matchesFound: number;
+  /**
+   * Kept for API back-compat. The location match is inferred, so the edge is
+   * now PROPOSED for human review (Iron Rule, ADR-0017), never written directly
+   * to kg_relationships — always 0. See relationshipsProposed.
+   */
   relationshipsCreated: number;
+  /** New (#1721): LOCATED_IN edges proposed this run (0 on dry-run). */
+  relationshipsProposed: number;
+  /** Matches skipped because a verified edge or open proposal already exists. */
   skippedExisting: number;
   unmatched: string[];
   durationMs: number;
@@ -55,6 +71,7 @@ interface ParentRow {
   id: string;
   entity_id: string;
   name: string;
+  entity_type: string;
 }
 
 async function findEquipmentWithLocation(
@@ -80,7 +97,7 @@ async function findParentByLocation(
   location: string,
 ): Promise<ParentRow | null> {
   const { rows } = await client.query<ParentRow>(
-    `SELECT id, entity_id, name
+    `SELECT id, entity_id, name, entity_type
      FROM kg_entities
      WHERE tenant_id = $1
        AND entity_type IN ('area','line')
@@ -91,38 +108,44 @@ async function findParentByLocation(
   return rows[0] ?? null;
 }
 
-async function relationshipExists(
+/**
+ * Propose `equipment LOCATED_IN parent` for human review instead of writing a
+ * `parent_of` edge straight to kg_relationships (Iron Rule, ADR-0017).
+ * `parent_of` maps to LOCATED_IN flipped, so the parent (area/line) → child
+ * (equipment) match is proposed as child LOCATED_IN parent. Dedup (verified
+ * edge OR open proposal, either direction) is handled inside
+ * upsertInferredProposal. Returns true when a new proposal was written
+ * (false = deduped — an edge/proposal already exists).
+ */
+async function proposeLocatedIn(
   client: PoolClient,
   tenantId: string,
-  sourceId: string,
-  targetId: string,
+  parent: { id: string; type: string },
+  equipment: { id: string; type: string },
 ): Promise<boolean> {
-  const { rows } = await client.query<{ exists: boolean }>(
-    `SELECT EXISTS (
-       SELECT 1 FROM kg_relationships
-       WHERE tenant_id = $1
-         AND source_id = $2
-         AND target_id = $3
-         AND relationship_type = 'parent_of'
-     ) AS exists`,
-    [tenantId, sourceId, targetId],
-  );
-  return rows[0]?.exists ?? false;
-}
-
-async function createParentOf(
-  client: PoolClient,
-  tenantId: string,
-  parentId: string,
-  childId: string,
-): Promise<void> {
-  await client.query(
-    `INSERT INTO kg_relationships
-       (tenant_id, source_id, target_id, relationship_type, confidence)
-     VALUES ($1, $2, $3, 'parent_of', 1.0)
-     ON CONFLICT DO NOTHING`,
-    [tenantId, parentId, childId],
-  );
+  const edge = mapToCanonicalEdge("parent_of");
+  if (!edge) return false;
+  // parent_of has flip:true → source/target swap so the equipment is LOCATED_IN
+  // the parent. raw source = parent, raw target = equipment.
+  const source = edge.flip ? equipment : parent;
+  const target = edge.flip ? parent : equipment;
+  const proposalId = await upsertInferredProposal(client, tenantId, {
+    sourceEntityId: source.id,
+    sourceEntityType: source.type,
+    targetEntityId: target.id,
+    targetEntityType: target.type,
+    relationshipType: edge.type,
+    confidence: HIERARCHY_RELATIONSHIP_CONFIDENCE,
+    reasoning: `Hierarchy backfill — equipment location string matched a ${parent.type} entity (original predicate "parent_of").`,
+    evidence: [
+      {
+        evidenceType: "manifest",
+        sourceDescription: `Location-string match against ${parent.type} "${parent.id}"`,
+        confidenceContribution: HIERARCHY_RELATIONSHIP_CONFIDENCE,
+      },
+    ],
+  });
+  return proposalId !== null;
 }
 
 export async function runHierarchyBackfill(
@@ -132,7 +155,7 @@ export async function runHierarchyBackfill(
   const start = Date.now();
   let equipmentScanned = 0;
   let matchesFound = 0;
-  let relationshipsCreated = 0;
+  let relationshipsProposed = 0;
   let skippedExisting = 0;
   const unmatched: string[] = [];
 
@@ -148,15 +171,17 @@ export async function runHierarchyBackfill(
         continue;
       }
       matchesFound++;
-      const exists = await relationshipExists(client, tenantId, parent.id, eq.id);
-      if (exists) {
-        skippedExisting++;
-        continue;
-      }
-      if (!dryRun) {
-        await createParentOf(client, tenantId, parent.id, eq.id);
-        relationshipsCreated++;
-      }
+      // dryRun reports candidate matches (matchesFound) but proposes nothing —
+      // upsertInferredProposal always writes, so it must be skipped here.
+      if (dryRun) continue;
+      const proposed = await proposeLocatedIn(
+        client,
+        tenantId,
+        { id: parent.id, type: parent.entity_type },
+        { id: eq.id, type: "equipment" },
+      );
+      if (proposed) relationshipsProposed++;
+      else skippedExisting++; // deduped: a verified edge or open proposal already exists
     }
   });
 
@@ -164,7 +189,8 @@ export async function runHierarchyBackfill(
     tenantId,
     equipmentScanned,
     matchesFound,
-    relationshipsCreated,
+    relationshipsCreated: 0,
+    relationshipsProposed,
     skippedExisting,
     unmatched,
     durationMs: Date.now() - start,

--- a/scripts/kg_write_guard_allowlist.txt
+++ b/scripts/kg_write_guard_allowlist.txt
@@ -16,11 +16,6 @@ mira-crawler/tasks/full_ingest_pipeline.py                 # _write_kg_edge — 
 # --- Technician-confirmation path (human-gated, mira-connect) ---
 mira-connectors/mira_connectors/store.py                   # confirmation_gate verified write on technician confirm
 
-# --- Not-yet-migrated hub writers (tracked by #1721; migrate → remove) ---
-mira-hub/src/lib/knowledge-graph/cmms-sync.ts              # TODO #1721 (blocked: has_work_order not in CHECK)
-mira-hub/src/lib/knowledge-graph/extractor.ts              # TODO #1721 (conversation extractor)
-mira-hub/src/lib/knowledge-graph/hierarchy-backfill.ts     # TODO #1721 (parent_of → LOCATED_IN decision)
-
 # --- Migrated in #1729; inserts removed once merged (allow until then) ---
 mira-hub/src/lib/knowledge-graph/queries.ts                # upsertSchematicComponents now proposes (#1729)
 mira-hub/src/lib/knowledge-graph/relationship-extractor.ts # now proposes (#1729)
@@ -34,4 +29,7 @@ mira-hub/scripts/seed-synthetic-users.ts                   # synthetic seed data
 mira-hub/src/app/api/proposals/[id]/decide/__tests__/route.test.ts  # asserts the decide route's insert
 mira-hub/src/lib/knowledge-graph/__tests__/queries-schematic.test.ts        # asserts schematic writer does NOT insert kg_relationships (#1729)
 mira-hub/src/lib/knowledge-graph/__tests__/relationship-extractor-store.test.ts  # asserts extractor does NOT insert kg_relationships (#1729)
+mira-hub/src/lib/knowledge-graph/__tests__/cmms-sync-propose.test.ts        # asserts cmms-sync does NOT insert kg_relationships (#1721)
+mira-hub/src/lib/knowledge-graph/__tests__/extractor-propose.test.ts        # asserts conversation extractor does NOT insert kg_relationships (#1721)
+mira-hub/src/lib/knowledge-graph/__tests__/hierarchy-backfill-propose.test.ts  # asserts hierarchy backfill does NOT insert kg_relationships (#1721)
 tools/seeds/demo-conveyor-001.sql                          # demo seed (commented inserts)


### PR DESCRIPTION
Closes the hub side of the KG **"propose, never auto-verify"** foundation (#1721 — final slice). The last three mira-hub TypeScript writers that wrote inferred edges straight to `kg_relationships` now **PROPOSE** via `upsertInferredProposal` (Iron Rule, ADR-0017). Sibling to the merged Python work (#1716) and the merged schematic/LLM-extractor slice (#1729).

## What changed

| Writer | Before | After |
|---|---|---|
| `extractor.ts` (conversation regex pass) | `upsertRelationship` → `kg_relationships`, conf 1.0 | `proposeConversationEdge`: `mentioned_tag`→`HAS_TAG`, `exhibited_fault`→`HAS_FAILURE_MODE`, `requires_part`→`HAS_PART` propose, conf 0.7 |
| `cmms-sync.ts` | `upsertRelationship` → `kg_relationships`, conf 1.0 | `proposeCmmsEdge`: `located_at`→`LOCATED_IN`, `has_work_order`→`HAS_WORK_ORDER`, `has_pm`→`HAS_PM_SCHEDULE` propose, conf 0.9 |
| `hierarchy-backfill.ts` | `createParentOf` → `parent_of` in `kg_relationships`, conf 1.0 | `proposeLocatedIn`: heuristic location match proposes `equipment LOCATED_IN area/line` (`parent_of`→`LOCATED_IN` **flipped**) |

- All emitted types route through the **existing** `mapToCanonicalEdge` map — no new mapping added.
- Migration **043** (already applied to staging + prod) supplies the `HAS_WORK_ORDER`/`HAS_PM_SCHEDULE`/`HAS_TAG` CHECK members.
- `hierarchy-backfill`: dropped the dead `parent_of` existence pre-check (nothing writes `parent_of` post-migration → it would peg `skippedExisting` to a wrong 0); dedup now via `upsertInferredProposal` (checks verified edge **and** open proposal, both directions); `if (!dryRun)` guard preserved.
- **API back-compat:** each result type keeps its old count field (now `0`, with a comment) and adds `relationshipsProposed`. No consumer breaks (`/api/kg/sync` returns the object verbatim; the hierarchy script logs it).

## ⚠️ Behavioral note (surfaced per #1716 precedent)

The extractor **regex** pass now proposes on every mentioned tag/fault/part for **every asset-chat turn** — a real jump in `/proposals` volume (the hub analogue of the #1716 Python "behavioral flood"). `upsertInferredProposal` dedup caps repeats, but reviewers should expect more rows in the proposal queue.

## Verification

- **8 new propose tests** (`cmms-sync-propose`, `extractor-propose`, `hierarchy-backfill-propose`): each writer proposes (`relationship_proposals`) and does **not** insert `kg_relationships`; canonical types + the `parent_of` flip asserted. **141/141** knowledge-graph tests pass.
- `eslint` + `tsc` clean on changed files (pre-existing unrelated red in `namespace/tree`, `rls-deny`, `command-center-freshness` untouched).
- `kg-write-guard` green: 8 sites all allowlisted (3 migrated sources **pruned**, 3 new test files **added** — they assert on the literal pattern, per the #1736 lesson).
- **Staging smoke** on `factorylm/stg` (throwaway tenant, real CHECK): confirmed 043 live, all six emitted canonical types accepted — `proposals=6 evidence=6 kg_relationships=0`, idempotent, self-cleaned.

Competing PRs (#1030/#1263/#1710/#642) settled with **no file overlap** with these three writers. `queries.ts::createRelationship` dead code (0 callers) left out of scope for a separate surgical follow-up.

Closes #1721.

🤖 Generated with [Claude Code](https://claude.com/claude-code)