### PR TITLE
fix(hub): wizard finish 500 — ON CONFLICT orphaned by migs 025/026

### DIFF
--- a/mira-hub/src/app/api/wizard/[step]/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/wizard/[step]/__tests__/route.test.ts
@@ -116,6 +116,15 @@ describe("POST /api/wizard/:step", () => {
     expect(sqls[0]).toMatch(/FROM wizard_progress[\s\S]+FOR UPDATE/);
     expect(sqls[1]).toMatch(/INSERT INTO kg_entities/);
     expect(sqls[2]).toMatch(/INSERT INTO kg_entities/);
+    // Regression guard: the kg_entities upsert MUST target the live unique index
+    // kg_entities_tenant_type_name_key (tenant_id, entity_type, name) created by
+    // migrations 025/026. The original (…, entity_id) target was orphaned when
+    // those migrations dropped that constraint, making every finish 500 with
+    // "no unique or exclusion constraint matching the ON CONFLICT specification".
+    for (const sql of [sqls[1], sqls[2]]) {
+      expect(sql).toMatch(/ON CONFLICT \(tenant_id, entity_type, name\)/);
+      expect(sql).not.toMatch(/ON CONFLICT \(tenant_id, entity_type, entity_id\)/);
+    }
     expect(sqls[3]).toMatch(/INSERT INTO namespace_versions/);
     expect(sqls[4]).toMatch(/INSERT INTO namespace_versions/);
     expect(sqls[5]).toMatch(/UPDATE wizard_progress[\s\S]+'completed'/);

--- a/mira-hub/src/app/api/wizard/[step]/route.ts
+++ b/mira-hub/src/app/api/wizard/[step]/route.ts
@@ -193,9 +193,8 @@ async function finishWizard(tenantId: string, userId: string) {
       const siteRes = await c.query<{ id: string }>(
         `INSERT INTO kg_entities (tenant_id, entity_type, entity_id, name, properties, uns_path)
          VALUES ($1, 'site', $2, $3, $4::jsonb, $5::ltree)
-         ON CONFLICT (tenant_id, entity_type, entity_id) DO UPDATE
-            SET name = EXCLUDED.name,
-                uns_path = EXCLUDED.uns_path,
+         ON CONFLICT (tenant_id, entity_type, name) DO UPDATE
+            SET uns_path = EXCLUDED.uns_path,
                 updated_at = now()
          RETURNING id`,
         [tenantId, siteSlug, site.name, JSON.stringify({ location: site.location ?? null, source: "onboarding_wizard" }), sitePathStr],
@@ -205,9 +204,8 @@ async function finishWizard(tenantId: string, userId: string) {
       const lineRes = await c.query<{ id: string }>(
         `INSERT INTO kg_entities (tenant_id, entity_type, entity_id, name, properties, uns_path)
          VALUES ($1, 'line', $2, $3, $4::jsonb, $5::ltree)
-         ON CONFLICT (tenant_id, entity_type, entity_id) DO UPDATE
-            SET name = EXCLUDED.name,
-                uns_path = EXCLUDED.uns_path,
+         ON CONFLICT (tenant_id, entity_type, name) DO UPDATE
+            SET uns_path = EXCLUDED.uns_path,
                 updated_at = now()
          RETURNING id`,
         [tenantId, lineSlug, line.name, JSON.stringify({ description: line.description ?? null, source: "onboarding_wizard" }), linePathStr],


### PR DESCRIPTION
## Symptom
`Create namespace` (Review step) → **500 "Finish failed"** on prod/staging. Reported on mobile web; reproduced via schema analysis.

## Root cause
`finishWizard` upserts `kg_entities` with `ON CONFLICT (tenant_id, entity_type, entity_id)`. Migrations **025/026** dropped that unique constraint and replaced it with the unique index `kg_entities_tenant_type_name_key (tenant_id, entity_type, name)`. Postgres raises **42P10 "no unique or exclusion constraint matching the ON CONFLICT specification"** → caught → 500. Pre-existing since 025/026; the onboarding wizard (incl. the new Train & approve step) just made it reachable.

## Fix
Retarget both `kg_entities` upserts to `(tenant_id, entity_type, name)` (the live index). Drop redundant `SET name = EXCLUDED.name`.

## Why CI didn't catch it
The wizard route test mocks `withTenantContext`/`query` with canned rows — SQL never touches a real schema. **Added a regression guard** asserting the ON CONFLICT target is `(…, name)` and not `(…, entity_id)`. Deeper gap (real-schema integration test) noted for follow-up.

## Verification
`vitest` 7/7 green; `tsc --noEmit` + `eslint` clean on changed files. Real-schema proof will be the prod retest after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)