### PR TITLE
fix(plc): ruff lint — split imports and semicolons in conv_simple_anomaly + bench tool

### DIFF
--- a/plc/conv_simple_anomaly/engine.py
+++ b/plc/conv_simple_anomaly/engine.py
@@ -14,11 +14,17 @@ Reuses the project's aiomqtt pattern (see plc/live-plc-bridge/bridge.py, mira-fa
 NOTE: not exercised in CI yet (needs a broker). The pure rule logic is covered by test_rules.py.
 """
 from __future__ import annotations
-import asyncio, json, logging, os, sqlite3, time, urllib.request
+
+import asyncio
+import json
+import logging
+import os
+import sqlite3
+import time
+import urllib.request
 from pathlib import Path
 
 import aiomqtt  # type: ignore
-
 import rules
 
 # Broker host must be set via env (MQTT_HOST) at deploy time; "localhost" is a safe

--- a/plc/conv_simple_anomaly/live_check.py
+++ b/plc/conv_simple_anomaly/live_check.py
@@ -9,7 +9,11 @@ Uses the SAME register map as plc/live-plc-bridge (kept in sync here so this too
 aiomqtt dependency). Read-only: never writes to the PLC.
 """
 from __future__ import annotations
-import argparse, sys, time
+
+import argparse
+import sys
+import time
+
 from pymodbus.client import ModbusTcpClient
 
 try:  # Windows consoles default to cp1252; rule messages are UTF-8
@@ -74,9 +78,12 @@ def watch(client, secs):
     while time.time() < t_end:
         now = time.time()
         try:
-            snap = poll(client); last_any = now
+            snap = poll(client)
+            last_any = now
         except Exception as e:
-            print(f"  {time.strftime('%H:%M:%S')}  poll error: {e}"); time.sleep(0.5); continue
+            print(f"  {time.strftime('%H:%M:%S')}  poll error: {e}")
+            time.sleep(0.5)
+            continue
         if snap.get(rules.T_FREQ) != freq_val:
             freq_val, freq_ts = snap.get(rules.T_FREQ), now
         cmd_run = snap.get(rules.T_CMD) in rules.DEFAULT_CFG["run_cmd_values"]
@@ -87,7 +94,8 @@ def watch(client, secs):
         cur = {a.rule_id: a for a in rules.evaluate(snap, derived)}
         ts = time.strftime("%H:%M:%S")
         for rid in cur.keys() - prev.keys():
-            a = cur[rid]; print(f"  {ts}  >>> FIRED  [{a.severity}] {rid}: {a.message}")
+            a = cur[rid]
+            print(f"  {ts}  >>> FIRED  [{a.severity}] {rid}: {a.message}")
         for rid in prev.keys() - cur.keys():
             print(f"  {ts}  --- cleared {rid}")
         if now >= next_hb:

