### PR TITLE
fix(quickstart): GTM hardening — citation relevance + e2e smoke gate (RED #2/#3)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -63,6 +63,17 @@ jobs:
           HUB_URL: https://app.factorylm.com
         run: npx playwright test --config playwright.smoke.config.ts
 
+      # Quickstart money-path smoke (GTM RED #3) — stdlib-only Python, no pip
+      # install. Belt-and-suspenders to the Playwright gate above: asserts
+      # /api/quickstart/ask returns a grounded answer OR an explicit refusal.
+      # The 429 flood is self-gated (SMOKE_RATE_LIMIT_CHECK) so we never hammer
+      # prod on every PR. Runnable by hand against localhost or prod; see the
+      # module docstring.
+      - name: Quickstart E2E smoke (Python, stdlib)
+        env:
+          QUICKSTART_SMOKE_URL: https://app.factorylm.com
+        run: python3 tests/smoke/test_quickstart_e2e.py
+
       - name: Upload failure screenshots
         if: failure()
         uses: actions/upload-artifact@v7

--- a/docs/gtm/go-to-market-hardening-checklist.md
+++ b/docs/gtm/go-to-market-hardening-checklist.md
@@ -33,6 +33,12 @@ BM25 chunks.
   **chunks** (before `buildGroundedContext`), so the LLM never sees the
   irrelevant content and `[n]` markers stay consistent. → `filterCitationsByRelevance()`
   in `manual-rag.ts`, wired into `quickstart/ask/route.ts`.
+  **Scope:** fires off the **picked manufacturer** (the request's `manufacturer`
+  field — exactly the fallback case where the bug bites). A stranger who picks
+  no manufacturer and types a free-text vendor mention ("my Danfoss VFD…") gets
+  `manufacturer=null` → passthrough; BM25 query-text ranking is the only defense
+  there. Free-text vendor extraction is out of scope on this surface. **Test the
+  Danfoss case via the manufacturer picker.**
 - [x] **RED #3 — Quickstart smoke gate.** End-to-end check on every deploy:
   POST a real maintenance question, assert non-empty answer + citations-or-
   explicit-refusal + no error status; assert 429 on the 21st rapid request

--- a/docs/gtm/go-to-market-hardening-checklist.md
+++ b/docs/gtm/go-to-market-hardening-checklist.md
@@ -1,0 +1,92 @@
+# Go-To-Market Hardening Checklist
+
+> **Owner:** GTM readiness · **Created:** 2026-06-10 · **Status:** in progress
+>
+> The #1 priority for going to market is a hardened set of stranger-facing
+> demo/product surfaces. This checklist tracks all four priorities and their
+> sub-items. Update it as items land.
+
+Status legend: `[ ]` not started · `[~]` in progress · `[x]` done
+
+---
+
+## Priority 1 — Quickstart chat path (`/api/quickstart/ask`)
+
+The public, no-auth "ask MIRA" experience on factorylm.com. A stranger types a
+maintenance question, picks a manufacturer (optional), and gets a grounded,
+cited answer. This is the first thing a prospect touches — it must not look
+like it hallucinates.
+
+**Surface:** `mira-hub` (TypeScript) — `src/app/api/quickstart/ask/route.ts`
++ `src/lib/manual-rag.ts`. Note: this path does **not** go through the Python
+`mira-bots/shared/engine.py`; citations are assembled in the TS route from
+BM25 chunks.
+
+- [x] **RED #1 — Rate limit.** Per-IP-hash in-memory limiter (20 req/min →
+  429). Shipped in **PR #1838** (`fix/quickstart-rate-limit`, merge
+  `5fd70dae`), verified on `origin/main`. Closes #1832.
+- [x] **RED #2 — Citation relevance enforcement.** After BM25 retrieval, drop
+  chunks whose manufacturer/model don't match the asked-about manufacturer
+  (the tenant-wide fallback could pull e.g. Siemens chunks for a Danfoss
+  question). Lightweight string match — no LLM call, no `uns_resolver` (there
+  is no `uns_context` on this anonymous surface). Filter applied to the
+  **chunks** (before `buildGroundedContext`), so the LLM never sees the
+  irrelevant content and `[n]` markers stay consistent. → `filterCitationsByRelevance()`
+  in `manual-rag.ts`, wired into `quickstart/ask/route.ts`.
+- [x] **RED #3 — Quickstart smoke gate.** End-to-end check on every deploy:
+  POST a real maintenance question, assert non-empty answer + citations-or-
+  explicit-refusal + no error status; assert 429 on the 21st rapid request
+  (localhost only). → `tests/smoke/test_quickstart_e2e.py`, wired into
+  `smoke-test.yml`.
+
+**Follow-up (out of scope here):** the Python bot engine (Telegram/Slack via
+`mira-bots/shared/engine.py` + `citation_compliance.py`) has the *same*
+wrong-manufacturer citation gap on a *different* surface. Tracked separately —
+do not fix inline with the quickstart work.
+
+---
+
+## Priority 2 — Command Center dashboard
+
+The Hub UNS-tree + live HMI display surface (`mira-hub`, Command Center pages).
+
+- [ ] Audit live-tile freshness / staleness guard on public-demo data.
+- [ ] Verify no "Coming Soon" / fake-data tiles are reachable in the demo path.
+- [ ] Confirm cloud-reach proxy (Phase 2) liveness probes are green.
+- [ ] Smoke check: Command Center loads with seeded demo data, no 5xx.
+
+_(Sub-items to be refined when this priority is picked up.)_
+
+---
+
+## Priority 3 — SimLab juice bottling demo
+
+The ProveIt-style deterministic simulated factory benchmark (`simlab/` +
+`tests/simlab/`).
+
+- [ ] Headless sim runs seeded + deterministic (11/11 tests green).
+- [ ] Eval harness produces a clean scorecard on the juice bottling line.
+- [ ] Demo entry point documented + reproducible from a cold checkout.
+- [ ] Smoke check: `simlab` boots on port 8099, golden run matches.
+
+_(Sub-items to be refined when this priority is picked up.)_
+
+---
+
+## Priority 4 — Fault Detective PLC bench
+
+The bench Fault-Detective demo (`plc/`, `docker-compose.fault-detective.yml`).
+
+- [ ] Confirm bench harness is clearly labeled bench-only (not a customer arch).
+- [ ] Live Modbus map deployed + verified (no `ILLEGAL_FUNCTION`).
+- [ ] Anomaly rules (A2/A7/A12) fire on the seeded fault scenarios.
+- [ ] Demo runbook reproducible; bench tools carry BENCH-ONLY banners.
+
+_(Sub-items to be refined when this priority is picked up.)_
+
+---
+
+## Change log
+
+- **2026-06-10** — Checklist created. Quickstart RED #1 verified merged;
+  RED #2 + RED #3 implemented on `feat/quickstart-gtm-hardening`.

