### PR TITLE
fix(engine): close the last cross-tenant read-back — decision-trace tenant attribution (isolation sweep)

### DIFF
--- a/mira-bots/shared/engine.py
+++ b/mira-bots/shared/engine.py
@@ -752,10 +752,6 @@ class Supervisor:
         self.print_ = PrintWorker(openwebui_url, api_key)
         self.plc = PLCWorker()
 
-        # Per-call tenant context (overridden by process(tenant_id=...) when provided)
-        self._current_tenant_id: str = self.tenant_id
-        self._current_mira_user_id: str = ""
-
         self._ensure_table()
 
     # ------------------------------------------------------------------
@@ -1181,13 +1177,9 @@ class Supervisor:
         EMBEDDING still uses the full ``message`` for semantic context. Default
         None = use ``message`` (chat surfaces unchanged).
         """
-        # Per-call tenant overrides constructor default. Stash on self so workers
-        # can reach the current request's tenant via self._current_tenant_id.
-        # Existing callers that don't pass the kwargs continue to use self.tenant_id
-        # from __init__ (set as the fallback below).
-        self._current_tenant_id = tenant_id or self.tenant_id
-        self._current_mira_user_id = mira_user_id or ""
-
+        # Per-call tenant flows through method params (tenant_id → process_full,
+        # workers, and the decision-trace) — NOT stashed on self, which a
+        # concurrent tenant would overwrite across this turn's awaits.
         # Read-only live-tag snapshot — gated on a confirmed asset (see helper).
         message = self._maybe_attach_live_snapshot(chat_id, message, live_tags, platform)
 
@@ -1265,6 +1257,7 @@ class Supervisor:
             platform=platform,
             latency_ms=elapsed_ms,
             tag_evidence=tag_evidence,
+            tenant_id=tenant_id,
         )
         return reply
 
@@ -1278,6 +1271,7 @@ class Supervisor:
         platform: str,
         latency_ms: int,
         tag_evidence: list | None = None,
+        tenant_id: str | None = None,
     ) -> None:
         """Schedule a non-blocking decision_traces write for this turn.
 
@@ -1303,7 +1297,10 @@ class Supervisor:
             else:
                 outcome = None
 
-            tenant_id = getattr(self, "_current_tenant_id", None) or self.tenant_id
+            # Use THIS turn's tenant, passed in by the caller — never a shared
+            # self._current_tenant_id read after process_full's awaits, which a
+            # concurrent tenant could overwrite (cross-tenant trace attribution).
+            tenant_id = tenant_id or self.tenant_id
 
             # Only attach RAG sources when THIS turn actually retrieved. Read
             # the per-turn snapshot threaded on the result dict (#1704) — NOT
