### PR TITLE
fix(engine): eliminate ALL cross-tenant RAGWorker read-back after awaits — complete #1704

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -1053,6 +1053,7 @@ class Supervisor:
         trace_id: str | None = None,
         next_state: str | None = None,
         dispatch_kind: str = "",
+        citation_evidence: dict | None = None,
     ) -> dict:
         """Build a standard process_full() result dict.
 
@@ -1060,6 +1061,12 @@ class Supervisor:
         can bypass replies it shouldn't second-guess (action_request,
         cmms_pending, dont_know, session_followup). Empty string = default
         diagnostic flow → gate runs normally.
+
+        citation_evidence carries THIS turn's per-call retrieval snapshot
+        (kb_status / chunks / sources / no_kb) from process_full() out to the
+        post-process_full() consumers in process() — the citation rewrite and
+        decision-trace — so they never read it off the shared RAGWorker
+        instance after an await (#1704). None on non-RAG turns.
         """
         return {
             "reply": reply,
@@ -1067,9 +1074,27 @@ class Supervisor:
             "trace_id": trace_id,
             "next_state": next_state,
             "dispatch_kind": dispatch_kind,
+            "_citation_evidence": citation_evidence,
         }
 
-    async def _enforce_citation_rewrite(self, reply: str, *, chat_id: str, fsm_state: str) -> str:
+    @staticmethod
+    def _evidence_from_parsed(parsed: dict) -> dict:
+        """Per-turn citation/grounding evidence carried on ``parsed`` (#1704).
+
+        Built from the snapshot _call_with_correction popped off ``state``;
+        threaded into the result dict so the rewrite + decision-trace read this
+        turn's data, never the shared self.rag.* attributes.
+        """
+        return {
+            "kb_status": parsed.get("_kb_status") or {},
+            "chunks": parsed.get("_last_chunks") or [],
+            "sources": parsed.get("_sources") or [],
+            "no_kb": parsed.get("_no_kb", False),
+        }
+
+    async def _enforce_citation_rewrite(
+        self, reply: str, *, chat_id: str, fsm_state: str, evidence: dict | None = None
+    ) -> str:
         """#1659 enforce-mode bridge: connect the insertion-only citation rewrite
         to this turn's retrieval set + the inference router.
 
@@ -1078,8 +1103,16 @@ class Supervisor:
         insertion-only second pass salvages it (validated for content
         preservation + real labels by the helper). Kill-switch
         ``MIRA_CITATION_REWRITE=0`` disables it; any error falls open.
+
+        ``evidence`` is THIS turn's per-call snapshot (chunks + kb_status),
+        threaded via the result dict. It is read ONLY from here, never from the
+        shared self.rag.* attributes a concurrent tenant overwrites (#1704). No
+        snapshot (non-RAG turn) → nothing to enforce → reply unchanged, with no
+        stale-shared fallback.
         """
         if os.getenv("MIRA_CITATION_REWRITE", "1") != "1":
+            return reply
+        if not evidence:
             return reply
         rag = getattr(self, "rag", None)
         if rag is None:
