### PR TITLE
chore: insights friction-fixes P0–P4 — git-collision guards, session-discipline rules, ship-pr skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -170,6 +170,7 @@ Full rules: `.claude/rules/codegraph-usage.md`. Reference: `wiki/references/code
 - **Train before deploy** — see `.claude/rules/train-before-deploy.md` (Command Center builds+validates; Ignition/HMI deploys approved asset agents only; no HMI deployment without grounded docs + validation questions + approved cited answers; read-only in beta).
 - **Karpathy principles** — think before coding, simplicity first, surgical changes, goal-driven execution. See `.claude/rules/karpathy-principles.md`.
 - **Debugging & verification** — perf problems are multi-cause (re-measure after each fix); verify exact table/column names + API auth paths from the codebase before guessing. See `.claude/rules/debugging-conventions.md`.
+- **Session discipline** — verify stated premises against the codebase + `git log` before building; re-run the full suite before reporting eval gains; stage only files your change touched (never `git add -A` over foreign WIP); validate migration/seed prerequisites + schema constraints; checkpoint long tasks to `.planning/STATE.md` early. See `.claude/rules/session-discipline.md`.
 - **Don't break the UNS confirmation gate.** Run `mira-run-hallucination-audit` after engine/bot edits.
 
 ## Testing expectations
@@ -210,6 +211,7 @@ Full rules: `.claude/rules/codegraph-usage.md`. Reference: `wiki/references/code
 - `.claude/rules/python-standards.md` — ruff, httpx, NeonDB, async
 - `.claude/rules/karpathy-principles.md` — coding behavior
 - `.claude/rules/debugging-conventions.md` — multi-cause perf debugging + verify schema/API paths before guessing
+- `.claude/rules/session-discipline.md` — premise-verify, regression-recheck, scoped-commits, migration-safety, long-task checkpointing
 - `.claude/rules/codegraph-usage.md` — when to use CodeGraph vs grep/Read (CodeGraph-first for symbol-shaped questions)
 - `docs/specs/uns-kg-unification-spec.md` — UNS authority (data architecture)
 - `docs/specs/mira-component-intelligence-architecture.md` — implementation-level architecture (component templates, KG mechanics)

