### PR TITLE
perf(hub): bound BM25 query to 32 terms — kills the OR-fanout blowup (#1766)

### DIFF
--- a/mira-hub/src/lib/__tests__/manual-rag.test.ts
+++ b/mira-hub/src/lib/__tests__/manual-rag.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { PoolClient } from "pg";
 import {
   appendManualContext,
+  boundBm25Query,
   buildGroundedContext,
   chunksToSources,
   retrieveManualChunks,
@@ -228,5 +229,69 @@ describe("chunksToSources", () => {
     expect(sources).toHaveLength(2);
     expect(sources[0].title).toBe("AB PF525");
     expect(sources[1].page).toBe(8);
+  });
+});
+
+const tokenCount = (s: string) => s.split(/\s+/).filter(Boolean).length;
+
+describe("boundBm25Query (#1766)", () => {
+  it("passes a normal-length query through verbatim (no grounding regression)", () => {
+    // Short technical tokens like "oC" MUST survive — the AND→OR fallback
+    // relies on them. Bounding is a no-op below the cap.
+    expect(boundBm25Query("what does oC mean?")).toBe("what does oC mean?");
+    expect(boundBm25Query("PowerFlex 525 fault F004 troubleshooting")).toBe(
+      "PowerFlex 525 fault F004 troubleshooting",
+    );
+  });
+
+  it("caps a pathologically long query to <= 32 tokens", () => {
+    const longQuery = Array.from({ length: 250 }, (_, i) => `signal${i}`).join(" ");
+    const bounded = boundBm25Query(longQuery);
+    expect(tokenCount(bounded)).toBeLessThanOrEqual(32);
+    expect(tokenCount(bounded)).toBe(32);
+  });
+
+  it("drops pure-digit, <=2-char, and stopword tokens when bounding a long query", () => {
+    // 40 tokens so the cap engages; mix in noise that must be dropped.
+    const noise = ["the", "and", "is", "it", "192", "502", "42", "to", "of"];
+    const useful = Array.from({ length: 31 }, (_, i) => `vfd${i}`);
+    const bounded = boundBm25Query([...noise, ...useful].join(" "));
+    const toks = bounded.split(/\s+/);
+    expect(toks).not.toContain("the");
+    expect(toks).not.toContain("192");
+    expect(toks).not.toContain("is");
+    expect(toks.every((t) => t.startsWith("vfd"))).toBe(true);
+  });
+
+  it("dedupes repeated tokens", () => {
+    const q = Array.from({ length: 40 }, () => "overcurrent").join(" ");
+    expect(boundBm25Query(q)).toBe("overcurrent");
+  });
+
+  it("never returns empty: a long all-noise query falls back to deduped raw tokens", () => {
+    const q = Array.from({ length: 40 }, (_, i) => (i % 2 ? "the" : "is")).join(" ");
+    const bounded = boundBm25Query(q);
+    expect(bounded.length).toBeGreaterThan(0);
+    expect(tokenCount(bounded)).toBeLessThanOrEqual(32);
+  });
+});
+
+describe("retrieveManualChunks term bounding (#1766)", () => {
+  it("sends a bounded (<= 32-term) tsquery param for a >200-token query", async () => {
+    // The OR fallback rewrites plainto's lexemes to `|`; bounding the $2 text
+    // caps that fanout, which is what turns the 31-45s query fast. We assert the
+    // cause (bounded param) rather than wall-clock, since the suite mocks pg.
+    const longQuery = Array.from({ length: 220 }, (_, i) => `term${i}`).join(" ");
+    const { client, calls } = makeClient([[row()]]);
+    await retrieveManualChunks(client, "tenant-1", longQuery);
+    expect(calls).toHaveLength(1);
+    const tsqueryParam = calls[0].params[1] as string;
+    expect(tokenCount(tsqueryParam)).toBeLessThanOrEqual(32);
+  });
+
+  it("leaves a normal query's tsquery param untouched", async () => {
+    const { client, calls } = makeClient([[row()]]);
+    await retrieveManualChunks(client, "tenant-1", "what is the torque spec");
+    expect(calls[0].params[1]).toBe("what is the torque spec");
   });
 });