--- a/plc/conv_simple_anomaly/rules.py
+++ b/plc/conv_simple_anomaly/rules.py
@@ -16,6 +16,7 @@ currently-deployed slave does NOT yet publish — those rules degrade silently (
 until the PLC Modbus-slave-map extension is reflashed. See README + specs/CONVEYOR_MACHINE_CARD.md.
 """
 from __future__ import annotations
+
 from dataclasses import dataclass, field
 
 CRITICAL, HIGH, MED, LOW, INFO = "CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"

--- a/plc/conv_simple_anomaly/test_rules.py
+++ b/plc/conv_simple_anomaly/test_rules.py
@@ -50,7 +50,8 @@ def test_a0_offline():
 
 
 def test_a1_comm_loss():
-    s = healthy_snap(); s["vfd/vfd101/comm_ok"] = False
+    s = healthy_snap()
+    s["vfd/vfd101/comm_ok"] = False
     assert "A1_COMM_STALE" in ids(s)
 
 
@@ -63,52 +64,65 @@ def test_a1_gates_vfd_rules():
 
 
 def test_a3_wiring_flag():
-    s = healthy_snap(); s["safety/wiring"] = True
+    s = healthy_snap()
+    s["safety/wiring"] = True
     assert "A3_ESTOP_WIRING" in ids(s)
 
 
 def test_a3_dual_channel_mismatch():
-    s = healthy_snap(); s["plc/di/di03_estop_no"] = True   # now both True = mismatch
+    s = healthy_snap()
+    s["plc/di/di03_estop_no"] = True  # now both True = mismatch
     assert "A3_ESTOP_WIRING" in ids(s)
 
 
 def test_a4_direction_fault():
-    s = healthy_snap(); s["plc/di/di00_fwd"] = True; s["plc/di/di01_rev"] = True
+    s = healthy_snap()
+    s["plc/di/di00_fwd"] = True
+    s["plc/di/di01_rev"] = True
     assert "A4_DIRECTION_FAULT" in ids(s)
 
 
 def test_a5_illegal_run_estop():
-    s = healthy_snap(); s["motor/m101/running"] = True; s["safety/estop"] = True
+    s = healthy_snap()
+    s["motor/m101/running"] = True
+    s["safety/estop"] = True
     assert "A5_ILLEGAL_RUN" in ids(s)
 
 
 def test_a5_illegal_run_contactor_open():
-    s = healthy_snap(); s["motor/m101/running"] = True; s["safety/contactor_q1"] = False
+    s = healthy_snap()
+    s["motor/m101/running"] = True
+    s["safety/contactor_q1"] = False
     assert "A5_ILLEGAL_RUN" in ids(s)
 
 
 def test_a6_not_responding_after_grace():
-    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18  # RUN, but motor not running
+    s = healthy_snap()
+    s["vfd/vfd101/cmd_word"] = 18  # RUN, but motor not running
     assert "A6_DRIVE_NOT_RESPONDING" not in ids(s, {**D0, "cmd_run_for_s": 1.0})  # within grace
     assert "A6_DRIVE_NOT_RESPONDING" in ids(s, {**D0, "cmd_run_for_s": 4.0})      # past grace
 
 
 def test_a8_overcurrent():
-    s = healthy_snap(); s["vfd/vfd101/current_a"] = 7.5  # > default FLA 5.0
+    s = healthy_snap()
+    s["vfd/vfd101/current_a"] = 7.5  # > default FLA 5.0
     assert "A8_OVERCURRENT" in ids(s)
     # custom FLA raises the bar
     assert "A8_OVERCURRENT" not in ids(s, cfg={"motor_fla_a": 10.0})
 
 
 def test_a9_dc_bus_low_and_high():
-    lo = healthy_snap(); lo["vfd/vfd101/dc_bus_v"] = 120.0
-    hi = healthy_snap(); hi["vfd/vfd101/dc_bus_v"] = 999.0
+    lo = healthy_snap()
+    lo["vfd/vfd101/dc_bus_v"] = 120.0
+    hi = healthy_snap()
+    hi["vfd/vfd101/dc_bus_v"] = 999.0
     assert "A9_DC_BUS" in ids(lo)
     assert "A9_DC_BUS" in ids(hi)
 
 
 def test_a10_freq_stuck_at_zero_fires():
-    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18  # RUN, freq stuck at 0.0
+    s = healthy_snap()
+    s["vfd/vfd101/cmd_word"] = 18  # RUN, freq stuck at 0.0
     assert "A10_FREQ_STUCK_ZERO" in ids(s, {**D0, "cmd_run_for_s": 6.0})
     assert "A10_FREQ_STUCK_ZERO" not in ids(s, {**D0, "cmd_run_for_s": 1.0})  # within grace
 
@@ -116,13 +130,15 @@ def test_a10_freq_stuck_at_zero_fires():
 def test_a10_no_startup_transient():
     # the instant RUN is pressed (cmd_run_for_s ~0) freq is still 0 after a long idle —
     # must NOT fire even though freq had been frozen at 0 for ages.
-    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18
+    s = healthy_snap()
+    s["vfd/vfd101/cmd_word"] = 18
     assert "A10_FREQ_STUCK_ZERO" not in ids(s, {**D0, "cmd_run_for_s": 0.5, "freq_frozen_s": 120.0})
 
 
 def test_a10_steady_speed_does_not_fire():
     # constant NON-zero Hz at steady running must NOT be flagged frozen
-    s = healthy_snap(); s.update({"vfd/vfd101/cmd_word": 18, "motor/m101/running": True,
+    s = healthy_snap()
+    s.update({"vfd/vfd101/cmd_word": 18, "motor/m101/running": True,
                                   "vfd/vfd101/freq": 30.0, "vfd/vfd101/current_a": 2.0})
     assert "A10_FREQ_STUCK_ZERO" not in ids(s, {**D0, "freq_frozen_s": 60.0})
     assert ids(s, {**D0, "freq_frozen_s": 60.0}) == set()  # fully healthy running
@@ -146,7 +162,8 @@ def test_new_rules_silent_when_signals_absent():
 
 
 def test_a2_vfd_fault_code_fires_and_decodes():
-    s = healthy_snap(); s["vfd/vfd101/fault_code"] = 21  # oL overload
+    s = healthy_snap()
+    s["vfd/vfd101/fault_code"] = 21  # oL overload
     got = {a.rule_id: a for a in evaluate(s, D0)}
     assert "A2_VFD_FAULT" in got
     assert "oL" in got["A2_VFD_FAULT"].message  # decoded from the GS10 manual table
@@ -158,7 +175,9 @@ def test_a2_no_fault_when_zero():
 
 def test_a2_gated_by_comm():
     # comm down -> fault_code is stale; A2 suppressed, only A1 fires
-    s = healthy_snap(); s["vfd/vfd101/comm_ok"] = False; s["vfd/vfd101/fault_code"] = 21
+    s = healthy_snap()
+    s["vfd/vfd101/comm_ok"] = False
+    s["vfd/vfd101/fault_code"] = 21
     assert "A2_VFD_FAULT" not in ids(s)
 
 
@@ -184,12 +203,14 @@ def test_a7_silent_when_tracking():
 
 def test_a7_silent_when_setpoint_zero():
     # setpoint 0 (no speed commanded) -> A7 must not fire even if output is 0
-    s = healthy_snap(); s["vfd/vfd101/cmd_word"] = 18
+    s = healthy_snap()
+    s["vfd/vfd101/cmd_word"] = 18
     assert "A7_FREQ_NOT_TRACKING" not in ids(s, {**D0, "cmd_run_for_s": 8.0})
 
 
 def test_a12_photoeye_latched_fires():
-    s = healthy_snap(); s["safety/pe_latched"] = True
+    s = healthy_snap()
+    s["safety/pe_latched"] = True
     assert "A12_PHOTOEYE_JAM" in ids(s)
 
 

--- a/tools/create_bench_equipment_node.py
+++ b/tools/create_bench_equipment_node.py
@@ -75,7 +75,8 @@ def main() -> int:
         ok = uns.is_valid_path(path)
         log.info("  [%s] %-18s %s  %s", etype, name, path, "OK" if ok else "INVALID PATH")
         if not ok:
-            log.error("invalid uns_path — aborting"); return 2
+            log.error("invalid uns_path — aborting")
+            return 2
     log.info("Planned edges:")
     for s, rel, t in edges:
         log.info("  %s -[%s]-> %s", s, rel, t)
@@ -85,13 +86,15 @@ def main() -> int:
         return 0
 
     if not tenant or not os.environ.get("NEON_DATABASE_URL"):
-        log.error("MIRA_TENANT_ID and NEON_DATABASE_URL required (run under doppler)."); return 2
+        log.error("MIRA_TENANT_ID and NEON_DATABASE_URL required (run under doppler).")
+        return 2
 
     ids: dict[str, str] = {}
     for etype, name, path, props in plan:
         eid = kg_writer.upsert_entity(tenant, etype, name, path, properties=props)
         if not eid:
-            log.error("upsert_entity failed for %s/%s", etype, name); return 1
+            log.error("upsert_entity failed for %s/%s", etype, name)
+            return 1
         ids[name] = eid
         log.info("upserted %-18s -> %s", name, eid)
     for s, rel, t in edges:


### PR DESCRIPTION
## Summary

- Fixes `E401`/`I001` (multi-import on one line, unsorted import blocks) in `engine.py`, `live_check.py`, and `rules.py` — auto-fixed by `ruff --fix`
- Fixes `E702` (multiple statements on one line, semicolon-separated) in `live_check.py`, `test_rules.py`, and `tools/create_bench_equipment_node.py` — split manually
- No logic changes; ruff gate now passes clean

These violations were introduced by #1865 (`feat(plc): A2/A7/A12 anomaly rules + bench bridge`) and blocked the stop hook on the adversarial review routine.

## Test plan

- [ ] `ruff check plc/conv_simple_anomaly/ tools/create_bench_equipment_node.py` — passes (verified locally)
- [ ] `pytest plc/conv_simple_anomaly/` — test logic unchanged, only formatting

https://claude.ai/code/session_01VwFrTnuz6Cyp6aW9kHtUqU

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwFrTnuz6Cyp6aW9kHtUqU)_