### PR TITLE
fix(engine): map 5 hallucinated FSM states to valid states (#867)

### DIFF
--- a/mira-bots/shared/fsm.py
+++ b/mira-bots/shared/fsm.py
@@ -102,6 +102,12 @@ _STATE_ALIASES: dict[str, str] = {
     "CLARIFY": "Q1",
     "GATHER": "Q1",
     "ESCALATE": "SAFETY_ALERT",
+    # LLM-invented states observed in benchmark v1.2.0 (issue #867)
+    "DEBUG": "DIAGNOSIS",
+    "TEST_PREP": "Q2",
+    "TRIP_CLASS_INQUIRY": "DIAGNOSIS",
+    "CHECKING_CONTACTOR": "DIAGNOSIS",
+    "INSPECTION": "Q3",
 }
 
 import re  # noqa: E402


### PR DESCRIPTION
Closes #867.

## Problem
Benchmark v1.2.0 showed the LLM emitting FSM states absent from `_STATE_ALIASES`, so `_advance_state()` rejected the transition and held at the current state.

## Fix
Add 5 aliases to `mira-bots/shared/fsm.py` `_STATE_ALIASES` (same safety-net pattern as the 2026-04-28 batch):

| Hallucinated | → Canonical |
|---|---|
| DEBUG | DIAGNOSIS |
| TEST_PREP | Q2 |
| TRIP_CLASS_INQUIRY | DIAGNOSIS |
| CHECKING_CONTACTOR | DIAGNOSIS |
| INSPECTION | Q3 |

Runtime coercion happens at `fsm.py:146`. The measurement helper at `benchmark_suite.py:986` is intentionally left untouched — coercing the engine's output is the fix; aliasing inside the scorer would mask, not fix.

## Verification
- `tests/test_fsm_properties.py` → **6 passed** locally. The `every-alias-maps-to-VALID_STATES` property covers the 5 new keys.
- Full benchmark (NeonDB + cascade) is the CI/staging gate — run there before merge.

## Scope
5-line dict addition. No behavior change beyond the 5 new coercions.