### PR TITLE
fix(hub): cross-vendor citation conflict-strip in quickstart/ask (C2)

### DIFF
--- a/mira-hub/src/app/api/quickstart/ask/route.ts
+++ b/mira-hub/src/app/api/quickstart/ask/route.ts
@@ -9,6 +9,7 @@ import {
   type ManualChunk,
   type ManualSource,
 } from "@/lib/manual-rag";
+import { stripConflictingVendors } from "@/lib/vendor-relevance";
 
 export const dynamic = "force-dynamic";
 
@@ -140,6 +141,14 @@ export async function POST(req: Request) {
     console.error("[quickstart/ask] retrieval failed:", err);
     // Continue — the model can still refuse with no context.
   }
+
+  // Cross-vendor conflict strip (mirrors rag_worker.CROSS_VENDOR_FILTER): the
+  // tenant-only / OR fallback in retrieveManualChunks can surface a chunk from
+  // the wrong manufacturer (e.g. a Siemens chunk for a Danfoss question). Drop
+  // those before they reach the context and the citation list. Prefer the
+  // explicit manufacturer the user picked; otherwise infer the vendor from the
+  // question text. No-op when no vendor resolves, and never strips to empty.
+  chunks = stripConflictingVendors(chunks, manufacturer ?? question);
 
   const context = buildGroundedContext(chunks);
   const userMsg = context

--- a/mira-hub/src/lib/__tests__/vendor-relevance.test.ts
+++ b/mira-hub/src/lib/__tests__/vendor-relevance.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveVendor,
+  stripConflictingVendors,
+  type VendorTaggable,
+} from "../vendor-relevance";
+
+const chunk = (manufacturer: string): VendorTaggable & { content: string } => ({
+  manufacturer,
+  content: `manual chunk for ${manufacturer || "<untagged>"}`,
+});
+
+describe("resolveVendor", () => {
+  it("resolves canonical vendor names and aliases", () => {
+    expect(resolveVendor("Danfoss")).toBe("Danfoss");
+    expect(resolveVendor("Siemens")).toBe("Siemens");
+    expect(resolveVendor("Allen-Bradley")).toBe("Rockwell Automation");
+    expect(resolveVendor("PowerFlex 525")).toBe("Rockwell Automation");
+    expect(resolveVendor("Rockwell Automation")).toBe("Rockwell Automation");
+  });
+
+  it("infers the vendor from a free-text question", () => {
+    expect(resolveVendor("Why is my Danfoss aqua drive faulting?")).toBe("Danfoss");
+    expect(resolveVendor("sinamics overvoltage on power-up")).toBe("Siemens");
+  });
+
+  it("returns null when no known vendor is mentioned", () => {
+    expect(resolveVendor("the conveyor keeps stopping")).toBeNull();
+    expect(resolveVendor("")).toBeNull();
+    expect(resolveVendor(null)).toBeNull();
+  });
+
+  it("does not fire short aliases on substrings of unrelated words", () => {
+    // "ab" (Rockwell), "sew" (SEW-Eurodrive), "delta" must be word-bounded.
+    expect(resolveVendor("please grab the manual")).toBeNull();
+    expect(resolveVendor("the question was answered")).toBeNull();
+  });
+
+  it("prefers the longest/most-specific alias", () => {
+    expect(resolveVendor("Rockwell Automation PowerFlex")).toBe("Rockwell Automation");
+    expect(resolveVendor("Bosch Rexroth")).toBe("Bosch Rexroth");
+  });
+});
+
+describe("stripConflictingVendors", () => {
+  it("strips a Siemens chunk from a Danfoss query (the core case)", () => {
+    const chunks = [chunk("Danfoss"), chunk("Siemens"), chunk("Danfoss")];
+    const out = stripConflictingVendors(chunks, "Danfoss");
+    expect(out).toHaveLength(2);
+    expect(out.every((c) => c.manufacturer === "Danfoss")).toBe(true);
+  });
+
+  it("infers the query vendor from question text when no explicit vendor", () => {
+    const chunks = [chunk("Siemens"), chunk("Danfoss")];
+    const out = stripConflictingVendors(chunks, "my Danfoss VLT is tripping");
+    expect(out).toHaveLength(1);
+    expect(out[0].manufacturer).toBe("Danfoss");
+  });
+
+  it("keeps untagged / generic chunks", () => {
+    const chunks = [chunk("Danfoss"), chunk(""), chunk("Siemens")];
+    const out = stripConflictingVendors(chunks, "Danfoss");
+    // Danfoss kept, untagged kept, Siemens dropped
+    expect(out.map((c) => c.manufacturer)).toEqual(["Danfoss", ""]);
+  });
+
+  it("keeps chunks tagged with an unknown vendor (cannot prove a conflict)", () => {
+    const chunks = [chunk("Danfoss"), chunk("Acme Custom Drives")];
+    const out = stripConflictingVendors(chunks, "Danfoss");
+    expect(out).toHaveLength(2);
+  });
+
+  it("keeps alias-family matches (Allen-Bradley for a PowerFlex query)", () => {
+    const chunks = [chunk("Allen-Bradley"), chunk("Siemens")];
+    const out = stripConflictingVendors(chunks, "PowerFlex 525 fault F004");
+    expect(out).toHaveLength(1);
+    expect(out[0].manufacturer).toBe("Allen-Bradley");
+  });
+
+  it("does not strip when the query resolves to no known vendor", () => {
+    const chunks = [chunk("Danfoss"), chunk("Siemens")];
+    const out = stripConflictingVendors(chunks, "the drive keeps tripping");
+    expect(out).toHaveLength(2);
+  });
+
+  it("never strips to empty — returns originals if every chunk conflicts", () => {
+    const chunks = [chunk("Siemens"), chunk("ABB")];
+    const out = stripConflictingVendors(chunks, "Danfoss");
+    expect(out).toHaveLength(2);
+  });
+
+  it("returns the input unchanged for an empty chunk list", () => {
+    expect(stripConflictingVendors([], "Danfoss")).toEqual([]);
+  });
+});