@@ -1087,8 +1120,8 @@ class Supervisor:
         try:
             return await _enforce_citation_via_rewrite(
                 reply,
-                getattr(rag, "last_chunks", None),
-                getattr(rag, "kb_status", None),
+                evidence.get("chunks"),
+                evidence.get("kb_status"),
                 fsm_state=fsm_state,
                 chat_id=chat_id,
                 llm_call=rag._call_llm,
@@ -1200,7 +1233,10 @@ class Supervisor:
         # admission. Runs post-quality-gate so the injected tag can't perturb
         # the gate; gated + fail-open inside the bridge.
         reply = await self._enforce_citation_rewrite(
-            reply, chat_id=chat_id, fsm_state=result.get("next_state", "")
+            reply,
+            chat_id=chat_id,
+            fsm_state=result.get("next_state", ""),
+            evidence=result.get("_citation_evidence"),
         )
         # H4 enforcer (2026-06-06): every reply must carry a [Source:] citation
         # or an explicit KB-gap admission. Applied AFTER the quality gate so the
@@ -1269,13 +1305,15 @@ class Supervisor:
 
             tenant_id = getattr(self, "_current_tenant_id", None) or self.tenant_id
 
-            # Only attach RAG sources when THIS turn actually retrieved — the
-            # worker's _last_sources persists across turns, so a non-RAG turn
-            # (greeting, WO action) would otherwise inherit the prior turn's
-            # manual evidence and disagree with citations_present.
-            rag = getattr(self, "rag", None)
-            retrieved = rag is not None and not getattr(rag, "_last_no_kb", True)
-            manual_sources = getattr(rag, "_last_sources", None) if retrieved else None
+            # Only attach RAG sources when THIS turn actually retrieved. Read
+            # the per-turn snapshot threaded on the result dict (#1704) — NOT
+            # the shared worker._last_sources, which persists across turns and,
+            # under concurrency, can hold another tenant's evidence. No snapshot
+            # (non-RAG turn) → no manual sources, which also keeps the trace in
+            # agreement with citations_present.
+            ev = result.get("_citation_evidence") or {}
+            retrieved = bool(ev) and not ev.get("no_kb", True)
+            manual_sources = (ev.get("sources") or None) if retrieved else None
 
             coro = write_trace(
                 tenant_id=tenant_id,
@@ -2610,6 +2648,7 @@ class Supervisor:
             self._infer_confidence(formatted),
             trace_id,
             state["state"],
+            citation_evidence=self._evidence_from_parsed(parsed),
         )
 
     # ------------------------------------------------------------------
@@ -3366,16 +3405,20 @@ class Supervisor:
                 return None, {"reply": f"MIRA error: {e}"}
 
             parsed = self._parse_response(raw)
-            # Promote this call's kb_status snapshot (stashed on ``state`` by
-            # rag.process() before its LLM await) onto ``parsed`` — the durable
-            # per-turn carrier the citation footer + relevance-strip read,
-            # instead of the shared self.rag.kb_status attribute a concurrent
-            # tenant can overwrite (#1704). Set on every attempt so the last
-            # one wins; survives _advance_state swapping the state dict.
-            parsed["_kb_status"] = state.get("_rag_kb_status") or {}
+            # Pop this call's citation/grounding evidence (stashed on ``state``
+            # by rag.process() before its LLM await) onto ``parsed`` — the
+            # durable per-turn carrier the footer, rewrite, grounding check, and
+            # decision-trace read, instead of the shared self.rag.* attributes a
+            # concurrent tenant overwrites (#1704). POP (not get) so the keys
+            # never reach _save_state. Set every attempt so the last one wins.
+            parsed["_kb_status"] = state.pop("_rag_kb_status", None) or {}
+            parsed["_sources"] = state.pop("_rag_sources", None) or []
+            parsed["_last_chunks"] = state.pop("_rag_last_chunks", None) or []
+            parsed["_no_kb"] = state.pop("_rag_no_kb", False)
 
-            # Check grounding: did we get sources and does response reference them?
-            if self._is_grounded(parsed, self.rag._last_sources):
+            # Check grounding against THIS turn's sources snapshot, never the
+            # shared self.rag._last_sources (#1704).
+            if self._is_grounded(parsed, parsed["_sources"]):
                 return raw, parsed
 
             # Not grounded on first attempt — rewrite and retry
@@ -3450,6 +3493,7 @@ class Supervisor:
             self._infer_confidence(formatted),
             None,
             state["state"],
+            citation_evidence=self._evidence_from_parsed(parsed),
         )
 
     # ------------------------------------------------------------------
@@ -3987,6 +4031,15 @@ class Supervisor:
                 raw_resp = await self.rag.process(
                     message, state, photo_b64=None, tenant_id=resolved_tenant
                 )
+                # This path calls rag.process() directly (no _call_with_correction),
+                # so pop the per-turn evidence off state here — BEFORE
+                # _record_exchange persists state — and thread it via result (#1704).
+                _evidence = {
+                    "kb_status": state.pop("_rag_kb_status", None) or {},
+                    "chunks": state.pop("_rag_last_chunks", None) or [],
+                    "sources": state.pop("_rag_sources", None) or [],
+                    "no_kb": state.pop("_rag_no_kb", False),
+                }
                 parsed = self._parse_response(raw_resp)
                 raw = parsed.get("reply", "") if parsed else ""
                 if raw:
