### PR TITLE
feat(hub): asset-agent validation lifecycle (train-before-deploy Phase 1)

### DIFF
--- a/mira-hub/db/migrations/046_asset_agent_status.sql
+++ b/mira-hub/db/migrations/046_asset_agent_status.sql
@@ -1,0 +1,108 @@
+BEGIN;
+
+-- Extensions this migration depends on (already created by 010/015 in the
+-- ordered pipeline; IF NOT EXISTS keeps a standalone apply self-contained).
+CREATE EXTENSION IF NOT EXISTS ltree;
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- Migration 046: `asset_agent_status` — per-asset agent lifecycle row.
+--
+-- Spec : docs/specs/asset-agent-validation-spec.md §6 (data model)
+-- Rule : .claude/rules/train-before-deploy.md
+--
+-- Role:
+--   One row per asset that has (or is building toward) a deployable agent.
+--   Tracks the lifecycle `draft → training → validating → approved → deployed`
+--   (+ `rejected` / `deprecated`) that gates when an asset's agent may answer
+--   on a deployment surface (Ignition / HMI). The deployment gate (a later,
+--   beta-gated phase behind ENFORCE_ASSET_AGENT_GATE) consults `state` here.
+--
+-- KEYING — `equipment_id` is `cmms_equipment.id`, the asset the Hub UI
+--   (`/assets/[id]`, AssetChat, QR) operates on. Spec §6 named this
+--   `kg_entity_id`, but the Hub asset surface is cmms_equipment-keyed and not
+--   every asset has a kg_entities node, so the lifecycle row is keyed to the
+--   asset the customer actually validates. `uns_path` (canonical UNS key, per
+--   .claude/rules/uns-compliance.md) is carried so the future deployment gate
+--   — which certifies direct connections by UNS path
+--   (.claude/rules/direct-connection-uns-certified.md) — can bridge to it.
+--   Soft link (no hard FK): kg_entities / installed_component_instances /
+--   cmms_equipment lineage is dual — same pattern as wiring_connections (026)
+--   and tag_events (033).
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS asset_agent_status (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id     UUID NOT NULL,
+
+    -- The asset this agent is scoped to. = cmms_equipment.id. Soft link.
+    equipment_id  UUID NOT NULL,
+
+    -- Resolved UNS path of the asset, when known. The future deployment gate
+    -- keys on this (canonical UNS-compliance key). Nullable: the asset may not
+    -- have a resolved UNS path yet.
+    uns_path      LTREE,
+
+    -- The lifecycle state. CHECK so a bad transition surfaces at write time.
+    state         TEXT NOT NULL DEFAULT 'draft'
+        CHECK (state IN (
+            'draft',       -- entity exists; agent not started
+            'training',    -- docs/tags attaching; proposals flowing
+            'validating',  -- grounded; validation Q&A in progress
+            'approved',    -- human signed off (requires approved_by)
+            'deployed',    -- live on a deployment surface
+            'rejected',    -- validation failed / agent pulled
+            'deprecated'   -- underlying asset/docs retired
+        )),
+
+    -- Promotion to 'approved' is ALWAYS a human action (spec §4 invariant).
+    -- A row in 'approved'/'deployed' without approved_by is a bug.
+    approved_by   TEXT,                  -- 'human:user_<uuid>'
+    approved_at   TIMESTAMPTZ,
+    deployed_at   TIMESTAMPTZ,
+    deployed_by   TEXT,
+    deploy_surface TEXT
+        CHECK (deploy_surface IS NULL OR deploy_surface IN (
+            'ignition', 'perspective', 'hub_display', 'qr'
+        )),
+
+    -- §5 acceptance signals the approve gate reads (persisted because the gate
+    -- reads them; display-only counts like doc_count are derived in the API).
+    citation_coverage INTEGER NOT NULL DEFAULT 0,  -- # validation Q with ≥1 citation
+    min_groundedness  SMALLINT,                     -- lowest groundedness across counted answers
+    last_validated_at TIMESTAMPTZ,
+
+    notes         TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+    UNIQUE (tenant_id, equipment_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_asset_agent_status_tenant_state
+    ON asset_agent_status (tenant_id, state);
+
+-- Future deployment gate looks up by UNS path.
+CREATE INDEX IF NOT EXISTS idx_asset_agent_status_uns
+    ON asset_agent_status USING GIST (tenant_id, uns_path)
+    WHERE uns_path IS NOT NULL;
+
+ALTER TABLE asset_agent_status ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS asset_agent_status_tenant ON asset_agent_status;
+CREATE POLICY asset_agent_status_tenant
+    ON asset_agent_status
+    USING (tenant_id = current_setting('app.tenant_id', true)::UUID
+           OR tenant_id = current_setting('app.current_tenant_id', true)::UUID);
+
+GRANT SELECT, INSERT, UPDATE ON asset_agent_status TO factorylm_app;
+
+COMMIT;
+
+
+-- ────────────────────────────────────────────────────────────────────────
+-- DOWN
+-- ────────────────────────────────────────────────────────────────────────
+-- BEGIN;
+-- DROP POLICY IF EXISTS asset_agent_status_tenant ON asset_agent_status;
+-- DROP TABLE IF EXISTS asset_agent_status;
+-- COMMIT;

--- a/mira-hub/db/migrations/047_asset_validation_qa.sql
+++ b/mira-hub/db/migrations/047_asset_validation_qa.sql
@@ -1,0 +1,67 @@
+BEGIN;
+
+-- Migration 047: `asset_validation_qa` — the validation transcript an approver
+-- signs off on, per asset.
+--
+-- Spec : docs/specs/asset-agent-validation-spec.md §6 (data model)
+-- Rule : .claude/rules/train-before-deploy.md
+--
+-- Role:
+--   One row per validation question asked against an asset's agent during the
+--   `validating` phase. The human reviewer marks each `reviewer_verdict`
+--   (good / bad / needs_review; NULL = not yet reviewed). The §5 approve gate
+--   counts rows where verdict='good' AND a citation resolves to a
+--   knowledge_entries chunk in the asset's UNS subtree.
+--
+-- KEYING — `equipment_id` is `cmms_equipment.id`, matching asset_agent_status
+--   (046). Soft link (dual lineage; no hard FK).
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS asset_validation_qa (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id     UUID NOT NULL,
+    equipment_id  UUID NOT NULL,            -- = cmms_equipment.id (the asset)
+
+    question        TEXT NOT NULL,
+    expected_answer TEXT,                   -- optional reviewer-provided ground truth
+    mira_answer     TEXT,
+
+    -- [{doc_id, page, source_url}] — the citations the answer resolved to.
+    citations       JSONB NOT NULL DEFAULT '[]'::JSONB,
+
+    groundedness         SMALLINT,          -- engine 1–5, copied from the turn
+    evidence_utilization REAL,              -- from benchmark_db
+
+    reviewer_verdict TEXT
+        CHECK (reviewer_verdict IS NULL
+               OR reviewer_verdict IN ('good', 'bad', 'needs_review')),
+    reviewed_by      TEXT,
+    reviewed_at      TIMESTAMPTZ,
+
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- All validation Q&A for one asset, newest first (Validate tab + approve gate).
+CREATE INDEX IF NOT EXISTS idx_asset_validation_qa_equipment
+    ON asset_validation_qa (tenant_id, equipment_id, created_at DESC);
+
+ALTER TABLE asset_validation_qa ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS asset_validation_qa_tenant ON asset_validation_qa;
+CREATE POLICY asset_validation_qa_tenant
+    ON asset_validation_qa
+    USING (tenant_id = current_setting('app.tenant_id', true)::UUID
+           OR tenant_id = current_setting('app.current_tenant_id', true)::UUID);
+
+GRANT SELECT, INSERT, UPDATE ON asset_validation_qa TO factorylm_app;
+
+COMMIT;
+
+
+-- ────────────────────────────────────────────────────────────────────────
+-- DOWN
+-- ────────────────────────────────────────────────────────────────────────
+-- BEGIN;
+-- DROP POLICY IF EXISTS asset_validation_qa_tenant ON asset_validation_qa;
+-- DROP TABLE IF EXISTS asset_validation_qa;
+-- COMMIT;

--- a/mira-hub/src/app/(hub)/assets/[id]/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { AssetChat } from "@/components/AssetChat";
 import { AssetIntelligencePanel } from "@/components/AssetIntelligencePanel";
+import { AssetValidateTab } from "@/components/AssetValidateTab";
 import { QrCodeModal } from "@/components/qr-code-modal";
 import { UploadPicker, type PickResult } from "@/components/UploadPicker";
 import { Badge } from "@/components/ui/badge";
@@ -207,7 +208,7 @@ export default function AssetDetailPage({ params }: { params: Promise<{ id: stri
 
           {/* Tabs */}
           <div className="flex gap-0 overflow-x-auto scrollbar-none -mb-px">
-            {["overview", "ask", "activity", "workorders", "documents", "parts", "intelligence"].map((tab) => (
+            {["overview", "ask", "activity", "workorders", "documents", "parts", "intelligence", "validate"].map((tab) => (
               <button
                 key={tab}
                 onClick={() => setActiveTab(tab)}
@@ -230,6 +231,10 @@ export default function AssetDetailPage({ params }: { params: Promise<{ id: stri
                    <span className="flex items-center gap-1">
                      <Brain className="w-3 h-3" /> Intel
                    </span>
+                 ) : tab === "validate" ? (
+                   <span className="flex items-center gap-1">
+                     <CheckCircle2 className="w-3 h-3" /> Validate
+                   </span>
                  ) : tab}
               </button>
             ))}
@@ -250,6 +255,7 @@ export default function AssetDetailPage({ params }: { params: Promise<{ id: stri
           {activeTab === "documents"     && <DocumentsTab assetId={id} assetTag={asset.tag} />}
           {activeTab === "parts"         && <PartsTab />}
           {activeTab === "intelligence"  && <AssetIntelligencePanel assetId={id} />}
+          {activeTab === "validate"      && <AssetValidateTab assetId={id} />}
         </div>
       )}
 

--- a/mira-hub/src/app/api/assets/[id]/agent-status/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/assets/[id]/agent-status/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+// Vitest coverage for GET /api/assets/[id]/agent-status.
+// Mocks the session + tenant-context so each test drives one code path.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/session", () => ({ sessionOr401: vi.fn() }));
+vi.mock("@/lib/tenant-context", () => ({ withTenantContext: vi.fn() }));
+
+import { GET } from "../route";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+const ID = "11111111-2222-3333-4444-555555555555";
+const TENANT = "tenant-aaaa";
+const session = { userId: "u_1", tenantId: TENANT, email: "x@y" };
+
+// A mock pg client whose query() answers by matching SQL fragments.
+function mockClient(handlers: Array<[RegExp, { rows: unknown[] }]>) {
+  return {
+    query: vi.fn(async (sql: string) => {
+      for (const [re, res] of handlers) if (re.test(sql)) return res;
+      return { rows: [] };
+    }),
+  };
+}
+
+function wireClient(client: { query: ReturnType<typeof vi.fn> }) {
+  vi.mocked(withTenantContext).mockImplementation(
+    ((_t: string, fn: (c: unknown) => unknown) => fn(client)) as never,
+  );
+}
+
+const params = Promise.resolve({ id: ID });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEON_DATABASE_URL = "postgres://test";
+  vi.mocked(sessionOr401).mockResolvedValue(session as never);
+});
+
+describe("GET agent-status", () => {
+  it("503 when DB not configured", async () => {
+    delete process.env.NEON_DATABASE_URL;
+    const res = await GET(new Request("http://t"), { params });
+    expect(res.status).toBe(503);
+  });
+
+  it("401 passthrough when unauthenticated", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }) as never,
+    );
+    const res = await GET(new Request("http://t"), { params });
+    expect(res.status).toBe(401);
+  });
+
+  it("404 when the asset does not exist", async () => {
+    wireClient(mockClient([[/FROM cmms_equipment/, { rows: [] }]]));
+    const res = await GET(new Request("http://t"), { params });
+    expect(res.status).toBe(404);
+  });
+
+  it("defaults to draft / exists=false when no status row", async () => {
+    wireClient(
+      mockClient([
+        [/FROM cmms_equipment/, { rows: [{ manufacturer: "Allen-Bradley", model_number: "525" }] }],
+        [/FROM asset_agent_status/, { rows: [] }],
+        [/COUNT\(DISTINCT source_url\)/, { rows: [{ n: 3 }] }],
+        [/FROM asset_validation_qa/, { rows: [{ total: 0, good: 0, good_cited: 0, min_ground: null }] }],
+      ]),
+    );
+    const res = await GET(new Request("http://t"), { params });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.state).toBe("draft");
+    expect(body.exists).toBe(false);
+    expect(body.docCount).toBe(3);
+    expect(body.readyToApprove).toBe(false);
+  });
+
+  it("reports readyToApprove when validating + §5 met", async () => {
+    wireClient(
+      mockClient([
+        [/FROM cmms_equipment/, { rows: [{ manufacturer: "AB", model_number: "" }] }],
+        [/FROM asset_agent_status/, { rows: [{ state: "validating" }] }],
+        [/COUNT\(DISTINCT source_url\)/, { rows: [{ n: 1 }] }],
+        [
+          /FROM asset_validation_qa/,
+          { rows: [{ total: 6, good: 5, good_cited: 5, min_ground: 4 }] },
+        ],
+      ]),
+    );
+    const res = await GET(new Request("http://t"), { params });
+    const body = await res.json();
+    expect(body.state).toBe("validating");
+    expect(body.citationCoverage).toBe(5);
+    expect(body.readyToApprove).toBe(true);
+  });
+});

--- a/mira-hub/src/app/api/assets/[id]/agent-status/route.ts
+++ b/mira-hub/src/app/api/assets/[id]/agent-status/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { meetsApprovalCriteria } from "@/lib/asset-agent-transition";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/assets/[id]/agent-status
+// The asset agent's lifecycle state + the derived signals the Validate tab and
+// the §5 approve gate read. `id` is a cmms_equipment.id.
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+
+  try {
+    const data = await withTenantContext(ctx.tenantId, async (c) => {
+      const asset = await c
+        .query(
+          `SELECT manufacturer, model_number FROM cmms_equipment
+           WHERE id = $1 AND tenant_id = $2 LIMIT 1`,
+          [id, ctx.tenantId],
+        )
+        .then((r) => r.rows[0] ?? null);
+      if (!asset) return { asset: null as null };
+
+      const status = await c
+        .query(
+          `SELECT state, approved_by, approved_at, deployed_at, deployed_by,
+                  deploy_surface, citation_coverage, min_groundedness,
+                  last_validated_at, notes
+           FROM asset_agent_status WHERE equipment_id = $1 LIMIT 1`,
+          [id],
+        )
+        .then((r) => r.rows[0] ?? null);
+
+      const mfr = (asset.manufacturer as string | null) ?? "";
+      const model = (asset.model_number as string | null) ?? "";
+      const docCount = mfr
+        ? await c
+            .query(
+              `SELECT COUNT(DISTINCT source_url)::int AS n FROM knowledge_entries
+               WHERE tenant_id = $1 AND LOWER(manufacturer) = LOWER($2)
+                 AND ($3 = '' OR model_number ILIKE '%' || $3 || '%')`,
+              [ctx.tenantId, mfr, model],
+            )
+            .then((r) => Number(r.rows[0]?.n ?? 0))
+        : 0;
+
+      const qa = await c
+        .query(
+          `SELECT
+             COUNT(*)::int AS total,
+             COUNT(*) FILTER (WHERE reviewer_verdict = 'good')::int AS good,
+             COUNT(*) FILTER (
+               WHERE reviewer_verdict = 'good' AND jsonb_array_length(citations) > 0
+             )::int AS good_cited,
+             MIN(groundedness) FILTER (WHERE reviewer_verdict = 'good') AS min_ground
+           FROM asset_validation_qa WHERE equipment_id = $1`,
+          [id],
+        )
+        .then((r) => r.rows[0]);
+
+      return { asset, status, docCount, qa };
+    });
+
+    if (!data.asset) {
+      return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+    }
+
+    const state = (data.status?.state as string) ?? "draft";
+    const citationCoverage = Number(data.qa?.good_cited ?? 0);
+    const minGroundedness =
+      data.qa?.min_ground == null ? null : Number(data.qa.min_ground);
+    // openSafetyCritical: deferred to a later phase (the gate fn supports it).
+    const approval = meetsApprovalCriteria({
+      citationCoverage,
+      minGroundedness,
+      openSafetyCritical: 0,
+    });
+
+    return NextResponse.json({
+      equipmentId: id,
+      state,
+      exists: !!data.status,
+      approvedBy: data.status?.approved_by ?? null,
+      approvedAt: data.status?.approved_at ?? null,
+      deployedAt: data.status?.deployed_at ?? null,
+      deployedBy: data.status?.deployed_by ?? null,
+      deploySurface: data.status?.deploy_surface ?? null,
+      docCount: data.docCount,
+      validationQuestionCount: Number(data.qa?.total ?? 0),
+      approvedAnswerCount: Number(data.qa?.good ?? 0),
+      citationCoverage,
+      minGroundedness,
+      readyToApprove: state === "validating" && approval.ok,
+      approvalReasons: approval.reasons,
+      lastValidatedAt: data.status?.last_validated_at ?? null,
+      notes: data.status?.notes ?? null,
+    });
+  } catch (err) {
+    console.error("[api/assets/[id]/agent-status GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/assets/[id]/agent-status/transition/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/assets/[id]/agent-status/transition/__tests__/route.test.ts
@@ -1,0 +1,119 @@
+// Vitest coverage for POST /api/assets/[id]/agent-status/transition.
+// transitionAssetAgent (the real helper) runs against the mocked client, so
+// the SQL dispatcher answers its SELECT … FOR UPDATE + UPDATE too.
+
+import { it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/session", () => ({ sessionOr401: vi.fn() }));
+vi.mock("@/lib/tenant-context", () => ({ withTenantContext: vi.fn() }));
+
+import { POST } from "../route";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+const ID = "11111111-2222-3333-4444-555555555555";
+const session = { userId: "u_1", tenantId: "tenant-aaaa", email: "x@y" };
+const params = Promise.resolve({ id: ID });
+
+function mockClient(handlers: Array<[RegExp, { rows: unknown[] }]>) {
+  return {
+    query: vi.fn(async (sql: string) => {
+      for (const [re, res] of handlers) if (re.test(sql)) return res;
+      return { rows: [] };
+    }),
+  };
+}
+function wire(client: { query: ReturnType<typeof vi.fn> }) {
+  vi.mocked(withTenantContext).mockImplementation(
+    ((_t: string, fn: (c: unknown) => unknown) => fn(client)) as never,
+  );
+}
+function post(body: unknown) {
+  return POST(new Request("http://t", { method: "POST", body: JSON.stringify(body) }), {
+    params,
+  });
+}
+
+const ASSET_OK: [RegExp, { rows: unknown[] }] = [
+  /SELECT 1 FROM cmms_equipment/,
+  { rows: [{ "?column?": 1 }] },
+];
+const INSERT_OK: [RegExp, { rows: unknown[] }] = [/INSERT INTO asset_agent_status/, { rows: [] }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEON_DATABASE_URL = "postgres://test";
+  vi.mocked(sessionOr401).mockResolvedValue(session as never);
+});
+
+it("400 on an invalid target state", async () => {
+  const res = await post({ to: "wizard" });
+  expect(res.status).toBe(400);
+});
+
+it("404 when the asset does not exist", async () => {
+  wire(mockClient([[/SELECT 1 FROM cmms_equipment/, { rows: [] }]]));
+  const res = await post({ to: "training" });
+  expect(res.status).toBe(404);
+});
+
+it("advances draft → training (200)", async () => {
+  wire(
+    mockClient([
+      ASSET_OK,
+      INSERT_OK,
+      [/SELECT state FROM asset_agent_status/, { rows: [{ state: "draft" }] }],
+      [/RETURNING id, equipment_id, state/, { rows: [{ id: "x", equipment_id: ID, state: "training" }] }],
+    ]),
+  );
+  const res = await post({ to: "training" });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.status.state).toBe("training");
+});
+
+it("409 on an illegal transition (draft → deployed)", async () => {
+  wire(
+    mockClient([
+      ASSET_OK,
+      INSERT_OK,
+      [/SELECT state FROM asset_agent_status/, { rows: [{ state: "draft" }] }],
+    ]),
+  );
+  const res = await post({ to: "deployed" });
+  expect(res.status).toBe(409);
+});
+
+it("422 when approving without meeting the §5 gate", async () => {
+  wire(
+    mockClient([
+      ASSET_OK,
+      INSERT_OK,
+      [/FROM asset_validation_qa/, { rows: [{ good_cited: 1, min_ground: 4 }] }],
+    ]),
+  );
+  const res = await post({ to: "approved" });
+  expect(res.status).toBe(422);
+  const body = await res.json();
+  expect(body.reasons?.length).toBeGreaterThan(0);
+});
+
+it("approves when the §5 gate passes (200, records actor)", async () => {
+  const client = mockClient([
+    ASSET_OK,
+    INSERT_OK,
+    [/FROM asset_validation_qa/, { rows: [{ good_cited: 5, min_ground: 4 }] }],
+    [/SET citation_coverage/, { rows: [] }],
+    [/SELECT state FROM asset_agent_status/, { rows: [{ state: "validating" }] }],
+    [
+      /RETURNING id, equipment_id, state/,
+      { rows: [{ id: "x", equipment_id: ID, state: "approved", approved_by: "human:u_1" }] },
+    ],
+  ]);
+  wire(client);
+  const res = await post({ to: "approved" });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.status.state).toBe("approved");
+  expect(body.status.approved_by).toBe("human:u_1");
+});

--- a/mira-hub/src/app/api/assets/[id]/agent-status/transition/route.ts
+++ b/mira-hub/src/app/api/assets/[id]/agent-status/transition/route.ts
@@ -1,0 +1,125 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import {
+  ASSET_AGENT_STATES,
+  type AssetAgentState,
+  transitionAssetAgent,
+  meetsApprovalCriteria,
+  IllegalTransitionError,
+  MissingActorError,
+} from "@/lib/asset-agent-transition";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/assets/[id]/agent-status/transition  { to, deploySurface? }
+// Advances the asset agent's lifecycle. All state changes go through the
+// transition helper (no raw UPDATE). Promotion to `approved` enforces the §5
+// gate server-side and records the human actor.
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { id } = await params;
+  const body = (await req.json().catch(() => ({}))) as {
+    to?: string;
+    deploySurface?: string;
+  };
+  const to = body.to as AssetAgentState | undefined;
+  if (!to || !(ASSET_AGENT_STATES as readonly string[]).includes(to)) {
+    return NextResponse.json(
+      { error: `'to' must be one of ${ASSET_AGENT_STATES.join(", ")}` },
+      { status: 400 },
+    );
+  }
+
+  const actor = `human:${ctx.userId}`;
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      const asset = await c
+        .query(
+          `SELECT 1 FROM cmms_equipment WHERE id = $1 AND tenant_id = $2 LIMIT 1`,
+          [id, ctx.tenantId],
+        )
+        .then((r) => r.rows[0] ?? null);
+      if (!asset) return { kind: "not_found" as const };
+
+      // Lazily materialise a draft row (with the asset's UNS path) so the first
+      // transition has something to advance.
+      await c.query(
+        `INSERT INTO asset_agent_status (tenant_id, equipment_id, uns_path, state)
+         SELECT $1, $2, e.uns_path, 'draft'
+         FROM cmms_equipment e WHERE e.id = $2 AND e.tenant_id = $1
+         ON CONFLICT (tenant_id, equipment_id) DO NOTHING`,
+        [ctx.tenantId, id],
+      );
+
+      // §5 gate: approval is only allowed when the validation evidence holds.
+      if (to === "approved") {
+        const qa = await c
+          .query(
+            `SELECT
+               COUNT(*) FILTER (
+                 WHERE reviewer_verdict = 'good' AND jsonb_array_length(citations) > 0
+               )::int AS good_cited,
+               MIN(groundedness) FILTER (WHERE reviewer_verdict = 'good') AS min_ground
+             FROM asset_validation_qa WHERE equipment_id = $1`,
+            [id],
+          )
+          .then((r) => r.rows[0]);
+        const citationCoverage = Number(qa?.good_cited ?? 0);
+        const minGroundedness = qa?.min_ground == null ? null : Number(qa.min_ground);
+        const gate = meetsApprovalCriteria({
+          citationCoverage,
+          minGroundedness,
+          openSafetyCritical: 0,
+        });
+        if (!gate.ok) {
+          return { kind: "gate_failed" as const, reasons: gate.reasons };
+        }
+        // Snapshot the signals onto the row so the future deployment gate has them.
+        await c.query(
+          `UPDATE asset_agent_status
+           SET citation_coverage = $2, min_groundedness = $3, last_validated_at = now()
+           WHERE equipment_id = $1`,
+          [id, citationCoverage, minGroundedness],
+        );
+      }
+
+      const updated = await transitionAssetAgent(c, {
+        equipmentId: id,
+        to,
+        approvedBy: actor,
+        deploySurface: body.deploySurface,
+      });
+      return { kind: "ok" as const, updated };
+    });
+
+    if (result.kind === "not_found") {
+      return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+    }
+    if (result.kind === "gate_failed") {
+      return NextResponse.json(
+        { error: "Approval criteria not met", reasons: result.reasons },
+        { status: 422 },
+      );
+    }
+    return NextResponse.json({ status: result.updated });
+  } catch (err) {
+    if (err instanceof IllegalTransitionError) {
+      return NextResponse.json({ error: err.message }, { status: 409 });
+    }
+    if (err instanceof MissingActorError) {
+      return NextResponse.json({ error: err.message }, { status: 422 });
+    }
+    console.error("[api/assets/[id]/agent-status/transition POST]", err);
+    return NextResponse.json({ error: "Transition failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/assets/[id]/validation-qa/[qaId]/verdict/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/assets/[id]/validation-qa/[qaId]/verdict/__tests__/route.test.ts
@@ -1,0 +1,69 @@
+// Vitest coverage for PUT /api/assets/[id]/validation-qa/[qaId]/verdict.
+
+import { it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/session", () => ({ sessionOr401: vi.fn() }));
+vi.mock("@/lib/tenant-context", () => ({ withTenantContext: vi.fn() }));
+
+import { PUT } from "../route";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+const ID = "11111111-2222-3333-4444-555555555555";
+const QA = "99999999-8888-7777-6666-555555555555";
+const session = { userId: "u_1", tenantId: "tenant-aaaa", email: "x@y" };
+const params = Promise.resolve({ id: ID, qaId: QA });
+
+function wire(rows: unknown[]) {
+  const client = {
+    query: vi.fn(async () => ({ rows })),
+  };
+  vi.mocked(withTenantContext).mockImplementation(
+    ((_t: string, fn: (c: unknown) => unknown) => fn(client)) as never,
+  );
+  return client;
+}
+function put(body: unknown) {
+  return PUT(new Request("http://t", { method: "PUT", body: JSON.stringify(body) }), {
+    params,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEON_DATABASE_URL = "postgres://test";
+  vi.mocked(sessionOr401).mockResolvedValue(session as never);
+});
+
+it("400 on an invalid verdict", async () => {
+  wire([]);
+  const res = await put({ verdict: "maybe" });
+  expect(res.status).toBe(400);
+});
+
+it("404 when the Q&A row is not found", async () => {
+  wire([]);
+  const res = await put({ verdict: "good" });
+  expect(res.status).toBe(404);
+});
+
+it("maps the approve alias to 'good' and records the reviewer", async () => {
+  const client = wire([
+    { id: QA, reviewer_verdict: "good", reviewed_by: "human:u_1", reviewed_at: "2026-06-07" },
+  ]);
+  const res = await put({ verdict: "approve" });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body.reviewerVerdict).toBe("good");
+  // verdict 'good' was written, not the raw alias
+  const sqlArgs = (client.query.mock.calls[0] as unknown[])[1] as unknown[];
+  expect(sqlArgs).toContain("good");
+  expect(sqlArgs).toContain("human:u_1");
+});
+
+it("maps reject → bad", async () => {
+  const client = wire([{ id: QA, reviewer_verdict: "bad" }]);
+  await put({ verdict: "reject" });
+  const sqlArgs = (client.query.mock.calls[0] as unknown[])[1] as unknown[];
+  expect(sqlArgs).toContain("bad");
+});

--- a/mira-hub/src/app/api/assets/[id]/validation-qa/[qaId]/verdict/route.ts
+++ b/mira-hub/src/app/api/assets/[id]/validation-qa/[qaId]/verdict/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+// Accept the spec verdicts plus the approve/reject aliases the UI uses.
+const VERDICT_ALIASES: Record<string, "good" | "bad" | "needs_review"> = {
+  good: "good",
+  bad: "bad",
+  needs_review: "needs_review",
+  approve: "good",
+  reject: "bad",
+};
+
+// PUT /api/assets/[id]/validation-qa/[qaId]/verdict  { verdict }
+// A human marks a validation answer good / bad / needs_review.
+export async function PUT(
+  req: Request,
+  { params }: { params: Promise<{ id: string; qaId: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+  const { id, qaId } = await params;
+
+  const body = (await req.json().catch(() => ({}))) as { verdict?: string };
+  const verdict = VERDICT_ALIASES[(body.verdict ?? "").trim().toLowerCase()];
+  if (!verdict) {
+    return NextResponse.json(
+      { error: "verdict must be one of good, bad, needs_review" },
+      { status: 400 },
+    );
+  }
+  const reviewer = `human:${ctx.userId}`;
+
+  try {
+    const row = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query(
+          `UPDATE asset_validation_qa
+             SET reviewer_verdict = $3, reviewed_by = $4, reviewed_at = now()
+           WHERE id = $1 AND equipment_id = $2
+           RETURNING id, reviewer_verdict, reviewed_by, reviewed_at`,
+          [qaId, id, verdict, reviewer],
+        )
+        .then((r) => r.rows[0] ?? null),
+    );
+    if (!row) {
+      return NextResponse.json({ error: "Validation Q&A not found" }, { status: 404 });
+    }
+    return NextResponse.json({
+      id: row.id,
+      reviewerVerdict: row.reviewer_verdict,
+      reviewedBy: row.reviewed_by,
+      reviewedAt: row.reviewed_at,
+    });
+  } catch (err) {
+    console.error("[api/assets/[id]/validation-qa/[qaId]/verdict PUT]", err);
+    return NextResponse.json({ error: "Update failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/assets/[id]/validation-qa/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/assets/[id]/validation-qa/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+// Vitest coverage for GET + POST /api/assets/[id]/validation-qa.
+
+import { it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/session", () => ({ sessionOr401: vi.fn() }));
+vi.mock("@/lib/tenant-context", () => ({ withTenantContext: vi.fn() }));
+
+import { GET, POST } from "../route";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+const ID = "11111111-2222-3333-4444-555555555555";
+const session = { userId: "u_1", tenantId: "tenant-aaaa", email: "x@y" };
+const params = Promise.resolve({ id: ID });
+
+function mockClient(handlers: Array<[RegExp, { rows: unknown[] }]>) {
+  return {
+    query: vi.fn(async (sql: string) => {
+      for (const [re, res] of handlers) if (re.test(sql)) return res;
+      return { rows: [] };
+    }),
+  };
+}
+function wire(client: { query: ReturnType<typeof vi.fn> }) {
+  vi.mocked(withTenantContext).mockImplementation(
+    ((_t: string, fn: (c: unknown) => unknown) => fn(client)) as never,
+  );
+}
+const ASSET_OK: [RegExp, { rows: unknown[] }] = [
+  /FROM cmms_equipment/,
+  { rows: [{ "?column?": 1 }] },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.NEON_DATABASE_URL = "postgres://test";
+  vi.mocked(sessionOr401).mockResolvedValue(session as never);
+});
+
+it("GET 404 when asset missing", async () => {
+  wire(mockClient([[/FROM cmms_equipment/, { rows: [] }]]));
+  const res = await GET(new Request("http://t"), { params });
+  expect(res.status).toBe(404);
+});
+
+it("GET returns the transcript shaped for the UI", async () => {
+  wire(
+    mockClient([
+      ASSET_OK,
+      [
+        /FROM asset_validation_qa/,
+        {
+          rows: [
+            {
+              id: "q1",
+              question: "Why faulted?",
+              citations: [{ doc_id: "d", page: 6 }],
+              reviewer_verdict: "good",
+              created_at: "2026-06-07",
+            },
+          ],
+        },
+      ],
+    ]),
+  );
+  const res = await GET(new Request("http://t"), { params });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(body[0].reviewerVerdict).toBe("good");
+  expect(body[0].citations[0].page).toBe(6);
+});
+
+it("POST 400 when question is blank", async () => {
+  wire(mockClient([ASSET_OK]));
+  const res = await POST(
+    new Request("http://t", { method: "POST", body: JSON.stringify({ question: "  " }) }),
+    { params },
+  );
+  expect(res.status).toBe(400);
+});
+
+it("POST 201 records a validation turn", async () => {
+  wire(
+    mockClient([
+      ASSET_OK,
+      [/INSERT INTO asset_agent_status/, { rows: [] }],
+      [
+        /INSERT INTO asset_validation_qa/,
+        { rows: [{ id: "q2", question: "Reset procedure?", citations: [] }] },
+      ],
+    ]),
+  );
+  const res = await POST(
+    new Request("http://t", {
+      method: "POST",
+      body: JSON.stringify({ question: "Reset procedure?", groundedness: 9 }),
+    }),
+    { params },
+  );
+  expect(res.status).toBe(201);
+  const body = await res.json();
+  expect(body.id).toBe("q2");
+});

--- a/mira-hub/src/app/api/assets/[id]/validation-qa/route.ts
+++ b/mira-hub/src/app/api/assets/[id]/validation-qa/route.ts
@@ -1,0 +1,149 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+function rowToQa(r: Record<string, unknown>) {
+  return {
+    id: r.id,
+    question: r.question,
+    expectedAnswer: r.expected_answer ?? null,
+    miraAnswer: r.mira_answer ?? null,
+    citations: r.citations ?? [],
+    groundedness: r.groundedness ?? null,
+    evidenceUtilization: r.evidence_utilization ?? null,
+    reviewerVerdict: r.reviewer_verdict ?? null,
+    reviewedBy: r.reviewed_by ?? null,
+    reviewedAt: r.reviewed_at ?? null,
+    createdAt: r.created_at ?? null,
+  };
+}
+
+// GET /api/assets/[id]/validation-qa — the validation transcript, newest first.
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+  const { id } = await params;
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      const asset = await c
+        .query(`SELECT 1 FROM cmms_equipment WHERE id = $1 AND tenant_id = $2 LIMIT 1`, [
+          id,
+          ctx.tenantId,
+        ])
+        .then((r) => r.rows[0] ?? null);
+      if (!asset) return null;
+      return c
+        .query(
+          `SELECT id, question, expected_answer, mira_answer, citations,
+                  groundedness, evidence_utilization, reviewer_verdict,
+                  reviewed_by, reviewed_at, created_at
+           FROM asset_validation_qa
+           WHERE equipment_id = $1
+           ORDER BY created_at DESC
+           LIMIT 200`,
+          [id],
+        )
+        .then((r) => r.rows);
+    });
+    if (result === null) {
+      return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+    }
+    return NextResponse.json(result.map(rowToQa));
+  } catch (err) {
+    console.error("[api/assets/[id]/validation-qa GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}
+
+// POST /api/assets/[id]/validation-qa — record a validation turn.
+// The Validate tab asks the question through the existing asset chat, then
+// posts the resulting answer + citations here for review (spec §8 reuses
+// AssetChat — no separate inference in this route).
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+  const { id } = await params;
+
+  const body = (await req.json().catch(() => ({}))) as {
+    question?: string;
+    expectedAnswer?: string;
+    miraAnswer?: string;
+    citations?: unknown;
+    groundedness?: number;
+    evidenceUtilization?: number;
+  };
+  const question = (body.question ?? "").trim();
+  if (!question) {
+    return NextResponse.json({ error: "question is required" }, { status: 400 });
+  }
+  const citations = Array.isArray(body.citations) ? body.citations : [];
+  const groundedness =
+    typeof body.groundedness === "number"
+      ? Math.max(1, Math.min(5, Math.round(body.groundedness)))
+      : null;
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      const asset = await c
+        .query(`SELECT 1 FROM cmms_equipment WHERE id = $1 AND tenant_id = $2 LIMIT 1`, [
+          id,
+          ctx.tenantId,
+        ])
+        .then((r) => r.rows[0] ?? null);
+      if (!asset) return null;
+
+      // Ensure a lifecycle row exists so the asset surfaces in the readiness list.
+      await c.query(
+        `INSERT INTO asset_agent_status (tenant_id, equipment_id, uns_path, state)
+         SELECT $1, $2, e.uns_path, 'draft'
+         FROM cmms_equipment e WHERE e.id = $2 AND e.tenant_id = $1
+         ON CONFLICT (tenant_id, equipment_id) DO NOTHING`,
+        [ctx.tenantId, id],
+      );
+
+      return c
+        .query(
+          `INSERT INTO asset_validation_qa
+             (tenant_id, equipment_id, question, expected_answer, mira_answer,
+              citations, groundedness, evidence_utilization)
+           VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)
+           RETURNING id, question, expected_answer, mira_answer, citations,
+                     groundedness, evidence_utilization, reviewer_verdict,
+                     reviewed_by, reviewed_at, created_at`,
+          [
+            ctx.tenantId,
+            id,
+            question,
+            body.expectedAnswer ?? null,
+            body.miraAnswer ?? null,
+            JSON.stringify(citations),
+            groundedness,
+            typeof body.evidenceUtilization === "number" ? body.evidenceUtilization : null,
+          ],
+        )
+        .then((r) => r.rows[0]);
+    });
+    if (result === null) {
+      return NextResponse.json({ error: "Asset not found" }, { status: 404 });
+    }
+    return NextResponse.json(rowToQa(result), { status: 201 });
+  } catch (err) {
+    console.error("[api/assets/[id]/validation-qa POST]", err);
+    return NextResponse.json({ error: "Insert failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/components/AssetValidateTab.tsx
+++ b/mira-hub/src/components/AssetValidateTab.tsx
@@ -7,6 +7,7 @@
 // Spec: docs/specs/asset-agent-validation-spec.md §8
 
 import { useCallback, useEffect, useState } from "react";
+import { API_BASE } from "@/lib/config";
 
 type State =
   | "draft"
@@ -63,12 +64,12 @@ export function AssetValidateTab({ assetId }: { assetId: string }) {
 
   const refresh = useCallback(async () => {
     try {
-      const sRes = await fetch(`/api/assets/${assetId}/agent-status`);
+      const sRes = await fetch(`${API_BASE}/api/assets/${assetId}/agent-status/`);
       if (sRes.ok) {
         const s = (await sRes.json()) as AgentStatus;
         setStatus(s);
       }
-      const qRes = await fetch(`/api/assets/${assetId}/validation-qa`);
+      const qRes = await fetch(`${API_BASE}/api/assets/${assetId}/validation-qa/`);
       if (qRes.ok) {
         const q = await qRes.json();
         if (Array.isArray(q)) setQa(q);
@@ -92,7 +93,7 @@ export function AssetValidateTab({ assetId }: { assetId: string }) {
     try {
       let answer = "";
       let citations: unknown[] = [];
-      const chatRes = await fetch(`/hub/api/assets/${assetId}/chat`, {
+      const chatRes = await fetch(`${API_BASE}/api/assets/${assetId}/chat/`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ messages: [{ role: "user", content: q }] }),
@@ -126,7 +127,7 @@ export function AssetValidateTab({ assetId }: { assetId: string }) {
           }
         }
       }
-      const res = await fetch(`/api/assets/${assetId}/validation-qa`, {
+      const res = await fetch(`${API_BASE}/api/assets/${assetId}/validation-qa/`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ question: q, miraAnswer: answer || null, citations }),
@@ -142,7 +143,7 @@ export function AssetValidateTab({ assetId }: { assetId: string }) {
   };
 
   const setVerdict = async (qaId: string, verdict: "good" | "bad") => {
-    await fetch(`/api/assets/${assetId}/validation-qa/${qaId}/verdict`, {
+    await fetch(`${API_BASE}/api/assets/${assetId}/validation-qa/${qaId}/verdict/`, {
       method: "PUT",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ verdict }),
@@ -154,7 +155,7 @@ export function AssetValidateTab({ assetId }: { assetId: string }) {
     setBusy(true);
     setError(null);
     try {
-      const res = await fetch(`/api/assets/${assetId}/agent-status/transition`, {
+      const res = await fetch(`${API_BASE}/api/assets/${assetId}/agent-status/transition/`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ to }),

--- a/mira-hub/src/components/AssetValidateTab.tsx
+++ b/mira-hub/src/components/AssetValidateTab.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+// Validate tab on the asset detail page. Drives the asset-agent lifecycle:
+// record validation Q&A, mark each answer good/bad, advance the state, and —
+// once the §5 gate passes — approve the agent for the HMI.
+//
+// Spec: docs/specs/asset-agent-validation-spec.md §8
+
+import { useCallback, useEffect, useState } from "react";
+
+type State =
+  | "draft"
+  | "training"
+  | "validating"
+  | "approved"
+  | "deployed"
+  | "rejected"
+  | "deprecated";
+
+interface AgentStatus {
+  state: State;
+  docCount: number;
+  validationQuestionCount: number;
+  approvedAnswerCount: number;
+  citationCoverage: number;
+  minGroundedness: number | null;
+  readyToApprove: boolean;
+  approvalReasons: string[];
+}
+
+interface QaRow {
+  id: string;
+  question: string;
+  miraAnswer: string | null;
+  citations: unknown[];
+  reviewerVerdict: "good" | "bad" | "needs_review" | null;
+}
+
+const STATE_COLOR: Record<State, string> = {
+  draft: "#6b7280",
+  training: "#d97706",
+  validating: "#2563eb",
+  approved: "#16a34a",
+  deployed: "#7c3aed",
+  rejected: "#dc2626",
+  deprecated: "#6b7280",
+};
+
+// The next forward lifecycle state, if any (mirrors the server-side graph).
+const NEXT: Partial<Record<State, State>> = {
+  draft: "training",
+  training: "validating",
+  validating: "approved",
+  approved: "deployed",
+};
+
+export function AssetValidateTab({ assetId }: { assetId: string }) {
+  const [status, setStatus] = useState<AgentStatus | null>(null);
+  const [qa, setQa] = useState<QaRow[]>([]);
+  const [question, setQuestion] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const sRes = await fetch(`/api/assets/${assetId}/agent-status`);
+      if (sRes.ok) {
+        const s = (await sRes.json()) as AgentStatus;
+        setStatus(s);
+      }
+      const qRes = await fetch(`/api/assets/${assetId}/validation-qa`);
+      if (qRes.ok) {
+        const q = await qRes.json();
+        if (Array.isArray(q)) setQa(q);
+      }
+    } catch {
+      /* silent — keep the last good view */
+    }
+  }, [assetId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const askQuestion = async () => {
+    if (!question.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/assets/${assetId}/validation-qa`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ question }),
+      });
+      if (!res.ok) throw new Error((await res.json()).error ?? "Failed to record question");
+      setQuestion("");
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const setVerdict = async (qaId: string, verdict: "good" | "bad") => {
+    await fetch(`/api/assets/${assetId}/validation-qa/${qaId}/verdict`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ verdict }),
+    });
+    await refresh();
+  };
+
+  const transition = async (to: State) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/assets/${assetId}/agent-status/transition`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ to }),
+      });
+      if (!res.ok) {
+        const b = await res.json();
+        throw new Error(
+          b.reasons?.length ? `${b.error}: ${b.reasons.join("; ")}` : b.error ?? "Transition failed",
+        );
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!status) {
+    return <div style={{ padding: 24, color: "var(--foreground-muted)" }}>Loading…</div>;
+  }
+
+  const next = NEXT[status.state];
+  const approveBlocked = status.state === "validating" && !status.readyToApprove;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20, padding: "4px 0" }}>
+      {/* Lifecycle header */}
+      <div style={{ display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+        <span
+          style={{
+            padding: "4px 12px",
+            borderRadius: 999,
+            fontSize: 13,
+            fontWeight: 600,
+            color: "#fff",
+            background: STATE_COLOR[status.state],
+            textTransform: "capitalize",
+          }}
+        >
+          {status.state}
+        </span>
+        <span style={{ color: "var(--foreground-muted)", fontSize: 13 }}>
+          {status.docCount} docs · {status.approvedAnswerCount}/{status.validationQuestionCount} answers
+          approved · citation coverage {status.citationCoverage}
+        </span>
+        <div style={{ flex: 1 }} />
+        {next && next !== "approved" && (
+          <button
+            onClick={() => transition(next)}
+            disabled={busy}
+            style={primaryBtn}
+          >
+            Advance to {next}
+          </button>
+        )}
+        {status.state === "validating" && (
+          <button
+            onClick={() => transition("approved")}
+            disabled={busy || approveBlocked}
+            title={approveBlocked ? status.approvalReasons.join("; ") : "Approve this agent for the HMI"}
+            style={{ ...primaryBtn, opacity: approveBlocked ? 0.5 : 1, background: "#16a34a" }}
+          >
+            Mark as Ready
+          </button>
+        )}
+        {status.state === "approved" && (
+          <button onClick={() => transition("deployed")} disabled={busy} style={{ ...primaryBtn, background: "#7c3aed" }}>
+            Deploy to HMI
+          </button>
+        )}
+      </div>
+
+      {approveBlocked && (
+        <div style={{ fontSize: 13, color: "#b45309" }}>
+          Not ready to approve: {status.approvalReasons.join("; ")}.
+        </div>
+      )}
+      {error && <div style={{ fontSize: 13, color: "#dc2626" }}>{error}</div>}
+
+      {/* Ask a validation question */}
+      <div style={{ display: "flex", gap: 8 }}>
+        <input
+          value={question}
+          onChange={(e) => setQuestion(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && askQuestion()}
+          placeholder="Ask a validation question for this asset…"
+          style={{
+            flex: 1,
+            padding: "8px 12px",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+            background: "var(--background)",
+            color: "var(--foreground)",
+          }}
+        />
+        <button onClick={askQuestion} disabled={busy || !question.trim()} style={primaryBtn}>
+          Record
+        </button>
+      </div>
+
+      {/* Validation transcript */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {qa.length === 0 && (
+          <div style={{ color: "var(--foreground-muted)", fontSize: 13 }}>
+            No validation questions yet. Ask one above to start validating this asset&apos;s agent.
+          </div>
+        )}
+        {qa.map((row) => (
+          <div
+            key={row.id}
+            style={{
+              border: "1px solid var(--border)",
+              borderRadius: 8,
+              padding: 12,
+              display: "flex",
+              flexDirection: "column",
+              gap: 6,
+            }}
+          >
+            <div style={{ fontWeight: 600, fontSize: 14 }}>{row.question}</div>
+            {row.miraAnswer && (
+              <div style={{ fontSize: 13, color: "var(--foreground-muted)" }}>{row.miraAnswer}</div>
+            )}
+            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <span style={{ fontSize: 12, color: "var(--foreground-muted)" }}>
+                {Array.isArray(row.citations) ? row.citations.length : 0} citations
+              </span>
+              <div style={{ flex: 1 }} />
+              <button
+                onClick={() => setVerdict(row.id, "good")}
+                style={{ ...verdictBtn, ...(row.reviewerVerdict === "good" ? goodActive : {}) }}
+              >
+                Good
+              </button>
+              <button
+                onClick={() => setVerdict(row.id, "bad")}
+                style={{ ...verdictBtn, ...(row.reviewerVerdict === "bad" ? badActive : {}) }}
+              >
+                Bad
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const primaryBtn: React.CSSProperties = {
+  padding: "8px 14px",
+  borderRadius: 8,
+  border: "none",
+  background: "var(--brand-blue)",
+  color: "#fff",
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: "pointer",
+};
+
+const verdictBtn: React.CSSProperties = {
+  padding: "4px 12px",
+  borderRadius: 6,
+  border: "1px solid var(--border)",
+  background: "var(--background)",
+  color: "var(--foreground)",
+  fontSize: 12,
+  cursor: "pointer",
+};
+
+const goodActive: React.CSSProperties = { background: "#16a34a", color: "#fff", borderColor: "#16a34a" };
+const badActive: React.CSSProperties = { background: "#dc2626", color: "#fff", borderColor: "#dc2626" };

--- a/mira-hub/src/components/AssetValidateTab.tsx
+++ b/mira-hub/src/components/AssetValidateTab.tsx
@@ -82,15 +82,54 @@ export function AssetValidateTab({ assetId }: { assetId: string }) {
     void refresh();
   }, [refresh]);
 
+  // Ask the question through the existing grounded asset chat (so the recorded
+  // answer carries real citations), then persist the turn for review. Spec §8.
   const askQuestion = async () => {
-    if (!question.trim()) return;
+    const q = question.trim();
+    if (!q) return;
     setBusy(true);
     setError(null);
     try {
+      let answer = "";
+      let citations: unknown[] = [];
+      const chatRes = await fetch(`/hub/api/assets/${assetId}/chat`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ messages: [{ role: "user", content: q }] }),
+      });
+      if (chatRes.ok && chatRes.body) {
+        const reader = chatRes.body.getReader();
+        const dec = new TextDecoder();
+        let buf = "";
+        let finished = false;
+        while (!finished) {
+          const r = await reader.read();
+          if (r.done) break;
+          buf += dec.decode(r.value, { stream: true });
+          const lines = buf.split("\n");
+          buf = lines.pop() ?? "";
+          for (const line of lines) {
+            const t = line.trim();
+            if (!t.startsWith("data:")) continue;
+            const data = t.slice(5).trim();
+            if (data === "[DONE]") {
+              finished = true;
+              break;
+            }
+            try {
+              const parsed = JSON.parse(data) as { content?: string; sources?: unknown[] };
+              if (Array.isArray(parsed.sources)) citations = parsed.sources;
+              if (parsed.content) answer += parsed.content;
+            } catch {
+              /* skip malformed chunk */
+            }
+          }
+        }
+      }
       const res = await fetch(`/api/assets/${assetId}/validation-qa`, {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ question }),
+        body: JSON.stringify({ question: q, miraAnswer: answer || null, citations }),
       });
       if (!res.ok) throw new Error((await res.json()).error ?? "Failed to record question");
       setQuestion("");
@@ -213,7 +252,7 @@ export function AssetValidateTab({ assetId }: { assetId: string }) {
           }}
         />
         <button onClick={askQuestion} disabled={busy || !question.trim()} style={primaryBtn}>
-          Record
+          {busy ? "Asking…" : "Ask MIRA"}
         </button>
       </div>
 

--- a/mira-hub/src/lib/asset-agent-transition.test.ts
+++ b/mira-hub/src/lib/asset-agent-transition.test.ts
@@ -1,0 +1,101 @@
+// Vitest coverage for the asset-agent lifecycle transition rules.
+//
+// Run: cd mira-hub && npx vitest run src/lib/asset-agent-transition
+//
+// These are PURE rules — no DB. The DB-applying wrapper (transitionAssetAgent)
+// is exercised through the route tests with a mocked tenant-context client.
+//
+// Spec: docs/specs/asset-agent-validation-spec.md §4 (lifecycle) + §5 (approve)
+
+import { describe, it, expect } from "vitest";
+import {
+  ASSET_AGENT_STATES,
+  validateTransition,
+  IllegalTransitionError,
+  MissingActorError,
+} from "./asset-agent-transition";
+
+describe("ASSET_AGENT_STATES", () => {
+  it("is the 7 spec states", () => {
+    expect([...ASSET_AGENT_STATES].sort()).toEqual(
+      [
+        "approved",
+        "deployed",
+        "deprecated",
+        "draft",
+        "rejected",
+        "training",
+        "validating",
+      ].sort(),
+    );
+  });
+});
+
+describe("validateTransition — legal forward path", () => {
+  const path: [string, string][] = [
+    ["draft", "training"],
+    ["training", "validating"],
+    ["validating", "approved"],
+    ["approved", "deployed"],
+  ];
+  for (const [from, to] of path) {
+    it(`${from} → ${to} is allowed`, () => {
+      const actor = to === "approved" ? { approvedBy: "human:user_1" } : undefined;
+      expect(() => validateTransition(from, to, actor)).not.toThrow();
+    });
+  }
+});
+
+describe("validateTransition — terminal/admin transitions", () => {
+  it("any active state → rejected is allowed", () => {
+    for (const from of ["draft", "training", "validating", "approved", "deployed"]) {
+      expect(() => validateTransition(from, "rejected")).not.toThrow();
+    }
+  });
+  it("validating → rejected (validation fail) is allowed", () => {
+    expect(() => validateTransition("validating", "rejected")).not.toThrow();
+  });
+  it("any state → deprecated is allowed", () => {
+    for (const from of ["draft", "training", "validating", "approved", "deployed"]) {
+      expect(() => validateTransition(from, "deprecated")).not.toThrow();
+    }
+  });
+});
+
+describe("validateTransition — illegal transitions throw", () => {
+  it("draft → approved (skips validation) throws", () => {
+    expect(() => validateTransition("draft", "approved", { approvedBy: "human:u" })).toThrow(
+      IllegalTransitionError,
+    );
+  });
+  it("draft → deployed throws", () => {
+    expect(() => validateTransition("draft", "deployed")).toThrow(IllegalTransitionError);
+  });
+  it("deployed → validating (backwards) throws", () => {
+    expect(() => validateTransition("deployed", "validating")).toThrow(IllegalTransitionError);
+  });
+  it("rejected → approved (no resurrection without restart) throws", () => {
+    expect(() => validateTransition("rejected", "approved", { approvedBy: "human:u" })).toThrow(
+      IllegalTransitionError,
+    );
+  });
+  it("unknown state throws", () => {
+    expect(() => validateTransition("bogus", "draft")).toThrow(IllegalTransitionError);
+  });
+});
+
+describe("validateTransition — approved requires a human actor (spec §4 invariant)", () => {
+  it("validating → approved WITHOUT approvedBy throws MissingActorError", () => {
+    expect(() => validateTransition("validating", "approved")).toThrow(MissingActorError);
+  });
+  it("validating → approved with empty approvedBy throws", () => {
+    expect(() => validateTransition("validating", "approved", { approvedBy: "  " })).toThrow(
+      MissingActorError,
+    );
+  });
+  it("validating → approved with an actor passes", () => {
+    expect(() =>
+      validateTransition("validating", "approved", { approvedBy: "human:user_42" }),
+    ).not.toThrow();
+  });
+});

--- a/mira-hub/src/lib/asset-agent-transition.test.ts
+++ b/mira-hub/src/lib/asset-agent-transition.test.ts
@@ -11,6 +11,8 @@ import { describe, it, expect } from "vitest";
 import {
   ASSET_AGENT_STATES,
   validateTransition,
+  meetsApprovalCriteria,
+  MIN_VALIDATION_QUESTIONS,
   IllegalTransitionError,
   MissingActorError,
 } from "./asset-agent-transition";
@@ -81,6 +83,43 @@ describe("validateTransition — illegal transitions throw", () => {
   });
   it("unknown state throws", () => {
     expect(() => validateTransition("bogus", "draft")).toThrow(IllegalTransitionError);
+  });
+});
+
+describe("meetsApprovalCriteria — spec §5 gate", () => {
+  it("passes with enough cited good answers and groundedness ≥4", () => {
+    const r = meetsApprovalCriteria({
+      citationCoverage: MIN_VALIDATION_QUESTIONS,
+      minGroundedness: 4,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.reasons).toEqual([]);
+  });
+  it("fails when too few cited good answers", () => {
+    const r = meetsApprovalCriteria({ citationCoverage: 2, minGroundedness: 5 });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.join(" ")).toMatch(/≥5/);
+  });
+  it("fails when a good answer is poorly grounded", () => {
+    const r = meetsApprovalCriteria({
+      citationCoverage: MIN_VALIDATION_QUESTIONS,
+      minGroundedness: 3,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.join(" ")).toMatch(/groundedness/);
+  });
+  it("fails when no answers counted (null groundedness)", () => {
+    const r = meetsApprovalCriteria({ citationCoverage: 0, minGroundedness: null });
+    expect(r.ok).toBe(false);
+  });
+  it("blocks on open safety-critical proposals", () => {
+    const r = meetsApprovalCriteria({
+      citationCoverage: MIN_VALIDATION_QUESTIONS,
+      minGroundedness: 5,
+      openSafetyCritical: 1,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reasons.join(" ")).toMatch(/safety/);
   });
 });
 

--- a/mira-hub/src/lib/asset-agent-transition.test.ts
+++ b/mira-hub/src/lib/asset-agent-transition.test.ts
@@ -100,15 +100,23 @@ describe("meetsApprovalCriteria — spec §5 gate", () => {
     expect(r.ok).toBe(false);
     expect(r.reasons.join(" ")).toMatch(/≥5/);
   });
-  it("fails when a good answer is poorly grounded", () => {
+  it("fails when a recorded groundedness is below threshold", () => {
     const r = meetsApprovalCriteria({
       citationCoverage: MIN_VALIDATION_QUESTIONS,
       minGroundedness: 3,
     });
     expect(r.ok).toBe(false);
-    expect(r.reasons.join(" ")).toMatch(/groundedness/);
+    expect(r.reasons.join(" ")).toMatch(/grounded/);
   });
-  it("fails when no answers counted (null groundedness)", () => {
+  it("passes with sufficient citations when groundedness is unscored (Hub surface)", () => {
+    // The Hub LLM-cascade chat emits citations but no 1–5 score; null must not block.
+    const r = meetsApprovalCriteria({
+      citationCoverage: MIN_VALIDATION_QUESTIONS,
+      minGroundedness: null,
+    });
+    expect(r.ok).toBe(true);
+  });
+  it("fails when no answers counted", () => {
     const r = meetsApprovalCriteria({ citationCoverage: 0, minGroundedness: null });
     expect(r.ok).toBe(false);
   });

--- a/mira-hub/src/lib/asset-agent-transition.ts
+++ b/mira-hub/src/lib/asset-agent-transition.ts
@@ -44,6 +44,39 @@ const ACTIVE_STATES: AssetAgentState[] = [
   "deployed",
 ];
 
+// §5 approval thresholds (spec defaults; configurable per tenant later).
+export const MIN_VALIDATION_QUESTIONS = 5;
+export const MIN_GROUNDEDNESS = 4;
+
+export interface ApprovalSignals {
+  citationCoverage: number; // # validation Q with verdict='good' AND ≥1 citation
+  minGroundedness: number | null; // lowest groundedness across the good answers
+  openSafetyCritical?: number; // pending safety_critical ai_suggestions on the asset
+}
+
+/**
+ * The spec §5 gate for advancing an asset agent to `approved`. Pure.
+ * Returns the decision plus the specific reasons it isn't met (for the UI).
+ */
+export function meetsApprovalCriteria(s: ApprovalSignals): {
+  ok: boolean;
+  reasons: string[];
+} {
+  const reasons: string[] = [];
+  if (s.citationCoverage < MIN_VALIDATION_QUESTIONS) {
+    reasons.push(
+      `need ≥${MIN_VALIDATION_QUESTIONS} good, cited answers (have ${s.citationCoverage})`,
+    );
+  }
+  if (s.minGroundedness == null || s.minGroundedness < MIN_GROUNDEDNESS) {
+    reasons.push(`every approved answer needs groundedness ≥${MIN_GROUNDEDNESS}`);
+  }
+  if ((s.openSafetyCritical ?? 0) > 0) {
+    reasons.push("resolve open safety-critical proposals first");
+  }
+  return { ok: reasons.length === 0, reasons };
+}
+
 export class IllegalTransitionError extends Error {
   constructor(from: string, to: string) {
     super(`Illegal asset-agent transition: ${from} → ${to}`);

--- a/mira-hub/src/lib/asset-agent-transition.ts
+++ b/mira-hub/src/lib/asset-agent-transition.ts
@@ -1,0 +1,160 @@
+// Asset-agent lifecycle transitions.
+//
+// The single place lifecycle state changes are validated. Per
+// docs/specs/asset-agent-validation-spec.md §6 and .claude/CLAUDE.md
+// (ADR-0017 pattern), routes MUST NOT run raw `UPDATE … SET state` — they go
+// through `transitionAssetAgent`, which validates the move before writing.
+//
+// Invariant (spec §4): promotion to `approved` is ALWAYS a human action. A
+// transition into `approved` without an actor is rejected here, not at the DB.
+
+import type { PoolClient } from "pg";
+
+export const ASSET_AGENT_STATES = [
+  "draft",
+  "training",
+  "validating",
+  "approved",
+  "deployed",
+  "rejected",
+  "deprecated",
+] as const;
+
+export type AssetAgentState = (typeof ASSET_AGENT_STATES)[number];
+
+// Forward lifecycle edges. `rejected` and `deprecated` are reachable from any
+// active state (admin pull / asset retirement) and are handled separately so
+// the map stays about the happy path.
+const FORWARD: Record<AssetAgentState, AssetAgentState[]> = {
+  draft: ["training"],
+  training: ["validating"],
+  validating: ["approved"],
+  approved: ["deployed"],
+  deployed: [],
+  rejected: [],
+  deprecated: [],
+};
+
+// Admin/system transitions allowed from any state that isn't already terminal.
+const ACTIVE_STATES: AssetAgentState[] = [
+  "draft",
+  "training",
+  "validating",
+  "approved",
+  "deployed",
+];
+
+export class IllegalTransitionError extends Error {
+  constructor(from: string, to: string) {
+    super(`Illegal asset-agent transition: ${from} → ${to}`);
+    this.name = "IllegalTransitionError";
+  }
+}
+
+export class MissingActorError extends Error {
+  constructor(to: string) {
+    super(`Transition to '${to}' requires a human actor (approvedBy)`);
+    this.name = "MissingActorError";
+  }
+}
+
+function isState(s: string): s is AssetAgentState {
+  return (ASSET_AGENT_STATES as readonly string[]).includes(s);
+}
+
+export interface TransitionActor {
+  approvedBy?: string;
+}
+
+/**
+ * Validate a lifecycle transition. Throws IllegalTransitionError for a move
+ * that isn't allowed, or MissingActorError when entering `approved` without a
+ * non-blank actor. Pure — no side effects.
+ */
+export function validateTransition(
+  from: string,
+  to: string,
+  actor: TransitionActor = {},
+): void {
+  if (!isState(from) || !isState(to)) {
+    throw new IllegalTransitionError(from, to);
+  }
+
+  const allowed =
+    FORWARD[from].includes(to) ||
+    // admin pull / retirement from any active state
+    ((to === "rejected" || to === "deprecated") && ACTIVE_STATES.includes(from));
+
+  if (!allowed) {
+    throw new IllegalTransitionError(from, to);
+  }
+
+  if (to === "approved" && !actor.approvedBy?.trim()) {
+    throw new MissingActorError(to);
+  }
+}
+
+export interface TransitionResult {
+  id: string;
+  equipment_id: string;
+  state: AssetAgentState;
+  approved_by: string | null;
+  approved_at: string | null;
+  deployed_at: string | null;
+  deployed_by: string | null;
+  deploy_surface: string | null;
+  updated_at: string;
+}
+
+/**
+ * Validate + apply a lifecycle transition for one asset's agent row, inside an
+ * already-tenant-scoped client (use via withTenantContext). Reads the current
+ * state, validates the move, then writes the new state and the relevant
+ * actor/timestamp columns. Returns the updated row, or null if no row exists
+ * for (tenant, equipment).
+ *
+ * `actor.approvedBy` is the human identity ('human:user_<uuid>'); required to
+ * enter `approved`, recorded as deployer when entering `deployed`.
+ */
+export async function transitionAssetAgent(
+  client: PoolClient,
+  args: {
+    equipmentId: string;
+    to: AssetAgentState;
+    approvedBy?: string;
+    deploySurface?: string;
+  },
+): Promise<TransitionResult | null> {
+  const { rows } = await client.query<{ state: string }>(
+    `SELECT state FROM asset_agent_status WHERE equipment_id = $1 FOR UPDATE`,
+    [args.equipmentId],
+  );
+  if (rows.length === 0) return null;
+
+  validateTransition(rows[0].state, args.to, { approvedBy: args.approvedBy });
+
+  const sets: string[] = ["state = $2", "updated_at = now()"];
+  const params: unknown[] = [args.equipmentId, args.to];
+
+  if (args.to === "approved") {
+    params.push(args.approvedBy);
+    sets.push(`approved_by = $${params.length}`, "approved_at = now()");
+  }
+  if (args.to === "deployed") {
+    params.push(args.approvedBy ?? null);
+    sets.push(`deployed_by = $${params.length}`, "deployed_at = now()");
+    if (args.deploySurface) {
+      params.push(args.deploySurface);
+      sets.push(`deploy_surface = $${params.length}`);
+    }
+  }
+
+  const { rows: updated } = await client.query<TransitionResult>(
+    `UPDATE asset_agent_status SET ${sets.join(", ")}
+     WHERE equipment_id = $1
+     RETURNING id, equipment_id, state, approved_by, approved_at,
+               deployed_at, deployed_by, deploy_surface, updated_at`,
+    params,
+  );
+  return updated[0];
+}

--- a/mira-hub/src/lib/asset-agent-transition.ts
+++ b/mira-hub/src/lib/asset-agent-transition.ts
@@ -57,6 +57,14 @@ export interface ApprovalSignals {
 /**
  * The spec §5 gate for advancing an asset agent to `approved`. Pure.
  * Returns the decision plus the specific reasons it isn't met (for the UI).
+ *
+ * Grounding bar: `citationCoverage` (good answers WITH a citation) is the
+ * primary, always-enforced requirement — that's grounded-by-citation + human
+ * verdict. The engine 1–5 groundedness is ADVISORY here: the Hub validation
+ * surface (LLM-cascade asset chat) doesn't emit a 1–5 score, so a null score
+ * does NOT block; a *recorded* score below threshold does. The hard engine
+ * groundedness gate applies at the deployment-gate phase, where the Python
+ * engine produces the turn (spec §2, §7).
  */
 export function meetsApprovalCriteria(s: ApprovalSignals): {
   ok: boolean;
@@ -68,8 +76,8 @@ export function meetsApprovalCriteria(s: ApprovalSignals): {
       `need ≥${MIN_VALIDATION_QUESTIONS} good, cited answers (have ${s.citationCoverage})`,
     );
   }
-  if (s.minGroundedness == null || s.minGroundedness < MIN_GROUNDEDNESS) {
-    reasons.push(`every approved answer needs groundedness ≥${MIN_GROUNDEDNESS}`);
+  if (s.minGroundedness != null && s.minGroundedness < MIN_GROUNDEDNESS) {
+    reasons.push(`an approved answer is poorly grounded (needs ≥${MIN_GROUNDEDNESS})`);
   }
   if ((s.openSafetyCritical ?? 0) > 0) {
     reasons.push("resolve open safety-critical proposals first");


### PR DESCRIPTION
## What

Implements **Phase 1** of `docs/specs/asset-agent-validation-spec.md` — the per-asset *train-before-deploy* lifecycle in mira-hub. A customer validates MIRA on a specific asset (ask grounded questions → mark answers good/bad) and **approves** it before it can answer on a deployment surface.

Lifecycle: `draft → training → validating → approved → deployed` (+ `rejected` / `deprecated`).

Doctrine + spec land in #1781 (`.claude/rules/train-before-deploy.md` + the spec). This is the implementation.

## Changes

- **Migrations 046/047** — `asset_agent_status` (lifecycle row) + `asset_validation_qa` (validation transcript). Tenant-scoped **RLS** (mirrors `027_ai_suggestions`), CHECK + UNIQUE constraints. Verified on an ephemeral Postgres: RLS isolation *as `factorylm_app`* (write tenant A → read as tenant B returns empty), CHECK rejects bad `state`/`verdict`, UNIQUE blocks dupes. Already applied to dev/staging under the old number; idempotent.
- **Transition helper** (`src/lib/asset-agent-transition.ts`) — the single validate+apply path for lifecycle changes (no raw `UPDATE … SET state`, per ADR-0017). Enforces the legal transition graph and the **human-actor invariant** (`approved` requires a recorded actor). Plus the §5 approval gate (`meetsApprovalCriteria`).
- **5 API routes** (all via `withTenantContext` → RLS): `GET agent-status`, `POST agent-status/transition` (server-side §5 gate on approve), `GET/POST validation-qa`, `PUT validation-qa/[qaId]/verdict`.
- **Validate tab** on `/assets/[id]` — state badge, doc/answer counts, ask a validation question, mark good/bad, advance the lifecycle, gated **"Mark as Ready"** that surfaces the §5 reasons when blocked.

## Decisions (please sanity-check)

1. **Keyed on `equipment_id` = `cmms_equipment.id`**, not spec §6's `kg_entity_id`. The Hub asset surface (`/assets/[id]`, AssetChat, QR) is cmms_equipment-keyed, `cmms_equipment` has no kg FK (only `uns_path`), and not every asset has a kg node — so the lifecycle row is keyed to the asset the customer actually validates. A nullable `uns_path` is carried as the bridge for the future deployment gate (the canonical UNS key). Soft FK (dual lineage — same as 026/033). Easy to rename if you'd rather key on kg_entity.
2. **Groundedness is advisory in the approve gate.** The Hub LLM-cascade chat emits citations but no 1–5 engine score, so a *null* score does not block — the bar is **grounded-by-citation + human verdict** (≥5 good answers each with a citation). A *recorded* low score still blocks. The hard engine-groundedness gate (spec §5 #3) belongs to the deployment-gate phase, where the Python engine produces the turn.

## Deferred to follow-up PRs (matches the spec's beta-gating)

- The `ignition_chat.py` deployment gate behind `ENFORCE_ASSET_AGENT_GATE` (touches the live direct-connection path — its own PR).
- The Python `asset_agent_transition.py` (only needed when the engine writes these tables, i.e. with the gate).
- The §5 open-`safety_critical` check (the gate fn supports it; wired to `ai_suggestions` later) and the e2e golden + `mira-run-hallucination-audit` extension.

## Test plan

- [x] **41 vitest tests** — 22 across the 5 routes (incl. RLS-scoped queries, the §5 gate 422, illegal-transition 409, verdict aliasing) + 19 on the transition helper / approval criteria.
- [x] Migrations verified on ephemeral Postgres (RLS as `factorylm_app`, CHECK, UNIQUE).
- [x] `tsc --noEmit` clean for all new files; eslint clean (the one `set-state-in-effect` notice matches the existing `DocumentsTab` fetch-on-mount in the same file).
- [ ] CI: watch **apply-and-verify** (proves `apply-migrations.yml`'s verify step handles 046/047) + Docker Build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## ⚠️ Before merge

**Migrations 046/047 are not applied to any environment yet.** Whoever merges must run `apply-migrations.yml` dev→staging→prod (`dry-run` then `apply`, `migrations=046,047`) — the Validate tab will 500 against a schema that lacks the columns until then.

The only red check (**Unit Tests**) is a pre-existing failure on `main` (`test_reranking.py::test_photo_query_embeds_with_asset_context`, broke with the "embed the clean query" recall change) — this PR touches zero Python. Spawned a separate task to fix it.
