### PR TITLE
docs(rules): debugging-conventions + ship/qa skills (#1813, #1814)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -169,6 +169,7 @@ Full rules: `.claude/rules/codegraph-usage.md`. Reference: `wiki/references/code
 - **CodeGraph-first exploration** — see `.claude/rules/codegraph-usage.md` (use `codegraph_context` / `codegraph_impact` before grep + Read for any symbol-shaped question).
 - **Train before deploy** — see `.claude/rules/train-before-deploy.md` (Command Center builds+validates; Ignition/HMI deploys approved asset agents only; no HMI deployment without grounded docs + validation questions + approved cited answers; read-only in beta).
 - **Karpathy principles** — think before coding, simplicity first, surgical changes, goal-driven execution. See `.claude/rules/karpathy-principles.md`.
+- **Debugging & verification** — perf problems are multi-cause (re-measure after each fix); verify exact table/column names + API auth paths from the codebase before guessing. See `.claude/rules/debugging-conventions.md`.
 - **Don't break the UNS confirmation gate.** Run `mira-run-hallucination-audit` after engine/bot edits.
 
 ## Testing expectations
@@ -208,6 +209,7 @@ Full rules: `.claude/rules/codegraph-usage.md`. Reference: `wiki/references/code
 - `.claude/rules/security-boundaries.md` — secrets, PII, safety keywords
 - `.claude/rules/python-standards.md` — ruff, httpx, NeonDB, async
 - `.claude/rules/karpathy-principles.md` — coding behavior
+- `.claude/rules/debugging-conventions.md` — multi-cause perf debugging + verify schema/API paths before guessing
 - `.claude/rules/codegraph-usage.md` — when to use CodeGraph vs grep/Read (CodeGraph-first for symbol-shaped questions)
 - `docs/specs/uns-kg-unification-spec.md` — UNS authority (data architecture)
 - `docs/specs/mira-component-intelligence-architecture.md` — implementation-level architecture (component templates, KG mechanics)

--- a/.claude/rules/debugging-conventions.md
+++ b/.claude/rules/debugging-conventions.md
@@ -1,0 +1,49 @@
+# Debugging & Verification Conventions
+
+Two recurring failure modes, codified from the 2026-06-08 /insights review.
+These complement `karpathy-principles.md` (behavior) — they govern *diagnosis
+discipline*, not syntax.
+
+## 1. Performance problems are multi-cause by default
+
+Do NOT declare a latency or slowness fix done after killing one bottleneck.
+After every fix, **re-measure**, then look for the next compounding layer.
+
+- State the dominant layer, fix it, re-measure, repeat until a numeric target
+  is met — not until the first fix lands.
+- Layers stack and hide each other: the AskMira `/ask` 45s→2.3s work took four
+  PRs (#1775/#1780/#1784/#1785) because BM25, fault/product extraction,
+  embedding, and an ILIKE scan each surfaced only *after* the previous fix.
+  A single-cause "it was BM25" call would have shipped a still-slow endpoint.
+- A status spike or one slow query is evidence of *a* cause, not *the* cause.
+  An HNSW index was a red herring there; the real cost was an ILIKE scan.
+
+**Rule:** for any perf task, report the per-layer reduction (p50/p95 before →
+after at each layer), not a single before/after number.
+
+## 2. Verify schema and API paths from the codebase before guessing
+
+Wrong table/column names produce **false negatives** (a db-inspect check
+reported `MISSING` because the table name was wrong, not because data was
+absent). Wrong auth paths waste cycles (`/api/auth/signin` vs `/auth/signin`,
+bcrypt prefix guesses on the Atlas signin work).
+
+- Resolve exact table/column names from migrations (`docs/migrations/`,
+  `mira-*/migrations/`) or CodeGraph before writing a query or asserting a row
+  is missing.
+- Resolve exact API auth paths from the route definitions (NextAuth subpath is
+  `/<base>/api/auth/...`; see the hub auth memory) — don't infer from the app
+  base URL.
+- A "MISSING" / 404 / 401 result against an unverified name or path is
+  **inconclusive**, not a finding. Confirm the name first, then trust the result.
+
+## When this applies
+
+- Any perf/latency/slowness diagnosis in `mira-bots/`, `mira-hub/`,
+  `mira-pipeline/`, `mira-web/`, or infra.
+- Any db-inspect / row-existence check, any new SQL, any auth-path probe.
+
+## When this does NOT apply
+
+- A genuinely single-step fix from a stack trace you already have open.
+- A perf change with one obvious cause already measured end-to-end.

--- a/.claude/skills/qa.md
+++ b/.claude/skills/qa.md
@@ -1,0 +1,38 @@
+---
+name: qa
+description: Use when running a Playwright/E2E QA spec against a deployed environment — confirms the latest commit is actually live FIRST, then runs the spec, reports pass/skip/fail counts, and updates the linked GitHub issue. Prevents the recurring false "QA failed" that is really "the deploy hadn't landed yet". Triggers on "run QA", "run the Playwright spec", "verify the deploy", "regression check the live site".
+---
+
+# qa
+
+Run an E2E/Playwright spec against a deployed environment **without** the recurring false negative where the spec fails only because the deploy hadn't landed. The fix is one extra step at the front: prove the build is live before you trust a failure.
+
+## Why this exists
+
+QA specs were repeatedly diagnosed as "VPS not deployed" — the spec ran against stale prod, failed, and the failure looked like a regression. A failure against a stale deploy is **inconclusive**, not a finding (see `.claude/rules/debugging-conventions.md` §2).
+
+## The loop
+
+1. **Confirm the build is live FIRST.** Before running any assertion:
+   - Get the expected commit: `git rev-parse --short HEAD` (or the PR's merge sha).
+   - Probe prod for it — a `/api/health` version field, image age, or a behavioural marker unique to this change.
+   - If the live build is older than the change under test → **stop**. The deploy hasn't landed; trigger/await it (see `ship`) before running the spec. Do NOT report the spec result as a regression.
+2. **Run the spec against the deployed URL** (not localhost — localhost can't catch deploy regressions):
+   - Hub proof specs: `mira-hub/tests/e2e/proof-pr-<N>.spec.ts` (pattern: `reference_hub_proof_spec_pattern`).
+   - mira-web visible surfaces: prefer `design-ship-routine`'s `bun run verify:live`.
+   - AskMira / kiosk: use the `askmira-tester` skill's regression bake.
+   - Windows note: Playwright CDP/websocket handshake is blocked by Defender on this host — use the documented fallback (`chrome --headless=new --screenshot=...` or the playwright MCP) rather than connectOverCDP.
+3. **Report pass / skip / fail counts** explicitly — not "looks good". Quote failing assertions verbatim.
+4. **Capture evidence** — screenshot of the green (or red) state to `tools/web-review-runs/<date>-pr-<N>/` or `docs/promo-screenshots/` per the screenshot rule.
+5. **Update the linked GitHub issue** — `gh issue comment <N>` with counts + evidence path. Cross-link the PR ↔ issue both directions.
+
+## Done-when
+
+The spec ran against a confirmed-live build, counts are reported, evidence is saved, and the linked issue is updated.
+
+## What NOT to do
+
+- ❌ Run the spec before confirming the build is live, then call a stale-deploy failure a regression.
+- ❌ Verify against localhost and call the deploy verified.
+- ❌ Report "QA passed" without the pass/skip/fail counts and a screenshot.
+- ❌ Use `connectOverCDP` on this Windows host (Defender blocks it).

--- a/.claude/skills/ship.md
+++ b/.claude/skills/ship.md
@@ -1,0 +1,53 @@
+---
+name: ship
+description: Use when taking a merged-or-ready feature branch live end-to-end — rebase on main, merge the PR, deploy the affected VPS service, and verify the live endpoint before reporting success. The cross-service ship loop. For visible mira-web changes delegate to design-ship-routine; for mira-ask/kiosk follow the kiosk runbook. Triggers on "ship it", "deploy this", "take it live", "merge and deploy".
+---
+
+# ship
+
+The end-to-end loop for taking a change live: rebase → merge → deploy → verify-200. Thin wrapper — it delegates the surface-specific parts to the skills/runbooks that already own them, and adds the cross-service deploy + live-verify discipline plus the branch-safety guard.
+
+## First: route to the right owner
+
+- **Visible mira-web change** (`/`, `/cmms`, `/pricing`, views, CSS) → use `design-ship-routine` instead. It owns snapshot→PR→deploy→`verify:live`. Don't reimplement it here.
+- **mira-ask / kiosk / `ask_api` / engine kiosk fast-path** → follow `docs/runbooks/kiosk-askmira-deploy-and-verify.md`. Critical: `mira-ask` is NOT in the deploy-vps default targets — dispatch explicitly.
+- **Engine / RAG / FSM / classifier change** → must pass the staging gate (`smoke-test.yml` + relevant `tests/eval/` regime) BEFORE merge. No exceptions.
+- **Anything else (backend service, infra)** → continue below.
+
+## Branch safety (non-negotiable — see issue #1810)
+
+- **Never auto-switch branches mid-sequence.** Print `git rev-parse --abbrev-ref HEAD` before any write and confirm it's the branch you intend.
+- **Never force-push a branch with an open PR** without explicit OK (rewrite invalidates in-progress reviews).
+- A git hook that auto-commits/auto-branches during this loop is a known hazard — if HEAD moves unexpectedly, STOP and re-orient, don't push.
+
+## The loop
+
+1. **Pre-flight.** `git fetch origin`. Confirm HEAD branch. `git log origin/main..HEAD --oneline` — know exactly what's shipping.
+2. **Rebase on main.** `git rebase origin/main`. Resolve conflicts; if a conflict is non-trivial, surface it — don't guess a merge.
+3. **Gate.** Engine/RAG/retrieval change? Confirm the staging gate passed. UI? screenshots committed. Otherwise the merge is premature.
+4. **Merge** (only with explicit user approval — merges + deploys each need their own one-word OK). Squash, conventional title, delete branch after.
+5. **Deploy** the affected service via `deploy-vps.yml`:
+   ```
+   gh workflow run deploy-vps.yml --repo Mikecranesync/MIRA -f services="<service>"
+   ```
+   Default targets: `mira-pipeline mira-ingest mira-mcp mira-hub mira-cmms-sync mira-bot-telegram mira-bot-slack`. **`mira-ask` and `mira-web` are NOT defaults** — name them explicitly. Never `docker compose` the VPS directly (prod-guard blocks it).
+6. **Verify live — 200 + behaviour, not "deploy ran".** Confirm the new commit is actually live (image age / behavioural probe), then:
+   ```
+   bash install/smoke_test.sh        # affected routes
+   curl -sS -o /dev/null -w '%{http_code}' https://<host>/<route>   # expect 200
+   ```
+   "No error from the deploy step" is NOT verification (see verify-before-done feedback). Read back the live state.
+7. **If verify fails** → rollback to prev sha, fix on a new branch, re-run the loop. Don't paper over.
+8. **If verify passes** → close the issue with the live evidence (status code / screenshot / probe output).
+
+## Done-when
+
+Live endpoint returns 200 AND the new behaviour is observed on prod — not on merge alone.
+
+## What NOT to do
+
+- ❌ Report "shipped" on merge. Not shipped until verified live (completion-vocabulary feedback).
+- ❌ Auto-switch/force-push a branch with an open PR.
+- ❌ Rely on the auto-deploy default targets for `mira-ask` / `mira-web`.
+- ❌ Skip the staging gate for engine/RAG/FSM/classifier changes.
+- ❌ Duplicate the mira-web ship steps here — delegate to `design-ship-routine`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,7 @@ Every Playwright proof-of-work screenshot must ALSO be saved to `docs/promo-scre
 - **Active namespace-builder plan:** `docs/plans/2026-05-15-maintenance-namespace-builder.md` — integrates with the 90-day plan (Units 2/4/9a fold in as Phase 1/2/4 components); has its own "Currently in-flight" section — check both.
 - **Dev loop (pre-commit + watcher):** `wiki/references/dev-loop.md`
 - **Karpathy principles (behavior rules):** `.claude/rules/karpathy-principles.md`
+- **Debugging & verification conventions:** `.claude/rules/debugging-conventions.md` — multi-cause perf debugging; verify schema/API paths before guessing
 - **Environments doctrine (dev / staging / prod):** `docs/environments.md`
 - **Enforcement layer:** `docs/specs/enforcement-layer-spec.md` — Playwright audit, write-path round-trip, enum drift, spec staleness, PR template, NeonDB canary
 - **Claude Code v2.1+ defaults (Opus 4.7, xhigh, /effort, /autofix-pr, Routines):** `wiki/references/claude-code-v2.1.md`


### PR DESCRIPTION
Implements **#1813** and **#1814** from the 2026-06-08 `/insights` review.

## #1813 — debugging & verification conventions
New `.claude/rules/debugging-conventions.md`, pointer-linked from both `CLAUDE.md` and `.claude/CLAUDE.md`:

1. **Performance problems are multi-cause by default** — re-measure after each fix, report per-layer p50/p95 reduction. Codifies the AskMira `/ask` 45s→2.3s lesson (BM25 → extraction → embed → ILIKE each surfaced only after the prior fix; #1775/#1780/#1784/#1785).
2. **Verify schema + API paths before guessing** — wrong table/column names produce false-negative `MISSING`; wrong auth paths waste cycles. A result against an unverified name/path is inconclusive, not a finding.

## #1814 — `/ship` and `/qa` skills (lean, no duplication)
- **`ship`** — cross-service rebase → merge → deploy(`deploy-vps.yml`) → verify-200 loop. **Delegates** the mira-web visible-ship loop to `design-ship-routine` and mira-ask to the kiosk runbook rather than re-implementing them. Encodes the branch-safety guard (no auto-switch / no force-push-with-open-PR) tied to #1810, and the `mira-ask`/`mira-web`-not-in-default-targets gotcha.
- **`qa`** — confirms the build is actually live **before** running a Playwright spec, so a stale deploy isn't misread as a regression; reports pass/skip/fail + updates the linked issue.

## Scope / notes
- Docs + `.claude/` only. No code, no deploy, no migration. Nothing to verify live.
- Off the locked marketplace objective (dev-workflow hygiene) but zero product risk and immediately useful to every session.
- Branched off `origin/main` via worktree to keep the diff clean (5 files, +143).

Closes #1813, closes #1814.