### PR TITLE
feat(engine): citation enforce-mode — salvage uncited grounded replies (#1659)

### DIFF
--- a/mira-bots/shared/citation_compliance.py
+++ b/mira-bots/shared/citation_compliance.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import logging
 import re
+from collections import Counter
+from collections.abc import Awaitable, Callable
 
-from .workers.rag_worker import CITATION_TAG_RE
+from .workers.rag_worker import CITATION_TAG_RE, format_source_label
 
 logger = logging.getLogger("mira-gsd")
 
@@ -94,3 +96,148 @@ def check_citation_compliance(
             len(tags),
         )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Enforce-mode: insertion-only second-pass citation rewrite (#1659)
+# ---------------------------------------------------------------------------
+#
+# `check_citation_compliance` (above) only *observes*. The H4 enforcer in
+# engine.py guarantees an uncited reply never reaches the user — but it does so
+# by appending a stock "I don't have docs" admission. That is the WRONG outcome
+# in the false-negative case: the KB *did* return chunks and the LLM answered
+# correctly, it just dropped the inline `[Source:]` tag. Telling the technician
+# "no docs" there is misleading and fails the beta gate.
+#
+# This helper salvages exactly that case with one INSERTION-ONLY second pass:
+# re-ask the LLM to return the same answer verbatim with `[Source: <label>]`
+# tags inserted, then validate the result. It NEVER changes content and NEVER
+# invents a citation — any failure falls back to the original reply, so the H4
+# admission still fires downstream. It is therefore safe by construction.
+
+_LABEL_RE = re.compile(r"\[Source:\s*(.+?)\s*\]", re.IGNORECASE)
+_WORD_RE = re.compile(r"\w+")
+
+_REWRITE_SYSTEM = (
+    "You are a citation formatter for maintenance answers. You are given an "
+    "answer and the reference sources it was based on. Return the answer "
+    "VERBATIM with one or more inline [Source: <label>] tags inserted next to "
+    "the facts they support.\n"
+    "Hard rules:\n"
+    "1. Change no other character — identical wording, numbers, units, and order.\n"
+    "2. Use ONLY the exact labels under AVAILABLE SOURCES. Never invent, alter, "
+    "abbreviate, or reformat a label.\n"
+    "3. Insert at least one [Source: ...] tag.\n"
+    "Output only the answer text with the tags — no preamble, no explanation."
+)
+
+
+def valid_source_labels(chunks: list[dict] | None) -> set[str]:
+    """The set of citation labels that legitimately back a reply.
+
+    Built from the retrieved chunks via ``format_source_label`` — the SAME
+    function the prompt builders use to wrap chunks — so a rewrite can only
+    cite a source that was actually retrieved. Chunks with no usable metadata
+    contribute no label (never an empty-string label).
+    """
+    labels: set[str] = set()
+    for chunk in chunks or []:
+        label = format_source_label(chunk)
+        if label:
+            labels.add(label)
+    return labels
+
+
+def _emitted_labels(text: str) -> set[str]:
+    return {m.group(1).strip() for m in _LABEL_RE.finditer(text or "")}
+
+
+def _strip_source_tags(text: str) -> str:
+    return CITATION_TAG_RE.sub("", text or "")
+
+
+def _content_preserved(original: str, rewritten: str) -> bool:
+    """True when the rewrite differs from the original ONLY by [Source:] tags.
+
+    Compares the multiset (``Counter``) of word tokens after stripping every
+    ``[Source:…]`` tag. Multiset (not set) equality so a dropped or altered
+    word — e.g. ``60Hz`` → ``50Hz`` — is caught, not just reordering.
+    """
+    orig = Counter(_WORD_RE.findall(_strip_source_tags(original).lower()))
+    new = Counter(_WORD_RE.findall(_strip_source_tags(rewritten).lower()))
+    return orig == new
+
+
+def _build_rewrite_messages(reply: str, labels: set[str]) -> list[dict]:
+    sources = "\n".join(f"- {label}" for label in sorted(labels))
+    user = (
+        f"AVAILABLE SOURCES (use these exact labels only):\n{sources}\n\n"
+        f"ANSWER TO TAG (return verbatim with [Source: ...] tags inserted):\n{reply}"
+    )
+    return [
+        {"role": "system", "content": _REWRITE_SYSTEM},
+        {"role": "user", "content": user},
+    ]
+
+
+async def enforce_citation_via_rewrite(
+    reply: str,
+    chunks: list[dict] | None,
+    kb_status: dict | None,
+    *,
+    fsm_state: str = "",
+    chat_id: str = "",
+    llm_call: Callable[[list[dict]], Awaitable[str]],
+) -> str:
+    """Salvage an uncited-but-grounded technical reply via one insertion-only pass.
+
+    Returns the rewritten (cited) reply only when ALL hold:
+      * a citation is *required* and *absent* (``check_citation_compliance``),
+      * the KB actually returned citable chunks (``valid_source_labels`` non-empty),
+      * the rewrite emits ≥1 tag and every emitted label is a real chunk label,
+      * the rewrite preserves the original content (tags-only diff).
+
+    Otherwise returns the ORIGINAL ``reply`` unchanged — the H4 enforcer then
+    appends its KB-gap admission downstream. Never raises: a failing/​erroring
+    ``llm_call`` falls back to the original reply (fail-open).
+    """
+    compliance = check_citation_compliance(reply, kb_status, fsm_state=fsm_state, chat_id=chat_id)
+    if not compliance["required"] or compliance["present"]:
+        return reply
+
+    labels = valid_source_labels(chunks)
+    if not labels:
+        return reply  # nothing legitimate to cite — leave it to the H4 admission
+
+    try:
+        rewritten = (await llm_call(_build_rewrite_messages(reply, labels)) or "").strip()
+    except Exception:
+        logger.warning(
+            "CITATION_REWRITE_LLM_ERROR chat_id=%s — keeping original reply",
+            chat_id,
+            exc_info=True,
+        )
+        return reply
+
+    if not rewritten:
+        return reply
+
+    emitted = _emitted_labels(rewritten)
+    if not emitted or not emitted <= labels:
+        logger.info(
+            "CITATION_REWRITE_REJECT_LABEL chat_id=%s emitted=%r valid=%r",
+            chat_id,
+            sorted(emitted),
+            sorted(labels),
+        )
+        return reply
+
+    if not _content_preserved(reply, rewritten):
+        logger.warning(
+            "CITATION_REWRITE_REJECT_DRIFT chat_id=%s — content changed beyond tag insertion",
+            chat_id,
+        )
+        return reply
+
+    logger.info("CITATION_REWRITE_OK chat_id=%s labels=%d", chat_id, len(emitted))
+    return rewritten

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -1068,9 +1068,7 @@ class Supervisor:
             "dispatch_kind": dispatch_kind,
         }
 
-    async def _enforce_citation_rewrite(
-        self, reply: str, *, chat_id: str, fsm_state: str
-    ) -> str:
+    async def _enforce_citation_rewrite(self, reply: str, *, chat_id: str, fsm_state: str) -> str:
         """#1659 enforce-mode bridge: connect the insertion-only citation rewrite
         to this turn's retrieval set + the inference router.
 

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -17,6 +17,7 @@ import httpx
 from . import quality_gate
 from .chat_tenant import resolve as resolve_tenant
 from .citation_compliance import check_citation_compliance as _check_citation_compliance
+from .citation_compliance import enforce_citation_via_rewrite as _enforce_citation_via_rewrite
 from .conversation_router import route_intent
 from .detection.recurring_fault import check_recurring_and_annotate
 from .dialogue_state import (
@@ -1067,6 +1068,40 @@ class Supervisor:
             "dispatch_kind": dispatch_kind,
         }
 
+    async def _enforce_citation_rewrite(
+        self, reply: str, *, chat_id: str, fsm_state: str
+    ) -> str:
+        """#1659 enforce-mode bridge: connect the insertion-only citation rewrite
+        to this turn's retrieval set + the inference router.
+
+        Returns ``reply`` unchanged unless it owes a citation, had retrieval
+        chunks, and dropped the ``[Source:]`` tag — in which case one
+        insertion-only second pass salvages it (validated for content
+        preservation + real labels by the helper). Kill-switch
+        ``MIRA_CITATION_REWRITE=0`` disables it; any error falls open.
+        """
+        if os.getenv("MIRA_CITATION_REWRITE", "1") != "1":
+            return reply
+        rag = getattr(self, "rag", None)
+        if rag is None:
+            return reply
+        try:
+            return await _enforce_citation_via_rewrite(
+                reply,
+                getattr(rag, "last_chunks", None),
+                getattr(rag, "kb_status", None),
+                fsm_state=fsm_state,
+                chat_id=chat_id,
+                llm_call=rag._call_llm,
+            )
+        except Exception:
+            logger.warning(
+                "CITATION_REWRITE_BRIDGE_ERROR chat_id=%s — keeping original reply",
+                chat_id,
+                exc_info=True,
+            )
+            return reply
+
     # ------------------------------------------------------------------
     # Entry points
     # ------------------------------------------------------------------
@@ -1159,6 +1194,14 @@ class Supervisor:
             message,
             result["reply"],
             dispatch_kind=result.get("dispatch_kind", ""),
+        )
+        # #1659 enforce-mode: if the reply owes a citation and the KB returned
+        # chunks but the LLM dropped the [Source:] tag, salvage it with one
+        # insertion-only rewrite BEFORE H4 falls back to a (misleading) KB-gap
+        # admission. Runs post-quality-gate so the injected tag can't perturb
+        # the gate; gated + fail-open inside the bridge.
+        reply = await self._enforce_citation_rewrite(
+            reply, chat_id=chat_id, fsm_state=result.get("next_state", "")
         )
         # H4 enforcer (2026-06-06): every reply must carry a [Source:] citation
         # or an explicit KB-gap admission. Applied AFTER the quality gate so the

--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -717,6 +717,16 @@ class RAGWorker:
         """Current KB coverage status set during the last process() call."""
         return self._kb_status
 
+    @property
+    def last_chunks(self) -> list[dict]:
+        """Retrieved NeonDB chunks from the last process() call.
+
+        Public accessor for the citation enforce-mode rewrite (#1659) so the
+        engine can build valid `[Source:]` labels without reaching into a
+        private attribute. Empty when the last turn retrieved nothing.
+        """
+        return self._last_neon_chunks
+
     def _build_prompt_with_chunks(
         self,
         state: dict,

--- a/mira-bots/tests/test_citation_rewrite.py
+++ b/mira-bots/tests/test_citation_rewrite.py
@@ -1,0 +1,196 @@
+"""TDD suite for #1659 citation enforce-mode — the insertion-only second-pass
+rewrite.
+
+The gap it closes: when the KB returned chunks (``kb_status`` covered/partial)
+and the LLM answered correctly but **dropped the inline ``[Source:]`` tag**, the
+existing H4 enforcer appends a misleading "I don't have docs" admission instead
+of salvaging the grounded answer. This rewrite re-asks the LLM to *insert* the
+citation tags (changing nothing else), validates the result, and only falls
+through to the admission when salvage genuinely fails.
+
+Safety constraints under test (per advisor):
+  * insertion-only — content must be byte-for-token preserved (no 60Hz→50Hz)
+  * no invented labels — every emitted ``[Source: X]`` must come from a chunk
+  * reject → return the ORIGINAL reply (H4 admission fires downstream)
+
+Run from the repo/worktree ROOT (cwd=mira-bots shadows stdlib ``email``):
+    python3.12 -m pytest mira-bots/tests/test_citation_rewrite.py -q
+"""
+
+from __future__ import annotations
+
+from shared.citation_compliance import (
+    enforce_citation_via_rewrite,
+    valid_source_labels,
+)
+
+# A retrieved chunk set whose label is "AutomationDirect GS10 — Chapter 5".
+CHUNKS = [
+    {
+        "manufacturer": "AutomationDirect",
+        "model_number": "GS10",
+        "metadata": {"section": "Chapter 5"},
+        "text": "Set P01-01 to 60Hz to configure the max output frequency.",
+    }
+]
+VALID_LABEL = "AutomationDirect GS10 — Chapter 5"
+COVERED = {"status": "covered"}
+
+# A technical reply that owes a citation but dropped the tag.
+UNCITED = "Set P01-01 to 60Hz to configure the max output frequency."
+CITED = f"Set P01-01 to 60Hz to configure the max output frequency. [Source: {VALID_LABEL}]"
+
+
+def _make_llm(return_value: str, calls: list):
+    async def _llm(messages):
+        calls.append(messages)
+        return return_value
+
+    return _llm
+
+
+# ---------------------------------------------------------------------------
+# valid_source_labels — pure helper
+# ---------------------------------------------------------------------------
+def test_valid_source_labels_builds_from_chunks():
+    assert valid_source_labels(CHUNKS) == {VALID_LABEL}
+    assert valid_source_labels([]) == set()
+    assert valid_source_labels(None) == set()
+    # chunks with no usable metadata produce no label (not an empty-string label)
+    assert valid_source_labels([{"manufacturer": "", "model_number": ""}]) == set()
+
+
+# ---------------------------------------------------------------------------
+# The salvage path
+# ---------------------------------------------------------------------------
+async def test_rewrite_salvages_uncited_technical_reply():
+    calls = []
+    llm = _make_llm(CITED, calls)
+    out = await enforce_citation_via_rewrite(
+        UNCITED, CHUNKS, COVERED, fsm_state="DIAGNOSIS", chat_id="c1", llm_call=llm
+    )
+    assert out == CITED
+    assert "[Source:" in out
+    assert len(calls) == 1  # the second-pass LLM call fired exactly once
+
+
+async def test_rewrite_accepts_tag_inserted_midsentence():
+    """Insertion mid-sentence (not just appended) still preserves content."""
+    calls = []
+    mid = f"Set P01-01 to 60Hz [Source: {VALID_LABEL}] to configure the max output frequency."
+    out = await enforce_citation_via_rewrite(
+        UNCITED,
+        CHUNKS,
+        COVERED,
+        fsm_state="DIAGNOSIS",
+        chat_id="c1",
+        llm_call=_make_llm(mid, calls),
+    )
+    assert out == mid
+    assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Safety: reject content drift + invented labels  → fall back to ORIGINAL
+# ---------------------------------------------------------------------------
+async def test_rewrite_rejects_content_drift():
+    """A rewrite that changes 60Hz→50Hz while 'adding a citation' is rejected."""
+    calls = []
+    drifted = f"Set P01-01 to 50Hz to configure the max output frequency. [Source: {VALID_LABEL}]"
+    out = await enforce_citation_via_rewrite(
+        UNCITED,
+        CHUNKS,
+        COVERED,
+        fsm_state="DIAGNOSIS",
+        chat_id="c1",
+        llm_call=_make_llm(drifted, calls),
+    )
+    assert out == UNCITED  # rejected → original, so H4 admission fires downstream
+    assert len(calls) == 1
+
+
+async def test_rewrite_rejects_invented_label():
+    """A [Source:] whose label is not in the chunk set is rejected (no inventing)."""
+    calls = []
+    invented = f"{UNCITED} [Source: Totally Made Up Manual — Page 9]"
+    out = await enforce_citation_via_rewrite(
+        UNCITED,
+        CHUNKS,
+        COVERED,
+        fsm_state="DIAGNOSIS",
+        chat_id="c1",
+        llm_call=_make_llm(invented, calls),
+    )
+    assert out == UNCITED
+
+
+async def test_rewrite_rejects_when_llm_drops_tag_entirely():
+    """If the second pass still returns no tag, fall back to the original."""
+    calls = []
+    out = await enforce_citation_via_rewrite(
+        UNCITED,
+        CHUNKS,
+        COVERED,
+        fsm_state="DIAGNOSIS",
+        chat_id="c1",
+        llm_call=_make_llm(UNCITED, calls),
+    )
+    assert out == UNCITED
+
+
+# ---------------------------------------------------------------------------
+# Gating: don't fire the second pass when it isn't owed
+# ---------------------------------------------------------------------------
+async def test_rewrite_skipped_when_already_cited():
+    calls = []
+    out = await enforce_citation_via_rewrite(
+        CITED, CHUNKS, COVERED, fsm_state="DIAGNOSIS", chat_id="c1", llm_call=_make_llm("x", calls)
+    )
+    assert out == CITED
+    assert calls == []  # no LLM call when a citation is already present
+
+
+async def test_rewrite_skipped_when_no_chunks():
+    calls = []
+    out = await enforce_citation_via_rewrite(
+        UNCITED, [], COVERED, fsm_state="DIAGNOSIS", chat_id="c1", llm_call=_make_llm("x", calls)
+    )
+    assert out == UNCITED
+    assert calls == []  # nothing to cite → no second pass
+
+
+async def test_rewrite_skipped_when_kb_uncovered():
+    calls = []
+    out = await enforce_citation_via_rewrite(
+        UNCITED,
+        CHUNKS,
+        {"status": "none"},
+        fsm_state="DIAGNOSIS",
+        chat_id="c1",
+        llm_call=_make_llm("x", calls),
+    )
+    assert out == UNCITED
+    assert calls == []  # citation not required when the KB returned nothing
+
+
+async def test_rewrite_skipped_when_not_technical():
+    calls = []
+    chatter = "Sure, happy to help — what would you like to know?"
+    out = await enforce_citation_via_rewrite(
+        chatter, CHUNKS, COVERED, fsm_state="GREETING", chat_id="c1", llm_call=_make_llm("x", calls)
+    )
+    assert out == chatter
+    assert calls == []  # non-technical reply owes no citation
+
+
+# ---------------------------------------------------------------------------
+# Robustness: fail-open if the second-pass LLM raises
+# ---------------------------------------------------------------------------
+async def test_rewrite_failopen_when_llm_raises():
+    async def _boom(_messages):
+        raise RuntimeError("provider down")
+
+    out = await enforce_citation_via_rewrite(
+        UNCITED, CHUNKS, COVERED, fsm_state="DIAGNOSIS", chat_id="c1", llm_call=_boom
+    )
+    assert out == UNCITED  # never raise to the caller; original reply survives


### PR DESCRIPTION
Closes the **enforce-mode leg of #1659** (Phase 7 — Citation ENFORCEMENT). Beta-critical: this is the **citation leg of the beta gate** ("a grounded answer *with citations*").

## The gap (verified, not assumed)
The H4 enforcer (`enforce_citation_or_gap_admission`, engine.py, 2026-06-06) already guarantees an uncited reply never reaches the user — but by **appending a stock "I don't have docs" admission**. That's the *wrong* outcome in the **false-negative case**: the KB *did* return chunks and the LLM answered correctly, it just dropped the inline `[Source:]` tag. A stranger's uploaded manual → chunks retrieved → correct answer → we wrongly say "no docs" = **gate FAIL**.

## The fix — one insertion-only second pass, gated to that case
Runs once in `process()` **after `_apply_quality_gate`, before H4** (production `process_full` is only reached via `process()`):

- **`citation_compliance.py`** — `enforce_citation_via_rewrite(...)` + pure helpers. Re-asks the LLM to return the answer **verbatim with `[Source: <label>]` tags inserted**, then validates:
  1. **No invented citations** — every emitted label must be a real retrieved-chunk label (`valid_source_labels` via `format_source_label`).
  2. **No content drift** — word **multiset** identical after stripping tags (guards `60Hz→50Hz`).
  - Any failure → return the **original** reply, so H4's admission still fires. Safe by construction: never changes content, never invents, never raises.
- **`rag_worker.py`** — `last_chunks` property (public accessor for the turn's chunks).
- **`engine.py`** — `_enforce_citation_rewrite` bridge; kill-switch `MIRA_CITATION_REWRITE=0`; fail-open.

## Groundedness / safety (per CLAUDE.md)
Net **groundedness-positive** and **gate-neutral** — runs after `process_full` + the quality gate, so it cannot affect UNS-gate timing. Hallucination-audit risk-grep on the diff is clean (no risk-language, no fake plant context, anti-invention guard present). The second LLM call fires only on the minority uncited-but-had-chunks path (latency-gated; relevant to #1766).

## Tests (evidence)
- New `tests/test_citation_rewrite.py` — **11 cases**: salvage, mid-sentence insert, **drift-reject**, **invented-label-reject**, tag-dropped-reject, 4 gating skips, fail-open. All green.
- Baselines green (`test_unit2_citations`, `test_citation_gate`, `test_engine_no_embedding_gs11`).
- Engine + DST + grounding sweeps: **182 + 149 passed, 0 regressions**.

## Deferred (noted on #1659, NOT in this PR)
The `troubleshooting_session` open/close/timeout lifecycle + nightly cron — coupled to the **still-incomplete Phase 6 UNS gate**. Tracked as the remaining half of #1659.

Built in an isolated worktree off `origin/main`. Hands off to the `ship` skill for merge→deploy→verify-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)