--- a/mira-hub/src/lib/manual-rag.ts
+++ b/mira-hub/src/lib/manual-rag.ts
@@ -34,6 +34,59 @@ export interface ManualSource {
 
 const MAX_CONTENT_CHARS = 1200;
 
+// #1766 — BM25 term bounding. Ports mira-bots/shared/neon_recall._recall_bm25's
+// 32-term cap to the Hub retrieval path. The OR fallback below rewrites
+// plainto's `&` lexemes to `|`; for a pathologically long query — the /ask
+// kiosk's ~440-token MACHINE_CONTEXT prefix is the known offender — that is a
+// ~438-term OR-fanout, and `to_tsquery` unioning hundreds of huge GIN posting
+// lists took 31-45s (issue #1766; engine-side neon_recall already has the fix).
+//
+// Bounding is a NO-OP for normal-length queries: any query of <= BM25_MAX_TERMS
+// raw tokens is passed through verbatim, so short technical tokens ("oC", "F4")
+// and the AND→OR natural-question grounding are unchanged. Only a query that
+// exceeds the cap is reduced to its <= BM25_MAX_TERMS most-selective tokens
+// (deduped; pure-digit, <=2-char, and stopword tokens dropped — Postgres'
+// 'english' config stems + drops its own stopwords downstream regardless).
+const BM25_MAX_TERMS = 32;
+
+// Local high-frequency stopwords. Mirrors neon_recall._COMMON_WORDS. The <=2-char
+// rule already covers the short ones; the multi-char entries are the ones that
+// matter once a query is long enough to bound.
+const BM25_STOPWORDS = new Set<string>([
+  "the", "and", "for", "with", "your", "its", "has", "was", "are", "can",
+  "not", "but", "that", "this", "what", "from", "how", "why", "when", "does",
+  "did", "any", "all", "also", "just", "like", "get", "got", "see", "saw",
+  "too", "our", "now", "try", "fix", "out", "off", "had", "may", "will",
+  "let", "run", "set", "use", "they", "them", "his", "her", "she",
+]);
+
+/**
+ * Bound the text handed to `plainto_tsquery` so a runaway query can't blow up
+ * the OR-fallback fanout. No-op for queries of <= BM25_MAX_TERMS raw tokens;
+ * caps longer ones. Never returns empty: if every token of a long query is
+ * filtered out, falls back to the deduped raw tokens (capped). Exported for
+ * unit testing.
+ */
+export function boundBm25Query(query: string): string {
+  const rawAll = query.match(/\w+/g) ?? [];
+  if (rawAll.length <= BM25_MAX_TERMS) return query;
+
+  const lowered = query.toLowerCase().match(/\w+/g) ?? [];
+  const seen = new Set<string>();
+  const tokens: string[] = [];
+  for (const tok of lowered) {
+    if (seen.has(tok)) continue;
+    seen.add(tok);
+    if (tok.length <= 2 || /^\d+$/.test(tok) || BM25_STOPWORDS.has(tok)) continue;
+    tokens.push(tok);
+    if (tokens.length >= BM25_MAX_TERMS) break;
+  }
+  if (tokens.length === 0) {
+    return Array.from(new Set(lowered)).slice(0, BM25_MAX_TERMS).join(" ");
+  }
+  return tokens.join(" ");
+}
+
 /**
  * Run BM25 retrieval. Tries a manufacturer-scoped query first; falls
  * back to a tenant-only query if zero hits or no manufacturer.
@@ -63,7 +116,7 @@ async function runBm25Query(
   topK: number,
   manufacturer: string | null,
 ): Promise<ManualChunk[]> {
-  const params: unknown[] = [tenantId, query];
+  const params: unknown[] = [tenantId, boundBm25Query(query)];
   let mfrClause = "";
   if (manufacturer) {
     params.push(`%${manufacturer}%`);
@@ -200,7 +253,7 @@ export async function retrieveNodeChunks(
           AND content_tsv @@ ${tsquery}
         ORDER BY rank DESC
         LIMIT $4`,
-      [tenantId, q, nodeIds, topK],
+      [tenantId, boundBm25Query(q), nodeIds, topK],
     );
     return res.rows;
   };


### PR DESCRIPTION
## What

Ports the engine-side 32-term BM25 bound (`mira-bots/shared/neon_recall._recall_bm25`) to the Hub retrieval path. Extends **#1766** (the issue tracks the engine/NeonDB path, where the fix already shipped — this brings it to the TS hub surface).

`retrieveManualChunks` / `retrieveNodeChunks` build an OR fallback (`to_tsquery` with plainto's lexemes rejoined by `|`) so natural questions ground. For a pathologically long query — the `/ask` kiosk's ~440-token `MACHINE_CONTEXT` prefix — that OR-fanout unions hundreds of huge GIN posting lists and takes **31-45s** (#1766).

## ⚠️ Stacked on #1807 (base = `lane/upload-retrieval-gate`, not `main`)

The 32-term bound only matters on the **OR fallback**, which lives on PR **#1807** (the lane branch), not yet on `main`. On `main`'s pure `plainto_tsquery` AND-path a 200-term query ANDs to ~nothing and is already fast, so a bound there is a near no-op and the perf verify would be meaningless. Per that dependency this PR targets the lane branch and **should merge after #1807**. Path-scoped freshness check: `origin/main`'s lead has not touched `manual-rag.ts`, so the stack is conflict-free.

## Changes

- `boundBm25Query(query)`: **no-op for queries of ≤ 32 raw tokens** — short technical tokens (`oC`, `F4`) and the AND→OR natural-question grounding from #1807 are completely unchanged (no regression). Only a longer query is capped to its ≤ 32 most-selective tokens (deduped; pure-digit, ≤2-char, and stopword tokens dropped). Never returns empty.
- Wired into the `$2` tsquery param of both `runBm25Query` and `retrieveNodeChunks`.

## GIN index — confirmed

`idx_knowledge_entries_content_tsv ON knowledge_entries USING GIN (content_tsv)` — `mira-core/mira-ingest/db/migrations/006_knowledge_tsvector.sql`.

## Verify

**vitest** (`bunx vitest run src/lib/__tests__/manual-rag.test.ts`) → **22/22 pass**, incl. `">200-token query → bounded ≤32-term param"` and `"normal query untouched"`.

**Real wall-clock** against dev Neon (83,784-row corpus, worst case = 220 highest-frequency lexemes / biggest posting lists):

| query | OR-query latency |
|---|---|
| UNBOUNDED (>200 term) | **40,304 ms** |
| BOUNDED (≤32 term) | **3,357 ms** (<5s ✓) |

12× speedup — reproduces the #1766 31-45s pathology and the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)