### PR TITLE
chore(tests): remove unused imports flagged by ruff

### DIFF
--- a/tests/test_guardrails_properties.py
+++ b/tests/test_guardrails_properties.py
@@ -11,12 +11,11 @@ Uses hypothesis to discover edge cases in:
 
 from __future__ import annotations
 
-import re
 import sys
 
 sys.path.insert(0, "mira-bots")
 
-from hypothesis import given, settings, strategies as st
+from hypothesis import given, strategies as st
 
 from shared.guardrails import (
     SAFETY_KEYWORDS,

--- a/tests/test_safety_coverage.py
+++ b/tests/test_safety_coverage.py
@@ -13,7 +13,7 @@ sys.path.insert(0, "mira-bots")
 
 import pytest
 
-from shared.guardrails import SAFETY_KEYWORDS, classify_intent, strip_mentions, _EDUCATIONAL_QUESTION_RE
+from shared.guardrails import SAFETY_KEYWORDS, classify_intent
 
 # ── Every keyword in SAFETY_KEYWORDS must fire ────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Remove unused `import re` and `settings` from `tests/test_guardrails_properties.py`
- Remove unused `strip_mentions` and `_EDUCATIONAL_QUESTION_RE` from `tests/test_safety_coverage.py`

Pre-existing ruff `F401` violations surfaced by the daily adversarial review stop hook. No logic changed.

## Test plan

- [ ] `ruff check tests/test_guardrails_properties.py tests/test_safety_coverage.py` → All checks passed

https://claude.ai/code/session_013rxhj151UsRznVzKKBiHEe

---
_Generated by [Claude Code](https://claude.ai/code/session_013rxhj151UsRznVzKKBiHEe)_