--- a/mira-hub/src/app/api/quickstart/ask/route.ts
+++ b/mira-hub/src/app/api/quickstart/ask/route.ts
@@ -5,6 +5,7 @@ import { withTenantContext } from "@/lib/tenant-context";
 import { cascadeComplete, type CascadeMessage } from "@/lib/llm/cascade";
 import {
   retrieveManualChunks,
+  filterCitationsByRelevance,
   buildGroundedContext,
   type ManualChunk,
   type ManualSource,
@@ -140,6 +141,13 @@ export async function POST(req: Request) {
     console.error("[quickstart/ask] retrieval failed:", err);
     // Continue — the model can still refuse with no context.
   }
+
+  // Drop chunks whose manufacturer is irrelevant to what was asked (the
+  // tenant-wide retrieval fallback can surface e.g. a Siemens manual for a
+  // Danfoss question). Filter BEFORE building context so the model never
+  // grounds on the wrong vendor and the [n] markers stay aligned with the
+  // returned citations. If this empties the set, cite-or-refuse kicks in.
+  chunks = filterCitationsByRelevance(chunks, manufacturer);
 
   const context = buildGroundedContext(chunks);
   const userMsg = context

--- a/mira-hub/src/lib/manual-rag.test.ts
+++ b/mira-hub/src/lib/manual-rag.test.ts
@@ -1,0 +1,69 @@
+// Vitest coverage for citation-relevance filtering on the public quickstart path.
+//
+// Run: cd mira-hub && npx vitest run src/lib/manual-rag
+//
+// PURE function — no DB. Guards the GTM RED #2 fix: BM25's tenant-wide fallback
+// can surface a chunk from the wrong vendor (e.g. a Siemens manual for a Danfoss
+// question). filterCitationsByRelevance drops those before they reach the model.
+
+import { describe, it, expect } from "vitest";
+import { filterCitationsByRelevance, type ManualChunk } from "./manual-rag";
+
+function chunk(partial: Partial<ManualChunk>): ManualChunk {
+  return {
+    content: "",
+    manufacturer: "",
+    modelNumber: "",
+    sourceUrl: "",
+    sourcePage: null,
+    title: "",
+    rank: 0,
+    ...partial,
+  };
+}
+
+describe("filterCitationsByRelevance", () => {
+  const danfoss = chunk({ manufacturer: "Danfoss", modelNumber: "VLT 2800" });
+  const siemens = chunk({ manufacturer: "Siemens", modelNumber: "SINAMICS G120" });
+  const generic = chunk({ manufacturer: "", title: "How a VFD works" });
+
+  it("drops the wrong-vendor chunk when a manufacturer is asked", () => {
+    const out = filterCitationsByRelevance([danfoss, siemens], "Danfoss");
+    expect(out).toEqual([danfoss]);
+  });
+
+  it("keeps generic (no-manufacturer) chunks as educational carve-outs", () => {
+    const out = filterCitationsByRelevance([siemens, generic], "Danfoss");
+    expect(out).toEqual([generic]);
+  });
+
+  it("passes everything through when no manufacturer is asked", () => {
+    const all = [danfoss, siemens, generic];
+    expect(filterCitationsByRelevance(all, null)).toEqual(all);
+    expect(filterCitationsByRelevance(all, "")).toEqual(all);
+  });
+
+  it("matches case- and spacing-insensitively", () => {
+    const rockwell = chunk({ manufacturer: "Rockwell Automation" });
+    expect(filterCitationsByRelevance([rockwell], "rockwell")).toEqual([rockwell]);
+    expect(filterCitationsByRelevance([rockwell], "ROCKWELL AUTOMATION")).toEqual([
+      rockwell,
+    ]);
+  });
+
+  it("recovers the vendor from model number or source URL when the manufacturer field is mislabeled", () => {
+    // Non-blank manufacturer that does NOT match the asked vendor, but the real
+    // vendor is encoded in the model number / source URL — must be rescued, not
+    // dropped (this is the branch past the blank-manufacturer carve-out).
+    const byModel = chunk({ manufacturer: "OEM Docs", modelNumber: "Danfoss VLT 2800" });
+    const byUrl = chunk({ manufacturer: "Distributor", sourceUrl: "https://danfoss.com/vlt.pdf" });
+    const out = filterCitationsByRelevance([byModel, byUrl, siemens], "Danfoss");
+    expect(out).toEqual([byModel, byUrl]);
+  });
+
+  it("never mutates the input array", () => {
+    const input = [danfoss, siemens];
+    filterCitationsByRelevance(input, "Danfoss");
+    expect(input).toHaveLength(2);
+  });
+});

--- a/mira-hub/src/lib/manual-rag.ts
+++ b/mira-hub/src/lib/manual-rag.ts
@@ -246,6 +246,57 @@ export function buildGroundedContext(chunks: ManualChunk[]): string {
 }
 
 /**
+ * Drop chunks whose manufacturer is plainly irrelevant to what the user asked.
+ *
+ * The public quickstart endpoint is anonymous — there is no UNS context, so the
+ * only relevance signal is the manufacturer the user picked. `retrieveManualChunks`
+ * falls back to a tenant-wide query when the manufacturer-scoped query returns
+ * nothing, which can surface e.g. a Siemens chunk for a Danfoss question. Citing
+ * the wrong vendor makes a correct answer look hallucinated, so we drop mismatched
+ * chunks here — BEFORE `buildGroundedContext`, so the model never grounds on them
+ * and the returned `[n]` markers stay aligned with the citation list.
+ *
+ * Lightweight string match only — no LLM call, no `uns_resolver` (this surface
+ * has no `state["uns_context"]`).
+ *
+ * Rules:
+ *  - No manufacturer asked → no signal to filter on → pass through unchanged.
+ *  - Manufacturer asked → keep a chunk when its manufacturer, model number, or
+ *    source URL mentions that manufacturer (normalized, either-direction match).
+ *  - Keep chunks with NO manufacturer — generic / educational, not vendor-specific.
+ *  - Drop chunks whose manufacturer is set but doesn't match.
+ */
+export function filterCitationsByRelevance(
+  chunks: ManualChunk[],
+  manufacturer: string | null | undefined,
+): ManualChunk[] {
+  const asked = normalizeVendor(manufacturer);
+  if (!asked) return chunks; // no manufacturer signal — nothing to filter on
+
+  return chunks.filter((c) => {
+    const chunkMfr = normalizeVendor(c.manufacturer);
+    if (!chunkMfr) return true; // generic / educational chunk — keep (carve-out)
+    if (vendorMatches(asked, chunkMfr)) return true;
+    // Some corpora leave manufacturer blank but encode the vendor in the model
+    // number or source URL — check those before dropping.
+    if (vendorMatches(asked, normalizeVendor(c.modelNumber))) return true;
+    if (normalizeVendor(c.sourceUrl).includes(asked)) return true;
+    return false;
+  });
+}
+
+/** Lowercase + strip every non-alphanumeric char (so URLs and spaced names compare cleanly). */
+function normalizeVendor(s: string | null | undefined): string {
+  return (s ?? "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+/** Substring match either direction — "danfoss" matches "danfossvlt" and vice versa. */
+function vendorMatches(a: string, b: string): boolean {
+  if (!a || !b) return false;
+  return a.includes(b) || b.includes(a);
+}
+
+/**
  * Append the retrieval block to an existing system prompt. Adds the
  * citation rule so the model uses `[n]` markers.
  */

--- a/mira-hub/tests/e2e/money-path.spec.ts
+++ b/mira-hub/tests/e2e/money-path.spec.ts
@@ -75,10 +75,16 @@ test.describe("money path — public grounded chat (P1-1)", () => {
     });
     expect(r.status()).toBe(200); // not 5xx, not a drained cascade
     const body = await r.json();
-    // Grounding contract: a non-empty answer + a citations array (cite-or-refuse).
+    // Grounding contract: a non-empty answer + a citations array.
     expect(typeof body.answer).toBe("string");
     expect(body.answer.trim().length).toBeGreaterThan(20);
     expect(Array.isArray(body.citations)).toBe(true);
+    // Cite-or-refuse (P0-3 / GTM RED #2): the reply must EITHER carry a citation
+    // OR be an explicit no-docs refusal — never a confident answer with zero
+    // grounding. This also guards the citation-relevance filter: if it drops all
+    // wrong-vendor chunks, the answer must fall through to a refusal, not bluff.
+    const refused = /don't have manuals|no manuals|sign up to upload/i.test(body.answer);
+    expect(body.citations.length > 0 || refused).toBe(true);
   });
 
   test("flooding /api/quickstart/ask returns 429 (P0-1, no break)", async ({ request }) => {

--- a/tests/smoke/test_quickstart_e2e.py
+++ b/tests/smoke/test_quickstart_e2e.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""End-to-end smoke check for the public Quickstart chat path (GTM RED #3).
+
+Dependency-light (stdlib only — no requests, no Playwright) so it runs anywhere:
+local dev box, CI runner, or by hand after a prod deploy.
+
+Asserts the stranger-facing /api/quickstart/ask contract:
+  1. A real maintenance question returns HTTP 200 with a non-empty answer.
+  2. The reply carries >=1 citation OR an explicit "no docs" refusal (cite-or-
+     refuse — never a confident answer with zero grounding).
+  3. The per-IP rate limiter trips to HTTP 429 under a rapid flood.
+
+Target defaults to localhost; override for prod:
+    QUICKSTART_SMOKE_URL=https://app.factorylm.com python tests/smoke/test_quickstart_e2e.py
+The 429 flood is localhost-only by default (flooding prod on every deploy is
+antisocial and can't pass pre-deploy); enable against a remote with
+    SMOKE_RATE_LIMIT_CHECK=1
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+BASE = os.environ.get("QUICKSTART_SMOKE_URL", "http://localhost:3000").rstrip("/")
+ENDPOINT = f"{BASE}/api/quickstart/ask"
+RATE_LIMIT_CHECK = os.environ.get("SMOKE_RATE_LIMIT_CHECK") == "1" or "localhost" in BASE
+# Phrases the cite-or-refuse system prompt emits when the KB has no coverage.
+REFUSAL_MARKERS = ("don't have manuals", "no manuals", "sign up to upload", "don't have manual")
+
+
+def _post(payload: dict, timeout: int = 45, url: str = ENDPOINT, _redirects: int = 0):
+    """POST JSON; return (status_code, parsed_body_or_text).
+
+    Follows 307/308 with the POST body intact (Next.js `trailingSlash` 308-
+    redirects /api/quickstart/ask → .../ask/). urllib won't follow 308 for POST,
+    so we do it by hand — once.
+    """
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        if e.code in (307, 308) and _redirects < 2:
+            loc = e.headers.get("Location")
+            if loc:
+                return _post(payload, timeout, urllib.parse.urljoin(url, loc), _redirects + 1)
+        body = e.read().decode()
+        try:
+            return e.code, json.loads(body)
+        except json.JSONDecodeError:
+            return e.code, body
+
+
+def check_grounded_answer() -> None:
+    status, body = _post({"question": "What causes a VFD to overheat?"})
+    assert status == 200, f"expected 200, got {status}: {body}"
+    assert isinstance(body, dict), f"expected JSON object, got {body!r}"
+    answer = (body.get("answer") or "").strip()
+    assert len(answer) > 20, f"answer too short / empty: {answer!r}"
+    citations = body.get("citations")
+    assert isinstance(citations, list), f"citations must be a list, got {citations!r}"
+    # Cite-or-refuse: either we grounded (>=1 citation) or we explicitly refused.
+    refused = any(m in answer.lower() for m in REFUSAL_MARKERS)
+    assert citations or refused, (
+        "answer has no citations and is not an explicit no-docs refusal "
+        f"(possible ungrounded answer): {answer!r}"
+    )
+    print(f"  ✓ grounded answer: {len(answer)} chars, {len(citations)} citation(s), refused={refused}")
+
+
+def check_rate_limit() -> None:
+    if not RATE_LIMIT_CHECK:
+        print("  ~ rate-limit flood skipped (set SMOKE_RATE_LIMIT_CHECK=1 to run against a remote)")
+        return
+    # Empty-body POSTs short-circuit at the 400 (missing question) AFTER the
+    # rate-limit check, so this floods the 20/min limiter WITHOUT burning cascade
+    # quota. >20 rapid requests in the window must return 429.
+    codes = [_post({}, timeout=10)[0] for _ in range(25)]
+    assert 429 in codes, f"limiter never tripped to 429 in 25 rapid POSTs: {codes}"
+    print(f"  ✓ rate limiter tripped to 429 ({codes.count(429)}/25 limited)")
+
+
+def main() -> int:
+    print(f"Quickstart smoke → {ENDPOINT}")
+    failures = []
+    for name, fn in (("grounded_answer", check_grounded_answer), ("rate_limit", check_rate_limit)):
+        try:
+            fn()
+        except AssertionError as e:
+            failures.append(name)
+            print(f"  ✗ {name}: {e}")
+        except Exception as e:  # noqa: BLE001 — surface network/transport errors as failures
+            failures.append(name)
+            print(f"  ✗ {name}: {type(e).__name__}: {e}")
+    if failures:
+        print(f"FAIL: {', '.join(failures)}")
+        return 1
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Go-to-market hardening — Quickstart chat path

The #1 GTM priority: harden the stranger-facing **public Quickstart "ask MIRA"** experience on factorylm.com (`/api/quickstart/ask`). This PR closes all three RED items and adds the tracking checklist for all four GTM priorities.

📋 Checklist: `docs/gtm/go-to-market-hardening-checklist.md`

### ⚠️ Implementation note (read first)
The RED #2/#3 instructions pointed at the **Python** engine (`mira-bots/shared/engine.py` + `citation_compliance.py`). I verified via CodeGraph that **the quickstart path never touches that engine** — it's entirely TypeScript in `mira-hub` (`quickstart/ask/route.ts` → `manual-rag.ts` → cascade). A Python-side filter would not have hardened the quickstart surface at all. So the fix lives in TS, where the bug actually is. The Python bot engine (Telegram/Slack) has the *same* wrong-vendor citation gap on a *separate* surface — flagged as follow-up in the checklist, **not** fixed inline (surgical scope).

### RED #1 — Rate limit ✅ (verify-only)
PR #1838 (`fix/quickstart-rate-limit`, merge `5fd70dae`) is **already merged and on `origin/main`** — 20 req/IP-min → 429. Nothing to do; verified.

### RED #2 — Citation relevance ✅
`retrieveManualChunks` falls back to a **tenant-wide** BM25 query when the manufacturer-scoped query returns 0 hits, so a Danfoss question could cite a Siemens manual → looks like a hallucination even when the answer text is right.

- New `filterCitationsByRelevance()` in `manual-rag.ts` — lightweight string match (manufacturer / model / source-url), **no LLM call**, no `uns_resolver` (anonymous surface, no `uns_context`).
- Keeps blank-manufacturer chunks (generic/educational carve-out); drops set-but-mismatched vendors.
- Wired into `route.ts` **before `buildGroundedContext`** so the model never grounds on the dropped chunk and `[n]` markers stay aligned with the returned citations. Empties → cite-or-refuse falls through to a refusal (the correct outcome).
- 6 pure-function vitest cases incl. the Siemens/Danfoss regression. ✅ pass, eslint clean.

### RED #3 — Quickstart smoke gate ✅
- New `tests/smoke/test_quickstart_e2e.py` — **stdlib-only** (no requests/Playwright), dual-target (localhost + prod). Asserts: 200 + non-empty answer; **≥1 citation OR explicit no-docs refusal**; flood → 429 (localhost/flag-gated so prod isn't hammered). Follows 308 trailing-slash redirects with the POST body intact.
  - **Verified PASS against prod**: 394-char answer, 5 citations.
- Wired into `smoke-test.yml` as a Python step (ubuntu has `python3`, no pip).
- Also strengthened the existing Playwright deploy gate (`money-path.spec.ts`) to enforce **citation-or-refusal** — so the always-on pre-deploy gate validates the RED #2 filter end-to-end (previously only asserted `citations` was an array).

### Blast radius
`codegraph_impact`/`callers`: `retrieveManualChunks`/`buildGroundedContext` are called by `quickstart/ask` and `assets/[id]/chat`. The new `filterCitationsByRelevance()` is a standalone export with **no existing-signature changes**, wired into the single quickstart call site only.

### Verification
- `npx vitest run src/lib/manual-rag.test.ts` → 6/6 pass
- `eslint` on changed TS → clean
- `ruff check` on the Python smoke → clean; `py_compile` ok
- `python3 tests/smoke/test_quickstart_e2e.py` against `app.factorylm.com` → **PASS** (429 flood not run against prod — denied/antisocial by design; covered by the gated Playwright check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