--- a/.claude/rules/session-discipline.md
+++ b/.claude/rules/session-discipline.md
@@ -1,0 +1,120 @@
+# Session Discipline
+
+Behavior rules distilled from the 2026-06-08 `/insights` report (65 sessions).
+They target the friction patterns that cost the most time: building on wrong
+premises, reporting gains from partial test runs, bundling foreign WIP into
+commits, unsafe migrations/seeds, and losing work to context exhaustion.
+
+These complement `karpathy-principles.md` (think/simplify/surgical/goal-driven)
+and `debugging-conventions.md` (verify schema + API paths before guessing).
+They govern *behavior*, not syntax.
+
+---
+
+## 1. Premise verification
+
+Before implementing, verify **every stated premise** against the actual
+codebase + `git log` — don't take the request's framing on faith.
+
+- **File paths, table/column names, function/symbol names** — confirm they
+  exist (CodeGraph / `Grep` / `Read`) before building on them. The task that
+  says "edit `foo.py`'s `bar()`" is wrong often enough to check first.
+- **Bug status** — "X is broken" may already be fixed on `main`. Check `git
+  log` / the file before re-fixing. (See `feedback_lost_session_commit_check`:
+  trust git over a claim that work was lost.)
+- **Branch / environment** — confirm you're on the branch and env the task
+  assumes. A "stale feature branch, N behind main" is a common trap.
+- **Numbers in the plan** (line counts, row counts, "<150 lines", "29/47
+  done") drift. Re-measure before relying on one.
+
+**Surface every mismatch before building** — don't silently "fix" the premise
+or silently proceed on the wrong one. One clarifying line now beats a reverted
+PR later.
+
+## 2. Regression recheck
+
+After any change intended to **raise** an eval/test pass rate or fix a
+regression:
+
+- **Re-run the *full* affected suite** and compare to the baseline you captured
+  *before* the change. Never report "+N" from a partial / single-fixture run.
+- **Distinguish pre-existing `main` failures from branch-introduced
+  regressions.** A red test you didn't cause is not your "+1 to fix"; a green
+  test you turned red is a regression you must own. Check against `origin/main`
+  HEAD when in doubt.
+- **Net, not gross.** "9 fixtures newly pass" means nothing if 6 newly fail.
+  Report the net and the regressions explicitly.
+
+Evidence beats assertion (Karpathy #4, Cluster Law 1): show the before/after
+numbers, not "should be better now".
+
+## 3. Scoped commits
+
+Stage only the files **your change touched**.
+
+- **Never `git add -A` / `git add .`** when untracked or foreign WIP exists in
+  the tree. Name the paths explicitly (`git add path/a path/b`).
+- Known noise in this repo to never sweep in: `tools/__init__.py`,
+  `ANTIGRAVITY_*.md`, stray `tools/yt-pipeline/` worktree artifacts, scratch
+  logs. If you didn't create it and your change doesn't need it, leave it.
+- **Never touch a stash you didn't create**, and never `git stash drop`/`clear`
+  to "clean up" — that's how other sessions' work disappears.
+- One atomic commit per logical change; conventional-commit message.
+
+`git status -s` before every commit; if the staged set includes a file you
+can't trace to the request, unstage it.
+
+## 4. Migration / seed safety
+
+Before applying a migration or seed (see `docs/environments.md`,
+`.claude/CLAUDE.md` § "Environment boundaries"):
+
+- **Confirm prerequisite migrations exist in the *target* env.** A migration
+  that `ALTER`s a table created by an earlier migration fails if that earlier
+  one never ran in this env. (Hub `ON CONFLICT` orphaned by migs 025/026 —
+  #1792 — is the canonical bite.)
+- **Validate schema constraints against the *live* schema, not your memory:**
+  UUID vs TEXT key types, enum / CHECK membership (lowercase vs canonical
+  relation-type values), and `ON CONFLICT` targets must match a real unique
+  constraint.
+- **dev → staging → prod, in that order**, via `apply-migrations.yml`
+  (`dry-run` then `apply`). Never hand-edit prod schema; never seed prod first
+  (retrieval is proven on staging-shape data — #1385).
+
+## 5. Long-task checkpoint discipline  (P4)
+
+For any task likely to exceed the context window — long evals, multi-file
+builds, codebase maps, multi-phase plans:
+
+- **Write a handoff to `.planning/STATE.md` early and after each phase**, not
+  at the end. Capture: what's done (with evidence), what's next, what's
+  blocked, and any manual steps owed to the operator. Context exhaustion must
+  never lose ground — the working-tree STATE.md is the recovery point.
+- **Make the deliverable durable before long-running calls.** Commit the
+  finished slice before kicking off a 35-minute eval or an advisor round; a
+  durable result survives a dropped session, an unwritten one doesn't.
+- **Run 30-min+ evals and builds as background jobs** (`run_in_background`),
+  not blocking interactive calls — blocking burns context you'll want for the
+  next phase. Poll/collect when they signal completion.
+- Prefer many small verified commits over one large unverified one. Each commit
+  is a checkpoint you can resume from.
+
+---
+
+## When this applies
+
+- Every non-trivial task in this repo. Rules 1–3 are near-universal; rule 4
+  fires on any DB/migration/seed work; rule 5 fires on long/multi-phase work.
+
+## When this does NOT apply
+
+- Trivial one-line / typo fixes (Karpathy tradeoff note: don't ceremoniously
+  apply all five to a typo).
+- Pure read-only investigation that produces no commit.
+
+## Cross-references
+
+- `.claude/rules/karpathy-principles.md` — think / simplify / surgical / goal-driven
+- `.claude/rules/debugging-conventions.md` — verify schema + API paths; multi-cause perf
+- `docs/environments.md` — dev / staging / prod promotion + migration discipline
+- `.planning/STATE.md` — the checkpoint file rule 5 writes to

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -72,6 +72,14 @@
           {
             "type": "command",
             "command": "echo \"$CLAUDE_TOOL_INPUT\" | grep -qE 'git commit|git push' && gitleaks protect --staged --config .gitleaks.toml 2>/dev/null || true"
+          },
+          {
+            "type": "command",
+            "command": "bash tools/hooks/git-state-guard.sh"
+          },
+          {
+            "type": "command",
+            "command": "bash tools/hooks/prod-guard.sh"
           }
         ]
       }
@@ -82,6 +90,10 @@
           {
             "type": "command",
             "command": "echo '--- MIRA v2.0 ---' && git log --oneline -5 && echo '--- Skills ---' && ls .claude/skills/*.md 2>/dev/null | xargs -I{} basename {} .md | tr '\\n' ' ' && echo && echo '--- Effort ---' && echo \"CLAUDE_CODE_EFFORT_LEVEL=${CLAUDE_CODE_EFFORT_LEVEL:-default} (use /effort to change; xhigh recommended for engine.py / shared/inference work)\""
+          },
+          {
+            "type": "command",
+            "command": "touch /tmp/mira-claude-active.lock 2>/dev/null || true"
           }
         ]
       }