@@ -1497,9 +1494,6 @@ class Supervisor:
         the chat ack message ("Processing photo 2/4..."). Callback exceptions
         are caught and logged so a flaky chat-edit can't take down the engine.
         """
-        self._current_tenant_id = tenant_id or getattr(self, "tenant_id", "") or ""
-        self._current_mira_user_id = mira_user_id or ""
-
         n = len(photos_b64)
         t0 = time.monotonic()
 

--- a/mira-bots/tests/test_engine.py
+++ b/mira-bots/tests/test_engine.py
@@ -1160,3 +1160,56 @@ class TestDecisionTraceIsolation:
             for t in list(supervisor._decision_trace_tasks):
                 await t
         assert captured.get("manual_sources") is None
+
+    @pytest.mark.asyncio
+    async def test_trace_attributed_to_passed_tenant_not_instance(self, supervisor):
+        # The decision trace must record THIS turn's tenant (passed by the
+        # caller), never a shared instance attr a concurrent tenant overwrites.
+        supervisor.tenant_id = "TENANT-Y-FALLBACK"  # would-be cross-tenant bleed
+        captured = {}
+
+        def fake_write_trace(**kw):
+            captured.update(kw)
+
+        with patch("shared.decision_trace.write_trace", side_effect=fake_write_trace):
+            supervisor._schedule_decision_trace(
+                chat_id="c",
+                message="why faulted?",
+                reply="r",
+                result={"reply": "r", "next_state": "DIAGNOSIS"},
+                platform="test",
+                latency_ms=1,
+                tag_evidence=None,
+                tenant_id="tenant-X",
+            )
+            for t in list(supervisor._decision_trace_tasks):
+                await t
+        assert captured.get("tenant_id") == "tenant-X"
+
+    @pytest.mark.asyncio
+    async def test_trace_tenant_falls_back_to_self_when_unset(self, supervisor):
+        supervisor.tenant_id = "ctor-tenant"
+        captured = {}
+
+        def fake_write_trace(**kw):
+            captured.update(kw)
+
+        with patch("shared.decision_trace.write_trace", side_effect=fake_write_trace):
+            supervisor._schedule_decision_trace(
+                chat_id="c",
+                message="m",
+                reply="r",
+                result={"reply": "r", "next_state": "IDLE"},
+                platform="test",
+                latency_ms=1,
+                tag_evidence=None,
+                tenant_id=None,
+            )
+            for t in list(supervisor._decision_trace_tasks):
+                await t
+        assert captured.get("tenant_id") == "ctor-tenant"
+
+    def test_supervisor_has_no_per_turn_tenant_attribute(self, supervisor):
+        # The shared per-turn tenant footgun is gone — nothing to race on.
+        assert not hasattr(supervisor, "_current_tenant_id")
+        assert not hasattr(supervisor, "_current_mira_user_id")


### PR DESCRIPTION
## What

The final instance of the cross-tenant read-back race class, found by sweeping the whole worker/Supervisor surface after #1846 + #1704 (PRs #1872/#1873) closed the `RAGWorker` ones.

`Supervisor` is one shared singleton across all tenants. It stashed the per-turn tenant on `self._current_tenant_id` at `process()` entry, then read it back in `_schedule_decision_trace` **after `process_full`'s awaits**. A concurrent tenant B entering `process()` during A's awaits overwrites it → **tenant A's `decision_traces` row is attributed to tenant B** (cross-tenant data-integrity bug in the trace table).

## Audit result (the sweep)

The user asked to sweep all shared workers for this class. Finding:

| Worker | Per-call `self.<attr>` writes | Verdict |
|---|---|---|
| `VisionWorker`, `NameplateWorker`, `PrintWorker`, `PLCWorker`, `NemotronClient`, `query_triage` | **none** — every `self.<attr>=` is `__init__`-time config | stateless per-call → **no race** |
| `RAGWorker` | citation/grounding state | fixed in #1872/#1873 |
| `Supervisor._current_tenant_id` | per-turn tenant | **this PR** |

So `RAGWorker` was the only stateful worker, and this Supervisor attr was the only remaining instance of the class.

## Fix

- Thread the per-call tenant to `_schedule_decision_trace` (new `tenant_id` param); it uses `tenant_id or self.tenant_id`, never `getattr(self, "_current_tenant_id")`.
- **Remove the shared per-turn state entirely** — `self._current_tenant_id` (one reader: the racy trace line) and `self._current_mira_user_id` (**zero** readers repo-wide). This kills the footgun: the old comment *"stash on self so workers can reach the current request's tenant"* actively invited this race, yet workers already get `tenant_id` as a method arg.
- `process_multi_photo`'s identical dead stash removed — it only calls `vision.process` (stateless), never traces or threads tenant, so removal is behavior-preserving. Its `tenant_id`/`mira_user_id` params stay for API compat (now unused).

## Objective proof

Repo-wide grep for `_current_tenant_id` / `_current_mira_user_id` → **ZERO functional hits** (a comment + one `hasattr` regression test only). The cross-tenant read-back class is now fully eliminated across workers AND the Supervisor.

## Verification

- 3 new tests: trace attributed to the **passed** tenant not a poisoned `self.tenant_id`; falls back to `self.tenant_id` when unset; Supervisor no longer exposes the per-turn attrs.
- GS11 grounding 6/6; **300 engine/worker/citation/trace/photo tests pass, 0 regressions**; `ruff check` + `ruff format --check` clean.

## Severity

Telemetry/data-integrity (decision_traces attribution), not user-facing reply content — lower than #1704's footer leak, but it's the last member of the class and a real tenant-attribution corruption under concurrent load. Closing it makes the multi-tenant story clean: no per-call state read off a shared singleton after an await, anywhere.

## Merge precondition

Engine change → staging gate before merge (passes in CI). Hand to `ship`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)