### PR TITLE
fix(hub): surface ai_suggestions in /proposals, not only relationship_proposals (#1663)

### DIFF
--- a/mira-hub/src/app/(hub)/knowledge/suggestions/page.tsx
+++ b/mira-hub/src/app/(hub)/knowledge/suggestions/page.tsx
@@ -38,9 +38,39 @@ interface Proposal {
   createdAt: string;
 }
 
+// ai_suggestions (mig 027) — the 5 non-edge suggestion types the photo→KG
+// flywheel writes (kg_entity / tag_mapping / component_profile /
+// uns_confirmation / namespace_move). Rendered read-only via the precomputed
+// title/body until the proposal-transition helper (#1662) wires approve/reject.
+// See #1663.
+interface Suggestion {
+  id: string;
+  suggestionType: string;
+  title: string | null;
+  body: string | null;
+  confidence: number;
+  status: string;
+  riskLevel: string;
+  createdBy: string;
+  sourceKind: string | null;
+  sourceDocumentId: string | null;
+  sourcePage: number | null;
+  createdAt: string;
+}
+
+const SUGGESTION_TYPE_LABELS: Record<string, string> = {
+  kg_entity: "New entity",
+  tag_mapping: "Tag mapping",
+  component_profile: "Component profile",
+  uns_confirmation: "UNS confirmation",
+  namespace_move: "Namespace change",
+};
+
 interface ProposalsResponse {
   proposals: Proposal[];
   total: number;
+  suggestions?: Suggestion[];
+  suggestionsTotal?: number;
 }
 
 const STATUS_TABS: Array<{ key: string; label: string }> = [
@@ -52,6 +82,7 @@ const STATUS_TABS: Array<{ key: string; label: string }> = [
 
 export default function ProposalsPage() {
   const [proposals, setProposals] = useState<Proposal[]>([]);
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState("proposed");
@@ -99,6 +130,7 @@ export default function ProposalsPage() {
         const data = (await res.json()) as ProposalsResponse;
         if (cancelled) return;
         setProposals(data.proposals);
+        setSuggestions(data.suggestions ?? []);
         setError(null);
       } catch (e) {
         if (cancelled) return;
@@ -153,7 +185,7 @@ export default function ProposalsPage() {
         <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">
           Failed to load: {error}
         </div>
-      ) : proposals.length === 0 ? (
+      ) : proposals.length === 0 && suggestions.length === 0 ? (
         <EmptyState statusFilter={statusFilter} />
       ) : (
         <div className="space-y-6" data-testid="proposals-list">
@@ -197,6 +229,7 @@ export default function ProposalsPage() {
               onDecide={decide}
             />
           )}
+          {suggestions.length > 0 && <SuggestionSection suggestions={suggestions} />}
         </div>
       )}
 
@@ -378,4 +411,82 @@ function groupByRiskLevel(proposals: Proposal[]): {
     medium: proposals.filter((p) => p.riskLevel === "medium"),
     low: proposals.filter((p) => p.riskLevel === "low" || !p.riskLevel),
   };
+}
+
+// Non-edge ai_suggestions render read-only here — the precomputed title/body
+// carry the human-readable content (mig 027). Approve/reject lands once the
+// proposal-transition helper (#1662) ships; until then the technician reviews
+// these in context. See #1663.
+function SuggestionSection({ suggestions }: { suggestions: Suggestion[] }) {
+  return (
+    <section data-testid="suggestions-section">
+      <h2 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+        Suggestions ({suggestions.length})
+      </h2>
+      <p className="mb-3 text-xs text-slate-400">
+        Entity, tag, component, UNS, and namespace proposals from ingestion and photo
+        scans. Approve/reject is coming with the transition helper (#1662).
+      </p>
+      <div className="space-y-2">
+        {suggestions.map((s) => (
+          <SuggestionCard key={s.id} suggestion={s} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SuggestionCard({ suggestion }: { suggestion: Suggestion }) {
+  const confidencePct = Math.round(suggestion.confidence * 100);
+  const accent =
+    suggestion.riskLevel === "safety_critical"
+      ? "border-l-red-500"
+      : suggestion.riskLevel === "high"
+        ? "border-l-amber-500"
+        : suggestion.riskLevel === "medium"
+          ? "border-l-blue-500"
+          : "border-l-slate-300";
+  const typeLabel =
+    SUGGESTION_TYPE_LABELS[suggestion.suggestionType] ?? suggestion.suggestionType;
+  return (
+    <article
+      className={`rounded-lg border border-slate-200 ${accent} border-l-4 bg-white p-4 shadow-sm`}
+      data-testid="suggestion-card"
+      data-suggestion-id={suggestion.id}
+      data-suggestion-type={suggestion.suggestionType}
+    >
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm">
+        {suggestion.riskLevel === "safety_critical" && (
+          <Shield className="h-4 w-4 shrink-0 text-red-500" aria-label="safety-critical" />
+        )}
+        <span className="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+          {typeLabel}
+        </span>
+        <span className="min-w-0 break-words font-semibold text-slate-900">
+          {suggestion.title ?? typeLabel}
+        </span>
+        <span className="ml-auto shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600">
+          {confidencePct}% confidence
+        </span>
+      </div>
+
+      {suggestion.body && <p className="mt-3 text-sm text-slate-600">{suggestion.body}</p>}
+
+      <footer className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs text-slate-400">
+        <span className="rounded bg-slate-100 px-2 py-0.5 text-slate-600">
+          {suggestion.status}
+        </span>
+        <span>by {suggestion.createdBy}</span>
+        {suggestion.sourceKind && (
+          <span className="flex items-center gap-1">
+            <FileText className="h-3 w-3" /> {suggestion.sourceKind}
+            {suggestion.sourcePage != null ? ` p.${suggestion.sourcePage}` : ""}
+          </span>
+        )}
+        <time className="ml-2" dateTime={suggestion.createdAt}>
+          {new Date(suggestion.createdAt).toLocaleDateString()}
+        </time>
+      </footer>
+    </article>
+  );
 }

--- a/mira-hub/src/app/api/proposals/route.ts
+++ b/mira-hub/src/app/api/proposals/route.ts
@@ -45,6 +45,25 @@ interface ProposalRow {
   created_at: string;
 }
 
+// ai_suggestions rows (mig 027). The 5 non-edge suggestion types — `kg_edge` is
+// the header-on-a-relationship_proposals row already covered above, so it is
+// excluded here to avoid double-rendering. ADR-0014 supersedes ADR-0013:
+// /proposals MUST surface these. See issue #1663.
+interface SuggestionRow {
+  id: string;
+  suggestion_type: string;
+  title: string | null;
+  body: string | null;
+  confidence: number;
+  status: string;
+  risk_level: string;
+  proposed_by: string;
+  source_kind: string | null;
+  source_document_id: string | null;
+  source_page: number | null;
+  created_at: string;
+}
+
 const DEFAULT_LIMIT = 100;
 const HARD_LIMIT = 500;
 const ALLOWED_STATUS = new Set([
@@ -55,6 +74,18 @@ const ALLOWED_STATUS = new Set([
   "deprecated",
   "contradicted",
 ]);
+
+// relationship_proposals status vocab → ai_suggestions status vocab (mig 027
+// CHECK: pending|accepted|rejected|deferred|superseded). Lets one `status`
+// query param drive both stores.
+const PROPOSAL_TO_SUGGESTION_STATUS: Record<string, string> = {
+  proposed: "pending",
+  reviewed: "deferred",
+  verified: "accepted",
+  rejected: "rejected",
+  deprecated: "superseded",
+  contradicted: "superseded",
+};
 
 export async function GET(req: Request) {
   if (!process.env.NEON_DATABASE_URL) {
@@ -142,9 +173,76 @@ export async function GET(req: Request) {
         .then((r) => r.rows),
     );
 
+    // ai_suggestions (mig 027) — the 5 non-edge suggestion types. Fetched in a
+    // separate tenant context and fail-soft: if the table is absent (mig 027 not
+    // applied to this DB) or the query errors, return [] rather than 500 the
+    // whole page — the edge-proposals path above must keep working. See #1663.
+    const sugFilters: string[] = [
+      "s.tenant_id = $1::uuid",
+      "s.suggestion_type <> 'kg_edge'",
+    ];
+    const sugParams: unknown[] = [ctx.tenantId];
+    if (statusParam !== "all") {
+      const sugStatuses = Array.from(
+        new Set(
+          statusParam
+            .split(",")
+            .map((s) => s.trim().toLowerCase())
+            .filter((s) => ALLOWED_STATUS.has(s))
+            .map((s) => PROPOSAL_TO_SUGGESTION_STATUS[s])
+            .filter(Boolean),
+        ),
+      );
+      // statusParam was validated non-empty above and the mapping is total, so
+      // sugStatuses is always non-empty here.
+      sugParams.push(sugStatuses);
+      sugFilters.push(`s.status = ANY($${sugParams.length})`);
+    }
+    sugParams.push(limit);
+    const sugLimitPlaceholder = `$${sugParams.length}`;
+
+    const suggestionRows: SuggestionRow[] = await withTenantContext(
+      ctx.tenantId,
+      (c) =>
+        c
+          .query<SuggestionRow>(
+            `SELECT
+                s.id,
+                s.suggestion_type,
+                s.title,
+                s.body,
+                s.confidence,
+                s.status,
+                s.risk_level,
+                s.proposed_by,
+                s.source_kind,
+                s.source_document_id::text AS source_document_id,
+                s.source_page,
+                s.created_at
+             FROM ai_suggestions s
+             WHERE ${sugFilters.join(" AND ")}
+             ORDER BY
+                CASE s.risk_level
+                  WHEN 'safety_critical' THEN 0
+                  WHEN 'high' THEN 1
+                  WHEN 'medium' THEN 2
+                  ELSE 3
+                END,
+                s.created_at DESC
+             LIMIT ${sugLimitPlaceholder}`,
+            sugParams,
+          )
+          .then((r) => r.rows),
+    ).catch((err) => {
+      console.error("[api/proposals GET] ai_suggestions query failed (soft)", err);
+      return [];
+    });
+
     return NextResponse.json({
       proposals: rows.map(rowToProposal),
       total: rows.length,
+      suggestions: suggestionRows.map(rowToSuggestion),
+      suggestionsTotal: suggestionRows.length,
       filters: { status: statusParam, type: typeParam, limit },
     });
   } catch (err) {
@@ -176,6 +274,23 @@ function rowToProposal(r: ProposalRow) {
     requiresHumanReview: r.requires_human_review,
     reasoning: r.reasoning,
     evidenceCount: Number(r.evidence_count) || 0,
+    createdAt: r.created_at,
+  };
+}
+
+function rowToSuggestion(r: SuggestionRow) {
+  return {
+    id: r.id,
+    suggestionType: r.suggestion_type,
+    title: r.title,
+    body: r.body,
+    confidence: r.confidence,
+    status: r.status,
+    riskLevel: r.risk_level,
+    createdBy: r.proposed_by,
+    sourceKind: r.source_kind,
+    sourceDocumentId: r.source_document_id,
+    sourcePage: r.source_page,
     createdAt: r.created_at,
   };
 }


### PR DESCRIPTION
Closes #1663.

## Problem
`mira-hub/src/app/api/proposals/route.ts` read **only** `relationship_proposals`. The 5 non-edge `ai_suggestions` types (kg_entity / tag_mapping / component_profile / uns_confirmation / namespace_move) written by the photo→KG flywheel were never surfaced — so the flywheel wrote proposals nobody could see. Per **ADR-0014 (migration 027), which supersedes ADR-0013**, /proposals must render these.

## Change
**API** — added a second, **fail-soft** query for `ai_suggestions WHERE suggestion_type <> 'kg_edge'` (kg_edge is the header over a `relationship_proposals` row already rendered → **no double-render**, per acceptance). Shared `?status` param translated to the ai_suggestions vocab. Returned as a separate `suggestions` array; existing `proposals`/`total` shape **unchanged**. The query is `.catch() → []` so a DB without migration 027 cannot 500 the page (the edge path keeps working).

**UI** — non-edge suggestions render **read-only** via the schema's precomputed `title`/`body` (mig 027 computes these at INSERT "so the Hub feed renders fast"), risk-accented, in a new *Suggestions* section.

## Scope boundary (matches issue)
Approve/reject wiring is **deferred to the proposal-transition helper (#1662)** — the issue's acceptance explicitly gates it on that helper. This PR is the **render half**.

## Verification
- ✅ `mira-hub` `tsc --noEmit` clean on both touched files (only pre-existing unrelated errors remain: `analysis.ts` implicit-any, missing `unpdf`, `bun:test`).
- ⚠️ **Visual render needs a staging DB seeded with `ai_suggestions` rows** — your staging gate. A nameplate-scan proposal should appear in the Suggestions section.

## Surgical notes
The existing `relationship_proposals` query is byte-for-byte unchanged. The route.ts doc-comment still cites ADR-0013 as canonical; left as-is to keep the diff tight — ADR-0014 supersession is noted at the new query.