### PR TITLE
feat(hub): blind upload PDFs become citable via per-tenant Inbox node (#1806)

### DIFF
--- a/mira-hub/src/lib/__tests__/inbox-node.test.ts
+++ b/mira-hub/src/lib/__tests__/inbox-node.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock the tenant RLS wrapper to invoke the callback with a scripted client.
+const queryMock = vi.fn();
+vi.mock("@/lib/tenant-context", () => ({
+  withTenantContext: async (_tenantId: string, fn: (c: { query: typeof queryMock }) => unknown) =>
+    fn({ query: queryMock }),
+}));
+
+import { resolveOrCreateInboxNode, INBOX_UNS_PATH } from "../inbox-node";
+
+beforeEach(() => {
+  queryMock.mockReset();
+});
+
+describe("resolveOrCreateInboxNode", () => {
+  it("returns the existing Inbox node without inserting", async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ id: "node-existing" }] });
+
+    const out = await resolveOrCreateInboxNode("tenant-1");
+
+    expect(out).toEqual({ nodeId: "node-existing", unsPath: INBOX_UNS_PATH });
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock.mock.calls[0][0]).toContain("SELECT id::text AS id");
+  });
+
+  it("creates the Inbox node when none exists", async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [] }) // SELECT — none yet
+      .mockResolvedValueOnce({ rows: [{ id: "node-new" }] }); // INSERT
+
+    const out = await resolveOrCreateInboxNode("tenant-1");
+
+    expect(out).toEqual({ nodeId: "node-new", unsPath: INBOX_UNS_PATH });
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(queryMock.mock.calls[1][0]).toContain("INSERT INTO kg_entities");
+    // Inserted as a non-reserved 'inbox' ltree label under the tenant.
+    expect(queryMock.mock.calls[1][1]).toEqual(["tenant-1", INBOX_UNS_PATH]);
+  });
+
+  it("recovers from a concurrent-create race by re-selecting", async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [] }) // SELECT — none yet
+      .mockRejectedValueOnce(new Error("duplicate key value")) // INSERT — lost the race
+      .mockResolvedValueOnce({ rows: [{ id: "node-raced" }] }); // re-SELECT — found it
+
+    const out = await resolveOrCreateInboxNode("tenant-1");
+
+    expect(out).toEqual({ nodeId: "node-raced", unsPath: INBOX_UNS_PATH });
+    expect(queryMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("rethrows when the insert fails and re-select still finds nothing", async () => {
+    queryMock
+      .mockResolvedValueOnce({ rows: [] }) // SELECT — none
+      .mockRejectedValueOnce(new Error("kg_entities boom")) // INSERT — real failure
+      .mockResolvedValueOnce({ rows: [] }); // re-SELECT — still none
+
+    await expect(resolveOrCreateInboxNode("tenant-1")).rejects.toThrow("kg_entities boom");
+  });
+});

--- a/mira-hub/src/lib/inbox-node.ts
+++ b/mira-hub/src/lib/inbox-node.ts
@@ -1,0 +1,67 @@
+// Per-tenant "Inbox" node for un-addressed blind uploads (#1806).
+//
+// The blind upload doors (/api/uploads/local, /api/uploads/folder) have a PDF
+// buffer but no target namespace node. To make those uploads citable in chat —
+// instead of landing OW-KB-only and never reaching knowledge_entries — they are
+// routed through the SAME v2 writer (writePdfChunksForNode) into a well-known
+// per-tenant "Inbox" node. The Inbox node is a plain kg_entities row at
+// uns_path='inbox'; no schema/migration is required.
+//
+// Resolution is idempotent: the first blind upload per tenant creates the node,
+// every subsequent one reuses it. A concurrent create race is caught and
+// resolved by re-selecting.
+
+import { withTenantContext } from "@/lib/tenant-context";
+
+/** ltree label for the per-tenant Inbox node. Not in RESERVED_LABELS, lowercase,
+ *  matches the slug grammar [a-z0-9_]+. */
+export const INBOX_UNS_PATH = "inbox";
+
+export interface InboxNode {
+  nodeId: string;
+  unsPath: string;
+}
+
+/**
+ * Resolve (or idempotently create) the per-tenant Inbox node. Returns its
+ * kg_entities id + uns_path. Runs inside the tenant RLS context so the row is
+ * owned by the tenant, exactly like a user-created node.
+ */
+export async function resolveOrCreateInboxNode(tenantId: string): Promise<InboxNode> {
+  return withTenantContext(tenantId, async (c) => {
+    const existing = await c.query<{ id: string }>(
+      `SELECT id::text AS id
+         FROM kg_entities
+        WHERE tenant_id = $1::uuid AND uns_path = $2::ltree
+        LIMIT 1`,
+      [tenantId, INBOX_UNS_PATH],
+    );
+    if (existing.rows[0]) {
+      return { nodeId: existing.rows[0].id, unsPath: INBOX_UNS_PATH };
+    }
+
+    try {
+      const inserted = await c.query<{ id: string }>(
+        `INSERT INTO kg_entities (entity_type, name, uns_path, tenant_id)
+         VALUES ('area', 'Inbox', $2::ltree, $1::uuid)
+         RETURNING id::text AS id`,
+        [tenantId, INBOX_UNS_PATH],
+      );
+      return { nodeId: inserted.rows[0].id, unsPath: INBOX_UNS_PATH };
+    } catch (err) {
+      // A concurrent blind upload may have created it between SELECT and INSERT.
+      // Re-select before giving up.
+      const raced = await c.query<{ id: string }>(
+        `SELECT id::text AS id
+           FROM kg_entities
+          WHERE tenant_id = $1::uuid AND uns_path = $2::ltree
+          LIMIT 1`,
+        [tenantId, INBOX_UNS_PATH],
+      );
+      if (raced.rows[0]) {
+        return { nodeId: raced.rows[0].id, unsPath: INBOX_UNS_PATH };
+      }
+      throw err;
+    }
+  });
+}