--- a/mira-hub/src/lib/vendor-relevance.ts
+++ b/mira-hub/src/lib/vendor-relevance.ts
@@ -1,0 +1,152 @@
+/**
+ * Vendor-alias citation relevance / cross-vendor conflict strip.
+ *
+ * Ports the CROSS_VENDOR_FILTER from `mira-bots/shared/workers/rag_worker.py`
+ * (≈ lines 585-610) to the Hub TS retrieval path. The bot drops BM25 chunks
+ * whose manufacturer doesn't match the vendor the query resolved to — so a
+ * Siemens manual chunk never grounds an answer to a Danfoss question — while
+ * keeping untagged/generic chunks and never stripping the result set to empty.
+ *
+ * The alias table mirrors `VENDOR_ALIASES` in
+ * `mira-bots/shared/uns_resolver.py`. Unlike the Python filter (which uses a
+ * raw `query_vendor in chunk.manufacturer` substring test), this canonicalizes
+ * BOTH the query vendor and each chunk's manufacturer through the alias table
+ * before comparing. That fixes the alias-family case the substring test misses
+ * (e.g. a chunk tagged "Allen-Bradley" is kept for a "Rockwell"/"PowerFlex"
+ * query — both canonicalize to "Rockwell Automation").
+ */
+
+// alias substring → canonical manufacturer display name. Mirrors
+// uns_resolver.VENDOR_ALIASES. Lowercase keys.
+const VENDOR_ALIASES: Record<string, string> = {
+  // Rockwell family
+  powerflex: "Rockwell Automation",
+  "allen-bradley": "Rockwell Automation",
+  "allen bradley": "Rockwell Automation",
+  "rockwell automation": "Rockwell Automation",
+  rockwell: "Rockwell Automation",
+  ab: "Rockwell Automation",
+  pf525: "Rockwell Automation",
+  pf527: "Rockwell Automation",
+  pf520: "Rockwell Automation",
+  pf40: "Rockwell Automation",
+  pf70: "Rockwell Automation",
+  pf753: "Rockwell Automation",
+  pf755: "Rockwell Automation",
+  // AutomationDirect family
+  gs10: "AutomationDirect",
+  gs20: "AutomationDirect",
+  gs1: "AutomationDirect",
+  gs2: "AutomationDirect",
+  gs3: "AutomationDirect",
+  gs4: "AutomationDirect",
+  gs4p: "AutomationDirect",
+  gs11: "AutomationDirect",
+  gs21: "AutomationDirect",
+  automationdirect: "AutomationDirect",
+  "automation direct": "AutomationDirect",
+  // Siemens family
+  micromaster: "Siemens",
+  sinamics: "Siemens",
+  siemens: "Siemens",
+  // Mitsubishi family
+  "mitsubishi electric": "Mitsubishi Electric",
+  mitsubishi: "Mitsubishi Electric",
+  "fr-e": "Mitsubishi Electric",
+  "fr-a": "Mitsubishi Electric",
+  "fr-d": "Mitsubishi Electric",
+  "fr-f": "Mitsubishi Electric",
+  // Danfoss
+  "aqua drive": "Danfoss",
+  danfoss: "Danfoss",
+  // Schneider
+  "schneider electric": "Schneider Electric",
+  schneider: "Schneider Electric",
+  // Bosch Rexroth
+  "bosch rexroth": "Bosch Rexroth",
+  rexroth: "Bosch Rexroth",
+  // SEW-Eurodrive
+  "sew-eurodrive": "SEW-Eurodrive",
+  sew: "SEW-Eurodrive",
+  movitrac: "SEW-Eurodrive",
+  movidrive: "SEW-Eurodrive",
+  // Yaskawa
+  a1000: "Yaskawa",
+  v1000: "Yaskawa",
+  j1000: "Yaskawa",
+  ga500: "Yaskawa",
+  ga700: "Yaskawa",
+  p1000: "Yaskawa",
+  e1000: "Yaskawa",
+  yaskawa: "Yaskawa",
+  // Singletons
+  abb: "ABB",
+  omron: "Omron",
+  eaton: "Eaton",
+  delta: "Delta Electronics",
+  lenze: "Lenze",
+  pilz: "Pilz",
+};
+
+// Longest aliases first so "rockwell automation" wins over "rockwell" and
+// "allen bradley" is matched before any shorter fragment.
+const SORTED_ALIASES = Object.keys(VENDOR_ALIASES).sort((a, b) => b.length - a.length);
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Resolve a manufacturer string OR free-text query to a canonical vendor
+ * display name, or null if no known vendor is mentioned. Aliases are matched
+ * on word boundaries so short aliases ("ab", "sew", "delta") don't fire on
+ * substrings of unrelated words ("grab", "answered", "deltap").
+ */
+export function resolveVendor(text: string | null | undefined): string | null {
+  if (!text) return null;
+  const lower = text.toLowerCase();
+  for (const alias of SORTED_ALIASES) {
+    const re = new RegExp(`(?<![a-z0-9])${escapeRegExp(alias)}(?![a-z0-9])`, "i");
+    if (re.test(lower)) return VENDOR_ALIASES[alias];
+  }
+  return null;
+}
+
+export interface VendorTaggable {
+  manufacturer: string;
+}
+
+/**
+ * Drop chunks whose manufacturer canonicalizes to a DIFFERENT known vendor
+ * than the query. Mirrors rag_worker's CROSS_VENDOR_FILTER:
+ *
+ * - When the query resolves to no known vendor, return the chunks unchanged
+ *   (we can't prove any conflict).
+ * - Keep chunks with no manufacturer tag (generic content — fault-code tables,
+ *   application notes).
+ * - Keep chunks whose manufacturer doesn't resolve to a known vendor (can't
+ *   prove a conflict — safer than the Python substring filter, which would
+ *   drop them).
+ * - Drop only chunks positively identified as a DIFFERENT vendor.
+ * - Never strip to empty: if the filter would remove every chunk, return the
+ *   original set (a wrong-vendor citation beats no citation at all, and the
+ *   cite-or-refuse prompt still guards the answer).
+ *
+ * @param queryVendor the manufacturer the user selected, or the raw question
+ *   text to infer the vendor from.
+ */
+export function stripConflictingVendors<T extends VendorTaggable>(
+  chunks: T[],
+  queryVendor: string | null | undefined,
+): T[] {
+  const canonical = resolveVendor(queryVendor);
+  if (!canonical || chunks.length === 0) return chunks;
+
+  const kept = chunks.filter((c) => {
+    if (!c.manufacturer || !c.manufacturer.trim()) return true;
+    const chunkVendor = resolveVendor(c.manufacturer);
+    return chunkVendor === null || chunkVendor === canonical;
+  });
+
+  return kept.length > 0 ? kept : chunks;
+}


