### PR TITLE
feat(ignition): Phase 6 — reject asset-specific turns with no UNS identifier (422 uns_required)

### DIFF
--- a/mira-pipeline/ignition_chat.py
+++ b/mira-pipeline/ignition_chat.py
@@ -23,6 +23,7 @@ from collections import OrderedDict
 from typing import Any, Callable, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi.responses import JSONResponse
 from ignition_audit import query_audit_rows, write_audit_row
 from pydantic import BaseModel
 
@@ -63,6 +64,45 @@ except Exception:  # pragma: no cover - shared not importable in this context
         "This asset hasn't been validated for MIRA yet. An admin needs to "
         "approve it in the Command Center before it can answer here."
     )
+
+
+# ── Direct-connection reject-on-missing-UNS contract (Phase 6) ───────────────
+# A direct-connection surface (this Ignition endpoint) that receives a turn with
+# NO UNS identifier must REJECT it (422 uns_required), NOT downgrade to a chat-
+# gate — see .claude/rules/direct-connection-uns-certified.md. The rule carves
+# out general/educational questions ("what is a VFD?"), which need no gate on any
+# surface; only asset-specific troubleshooting is rejected. We tell them apart
+# with the engine's own intent classifier so the endpoint and the engine's UNS
+# gate never disagree.
+#
+# `_ASSET_SPECIFIC_INTENTS` mirrors `engine._GATED_INTENTS` (the intents the UNS
+# gate fires on). Kept as a small local literal so importing this module never
+# drags in the full engine; the values are stable. If engine._GATED_INTENTS
+# changes, update this set too.
+_ASSET_SPECIFIC_INTENTS = frozenset({"diagnose_equipment", "schedule_maintenance"})
+
+try:
+    from shared.conversation_router import route_intent as _route_intent
+except Exception:  # pragma: no cover - shared not importable in this context
+    _route_intent = None  # type: ignore[assignment]
+
+
+async def _is_asset_specific(question: str) -> bool:
+    """True when ``question`` is asset-specific troubleshooting (so a turn with
+    no UNS identifier must be rejected). Uses the engine's own intent classifier.
+
+    Fails OPEN — returns False (→ treat as a general chat turn, do NOT reject) —
+    when the classifier is unavailable or errors, so a Neon/LLM blip can never
+    brick a working HMI.
+    """
+    if _route_intent is None:
+        return False
+    try:
+        result = await _route_intent(question, [])
+        return result.get("intent") in _ASSET_SPECIFIC_INTENTS
+    except Exception:
+        logger.warning("IGNITION_CHAT uns_required_classify_failed — failing open to plain chat")
+        return False
 
 
 # ── Nonce replay store (in-process LRU) ──────────────────────────────────────
@@ -293,8 +333,8 @@ def build_router(get_engine: Callable[[], Any]) -> APIRouter:
     """Build the APIRouter. Caller injects a getter for the live Supervisor instance."""
     router = APIRouter()
 
-    @router.post("/api/v1/ignition/chat")
-    async def ignition_chat(request: Request) -> dict[str, Any]:
+    @router.post("/api/v1/ignition/chat", response_model=None)
+    async def ignition_chat(request: Request) -> dict[str, Any] | JSONResponse:
         if not MIRA_IGNITION_HMAC_KEY:
             logger.error("IGNITION_CHAT MIRA_IGNITION_HMAC_KEY not configured")
             raise HTTPException(503, "Ignition HMAC key not configured")
@@ -330,15 +370,28 @@ def build_router(get_engine: Callable[[], Any]) -> APIRouter:
 
         tag_reads = sorted((req.tag_snapshot or {}).keys())
 