@@ -4005,6 +4058,7 @@ class Supervisor:
                         self._infer_confidence(raw),
                         trace_id,
                         state.get("state", "IDLE"),
+                        citation_evidence=_evidence,
                     )
             except Exception as exc:
                 logger.warning("GENERAL_QUESTION_RAG_FAILURE error=%s — falling through", exc)

--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -2595,7 +2595,7 @@ class Supervisor:
         # confidently-wrong attribution never reaches the technician.
         _cc = _check_citation_compliance(
             formatted,
-            getattr(self.rag, "kb_status", {}),
+            parsed.get("_kb_status") or {},
             fsm_state=state.get("state", ""),
             chat_id=chat_id,
             uns_context=(state.get("context") or {}).get("uns_context"),
@@ -3366,6 +3366,13 @@ class Supervisor:
                 return None, {"reply": f"MIRA error: {e}"}
 
             parsed = self._parse_response(raw)
+            # Promote this call's kb_status snapshot (stashed on ``state`` by
+            # rag.process() before its LLM await) onto ``parsed`` — the durable
+            # per-turn carrier the citation footer + relevance-strip read,
+            # instead of the shared self.rag.kb_status attribute a concurrent
+            # tenant can overwrite (#1704). Set on every attempt so the last
+            # one wins; survives _advance_state swapping the state dict.
+            parsed["_kb_status"] = state.get("_rag_kb_status") or {}
 
             # Check grounding: did we get sources and does response reference them?
             if self._is_grounded(parsed, self.rag._last_sources):
@@ -3429,7 +3436,7 @@ class Supervisor:
 
         _cc = _check_citation_compliance(
             formatted,
-            getattr(self.rag, "kb_status", {}),
+            parsed.get("_kb_status") or {},
             fsm_state=state.get("state", ""),
             chat_id=chat_id,
             uns_context=ctx.get("uns_context"),
@@ -5356,8 +5363,15 @@ class Supervisor:
         return advance_state(state, parsed)
 
     def _format_reply(self, parsed: dict, user_message: str = "") -> str:
-        """Format parsed response for display. Delegates to response_formatter.format_reply."""
-        kb_status = getattr(self.rag, "kb_status", None) or {}
+        """Format parsed response for display. Delegates to response_formatter.format_reply.
+
+        Reads kb_status from this turn's ``parsed`` (the per-call snapshot
+        threaded by _call_with_correction), NOT the shared self.rag.kb_status
+        attribute a concurrent tenant can overwrite (#1704). A reply that did
+        not run RAG retrieval carries no snapshot → no citation footer, which
+        is correct (it had nothing to cite).
+        """
+        kb_status = parsed.get("_kb_status") or {}
         return format_reply(parsed, user_message, kb_status)
 
     # ------------------------------------------------------------------

--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -628,19 +628,16 @@ class RAGWorker:
             self._last_sources = chunk_texts
             self._last_distances = [c.get("similarity", 0.0) for c in neon_chunks]
             # Snapshot before any await so concurrent sessions can't overwrite
-            # this call's metadata (fixes #1082 Nemotron rerank race).
+            # this call's metadata (fixes #1082 Nemotron rerank race). These
+            # pre-await locals are the ONLY safe source for the state stash
+            # below — reading self._last_* after the rerank await would re-race
+            # (#1704). ``local_sources`` keeps the pre-rerank texts _is_grounded
+            # has always used.
+            local_sources = list(chunk_texts)
             local_neon_chunks = list(neon_chunks)
             self._last_neon_chunks = local_neon_chunks
-            # Snapshot kb_status before the LLM await too (#1704): the citation
-            # footer + relevance-strip read it back user-facing in engine.py
-            # after this call's await, so a concurrent tenant overwriting
-            # self._kb_status would bleed its citations into this reply. Stash
-            # the per-call snapshot on this call's own ``state`` dict; the engine
-            # promotes it to ``parsed["_kb_status"]`` in _call_with_correction.
             local_kb_status = self._compute_kb_status(neon_chunks, bool(chunk_texts))
             self._kb_status = local_kb_status
-            if isinstance(state, dict):
-                state["_rag_kb_status"] = local_kb_status
 
             async with spans.vector_search(
                 rewritten, self._last_sources[:5], self._last_distances[:5]
@@ -707,6 +704,23 @@ class RAGWorker:
                     messages = self._build_prompt(
                         state, rewritten, photo_b64, kg_context=local_kg_context
                     )
+
+            # Snapshot ALL of this call's citation/grounding evidence onto its
+            # own ``state`` dict immediately before the LLM await (#1704).
+            # RAGWorker is a singleton shared across tenants; engine.py reads
+            # this evidence back AFTER the await (citation footer, citation
+            # rewrite, grounding check, decision-trace), so reading it off the
+            # shared instance lets a concurrent tenant's data bleed in. The
+            # engine POPS these keys into the per-turn parsed/result payload
+            # (so they never persist to the session row) and never falls back
+            # to self.* when a key is absent. The clarification early-return
+            # above skips this — a no-coverage turn correctly carries nothing.
+            if isinstance(state, dict):
+                state["_rag_kb_status"] = local_kb_status
+                state["_rag_sources"] = local_sources
+                state["_rag_last_chunks"] = local_neon_chunks
+                state["_rag_no_kb"] = self._last_no_kb
+
             t0 = time.monotonic()
             raw = await self._call_llm(messages, model=model)
             elapsed_ms = int((time.monotonic() - t0) * 1000)

--- a/mira-bots/shared/workers/rag_worker.py
+++ b/mira-bots/shared/workers/rag_worker.py
@@ -631,7 +631,16 @@ class RAGWorker:
             # this call's metadata (fixes #1082 Nemotron rerank race).
             local_neon_chunks = list(neon_chunks)
             self._last_neon_chunks = local_neon_chunks
-            self._kb_status = self._compute_kb_status(neon_chunks, bool(chunk_texts))
+            # Snapshot kb_status before the LLM await too (#1704): the citation
+            # footer + relevance-strip read it back user-facing in engine.py
+            # after this call's await, so a concurrent tenant overwriting
+            # self._kb_status would bleed its citations into this reply. Stash
+            # the per-call snapshot on this call's own ``state`` dict; the engine
+            # promotes it to ``parsed["_kb_status"]`` in _call_with_correction.
+            local_kb_status = self._compute_kb_status(neon_chunks, bool(chunk_texts))
+            self._kb_status = local_kb_status
+            if isinstance(state, dict):
+                state["_rag_kb_status"] = local_kb_status
 
             async with spans.vector_search(
                 rewritten, self._last_sources[:5], self._last_distances[:5]

--- a/mira-bots/tests/test_engine.py
+++ b/mira-bots/tests/test_engine.py
@@ -908,12 +908,8 @@ class TestDSTActiveSessionGuard:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("fsm_state", ["Q1", "Q2", "Q3", "DIAGNOSIS", "FIX_STEP"])
-    @pytest.mark.parametrize(
-        "dispatch_kind", [DISPATCH_ASK_PROCEDURAL, DISPATCH_ASK_GENERAL]
-    )
-    async def test_active_session_returns_none(
-        self, supervisor, fsm_state, dispatch_kind
-    ):
+    @pytest.mark.parametrize("dispatch_kind", [DISPATCH_ASK_PROCEDURAL, DISPATCH_ASK_GENERAL])
+    async def test_active_session_returns_none(self, supervisor, fsm_state, dispatch_kind):
         """All active diagnostic states (Q1+) must return None, not call an IDLE-resetting handler."""
         from shared.dialogue_state import DialogueState
         from unittest.mock import MagicMock
@@ -924,8 +920,9 @@ class TestDSTActiveSessionGuard:
         new_ds.write_to_engine_state = MagicMock()
         plan = self._mock_plan(dispatch_kind)
 
-        with patch("shared.engine.DialogueState") as mock_ds_cls, patch(
-            "shared.engine.track_turn", new=AsyncMock(return_value=(new_ds, plan))
+        with (
+            patch("shared.engine.DialogueState") as mock_ds_cls,
+            patch("shared.engine.track_turn", new=AsyncMock(return_value=(new_ds, plan))),
         ):
             mock_ds_cls.from_engine_state.return_value = ds
             result = await supervisor._maybe_dispatch_via_dst(
@@ -936,3 +933,77 @@ class TestDSTActiveSessionGuard:
             f"DST returned a non-None result for {dispatch_kind} in {fsm_state} — "
             "this would reset FSM to IDLE via _handle_instructional_question"
         )
+
+
+# ---------------------------------------------------------------------------
+# kb_status isolation (#1704 cross-tenant citation race)
+# ---------------------------------------------------------------------------
+
+
+class TestKbStatusIsolation:
+    """The citation footer + relevance-strip must read THIS turn's kb_status
+    snapshot (threaded on ``parsed``), never the shared ``self.rag.kb_status``
+    attribute a concurrent tenant can overwrite mid-await (#1704).
+    """
+
+    _X = {
+        "status": "covered",
+        "citations": [
+            {
+                "manufacturer": "Rockwell",
+                "model_number": "PowerFlex 525",
+                "source_url": "",
+                "section": "Fault Codes",
+                "page_num": None,
+            }
+        ],
+    }
+    _Y = {
+        "status": "covered",
+        "citations": [
+            {
+                "manufacturer": "Danfoss",
+                "model_number": "FC 202",
+                "source_url": "",
+                "section": "Wiring",
+                "page_num": None,
+            }
+        ],
+    }
+
+    def test_format_reply_uses_parsed_snapshot_not_self(self, supervisor):
+        # Poison the shared attribute with tenant Y; this turn's parsed carries X.
+        supervisor.rag.kb_status = self._Y
+        parsed = {"reply": "Check the drive.", "_kb_status": self._X}
+        out = supervisor._format_reply(parsed, user_message="why is it faulted?")
+        assert "Rockwell" in out  # this turn's citation rendered
+        assert "Danfoss" not in out  # concurrent tenant's poison NOT leaked
+
+    def test_format_reply_no_snapshot_means_no_footer(self, supervisor):
+        # A non-RAG reply carries no _kb_status → no footer, even if the shared
+        # attribute holds a stale (possibly other-tenant) value.
+        supervisor.rag.kb_status = self._Y
+        parsed = {"reply": "Hi there, how can I help?"}
+        out = supervisor._format_reply(parsed, user_message="hi")
+        assert "--- Sources ---" not in out
+        assert "Danfoss" not in out
+
+    @pytest.mark.asyncio
+    async def test_call_with_correction_promotes_state_snapshot(self, supervisor):
+        # rag.process() stashes the pre-await snapshot on the call's state dict;
+        # _call_with_correction must promote it onto parsed so it survives later
+        # state mutation and reaches _format_reply / the relevance strip.
+        async def fake_process(query, state, **kw):
+            state["_rag_kb_status"] = self._X  # mimic process() pre-await stash
+            return '{"reply": "ok", "next_state": "Q1"}'
+
+        supervisor.rag.process = AsyncMock(side_effect=fake_process)
+        supervisor.rag._last_sources = []
+        supervisor.nemotron.enabled = False
+        supervisor._build_kg_context = AsyncMock(return_value="")
+        supervisor._build_live_data_context = AsyncMock(return_value="")
+
+        _raw, parsed = await supervisor._call_with_correction(
+            "why faulted?", {"state": "Q1", "asset_identified": ""}
+        )
+        assert parsed["_kb_status"] == self._X

--- a/mira-bots/tests/test_engine.py
+++ b/mira-bots/tests/test_engine.py
@@ -116,6 +116,7 @@ class TestMakeResult:
             "trace_id": "trace-123",
             "next_state": "Q1",
             "dispatch_kind": "",
+            "_citation_evidence": None,
         }
 
     def test_defaults(self):
@@ -1007,3 +1008,155 @@ class TestKbStatusIsolation:
             "why faulted?", {"state": "Q1", "asset_identified": ""}
         )
         assert parsed["_kb_status"] == self._X
+
+
+# ---------------------------------------------------------------------------
+# Remaining #1704 read-back races: citation rewrite, grounding, decision-trace
+# ---------------------------------------------------------------------------
+
+
+class TestCitationRewriteIsolation:
+    """_enforce_citation_rewrite must use THIS turn's evidence (chunks+kb_status
+    threaded via the result dict), never the shared self.rag.last_chunks /
+    kb_status a concurrent tenant overwrites (#1704)."""
+
+    @pytest.mark.asyncio
+    async def test_rewrite_uses_evidence_not_shared_rag(self, supervisor):
+        supervisor.rag.last_chunks = [{"manufacturer": "Danfoss"}]  # poison
+        supervisor.rag.kb_status = {"citations": [{"manufacturer": "Danfoss"}]}  # poison
+        ev_chunks = [{"manufacturer": "Rockwell", "content": "F004"}]
+        ev_kb = {"citations": [{"manufacturer": "Rockwell"}]}
+        captured = {}
+
+        async def fake_helper(reply, chunks, kb_status, **kw):
+            captured["chunks"] = chunks
+            captured["kb_status"] = kb_status
+            return reply
+
+        with patch("shared.engine._enforce_citation_via_rewrite", side_effect=fake_helper):
+            with patch.dict("os.environ", {"MIRA_CITATION_REWRITE": "1"}):
+                await supervisor._enforce_citation_rewrite(
+                    "the drive faulted",
+                    chat_id="c",
+                    fsm_state="DIAGNOSIS",
+                    evidence={"chunks": ev_chunks, "kb_status": ev_kb},
+                )
+        assert captured["chunks"] == ev_chunks  # this turn's chunks
+        assert captured["kb_status"] == ev_kb
+        assert "Danfoss" not in str(captured)  # concurrent tenant's poison unused
+
+    @pytest.mark.asyncio
+    async def test_rewrite_no_evidence_returns_unchanged_no_rag_read(self, supervisor):
+        # No per-turn snapshot → no rewrite, and the shared helper (which would
+        # read rag state) is never invoked. Requirement #5: no stale fallback.
+        supervisor.rag.last_chunks = [{"manufacturer": "Danfoss"}]  # would-be poison
+        called = False
+
+        async def fake_helper(*a, **k):
+            nonlocal called
+            called = True
+            return "REWRITTEN"
+
+        with patch("shared.engine._enforce_citation_via_rewrite", side_effect=fake_helper):
+            with patch.dict("os.environ", {"MIRA_CITATION_REWRITE": "1"}):
+                out = await supervisor._enforce_citation_rewrite(
+                    "original reply", chat_id="c", fsm_state="DIAGNOSIS", evidence=None
+                )
+        assert out == "original reply"
+        assert called is False
+
+
+class TestGroundingIsolation:
+    """_call_with_correction must check grounding against THIS turn's sources
+    snapshot (popped off state), never the shared self.rag._last_sources (#1704)."""
+
+    @pytest.mark.asyncio
+    async def test_grounding_keys_off_snapshot_not_shared(self, supervisor):
+        supervisor.rag._last_sources = ["tenant Y overcurrent fault drive motor cable"]  # poison
+
+        async def fake_process(query, state, **kw):
+            state["_rag_sources"] = ["tenant X alpha bravo charlie delta echo"]
+            return '{"reply": "alpha bravo charlie delta echo", "next_state": "DIAGNOSIS"}'
+
+        supervisor.rag.process = AsyncMock(side_effect=fake_process)
+        supervisor.nemotron.enabled = False
+        supervisor._build_kg_context = AsyncMock(return_value="")
+        supervisor._build_live_data_context = AsyncMock(return_value="")
+
+        captured = {}
+        original = supervisor._is_grounded
+
+        def spy(parsed, sources):
+            captured["sources"] = sources
+            return original(parsed, sources)
+
+        supervisor._is_grounded = spy
+        await supervisor._call_with_correction("q", {"state": "DIAGNOSIS", "asset_identified": ""})
+        assert captured["sources"] == ["tenant X alpha bravo charlie delta echo"]
+        assert "tenant Y" not in " ".join(captured["sources"])
+
+
+class TestDecisionTraceIsolation:
+    """_schedule_decision_trace must derive manual_sources from the per-turn
+    snapshot on the result dict, never the shared self.rag._last_sources (#1704)."""
+
+    @pytest.mark.asyncio
+    async def test_manual_sources_from_snapshot_not_shared(self, supervisor):
+        supervisor.rag._last_sources = ["POISON tenant Y source"]  # shared — must be ignored
+        supervisor.rag._last_no_kb = False
+        result = {
+            "reply": "r",
+            "next_state": "DIAGNOSIS",
+            "_citation_evidence": {
+                "sources": ["tenant X manual section 5"],
+                "no_kb": False,
+                "kb_status": {},
+                "chunks": [],
+            },
+        }
+        captured = {}
+
+        # write_trace is async → patch() makes it an AsyncMock; the side_effect
+        # fires only when the fire-and-forget task is awaited, so drain the
+        # scheduled task before asserting.
+        def fake_write_trace(**kw):
+            captured.update(kw)
+
+        with patch("shared.decision_trace.write_trace", side_effect=fake_write_trace):
+            supervisor._schedule_decision_trace(
+                chat_id="c",
+                message="why faulted?",
+                reply="r",
+                result=result,
+                platform="test",
+                latency_ms=1,
+                tag_evidence=None,
+            )
+            for t in list(supervisor._decision_trace_tasks):
+                await t
+        assert captured.get("manual_sources") == ["tenant X manual section 5"]
+        assert "POISON" not in str(captured.get("manual_sources"))
+
+    @pytest.mark.asyncio
+    async def test_no_evidence_means_no_manual_sources(self, supervisor):
+        supervisor.rag._last_sources = ["POISON would-be stale source"]
+        supervisor.rag._last_no_kb = False
+        result = {"reply": "hi", "next_state": "IDLE"}  # non-RAG turn, no evidence
+        captured = {}
+
+        def fake_write_trace(**kw):
+            captured.update(kw)
+
+        with patch("shared.decision_trace.write_trace", side_effect=fake_write_trace):
+            supervisor._schedule_decision_trace(
+                chat_id="c",
+                message="hi",
+                reply="hi",
+                result=result,
+                platform="test",
+                latency_ms=1,
+                tag_evidence=None,
+            )
+            for t in list(supervisor._decision_trace_tasks):
+                await t
+        assert captured.get("manual_sources") is None

--- a/mira-bots/tests/test_reranking.py
+++ b/mira-bots/tests/test_reranking.py
@@ -286,3 +286,40 @@ class TestRerankingIntegration:
             await worker.process("What causes F004?", _base_state())
 
         worker.nemotron.rerank.assert_not_called()
+
+
+# -- kb_status snapshot stash (#1704 cross-tenant citation race) ---------------
+
+
+class TestKbStatusStash:
+    """process() must stash its per-call kb_status snapshot on the call's own
+    ``state`` dict (before the LLM await), so the engine threads THIS turn's
+    citations to the footer instead of the shared self._kb_status a concurrent
+    tenant can overwrite (#1704)."""
+
+    @pytest.mark.asyncio
+    async def test_process_stashes_kb_status_on_state(self):
+        worker = _make_rag_worker()
+        worker._call_llm = AsyncMock(return_value='{"reply": "ok", "next_state": "Q1"}')
+        worker._embed_ollama = AsyncMock(return_value=[0.1] * 768)
+        chunks = [
+            {
+                "content": "PowerFlex 525 fault F004 overcurrent",
+                "similarity": 0.9,
+                "manufacturer": "Rockwell",
+                "model_number": "PowerFlex 525",
+                "equipment_type": "",
+                "source_type": "",
+                "metadata": {},
+            },
+        ]
+        state = _base_state()
+        with patch("shared.workers.rag_worker._neon_recall") as mock_neon:
+            mock_neon.recall_knowledge.return_value = chunks
+            await worker.process("What causes F004?", state)
+
+        snap = state.get("_rag_kb_status")
+        assert snap is not None
+        assert snap is worker._kb_status  # the call-local snapshot, same object
+        assert snap.get("citations")  # carries this turn's citations
+        assert snap["citations"][0]["manufacturer"] == "Rockwell"


### PR DESCRIPTION
## What

**Complete fix for #1704** — closes every cross-tenant read-back of the shared singleton `RAGWorker` after an async `await`. Two commits:

1. **Footer + relevance-strip** (`e38205e6`): `_kb_status` snapshot → `parsed["_kb_status"]`, read by the citation footer (`_format_reply`) + relevance-strip (`_check_citation_compliance`).
2. **The remaining three** (`bba24bae`): citation rewrite, grounding check, decision-trace.

`RAGWorker` is one shared instance on `Supervisor` (`engine.py:744`); `mira-pipeline/main.py:256` runs ONE Supervisor across concurrent async tenant requests, so any per-call value written before the in-`process` LLM `await` and read back after it can be overwritten by a concurrent tenant. The four reads:

| Read site | Shared attr | Severity |
|---|---|---|
| `_format_reply` / `_check_citation_compliance` | `kb_status` | **user-visible** — citation footer (mfr/model/source_url) |
| `_enforce_citation_rewrite` (L1090-91) | `last_chunks` + `kb_status` | **user-visible** — inserts `[Source:]` tags |
| `_is_grounded` (L3378) | `_last_sources` | grounding verdict |
| `_schedule_decision_trace` (L1277-78) | `_last_sources` + `_last_no_kb` | telemetry (`manual_sources`) |

## Fix — one per-call snapshot carrier

- `rag.process()` snapshots ALL evidence (kb_status, sources, last_chunks, no_kb) onto **this call's own `state` dict** in one block immediately **before the LLM await**, from **pre-await locals** (`local_sources`/`local_neon_chunks`/`local_kb_status`; `no_kb` is finalized just before, no await between). The clarification early-return skips it → a no-coverage turn correctly carries nothing.
- `_call_with_correction` **pops** them off `state` onto `parsed` (pop, not get → keys never reach `_save_state`) and grounds against `parsed["_sources"]`.
- The 3 RAG result-build sites thread the snapshot into `result` via a new `_make_result(citation_evidence=…)` param (main + session from `parsed`; the fast-vendor `rag.process` path pops from `state` before `_record_exchange` persists).
- `_enforce_citation_rewrite` + `_schedule_decision_trace` read the snapshot from `result`, with **no fallback** to `self.rag.*`. No per-turn snapshot (non-RAG turn) → no rewrite / no manual_sources — render nothing rather than fall back to stale shared state.

## Objective proof

Repo-wide grep for `rag.kb_status` / `rag.last_chunks` / `rag._last_sources` / `rag._last_no_kb` / `rag._last_neon_chunks` / `getattr(rag, …)` reads (incl. local aliases) across `mira-bots/`, excluding tests + `rag_worker.process()` itself (where they're set, all from pre-await locals): **ZERO functional hits.** All shared read-back after awaits is eliminated.

## Live, not latent

No flag gates the footer / relevance-strip / rewrite (`MIRA_CITATION_REWRITE=1` default) — they're the default chat path. The race fires whenever concurrent multi-tenant turns share the one Supervisor/RAGWorker in the VPS pipeline event loop.

## Verification

- **9 deterministic isolation tests**: footer uses snapshot not poisoned `self.rag.kb_status`; rewrite uses threaded evidence not poisoned `last_chunks`+`kb_status`; rewrite `evidence=None` → reply unchanged, helper never invoked (no stale fallback); grounding keys off popped sources not poisoned `_last_sources`; decision-trace `manual_sources` from snapshot, `None` when no evidence; `process()` stashes; `_call_with_correction` promotes.
- **GS11 grounding** 6/6 + 12/12 (mandatory per `bot-grounding-tests`).
- **294 engine/worker/citation/trace + 114 citation/DST tests pass, 0 regressions**; `ruff check` + `ruff format --check` clean; `_make_result` contract test updated for the new key.

## Scope — #1704 fully closed

Both the user-visible citation leak and the internal grounding/telemetry reads are fixed. The `kb_status`/`last_chunks` **properties** on RAGWorker remain (only tests read them now). No remaining `self.rag.*` post-await read-back anywhere.

## Merge precondition (operator)

RAG/retrieval + engine change → owes the **staging gate** before merge (passes in CI). Hand to `ship`. CodeGraph wasn't initialized in the worktree; the manual + repo-wide grep is the substitute for `codegraph_impact`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)