### PR TITLE
chore(graphify): union merge-driver for graph.json + coding usage docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,9 @@
 # Vendored third-party JS — preserve bytes exactly so SRI hashes stay valid
 mira-web/public/lib/*.js binary
 mira-web/public/lib/*.css binary
+
+# Graphify code knowledge graph — union-merge instead of textual conflict.
+# Requires the one-time local driver config (see wiki/orchestrator/kg/README.md):
+#   git config merge.graphify.driver "graphify merge-driver %O %A %B"
+# Without that config, git falls back to the default merge + a harmless warning.
+wiki/orchestrator/kg/graph.json merge=graphify

--- a/wiki/orchestrator/kg/README.md
+++ b/wiki/orchestrator/kg/README.md
@@ -67,6 +67,44 @@ cp $RUN/build/graphify-out/{graph.json,graph.html,GRAPH_REPORT.md} wiki/orchestr
 After code changes you can refresh AST-only edges with **no API cost**:
 `graphify update <path>` (semantic edges go stale until the next full extract).
 
+## Using it while coding
+
+The graphify skill is published into Claude Code on CHARLIE
+(`graphify install --platform claude` → `~/.claude/skills/graphify/`). In a
+Claude Code session, `/graphify` activates it. The graphify CLI is a uv tool
+(`graphifyy` 0.8.35) on `~/.local/bin`.
+
+Because this repo's graph lives at `wiki/orchestrator/kg/graph.json` (not the
+default `graphify-out/graph.json`), pass `--graph` to query it directly:
+
+```bash
+G=wiki/orchestrator/kg/graph.json
+graphify explain  "resolve_uns_path"      --graph "$G"   # node + neighbors
+graphify affected "engine.py" --depth 1   --graph "$G"   # reverse-impact / blast radius
+graphify path     "engine.py" "router.py" --graph "$G"   # shortest path between two nodes
+graphify query    "how does a turn reach the cascade?"   --graph "$G"
+```
+
+## graph.json merge-driver (devops)
+
+`graph.json` is ~91k lines, so two branches that both refresh it textually
+conflict on nearly every merge. A git **union merge-driver** (graphify's own)
+resolves that automatically — it takes the union of nodes/edges from both sides
+instead of a line conflict.
+
+- **Committed:** `.gitattributes` maps `wiki/orchestrator/kg/graph.json → merge=graphify`.
+- **One-time per clone** (the driver definition is *not* committable — it lives in
+  local git config):
+
+  ```bash
+  git config merge.graphify.driver "graphify merge-driver %O %A %B"
+  git config merge.graphify.name   "graphify graph.json union merge"
+  ```
+
+  Without it, git ignores the attribute and falls back to the default merge with a
+  harmless warning — nothing breaks, you just get textual conflicts on `graph.json`.
+  Already configured on CHARLIE.
+
 ## Known limitations
 
 - **Community names are `Community N` placeholders.** Graphify labels all 344


### PR DESCRIPTION
## What

Two small, scoped pieces to make graphify useful in our coding + devops (per the agreed scope — Claude Code publish + graph.json merge-driver only):

1. **graph.json merge-driver (devops).** `wiki/orchestrator/kg/graph.json` is ~91k lines, so any two branches that both refresh it conflict textually on nearly every merge. This wires graphify's own **union** merge-driver so git takes the node/edge union instead of a line conflict.
   - `.gitattributes`: `wiki/orchestrator/kg/graph.json merge=graphify`
   - README: the **one-time per-clone** `git config merge.graphify.driver ...` (the driver definition isn't committable — it's local git config). Already configured on CHARLIE.

2. **Coding usage docs.** The graphify skill is now published into Claude Code on CHARLIE (`graphify install --platform claude` → `~/.claude/skills/graphify/`, `/graphify` in-session). README now documents how to query *this repo's* graph, which lives at the non-default `wiki/orchestrator/kg/graph.json` (so commands need `--graph`).

## Verified

Driver tested on a **real 3-way merge** of the actual graph.json: a divergent node added to each side, both unioned into the result (3576 → 3578 nodes), exit 0, written to `%A` as git expects.

## Safety

The `merge=graphify` attribute is **inert** on any clone that hasn't run the one-time `git config` — git just falls back to the default merge with a harmless warning. So this can't break merges for anyone who hasn't opted in. No code paths touched; `.gitattributes` + docs only.

## Not in scope (deliberately)

`graphify hook install` would also add post-commit/post-checkout auto-refresh hooks — **not** done, since (a) it wasn't selected and (b) it could collide with MIRA's existing `.githooks/` path. Auto-refresh and PR impact-analysis remain available as future opt-ins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)