-        # Direct-connection provenance: an Ignition turn arriving with an asset
-        # identifier is UNS-certified by construction — the WebDev/Perspective
-        # surface already knows which machine the technician is on. Mark the
-        # turn so the engine stamps state["uns_context"]["source"] and the
-        # decision trace records it. A turn WITHOUT an asset id is treated as a
-        # plain chat turn here (the reject-on-missing-identifier contract is the
-        # broader Phase-6 gate-bypass work — see
-        # .claude/rules/direct-connection-uns-certified.md).
-        uns_source = "direct_connection" if (asset_id or req.asset_context) else None
+        # Direct-connection provenance + reject-on-missing-identifier contract
+        # (Phase 6; .claude/rules/direct-connection-uns-certified.md).
+        #   - WITH an asset identifier → UNS-certified by construction: mark the
+        #     turn direct_connection so the engine stamps
+        #     state["uns_context"]["source"] and skips the chat-gate.
+        #   - WITHOUT an identifier → the rule forbids downgrading to a chat-gate.
+        #     If the turn is asset-specific troubleshooting, REJECT it
+        #     (422 uns_required). General/educational questions need no gate on
+        #     any surface, so they pass through as a plain chat turn. The
+        #     classifier fails open (treated as general) so a blip never bricks
+        #     the HMI.
+        if asset_id or req.asset_context:
+            uns_source = "direct_connection"
+        else:
+            uns_source = None
+            if await _is_asset_specific(question):
+                logger.info(
+                    "IGNITION_CHAT uns_required tenant=%s — asset-specific turn with no "
+                    "UNS identifier; rejecting (not downgrading to chat-gate)",
+                    tenant_id,
+                )
+                return JSONResponse(status_code=422, content={"error": "uns_required"})
 
         # Structured tag evidence for the decision trace (Phase 9). The Ignition
         # turn already carries the live snapshot; surface it as evidence rows so

--- a/mira-pipeline/tests/test_ignition_chat_direct_connection.py
+++ b/mira-pipeline/tests/test_ignition_chat_direct_connection.py
@@ -3,8 +3,15 @@
 An Ignition turn arriving with an asset identifier is UNS-certified by
 construction, so ignition_chat must pass ``uns_source="direct_connection"`` to
 ``engine.process`` (the engine then stamps state["uns_context"]["source"], which
-the decision trace records). A turn with no asset id stays a plain chat turn
-(uns_source=None). See .claude/rules/direct-connection-uns-certified.md.
+the decision trace records).
+
+Phase 6 reject-on-missing-identifier contract: a turn with NO asset identifier
+is REJECTED (422 ``{"error":"uns_required"}``) when it's asset-specific
+troubleshooting — the connection is the gate; a direct surface must not downgrade
+to a chat-gate. General/educational questions carry no asset and are answered as
+a plain chat turn (uns_source=None). The intent classifier fails open (→ plain
+chat) so a blip never bricks the HMI. See
+.claude/rules/direct-connection-uns-certified.md.
 
 The engine is a recording mock — we assert on the kwargs ignition_chat forwards,
 not on engine behaviour. HMAC is bypassed by monkeypatching the verifier so the
@@ -34,9 +41,7 @@ def recording_engine():
 def client(monkeypatch, recording_engine):
     # Bypass HMAC: pretend every request authenticates as tenant "t-1".
     monkeypatch.setattr(ignition_chat, "MIRA_IGNITION_HMAC_KEY", "test-key")
-    monkeypatch.setattr(
-        ignition_chat, "_verify_hmac", lambda headers, body, key: "t-1"
-    )
+    monkeypatch.setattr(ignition_chat, "_verify_hmac", lambda headers, body, key: "t-1")
     app = FastAPI()
     app.include_router(ignition_chat.build_router(lambda: recording_engine))
     return TestClient(app, raise_server_exceptions=False), recording_engine
@@ -65,18 +70,67 @@ def test_asset_context_marks_direct_connection(client):
         tc,
         {
             "query": "is the drive faulted?",
-            "asset_context": {"site": "lake_wales", "area": "conveyor_lab", "equipment": "gs10_vfd"},
+            "asset_context": {
+                "site": "lake_wales",
+                "area": "conveyor_lab",
+                "equipment": "gs10_vfd",
+            },
         },
     )
     assert resp.status_code == 200
     assert engine.process.await_args.kwargs.get("uns_source") == "direct_connection"
 
 
-def test_no_asset_id_is_plain_chat_turn(client):
+def test_no_asset_id_general_question_is_plain_chat(client, monkeypatch):
+    """A general/educational question with no asset id is NOT rejected — the
+    direct-connection rule carves out general questions on any surface."""
     tc, engine = client
+    # Classifier says this is not asset-specific troubleshooting.
+    monkeypatch.setattr(
+        ignition_chat,
+        "_route_intent",
+        AsyncMock(return_value={"intent": "find_documentation"}),
+    )
     resp = _post(tc, {"query": "what is a VFD?"})
     assert resp.status_code == 200
