### PR TITLE
fix(quickstart): fault-code-aware retrieval — stop false-refusal on PowerFlex F004 demo

### DIFF
--- a/mira-hub/src/app/api/quickstart/ask/route.ts
+++ b/mira-hub/src/app/api/quickstart/ask/route.ts
@@ -6,6 +6,7 @@ import { cascadeComplete, type CascadeMessage } from "@/lib/llm/cascade";
 import {
   retrieveManualChunks,
   buildGroundedContext,
+  isRefusalAnswer,
   type ManualChunk,
   type ManualSource,
 } from "@/lib/manual-rag";
@@ -178,12 +179,18 @@ export async function POST(req: Request) {
     );
   }
 
-  const citations: ManualSource[] = chunks.map((c, i) => ({
-    index: i + 1,
-    title: [c.manufacturer, c.modelNumber].filter(Boolean).join(" ") || c.title,
-    url: c.sourceUrl || null,
-    page: c.sourcePage,
-  }));
+  // Suppress phantom citation cards on a refusal: chunks render 1:1, so an
+  // answer that says "I don't have manuals for that" would otherwise ship with
+  // up-to-6 citation cards — the contradiction reported in PR #1875. When the
+  // model refuses, it cited nothing, so the citation list is a lie. (#1875)
+  const citations: ManualSource[] = isRefusalAnswer(result.content)
+    ? []
+    : chunks.map((c, i) => ({
+        index: i + 1,
+        title: [c.manufacturer, c.modelNumber].filter(Boolean).join(" ") || c.title,
+        url: c.sourceUrl || null,
+        page: c.sourcePage,
+      }));
 
   return NextResponse.json({
     answer: result.content,

--- a/mira-hub/src/lib/__tests__/manual-rag.test.ts
+++ b/mira-hub/src/lib/__tests__/manual-rag.test.ts
@@ -5,6 +5,8 @@ import {
   boundBm25Query,
   buildGroundedContext,
   chunksToSources,
+  extractFaultCodes,
+  isRefusalAnswer,
   retrieveManualChunks,
   retrieveNodeChunks,
   type ManualChunk,
@@ -293,5 +295,104 @@ describe("retrieveManualChunks term bounding (#1766)", () => {
     const { client, calls } = makeClient([[row()]]);
     await retrieveManualChunks(client, "tenant-1", "what is the torque spec");
     expect(calls[0].params[1]).toBe("what is the torque spec");
+  });
+});
+
+describe("extractFaultCodes (#1875)", () => {
+  it("extracts a single-letter fault code from a verbose question", () => {
+    expect(
+      extractFaultCodes(
+        "My Allen-Bradley PowerFlex 525 is showing fault F004, what does it mean?",
+      ),
+    ).toEqual(["F004"]);
+  });
+
+  it("extracts bare and multiple codes, uppercased + de-duplicated", () => {
+    expect(extractFaultCodes("F004")).toEqual(["F004"]);
+    expect(extractFaultCodes("faults e001 and A002")).toEqual(["E001", "A002"]);
+    expect(extractFaultCodes("F004 again F004")).toEqual(["F004"]);
+    expect(extractFaultCodes("F0004 underflow")).toEqual(["F0004"]);
+  });
+
+  it("does NOT match model numbers, two-letter prefixes, bare digits, or single-digit codes", () => {
+    expect(extractFaultCodes("PowerFlex 525")).toEqual([]); // 525 = digits only
+    expect(extractFaultCodes("GS10 drive overcurrent")).toEqual([]); // two-letter prefix
+    expect(extractFaultCodes("what is the torque spec")).toEqual([]);
+    expect(extractFaultCodes("fault F4")).toEqual([]); // single digit — known limit
+  });
+});
+
+describe("retrieveManualChunks fault-code prioritization (#1875)", () => {
+  it("runs an extra code-scoped pass and promotes the code-bearing chunk above the generic BM25 result", async () => {
+    const generic = row({
+      content: "PowerFlex 525 general overview, mounting and wiring.",
+      source_page: 12,
+      source_url: "pf525-overview.pdf",
+    });
+    const f004 = row({
+      content: "F004 UnderVoltage: incoming AC line low. Check incoming line power.",
+      source_page: 670,
+      source_url: "520-um001.pdf",
+    });
+    // call 1 = main AND pass (returns the generic row, non-empty ⇒ no OR fallback)
+    // call 2 = fault-code pass keyed on "F004" (returns the F004 row)
+    const { client, calls } = makeClient([[generic], [f004]]);
+    const out = await retrieveManualChunks(
+      client,
+      "tenant-1",
+      "My Allen-Bradley PowerFlex 525 is showing fault F004, what does it mean?",
+      { topK: 6 },
+    );
+    expect(calls.length).toBe(2);
+    expect(calls[1].params[1]).toBe("F004"); // code pass queries on the code alone
+    expect(out.map((c) => c.sourcePage)).toContain(670); // F004 chunk retrieved
+    expect(out[0].sourcePage).toBe(670); // promoted ahead of the generic chunk
+    expect(out.length).toBe(2); // deduped, both distinct
+  });
+
+  it("dedupes when the code pass returns the same chunk as the main pass", async () => {
+    const f004 = row({
+      content: "F004 UnderVoltage table row.",
+      source_page: 670,
+      source_url: "520-um001.pdf",
+    });
+    // main pass returns the F004 row; code pass returns the SAME row → 1 result
+    const { client } = makeClient([[f004], [f004]]);
+    const out = await retrieveManualChunks(client, "tenant-1", "fault F004 meaning", {
+      topK: 6,
+    });
+    expect(out.length).toBe(1);
+    expect(out[0].sourcePage).toBe(670);
+  });
+
+  it("does not run a code pass for a code-free query (no behavior change)", async () => {
+    const { client, calls } = makeClient([[row()]]);
+    await retrieveManualChunks(client, "tenant-1", "what is the torque spec", {
+      topK: 6,
+    });
+    expect(calls.length).toBe(1);
+  });
+});
+
+describe("isRefusalAnswer (#1875 phantom-citation gate)", () => {
+  it("detects the quickstart cite-or-refuse sentence (case-insensitive, mid-answer)", () => {
+    expect(
+      isRefusalAnswer(
+        "I don't have manuals for that in the public knowledge base — sign up to upload your own.",
+      ),
+    ).toBe(true);
+    expect(
+      isRefusalAnswer(
+        "I DON'T HAVE MANUALS FOR THAT IN THE PUBLIC KNOWLEDGE BASE. The context blocks do not mention F081.",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for a real grounded answer and for empty input", () => {
+    expect(isRefusalAnswer("For fault F004, the most likely cause is UnderVoltage [1].")).toBe(
+      false,
+    );
+    expect(isRefusalAnswer("")).toBe(false);
+    expect(isRefusalAnswer(null)).toBe(false);
   });
 });

--- a/mira-hub/src/lib/__tests__/vendor-relevance.test.ts
+++ b/mira-hub/src/lib/__tests__/vendor-relevance.test.ts
@@ -77,6 +77,19 @@ describe("stripConflictingVendors", () => {
     expect(out[0].manufacturer).toBe("Allen-Bradley");
   });
 
+  it("strips a wrong-vendor chunk sharing the same fault code (#1875 code-pass leak guard)", () => {
+    // The #1875 fault-code pass can surface another vendor's F004 chunk; the
+    // route runs this strip on the merged set, so the wrong vendor never leaks
+    // into the answer/citations for an Allen-Bradley question.
+    const chunks = [chunk("Rockwell Automation"), chunk("Siemens")];
+    const out = stripConflictingVendors(
+      chunks,
+      "My Allen-Bradley PowerFlex 525 is showing fault F004",
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].manufacturer).toBe("Rockwell Automation");
+  });
+
   it("does not strip when the query resolves to no known vendor", () => {
     const chunks = [chunk("Danfoss"), chunk("Siemens")];
     const out = stripConflictingVendors(chunks, "the drive keeps tripping");

--- a/mira-hub/src/lib/manual-rag.ts
+++ b/mira-hub/src/lib/manual-rag.ts
@@ -87,9 +87,57 @@ export function boundBm25Query(query: string): string {
   return tokens.join(" ");
 }
 
+// #1875 — fault-code token detector. A SINGLE letter followed by 2-4 digits:
+// matches F004, F0004, E001, A002 (and parameter tokens like b005 — boosting a
+// chunk that names them verbatim is still good retrieval). Deliberately does
+// NOT match two-letter model prefixes (PF525, GS10) or bare model numbers
+// (525) so the code pass never fires on a vendor/model token. Known limit:
+// single-digit codes ("F4") are not matched — widening to \d{1,4} would start
+// catching false positives, so terse codes rely on the normal BM25 path.
+const FAULT_CODE_RE = /\b[A-Za-z]\d{2,4}\b/g;
+
+/**
+ * Extract fault-code tokens from a query, uppercased and de-duplicated.
+ * Exported for unit testing. Empty array ⇒ the caller skips the code pass.
+ */
+export function extractFaultCodes(query: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const m of query.matchAll(FAULT_CODE_RE)) {
+    const code = m[0].toUpperCase();
+    if (!seen.has(code)) {
+      seen.add(code);
+      out.push(code);
+    }
+  }
+  return out;
+}
+
+function dedupeChunks(chunks: ManualChunk[]): ManualChunk[] {
+  const seen = new Set<string>();
+  const out: ManualChunk[] = [];
+  for (const c of chunks) {
+    const key = `${c.sourceUrl}|${c.sourcePage}|${c.content}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(c);
+  }
+  return out;
+}
+
 /**
  * Run BM25 retrieval. Tries a manufacturer-scoped query first; falls
  * back to a tenant-only query if zero hits or no manufacturer.
+ *
+ * #1875 fault-code prioritization: a verbose natural-language question
+ * ("…PowerFlex 525 is showing fault F004, what does it mean?") dilutes the
+ * BM25/OR ranking so the chunk that documents the code ranks below top-K and
+ * the model honestly refuses ("the context blocks do not mention F004") even
+ * though the chunk exists — proven live: the terse query "F004" retrieves and
+ * answers it. Mirrors the engine's `recall_fault_code` *intent* (not its RRF /
+ * structured-table apparatus): when the query names a fault code, run one extra
+ * pass keyed on the code alone and merge those chunks AHEAD of the main result.
+ * Additive only — never removes a main-pass chunk, never causes a refusal.
  */
 export async function retrieveManualChunks(
   client: PoolClient,
@@ -102,11 +150,42 @@ export async function retrieveManualChunks(
   const topK = opts.topK ?? 6;
   const mfr = (opts.manufacturer ?? "").trim();
 
+  // Main pass (manufacturer-scoped first, tenant-only fallback).
+  let main: ManualChunk[];
   if (mfr) {
     const scoped = await runBm25Query(client, tenantId, q, topK, mfr);
-    if (scoped.length > 0) return scoped;
+    main = scoped.length > 0 ? scoped : await runBm25Query(client, tenantId, q, topK, null);
+  } else {
+    main = await runBm25Query(client, tenantId, q, topK, null);
   }
-  return runBm25Query(client, tenantId, q, topK, null);
+
+  const codes = extractFaultCodes(q);
+  if (codes.length === 0) return main;
+
+  // Code pass: query on the code(s) alone (the terse form that reliably
+  // surfaces the documenting chunk), manufacturer-scoped first then fallback.
+  const codeQuery = codes.join(" ");
+  let codeHits = mfr ? await runBm25Query(client, tenantId, codeQuery, topK, mfr) : [];
+  if (codeHits.length === 0) {
+    codeHits = await runBm25Query(client, tenantId, codeQuery, topK, null);
+  }
+  if (codeHits.length === 0) return main;
+
+  return dedupeChunks([...codeHits, ...main]).slice(0, topK);
+}
+
+// #1875 — the exact cite-or-refuse sentence the quickstart system prompt tells
+// the model to emit when context has no support. The route uses this to
+// suppress phantom citation cards on a refusal (chunks render 1:1, so a refusal
+// otherwise ships with 6 citations under "I don't have manuals" — the
+// contradiction reported in PR #1875). Kept here so it is unit-testable.
+export const QUICKSTART_REFUSAL_MARK =
+  "I don't have manuals for that in the public knowledge base";
+
+/** True when an answer is the quickstart cite-or-refuse refusal. */
+export function isRefusalAnswer(answer: string | null | undefined): boolean {
+  if (!answer) return false;
+  return answer.toLowerCase().includes(QUICKSTART_REFUSAL_MARK.toLowerCase());
 }
 
 async function runBm25Query(


### PR DESCRIPTION
## The bug (PR #1875, Surface 2)

Public quickstart chat refused the **canonical demo question** — *"My Allen-Bradley PowerFlex 525 is showing fault F004, what does it mean?"* — with *"I don't have manuals for that in the public knowledge base"* **while rendering 6 PowerFlex 525 citations.** Money-path contradiction.

## Diagnosis — the PR #1875 hypothesis was wrong (proven by live probes)

| Probe | Result |
|---|---|
| `{"question":"My Allen-Bradley PowerFlex 525 … fault F004 …"}` (verbose) | ❌ refuses, *"context blocks [1]-[6] do not mention F004"* |
| `{"question":"fault F004"}` | ✅ *"For fault F004 … UnderVoltage …"* |
| `{"question":"F004"}` | ✅ answers |

So **the F004 chunk exists and is retrievable**, and `Allen-Bradley→Rockwell` **already exists** in `vendor-relevance.ts` — aliasing was never the cause. The real cause: the verbose query's extra tokens (`allen`, `bradley`, `powerflex`, `525`, `showing`, `mean`…) dilute the BM25 OR-fallback ranking so the F004 chunk drops below top-6 and the model **honestly** refuses.

## Fix (narrow, additive)

- **`extractFaultCodes()`** — detect single-letter + 2–4-digit codes (`F004`/`E001`/`A002`); deliberately skips two-letter model prefixes (`PF525`/`GS10`) and bare digits (`525`). Known limit: single-digit codes (`F4`) rely on the normal path.
- **`retrieveManualChunks()`** — when the query names a code, run one extra pass keyed on the code alone (the terse form that already retrieves the row) and merge those chunks **ahead** of the main BM25 result (dedup, cap topK). **Never removes a main-pass chunk, never causes a refusal.** Mirrors the engine's `recall_fault_code` *intent*, not its RRF/structured-table apparatus.
- **`isRefusalAnswer()` + route gate** — suppress phantom citation cards when the model refuses (chunks render 1:1, so a refusal otherwise ships with 6 citations — the other half of the contradiction).

Refusal logic is **not** weakened globally; the cross-vendor `stripConflictingVendors` strip is unchanged and still runs on the merged set (leak-guard test added).

## Evidence

- **+10 tests** (`extractFaultCodes`, code-pass prioritization, dedup, no-op on code-free queries, `isRefusalAnswer`, cross-vendor F004 leak guard).
- `npx vitest run src/lib` → **417/417 green**; `eslint` clean on all 4 files; **no new `tsc` errors** (the 7 pre-existing are in untouched `namespace/tree` + `rls-deny` test files).
- Cannot verify live this session (PR→smoke→deploy-vps); the regression test is the durable proof. The live probes above document the **current broken** prod state.

Closes the Surface 2 false-refusal item in PR #1875. Diagnosis correction + provider-fallback + mig-048 notes pushed to the #1875 checklist branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)