### PR TITLE
feat(simlab): bind scenario runner to SIMLAB_TENANT_ID so recall cites the seeded docs (#1835 follow-up)

### DIFF
--- a/simlab/__init__.py
+++ b/simlab/__init__.py
@@ -35,6 +35,14 @@ customer PLC code and no confidential plant data is used. Every reading carries
 
 from __future__ import annotations
 
-__all__ = ["__version__"]
+__all__ = ["SIMLAB_TENANT_ID", "__version__"]
 
 __version__ = "0.1.0"
+
+# Fixed, well-known tenant for the SimLab Florida-Natural juice-bottling demo.
+# A reserved 0-prefixed UUID so it can be seeded to dev or prod without colliding
+# with a real customer. Single source of truth: the doc-seed
+# (tools/seeds/seed-simlab-docs.py) ingests knowledge_entries under it, and the
+# scenario runner (tests/simlab/runner.py) binds the Supervisor to it so recall
+# actually surfaces those docs at scenario runtime. Both import from here.
+SIMLAB_TENANT_ID = "00000000-0000-0000-0000-000000515ab1"

--- a/tests/simlab/runner.py
+++ b/tests/simlab/runner.py
@@ -181,14 +181,23 @@ async def run_scenario(
 
 
 def _build_supervisor():
+    from simlab import SIMLAB_TENANT_ID
     from shared.engine import Supervisor
 
     db_path = os.getenv("SIMLAB_DB_PATH", "/tmp/mira_simlab.db")
+    # Bind the Supervisor to the SimLab demo tenant so KB recall surfaces the
+    # ingested juice-bottling docs (seeded under SIMLAB_TENANT_ID by
+    # tools/seeds/seed-simlab-docs.py). run_scenario calls process_full directly
+    # (it pre-seeds the direct_connection UNS context), so the per-call tenant is
+    # never set by process(); recall falls back to self.rag.tenant_id, which this
+    # constructor arg populates. Without it, scenarios recall under the empty
+    # tenant and can never cite the SimLab corpus. (#1816 follow-up to #1835.)
     return Supervisor(
         db_path=db_path,
         openwebui_url=os.getenv("OPENWEBUI_URL", "http://localhost:3000"),
         api_key=os.getenv("OPENWEBUI_API_KEY", ""),
         collection_id=os.getenv("OPENWEBUI_COLLECTION_ID", ""),
+        tenant_id=SIMLAB_TENANT_ID,
     )
 
 

--- a/tests/simlab/test_runner_tenant.py
+++ b/tests/simlab/test_runner_tenant.py
@@ -1,0 +1,44 @@
+"""#1835 follow-up — the SimLab scenario runner must bind the Supervisor to
+``SIMLAB_TENANT_ID`` so KB recall surfaces the ingested juice-bottling docs.
+
+``run_scenario`` calls ``process_full`` directly (it pre-seeds the
+``direct_connection`` UNS context), so the per-call tenant is never set by
+``process()``; recall falls back to ``self.rag.tenant_id``, which the Supervisor
+constructor arg populates. Without it, scenarios recall under the empty tenant
+and can never cite the SimLab corpus seeded by
+``tools/seeds/seed-simlab-docs.py``.
+
+This asserts the WIRING (the constructor ``tenant_id``). The end-to-end
+"scenarios cite the docs" payoff additionally needs a live dev Neon with the seed
+applied (``seed-simlab-docs.py --commit``) and is verified there — not offline.
+
+Run from the repo/worktree ROOT (cwd=mira-bots shadows stdlib ``email``):
+    python3.12 -m pytest tests/simlab/test_runner_tenant.py -q
+"""
+
+from __future__ import annotations
+
+import shared.engine
+
+from simlab import SIMLAB_TENANT_ID
+
+
+def test_build_supervisor_binds_simlab_tenant(monkeypatch):
+    captured: dict = {}
+
+    class _FakeSupervisor:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    # _build_supervisor does `from shared.engine import Supervisor` at call time,
+    # so patching the module attribute is enough.
+    monkeypatch.setattr(shared.engine, "Supervisor", _FakeSupervisor)
+
+    from tests.simlab import runner
+
+    runner._build_supervisor()
+
+    assert captured.get("tenant_id") == SIMLAB_TENANT_ID, (
+        "SimLab runner must construct the Supervisor with tenant_id="
+        "SIMLAB_TENANT_ID so recall surfaces the seeded juice-bottling docs"
+    )

--- a/tools/seeds/seed-simlab-docs.py
+++ b/tools/seeds/seed-simlab-docs.py
@@ -66,13 +66,13 @@ DOCS_ROOT = REPO_ROOT / "simlab" / "docs"
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from simlab import SIMLAB_TENANT_ID  # noqa: E402 — single source of truth
 from simlab.lines.juice_bottling import build_line  # noqa: E402
 from simlab.uns import LINE, SITE, asset_path  # noqa: E402
 
-# Fixed, well-known tenant for the SimLab Florida-Natural juice-bottling demo.
-# (Same pattern as the other demo seeds — a reserved 0-prefixed UUID so it can
-# be applied to dev or prod without colliding with a real customer.)
-SIMLAB_TENANT_ID = "00000000-0000-0000-0000-000000515ab1"
+# SIMLAB_TENANT_ID (the fixed Florida-Natural demo tenant) is defined once in
+# simlab/__init__.py and imported here so the seed and the scenario runner can
+# never drift to different tenants.
 
 # filename stem (under simlab/docs/<asset>/) -> source_type label. Mirrors the
 # existing source_type convention in sibling seeds (e.g. 'fault_code_table').


### PR DESCRIPTION
The documented follow-up to **#1835** (closed by PR #1842) / **#1816**. #1842 ingested the 77 SimLab juice-bottling docs (242 chunks) into `knowledge_entries` under `SIMLAB_TENANT_ID` — but the scenario runner never recalled under that tenant, so **the ingested corpus was never cited at scenario runtime**. #1842 explicitly flagged this as the next step ("one line at the call site").

## Root cause (verified against the engine's tenant flow)
`run_scenario` calls `supervisor.process_full(...)` **directly** (it pre-seeds the `direct_connection` UNS context to skip the gate). `process_full` resolves the recall tenant as `resolve_tenant(chat_id) or self.rag.tenant_id`:
- `resolve_tenant("simlab_…")` → `""` (no `chat_tenant_map` row),
- so it falls back to `self.rag.tenant_id` — which was **empty** because `_build_supervisor()` constructed the Supervisor with no `tenant_id`.

Result: scenarios recalled under the empty tenant and could never surface the SimLab corpus.

## Fix
- `tests/simlab/runner.py` — `_build_supervisor()` now passes `tenant_id=SIMLAB_TENANT_ID`. (Constructor → `self.tenant_id` → rag worker `self.rag.tenant_id`, engine.py:748; confirmed `_current_tenant_id` initializes from it at engine.py:754.)
- `simlab/__init__.py` — `SIMLAB_TENANT_ID` is now the **single source of truth**.
- `tools/seeds/seed-simlab-docs.py` — imports it (drops the duplicate UUID literal, so the seed and runner can never drift to different tenants).
- `tests/simlab/test_runner_tenant.py` — asserts the constructor binding.

## Verification
`tests/simlab/test_runner_tenant.py` + `test_juice_bottling.py` → **12 passed**; `simlab` imports cleanly; seed `py_compile`s; ruff clean.

**Scope honesty:** this wires the tenant. The end-to-end "scenarios cite the docs" payoff additionally needs a live dev Neon with the seed applied (`seed-simlab-docs.py --commit`) and is verified there — not in offline CI. The test asserts the constructor binding, which is the code-level guarantee.

Built in an isolated worktree off `origin/main`. Hands off to `ship` for deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)