-    # No asset identifier → not a direct connection; chat gate territory.
+    engine.process.assert_awaited_once()
+    assert engine.process.await_args.kwargs.get("uns_source") is None
+
+
+def test_no_asset_id_asset_specific_is_rejected_422(client, monkeypatch):
+    """An asset-specific troubleshooting turn with NO UNS identifier is REJECTED
+    (422 uns_required) — NOT downgraded to a chat-gate. The connection is the
+    gate; a direct surface that can't say which machine must reject."""
+    tc, engine = client
+    monkeypatch.setattr(
+        ignition_chat,
+        "_route_intent",
+        AsyncMock(return_value={"intent": "diagnose_equipment"}),
+    )
+    resp = _post(tc, {"query": "why did the conveyor stop?"})
+    assert resp.status_code == 422
+    assert resp.json() == {"error": "uns_required"}
+    engine.process.assert_not_awaited()  # rejected before reaching the engine
+
+
+def test_no_asset_id_classifier_failure_fails_open(client, monkeypatch):
+    """If the intent classifier errors, fail OPEN to a plain chat turn (200) —
+    a Neon/LLM blip must never brick the HMI by rejecting good turns."""
+    tc, engine = client
+    monkeypatch.setattr(
+        ignition_chat, "_route_intent", AsyncMock(side_effect=RuntimeError("router down"))
+    )
+    resp = _post(tc, {"query": "why did the conveyor stop?"})
+    assert resp.status_code == 200
+    assert engine.process.await_args.kwargs.get("uns_source") is None
+
+
+def test_no_asset_id_classifier_unavailable_fails_open(client, monkeypatch):
+    """If shared/ isn't mounted (_route_intent is None), fail open to plain chat."""
+    tc, engine = client
+    monkeypatch.setattr(ignition_chat, "_route_intent", None)
+    resp = _post(tc, {"query": "why did the conveyor stop?"})
+    assert resp.status_code == 200
     assert engine.process.await_args.kwargs.get("uns_source") is None
 
 


### PR DESCRIPTION
Master-plan **Phase 6**, the *reject-on-missing-identifier* half of the direct-connection UNS contract. Unblocks the deferred #1659 troubleshooting-session lifecycle (which needs the gate's open/gate-pass signal).

## What was already done (verified, not rebuilt)
The Ignition cloud-chat endpoint already marks turns carrying an asset identifier as `direct_connection`, passes it to `engine.process`, and the engine already **skips the chat-gate** on `source=="direct_connection"` (engine.py `_should_fire_uns_gate`). The engine comment flags the remaining piece as "still P6".

## The gap this closes
A turn with **no** asset identifier was silently **downgraded to a chat-gate** (`uns_source=None`) — which `.claude/rules/direct-connection-uns-certified.md` explicitly forbids: *"REJECT, do not downgrade — the connection is the gate."*

## The fix (intent-gated reject)
A turn with no `asset_id`/`asset_context` is now **rejected `422 {"error":"uns_required"}`** — **but only when it's asset-specific troubleshooting**. The rule carves out general/educational questions ("what is a VFD?"), which need no gate on any surface; those still answer as a plain chat turn. The two are told apart by the **engine's own intent classifier** (`shared.conversation_router.route_intent` + the `_GATED_INTENTS` set) so the endpoint and the engine's UNS gate never disagree.

**Fail-open by design:** if the classifier is unavailable (`shared/` not mounted) or errors, the turn is treated as plain chat (200) — a Neon/LLM blip can never brick a working HMI.

### Why intent-gating, not a blunt reject
The plan's one-line acceptance ("no asset_context → 422") conflicts with the rule's own educational carve-out *and* the shipped `test_no_asset_id_is_plain_chat_turn` (`"what is a VFD?"` → 200). Intent-gating satisfies all three: rejects asset-specific no-id turns, preserves educational passthrough.

## Deferred (still Phase 6 — noted for follow-up)
- The site→area→line→machine **hierarchy resolver** in `uns_resolver.py`.
- **Reject-on-unresolvable** (vs. just missing).
Both depend on the `asset_context → uns_path` resolver that is **non-functional today** (`ignition_chat.py` note ~L214). The confirmation-card hierarchy UX rides on the resolver too.

## Tests (evidence)
`test_ignition_chat_direct_connection.py` — **8 passed**: general-question passthrough (200/None), **asset-specific → 422** (engine `assert_not_awaited`), and two fail-open cases (classifier raises / `_route_intent` None). Existing direct-connection + tag-evidence cases unchanged.

**Pre-existing, NOT mine:** `test_ignition_chat_gate.py` shows 7 failures only in the *combined* dir run (cross-file pollution from the separate asset-agent gate, PR #1783) — present at the zero-diff baseline; passes 12/12 in isolation. Untouched here.

## Safety / groundedness
Engine-adjacent but **changes no engine gate logic** — only the adapter's reject-vs-downgrade decision. Hallucination-audit risk-grep on the diff is clean. No golden-suite impact.

Built in an isolated worktree off `origin/main` (rebased clean). Hands off to `ship` for deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)