### PR TITLE
ci(hub): run mira-hub vitest in CI as a path-filtered guard (#1809)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,46 @@ jobs:
         working-directory: mira-connectors
         run: pytest tests/ -v
 
+  mira-hub-unit:
+    name: Hub Unit Tests
+    runs-on: ubuntu-latest
+    # Path-filtered guard for the mira-hub vitest suite (#1809). The hub's unit
+    # tests — incl. manual-rag.test.ts, which pins BM25 retrieval grounding —
+    # previously never ran in CI, so regressions shipped unguarded.
+    #
+    # Designed to be SAFE as a required status check: the job ALWAYS runs and
+    # reports a status, but only installs deps + runs vitest when mira-hub
+    # actually changed (dorny/paths-filter). On PRs that don't touch mira-hub the
+    # filter short-circuits to a trivially-green job, so a required check never
+    # blocks unrelated PRs. (Docs-only PRs are already skipped at the workflow
+    # `paths-ignore` level, same as every other ci.yml job.)
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            hub:
+              - 'mira-hub/**'
+
+      - uses: oven-sh/setup-bun@v2
+        if: steps.changes.outputs.hub == 'true'
+        with:
+          bun-version: latest
+
+      - name: Install mira-hub dependencies
+        if: steps.changes.outputs.hub == 'true'
+        working-directory: mira-hub
+        run: bun install --frozen-lockfile
+
+      - name: Run vitest unit suite
+        # `bun run test` == `vitest run`; the include glob (src/**/*.test.ts)
+        # covers manual-rag.test.ts and the rest of the hub unit suite.
+        if: steps.changes.outputs.hub == 'true'
+        working-directory: mira-hub
+        run: bun run test
+
   architecture-check:
     name: Architecture Check
     runs-on: ubuntu-latest

--- a/mira-hub/src/lib/command-center-freshness.test.ts
+++ b/mira-hub/src/lib/command-center-freshness.test.ts
@@ -2,7 +2,7 @@
  * Pure-logic tests for Command Center tag freshness. Framework-free — runs with
  * `bun test src/lib/command-center-freshness.test.ts` without `bun install`.
  */
-import { expect, test, describe } from "bun:test";
+import { expect, test, describe } from "vitest";
 import {
   DEFAULT_FRESHNESS_WINDOW_S,
   type FreshnessTagRow,

--- a/mira-hub/src/lib/workflow.test.ts
+++ b/mira-hub/src/lib/workflow.test.ts
@@ -6,7 +6,7 @@
  * so no Postgres is required; the SQL itself is proven by the Python wrapper's
  * round-trip test against an ephemeral pg (the SQL is identical).
  */
-import { expect, test, describe } from "bun:test";
+import { expect, test, describe } from "vitest";
 import {
   type CreateRowInput,
   type CreateRowResult,


### PR DESCRIPTION
## What

Closes the CI gap in **#1809**: the `mira-hub` vitest unit suite never ran in CI, so its regression guards — notably `src/lib/__tests__/manual-rag.test.ts`, which pins BM25 retrieval grounding — shipped unguarded.

## Changes

1. **New `mira-hub-unit` job in `ci.yml`.** Path-filtered with `dorny/paths-filter@v3`:
   - The job **always runs** and reports a status, so it is **safe to mark as a required check** — it will not deadlock PRs that don't touch `mira-hub`.
   - It only sets up bun + installs deps + runs `bun run test` **when `mira-hub/**` changed**; otherwise it short-circuits to a trivially-green job.
   - Bun setup mirrors the existing `oauth-redirect-canary.yml` precedent (`oven-sh/setup-bun@v2`, `bun-version: latest`).

2. **Fix two hub test files that imported `bun:test`** (`workflow.test.ts`, `command-center-freshness.test.ts`). They use only `describe/test/expect` (no bun-only APIs, no live pg), so switching to `from "vitest"` is behavior-preserving and brings **31 previously-unrun tests (412 → 443)** into the suite. Without this, `vitest run` is red and the new job could never go green.

## Verify

```
cd mira-hub && bun run test
# → Test Files 46 passed (46) / Tests 443 passed (443), incl. manual-rag.test.ts
```
`bun install --frozen-lockfile` is clean; `ci.yml` parses.

## ⚠️ Human step — mark the check required (shared-system / branch-protection change)

The job is implemented and verified, but **marking it a *required* status check is a branch-protection edit** (currently the only required context is `staging-gate`). That's an admin/shared-system change I did not make unprompted. To require it after this merges and the check has run once:

```
gh api -X PATCH repos/Mikecranesync/MIRA/branches/main/protection/required_status_checks \
  -f 'contexts[]=staging-gate' -f 'contexts[]=Hub Unit Tests'
```

Note: like every `ci.yml` job, this one is skipped on docs-only PRs (workflow-level `paths-ignore`), the same known property as `staging-gate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)