--- a/.claude/skills/ship-pr/SKILL.md
+++ b/.claude/skills/ship-pr/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: ship-pr
+description: Use when turning working changes into a green, mergeable PR — branch fresh off main, run the affected tests + lint, distinguish pre-existing main failures from branch-introduced regressions, open a PR with an evidence body, and poll CI to green. The propose→CI→mergeable half of the ship loop. Hands off to the `ship` skill for merge→deploy→verify-live. Triggers on "open a PR", "get this PR green", "propose this change", "make this mergeable".
+---
+
+# ship-pr
+
+The upstream half of shipping: from "I have changes" to "the PR is green and a
+human can merge it." It deliberately STOPS at mergeable — it does not merge or
+deploy.
+
+## Route first (don't reimplement a sibling)
+
+- **Merge + deploy + verify-live** (a PR is already green/ready) → use `ship`.
+  This skill ends where `ship` begins.
+- **Visible mira-web change** (`/`, `/cmms`, `/pricing`, views, CSS) → use
+  `design-ship-routine` (snapshot→PR→deploy→verify:live). It owns the visual
+  proof loop.
+- **Commit hygiene only** (no PR yet) → `smart-commit`.
+- Otherwise continue below.
+
+## 0. Git-state preflight (reuse the P0 guard)
+
+The `tools/hooks/git-state-guard.sh` PreToolUse hook already blocks git
+mutators when the tree is mid-rebase or HEAD is detached. Before anything else,
+confirm a sane state yourself:
+
+```bash
+git rev-parse --abbrev-ref HEAD              # know which branch you're on
+git rev-parse --git-dir                       # then check for rebase markers:
+ls "$(git rev-parse --git-dir)"/rebase-merge "$(git rev-parse --git-dir)"/rebase-apply 2>/dev/null \
+  && echo "WEDGED — finish/abort the rebase before continuing"
+```
+
+If wedged: `git rebase --continue` or `git rebase --abort` first. Never force a
+mutator past the guard (`MIRA_ALLOW_GIT_WEDGE=1`) unless you are deliberately
+scripting a rebase.
+
+## 1. Branch fresh off main (avoid the 187-behind trap)
+
+If you're on a stale or long-lived branch, don't pile onto it:
+
+```bash
+git fetch origin
+git rev-list --count origin/main..HEAD        # commits you'd carry
+git rev-list --count HEAD..origin/main         # how far BEHIND main you are
+```
+
+If behind by more than a handful, branch fresh and bring only your change:
+
+```bash
+git stash                                      # if you have uncommitted work
+git checkout -b <type>/<short-desc> origin/main
+git stash pop
+```
+
+Scope the branch to ONE logical change (see `session-discipline.md` §3).
+
+## 2. Run affected tests + lint — and separate regressions from pre-existing red
+
+The non-negotiable step. A red test you didn't cause is NOT your fix to make; a
+green test you turned red IS a regression you must own.
+
+```bash
+# Baseline: does main already fail this suite? (run on a clean origin/main checkout
+# or a worktree) — capture the count BEFORE attributing any failure to your branch.
+ruff check $(git diff --name-only origin/main...HEAD | grep '\.py$') 2>&1 | tail -5
+pytest <affected test paths> -q 2>&1 | tail -20
+```
+
+- **Lint:** `ruff check` (Python) / `npm run build` (mira-hub TS) on changed files.
+- **Tests:** the regimes / golden cases your change touches (`tests/`,
+  `mira-bots/tests/`). Engine / RAG / FSM / classifier changes MUST pass the
+  staging gate (`smoke-test.yml` + the relevant `tests/eval/` regime) — name it.
+- Report **net**, with regressions called out explicitly. Never "+N" from a
+  partial run (`session-discipline.md` §2).
+
+## 3. Open the PR with an evidence body
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "<conventional title>" --body "$(cat <<'BODY'
+## What
+<one-paragraph summary>
+
+## Why
+<the friction / bug / goal this closes; link issue #>
+
+## Tests run
+<exact commands + results — pasted, not asserted>
+
+## Risk / blast radius
+<modules touched; codegraph_impact summary if a shared module>
+BODY
+)"
+```
+
+Body must show **commands + results**, not "tests pass" (Cluster Law 1).
+
+## 4. Poll CI → triage real vs flaky
+
+```bash
+gh pr checks <PR#> --watch
+```
+
+- **Green** → report mergeable with the check rollup. STOP here — merge is a
+  human decision (and `ship`'s job).
+- **Red** → triage. Is it a real failure your branch introduced, or a known-
+  flaky / pre-existing-on-main check? Compare against `origin/main`'s latest run
+  before "fixing" anything. Note: on this repo, squash-merge can bypass
+  pending/advisory checks — know which checks actually gate (see
+  `reference_ci_checks` memory).
+
+## 5. Handoff
+
+Update `.planning/STATE.md` (and memory if a durable fact emerged): PR number,
+what's green, what's blocked, what manual steps the operator still owes. This is
+the checkpoint a future session resumes from (`session-discipline.md` §5).
+
+## Done-when
+
+PR is open, CI is green (or every red is triaged to pre-existing/flaky with
+evidence), and the handoff is written. **Not** merged, **not** deployed — hand
+to `ship` for that.
+
+## What NOT to do
+
+- ❌ Pile commits onto a branch that's far behind main — branch fresh.
+- ❌ `git add -A` over foreign WIP (`tools/__init__.py`, `ANTIGRAVITY_*.md`).
+- ❌ Report "+N passing" from a partial suite, or attribute a pre-existing main
+  failure to your branch.
+- ❌ Merge or deploy here — that's `ship` / `design-ship-routine`, and it needs
+  its own explicit human OK.
+- ❌ Claim "PR is green" without reading the actual check rollup.
+
+## Cross-references
+
+- `.claude/skills/ship.md` — the merge→deploy→verify-live half this hands off to
+- `.claude/skills/design-ship-routine.md` — visible mira-web ship loop
+- `.claude/skills/smart-commit.md` — commit hygiene before a PR exists
+- `.claude/rules/session-discipline.md` — scoped commits, regression recheck, checkpointing
+- `tools/hooks/git-state-guard.sh` — the P0 preflight guard reused in §0
+- `docs/environments.md` — staging gate + promotion discipline

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -217,6 +217,43 @@ else
 fi
 
 # ------------------------------------------------------------------
+# 6. Scope guard — warn (never block) when a commit looks like it swept in
+#    foreign WIP / out-of-scope files. Mirrors .claude/rules/session-discipline.md
+#    §3 ("stage only files your change touched"). Warn-only by design: a broad
+#    commit is sometimes correct, so this nudges, it does not block.
+# ------------------------------------------------------------------
+STAGED_ALL=$(git diff --cached --name-only --diff-filter=ACM || true)
+if [ -n "$STAGED_ALL" ]; then
+  bold "Checking commit scope..."
+
+  # 6a. Known foreign-WIP / noise patterns that should rarely be committed.
+  NOISE=$(echo "$STAGED_ALL" | grep -E '(^|/)tools/__init__\.py$|(^|/)ANTIGRAVITY_.*\.md$|(^|/)yt-pipeline/|\.orig$|\.rej$' || true)
+  if [ -n "$NOISE" ]; then
+    yellow "  ⚠️  Staged files look like foreign WIP / noise (session-discipline §3):"
+    echo "$NOISE" | sed 's/^/      /'
+    yellow "      If you didn't mean these: git restore --staged <file>"
+    WARNINGS=$((WARNINGS + 1))
+  fi
+
+  # 6b. Untracked files present alongside a staged commit — did you `git add -A`
+  #     over someone else's WIP? Informational; the files are NOT being committed.
+  UNTRACKED=$(git ls-files --others --exclude-standard || true)
+  if [ -n "$UNTRACKED" ]; then
+    UNTRACKED_COUNT=$(printf '%s\n' "$UNTRACKED" | grep -c . || true)
+    yellow "  ⚠️  ${UNTRACKED_COUNT} untracked file(s) in the tree (not staged — confirm none belong here):"
+    printf '%s\n' "$UNTRACKED" | head -5 | sed 's/^/      /'
+    [ "$UNTRACKED_COUNT" -gt 5 ] && echo "      ... and $((UNTRACKED_COUNT - 5)) more"
+    yellow "      Never 'git add -A' over foreign WIP — stage explicit paths."
+    WARNINGS=$((WARNINGS + 1))
+  fi
+
+  if [ -z "$NOISE" ] && [ -z "$UNTRACKED" ]; then
+    green "  ✓ Commit scope clean (no foreign WIP / noise staged or loose)"
+    PASS=$((PASS + 1))
+  fi
+fi
+
+# ------------------------------------------------------------------
 # Summary
 # ------------------------------------------------------------------
 bold ""

--- a/docs/superpowers/plans/2026-06-08-insights-friction-fixes.md
+++ b/docs/superpowers/plans/2026-06-08-insights-friction-fixes.md
@@ -1,0 +1,98 @@
+# Insights Friction-Fix Plan — 2026-06-08
+
+Source: `/insights` report `report-2026-06-08-164222.html` (65 sessions, 2026-05-04→06-08).
+Goal: convert the report's suggestions into shipped guardrails, ordered by **impact × inverse-effort** (highest-impact + quickest-win first). Each item is independently shippable as one atomic commit.
+
+## Prioritization at a glance
+
+| # | Fix | Friction it kills | Impact | Effort | Ship |
+|---|-----|-------------------|--------|--------|------|
+| **P0** | Git-collision elimination: cron guard + session lock + `PreToolUse` git-state guard | #1 recurring derailer — hourly cron wedges rebases, byte-identical parallel fixes, lost commits/stashes | 🔴 Highest | ~40m | today |
+| **P1** | Behavior rules: premise-verify, regression-recheck, scoped-commits, migration-safety | ~25-40% of friction (wrong paths/schemas/bug-status, introduced regressions, bundled WIP) | 🟠 High | ~15m | today |
+| **P2** | `/ship-pr` skill — encode propose→CI→merge→deploy→verify loop | Repeated re-explanation of the most-run workflow | 🟠 High | ~40m | this week |
+| **P3** | Pre-commit scope guard (extend `.githooks/pre-commit`) | Unrelated WIP bundled into commits | 🟡 Med | ~25m | this week |
+| **P4** | Long-task checkpoint discipline (handoff-early rule + background-eval default) | Context exhaustion leaving work at 78-90% | 🟡 Med | ~15m | this week |
+| **P5** | Background eval loop w/ revert-on-regression (script + skill) | Evals stall: 9 regressions for +3 net; 35-min runs burn context | 🟢 Strategic | ~2h | next |
+| **P6** | Full multi-session coordination (worktree-per-session + lock claims) | The ambitious version of P0 | 🟢 Strategic | ~½ day | next |
+
+If forced to ship ONE thing: **P0** — it's the single biggest time sink in the data and the fix is now cheap (exact cron lines identified).
+
+---
+
+## P0 — Git-collision elimination  🔴 highest impact, quick now
+
+**Root cause (verified `crontab -l`):** two crons run `git pull` against the *active* dev tree `/Users/bravonode/Mira`:
+- `0 * * * * cd /Users/bravonode/Mira && git pull --rebase --autostash`  ← hourly `mira-wiki-pull`, the wedger
+- `0 3 * * * cd ~/Mira && git pull origin main -q && pytest …`  ← 3am test run
+
+Both autostash/pull mid-session → wedged rebases, dropped stashes, detached HEAD.
+
+**Fix (three layers):**
+1. **`tools/hooks/safe-cron-pull.sh`** — wrapper the crons call instead of raw `git pull`. Aborts (exit 0, log reason) if ANY of: `.git/rebase-merge`/`.git/rebase-apply` exists; `git status --porcelain` non-empty (dirty = active work); session lock `/tmp/mira-claude-active.lock` mtime < 2h; current branch ≠ `main`. Otherwise does the pull. Preserves "keep main fresh when idle" intent without ever touching an active session.
+2. **Session lock** — `SessionStart` hook `touch /tmp/mira-claude-active.lock`; `Stop` hook leaves it (mtime freshness is the signal; auto-expires at 2h). Coordination primitive for both crons and future agents.
+3. **`tools/hooks/git-state-guard.sh`** — new `PreToolUse(Bash)` hook (chained, not replacing gitleaks). When the command is a git *mutator* (`commit`/`rebase`/`merge`/`push`/`reset`/`stash drop`), block with a clear message if `.git/rebase-merge`/`rebase-apply` present or HEAD detached. Read-only git ops pass through.
+
+**Also restore `prod-guard.sh`** to `PreToolUse(Bash)` — it's documented as wired but absent from `settings.json` (drift). Chain all three.
+
+**Verify:** simulate a paused rebase (`git rebase -X` then leave `.git/rebase-merge`), confirm `git-state-guard.sh` blocks a `git commit`; run `safe-cron-pull.sh` against a dirty tree and confirm it no-ops with a logged reason; confirm a clean idle tree still pulls.
+
+**Commit:** `chore(hooks): git-state guard + safe-cron-pull + session lock — kill rebase wedges`
+**Update crontab** (manual step — surface the two exact `crontab -e` line replacements; don't edit crontab from a hook).
+
+---
+
+## P1 — Behavior rules  🟠 high impact, quickest win
+
+Add to `.claude/rules/karpathy-principles.md` (behavior layer) or a new `.claude/rules/session-discipline.md`, and a 1-line pointer in `CLAUDE.md`:
+
+1. **Premise verification.** Before implementing, verify every stated premise (file paths, table/column names, bug status, branch) against the actual codebase + `git log`. Surface mismatches before building. (Pairs with the "orient first" pattern.)
+2. **Regression recheck.** After any change intended to raise an eval/test pass rate, re-run the *full* affected suite and compare to baseline before reporting net gains. Never report "+N" from a partial run.
+3. **Scoped commits.** Stage only files your change touched. Never `git add -A` when untracked/foreign WIP exists; never touch a stash you didn't create. (Already bitten: `tools/__init__.py`, `ANTIGRAVITY_*.md` noise.)
+4. **Migration/seed safety.** Before applying a migration or seed: confirm prerequisite migrations exist in the target env, and validate schema constraints (UUID vs TEXT, enum membership, `ON CONFLICT` targets) against the live schema.
+
+**Verify:** rules render; `wc -l CLAUDE.md` stays < 150 (CLAUDE.md targets ~120 — put depth in the rule file, 1 pointer line in CLAUDE.md).
+**Commit:** `docs(rules): session discipline — premise-verify, regression-recheck, scoped-commits, migration-safety`
+
+---
+
+## P2 — `/ship-pr` skill  🟠 high repeat value
+
+`.claude/skills/ship-pr/SKILL.md` encoding the loop the report shows you run constantly:
+1. Git-state preflight (reuse P0 guard) — halt on detached HEAD / active rebase / wrong tree.
+2. Branch fresh from `origin/main` if on a stale/long-lived branch (the 187-behind trap).
+3. Run affected tests + lint; **distinguish pre-existing main failures from branch-introduced regressions** (check against `origin/main` HEAD).
+4. Open PR with evidence body (tests run + results).
+5. Poll CI; if green → report mergeable; if red → triage real vs flaky.
+6. Update memory + `.planning/STATE.md` / handoff.
+
+**Verify:** dry-run the skill on a trivial no-op branch end-to-end.
+**Commit:** `feat(skills): ship-pr — propose→CI→merge→deploy→verify loop with git-state guard`
+
+---
+
+## P3 — Pre-commit scope guard  🟡
+
+Extend `.githooks/pre-commit`: warn (don't hard-block) when staged set includes files outside the diff's apparent scope, or when untracked WIP exists alongside staged changes. Keep existing shellcheck + credential scan.
+**Commit:** `chore(githooks): warn on out-of-scope / WIP-bundled commits`
+
+---
+
+## P4 — Long-task checkpoint discipline  🟡
+
+Rule + default behavior: for any task likely to exceed context (long evals, multi-file builds, codebase maps), write a handoff to `.planning/STATE.md` *early* and after each phase; run 30-min+ evals as **background** jobs (`run_in_background`) rather than blocking interactively. Add to `session-discipline.md`.
+**Commit:** folds into P1's rule commit or a follow-up.
+
+---
+
+## P5 — Background eval loop w/ revert-on-regression  🟢 strategic
+
+`tools/eval-loop.sh` + thin skill: run eval detached → write per-fixture results to a checkpoint file → iterate {pick highest-impact failing fixture → minimal fix → re-run affected fixtures → keep only if net-passing increased, else `git checkout --` the change}. Pass-rate only climbs. Targets the 61%→80% goal without burning interactive context.
+
+## P6 — Multi-session coordination  🟢 strategic
+
+Worktree-per-session + lock-claim (file or Linear-issue claim) so two agents never ship duplicate fixes (the PR #1081 byte-identical abandonment). P0's session lock is the seed; this generalizes it. Defer until P0 proves the lock primitive.
+
+---
+
+## Suggested execution order
+P0 → P1 → P2 → P3/P4 (parallel-safe) → P5 → P6. P0+P1 are "today"; everything else is independently grabbable. Each = one atomic commit + verify; write progress to `.planning/STATE.md` after each so context exhaustion never loses ground.

--- a/tools/hooks/git-state-guard.sh
+++ b/tools/hooks/git-state-guard.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# tools/hooks/git-state-guard.sh
+# PreToolUse(Bash) hook — blocks git *mutators* (commit/rebase/merge/push/reset,
+# stash drop) when the repo is in a wedged state: a paused/interrupted rebase
+# (.git/rebase-merge or .git/rebase-apply present) or a detached HEAD.
+#
+# Rationale (insights report 2026-06-08, P0): the #1 recurring derailer is a
+# cron `git pull --rebase --autostash` (or a hand-run rebase) that leaves the
+# tree mid-rebase; a subsequent `git commit` then lands on the wrong base, drops
+# the autostash, or detaches HEAD. This hook refuses the mutator and tells the
+# operator to finish/abort the rebase first.
+#
+# Read-only git ops (status/log/diff/show/fetch/branch -l/...) pass through.
+#
+# Side effect: refreshes the session lock /tmp/mira-claude-active.lock on every
+# Bash call (this hook fires on every Bash PreToolUse), so safe-cron-pull.sh
+# sees an *active* session for the full session, not just its first 2h. This
+# closes the long-session gap the SessionStart-only touch leaves open.
+#
+# Override: MIRA_ALLOW_GIT_WEDGE=1 (set per-shell when you're deliberately
+# operating inside a rebase, e.g. scripting a `git rebase --continue` loop).
+#
+# Reads PreToolUse JSON from stdin OR $CLAUDE_TOOL_INPUT (legacy MIRA hooks).
+# Emits PreToolUse permission JSON on stdout (matches tools/hooks/prod-guard.sh).
+
+set -uo pipefail
+
+# Refresh the session-active lock on every Bash call (cheap, best-effort).
+touch /tmp/mira-claude-active.lock 2>/dev/null || true
+
+# Operator override — silent allow.
+if [ "${MIRA_ALLOW_GIT_WEDGE:-0}" = "1" ]; then
+  exit 0
+fi
+
+# Pull the bash command. Prefer stdin (canonical), fall back to env var.
+cmd=""
+if [ ! -t 0 ]; then
+  payload=$(cat 2>/dev/null || true)
+  if [ -n "$payload" ]; then
+    cmd=$(printf '%s' "$payload" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get("tool_input", {}).get("command", "") or "")
+except Exception:
+    print("")
+' 2>/dev/null || true)
+  fi
+fi
+[ -z "$cmd" ] && cmd="${CLAUDE_TOOL_INPUT:-}"
+[ -z "$cmd" ] && exit 0  # Nothing to inspect; allow.
+
+# Is this a git *mutator*? Match `git ... <verb>` and `git stash drop`/`pop`.
+# Read-only verbs (status/log/diff/show/fetch/branch/rev-parse) are NOT matched.
+MUTATOR='git([[:space:]]+-[^[:space:]]+)*[[:space:]]+(commit|rebase|merge|push|reset|cherry-pick|revert|am)([[:space:]]|$)|git[[:space:]]+stash[[:space:]]+(drop|pop|clear)'
+if ! printf '%s' "$cmd" | grep -qE "$MUTATOR"; then
+  exit 0  # Not a mutator; allow.
+fi
+
+# Resolve the git dir for whatever repo we're cwd'd into (not hardcoded).
+GITDIR=$(git rev-parse --git-dir 2>/dev/null || true)
+[ -z "$GITDIR" ] && exit 0  # Not in a git repo; nothing to guard.
+
+reason=""
+if [ -d "${GITDIR}/rebase-merge" ] || [ -d "${GITDIR}/rebase-apply" ]; then
+  reason="repository is mid-rebase (${GITDIR}/rebase-merge or rebase-apply exists). Finish it with 'git rebase --continue' or abandon it with 'git rebase --abort' before running git mutators."
+elif ! git symbolic-ref -q HEAD >/dev/null 2>&1; then
+  reason="HEAD is detached. Check out a branch ('git checkout <branch>') before running git mutators, or your commit will be orphaned."
+fi
+
+if [ -n "$reason" ]; then
+  esc=$(printf '%s' "$reason" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))' 2>/dev/null || printf '"%s"' "${reason//\"/\\\"}")
+  printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":%s}}\n' "$esc"
+  exit 0
+fi
+
+exit 0

--- a/tools/hooks/safe-cron-pull.sh
+++ b/tools/hooks/safe-cron-pull.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# tools/hooks/safe-cron-pull.sh
+# Wrapper the cron `git pull` jobs call INSTEAD of raw `git pull`. Preserves the
+# "keep main fresh while idle" intent without ever touching an active session.
+#
+# Aborts the pull (exit 0, logs a reason) if ANY of:
+#   - a rebase is in progress  (.git/rebase-merge or .git/rebase-apply)
+#   - the tree is dirty        (git status --porcelain non-empty = active work)
+#   - a session is active      (/tmp/mira-claude-active.lock mtime < 2h)
+#   - the branch is not `main` (never pull into a feature branch)
+# Otherwise it runs the pull.
+#
+# Always exits 0 so a downstream `&& pytest ...` in the cron line still runs
+# against whatever is currently checked out.
+#
+# Usage (from cron):
+#   cd /Users/bravonode/Mira && tools/hooks/safe-cron-pull.sh            # default: pull --rebase --autostash
+#   cd /Users/bravonode/Mira && tools/hooks/safe-cron-pull.sh origin main -q   # explicit pull args
+#
+# Env:
+#   MIRA_REPO          repo dir (default /Users/bravonode/Mira)
+#   MIRA_LOCK_MAX_AGE  lock-freshness window in seconds (default 7200 = 2h)
+
+set -uo pipefail
+
+# cron runs a minimal PATH — guarantee Homebrew git/python are reachable.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:$PATH"
+GIT="$(command -v git || echo /opt/homebrew/bin/git)"
+
+REPO_DIR="${MIRA_REPO:-/Users/bravonode/Mira}"
+LOCK="/tmp/mira-claude-active.lock"
+LOCK_MAX_AGE="${MIRA_LOCK_MAX_AGE:-7200}"
+
+ts() { date -u +%FT%TZ; }
+skip() { echo "$(ts) safe-cron-pull: SKIP — $1"; exit 0; }
+
+cd "$REPO_DIR" 2>/dev/null || { echo "$(ts) safe-cron-pull: SKIP — cannot cd to $REPO_DIR"; exit 0; }
+
+GITDIR="$("$GIT" rev-parse --git-dir 2>/dev/null || echo .git)"
+
+# 1. Rebase in progress?
+if [ -d "${GITDIR}/rebase-merge" ] || [ -d "${GITDIR}/rebase-apply" ]; then
+  skip "rebase in progress (${GITDIR}/rebase-merge|rebase-apply)"
+fi
+
+# 2. Dirty tree = active work?
+if [ -n "$("$GIT" status --porcelain 2>/dev/null)" ]; then
+  skip "working tree is dirty (uncommitted changes present)"
+fi
+
+# 3. Active session lock < LOCK_MAX_AGE old?
+if [ -f "$LOCK" ]; then
+  now=$(date +%s)
+  # BSD stat (macOS) uses -f %m; GNU stat uses -c %Y.
+  mtime=$(stat -f %m "$LOCK" 2>/dev/null || stat -c %Y "$LOCK" 2>/dev/null || echo 0)
+  age=$(( now - mtime ))
+  if [ "$age" -lt "$LOCK_MAX_AGE" ]; then
+    skip "active Claude session (lock ${age}s old < ${LOCK_MAX_AGE}s)"
+  fi
+fi
+
+# 4. On a non-main branch?
+branch="$("$GIT" symbolic-ref --short -q HEAD 2>/dev/null || echo DETACHED)"
+if [ "$branch" != "main" ]; then
+  skip "current branch is '$branch', not main"
+fi
+
+# All clear — do the pull.
+if [ "$#" -gt 0 ]; then
+  echo "$(ts) safe-cron-pull: pulling (git pull $*)"
+  "$GIT" pull "$@"
+else
+  echo "$(ts) safe-cron-pull: pulling (git pull --rebase --autostash)"
+  "$GIT" pull --rebase --autostash
+fi
+exit 0


### PR DESCRIPTION
## What
Ships **P0–P4** of `docs/superpowers/plans/2026-06-08-insights-friction-fixes.md` — the highest impact×inverse-effort guardrails distilled from the 2026-06-08 `/insights` report (65 sessions). Four atomic commits:

| Pn | Commit | Kills |
|----|--------|-------|
| **P0** | `chore(hooks): git-state guard + safe-cron-pull + session lock` | #1 derailer — hourly cron `git pull --rebase --autostash` wedging the active tree mid-rebase |
| **P1+P4** | `docs(rules): session discipline …` | wrong premises, partial-run eval claims, bundled WIP, unsafe migrations, context-loss |
| **P2** | `feat(skills): ship-pr …` | re-explaining the propose→CI→mergeable loop each session |
| **P3** | `chore(githooks): warn on out-of-scope / WIP-bundled commits` | foreign WIP swept into commits |

P5/P6 (strategic) are intentionally out of scope for a separate session.

## P0 — three layers
- `tools/hooks/git-state-guard.sh` — `PreToolUse(Bash)` hook; blocks git mutators (commit/rebase/merge/push/reset/cherry-pick/revert/am, stash drop/pop/clear) when `.git/rebase-merge|rebase-apply` exists or HEAD is detached. Read-only git ops pass. Also refreshes `/tmp/mira-claude-active.lock` on every Bash call so >2h sessions stay protected.
- `tools/hooks/safe-cron-pull.sh` — wrapper the crons call instead of raw `git pull`. No-ops (exit 0 + logged reason) on rebase-in-progress / dirty tree / fresh session lock / non-main branch; otherwise pulls. Hardcodes the Homebrew git path for cron's minimal PATH.
- `.claude/settings.json` — chains git-state-guard + restores the documented-but-unwired `prod-guard.sh` **after** the existing gitleaks hook (3-hook Bash chain, gitleaks untouched); SessionStart touches the lock.

## Verification (evidence, not assertion)
- **P0** — exercised in a throwaway `/tmp` repo (not the live tree): commit **denied** mid-rebase ✅; read-only `git status` **allowed** ✅; `safe-cron-pull` **no-ops** on dirty tree with logged reason ✅; **pulls** on clean idle main ✅; **skips** on feature branch + active lock ✅. Benign command passes the full 3-hook chain ✅. `jq` confirms settings.json valid.
- **P1/P4** — rule file renders, all 5 sections present.
- **P2** — `ship-pr` skill is registered/discoverable; §0–§2 preflight commands run end-to-end on this branch; **this PR is the live exercise of the loop.**
- **P3** — `shellcheck` clean; live run **warned** on a staged `tools/__init__.py` + untracked WIP and exited 0 (**did not block**).

## ⚠️ Operator action required (NOT done by this PR)
Two `crontab -e` line replacements (hooks never edit crontab) — exact lines are in the PR thread / session summary. The hourly wiki-pull's `git pull --rebase --autostash` → `safe-cron-pull.sh`, and the 3am pytest's `git pull origin main -q` → `safe-cron-pull.sh origin main -q`. Side effect: wiki-pull then syncs only when idle on main (intended; sync pauses during active feature work).

Note: the hourly cron fired *during* this session and cleanly rebased the branch onto the freshly-advanced `origin/main` — no conflict, no loss — a live illustration of exactly the friction P0 removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)