### PR TITLE
fix(hub): Command Center — every node selectable, detail panel no longer freezes (v2.2.1)

### DIFF
--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## v2.2.1 — 2026-06-11
+- fix(hub): Command Center — every tree node is now selectable; the detail panel no longer freezes on the one live-display node. Selection was gated on `hasLiveDisplay`, swallowing clicks on VFDs / PLCs / folders. Refresh button now spins + disables while fetching. (#1881)
+
 ## v2.2.0 — 2026-06-07
 - fix(hub): Command Center selecting a node with a live display renders **"Open Live View"** button (target=`_blank`, rel=`noopener noreferrer`) instead of an embedded iframe. Iframe was XFO=SAMEORIGIN blocked. Top-level navigation ignores XFO; matches direct-connection handoff model. (#1765)
 

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/app/(hub)/command-center/page.tsx
+++ b/mira-hub/src/app/(hub)/command-center/page.tsx
@@ -58,6 +58,7 @@ export default function CommandCenterPage() {
   const [loading, setLoading] = useState(true);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [selected, setSelected] = useState<CCNode | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
 
   const refresh = useCallback(async () => {
     try {
@@ -100,6 +101,14 @@ export default function CommandCenterPage() {
     return findById(data.nodes, selected.id) ?? selected;
   }, [data, selected]);
 
+  // Manual refresh: show a spinner so the click reads as doing something. The
+  // background poll (POLL_MS) keeps re-fetching silently and must NOT flip this.
+  const manualRefresh = async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    try { await refresh(); } finally { setRefreshing(false); }
+  };
+
   const toggle = (id: string) =>
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -119,10 +128,12 @@ export default function CommandCenterPage() {
           {data && <FreshnessSummary counts={data.freshnessCounts}
             displaysTotal={data.displaysTotal} reachable={data.liveCount} />}
         </div>
-        <button onClick={() => refresh()}
-          className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium hover:bg-black/5"
+        <button onClick={() => void manualRefresh()}
+          disabled={refreshing}
+          className="flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium hover:bg-black/5 disabled:opacity-50"
           title="Refresh">
-          <RefreshCw className="h-3.5 w-3.5" /> Refresh
+          <RefreshCw className={`h-3.5 w-3.5 ${refreshing ? "animate-spin" : ""}`} />
+          {refreshing ? "Refreshing…" : "Refresh"}
         </button>
       </div>
 
@@ -176,7 +187,11 @@ function TreeRow({
           backgroundColor: isSelected ? "#2563EB14" : undefined,
         }}
         onClick={() => {
-          if (node.hasLiveDisplay) onSelect(node);
+          // Every node is selectable — the Viewer renders the right state per
+          // node (live display, "no display configured", or no-tags). Gating
+          // selection on hasLiveDisplay froze the detail panel on the one
+          // display node and swallowed every other click.
+          onSelect(node);
           if (hasChildren) toggle(node.id);
         }}
       >
@@ -284,8 +299,8 @@ function Viewer({ node }: { node: CCNode | null }) {
   if (!node) {
     return (
       <Empty icon={MonitorPlay}
-        title="Select an asset with a live display"
-        sub="Equipment with a green dot has a screen you can watch." />
+        title="Select a node to see its details"
+        sub="Equipment with a green dot has a live screen you can watch." />
     );
   }
   if (!node.hasLiveDisplay || !node.displayId) {


### PR DESCRIPTION
## What

The Command Center detail panel was **frozen on the one live-display node** (Conveyor 1). Clicking any other tree node — GS10 VFD, Micro820 PLC, Photoeye, or any folder — did nothing; the right panel stayed locked.

## Root cause

`page.tsx` tree-row `onClick` gated selection on `node.hasLiveDisplay`:

```tsx
if (node.hasLiveDisplay) onSelect(node);   // ← swallowed every non-display click
```

Only Conveyor 1 has a live display, so it was the only node that ever selected. The Viewer **already** renders a correct *"No live display configured for this asset"* state for non-display nodes — it was simply unreachable.

## Fix (surgical)

- Remove the gate: **always** `onSelect(node)` on row click. Every node now updates the panel.
- Refresh button **spins + disables** while fetching (background poll left untouched), so a manual click visibly responds.
- No-selection empty-state copy updated to match (any node is selectable now).

One file changed: `mira-hub/src/app/(hub)/command-center/page.tsx` (+ version/changelog).

## How found

Post-deploy **command-center / namespace-inline-create E2E** went red — every UI scenario timed out on `expect(...).toBeVisible()` because the detail never updated. Confirmed by manual audit 2026-06-11 (owner session, app.factorylm.com/command-center).

## NOT in scope (verified working-as-designed, not bugs)

- **"display down"** — `node.live` is the VPS's HTTP reachability probe of the display URL. The demo display points at the PLC-laptop Ignition gateway on Tailscale (`100.72.2.99`), which the prod VPS cannot reach. The status is **accurate**. Separate decision: expose a public demo display, or accept it.
- **"0 live · 0 stale · 0 sim / No tags"** — no tag mappings seeded for the demo nodes. A **seed** gap, not a render bug. Separate decision: seed simulated tags, or accept.

Both are tracked as decisions for @Mikecranesync, not code changes here (keeps this PR surgical).

## Verification

- [x] `tsc --noEmit` clean (no command-center errors)
- [ ] Post-deploy command-center E2E green (gate)
- [ ] Authed prod screenshots of panel updating across 3 node types → `docs/promo-screenshots/` (needs owner session post-deploy)

mira-hub **v2.2.1** (patch — hotfix on released line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)