### PR DESCRIPTION
## What

Ports the **CROSS_VENDOR_FILTER** from `mira-bots/shared/workers/rag_worker.py` (~L585-610) to the Hub TS retrieval path (item **C2**). The tenant-only / OR fallback in `retrieveManualChunks` can surface a chunk from the wrong manufacturer — e.g. a **Siemens** manual chunk grounding an answer to a **Danfoss** question — which then becomes a misleading citation on the public quickstart door.

> Note: the goal referenced `citation_compliance.py:393-478`, but that file is only 96 lines — the real cross-vendor logic lives in `rag_worker.py`. This PR mirrors that.

## Changes

- **New `mira-hub/src/lib/vendor-relevance.ts`**
  - `VENDOR_ALIASES` mirrors `mira-bots/shared/uns_resolver.py`.
  - `resolveVendor(text)` canonicalizes a manufacturer string **or** a free-text question to a canonical vendor. Word-boundary alias matching so short aliases (`ab`, `sew`, `delta`) don't fire on substrings of unrelated words.
  - `stripConflictingVendors(chunks, queryVendor)` drops chunks positively identified as a **different** vendor; **keeps** untagged + unknown-vendor chunks; **never strips to empty**. Canonicalizing *both* sides (vs the Python substring test) fixes the alias-family case — an `Allen-Bradley` chunk is kept for a `PowerFlex`/`Rockwell` query.
- **Wire into `quickstart/ask`** after retrieval, before context + citations are built. Prefers the explicit `manufacturer`; otherwise infers the vendor from the question.

## Scope note — `/api/mira/ask` deliberately not wired

The goal named `mira/ask` too, but that route builds citations from **KG / component-template / live-signal rows** — there is **no manual-chunk retrieval** there, and an asset legitimately carries **mixed-vendor components** (a Danfoss drive + a Siemens PLC on one machine). A vendor strip there would wrongly drop valid context. Verified by reading the route. Surfacing this rather than forcing an incorrect edit.

## Verify

```
cd mira-hub && bunx vitest run src/lib/__tests__/vendor-relevance.test.ts
# → 13/13 pass, incl. "strips a Siemens chunk from a Danfoss query"
```
eslint clean on changed files; the only `tsc` errors are pre-existing on `main` (unrelated test fixtures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)