### PR TITLE
perf(recall): embed the clean query, not the 440-token /ask card (#1766)

### DIFF
--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -458,17 +458,24 @@ class RAGWorker:
                                 len(neon_chunks),
                             )
                         else:
+                            # Embed the CLEAN recall_query, not the enriched blob
+                            # (#1766 follow-up). Prod RAG_STAGE_TIMING showed the
+                            # embed of the ~2760-char /ask MACHINE_CONTEXT card was
+                            # 3-5s on CPU Ollama — the dominant latency after the
+                            # recall fix. recall_query is the trimmed question+status
+                            # (~200 chars) → embed drops to <1s, and the vector is
+                            # question-focused rather than blurred by the static card.
+                            # For chat surfaces recall_query == message, so their
+                            # embedding is unchanged (only the /ask kiosk sets
+                            # state["retrieval_query"]).
                             _t_emb = time.monotonic()
-                            embedding = await self._embed_ollama(embed_query)
+                            embedding = await self._embed_ollama(recall_query)
                             _embed_ms = int((time.monotonic() - _t_emb) * 1000)
                             # Call recall_knowledge unconditionally — it now
                             # falls through to lexical streams when embedding
                             # is None (Ollama sidecar down). Pre-fix this gate
                             # short-circuited BM25 and produced NO_KB_COVERAGE
                             # despite KB rows being lexically retrievable.
-                            # query_text = recall_query (clean) so fault/product/
-                            # BM25 extraction doesn't key off the static context
-                            # card (#1766); embedding still uses embed_query.
                             _t_rec = time.monotonic()
                             neon_chunks = _neon_recall.recall_knowledge(
                                 embedding,
@@ -481,7 +488,7 @@ class RAGWorker:
                                 "recall_chars=%d n_chunks=%d",
                                 _embed_ms,
                                 _recall_ms,
-                                len(embed_query),
+                                len(recall_query),
                                 len(recall_query),
                                 len(neon_chunks),
                             )


### PR DESCRIPTION
## Context
Third in the #1766 chain. #1775 bounded BM25 (50s→9s). #1780 threaded a clean retrieval query into the lexical streams (recall_chars 2762→200, fault_codes 12→1, products 3→0) — but prod `RAG_STAGE_TIMING` then showed the **embed** is the new dominant cost.

## Evidence
```
RAG_STAGE_TIMING embed_ms=2730-4942 recall_ms=1636-3645 embed_chars=2762 recall_chars=210
LLM_CALL latency_ms ~1000
```
Real grounded `/ask` ≈ **8–11s**, not <5s. The embed runs on the full ~2760-char MACHINE_CONTEXT card via **CPU Ollama** = 3–5s.

## Fix
Embed the **clean `recall_query`** (trimmed question + decoded status block, ~200 chars) instead of the enriched blob. Embed drops to <1s and the vector becomes question-focused.

- **Citations unaffected** — the answer grounds from the in-prompt MACHINE_CONTEXT; lexical streams already use `recall_query` (#1780).
- **Scoped + backward-compatible** — chat surfaces have `recall_query == message`, so their embedding is byte-for-byte unchanged. Only the `/ask` kiosk path changes.
- Per Mike's "embed short question + DB index" decision; this is the code half.

## Note
This intentionally overrides the original goal's "keep the embed enriched" guidance — that note predated the `RAG_STAGE_TIMING` evidence that the embed is the bottleneck.

## Gate
Offline grounding + quality + hybrid (24+12) green. Post-deploy: warm latency (<5s target) + Q1/Q4/Q11 grounding (GS10/AutomationDirect/CE10) + `RAG_STAGE_TIMING` confirming the embed drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)