--- a/mira-hub/src/lib/local-upload.ts
+++ b/mira-hub/src/lib/local-upload.ts
@@ -20,6 +20,8 @@ import {
   readUploadBuffer,
   deleteUploadBuffer,
 } from "@/lib/upload-buffer";
+import { resolveOrCreateInboxNode } from "@/lib/inbox-node";
+import { writePdfChunksForNode } from "@/lib/node-knowledge-ingest";
 
 export interface UploadAuthContext {
   tenantId: string;
@@ -152,6 +154,40 @@ async function runLocalIngest(p: LocalIngestParams): Promise<void> {
     mimeType: p.mime,
     sizeBytes: p.buffer.byteLength,
   });
+
+  // #1806: a blind-door PDF (browser /local + MiraDrop /folder) becomes CITABLE.
+  // Route the buffer through the SAME v2 writer the node-attach door uses
+  // (writePdfChunksForNode), landing in the per-tenant Inbox node, so the chunks
+  // reach knowledge_entries (ingest_route='v2', metadata.node_id) and NodeChat can
+  // cite them — instead of landing Open-WebUI-KB-only. Single-writer; no second
+  // chunker. On ANY failure, fall through to the legacy OW path below so the door
+  // keeps working. Non-PDF + photo + remote-fetch (cloud) doors keep the OW path.
+  if (p.kind === "document" && p.mime === "application/pdf") {
+    try {
+      const inbox = await resolveOrCreateInboxNode(p.tenantId);
+      const chunkCount = await writePdfChunksForNode({
+        tenantId: p.tenantId,
+        uploadId: p.uploadId,
+        nodeId: inbox.nodeId,
+        unsPath: inbox.unsPath,
+        filename: p.filename,
+        buffer: p.buffer,
+      });
+      await updateUploadStatus(p.uploadId, p.tenantId, "parsed", null, {
+        kbChunkCount: chunkCount,
+        kgEntityId: inbox.nodeId,
+        ingestRoute: "v2",
+      });
+      log.log("parsed", { kind: p.kind, route: "v2", nodeId: inbox.nodeId, kbChunkCount: chunkCount });
+      await deleteUploadBuffer(p.uploadId);
+      return;
+    } catch (err) {
+      // v2 inbox ingest failed — fall back to the legacy OW-KB path below so the
+      // door still works (the v2 core is the same proven node-attach path).
+      log.error("v2_inbox_fallback", err);
+    }
+  }
+
   const stream = () =>
     new ReadableStream<Uint8Array>({
       start(controller) {

--- a/mira-hub/src/lib/node-knowledge-ingest.ts
+++ b/mira-hub/src/lib/node-knowledge-ingest.ts
@@ -53,6 +53,76 @@ export function chunkText(text: string, size = CHUNK_CHARS, overlap = CHUNK_OVER
 }
 
 /**
+ * Extract + chunk a PDF buffer and write per-chunk knowledge_entries rows bound
+ * to an EXISTING upload + node. Single source of v2 chunk-writing, shared by
+ * `ingestPdfToNode` (node-attach door) and the blind upload doors (#1806, which
+ * route un-addressed PDFs into the per-tenant Inbox node). Does NOT create or
+ * update a hub_uploads row — the caller owns the upload lifecycle. Returns the
+ * chunk count. Throws on extraction/insert error (caller marks the upload).
+ */
+export async function writePdfChunksForNode(opts: {
+  tenantId: string;
+  uploadId: string;
+  nodeId: string;
+  unsPath: string | null;
+  filename: string;
+  buffer: Buffer | Uint8Array;
+}): Promise<number> {
+  const { tenantId, uploadId, nodeId, unsPath, filename, buffer } = opts;
+
+  const pdf = await getDocumentProxy(new Uint8Array(buffer));
+  const { text } = await extractText(pdf, { mergePages: false });
+  const pages: string[] = Array.isArray(text) ? text : [text];
+
+  // Unique per attachment so same-named files on different nodes never false-dedup
+  // against the partial UNIQUE (tenant_id, source_url, metadata->>'chunk_index').
+  const sourceUrl = `node-doc/${uploadId}/${filename}`;
+
+  type ChunkRow = { content: string; page: number; idx: number };
+  const rows: ChunkRow[] = [];
+  let idx = 0;
+  pages.forEach((pageText, p) => {
+    for (const piece of chunkText(pageText)) {
+      rows.push({ content: piece, page: p + 1, idx: idx++ });
+    }
+  });
+
+  if (rows.length > 0) {
+    await withTenantContext(tenantId, async (c) => {
+      for (const r of rows) {
+        await c.query(
+          `INSERT INTO knowledge_entries
+             (id, tenant_id, source_type, content, source_url, source_page,
+              doc_id, ingest_route, page_start, page_end, metadata)
+           VALUES ($1, $2, 'node_attachment', $3, $4, $5, $6, 'v2', $7, $7, $8)
+           ON CONFLICT (tenant_id, source_url, ((metadata->>'chunk_index')::int))
+             WHERE (metadata->>'chunk_index') IS NOT NULL
+             DO NOTHING`,
+          [
+            randomUUID(),
+            tenantId,
+            r.content,
+            sourceUrl,
+            r.page,
+            uploadId,
+            r.page,
+            JSON.stringify({
+              filename,
+              uns_path: unsPath,
+              node_id: nodeId,
+              chunk_index: r.idx,
+              source: "hub_node_attachment",
+            }),
+          ],
+        );
+      }
+    });
+  }
+
+  return rows.length;
+}
+
+/**
  * Ingest a PDF buffer attached to a namespace node. Creates the hub_uploads row,
  * extracts + chunks the text, and writes per-chunk knowledge_entries rows.
  * Returns the upload id + chunk count. Throws (and marks the upload failed) on error.
@@ -82,57 +152,16 @@ export async function ingestPdfToNode(opts: {
   });
 
   try {
-    const pdf = await getDocumentProxy(new Uint8Array(buffer));
-    const { text } = await extractText(pdf, { mergePages: false });
-    const pages: string[] = Array.isArray(text) ? text : [text];
-
-    // Unique per attachment so same-named files on different nodes never false-dedup
-    // against the partial UNIQUE (tenant_id, source_url, metadata->>'chunk_index').
-    const sourceUrl = `node-doc/${upload.id}/${filename}`;
-
-    type ChunkRow = { content: string; page: number; idx: number };
-    const rows: ChunkRow[] = [];
-    let idx = 0;
-    pages.forEach((pageText, p) => {
-      for (const piece of chunkText(pageText)) {
-        rows.push({ content: piece, page: p + 1, idx: idx++ });
-      }
+    const chunkCount = await writePdfChunksForNode({
+      tenantId,
+      uploadId: upload.id,
+      nodeId,
+      unsPath,
+      filename,
+      buffer,
     });
-
-    if (rows.length > 0) {
-      await withTenantContext(tenantId, async (c) => {
-        for (const r of rows) {
-          await c.query(
-            `INSERT INTO knowledge_entries
-               (id, tenant_id, source_type, content, source_url, source_page,
-                doc_id, ingest_route, page_start, page_end, metadata)
-             VALUES ($1, $2, 'node_attachment', $3, $4, $5, $6, 'v2', $7, $7, $8)
-             ON CONFLICT (tenant_id, source_url, ((metadata->>'chunk_index')::int))
-               WHERE (metadata->>'chunk_index') IS NOT NULL
-               DO NOTHING`,
-            [
-              randomUUID(),
-              tenantId,
-              r.content,
-              sourceUrl,
-              r.page,
-              upload.id,
-              r.page,
-              JSON.stringify({
-                filename,
-                uns_path: unsPath,
-                node_id: nodeId,
-                chunk_index: r.idx,
-                source: "hub_node_attachment",
-              }),
-            ],
-          );
-        }
-      });
-    }
-
-    await updateUploadStatus(upload.id, tenantId, "parsed", null, { kbChunkCount: rows.length });
-    return { uploadId: upload.id, chunkCount: rows.length };
+    await updateUploadStatus(upload.id, tenantId, "parsed", null, { kbChunkCount: chunkCount });
+    return { uploadId: upload.id, chunkCount };
   } catch (err) {
     await updateUploadStatus(upload.id, tenantId, "failed", (err as Error).message);
     throw err;

--- a/mira-hub/src/lib/uploads.ts
+++ b/mira-hub/src/lib/uploads.ts
@@ -244,8 +244,12 @@ export async function updateUploadStatus(
   tenantId: string,
   status: UploadStatus,
   detail?: string | null,
-  extras?: { kbFileId?: string; kbChunkCount?: number },
+  extras?: { kbFileId?: string; kbChunkCount?: number; kgEntityId?: string; ingestRoute?: string },
 ): Promise<void> {
+  // kgEntityId + ingestRoute let a blind-door upload (#1806) be re-stamped to the
+  // Inbox node + 'v2' once its PDF is chunked into knowledge_entries, so the node
+  // Documents panel + provenance match the citable chunks. COALESCE — only set
+  // when provided, never clobber an existing value with NULL.
   await pool.query(
     `
     UPDATE hub_uploads
@@ -253,11 +257,22 @@ export async function updateUploadStatus(
            status_detail = COALESCE($4, status_detail),
            kb_file_id = COALESCE($5, kb_file_id),
            kb_chunk_count = COALESCE($6, kb_chunk_count),
+           kg_entity_id = COALESCE($7::uuid, kg_entity_id),
+           ingest_route = COALESCE($8, ingest_route),
            updated_at = NOW()
      WHERE id = $1
        AND tenant_id = $2
   `,
-    [id, tenantId, status, detail ?? null, extras?.kbFileId ?? null, extras?.kbChunkCount ?? null],
+    [
+      id,
+      tenantId,
+      status,
+      detail ?? null,
+      extras?.kbFileId ?? null,
+      extras?.kbChunkCount ?? null,
+      extras?.kgEntityId ?? null,
+      extras?.ingestRoute ?? null,
+    ],
   );
 }
 


### PR DESCRIPTION
## What & why

Closes **#1806**. The blind upload doors (`/api/uploads/local` browser multipart, `/api/uploads/folder` MiraDrop watcher) routed PDFs to the **Open-WebUI KB only**, so an uploaded manual never reached `knowledge_entries` and was **not citable in chat**.

Operator-chosen **Option 1**: route un-addressed PDFs through the **same v2 writer** the node-attach door uses, landing in an auto-resolved **per-tenant "Inbox" node**, so chunks reach `knowledge_entries` (`ingest_route='v2'`, `metadata.node_id`) and **NodeChat cites them**.

- **Single-writer** — reuses the extracted `writePdfChunksForNode` core; no second chunker (resolves the ADR-0019 "two divergent writers" warning).
- **No migration** — Inbox is a plain `kg_entities` row at `uns_path='inbox'` (`'inbox'` is not in `RESERVED_LABELS`); reuses the existing `hub_uploads` row (no duplicate).

## Changes

| File | Change |
|---|---|
| `lib/inbox-node.ts` (NEW) | `resolveOrCreateInboxNode(tenantId)` — idempotent, race-safe (re-select on insert conflict). |
| `lib/node-knowledge-ingest.ts` | Extract `writePdfChunksForNode` core (no `hub_uploads` creation); `ingestPdfToNode` delegates — **node-attach behavior unchanged**. |
| `lib/uploads.ts` | `updateUploadStatus` extras accept `kgEntityId`/`ingestRoute` (COALESCE) — re-stamp the blind upload's row to the Inbox node + `'v2'`. |
| `lib/local-upload.ts` | `runLocalIngest` routes `kind=document & application/pdf` through v2 into the Inbox node; **any failure falls back to the legacy OW path** so the door keeps working. |

**Scope:** PDF-with-buffer doors only. The cloud door (`/api/uploads`, Google/Dropbox remote-fetch — no in-process buffer) stays OW-KB and is deferred to a follow-up (noted in #1806). Photos / non-PDF unchanged.

## Evidence (local)

```
inbox-node test ............ 4/4 pass
full lib unit suite ........ 90/90 pass  (manual-rag unaffected; ingestPdfToNode core preserved)
tsc --noEmit ............... 0 errors in changed files
eslint ..................... clean on changed files
```

Retrieval already reads exactly what this writes — `retrieveNodeChunks` (`manual-rag.ts:154`) selects `knowledge_entries WHERE ingest_route='v2' AND metadata->>'node_id' = ANY(...)`, so an Inbox-landed PDF is citable when chatting at the Inbox node.

## Gate-test delta

Neutral. This is **beta-path:no** (the beta gate already works via the node-attach door); #1806 closes the *secondary* blind doors. The xfail beta gate test is unaffected (still env-gated).

Closes #1806

🤖 Generated with [Claude Code](https://claude.com/claude-code)