### PR TITLE
feat(plc): A2/A7/A12 anomaly rules + bench bridge — refreshed onto current main (was #1638)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,7 +10,7 @@ Each MIRA module falls into one of four layers. Dependencies flow **downward onl
 ```
 ┌─────────────────────────────────────────────────────────┐
 │  PRESENTATION (user-facing surfaces)                     │
-│  mira-web · mira-hud · atlas-frontend                   │
+│  mira-web · mira-hub · mira-hud · atlas-frontend        │
 ├─────────────────────────────────────────────────────────┤
 │  ADAPTERS (protocol translation → engine)                │
 │  mira-bots/{telegram,slack,reddit} · mira-pipeline       │
@@ -72,4 +72,8 @@ Alpha (Celery orchestrator) ──tailscale──→ Bravo (Ollama compute)
 | mira-pipeline | Adapter | mira-pipeline | 9099 | ✓ |
 | mira-bots/{tg,slack} | Adapter | mira-bot-{telegram,slack} | — | via shared |
 | mira-web | Presentation | mira-web | 3200→3000 | ✓ |
-| mira-hud | Presentation | — (standalone) | — | ✓ |
+| mira-hub | Presentation | mira-hub | 3101→3000 | ✓ |
+| mira-hud | Presentation | — (standalone, heads-up display) | — | ✓ |
+| live-plc-bridge | Infra | mira-live-plc-bridge | — | (bench Modbus→MQTT ingest, read-only) |
+| conv_simple_anomaly | Engine | mira-conv-simple-anomaly | — | (bench machine-card rule engine) |
+| mira-fault-detective | Engine | mira-fault-detective | — | (cv101 demo rule engine) |

--- a/docker-compose.fault-detective.yml
+++ b/docker-compose.fault-detective.yml
@@ -80,6 +80,27 @@ services:
       - core-net
     restart: unless-stopped
 
+  conv-simple-anomaly:
+    build:
+      context: ./plc/conv_simple_anomaly
+    container_name: mira-conv-simple-anomaly
+    mem_limit: 256m
+    memswap_limit: 256m
+    environment:
+      MQTT_HOST: mosquitto
+      MQTT_PORT: "1883"
+      UNS_PREFIX: demo/cell1/conveyor/cv101
+      DB_PATH: /mira-db/mira.db
+      LOG_LEVEL: INFO
+    volumes:
+      - ./mira-bridge/data:/mira-db
+    depends_on:
+      mosquitto:
+        condition: service_healthy
+    networks:
+      - core-net
+    restart: unless-stopped
+
   # Stream A: live Micro 820 Modbus TCP -> MQTT ingest (real bench PLC data).
   # Publishes source-qualified _streams/bridge/* topics; the Node-RED flow runs
   # a redundant Stream B under _streams/nr/*, and the dashboard selector picks

--- a/docker-compose.fault-detective.yml
+++ b/docker-compose.fault-detective.yml
@@ -90,6 +90,7 @@ services:
       MQTT_HOST: mosquitto
       MQTT_PORT: "1883"
       UNS_PREFIX: demo/cell1/conveyor/cv101
+      UNS_EQUIPMENT_PATH: enterprise.factorylm.site.bench.area.conv_simple.equipment.cv101
       DB_PATH: /mira-db/mira.db
       LOG_LEVEL: INFO
     volumes:

--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -377,6 +377,12 @@ services:
       # "which equipment?" UNS confirmation gate so MIRA answers directly.
       # Scoped to mira-ask ONLY — the Telegram/Slack bots keep the gate.
       MIRA_UNS_GATE_ENABLED: "0"
+      # Grounded diagnostic questions run the full RAG+rerank+LLM pipeline,
+      # measured ~45s on the kiosk — past the 30s default, which returns the
+      # "taking longer than usual" fallback instead of the answer. A wall-
+      # mounted kiosk can wait; raise the engine's internal process timeout.
+      # Scoped to mira-ask only.
+      MIRA_PROCESS_TIMEOUT: "90"
     volumes:
       - /opt/mira/data:/mira-db
     networks:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,7 +10,7 @@ Each MIRA module falls into one of four layers. Dependencies flow **downward onl
 ```
 ┌─────────────────────────────────────────────────────────┐
 │  PRESENTATION (user-facing surfaces)                     │
-│  mira-web · mira-hud · atlas-frontend                   │
+│  mira-web · mira-hub · mira-hud · atlas-frontend        │
 ├─────────────────────────────────────────────────────────┤
 │  ADAPTERS (protocol translation → engine)                │
 │  mira-bots/{telegram,slack,reddit} · mira-pipeline       │
@@ -72,4 +72,8 @@ Alpha (Celery orchestrator) ──tailscale──→ Bravo (Ollama compute)
 | mira-pipeline | Adapter | mira-pipeline | 9099 | ✓ |
 | mira-bots/{tg,slack} | Adapter | mira-bot-{telegram,slack} | — | via shared |
 | mira-web | Presentation | mira-web | 3200→3000 | ✓ |
-| mira-hud | Presentation | — (standalone) | — | ✓ |
+| mira-hub | Presentation | mira-hub | 3101→3000 | ✓ |
+| mira-hud | Presentation | — (standalone, heads-up display) | — | ✓ |
+| live-plc-bridge | Infra | mira-live-plc-bridge | — | (bench Modbus→MQTT ingest, read-only) |
+| conv_simple_anomaly | Engine | mira-conv-simple-anomaly | — | (bench machine-card rule engine) |
+| mira-fault-detective | Engine | mira-fault-detective | — | (cv101 demo rule engine) |

--- a/mira-core/scripts/seed_fault_codes.py
+++ b/mira-core/scripts/seed_fault_codes.py
@@ -11,6 +11,9 @@ Target families (issue #193):
   - Siemens G120 (supplement existing sparse coverage)
   - AutomationDirect GS10/GS20 (supplement existing sparse coverage)
   - Rockwell PowerFlex 525/40 (supplement existing sparse coverage)
+  - AutomationDirect DURApulse GS10 NUMERIC codes (the bench Conv_Simple machine
+    reports faults as the numeric low byte of Modbus register 0x2100, not the keypad
+    mnemonic; these rows let conv_simple_anomaly A2 faults join the KB by numeric code)
 
 Usage:
     doppler run --project factorylm --config prd -- \
@@ -1010,6 +1013,37 @@ POWERFLEX_SUPPLEMENT: list[tuple[str, str, str, str, str, str, str]] = [
 ]
 
 
+# DURApulse GS10 NUMERIC fault codes — the value of the low byte of Modbus register
+# 0x2100 (high byte = warning). This is what the Conv_Simple bench actually reports over
+# Modbus, vs. the keypad mnemonics in GS_SUPPLEMENT above. Both formats are seeded so a
+# numeric bench fault (e.g. 21) AND a keypad mnemonic (e.g. "OL") resolve for GS10.
+# Source: DURApulse GS10 User Manual, P06.17 fault-record ranges (same source as
+# conv_simple_anomaly/rules.py GS10_FAULT_CODES). description = "<mnemonic> — <meaning>".
+GS10_NUMERIC: dict[int, str] = {
+    1: "ocA — over-current during acceleration", 2: "ocd — over-current during deceleration",
+    3: "ocn — over-current at constant speed", 4: "GFF — ground fault",
+    6: "ocS — over-current at stop", 7: "ovA — over-voltage during acceleration",
+    8: "ovd — over-voltage during deceleration", 9: "ovn — over-voltage at constant speed",
+    10: "ovS — over-voltage at stop", 11: "LvA — low-voltage during acceleration",
+    12: "Lvd — low-voltage during deceleration", 13: "Lvn — low-voltage at constant speed",
+    14: "LvS — low-voltage at stop", 15: "orP — input phase loss",
+    16: "oH1 — IGBT overheating", 18: "tH1o — IGBT temperature detection failure",
+    21: "oL — overload", 22: "EoL1 — electronic thermal relay 1 protection",
+    23: "EoL2 — electronic thermal relay 2 protection", 24: "oH3 — motor PTC overheating",
+    26: "ot1 — over-torque 1", 27: "ot2 — over-torque 2", 28: "uC — under-current",
+    31: "cF2 — EEPROM read error", 33: "cd1 — U-phase error", 34: "cd2 — V-phase error",
+    35: "cd3 — W-phase error", 36: "Hd0 — cc (current clamp) hardware error",
+    37: "Hd1 — oc (over-current) hardware error", 40: "AUE — auto-tuning error",
+    41: "AFE — PID loss (AI-V)", 48: "ACE — AI-C loss", 49: "EF — external fault",
+    50: "EF1 — emergency stop", 51: "bb — external base block", 52: "Pcod — password locked",
+    54: "CE1 — illegal command", 55: "CE2 — illegal data address", 56: "CE3 — illegal data value",
+    57: "CE4 — data written to read-only address", 58: "CE10 — Modbus transmission time-out",
+    63: "oSL — over-slip error", 82: "oPL1 — output phase loss U", 83: "oPL2 — output phase loss V",
+    84: "oPL3 — output phase loss W", 87: "oL3 — low-frequency overload protection",
+    140: "Hd6 — oc hardware error", 141: "b4GF — ground fault before run", 159: "Hd7 — gate driver error",
+}
+
+
 def _insert(
     conn,
     text_fn,
@@ -1083,7 +1117,17 @@ def main() -> None:
     all_codes.extend(GS_SUPPLEMENT)
     all_codes.extend(POWERFLEX_SUPPLEMENT)
 
-    log.info("Seeding %d fault codes across 6 VFD families", len(all_codes))
+    # DURApulse GS10 numeric (Modbus 0x2100) codes — what the Conv_Simple bench reports.
+    for num, desc in sorted(GS10_NUMERIC.items()):
+        all_codes.append((
+            str(num), desc,
+            "GS10 trips and records this fault in P06.17; read over Modbus as the low byte of register 0x2100.",
+            "Identify the named condition, clear the root cause, then reset the drive. "
+            "See the DURApulse GS10 User Manual fault-code (P06.17) section.",
+            "trip", "AutomationDirect", "GS10",
+        ))
+
+    log.info("Seeding %d fault codes across 6 VFD families (+ GS10 numeric Modbus codes)", len(all_codes))
 
     if args.dry_run:
         for code, desc, cause, action, sev, mfr, model in all_codes:

--- a/plc/conv_simple_anomaly/DEPLOY.md
+++ b/plc/conv_simple_anomaly/DEPLOY.md
@@ -1,0 +1,68 @@
+# Deploying the Conv_Simple anomaly engine (always-on alerts)
+
+**What this gives you:** real bench-PLC faults surfaced in Telegram `/fault`, the MCP
+`/api/faults/active` API, and ntfy push — always-on, no laptop session required.
+
+Verified end-to-end live on 2026-06-01 (laptop bridge → VPS broker → engine, idle-clean).
+
+## Topology (why it's two services on two hosts)
+```
+  PLC laptop (bench LAN)                     VPS factorylm-prod (100.68.120.99)
+  ┌─────────────────────┐   MQTT 1883        ┌──────────────────────────────┐
+  │ live-plc-bridge.py  │ ───(Tailscale)───▶ │ mira-mosquitto                │
+  │ reads PLC 192.168.. │                    │   ▲                          │
+  └─────────────────────┘                    │   │ _streams/bridge/#        │
+                                              │ conv_simple_anomaly engine   │
+                                              │   └▶ conveyor_events (mira.db)│
+                                              │      + diagnostics + ntfy    │
+                                              └──────────────────────────────┘
+```
+The **VPS cannot reach the PLC** (no route to `192.168.1.0/24`, per the Tailscale route
+gotcha), so the bridge MUST run on the **PLC laptop**. Only the engine runs on the VPS.
+
+> ⚠️ Enable BOTH together. A persistent engine with no running bridge will see stale data
+> and fire `A0_OFFLINE` into the fault table (spurious "PLC offline" pages). Don't deploy
+> one without the other.
+
+## 1. Laptop bridge (PLC laptop, Windows) — must be persistent
+```powershell
+# one-off (this session):
+$env:PLC_HOST="192.168.1.100"; $env:MQTT_HOST="100.68.120.99"
+$env:UNS_PREFIX="demo/cell1/conveyor/cv101"
+python -u plc\live-plc-bridge\bridge.py     # needs: pip install aiomqtt pymodbus
+```
+For always-on, register it as a **Scheduled Task** (Trigger: At log on / At startup;
+Action: the command above; Restart on failure). The bridge auto-reconnects to both PLC and
+broker, so a task that simply keeps it running is enough.
+
+## 2. Engine (VPS) — reversible container
+```bash
+# stage code (any dir; does NOT touch the /opt/mira git checkout):
+mkdir -p /opt/conv-simple-anomaly
+scp plc/conv_simple_anomaly/{rules.py,engine.py,config.yaml,requirements.txt} \
+    factorylm-prod:/opt/conv-simple-anomaly/
+
+ssh factorylm-prod 'docker run -d --restart unless-stopped --name mira-conv-simple-anomaly \
+  --network mira-plc-dash_default \
+  -v /opt/conv-simple-anomaly:/app -w /app \
+  -v /opt/mira/mira-bridge/data:/mira-db \
+  -e MQTT_HOST=mira-mosquitto -e MQTT_PORT=1883 \
+  -e UNS_PREFIX=demo/cell1/conveyor/cv101 \
+  -e DB_PATH=/mira-db/mira.db -e LOG_LEVEL=INFO \
+  -e NTFY_URL=https://ntfy.sh -e NTFY_TOPIC=mira-factorylm-alerts \
+  python:3.12-slim sh -c "pip install -q aiomqtt PyYAML && python -u engine.py"'
+```
+- `mira-mosquitto` lives on the `mira-plc-dash_default` network (not `core-net`).
+- The shared fault DB is the host dir `/opt/mira/mira-bridge/data` → container `/mira-db`.
+- Omit `NTFY_*` to run without push (DB + diagnostics only).
+- Roll back: `ssh factorylm-prod 'docker rm -f mira-conv-simple-anomaly'`.
+
+## 3. Verify
+```bash
+ssh factorylm-prod 'docker logs --tail 20 mira-conv-simple-anomaly'   # "subscribing ..."
+# engine heartbeat (should show active:[] at idle):
+ssh factorylm-prod 'timeout 4 docker exec mira-mosquitto mosquitto_sub -h localhost \
+  -t demo/cell1/conveyor/cv101/diagnostics/conv_simple_anomaly -v'
+```
+Then trip a fault at the bench (unplug RS-485 → A1; e-stop → A5) and confirm it appears in
+Telegram `/fault`.

--- a/plc/conv_simple_anomaly/DEPLOY.md
+++ b/plc/conv_simple_anomaly/DEPLOY.md
@@ -55,6 +55,7 @@ ssh factorylm-prod 'docker run -d --restart unless-stopped --name mira-conv-simp
   -v /opt/mira/mira-bridge/data:/mira-db \
   -e MQTT_HOST=mira-mosquitto -e MQTT_PORT=1883 \
   -e UNS_PREFIX=demo/cell1/conveyor/cv101 \
+  -e UNS_EQUIPMENT_PATH=enterprise.factorylm.site.bench.area.conv_simple.equipment.cv101 \
   -e DB_PATH=/mira-db/mira.db -e LOG_LEVEL=INFO \
   -e NTFY_URL=https://ntfy.sh -e NTFY_TOPIC=mira-factorylm-alerts \
   python:3.12-slim sh -c "pip install -q aiomqtt PyYAML && python -u engine.py"'

--- a/plc/conv_simple_anomaly/DEPLOY.md
+++ b/plc/conv_simple_anomaly/DEPLOY.md
@@ -35,6 +35,13 @@ For always-on, register it as a **Scheduled Task** (Trigger: At log on / At star
 Action: the command above; Restart on failure). The bridge auto-reconnects to both PLC and
 broker, so a task that simply keeps it running is enough.
 
+> ⚠️ **Use a boot-scoped Scheduled Task, not a Startup-folder launcher.** A Startup-folder
+> (or "At log on") launcher is **logon-scoped** — it stops the moment the user logs out, which
+> with the always-on engine produces spurious `A0_OFFLINE` alerts every time someone logs off
+> the laptop. The correct always-on mechanism is a **boot-scoped Scheduled Task**: Trigger
+> **"At startup"**, **"Run whether user is logged on or not"**, and **"Restart on failure"**.
+> Registering a task that runs whether logged on or not requires **administrator rights**.
+
 ## 2. Engine (VPS) — reversible container
 ```bash
 # stage code (any dir; does NOT touch the /opt/mira git checkout):
@@ -52,9 +59,18 @@ ssh factorylm-prod 'docker run -d --restart unless-stopped --name mira-conv-simp
   -e NTFY_URL=https://ntfy.sh -e NTFY_TOPIC=mira-factorylm-alerts \
   python:3.12-slim sh -c "pip install -q aiomqtt PyYAML && python -u engine.py"'
 ```
-- `mira-mosquitto` lives on the `mira-plc-dash_default` network (not `core-net`).
+- `mira-mosquitto` lives on the `mira-plc-dash_default` network (not `core-net`). This is
+  the network the engine `docker run` above joins and is correct for the current VPS.
+  > ⚠️ **Network-name drift:** the committed `docker-compose.fault-detective.yml` instead
+  > declares an **external `core-net`** and refers to the broker by service name
+  > **`mosquitto`** (not container `mira-mosquitto`). Both facts are accurate for their
+  > respective contexts, but a future compose-based deploy of this engine must target the
+  > network/service name that the broker actually runs on for that deploy — reconcile before
+  > switching from this `docker run` recipe to compose.
 - The shared fault DB is the host dir `/opt/mira/mira-bridge/data` → container `/mira-db`.
 - Omit `NTFY_*` to run without push (DB + diagnostics only).
+- `A0_OFFLINE` now pages at **LOW** priority by design (infrastructure-liveness signal), so a
+  brief bridge outage will **not** send an urgent page — only genuine machine faults do.
 - Roll back: `ssh factorylm-prod 'docker rm -f mira-conv-simple-anomaly'`.
 
 ## 3. Verify

--- a/plc/conv_simple_anomaly/Dockerfile
+++ b/plc/conv_simple_anomaly/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY engine.py rules.py config.yaml ./
+CMD ["python", "-u", "engine.py"]

--- a/plc/conv_simple_anomaly/README.md
+++ b/plc/conv_simple_anomaly/README.md
@@ -47,6 +47,10 @@ Adding these = a CCW `MbSrvConf.xml` change + reflash (see the `modbus-slave` sk
 # logic (no broker needed):
 pytest plc/conv_simple_anomaly/                # 15 tests
 
+# LIVE check against the real PLC (no broker / no Docker — reads 192.168.1.100:502 and runs the rules):
+python plc/conv_simple_anomaly/live_check.py --secs 4
+# (verified 2026-06-01 on the bench: correctly fired A1 when vfd_comm_ok was False)
+
 # live (needs the broker + live-plc-bridge running):
 pip install -r plc/conv_simple_anomaly/requirements.txt
 MQTT_HOST=100.68.120.99 UNS_PREFIX=demo/cell1/conveyor/cv101 \

--- a/plc/conv_simple_anomaly/README.md
+++ b/plc/conv_simple_anomaly/README.md
@@ -1,0 +1,57 @@
+# Conv_Simple anomaly engine (machine-card invariants)
+
+**What this is:** an *additive* anomaly detector for the **real Conv_Simple bench** (Micro820 +
+GS10), separate from the `mira-fault-detective` **cv101 demo** (vision + PE-101/102 + fuses). It
+applies the invariants from `MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md` to the live tag stream that
+`plc/live-plc-bridge` already publishes, and routes anomalies through the **existing** surfaces.
+
+It does **not** modify the demo. It reuses: the Mosquitto broker, the `live-plc-bridge` UNS stream,
+the shared `conveyor_events` SQLite table (so Telegram `/fault` + MCP `/api/faults/active` show
+these for free), and ntfy push.
+
+## Pipeline
+```
+live-plc-bridge ──(UNS JSON)──▶ Mosquitto ──▶ conv_simple_anomaly.engine
+   {prefix}/_streams/bridge/#                     ├─ rules.evaluate(snapshot, derived, cfg)
+                                                   ├─ conveyor_events row (per new anomaly)
+                                                   ├─ {prefix}/diagnostics/conv_simple_anomaly
+                                                   └─ ntfy (HIGH/CRITICAL)
+```
+
+## Rules implemented (computable from today's bridge stream)
+| ID | Anomaly | Signals |
+|---|---|---|
+| A0 | PLC/bridge offline | no fresh data ≥ `offline_s` |
+| A1 | GS10 RS-485 link down (trust gate) | `vfd/vfd101/comm_ok` = False |
+| A3 | E-stop dual-channel wiring fault | `safety/wiring` or `di02_estop_nc == di03_estop_no` |
+| A4 | Direction fault | `di00_fwd` and `di01_rev` |
+| A5 | Belt running while not permitted | `motor running` ∧ (estop ∨ wiring ∨ ¬contactor) |
+| A6 | Drive not responding to RUN | `cmd_word∈{18,20}` ∧ ¬running ≥ `cmd_run_grace_s` |
+| A8 | Output over motor FLA | `current_a` > `motor_fla_a` |
+| A9 | DC bus out of range | `dc_bus_v` ∉ [`dc_bus_lo_v`,`dc_bus_hi_v`] |
+| A10 | Output frequency frozen | RUN ∧ `freq` unchanged ≥ `freq_frozen_s` |
+
+VFD-value rules (A6/A8/A9/A10) are gated by the §7 trust gate — suppressed when `comm_ok` is False
+(values are stale; A1 fires instead).
+
+## NOT yet implemented — need a PLC Modbus-slave-map extension
+The deployed 502 slave (13 coils + 5 HRs) does **not** expose these, so the bridge can't publish them:
+- **A2** GS10 fault-code decode — needs `0x2100` low byte in the slave map (decode table = machine card §5).
+- **A7** frequency-not-tracking-setpoint — needs the freq **setpoint** (only the cmd echo is published).
+- **A12** photo-eye jam — needs `DI_05` / `pe_latched` (not in the bridge map; the demo uses vision/PE-102).
+Adding these = a CCW `MbSrvConf.xml` change + reflash (see the `modbus-slave` skill) **then** extend
+`live-plc-bridge` reads. Tracked as follow-on.
+
+## Run
+```bash
+# logic (no broker needed):
+pytest plc/conv_simple_anomaly/                # 15 tests
+
+# live (needs the broker + live-plc-bridge running):
+pip install -r plc/conv_simple_anomaly/requirements.txt
+MQTT_HOST=100.68.120.99 UNS_PREFIX=demo/cell1/conveyor/cv101 \
+MIRA_DB=/mira-db/mira.db NTFY_URL=https://ntfy.sh NTFY_TOPIC=mira-factorylm-alerts \
+python plc/conv_simple_anomaly/engine.py
+```
+Confirm the starred thresholds in `config.yaml` (motor FLA, DC-bus window) against the nameplate / a golden run.
+A Docker service can be added to `docker-compose.fault-detective.yml` later (mirrors `fault-detective`).

--- a/plc/conv_simple_anomaly/README.md
+++ b/plc/conv_simple_anomaly/README.md
@@ -31,21 +31,31 @@ live-plc-bridge ──(UNS JSON)──▶ Mosquitto ──▶ conv_simple_anomal
 | A9 | DC bus out of range | `dc_bus_v` ∉ [`dc_bus_lo_v`,`dc_bus_hi_v`] |
 | A10 | Output frequency frozen | RUN ∧ `freq` unchanged ≥ `freq_frozen_s` |
 
-VFD-value rules (A6/A8/A9/A10) are gated by the §7 trust gate — suppressed when `comm_ok` is False
-(values are stale; A1 fires instead).
+VFD-value rules (A2/A6/A7/A8/A9/A10) are gated by the §7 trust gate — suppressed when `comm_ok` is
+False (values are stale; A1 fires instead).
 
-## NOT yet implemented — need a PLC Modbus-slave-map extension
-The deployed 502 slave (13 coils + 5 HRs) does **not** expose these, so the bridge can't publish them:
-- **A2** GS10 fault-code decode — needs `0x2100` low byte in the slave map (decode table = machine card §5).
-- **A7** frequency-not-tracking-setpoint — needs the freq **setpoint** (only the cmd echo is published).
-- **A12** photo-eye jam — needs `DI_05` / `pe_latched` (not in the bridge map; the demo uses vision/PE-102).
-Adding these = a CCW `MbSrvConf.xml` change + reflash (see the `modbus-slave` skill) **then** extend
-`live-plc-bridge` reads. Tracked as follow-on.
+## Rules implemented but awaiting slave-map v2 (degrade silently until reflash)
+The rule logic for these is **written and unit-tested** (`rules.py` + `test_rules.py`); they fire
+the moment the bridge publishes their topics. Until the PLC slave map is extended + reflashed, the
+deployed 502 slave (13 coils + 5 HRs) does not publish them, so `snap.get(...) -> None` and they
+stay silent (verified live 2026-06-01 — no false fires).
+
+| ID | Anomaly | New topic needed | Source register |
+|---|---|---|---|
+| A2 | GS10 drive fault active (decoded) | `vfd/vfd101/fault_code` (+`warn_code`) | `0x2100` low byte / high byte |
+| A7 | Output Hz not tracking setpoint | `vfd/vfd101/freq_setpoint` | `0x2101` (freq command) |
+| A12 | Photo-eye soft-stop (jam/blockage) | `safety/pe_latched` (+`plc/di/di05_photoeye`) | `DI_05` latch (ladder global) |
+
+To activate: **(1)** add the registers to the CCW `MbSrvConf.xml` (`modbus-slave` skill) + reflash
+(`ccw-build`); **(2)** uncomment the matching entries in `live-plc-bridge/bridge.py` (`COIL_TOPICS` /
+`HR_SPECS` + the `COIL_READS` / `HR_READS` plan) and `live_check.py`. The GS10 fault decode table
+lives in `rules.GS10_FAULT_CODES` (sourced from the DURApulse GS10 UM §P06.17) and the invariants in
+`MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md`.
 
 ## Run
 ```bash
 # logic (no broker needed):
-pytest plc/conv_simple_anomaly/                # 15 tests
+pytest plc/conv_simple_anomaly/                # 26 tests
 
 # LIVE check against the real PLC (no broker / no Docker — reads 192.168.1.100:502 and runs the rules):
 python plc/conv_simple_anomaly/live_check.py --secs 4

--- a/plc/conv_simple_anomaly/config.yaml
+++ b/plc/conv_simple_anomaly/config.yaml
@@ -5,5 +5,5 @@ dc_bus_lo_v: 250.0      # * DC-bus undervoltage (A9); idle nominal ~327 V
 dc_bus_hi_v: 410.0      # * DC-bus overvoltage (A9)
 freq_frozen_s: 5.0      # A10 — output Hz unchanged this long while commanded RUN
 cmd_run_grace_s: 3.0    # A6 — RUN commanded but motor not running this long
-offline_s: 30.0         # A0 — no fresh PLC data this long
+offline_s: 120.0        # A0 — no fresh PLC data this long; longer grace reduces spurious A0_OFFLINE pages from brief bridge/network blips
 run_cmd_values: [18, 20]  # GS10 cmd word 18=FWD+RUN, 20=REV+RUN

--- a/plc/conv_simple_anomaly/config.yaml
+++ b/plc/conv_simple_anomaly/config.yaml
@@ -1,0 +1,9 @@
+# Conv_Simple anomaly thresholds. Starred values must be CONFIRMED on the bench
+# (motor nameplate FLA, GS10 DC-bus envelope from a golden run). See rules.DEFAULT_CFG.
+motor_fla_a: 5.0        # * motor full-load amps (A8 overcurrent) — set from the nameplate
+dc_bus_lo_v: 250.0      # * DC-bus undervoltage (A9); idle nominal ~327 V
+dc_bus_hi_v: 410.0      # * DC-bus overvoltage (A9)
+freq_frozen_s: 5.0      # A10 — output Hz unchanged this long while commanded RUN
+cmd_run_grace_s: 3.0    # A6 — RUN commanded but motor not running this long
+offline_s: 30.0         # A0 — no fresh PLC data this long
+run_cmd_values: [18, 20]  # GS10 cmd word 18=FWD+RUN, 20=REV+RUN

--- a/plc/conv_simple_anomaly/engine.py
+++ b/plc/conv_simple_anomaly/engine.py
@@ -1,0 +1,178 @@
+"""
+Conv_Simple anomaly engine — additive subscriber.
+
+Consumes the real PLC stream from `plc/live-plc-bridge` on the existing Mosquitto broker,
+applies the machine-card invariants in `rules.py`, debounces, and routes anomalies the SAME
+way the cv101 demo does so existing surfaces pick them up for free:
+  - writes rows to the shared `conveyor_events` SQLite table (Telegram /fault + MCP /api/faults/active read it)
+  - publishes the current top anomaly JSON to `{UNS_PREFIX}/diagnostics/conv_simple_anomaly`
+  - ntfy push for HIGH/CRITICAL (NTFY_URL/NTFY_TOPIC)
+
+It does NOT modify mira-fault-detective (the demo's cv101 rules) — it runs alongside.
+Reuses the project's aiomqtt pattern (see plc/live-plc-bridge/bridge.py, mira-fault-detective/engine.py).
+
+NOTE: not exercised in CI yet (needs a broker). The pure rule logic is covered by test_rules.py.
+"""
+from __future__ import annotations
+import asyncio, json, logging, os, sqlite3, time, urllib.request
+from pathlib import Path
+
+import aiomqtt  # type: ignore
+
+import rules
+
+MQTT_HOST = os.environ.get("MQTT_HOST", "100.68.120.99")
+MQTT_PORT = int(os.environ.get("MQTT_PORT", "1883"))
+UNS_PREFIX = os.environ.get("UNS_PREFIX", "demo/cell1/conveyor/cv101")
+BRIDGE_SUB = f"{UNS_PREFIX}/_streams/bridge/#"
+DIAG_TOPIC = f"{UNS_PREFIX}/diagnostics/conv_simple_anomaly"
+DB_PATH = os.environ.get("MIRA_DB", "/mira-db/mira.db")
+TICK_MS = int(os.environ.get("TICK_MS", "500"))
+CLEAR_S = float(os.environ.get("CLEAR_S", "3.0"))
+NTFY_URL = os.environ.get("NTFY_URL", "")
+NTFY_TOPIC = os.environ.get("NTFY_TOPIC", "")
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+
+logging.basicConfig(level=LOG_LEVEL, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("conv-simple-anomaly")
+
+
+def load_cfg() -> dict:
+    p = Path(__file__).with_name("config.yaml")
+    cfg = dict(rules.DEFAULT_CFG)
+    if p.exists():
+        try:
+            import yaml  # optional
+            data = yaml.safe_load(p.read_text()) or {}
+            cfg.update({k: v for k, v in data.items() if k in rules.DEFAULT_CFG})
+        except Exception as e:  # pragma: no cover
+            log.warning("config.yaml ignored (%s); using defaults", e)
+    return cfg
+
+
+class Tracker:
+    """Latest snapshot + the temporal facts the rules need (derived)."""
+    def __init__(self):
+        self.snap: dict = {}
+        self.last_seen: dict = {}
+        self.last_any: float = 0.0
+        self._freq_val = None
+        self._freq_change_ts = 0.0
+        self._cmd_run_since = 0.0
+
+    def update(self, rel_topic: str, value, ts: float):
+        self.snap[rel_topic] = value
+        self.last_seen[rel_topic] = ts
+        self.last_any = max(self.last_any, ts)
+        if rel_topic == rules.T_FREQ:
+            if value != self._freq_val:
+                self._freq_val = value
+                self._freq_change_ts = ts
+        if rel_topic == rules.T_CMD:
+            running_cmd = value in rules.DEFAULT_CFG["run_cmd_values"]
+            if running_cmd and self._cmd_run_since == 0.0:
+                self._cmd_run_since = ts
+            elif not running_cmd:
+                self._cmd_run_since = 0.0
+
+    def derived(self, now: float) -> dict:
+        return {
+            "now": now,
+            "max_stale_s": (now - self.last_any) if self.last_any else 1e9,
+            "freq_frozen_s": (now - self._freq_change_ts) if self._freq_change_ts else 0.0,
+            "cmd_run_for_s": (now - self._cmd_run_since) if self._cmd_run_since else 0.0,
+        }
+
+
+def _init_db():
+    try:
+        conn = sqlite3.connect(DB_PATH, timeout=5)
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("""CREATE TABLE IF NOT EXISTS conveyor_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts TEXT NOT NULL, fault TEXT NOT NULL, confidence REAL NOT NULL,
+            evidence_json TEXT NOT NULL DEFAULT '[]', affected_json TEXT NOT NULL DEFAULT '[]',
+            resolved_ts TEXT)""")
+        conn.commit()
+        return conn
+    except Exception as e:  # pragma: no cover
+        log.warning("SQLite unavailable (%s) — events not persisted", e)
+        return None
+
+
+def _persist(conn, a: rules.Anomaly):
+    if not conn:
+        return
+    try:
+        conn.execute(
+            "INSERT INTO conveyor_events (ts, fault, confidence, evidence_json, affected_json) "
+            "VALUES (?,?,?,?,?)",
+            (time.strftime("%Y-%m-%dT%H:%M:%S"), f"{a.rule_id}: {a.title}", a.confidence,
+             json.dumps(a.evidence, default=str), json.dumps(a.components)))
+        conn.commit()
+    except Exception as e:  # pragma: no cover
+        log.warning("persist failed: %s", e)
+
+
+def _ntfy(a: rules.Anomaly):
+    if not (NTFY_URL and NTFY_TOPIC and a.severity in (rules.HIGH, rules.CRITICAL)):
+        return
+    try:  # pragma: no cover
+        req = urllib.request.Request(
+            f"{NTFY_URL.rstrip('/')}/{NTFY_TOPIC}", data=a.message.encode(),
+            headers={"Title": f"[{a.severity}] {a.title}", "Priority": "urgent",
+                     "Tags": "rotating_light"})
+        urllib.request.urlopen(req, timeout=5)
+    except Exception as e:
+        log.warning("ntfy failed: %s", e)
+
+
+async def run():  # pragma: no cover (needs a broker)
+    cfg = load_cfg()
+    conn = _init_db()
+    tr = Tracker()
+    active: dict[str, float] = {}   # rule_id -> last_seen_active ts
+    log.info("subscribing %s @ %s:%s", BRIDGE_SUB, MQTT_HOST, MQTT_PORT)
+    async with aiomqtt.Client(hostname=MQTT_HOST, port=MQTT_PORT) as client:
+        await client.subscribe(BRIDGE_SUB)
+
+        async def reader():
+            async for m in client.messages:
+                try:
+                    payload = json.loads(m.payload)
+                    value, ts = payload.get("value"), float(payload.get("ts", time.time()))
+                except Exception:
+                    continue
+                rel = str(m.topic).split("/_streams/bridge/", 1)[-1]
+                tr.update(rel, value, ts)
+
+        async def ticker():
+            while True:
+                await asyncio.sleep(TICK_MS / 1000.0)
+                now = time.time()
+                found = {a.rule_id: a for a in rules.evaluate(tr.snap, tr.derived(now), cfg)}
+                for rid, a in found.items():
+                    if rid not in active:
+                        log.warning("ANOMALY %s [%s] %s", rid, a.severity, a.message)
+                        _persist(conn, a)
+                        _ntfy(a)
+                    active[rid] = now
+                # publish current worst + clear stale latches
+                order = {rules.CRITICAL: 0, rules.HIGH: 1, rules.MED: 2, rules.LOW: 3, rules.INFO: 4}
+                worst = min(found.values(), key=lambda a: order.get(a.severity, 9), default=None)
+                await client.publish(DIAG_TOPIC, json.dumps({
+                    "ts": now,
+                    "active": [{"rule_id": a.rule_id, "severity": a.severity, "title": a.title}
+                               for a in found.values()],
+                    "top": None if not worst else {"rule_id": worst.rule_id, "severity": worst.severity,
+                                                   "title": worst.title, "message": worst.message},
+                }, default=str))
+                for rid in [r for r, t in active.items() if now - t > CLEAR_S]:
+                    log.info("cleared %s", rid)
+                    active.pop(rid, None)
+
+        await asyncio.gather(reader(), ticker())
+
+
+if __name__ == "__main__":  # pragma: no cover
+    asyncio.run(run())

--- a/plc/conv_simple_anomaly/engine.py
+++ b/plc/conv_simple_anomaly/engine.py
@@ -28,6 +28,13 @@ MQTT_PORT = int(os.environ.get("MQTT_PORT", "1883"))
 UNS_PREFIX = os.environ.get("UNS_PREFIX", "demo/cell1/conveyor/cv101")
 BRIDGE_SUB = f"{UNS_PREFIX}/_streams/bridge/#"
 DIAG_TOPIC = f"{UNS_PREFIX}/diagnostics/conv_simple_anomaly"
+# Canonical ISA-95 UNS path for THIS bench machine — decoupled from UNS_PREFIX above
+# (the live MQTT topic stays demo/cell1/... so the existing dashboard keeps working).
+# Stamped onto every event + diagnostics publish so a fault is addressable to its
+# equipment node and can later join the knowledge graph (kg_entities). Override per deploy.
+UNS_EQUIPMENT_PATH = os.environ.get(
+    "UNS_EQUIPMENT_PATH",
+    "enterprise.factorylm.site.bench.area.conv_simple.equipment.cv101")
 DB_PATH = os.environ.get("MIRA_DB", "/mira-db/mira.db")
 TICK_MS = int(os.environ.get("TICK_MS", "500"))
 CLEAR_S = float(os.environ.get("CLEAR_S", "3.0"))
@@ -108,8 +115,11 @@ def _persist(conn, a: rules.Anomaly):
     # The conveyor_events table is shared with mira-fault-detective on the same SQLite
     # WAL, so an INSERT can lose the write lock momentarily. Retry up to 5 times with a
     # short backoff on "database is locked" (mirrors mira-fault-detective/engine.py).
+    # affected_json carries the canonical UNS equipment path first, so a stored fault
+    # is addressable to its namespace node (joinable to kg_entities downstream).
     row = (time.strftime("%Y-%m-%dT%H:%M:%S"), f"{a.rule_id}: {a.title}", a.confidence,
-           json.dumps(a.evidence, default=str), json.dumps(a.components))
+           json.dumps(a.evidence, default=str),
+           json.dumps([{"uns_path": UNS_EQUIPMENT_PATH}, *a.components]))
     for attempt in range(5):
         try:
             conn.execute(
@@ -185,6 +195,7 @@ async def run():  # pragma: no cover (needs a broker)
                 worst = min(found.values(), key=lambda a: order.get(a.severity, 9), default=None)
                 await client.publish(DIAG_TOPIC, json.dumps({
                     "ts": now,
+                    "uns_path": UNS_EQUIPMENT_PATH,
                     "active": [{"rule_id": a.rule_id, "severity": a.severity, "title": a.title}
                                for a in found.values()],
                     "top": None if not worst else {"rule_id": worst.rule_id, "severity": worst.severity,

--- a/plc/conv_simple_anomaly/engine.py
+++ b/plc/conv_simple_anomaly/engine.py
@@ -21,7 +21,9 @@ import aiomqtt  # type: ignore
 
 import rules
 
-MQTT_HOST = os.environ.get("MQTT_HOST", "100.68.120.99")
+# Broker host must be set via env (MQTT_HOST) at deploy time; "localhost" is a safe
+# default that does not hardcode any specific VPS/broker IP.
+MQTT_HOST = os.environ.get("MQTT_HOST", "localhost")
 MQTT_PORT = int(os.environ.get("MQTT_PORT", "1883"))
 UNS_PREFIX = os.environ.get("UNS_PREFIX", "demo/cell1/conveyor/cv101")
 BRIDGE_SUB = f"{UNS_PREFIX}/_streams/bridge/#"
@@ -103,24 +105,45 @@ def _init_db():
 def _persist(conn, a: rules.Anomaly):
     if not conn:
         return
-    try:
-        conn.execute(
-            "INSERT INTO conveyor_events (ts, fault, confidence, evidence_json, affected_json) "
-            "VALUES (?,?,?,?,?)",
-            (time.strftime("%Y-%m-%dT%H:%M:%S"), f"{a.rule_id}: {a.title}", a.confidence,
-             json.dumps(a.evidence, default=str), json.dumps(a.components)))
-        conn.commit()
-    except Exception as e:  # pragma: no cover
-        log.warning("persist failed: %s", e)
+    # The conveyor_events table is shared with mira-fault-detective on the same SQLite
+    # WAL, so an INSERT can lose the write lock momentarily. Retry up to 5 times with a
+    # short backoff on "database is locked" (mirrors mira-fault-detective/engine.py).
+    row = (time.strftime("%Y-%m-%dT%H:%M:%S"), f"{a.rule_id}: {a.title}", a.confidence,
+           json.dumps(a.evidence, default=str), json.dumps(a.components))
+    for attempt in range(5):
+        try:
+            conn.execute(
+                "INSERT INTO conveyor_events (ts, fault, confidence, evidence_json, affected_json) "
+                "VALUES (?,?,?,?,?)", row)
+            conn.commit()
+            return
+        except sqlite3.OperationalError as e:  # pragma: no cover
+            if attempt == 4:
+                log.warning("persist failed after retries: %s", e)
+                return
+            time.sleep(0.2 * (attempt + 1))
+        except Exception as e:  # pragma: no cover
+            log.warning("persist failed: %s", e)
+            return
 
 
 def _ntfy(a: rules.Anomaly):
     if not (NTFY_URL and NTFY_TOPIC and a.severity in (rules.HIGH, rules.CRITICAL)):
         return
+    # A0_OFFLINE is an infrastructure-liveness signal that false-fires whenever the
+    # laptop bridge stops (restart/logout/network blip). De-prioritize it to "low" with
+    # an [infra] title so it does not send a spurious URGENT page; all other
+    # HIGH/CRITICAL anomalies keep "urgent".
+    if a.rule_id == "A0_OFFLINE":
+        title = f"[infra] [{a.severity}] {a.title}"
+        priority = "low"
+    else:
+        title = f"[{a.severity}] {a.title}"
+        priority = "urgent"
     try:  # pragma: no cover
         req = urllib.request.Request(
             f"{NTFY_URL.rstrip('/')}/{NTFY_TOPIC}", data=a.message.encode(),
-            headers={"Title": f"[{a.severity}] {a.title}", "Priority": "urgent",
+            headers={"Title": title, "Priority": priority,
                      "Tags": "rotating_light"})
         urllib.request.urlopen(req, timeout=5)
     except Exception as e:

--- a/plc/conv_simple_anomaly/live_check.py
+++ b/plc/conv_simple_anomaly/live_check.py
@@ -1,0 +1,123 @@
+"""
+Live check — read the REAL PLC over Modbus TCP and run the machine-card anomaly rules,
+no broker / no Docker required. Verifies the rules against actual hardware and prints the
+current machine snapshot.
+
+  python plc/conv_simple_anomaly/live_check.py [--host 192.168.1.100] [--secs 4]
+
+Uses the SAME register map as plc/live-plc-bridge (kept in sync here so this tool has no
+aiomqtt dependency). Read-only: never writes to the PLC.
+"""
+from __future__ import annotations
+import argparse, sys, time
+from pymodbus.client import ModbusTcpClient
+
+try:  # Windows consoles default to cp1252; rule messages are UTF-8
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+import rules
+
+# --- bridge map (0-based pymodbus offsets) -- mirror of live-plc-bridge ---
+COIL_TOPICS = {
+    0: "motor/m101/running", 3: "vfd/vfd101/comm_ok", 5: "safety/estop", 9: "safety/wiring",
+    11: "plc/di/di00_fwd", 12: "plc/di/di01_rev", 13: "plc/di/di02_estop_nc",
+    14: "plc/di/di03_estop_no", 15: "plc/di/di04_pbrun", 16: "plc/do/do00_green",
+    17: "plc/do/do01_red", 18: "safety/contactor_q1", 19: "plc/do/do03_pbrun_led",
+}
+HR_SPECS = {106: ("vfd/vfd101/freq", 100.0), 107: ("vfd/vfd101/current_a", 100.0),
+            108: ("vfd/vfd101/voltage_v", 10.0), 109: ("vfd/vfd101/dc_bus_v", 10.0),
+            114: ("vfd/vfd101/cmd_word", 1.0)}
+COIL_READS = [(0, 1), (3, 1), (5, 1), (9, 1), (11, 9)]
+HR_READS = [(106, 4), (114, 1)]
+UNIT = 1
+
+
+def _read(fn, addr, count):
+    for kw in ({"count": count, "slave": UNIT}, {"count": count, "device_id": UNIT}):
+        try:
+            return fn(addr, **kw)
+        except TypeError:
+            continue
+    return fn(addr, count)
+
+
+def poll(client) -> dict:
+    snap: dict = {}
+    for off, cnt in COIL_READS:
+        rr = _read(client.read_coils, off, cnt)
+        if rr.isError():
+            raise RuntimeError(f"coil read @{off} failed: {rr}")
+        for i in range(cnt):
+            if off + i in COIL_TOPICS:
+                snap[COIL_TOPICS[off + i]] = bool(rr.bits[i])
+    for off, cnt in HR_READS:
+        rr = _read(client.read_holding_registers, off, cnt)
+        if rr.isError():
+            raise RuntimeError(f"HR read @{off} failed: {rr}")
+        for i in range(cnt):
+            if off + i in HR_SPECS:
+                topic, div = HR_SPECS[off + i]
+                snap[topic] = rr.registers[i] / div if div != 1.0 else rr.registers[i]
+    return snap
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", default="192.168.1.100")
+    ap.add_argument("--port", type=int, default=502)
+    ap.add_argument("--secs", type=float, default=4.0)
+    args = ap.parse_args()
+
+    client = ModbusTcpClient(args.host, port=args.port, timeout=2)
+    if not client.connect():
+        print(f"FAIL: cannot connect to PLC {args.host}:{args.port}")
+        return 2
+
+    last_any = 0.0
+    freq_val, freq_ts = None, 0.0
+    cmd_run_since = 0.0
+    t_end = time.time() + args.secs
+    snap: dict = {}
+    try:
+        while time.time() < t_end:
+            now = time.time()
+            try:
+                snap = poll(client)
+                last_any = now
+            except Exception as e:
+                print("poll error:", e)
+                time.sleep(0.5)
+                continue
+            if snap.get(rules.T_FREQ) != freq_val:
+                freq_val, freq_ts = snap.get(rules.T_FREQ), now
+            cmd_run = snap.get(rules.T_CMD) in rules.DEFAULT_CFG["run_cmd_values"]
+            cmd_run_since = (cmd_run_since or now) if cmd_run else 0.0
+            time.sleep(0.5)
+    finally:
+        client.close()
+
+    now = time.time()
+    derived = {"now": now, "max_stale_s": (now - last_any) if last_any else 1e9,
+               "freq_frozen_s": (now - freq_ts) if freq_ts else 0.0,
+               "cmd_run_for_s": (now - cmd_run_since) if cmd_run_since else 0.0}
+
+    print("\n=== LIVE PLC SNAPSHOT ===")
+    for k in sorted(snap):
+        print(f"  {k:32} = {snap[k]}")
+    print(f"  (derived: stale {derived['max_stale_s']:.1f}s, freq_frozen {derived['freq_frozen_s']:.1f}s, "
+          f"cmd_run_for {derived['cmd_run_for_s']:.1f}s)")
+
+    anomalies = rules.evaluate(snap, derived)
+    print("\n=== ANOMALIES ===")
+    if not anomalies:
+        print("  none — machine state is within all machine-card invariants.")
+    else:
+        for a in anomalies:
+            print(f"  [{a.severity}] {a.rule_id}: {a.message}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plc/conv_simple_anomaly/live_check.py
+++ b/plc/conv_simple_anomaly/live_check.py
@@ -63,17 +63,65 @@ def poll(client) -> dict:
     return snap
 
 
+def watch(client, secs):
+    """Continuous monitor: poll + evaluate every 0.5s, print when anomalies fire/clear,
+    with a periodic heartbeat. For tripping faults at the bench and watching live."""
+    freq_val, freq_ts, cmd_run_since, last_any = None, 0.0, 0.0, 0.0
+    prev: dict = {}
+    t_end = time.time() + secs
+    next_hb = 0.0
+    print(f"WATCHING {secs:.0f}s — trip a fault and watch (Ctrl-C to stop)\n")
+    while time.time() < t_end:
+        now = time.time()
+        try:
+            snap = poll(client); last_any = now
+        except Exception as e:
+            print(f"  {time.strftime('%H:%M:%S')}  poll error: {e}"); time.sleep(0.5); continue
+        if snap.get(rules.T_FREQ) != freq_val:
+            freq_val, freq_ts = snap.get(rules.T_FREQ), now
+        cmd_run = snap.get(rules.T_CMD) in rules.DEFAULT_CFG["run_cmd_values"]
+        cmd_run_since = (cmd_run_since or now) if cmd_run else 0.0
+        derived = {"now": now, "max_stale_s": now - last_any,
+                   "freq_frozen_s": (now - freq_ts) if freq_ts else 0.0,
+                   "cmd_run_for_s": (now - cmd_run_since) if cmd_run_since else 0.0}
+        cur = {a.rule_id: a for a in rules.evaluate(snap, derived)}
+        ts = time.strftime("%H:%M:%S")
+        for rid in cur.keys() - prev.keys():
+            a = cur[rid]; print(f"  {ts}  >>> FIRED  [{a.severity}] {rid}: {a.message}")
+        for rid in prev.keys() - cur.keys():
+            print(f"  {ts}  --- cleared {rid}")
+        if now >= next_hb:
+            print(f"  {ts}  · run={snap.get(rules.T_RUN)} cmd={snap.get(rules.T_CMD)} "
+                  f"comm={snap.get(rules.T_COMM)} estop={snap.get(rules.T_ESTOP)} "
+                  f"freq={snap.get(rules.T_FREQ)} cur={snap.get(rules.T_CUR)} "
+                  f"dcbus={snap.get(rules.T_DCBUS)} active={sorted(cur) or '[]'}")
+            next_hb = now + 5
+        prev = cur
+        time.sleep(0.5)
+    print("\nwatch done.")
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--host", default="192.168.1.100")
     ap.add_argument("--port", type=int, default=502)
     ap.add_argument("--secs", type=float, default=4.0)
+    ap.add_argument("--watch", action="store_true", help="continuous live monitor")
     args = ap.parse_args()
+    if args.watch and args.secs < 30:
+        args.secs = 240.0
 
     client = ModbusTcpClient(args.host, port=args.port, timeout=2)
     if not client.connect():
         print(f"FAIL: cannot connect to PLC {args.host}:{args.port}")
         return 2
+
+    if args.watch:
+        try:
+            watch(client, args.secs)
+        finally:
+            client.close()
+        return 0
 
     last_any = 0.0
     freq_val, freq_ts = None, 0.0

--- a/plc/conv_simple_anomaly/requirements.txt
+++ b/plc/conv_simple_anomaly/requirements.txt
@@ -1,0 +1,3 @@
+aiomqtt==2.3.0
+PyYAML>=6.0
+# rules.py + test_rules.py are pure stdlib (run: pytest plc/conv_simple_anomaly/)

--- a/plc/conv_simple_anomaly/requirements.txt
+++ b/plc/conv_simple_anomaly/requirements.txt
@@ -1,3 +1,3 @@
 aiomqtt==2.3.0
-PyYAML>=6.0
+PyYAML==6.0.2
 # rules.py + test_rules.py are pure stdlib (run: pytest plc/conv_simple_anomaly/)

--- a/plc/conv_simple_anomaly/rules.py
+++ b/plc/conv_simple_anomaly/rules.py
@@ -152,18 +152,24 @@ def r_a9_dcbus(snap, d, cfg):
     return None
 
 
-def r_a10_freq_frozen(snap, d, cfg):
+def r_a10_freq_stuck_zero(snap, d, cfg):
+    # Commanded RUN but output Hz stuck at ~0 -> drive not producing output.
+    # (A constant NON-zero Hz at steady speed is normal and must NOT trip this.)
+    # Gate on time SINCE the RUN command (cmd_run_for_s), not absolute freq-frozen time,
+    # so the idle period where Hz legitimately sat at 0 doesn't count (no startup transient).
+    freq = snap.get(T_FREQ)
     if (snap.get(T_CMD) in cfg["run_cmd_values"] and _vfd_trustworthy(snap)
-            and d.get("freq_frozen_s", 0.0) >= cfg["freq_frozen_s"]):
-        return Anomaly("A10_FREQ_FROZEN", MED, "Output frequency frozen",
-                       f"Commanded RUN but output Hz unchanged for {d['freq_frozen_s']:.0f}s — "
-                       "stale read or the drive is not following.",
+            and isinstance(freq, (int, float)) and freq <= 0.1
+            and d.get("cmd_run_for_s", 0.0) >= cfg["freq_frozen_s"]):
+        return Anomaly("A10_FREQ_STUCK_ZERO", MED, "Output frequency stuck at zero",
+                       f"Commanded RUN for {d['cmd_run_for_s']:.0f}s but output Hz is still 0 — "
+                       "the drive is not following the run command.",
                        _ev(snap, T_FREQ, T_CMD), ["gs10"])
     return None
 
 
 RULES = [r_a0_offline, r_a1_comm, r_a3_estop_wiring, r_a4_direction, r_a5_illegal_run,
-         r_a6_not_responding, r_a8_overcurrent, r_a9_dcbus, r_a10_freq_frozen]
+         r_a6_not_responding, r_a8_overcurrent, r_a9_dcbus, r_a10_freq_stuck_zero]
 
 
 def evaluate(snap: dict, derived: dict, cfg: dict | None = None) -> list[Anomaly]:

--- a/plc/conv_simple_anomaly/rules.py
+++ b/plc/conv_simple_anomaly/rules.py
@@ -10,9 +10,10 @@ live tag stream published by `plc/live-plc-bridge` (UNS relative topics). Pure f
             {now, max_stale_s, freq_frozen_s, cmd_run_for_s}
 `cfg`     : thresholds (see DEFAULT_CFG; bench values marked CONFIRM).
 
-Covers A0,A1,A3,A4,A5,A6,A8,A9,A10. NOT covered (need a PLC Modbus-slave-map extension —
-the deployed slave does not expose these): A2 GS10 fault-code (0x2100), A7 freq setpoint,
-A12 photo-eye DI_05 / pe_latched. See README.
+Covers A0,A1,A2,A3,A4,A5,A6,A7,A8,A9,A10,A12. A2/A7/A12 read slave-map v2 signals
+(GS10 fault-code 0x2100, freq setpoint 0x2101, photo-eye DI_05 / pe_latched) that the
+currently-deployed slave does NOT yet publish — those rules degrade silently (snap.get -> None)
+until the PLC Modbus-slave-map extension is reflashed. See README + specs/CONVEYOR_MACHINE_CARD.md.
 """
 from __future__ import annotations
 from dataclasses import dataclass, field
@@ -44,7 +45,32 @@ DEFAULT_CFG = {
     "cmd_run_grace_s": 3.0,    # A6 — RUN commanded but not running this long
     "offline_s": 30.0,         # A0 — no fresh data this long
     "run_cmd_values": (18, 20),  # GS10 cmd word: 18=FWD+RUN, 20=REV+RUN (§4)
+    "freq_track_tol_hz": 3.0,  # A7 — allowed |output Hz − setpoint Hz| at steady state
+    "freq_track_grace_s": 5.0, # A7 — accel grace after RUN before A7 may fire
 }
+
+# GS10 fault/error codes — low byte of register 0x2100 (manual §P06.17 ranges,
+# DURApulse GS10 UM 1st Ed Rev B). Used by A2 to decode vfd/vfd101/fault_code.
+GS10_FAULT_CODES = {
+    1: "ocA (over-current accel)", 2: "ocd (over-current decel)", 3: "ocn (over-current run)",
+    4: "GFF (ground fault)", 6: "ocS (over-current at stop)", 7: "ovA (over-voltage accel)",
+    8: "ovd (over-voltage decel)", 9: "ovn (over-voltage run)", 10: "ovS (over-voltage stop)",
+    11: "LvA (low-voltage accel)", 12: "Lvd (low-voltage decel)", 13: "Lvn (low-voltage run)",
+    14: "LvS (low-voltage stop)", 15: "orP (phase loss)", 16: "oH1 (IGBT overheat)",
+    18: "tH1o (IGBT temp sensor)", 21: "oL (overload)", 22: "EoL1 (thermal relay 1)",
+    23: "EoL2 (thermal relay 2)", 24: "oH3 (motor PTC overheat)", 26: "ot1 (over-torque 1)",
+    27: "ot2 (over-torque 2)", 28: "uC (under-current)", 31: "cF2 (EEPROM read)",
+    33: "cd1 (U-phase)", 34: "cd2 (V-phase)", 35: "cd3 (W-phase)", 36: "Hd0 (cc hardware)",
+    37: "Hd1 (oc hardware)", 40: "AUE (auto-tune)", 41: "AFE (PID loss AI-V)", 48: "ACE (AI-C loss)",
+    49: "EF (external fault)", 50: "EF1 (emergency stop)", 51: "bb (base block)",
+    52: "Pcod (password locked)", 54: "CE1 (illegal command)", 55: "CE2 (illegal data address)",
+    56: "CE3 (illegal data value)", 57: "CE4 (write to read-only)", 58: "CE10 (Modbus timeout)",
+    63: "oSL (over-slip)", 82: "oPL1 (output phase loss U)", 83: "oPL2 (output phase loss V)",
+    84: "oPL3 (output phase loss W)", 87: "oL3 (low-freq overload)", 140: "Hd6 (oc hardware)",
+    141: "b4GF (GFF before run)", 159: "Hd7 (gate driver)",
+}
+# Codes that trip the drive hard / risk damage → CRITICAL; everything else HIGH.
+_GS10_CRITICAL = {1, 2, 3, 4, 6, 7, 8, 9, 10, 15, 16, 33, 34, 35, 36, 37, 82, 83, 84, 140, 141, 159}
 
 # bridge UNS-relative topics (from live-plc-bridge)
 T_RUN = "motor/m101/running"
@@ -56,6 +82,12 @@ T_DI00, T_DI01 = "plc/di/di00_fwd", "plc/di/di01_rev"
 T_DI02, T_DI03 = "plc/di/di02_estop_nc", "plc/di/di03_estop_no"
 T_FREQ, T_CUR, T_DCBUS, T_CMD = (
     "vfd/vfd101/freq", "vfd/vfd101/current_a", "vfd/vfd101/dc_bus_v", "vfd/vfd101/cmd_word")
+# slave-map v2 topics (A2/A7/A12) — published once the PLC slave map is extended + reflashed
+T_FAULT = "vfd/vfd101/fault_code"      # low byte of GS10 0x2100
+T_WARN = "vfd/vfd101/warn_code"        # high byte of GS10 0x2100
+T_FREQ_SP = "vfd/vfd101/freq_setpoint" # commanded Hz (GS10 0x2101)
+T_PE_LATCH = "safety/pe_latched"       # photo-eye latching soft-stop engaged
+T_DI05 = "plc/di/di05_photoeye"        # raw photo-eye beam state
 
 
 def _ev(snap, *keys):
@@ -168,8 +200,53 @@ def r_a10_freq_stuck_zero(snap, d, cfg):
     return None
 
 
-RULES = [r_a0_offline, r_a1_comm, r_a3_estop_wiring, r_a4_direction, r_a5_illegal_run,
-         r_a6_not_responding, r_a8_overcurrent, r_a9_dcbus, r_a10_freq_stuck_zero]
+def r_a2_vfd_fault(snap, d, cfg):
+    # GS10 active fault (low byte of 0x2100). Trust-gated: stale when comm is down.
+    code = snap.get(T_FAULT)
+    if _vfd_trustworthy(snap) and isinstance(code, (int, float)) and int(code) != 0:
+        code = int(code)
+        name = GS10_FAULT_CODES.get(code, "unknown")
+        sev = CRITICAL if code in _GS10_CRITICAL else HIGH
+        return Anomaly("A2_VFD_FAULT", sev, "GS10 drive fault active",
+                       f"GS10 reports fault code {code}: {name} — the drive has tripped "
+                       "(0x2100 low byte). Clear the cause and reset the drive.",
+                       _ev(snap, T_FAULT, T_WARN), ["gs10"])
+    return None
+
+
+def r_a7_freq_not_tracking(snap, d, cfg):
+    # Commanded RUN with a nonzero speed setpoint, but output Hz is not reaching it
+    # (after the accel grace). Distinct from A10 (output stuck at ~0): A7 catches
+    # "running but can't hold commanded speed" (drag / current-limit / load).
+    sp, out = snap.get(T_FREQ_SP), snap.get(T_FREQ)
+    if (snap.get(T_CMD) in cfg["run_cmd_values"] and _vfd_trustworthy(snap)
+            and isinstance(sp, (int, float)) and sp > 0.1
+            and isinstance(out, (int, float))
+            and abs(out - sp) > cfg["freq_track_tol_hz"]
+            and d.get("cmd_run_for_s", 0.0) >= cfg["freq_track_grace_s"]):
+        return Anomaly("A7_FREQ_NOT_TRACKING", MED, "Output Hz not tracking setpoint",
+                       f"Commanded {sp:.1f} Hz but output is {out:.1f} Hz "
+                       f"(off by {abs(out - sp):.1f} Hz > {cfg['freq_track_tol_hz']:.1f}) for "
+                       f"{d['cmd_run_for_s']:.0f}s — drive not reaching commanded speed "
+                       "(mechanical drag, current-limit, or load).",
+                       _ev(snap, T_FREQ_SP, T_FREQ, T_CUR), ["gs10", "motor", "belt"])
+    return None
+
+
+def r_a12_photoeye_jam(snap, d, cfg):
+    # Photo-eye latching soft-stop engaged (DI_05 beam blocked → PLC latched a STOP).
+    # The authoritative signal is pe_latched (PLC latch); DI_05 is the raw beam.
+    if snap.get(T_PE_LATCH) is True:
+        return Anomaly("A12_PHOTOEYE_JAM", HIGH, "Photo-eye soft-stop (jam/blockage)",
+                       "Photo-eye DI_05 latched a soft-stop — an object is blocking the infeed "
+                       "beam (jam/backup); the belt is held stopped until Start re-arms it.",
+                       _ev(snap, T_PE_LATCH, T_DI05), ["photoeye", "belt"])
+    return None
+
+
+RULES = [r_a0_offline, r_a1_comm, r_a2_vfd_fault, r_a3_estop_wiring, r_a4_direction,
+         r_a5_illegal_run, r_a6_not_responding, r_a7_freq_not_tracking, r_a8_overcurrent,
+         r_a9_dcbus, r_a10_freq_stuck_zero, r_a12_photoeye_jam]
 
 
 def evaluate(snap: dict, derived: dict, cfg: dict | None = None) -> list[Anomaly]:

--- a/plc/conv_simple_anomaly/rules.py
+++ b/plc/conv_simple_anomaly/rules.py
@@ -1,0 +1,177 @@
+"""
+Conv_Simple machine-card anomaly rules (additive — does NOT touch the cv101 demo).
+
+These are the invariants from `MIRA_PLC/specs/CONVEYOR_MACHINE_CARD.md`, applied to the
+live tag stream published by `plc/live-plc-bridge` (UNS relative topics). Pure functions:
+`evaluate(snap, derived, cfg) -> list[Anomaly]` — no I/O, fully unit-testable.
+
+`snap`    : latest value keyed by the bridge's UNS-relative topic (see live-plc-bridge COIL_TOPICS / HR_SPECS).
+`derived` : temporal facts the engine computes from history:
+            {now, max_stale_s, freq_frozen_s, cmd_run_for_s}
+`cfg`     : thresholds (see DEFAULT_CFG; bench values marked CONFIRM).
+
+Covers A0,A1,A3,A4,A5,A6,A8,A9,A10. NOT covered (need a PLC Modbus-slave-map extension —
+the deployed slave does not expose these): A2 GS10 fault-code (0x2100), A7 freq setpoint,
+A12 photo-eye DI_05 / pe_latched. See README.
+"""
+from __future__ import annotations
+from dataclasses import dataclass, field
+
+CRITICAL, HIGH, MED, LOW, INFO = "CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"
+_CONF = {CRITICAL: 1.0, HIGH: 0.9, MED: 0.75, LOW: 0.6, INFO: 0.5}
+
+
+@dataclass
+class Anomaly:
+    rule_id: str
+    severity: str
+    title: str
+    message: str
+    evidence: list = field(default_factory=list)
+    components: list = field(default_factory=list)
+
+    @property
+    def confidence(self) -> float:
+        return _CONF.get(self.severity, 0.6)
+
+
+# Bench-tunable thresholds. CONFIRM the starred ones against the motor nameplate / a golden run.
+DEFAULT_CFG = {
+    "motor_fla_a": 5.0,        # * motor full-load amps (A8 overcurrent)
+    "dc_bus_lo_v": 250.0,      # * DC-bus undervoltage (A9); nominal ~327 V idle
+    "dc_bus_hi_v": 410.0,      # * DC-bus overvoltage (A9)
+    "freq_frozen_s": 5.0,      # A10 — Hz unchanged this long while commanded RUN
+    "cmd_run_grace_s": 3.0,    # A6 — RUN commanded but not running this long
+    "offline_s": 30.0,         # A0 — no fresh data this long
+    "run_cmd_values": (18, 20),  # GS10 cmd word: 18=FWD+RUN, 20=REV+RUN (§4)
+}
+
+# bridge UNS-relative topics (from live-plc-bridge)
+T_RUN = "motor/m101/running"
+T_COMM = "vfd/vfd101/comm_ok"
+T_ESTOP = "safety/estop"
+T_WIRING = "safety/wiring"
+T_CONTACTOR = "safety/contactor_q1"
+T_DI00, T_DI01 = "plc/di/di00_fwd", "plc/di/di01_rev"
+T_DI02, T_DI03 = "plc/di/di02_estop_nc", "plc/di/di03_estop_no"
+T_FREQ, T_CUR, T_DCBUS, T_CMD = (
+    "vfd/vfd101/freq", "vfd/vfd101/current_a", "vfd/vfd101/dc_bus_v", "vfd/vfd101/cmd_word")
+
+
+def _ev(snap, *keys):
+    return [{"topic": k, "value": snap.get(k)} for k in keys]
+
+
+def _vfd_trustworthy(snap) -> bool:
+    """The §7 trust gate: VFD analog/echo values are stale when comm_ok is explicitly False."""
+    return snap.get(T_COMM) is not False
+
+
+# ---- rules (each returns Anomaly | None) ----
+def r_a0_offline(snap, d, cfg):
+    if d.get("max_stale_s", 0.0) >= cfg["offline_s"]:
+        return Anomaly("A0_OFFLINE", CRITICAL, "PLC/bridge offline",
+                       f"No fresh PLC data for {d['max_stale_s']:.0f}s (>= {cfg['offline_s']:.0f}s).",
+                       [{"topic": "_stale_s", "value": round(d.get("max_stale_s", 0.0), 1)}],
+                       ["plc", "bridge"])
+    return None
+
+
+def r_a1_comm(snap, d, cfg):
+    if snap.get(T_COMM) is False:
+        return Anomaly("A1_COMM_STALE", CRITICAL, "GS10 RS-485 link down",
+                       "vfd_comm_ok is FALSE — the PLC↔GS10 serial link is down; all VFD "
+                       "values are stale (frozen from the last good poll).",
+                       _ev(snap, T_COMM), ["gs10", "rs485"])
+    return None
+
+
+def r_a3_estop_wiring(snap, d, cfg):
+    a, b = snap.get(T_DI02), snap.get(T_DI03)            # healthy: DI_02 NC=True, DI_03 NO=False
+    mismatch = a is not None and b is not None and a == b  # same state = broken/shorted wire
+    if snap.get(T_WIRING) is True or mismatch:
+        return Anomaly("A3_ESTOP_WIRING", HIGH, "E-stop wiring fault",
+                       "Dual-channel e-stop disagreement (DI_02 NC and DI_03 NO read the SAME) "
+                       "or the wiring-fault flag is set — broken/shorted e-stop wire; drive not permitted.",
+                       _ev(snap, T_WIRING, T_DI02, T_DI03), ["estop", "wiring"])
+    return None
+
+
+def r_a4_direction(snap, d, cfg):
+    if snap.get(T_DI00) and snap.get(T_DI01):
+        return Anomaly("A4_DIRECTION_FAULT", MED, "Direction fault",
+                       "FWD (DI_00) and REV (DI_01) are both commanded — the PLC commands STOP.",
+                       _ev(snap, T_DI00, T_DI01), ["selector"])
+    return None
+
+
+def r_a5_illegal_run(snap, d, cfg):
+    if not snap.get(T_RUN):
+        return None
+    reasons = []
+    if snap.get(T_ESTOP):
+        reasons.append("e-stop active")
+    if snap.get(T_WIRING):
+        reasons.append("wiring fault")
+    if snap.get(T_CONTACTOR) is False:
+        reasons.append("contactor open")
+    if reasons:
+        return Anomaly("A5_ILLEGAL_RUN", HIGH, "Belt running while not permitted",
+                       "Motor reports RUNNING but it should not be: " + ", ".join(reasons) + ".",
+                       _ev(snap, T_RUN, T_ESTOP, T_WIRING, T_CONTACTOR), ["motor", "safety"])
+    return None
+
+
+def r_a6_not_responding(snap, d, cfg):
+    if (snap.get(T_CMD) in cfg["run_cmd_values"] and _vfd_trustworthy(snap)
+            and not snap.get(T_RUN) and d.get("cmd_run_for_s", 0.0) >= cfg["cmd_run_grace_s"]):
+        return Anomaly("A6_DRIVE_NOT_RESPONDING", MED, "Drive not responding to RUN",
+                       f"Command word is RUN ({snap.get(T_CMD)}) for {d['cmd_run_for_s']:.0f}s "
+                       "but the motor is not running.",
+                       _ev(snap, T_CMD, T_RUN), ["gs10", "motor"])
+    return None
+
+
+def r_a8_overcurrent(snap, d, cfg):
+    cur = snap.get(T_CUR)
+    if _vfd_trustworthy(snap) and isinstance(cur, (int, float)) and cur > cfg["motor_fla_a"]:
+        return Anomaly("A8_OVERCURRENT", HIGH, "VFD output over motor FLA",
+                       f"Output current {cur:.2f} A exceeds motor FLA {cfg['motor_fla_a']:.2f} A — "
+                       "possible overload/jam (cf. GS10 oL fault 21).",
+                       _ev(snap, T_CUR), ["motor", "belt"])
+    return None
+
+
+def r_a9_dcbus(snap, d, cfg):
+    v = snap.get(T_DCBUS)
+    if _vfd_trustworthy(snap) and isinstance(v, (int, float)) and (v < cfg["dc_bus_lo_v"] or v > cfg["dc_bus_hi_v"]):
+        return Anomaly("A9_DC_BUS", MED, "DC bus voltage out of range",
+                       f"DC bus {v:.0f} V is outside [{cfg['dc_bus_lo_v']:.0f}, {cfg['dc_bus_hi_v']:.0f}] V "
+                       "(nominal ~327 V; low → GS10 Lvd 12).",
+                       _ev(snap, T_DCBUS), ["gs10", "power"])
+    return None
+
+
+def r_a10_freq_frozen(snap, d, cfg):
+    if (snap.get(T_CMD) in cfg["run_cmd_values"] and _vfd_trustworthy(snap)
+            and d.get("freq_frozen_s", 0.0) >= cfg["freq_frozen_s"]):
+        return Anomaly("A10_FREQ_FROZEN", MED, "Output frequency frozen",
+                       f"Commanded RUN but output Hz unchanged for {d['freq_frozen_s']:.0f}s — "
+                       "stale read or the drive is not following.",
+                       _ev(snap, T_FREQ, T_CMD), ["gs10"])
+    return None
+
+
+RULES = [r_a0_offline, r_a1_comm, r_a3_estop_wiring, r_a4_direction, r_a5_illegal_run,
+         r_a6_not_responding, r_a8_overcurrent, r_a9_dcbus, r_a10_freq_frozen]
+
+
+def evaluate(snap: dict, derived: dict, cfg: dict | None = None) -> list[Anomaly]:
+    """Run every rule against a snapshot; return the list of active anomalies."""
+    merged = {**DEFAULT_CFG, **(cfg or {})}
+    out = []
+    for rule in RULES:
+        a = rule(snap, derived or {}, merged)
+        if a is not None:
+            out.append(a)
+    return out

--- a/plc/conv_simple_anomaly/test_rules.py
+++ b/plc/conv_simple_anomaly/test_rules.py
@@ -18,6 +18,12 @@ def healthy_snap():
         "vfd/vfd101/current_a": 0.0,
         "vfd/vfd101/dc_bus_v": 327.0,
         "vfd/vfd101/cmd_word": 1,       # STOP
+        # --- slave-map v2 signals (A2/A7/A12); healthy defaults ---
+        "vfd/vfd101/fault_code": 0,     # 0 = no fault record
+        "vfd/vfd101/warn_code": 0,
+        "vfd/vfd101/freq_setpoint": 0.0,
+        "safety/pe_latched": False,     # photo-eye soft-stop not engaged
+        "plc/di/di05_photoeye": False,  # beam clear
     }
 
 
@@ -125,3 +131,67 @@ def test_a10_steady_speed_does_not_fire():
 def test_confidence_mapping():
     a = rules.r_a1_comm({"vfd/vfd101/comm_ok": False}, D0, rules.DEFAULT_CFG)
     assert a.confidence == 1.0  # CRITICAL
+
+
+# --- A2/A7/A12: slave-map v2 signals (degrade silently when topics absent) ---
+
+def test_new_rules_silent_when_signals_absent():
+    # the currently-deployed slave does not publish these topics; rules must not
+    # fire on missing data (snap.get -> None), only on real values.
+    s = healthy_snap()
+    for k in ("vfd/vfd101/fault_code", "vfd/vfd101/warn_code",
+              "vfd/vfd101/freq_setpoint", "safety/pe_latched", "plc/di/di05_photoeye"):
+        s.pop(k, None)
+    assert {"A2_VFD_FAULT", "A7_FREQ_NOT_TRACKING", "A12_PHOTOEYE_JAM"} & ids(s) == set()
+
+
+def test_a2_vfd_fault_code_fires_and_decodes():
+    s = healthy_snap(); s["vfd/vfd101/fault_code"] = 21  # oL overload
+    got = {a.rule_id: a for a in evaluate(s, D0)}
+    assert "A2_VFD_FAULT" in got
+    assert "oL" in got["A2_VFD_FAULT"].message  # decoded from the GS10 manual table
+
+
+def test_a2_no_fault_when_zero():
+    assert "A2_VFD_FAULT" not in ids(healthy_snap())  # fault_code 0 = no fault
+
+
+def test_a2_gated_by_comm():
+    # comm down -> fault_code is stale; A2 suppressed, only A1 fires
+    s = healthy_snap(); s["vfd/vfd101/comm_ok"] = False; s["vfd/vfd101/fault_code"] = 21
+    assert "A2_VFD_FAULT" not in ids(s)
+
+
+def test_a7_freq_not_tracking_setpoint():
+    # commanded RUN, setpoint 30 Hz, output stuck at 12 Hz past the grace -> A7
+    s = healthy_snap()
+    s.update({"vfd/vfd101/cmd_word": 18, "motor/m101/running": True,
+              "vfd/vfd101/freq_setpoint": 30.0, "vfd/vfd101/freq": 12.0,
+              "vfd/vfd101/current_a": 2.0})
+    assert "A7_FREQ_NOT_TRACKING" in ids(s, {**D0, "cmd_run_for_s": 8.0})
+    # within the accel grace -> must NOT fire (ramp-up is normal)
+    assert "A7_FREQ_NOT_TRACKING" not in ids(s, {**D0, "cmd_run_for_s": 2.0})
+
+
+def test_a7_silent_when_tracking():
+    # output within tolerance of setpoint -> healthy, no A7
+    s = healthy_snap()
+    s.update({"vfd/vfd101/cmd_word": 18, "motor/m101/running": True,
+              "vfd/vfd101/freq_setpoint": 30.0, "vfd/vfd101/freq": 29.5,
+              "vfd/vfd101/current_a": 2.0})
+    assert "A7_FREQ_NOT_TRACKING" not in ids(s, {**D0, "cmd_run_for_s": 8.0})
+
+
+def test_a7_silent_when_setpoint_zero():
+    # setpoint 0 (no speed commanded) -> A7 must not fire even if output is 0
+    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18
+    assert "A7_FREQ_NOT_TRACKING" not in ids(s, {**D0, "cmd_run_for_s": 8.0})
+
+
+def test_a12_photoeye_latched_fires():
+    s = healthy_snap(); s["safety/pe_latched"] = True
+    assert "A12_PHOTOEYE_JAM" in ids(s)
+
+
+def test_a12_silent_when_clear():
+    assert "A12_PHOTOEYE_JAM" not in ids(healthy_snap())

--- a/plc/conv_simple_anomaly/test_rules.py
+++ b/plc/conv_simple_anomaly/test_rules.py
@@ -1,0 +1,112 @@
+"""Unit tests for the Conv_Simple machine-card anomaly rules. Run: pytest plc/conv_simple_anomaly/"""
+import rules
+from rules import evaluate
+
+
+def healthy_snap():
+    return {
+        "motor/m101/running": False,
+        "vfd/vfd101/comm_ok": True,
+        "safety/estop": False,
+        "safety/wiring": False,
+        "safety/contactor_q1": True,
+        "plc/di/di00_fwd": False,
+        "plc/di/di01_rev": False,
+        "plc/di/di02_estop_nc": True,   # NC healthy = True
+        "plc/di/di03_estop_no": False,  # NO healthy = False
+        "vfd/vfd101/freq": 0.0,
+        "vfd/vfd101/current_a": 0.0,
+        "vfd/vfd101/dc_bus_v": 327.0,
+        "vfd/vfd101/cmd_word": 1,       # STOP
+    }
+
+
+D0 = {"now": 0.0, "max_stale_s": 0.0, "freq_frozen_s": 0.0, "cmd_run_for_s": 0.0}
+
+
+def ids(snap, d=D0, cfg=None):
+    return {a.rule_id for a in evaluate(snap, d, cfg)}
+
+
+def test_healthy_is_silent():
+    assert ids(healthy_snap()) == set()
+
+
+def test_running_healthy_is_silent():
+    s = healthy_snap()
+    s.update({"motor/m101/running": True, "vfd/vfd101/freq": 30.0,
+              "vfd/vfd101/current_a": 2.0, "vfd/vfd101/cmd_word": 18, "plc/di/di00_fwd": True})
+    assert ids(s) == set()
+
+
+def test_a0_offline():
+    assert "A0_OFFLINE" in ids(healthy_snap(), {**D0, "max_stale_s": 31.0})
+
+
+def test_a1_comm_loss():
+    s = healthy_snap(); s["vfd/vfd101/comm_ok"] = False
+    assert "A1_COMM_STALE" in ids(s)
+
+
+def test_a1_gates_vfd_rules():
+    # comm down -> overcurrent/dcbus must be suppressed (values are stale), only A1 fires
+    s = healthy_snap()
+    s.update({"vfd/vfd101/comm_ok": False, "vfd/vfd101/current_a": 99.0, "vfd/vfd101/dc_bus_v": 10.0})
+    got = ids(s)
+    assert got == {"A1_COMM_STALE"}
+
+
+def test_a3_wiring_flag():
+    s = healthy_snap(); s["safety/wiring"] = True
+    assert "A3_ESTOP_WIRING" in ids(s)
+
+
+def test_a3_dual_channel_mismatch():
+    s = healthy_snap(); s["plc/di/di03_estop_no"] = True   # now both True = mismatch
+    assert "A3_ESTOP_WIRING" in ids(s)
+
+
+def test_a4_direction_fault():
+    s = healthy_snap(); s["plc/di/di00_fwd"] = True; s["plc/di/di01_rev"] = True
+    assert "A4_DIRECTION_FAULT" in ids(s)
+
+
+def test_a5_illegal_run_estop():
+    s = healthy_snap(); s["motor/m101/running"] = True; s["safety/estop"] = True
+    assert "A5_ILLEGAL_RUN" in ids(s)
+
+
+def test_a5_illegal_run_contactor_open():
+    s = healthy_snap(); s["motor/m101/running"] = True; s["safety/contactor_q1"] = False
+    assert "A5_ILLEGAL_RUN" in ids(s)
+
+
+def test_a6_not_responding_after_grace():
+    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18  # RUN, but motor not running
+    assert "A6_DRIVE_NOT_RESPONDING" not in ids(s, {**D0, "cmd_run_for_s": 1.0})  # within grace
+    assert "A6_DRIVE_NOT_RESPONDING" in ids(s, {**D0, "cmd_run_for_s": 4.0})      # past grace
+
+
+def test_a8_overcurrent():
+    s = healthy_snap(); s["vfd/vfd101/current_a"] = 7.5  # > default FLA 5.0
+    assert "A8_OVERCURRENT" in ids(s)
+    # custom FLA raises the bar
+    assert "A8_OVERCURRENT" not in ids(s, cfg={"motor_fla_a": 10.0})
+
+
+def test_a9_dc_bus_low_and_high():
+    lo = healthy_snap(); lo["vfd/vfd101/dc_bus_v"] = 120.0
+    hi = healthy_snap(); hi["vfd/vfd101/dc_bus_v"] = 999.0
+    assert "A9_DC_BUS" in ids(lo)
+    assert "A9_DC_BUS" in ids(hi)
+
+
+def test_a10_freq_frozen_while_running():
+    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18
+    assert "A10_FREQ_FROZEN" in ids(s, {**D0, "freq_frozen_s": 6.0})
+    assert "A10_FREQ_FROZEN" not in ids(s, {**D0, "freq_frozen_s": 1.0})
+
+
+def test_confidence_mapping():
+    a = rules.r_a1_comm({"vfd/vfd101/comm_ok": False}, D0, rules.DEFAULT_CFG)
+    assert a.confidence == 1.0  # CRITICAL

--- a/plc/conv_simple_anomaly/test_rules.py
+++ b/plc/conv_simple_anomaly/test_rules.py
@@ -101,10 +101,25 @@ def test_a9_dc_bus_low_and_high():
     assert "A9_DC_BUS" in ids(hi)
 
 
-def test_a10_freq_frozen_while_running():
+def test_a10_freq_stuck_at_zero_fires():
+    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18  # RUN, freq stuck at 0.0
+    assert "A10_FREQ_STUCK_ZERO" in ids(s, {**D0, "cmd_run_for_s": 6.0})
+    assert "A10_FREQ_STUCK_ZERO" not in ids(s, {**D0, "cmd_run_for_s": 1.0})  # within grace
+
+
+def test_a10_no_startup_transient():
+    # the instant RUN is pressed (cmd_run_for_s ~0) freq is still 0 after a long idle —
+    # must NOT fire even though freq had been frozen at 0 for ages.
     s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18
-    assert "A10_FREQ_FROZEN" in ids(s, {**D0, "freq_frozen_s": 6.0})
-    assert "A10_FREQ_FROZEN" not in ids(s, {**D0, "freq_frozen_s": 1.0})
+    assert "A10_FREQ_STUCK_ZERO" not in ids(s, {**D0, "cmd_run_for_s": 0.5, "freq_frozen_s": 120.0})
+
+
+def test_a10_steady_speed_does_not_fire():
+    # constant NON-zero Hz at steady running must NOT be flagged frozen
+    s = healthy_snap(); s.update({"vfd/vfd101/cmd_word": 18, "motor/m101/running": True,
+                                  "vfd/vfd101/freq": 30.0, "vfd/vfd101/current_a": 2.0})
+    assert "A10_FREQ_STUCK_ZERO" not in ids(s, {**D0, "freq_frozen_s": 60.0})
+    assert ids(s, {**D0, "freq_frozen_s": 60.0}) == set()  # fully healthy running
 
 
 def test_confidence_mapping():

--- a/plc/live-plc-bridge/MIRA-LivePLCBridge-Boot.xml
+++ b/plc/live-plc-bridge/MIRA-LivePLCBridge-Boot.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<!-- Boot-scoped Scheduled Task for the live-plc-bridge (the bench PLC->MQTT bridge).
+     Runs at startup whether or not a user is logged on, restarts on failure, and uses
+     LogonType S4U (the user's own account, NO stored password, NO SYSTEM escalation).
+     This is the always-on mechanism DEPLOY.md prescribes — it replaces the logon-scoped
+     Startup-folder launcher, so it does NOT stop on logout (which would have produced
+     spurious A0_OFFLINE pages).
+
+     INSTALL (run in an ADMIN PowerShell/cmd):
+       schtasks /Create /TN "MIRA-LivePLCBridge" /XML "C:\Users\hharp\Documents\MIRA-monorepo\plc\live-plc-bridge\MIRA-LivePLCBridge-Boot.xml" /F
+     Then REMOVE the old logon-scoped launcher so the bridge doesn't double-run:
+       Remove-Item "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Startup\MIRA-LivePLCBridge.vbs"
+     Verify:  schtasks /Query /TN "MIRA-LivePLCBridge" /V /FO LIST
+-->
+<Task version="1.3" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Always-on live-plc-bridge: streams the bench Micro 820 / GS10 PLC to the VPS MQTT broker for anomaly detection.</Description>
+    <URI>\MIRA-LivePLCBridge</URI>
+  </RegistrationInfo>
+  <Triggers>
+    <BootTrigger>
+      <Enabled>true</Enabled>
+    </BootTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <UserId>LAPTOP-0KA3C70H\hharp</UserId>
+      <LogonType>S4U</LogonType>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>true</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RestartOnFailure>
+      <Interval>PT1M</Interval>
+      <Count>999</Count>
+    </RestartOnFailure>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>C:\Users\hharp\Documents\MIRA-monorepo\plc\live-plc-bridge\run_bridge_laptop.bat</Command>
+    </Exec>
+  </Actions>
+</Task>

--- a/plc/live-plc-bridge/bridge.py
+++ b/plc/live-plc-bridge/bridge.py
@@ -29,6 +29,7 @@ import asyncio
 import json
 import logging
 import os
+import sys
 import time
 from typing import Optional
 
@@ -121,7 +122,17 @@ def _envelope(value, ts: Optional[float] = None) -> str:
 
 
 async def _read_block(fn, offset: int, count: int):
-    rr = await fn(offset, count=count, slave=PLC_UNIT)
+    # pymodbus renamed the unit kwarg (slave -> device_id) across 3.x; try both,
+    # then positional, so the bridge runs on whatever the bench laptop has installed.
+    rr = None
+    for kw in ({"count": count, "device_id": PLC_UNIT}, {"count": count, "slave": PLC_UNIT}):
+        try:
+            rr = await fn(offset, **kw)
+            break
+        except TypeError:
+            continue
+    if rr is None:
+        rr = await fn(offset, count)
     if rr.isError():
         raise IOError(f"modbus read error @{offset} x{count}: {rr}")
     return rr
@@ -183,4 +194,10 @@ async def run() -> None:
 
 
 if __name__ == "__main__":
+    # On Windows the default ProactorEventLoop lacks add_reader/add_writer, which
+    # pymodbus' async client + aiomqtt require. The bench bridge runs on the
+    # Windows PLC laptop (only host with a route to 192.168.1.0/24), so select the
+    # SelectorEventLoop there. No effect on the Linux container deploy.
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     asyncio.run(run())

--- a/plc/live-plc-bridge/bridge.py
+++ b/plc/live-plc-bridge/bridge.py
@@ -67,6 +67,9 @@ COIL_TOPICS: dict[int, str] = {
     17: "plc/do/do01_red",
     18: "safety/contactor_q1",
     19: "plc/do/do03_pbrun_led",
+    # --- slave-map v2 (A12 photo-eye): enable after the MbSrvConf.xml reflash ---
+    # 20: "plc/di/di05_photoeye",   # raw photo-eye beam
+    # 21: "safety/pe_latched",      # photo-eye latching soft-stop engaged
 }
 
 # HR offset -> (relative topic, scale divisor). vfd_comm_ok (coil 3) is the
@@ -77,9 +80,15 @@ HR_SPECS: dict[int, tuple[str, float]] = {
     108: ("vfd/vfd101/voltage_v", 10.0),   # output V x10
     109: ("vfd/vfd101/dc_bus_v", 10.0),    # DC bus V x10
     114: ("vfd/vfd101/cmd_word", 1.0),     # GS10 command echo (1=STOP 18=FWD 20=REV)
+    # --- slave-map v2 (A2 fault decode / A7 setpoint): enable after the reflash ---
+    # 110: ("vfd/vfd101/fault_raw", 1.0),    # GS10 0x2100: hi byte=warn, lo byte=fault (split in decode)
+    # 111: ("vfd/vfd101/freq_setpoint", 100.0),  # GS10 0x2101 freq command x100
 }
 
 # Read plan: blocks that are fully mapped (no unmapped address inside a span).
+# The Micro 820 rejects a read that spans an unmapped address, so the plan only
+# covers mapped blocks. After the slave-map v2 reflash, widen these spans (e.g.
+# HR (106, 6) to pick up 110/111) and uncomment the HR_SPECS/COIL_TOPICS above.
 COIL_READS = [(0, 1), (3, 1), (5, 1), (9, 1), (11, 9)]  # (offset, count)
 HR_READS = [(106, 4), (114, 1)]
 

--- a/plc/live-plc-bridge/run_bridge_laptop.bat
+++ b/plc/live-plc-bridge/run_bridge_laptop.bat
@@ -1,0 +1,14 @@
+@echo off
+REM Always-on launcher for the live-plc-bridge on the PLC laptop (bench LAN host).
+REM Publishes real Micro 820 / GS10 data to the VPS broker so the VPS anomaly
+REM engine can run 24/7. Registered as a Scheduled Task (at log on). See DEPLOY.md.
+set PLC_HOST=192.168.1.100
+set PLC_PORT=502
+set MQTT_HOST=100.68.120.99
+set MQTT_PORT=1883
+set UNS_PREFIX=demo/cell1/conveyor/cv101
+set STREAM=bridge
+set SOURCE=plc-bridge
+set POLL_MS=500
+set LOG_LEVEL=INFO
+"C:\Users\hharp\AppData\Local\Python\pythoncore-3.14-64\python.exe" -u "C:\Users\hharp\Documents\MIRA-monorepo\plc\live-plc-bridge\bridge.py" >> "%LOCALAPPDATA%\mira-live-plc-bridge.log" 2>&1

--- a/tools/create_bench_equipment_node.py
+++ b/tools/create_bench_equipment_node.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Create the Conv_Simple bench equipment node in the knowledge graph.
+
+Models the real bench as a site-side equipment instance under the canonical
+ISA-95 UNS, links its VFD component to the GS10 catalog node so the drive's
+manuals + fault codes are reachable by graph traversal, and stamps the live
+data hooks (Modbus host, MQTT prefix, diagnostics topic) as properties.
+
+All writes go through the canonical idempotent helpers (ingest.kg_writer), so
+re-running is safe. Entities land approval_state='verified' (the column
+default) — this is a deliberate, human-authorized assertion, not an AI proposal.
+
+Usage (dry run prints the plan, NO DB writes):
+    python tools/create_bench_equipment_node.py
+Commit (writes to NeonDB — run under doppler so NEON_DATABASE_URL/MIRA_TENANT_ID resolve):
+    doppler run --project factorylm --config prd -- \\
+      python tools/create_bench_equipment_node.py --commit
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "mira-crawler"))
+
+from ingest import kg_writer, uns  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("create-bench-equipment-node")
+
+# Bench identity (slugs feed the ISA-95 path builder).
+COMPANY, SITE, AREA, EQUIPMENT_ID = "factorylm", "bench", "conv_simple", "cv101"
+
+BENCH_PROPS = {
+    "description": "Conv_Simple bench conveyor (Micro820 + GS10 demo rig)",
+    "plc": "Allen-Bradley Micro820 2080-LC20-20QBB",
+    "drive": "AutomationDirect DURApulse GS10",
+    "modbus_tcp": "192.168.1.100:502",
+    "mqtt_prefix": "demo/cell1/conveyor/cv101",
+    "diagnostics_topic": "demo/cell1/conveyor/cv101/diagnostics/conv_simple_anomaly",
+    "anomaly_engine": "conv_simple_anomaly",
+    "source": "create_bench_equipment_node.py",
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--commit", action="store_true", help="write to NeonDB (else dry-run)")
+    args = ap.parse_args()
+
+    tenant = os.environ.get("MIRA_TENANT_ID")
+
+    bench_path = uns.assigned_equipment_path(COMPANY, SITE, AREA, EQUIPMENT_ID)
+    gs10_path = uns.equipment_unassigned_path("AutomationDirect", "GS10")
+    vfd_path = uns.equipment_subnode_path(bench_path, "component", "vfd")
+
+    plan = [
+        ("equipment", "Conv_Simple cv101", bench_path, BENCH_PROPS),
+        ("equipment", "GS10", gs10_path,
+         {"manufacturer": "AutomationDirect", "catalog_node": True}),
+        ("component", "cv101 VFD (GS10)", vfd_path,
+         {"manufacturer": "AutomationDirect", "model": "GS10", "role": "conveyor drive"}),
+    ]
+    edges = [
+        ("Conv_Simple cv101", "has_component", "cv101 VFD (GS10)"),
+        ("cv101 VFD (GS10)", "instance_of", "GS10"),
+    ]
+
+    log.info("Planned entities:")
+    for etype, name, path, _ in plan:
+        ok = uns.is_valid_path(path)
+        log.info("  [%s] %-18s %s  %s", etype, name, path, "OK" if ok else "INVALID PATH")
+        if not ok:
+            log.error("invalid uns_path — aborting"); return 2
+    log.info("Planned edges:")
+    for s, rel, t in edges:
+        log.info("  %s -[%s]-> %s", s, rel, t)
+
+    if not args.commit:
+        log.info("DRY RUN — no DB writes. Re-run with --commit (under doppler) to apply.")
+        return 0
+
+    if not tenant or not os.environ.get("NEON_DATABASE_URL"):
+        log.error("MIRA_TENANT_ID and NEON_DATABASE_URL required (run under doppler)."); return 2
+
+    ids: dict[str, str] = {}
+    for etype, name, path, props in plan:
+        eid = kg_writer.upsert_entity(tenant, etype, name, path, properties=props)
+        if not eid:
+            log.error("upsert_entity failed for %s/%s", etype, name); return 1
+        ids[name] = eid
+        log.info("upserted %-18s -> %s", name, eid)
+    for s, rel, t in edges:
+        rid = kg_writer.upsert_relationship(tenant, ids[s], ids[t], rel)
+        log.info("edge %s -[%s]-> %s : %s", s, rel, t, rid or "FAILED")
+    log.info("Done. Bench equipment node id = %s", ids["Conv_Simple cv101"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Refresh of #1638 onto current main (the original was 218 commits behind with a stale `docker-compose.saas.yml` conflict).

**Unchanged content** from #1638 — the unique bench anomaly subsystem:
- `plc/conv_simple_anomaly/` — A2/A7/A12 anomaly rules (GS10 fault decode, freq-tracking, photo-eye), `live_check.py`, machine-card rules, tests
- `plc/live-plc-bridge/` — bench bridge runs on the Windows bench laptop (BENCH-ONLY)
- `docker-compose.fault-detective.yml` — bench harness
- `mira-core/scripts/seed_fault_codes.py`, `tools/create_bench_equipment_node.py` — UNS bench equipment node + GS10 numeric fault seeds
- `ARCHITECTURE.md` / `docs/ARCHITECTURE.md` updates

**Conflict resolved:** `docker-compose.saas.yml` — kept main's `MIRA_DIRECT_ANSWER_MODE` and #1638's `MIRA_PROCESS_TIMEOUT: 90` on `mira-ask` (both env vars retained). No bench tool is added to the customer compose (fieldbus-readonly rule honored).

Supersedes #1638. Bench-only `plc/` code; not in any customer-shipped surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)