### PR TITLE
feat(simlab): seed SimLab maintenance docs into knowledge_entries (closes #1835)

### DIFF
--- a/.github/workflows/apply-seeds.yml
+++ b/.github/workflows/apply-seeds.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       seeds:
-        description: 'Seeds to apply (comma-separated basenames without .sql, or "all"). Choices: gs10-vfd-knowledge, gs11-field-guide-knowledge, demo-conveyor-001, all.'
+        description: 'Seeds to apply (comma-separated basenames without .sql, or "all"). Choices: gs10-vfd-knowledge, gs11-field-guide-knowledge, demo-conveyor-001, simlab-docs, all. NOTE: simlab-docs is a Python seed (tools/seeds/seed-simlab-docs.py) with its own fixed SimLab tenant — it ignores the tenant_id input and only runs once PR #1816 (simlab/docs/) is on the checked-out ref.'
         required: true
         default: 'all'
         type: string
@@ -139,6 +139,9 @@ jobs:
           fi
           REQUESTED="${{ inputs.seeds }}"
           FILES=()
+          # simlab-docs is a Python seed, not a .sql file — it's resolved into
+          # its own apply step, never the psql plan. Track it separately.
+          RUN_SIMLAB=false
           if [ "$REQUESTED" = "all" ]; then
             for f in "$SEED_DIR/gs10-vfd-knowledge.sql" \
                      "$SEED_DIR/gs11-field-guide-knowledge.sql" \
@@ -149,10 +152,15 @@ jobs:
                 echo "::warning::expected seed missing: $f"
               fi
             done
+            RUN_SIMLAB=true
           else
             IFS=',' read -ra NAMES <<< "$REQUESTED"
             for n in "${NAMES[@]}"; do
               n_trimmed="$(echo "$n" | xargs)"
+              if [ "$n_trimmed" = "simlab-docs" ]; then
+                RUN_SIMLAB=true
+                continue
+              fi
               candidate="$SEED_DIR/${n_trimmed}.sql"
               if [ ! -f "$candidate" ]; then
                 echo "::error::No seed file matched: $candidate"
@@ -161,13 +169,21 @@ jobs:
               FILES+=("$candidate")
             done
           fi
-          if [ "${#FILES[@]}" -eq 0 ]; then
-            echo "::error::Resolved zero seed files."
+          echo "run_simlab=$RUN_SIMLAB" >> "$GITHUB_OUTPUT"
+          if [ "${#FILES[@]}" -eq 0 ] && [ "$RUN_SIMLAB" != "true" ]; then
+            echo "::error::Resolved zero seeds (no .sql files and no simlab-docs)."
             exit 1
           fi
-          printf '%s\n' "${FILES[@]}" > .seed_plan
-          echo "Plan:"
+          # .seed_plan may be empty when only simlab-docs was requested — the
+          # psql steps below loop over zero files, which is a safe no-op. Write a
+          # truly-empty file (no blank line) so `while read` reads nothing.
+          : > .seed_plan
+          if [ "${#FILES[@]}" -gt 0 ]; then
+            printf '%s\n' "${FILES[@]}" > .seed_plan
+          fi
+          echo "Plan (.sql):"
           cat .seed_plan
+          echo "Run SimLab Python seed: $RUN_SIMLAB"
 
       - name: Summarise plan
         run: |
@@ -286,4 +302,48 @@ jobs:
           if [ "$PSQL_EXIT" -ne 0 ]; then
             echo "::error::psql post-check failed with exit $PSQL_EXIT"
             exit "$PSQL_EXIT"
+          fi
+
+      # ── SimLab doc seed (Python) ───────────────────────────────────────────
+      # Separate from the psql plan: reads the 77 markdown fixtures under
+      # simlab/docs/, chunks them, and inserts under its OWN fixed SimLab tenant
+      # (ignores inputs.tenant_id). Guarded — no-ops with a warning until PR
+      # #1816 (simlab/docs/) is on the checked-out ref.
+      - name: Apply SimLab doc seed (Python)
+        if: steps.resolve.outputs.run_simlab == 'true'
+        run: |
+          set -euo pipefail
+          SEED_PY="tools/seeds/seed-simlab-docs.py"
+          if [ ! -f "$SEED_PY" ] || [ ! -d "simlab/docs" ]; then
+            echo "::warning::SimLab seed skipped — $SEED_PY or simlab/docs/ not on this ref (merge PR #1816 first)."
+            echo "### SimLab doc seed: SKIPPED (simlab/docs not present on ref)" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          python3 -m pip install --quiet 'psycopg[binary]==3.*'
+          export NEON_DATABASE_URL="$DATABASE_URL"
+          if [ "${{ inputs.mode }}" = "apply" ]; then
+            echo "::group::SimLab seed --commit"
+            python3 "$SEED_PY" --commit
+            echo "::endgroup::"
+            echo "::group::SimLab seed --verify (BM25 retrievability proof)"
+            python3 "$SEED_PY" --verify | tee /tmp/simlab_verify.out
+            echo "::endgroup::"
+            {
+              echo ""
+              echo "### SimLab doc seed (Python) — applied + verified"
+              echo '```'
+              cat /tmp/simlab_verify.out
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::group::SimLab seed --dry-run"
+            python3 "$SEED_PY" --dry-run | tee /tmp/simlab_dry.out
+            echo "::endgroup::"
+            {
+              echo ""
+              echo "### SimLab doc seed (Python) — dry-run (rolled back)"
+              echo '```'
+              cat /tmp/simlab_dry.out
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/tools/seeds/README.md
+++ b/tools/seeds/README.md
@@ -8,6 +8,7 @@ tenant UUID so it can be applied to dev or prod without touching real customers.
 | `demo-conveyor-001.sql` | `00000000-0000-0000-0000-0000000000d1` ("demo") | Conveyor 001 (`CV-001`) | 5 components (PE/MTR/VFD/PLC/PANEL), PE-001 full template, ISA-95 UNS paths, PLC tag bindings (4 entities), 12 verified relationship proposals + evidence, promoted into `kg_relationships` |
 | `run_demo_seed.py` | — | — | Python runner: `--dry-run` (rollback), `--commit`, `--verify` |
 | `beta-demo-tenant.md` | `…d1` ("demo") | Garage conveyor (CV-101) | **Manifest** — how to stand up the full beta demo tenant from the seeds above (apply order, known-good GS10 `oC` Q/A, first-run empty-state design). Start here for "Path to Beta". |
+| `seed-simlab-docs.py` | `00000000-0000-0000-0000-000000515ab1` ("SimLab") | Juice bottling line (11 assets) | Ingests the 77 synthetic maintenance markdown fixtures under `simlab/docs/<asset_id>/` (7 doc types × 11 assets) into `knowledge_entries`, chunked for BM25, UNS-tagged in `isa95_path` via `simlab.uns.asset_path`, `source_system="simulator"`/`simulated=true` in metadata. Closes #1835. Requires PR #1816's `simlab/docs/`. |
 
 ## Prerequisites
 
@@ -72,4 +73,47 @@ Query the demo subtree:
 SELECT entity_type, entity_id, name FROM kg_entities
 WHERE uns_path <@ 'enterprise.demo.site.lake_wales.area.assembly.line.line_a.equipment.cv_001'::ltree
 ORDER BY uns_path;
+```
+
+## SimLab doc seed (`seed-simlab-docs.py`)
+
+Ingests the SimLab juice-bottling maintenance docs so the engine can **cite**
+them during SimLab scenarios. Reads `simlab/docs/<asset_id>/*.md` (7 doc types ×
+11 assets = 77 files), chunks each on `##` sections (H1 title prepended for
+context; oversize sections soft-split at ~1800 chars), and inserts into
+`knowledge_entries` under the fixed SimLab tenant.
+
+```bash
+# Local — DEV ONLY (the docs are synthetic; never seed prod from a code shell)
+doppler run --project factorylm --config dev -- \
+  .venv/bin/python tools/seeds/seed-simlab-docs.py --dry-run   # validate, rollback
+doppler run --project factorylm --config dev -- \
+  .venv/bin/python tools/seeds/seed-simlab-docs.py --commit    # apply (242 chunks)
+doppler run --project factorylm --config dev -- \
+  .venv/bin/python tools/seeds/seed-simlab-docs.py --verify    # counts + BM25 proof
+```
+
+- **Schema facts:** `knowledge_entries.tenant_id` is **UUID** (FK → `tenants.id`;
+  the seed inserts an idempotent `tenants` row first). `source_system`/`simulated`
+  live in `metadata` JSONB (no dedicated columns). UNS path → `isa95_path`.
+- **Idempotency:** `ON CONFLICT` on the partial unique index `idx_ke_chunk_dedup`
+  `(tenant_id, source_url, (metadata->>'chunk_index')::int)`. Re-running inserts 0.
+  `DO NOTHING` → edits to a doc are **not** re-synced (clear the tenant to reload).
+- **`--verify` proves citability, not just row count:** it replays the engine's
+  OR-fanout BM25 query (`mira-bots/shared/neon_recall.py::_recall_bm25`) for canned
+  probes and asserts the expected asset is in the top-K candidate set. It does
+  **not** assert rank-#1: `_recall_bm25` is tenant-wide (no asset scoping), so
+  vocabulary-sharing siblings (filler/rinser both "nozzle/pressure") can outrank
+  the target on a generic query. At runtime the engine disambiguates via the
+  SimLab `direct_connection` `asset_id` + RRF fusion — wiring that asset scope
+  into `tests/simlab/runner.py` (which binds no tenant today) is the #1816
+  follow-up, **not** this ingestion PR.
+- **Via workflow:** `apply-seeds.yml` with `seeds=simlab-docs` (or `all`) runs this
+  as a dedicated Python step — `dry-run` rolls back, `apply` commits + verifies.
+  It ignores the `tenant_id` input (own fixed tenant) and no-ops until `simlab/`
+  is on the checked-out ref.
+
+UNS subtree (canonical lowercase ltree, built by `simlab.uns.asset_path`):
+```
+enterprise.florida_natural_demo.plant1.juice_bottling.line01.{depalletizer01|conveyorzone01|conveyorzone02|rinser01|filler01|capper01|labeler01|casepacker01|palletizer01|airsystem01|cipskid01}
 ```

--- a/tools/seeds/seed-simlab-docs.py
+++ b/tools/seeds/seed-simlab-docs.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+"""Seed SimLab juice-bottling maintenance docs into ``knowledge_entries``.
+
+Reads the 77 synthetic markdown fixtures under ``simlab/docs/<asset_id>/``,
+chunks them for BM25 retrieval, and inserts UNS-tagged rows into
+``knowledge_entries`` so the diagnostic engine can *cite* them during SimLab
+juice-bottling scenarios. Closes #1835.
+
+The docs are fully synthetic (Florida Natural Demo) — no proprietary customer
+data. Every row is tagged ``source_system="simulator"`` / ``simulated=true`` in
+``metadata`` (knowledge_entries has no dedicated columns for these), and carries
+the canonical lowercase ltree UNS path in ``isa95_path``
+(e.g. ``enterprise.florida_natural_demo.plant1.juice_bottling.line01.filler01``)
+built by :func:`simlab.uns.asset_path` — never hand-formatted
+(see ``.claude/rules/uns-compliance.md``).
+
+Tenant
+------
+The SimLab demo is seeded under a fixed, well-known tenant UUID
+:data:`SIMLAB_TENANT_ID`. ``knowledge_entries.tenant_id`` is **UUID** (verified
+against dev Neon — the old ``-- Tenant: TEXT`` headers in sibling .sql seeds and
+the apply-seeds.yml comment are stale).
+
+Scope honesty: ingestion alone does NOT make scenarios cite at *runtime*. The
+SimLab runner (``tests/simlab/runner.py``) currently binds no tenant, so it does
+not yet query KB recall with this tenant_id. Wiring the runner to recall under
+``SIMLAB_TENANT_ID`` is the documented next step (#1816 follow-up), one line at
+the call site. This script only closes the ingestion half.
+
+Usage — ALWAYS dev for local testing; NEVER prd from a code shell:
+  doppler run --project factorylm --config dev -- \
+    .venv/bin/python tools/seeds/seed-simlab-docs.py --dry-run
+  doppler run --project factorylm --config dev -- \
+    .venv/bin/python tools/seeds/seed-simlab-docs.py --commit
+  doppler run --project factorylm --config dev -- \
+    .venv/bin/python tools/seeds/seed-simlab-docs.py --verify
+
+Idempotency
+-----------
+Every chunk carries a stable ``source_url`` + ``metadata.chunk_index``; the
+INSERT uses ``ON CONFLICT`` against the partial unique index
+``idx_ke_chunk_dedup`` ``(tenant_id, source_url, (metadata->>'chunk_index')::int)
+WHERE metadata->>'chunk_index' IS NOT NULL`` → re-running is a no-op. Chunking is
+deterministic, so chunk_index is stable on unchanged input. ``DO NOTHING`` means
+a re-seed will NOT pick up *edits* to a doc (no duplicates, but no content
+re-sync either) — bump the doc or clear the tenant to re-ingest changed text.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import sys
+from pathlib import Path
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_ROOT = REPO_ROOT / "simlab" / "docs"
+
+# Make the top-level ``simlab`` package importable so we reuse the canonical
+# UNS path builder + asset model instead of re-deriving either.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from simlab.lines.juice_bottling import build_line  # noqa: E402
+from simlab.uns import LINE, SITE, asset_path  # noqa: E402
+
+# Fixed, well-known tenant for the SimLab Florida-Natural juice-bottling demo.
+# (Same pattern as the other demo seeds — a reserved 0-prefixed UUID so it can
+# be applied to dev or prod without colliding with a real customer.)
+SIMLAB_TENANT_ID = "00000000-0000-0000-0000-000000515ab1"
+
+# filename stem (under simlab/docs/<asset>/) -> source_type label. Mirrors the
+# existing source_type convention in sibling seeds (e.g. 'fault_code_table').
+DOC_SOURCE_TYPE: dict[str, str] = {
+    "operator_quick_guide": "operator_guide",
+    "troubleshooting": "troubleshooting_guide",
+    "fault_code_table": "fault_code_table",
+    "pm_checklist": "pm_checklist",
+    "plc_tag_description_sheet": "plc_tag_sheet",
+    "spare_parts_notes": "spare_parts",
+    "electrical_io_notes": "electrical_io",
+}
+
+MAX_CHUNK_CHARS = 1800  # soft cap; oversize H2 sections split on blank lines
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("simlab-seed")
+
+
+def get_database_url() -> str:
+    url = os.getenv("NEON_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not url:
+        log.error(
+            "DATABASE_URL/NEON_DATABASE_URL not set. Run under doppler: "
+            "`doppler run --project factorylm --config dev -- ...`"
+        )
+        sys.exit(2)
+    return url
+
+
+_H1_RE = re.compile(r"^#\s+(.*)$", re.MULTILINE)
+_H2_SPLIT_RE = re.compile(r"^(##\s+.*)$", re.MULTILINE)
+_H2_TITLE_RE = re.compile(r"^##\s+(.*)$")
+
+
+def _soft_split(body: str, limit: int) -> list[str]:
+    """Split an oversize section into <=limit-ish pieces on blank lines."""
+    if len(body) <= limit:
+        return [body]
+    pieces: list[str] = []
+    cur: list[str] = []
+    cur_len = 0
+    for para in body.split("\n\n"):
+        plen = len(para) + 2
+        if cur and cur_len + plen > limit:
+            pieces.append("\n\n".join(cur))
+            cur, cur_len = [], 0
+        cur.append(para)
+        cur_len += plen
+    if cur:
+        pieces.append("\n\n".join(cur))
+    return pieces
+
+
+def chunk_markdown(text: str) -> list[tuple[str, str]]:
+    """Chunk a markdown doc into (section_label, chunk_text) pairs.
+
+    Splits on level-2 (``##``) headings; the H1 doc title is prepended to every
+    chunk so each is self-describing for BM25 + citation. Oversize sections are
+    soft-split on blank lines. Deterministic for a fixed input.
+    """
+    m = _H1_RE.search(text)
+    title = m.group(1).strip() if m else ""
+    title_prefix = f"# {title}\n\n" if title else ""
+
+    parts = _H2_SPLIT_RE.split(text)
+    # parts[0] = preamble (intro before first ##); then alternating header, body.
+    chunks: list[tuple[str, str]] = []
+
+    def _emit(label: str, raw: str) -> None:
+        raw = raw.strip()
+        if not raw:
+            return
+        for piece in _soft_split(raw, MAX_CHUNK_CHARS):
+            chunks.append((label, f"{title_prefix}{piece}".strip()))
+
+    preamble = parts[0]
+    # Drop the bare H1 line from the preamble — it is re-added via title_prefix.
+    if m:
+        preamble = preamble.replace(m.group(0), "", 1)
+    _emit("intro", preamble)
+
+    for i in range(1, len(parts), 2):
+        header = parts[i]
+        body = parts[i + 1] if i + 1 < len(parts) else ""
+        hm = _H2_TITLE_RE.match(header.strip())
+        label = hm.group(1).strip() if hm else "section"
+        _emit(label, f"{header}\n{body}")
+
+    return chunks
+
+
+def collect_rows() -> list[dict]:
+    """Read every fixture, build one row dict per chunk. Pure (no DB)."""
+    line = build_line()
+    assets = {a.asset_id: a for a in line.all_assets()}
+
+    rows: list[dict] = []
+    missing_dirs: list[str] = []
+    for asset_id, asset in assets.items():
+        asset_dir = DOCS_ROOT / asset_id
+        if not asset_dir.is_dir():
+            missing_dirs.append(asset_id)
+            continue
+        uns_path = asset_path(asset_id)
+        for md in sorted(asset_dir.glob("*.md")):
+            stem = md.stem
+            source_type = DOC_SOURCE_TYPE.get(stem, stem)
+            doc_text = md.read_text(encoding="utf-8")
+            chunks = chunk_markdown(doc_text)
+            # Stable, simulator-provenance URL ending in the filename so the
+            # citation surface (and the SimLab rubric, which string-matches doc
+            # filenames) sees it.
+            source_url = f"simlab://{SITE}/{LINE}/{asset_id}/{md.name}"
+            for idx, (section, content) in enumerate(chunks):
+                rows.append(
+                    {
+                        "tenant_id": SIMLAB_TENANT_ID,
+                        "source_type": source_type,
+                        "equipment_type": asset.asset_type,
+                        "content": content,
+                        "source_url": source_url,
+                        "source_page": idx,
+                        "source_ref": f"{asset.display_name} — {stem.replace('_', ' ')}",
+                        "isa95_path": uns_path,
+                        "equipment_id": asset_id,
+                        "chunk_type": source_type,
+                        "metadata": {
+                            "source_system": "simulator",
+                            "simulated": True,
+                            "simlab": True,
+                            "site_id": SITE,
+                            "line_id": LINE,
+                            "asset_id": asset_id,
+                            "asset_type": asset.asset_type,
+                            "asset_display_name": asset.display_name,
+                            "doc_type": source_type,
+                            "doc_title": stem,
+                            "source_file": md.name,
+                            "uns_path": uns_path,
+                            "section": section,
+                            "chunk_index": idx,
+                            "chunk_count": len(chunks),
+                        },
+                    }
+                )
+        log.info(
+            "  %-16s %2d chunks across %d docs",
+            asset_id,
+            sum(1 for r in rows if r["equipment_id"] == asset_id),
+            len(list(asset_dir.glob("*.md"))),
+        )
+    if missing_dirs:
+        log.warning("No docs dir for assets: %s", ", ".join(missing_dirs))
+    return rows
+
+
+_INSERT_SQL = """
+INSERT INTO knowledge_entries (
+    tenant_id, source_type, equipment_type, content,
+    source_url, source_page, source_ref, isa95_path, equipment_id,
+    chunk_type, data_type, input_type, is_private, verified, metadata
+) VALUES (
+    %(tenant_id)s, %(source_type)s, %(equipment_type)s, %(content)s,
+    %(source_url)s, %(source_page)s, %(source_ref)s, %(isa95_path)s, %(equipment_id)s,
+    %(chunk_type)s, 'manual', 'text', true, true, %(metadata)s
+)
+ON CONFLICT (tenant_id, source_url, ((metadata->>'chunk_index')::int))
+    WHERE (metadata->>'chunk_index') IS NOT NULL
+DO NOTHING
+"""
+
+
+_ENSURE_TENANT_SQL = """
+INSERT INTO tenants (id, name, contact_email, subscription_tier, subscription_status)
+VALUES (%s, %s, %s, 'internal', 'active')
+ON CONFLICT (id) DO NOTHING
+"""
+
+
+def ensure_tenant(cur) -> None:
+    """knowledge_entries.tenant_id FKs to tenants(id) — the SimLab demo tenant
+    must exist first. Idempotent."""
+    cur.execute(
+        _ENSURE_TENANT_SQL,
+        (
+            SIMLAB_TENANT_ID,
+            "SimLab — Florida Natural Juice Bottling Demo",
+            "simlab@factorylm.local",
+        ),
+    )
+
+
+def _count(cur) -> int:
+    cur.execute(
+        "SELECT count(*) FROM knowledge_entries WHERE tenant_id = %s "
+        "AND metadata->>'source_system' = 'simulator'",
+        (SIMLAB_TENANT_ID,),
+    )
+    return cur.fetchone()[0]
+
+
+def run_seed(commit: bool) -> None:
+    rows = collect_rows()
+    log.info("Built %d chunk rows from %s", len(rows), DOCS_ROOT)
+    params = [{**r, "metadata": Jsonb(r["metadata"])} for r in rows]
+
+    with psycopg.connect(get_database_url(), autocommit=False) as conn:
+        with conn.cursor() as cur:
+            ensure_tenant(cur)
+            before = _count(cur)
+            cur.executemany(_INSERT_SQL, params)
+            after = _count(cur)
+            inserted = after - before
+            log.info(
+                "rows before=%d  after=%d  inserted=%d  skipped(existing)=%d",
+                before,
+                after,
+                inserted,
+                len(rows) - inserted,
+            )
+        if commit:
+            conn.commit()
+            log.info("✔ Committed %d new chunk(s) under tenant %s.", inserted, SIMLAB_TENANT_ID)
+        else:
+            conn.rollback()
+            log.info("✔ Validated (dry-run, rolled back). Would insert %d new chunk(s).", inserted)
+
+
+# Canned retrievability probes. Each: (free-text query, expected asset).
+#
+# These prove the seed is *citable* via the same OR-fanout BM25 semantics the
+# engine uses (mira-bots/shared/neon_recall.py::_recall_bm25) — not just present.
+# The PASS bar is "expected asset is in the top-K candidate set", NOT "ranks #1":
+# _recall_bm25 is tenant-WIDE (no isa95_path/asset scoping), so for a generic
+# question the densest-vocabulary sibling can outrank the target (filler & rinser
+# both say "nozzle/pressure"; depalletizer & casepacker both "jam/pick"). At
+# runtime the engine disambiguates via the SimLab direct-connection asset_id +
+# RRF fusion over vector/BM25/like — wiring that asset scope into the runner is
+# the #1816 follow-up, not this ingestion PR. Top-K membership is the right,
+# honest bar here: the doc IS in the set the engine cites from.
+_PROBE_TOPK = 5
+_PROBES: list[tuple[str, str]] = [
+    ("filler underfill low bowl pressure nozzle clogged", "filler01"),
+    ("capper missing cap low torque application", "capper01"),
+    ("rinser bottle spray water rinse nozzle pressure", "rinser01"),
+    ("depalletizer layer pick vacuum cup jam", "depalletizer01"),
+    ("CIP skid caustic concentration wash cycle temperature", "cipskid01"),
+    ("labeler label placement glue applicator", "labeler01"),
+    ("palletizer pallet layer pattern infeed", "palletizer01"),
+]
+
+
+def _bm25(cur, query_text: str, limit: int = 5) -> list[tuple[str, str, float]]:
+    """Replicate _recall_bm25's OR-fanout query (tenant-scoped) — thin, no engine
+    import. tokens -> 't1 | t2 | ...' -> to_tsquery('english', ...)."""
+    tokens = re.findall(r"\w+", query_text)
+    tsq = " | ".join(tokens)
+    cur.execute(
+        "SELECT source_url, metadata->>'asset_id' AS asset, "
+        "       ts_rank_cd(content_tsv, to_tsquery('english', %s)) AS sim "
+        "FROM knowledge_entries "
+        "WHERE tenant_id = %s "
+        "  AND content_tsv @@ to_tsquery('english', %s) "
+        "ORDER BY sim DESC LIMIT %s",
+        (tsq, SIMLAB_TENANT_ID, tsq, limit),
+    )
+    return [(r[0], r[1], float(r[2])) for r in cur.fetchall()]
+
+
+def verify() -> int:
+    """Read-only: row counts + a real BM25 retrievability proof per probe."""
+    failures = 0
+    with psycopg.connect(get_database_url(), autocommit=True) as conn, conn.cursor() as cur:
+        total = _count(cur)
+        log.info("knowledge_entries simulator rows for tenant %s: %d", SIMLAB_TENANT_ID, total)
+        if total == 0:
+            log.error("✗ No SimLab rows present — run --commit first.")
+            return 1
+
+        # Completeness: every source .md file on disk must have produced >=1 row.
+        # The per-asset chunk log counts globbed files, not files-that-yielded-
+        # rows, so a silently-empty fixture would otherwise go unnoticed.
+        disk_files = sorted(p for p in DOCS_ROOT.glob("*/*.md"))
+        cur.execute(
+            "SELECT count(DISTINCT source_url) FROM knowledge_entries WHERE tenant_id = %s",
+            (SIMLAB_TENANT_ID,),
+        )
+        distinct_urls = cur.fetchone()[0]
+        complete = distinct_urls == len(disk_files)
+        log.info(
+            "  %s completeness: %d distinct source_url rows vs %d .md files on disk",
+            "✔" if complete else "✗",
+            distinct_urls,
+            len(disk_files),
+        )
+        if not complete:
+            failures += 1
+
+        cur.execute(
+            "SELECT metadata->>'asset_id' AS asset, count(*) "
+            "FROM knowledge_entries WHERE tenant_id = %s "
+            "AND metadata->>'source_system' = 'simulator' "
+            "GROUP BY 1 ORDER BY 1",
+            (SIMLAB_TENANT_ID,),
+        )
+        for asset, n in cur.fetchall():
+            log.info("  %-16s %3d chunks", asset, n)
+
+        log.info("BM25 retrievability probes (engine-path semantics, top-%d):", _PROBE_TOPK)
+        for query, expected in _PROBES:
+            hits = _bm25(cur, query, limit=_PROBE_TOPK)
+            assets = [h[1] for h in hits]
+            in_topk = expected in assets
+            failures += 0 if in_topk else 1
+            mark = "✔" if in_topk else "✗"
+            rank = assets.index(expected) + 1 if in_topk else None
+            log.info(
+                "  %s '%s' -> %s in top-%d (rank %s, top1=%s) [%d hits]",
+                mark,
+                query,
+                expected,
+                _PROBE_TOPK,
+                rank,
+                assets[0] if assets else None,
+                len(hits),
+            )
+    if failures:
+        log.error(
+            "✗ %d/%d probes did not surface the expected asset in top-%d — docs may not be citable.",
+            failures,
+            len(_PROBES),
+            _PROBE_TOPK,
+        )
+        return 1
+    log.info(
+        "✔ All %d retrievability probes surfaced the expected asset — docs are citable.",
+        len(_PROBES),
+    )
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--dry-run", action="store_true", help="Apply in a transaction, then rollback.")
+    g.add_argument("--commit", action="store_true", help="Apply and commit.")
+    g.add_argument(
+        "--verify", action="store_true", help="Read-only: counts + BM25 retrievability proof."
+    )
+    args = ap.parse_args()
+
+    if not DOCS_ROOT.is_dir():
+        log.error(
+            "SimLab docs dir missing: %s (run on a branch with PR #1816's simlab/docs/)", DOCS_ROOT
+        )
+        return 2
+
+    if args.verify:
+        return verify()
+    run_seed(commit=args.commit)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Ingests the **77 synthetic juice-bottling maintenance fixtures** (7 doc types × 11 assets) from `simlab/docs/` into `knowledge_entries`, so the diagnostic engine can **cite** them during SimLab scenarios. Closes #1835.

Stacked on #1816 (`feat/simlab-juice-bottling`), which carries `simlab/docs/`. Diff here is just the seed + workflow wiring + README.

## Files

| File | What |
|---|---|
| `tools/seeds/seed-simlab-docs.py` | Reads + section-chunks each markdown doc (**242 chunks**), inserts UNS-tagged rows. `--dry-run` / `--commit` / `--verify`. |
| `.github/workflows/apply-seeds.yml` | New `simlab-docs` choice → dedicated Python apply step. |
| `tools/seeds/README.md` | Seed entry + idempotency / retrievability / runtime-scope notes. |

## Key decisions (grounded in live dev schema, not stale headers)

- **`tenant_id` is UUID**, FK → `tenants.id` (the seed inserts an idempotent `tenants` row first). The `-- Tenant: TEXT` headers in sibling `.sql` seeds and the apply-seeds.yml comment are **stale** — verified against dev Neon.
- **`source_system="simulator"` / `simulated=true`** go in `metadata` JSONB — `knowledge_entries` has no dedicated columns.
- **UNS path → `isa95_path`**, built by `simlab.uns.asset_path()` (reused, never hand-formatted — `.claude/rules/uns-compliance.md`). Canonical lowercase ltree, e.g. `enterprise.florida_natural_demo.plant1.juice_bottling.line01.filler01`.
- **Chunked for BM25**: split on `##` sections, H1 title prepended for context, oversize sections soft-split ~1800 chars → `content_tsv` (generated) drives retrieval.
- **Idempotent**: `ON CONFLICT` on the partial unique index `idx_ke_chunk_dedup (tenant_id, source_url, (metadata->>'chunk_index')::int)`. Re-run inserts 0.

## Verification (factorylm/dev — never prod from a code shell)

```
rows before=0  after=242  inserted=242
rows before=242 after=242 inserted=0   ← idempotent re-run
✔ All 7 retrievability probes surfaced the expected asset — docs are citable.
```

`--verify` does **not** just count rows — it replays the engine's OR-fanout BM25 query (`mira-bots/shared/neon_recall.py::_recall_bm25`) and asserts the expected asset is in the **top-K candidate set**. It deliberately does *not* assert rank-#1: `_recall_bm25` is tenant-wide (no asset scoping), so vocabulary-sharing siblings (filler/rinser both "nozzle/pressure") can outrank the target on a generic query. Top-K membership is the honest bar for "is this doc citable."

## Scope honesty

Ingestion alone does **not** make scenarios cite at *runtime*. `tests/simlab/runner.py` binds no tenant today, so it doesn't yet recall under this tenant. Wiring it to query KB recall with `SIMLAB_TENANT_ID` (a named constant, one line at the call site) is the documented #1816 follow-up — out of scope here. Closing #1835 = ingestion done.

## Notes

- The Python apply step **no-ops with a warning** until `simlab/` is on the checked-out ref (i.e. after #1816 merges) — `apply-seeds.yml` runs against the default branch on dispatch.
- Two pre-existing `SC2129` actionlint *style* warnings in untouched `apply-seeds.yml` steps are left as-is (not a regression; surgical-change discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)