### PR TITLE
fix(hub): rate-limit /api/quickstart/ask — closes #1832

### DIFF
--- a/mira-hub/src/app/api/quickstart/ask/route.ts
+++ b/mira-hub/src/app/api/quickstart/ask/route.ts
@@ -1,4 +1,6 @@
 import { NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { createHash } from "crypto";
 import { withTenantContext } from "@/lib/tenant-context";
 import { cascadeComplete, type CascadeMessage } from "@/lib/llm/cascade";
 import {
@@ -9,6 +11,29 @@ import {
 } from "@/lib/manual-rag";
 
 export const dynamic = "force-dynamic";
+
+// Per-IP-hash rate limit for this public, unauthenticated LLM endpoint.
+// In-memory (per-instance) — sufficient while the hub runs as a single
+// container (see root CLAUDE.md Container Map). Mirrors the intent of
+// /api/public/report's DB-backed IP-hash limiter. If the hub scales
+// horizontally, port to a shared store / quickstart_rate table.
+const QUICKSTART_MAX_PER_MIN = 20;
+const QUICKSTART_WINDOW_MS = 60_000;
+const quickstartHits = new Map<string, number[]>();
+
+function quickstartRateLimited(ipHash: string): boolean {
+  const now = Date.now();
+  const cutoff = now - QUICKSTART_WINDOW_MS;
+  const hits = (quickstartHits.get(ipHash) ?? []).filter((t) => t > cutoff);
+  hits.push(now);
+  quickstartHits.set(ipHash, hits);
+  if (quickstartHits.size > 5000) {
+    for (const [k, v] of quickstartHits) {
+      if (v.every((t) => t <= cutoff)) quickstartHits.delete(k);
+    }
+  }
+  return hits.length > QUICKSTART_MAX_PER_MIN;
+}
 
 // See /api/quickstart/manufacturers/route.ts for the rationale on
 // QUICKSTART_TENANT_ID. Production sets it via Doppler / docker-compose;
@@ -67,6 +92,20 @@ const SYSTEM_PROMPT = [
 export async function POST(req: Request) {
   if (!process.env.NEON_DATABASE_URL) {
     return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+
+  // Rate limit before any work — we never store raw IPs.
+  const rlHdrs = await headers();
+  const rawIp =
+    rlHdrs.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    rlHdrs.get("x-real-ip") ??
+    "unknown";
+  const ipHash = createHash("sha256").update(rawIp).digest("hex");
+  if (quickstartRateLimited(ipHash)) {
+    return NextResponse.json(
+      { error: "Too many requests — slow down and try again in a minute." },
+      { status: 429 },
+    );
   }
 
   let body: AskPayload;


### PR DESCRIPTION
## What

Adds a per-IP-hash rate limiter (20 req/IP/min) to the public, unauthenticated `POST /api/quickstart/ask` endpoint in `mira-hub`.

Closes #1832.

## Why

Orchestrator-pulse Lens A flagged `/api/quickstart/ask` as a public, no-auth LLM endpoint that fires a `cascadeComplete` (Groq → Cerebras → Gemini, all shared free-tier) on **every POST** with no throttle. One script could drain the provider quota for the entire beta cohort — both a cost problem and a denial-of-service against beta testers.

## How

Ports the proven IP-hash pattern from `/api/public/report`:
- `sha256` hash of `x-forwarded-for` → `x-real-ip` → `"unknown"` (raw IPs are never stored)
- Rate check runs **before any work** (before JSON parse, retrieval, or the cascade)
- 21st request in a 60s window returns **HTTP 429**

The limiter is in-memory (per-instance), which is sufficient while the hub runs as a single container (root `CLAUDE.md` Container Map). If the hub scales horizontally, port to a shared store / `quickstart_rate` table — noted in a code comment.

Patch source: `wiki/orchestrator/patches/2026-06-08-quickstart-rate-limit.patch`.

## Verification

- `cd mira-hub && npx tsc --noEmit` → **0 new errors** introduced (17 errors pre-exist on `main`: missing dev deps `graphology`/`unpdf` + `bun:test` files — unrelated to this change). Confirmed by diffing error count with/without the patch.
- Limiter algorithm unit-tested in isolation: requests 1–20 allowed, 21st+ return 429, distinct IPs isolated, window slides after 60s. ✅
- Pattern mirrors `/api/public/report`'s existing sha256 IP-hash limiter.

> Single-container in-memory limiter is the right scope for the beta gate. Note: an attacker behind multiple IPs / spoofed `x-forwarded-for` could still cycle keys — same limitation as the existing `/api/public/report` limiter; a shared-store/quota approach is the follow-up if/when the hub scales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)