### PR TITLE
fix(hub): sync package-lock.json with graphology deps — unblock Smoke/deploy gate

### DIFF
--- a/mira-hub/package-lock.json
+++ b/mira-hub/package-lock.json
@@ -35,6 +35,10 @@
         "clsx": "^2.1.1",
         "dexie": "^4.0.11",
         "fft-js": "^0.0.12",
+        "graphology": "^0.26.0",
+        "graphology-communities-louvain": "^2.0.2",
+        "graphology-metrics": "^2.4.0",
+        "graphology-types": "^0.24.8",
         "jose": "^5.10.0",
         "libsodium-wrappers": "^0.7.15",
         "lucide-react": "^1.8.0",
@@ -6164,6 +6168,12 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/@yomguithereal/helpers": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@yomguithereal/helpers/-/helpers-1.1.1.tgz",
+      "integrity": "sha512-UYvAq/XCA7xoh1juWDYsq3W0WywOB+pz8cgVnE1b45ZfdMhBvHDrgmSFG3jXeZSr2tMTYLGHFHON+ekG05Jebg==",
+      "license": "MIT"
+    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -9279,6 +9289,92 @@
       "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
       "license": "MIT"
     },
+    "node_modules/graphology": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/graphology/-/graphology-0.26.0.tgz",
+      "integrity": "sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==",
+      "license": "MIT",
+      "dependencies": {
+        "events": "^3.3.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.24.0"
+      }
+    },
+    "node_modules/graphology-communities-louvain": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/graphology-communities-louvain/-/graphology-communities-louvain-2.0.2.tgz",
+      "integrity": "sha512-zt+2hHVPYxjEquyecxWXoUoIuN/UvYzsvI7boDdMNz0rRvpESQ7+e+Ejv6wK7AThycbZXuQ6DkG8NPMCq6XwoA==",
+      "license": "MIT",
+      "dependencies": {
+        "graphology-indices": "^0.17.0",
+        "graphology-utils": "^2.4.4",
+        "mnemonist": "^0.39.0",
+        "pandemonium": "^2.4.1"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.19.0"
+      }
+    },
+    "node_modules/graphology-indices": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/graphology-indices/-/graphology-indices-0.17.0.tgz",
+      "integrity": "sha512-A7RXuKQvdqSWOpn7ZVQo4S33O0vCfPBnUSf7FwE0zNCasqwZVUaCXePuWo5HBpWw68KJcwObZDHpFk6HKH6MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graphology-utils": "^2.4.2",
+        "mnemonist": "^0.39.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.20.0"
+      }
+    },
+    "node_modules/graphology-metrics": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/graphology-metrics/-/graphology-metrics-2.4.0.tgz",
+      "integrity": "sha512-7WOfOP+mFLCaTJx55Qg4eY+211vr1/b3D/R3biz3SXGhAaCVcWYkfabnmO4O4WBNWANEHtVnFrGgJ0kj6MM6xw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphology-indices": "^0.17.0",
+        "graphology-shortest-path": "^2.0.0",
+        "graphology-utils": "^2.4.4",
+        "mnemonist": "^0.39.0",
+        "pandemonium": "2.4.1"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.20.0"
+      }
+    },
+    "node_modules/graphology-shortest-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/graphology-shortest-path/-/graphology-shortest-path-2.1.0.tgz",
+      "integrity": "sha512-KbT9CTkP/u72vGEJzyRr24xFC7usI9Es3LMmCPHGwQ1KTsoZjxwA9lMKxfU0syvT/w+7fZUdB/Hu2wWYcJBm6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@yomguithereal/helpers": "^1.1.1",
+        "graphology-indices": "^0.17.0",
+        "graphology-utils": "^2.4.3",
+        "mnemonist": "^0.39.0"
+      },
+      "peerDependencies": {
+        "graphology-types": ">=0.20.0"
+      }
+    },
+    "node_modules/graphology-types": {
+      "version": "0.24.8",
+      "resolved": "https://registry.npmjs.org/graphology-types/-/graphology-types-0.24.8.tgz",
+      "integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
+      "license": "MIT"
+    },
+    "node_modules/graphology-utils": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/graphology-utils/-/graphology-utils-2.5.2.tgz",
+      "integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphology-types": ">=0.23.0"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -10764,6 +10860,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.39.8",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.39.8.tgz",
+      "integrity": "sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^2.0.1"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11321,6 +11426,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obliterator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+      "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+      "license": "MIT"
+    },
     "node_modules/oidc-token-hash": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
@@ -11449,6 +11560,15 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/pandemonium": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/pandemonium/-/pandemonium-2.4.1.tgz",
+      "integrity": "sha512-wRqjisUyiUfXowgm7MFH2rwJzKIr20rca5FsHXCMNm1W5YPP1hCtrZfgmQ62kP7OZ7Xt+cR858aB28lu5NX55g==",
+      "license": "MIT",
+      "dependencies": {
+        "mnemonist": "^0.39.2"
+      }
     },
     "node_modules/papaparse": {
       "version": "5.5.3",


### PR DESCRIPTION
## Root cause

`mira-hub/package.json` declares the graphology / force-graph deps added for the KG `/knowledge/map` work:

```
"graphology": "^0.26.0",
"graphology-communities-louvain": "^2.0.2",
"graphology-metrics": "^2.4.0",
"graphology-types": "^0.24.8",
"react-force-graph-2d": "^1.29.1",
```

…but `mira-hub/package-lock.json` was **never regenerated** when they were added — it contained **zero** graphology entries. `npm ci` refuses to install when the lock is out of sync with `package.json`, so the **`Install mira-hub npm deps`** step in `smoke-test.yml` failed on **every PR and on `main`**:

```
npm error code EUSAGE
npm error `npm ci` can only install packages when your package.json and
package-lock.json ... are in sync.
npm error Missing: graphology@0.26.0 from lock file
npm error Missing: graphology-types@0.24.8 ... (+ the rest of the graphology family,
          mnemonist, pandemonium, @yomguithereal/helpers, obliterator)
```

### Why it matters
`Smoke Test` → gates `deploy-vps.yml` (`workflow_run` on "Smoke Test" completed). While Smoke is red, **`Deploy to VPS` is `skipped`** — i.e. the entire VPS deploy pipeline was blocked. The failure is lock drift, not a code regression, which is why it showed up as the "known E2E npm ci failure" on unrelated PRs.

## Fix

Regenerated the lock in sync with `package.json`:

```
cd mira-hub && npm install --package-lock-only --ignore-scripts
```

- **Lock-file-only diff** (no `package.json` change, no source change).
- `lockfileVersion` stays **3** (no format churn; CI uses Node 20 which reads v3).
- graphology + transitive deps (via `react-force-graph-2d`) now present in the lock.

## Verification

```
$ npm ci --ignore-scripts --dry-run
added 875 packages in 485ms
exit code: 0           # no EUSAGE, lock now in sync
```

This is the follow-up flagged in the beta-readiness merge session (4/6 PRs merged; #1837 + #1841 were left blocked for separate reasons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)