### PR TITLE
fix(hub): add kg_relationships.relationship_proposal_id — unblocks Suggestions "Verify" 500 (#1890)

### DIFF
--- a/mira-hub/db/migrations/050_kg_relationships_proposal_id.sql
+++ b/mira-hub/db/migrations/050_kg_relationships_proposal_id.sql
@@ -1,0 +1,45 @@
+BEGIN;
+
+-- Migration 050: provenance back-link column on kg_relationships.
+--
+-- Issue: #1890 ([knowledge-review] P0 — Suggestions "Verify" 500s in every env)
+-- ADR  : docs/adr/0017-proposal-state-machine-mapping.md
+-- Spec : docs/specs/maintenance-namespace-builder-spec.md §"Proposal queue"
+--
+-- The /api/proposals/[id]/decide endpoint (verify branch) writes
+-- kg_relationships.relationship_proposal_id on both the INSERT (new edge) and
+-- the UPDATE (existing edge) paths, recording which relationship_proposal a
+-- verified edge was promoted from. The column was only ever described in a
+-- COMMENT in 027_ai_suggestions.sql — no migration created it. Live dev/staging/
+-- prod kg_relationships had no such column, so every "Verify" click 500'd with
+-- `column "relationship_proposal_id" of relation "kg_relationships" does not
+-- exist`. ("Reject" took the no-kg-write path, so it returned 200 — masking the
+-- gap.) This is the same class of bug 029 fixed for approval_state/proposed_by/
+-- evidence_summary: the route shipped ahead of its schema.
+--
+-- ON DELETE SET NULL: this is a provenance back-link, not an ownership edge.
+-- A verified kg_relationships edge must survive the deletion of the proposal it
+-- came from (the edge is now its own truth); the link just goes null.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS (carries the FK) + CREATE INDEX IF NOT
+-- EXISTS. Safe to re-run — applied to dev manually, recorded in the
+-- schema_migrations ledger when apply-migrations.yml runs it on staging/prod.
+
+ALTER TABLE kg_relationships
+  ADD COLUMN IF NOT EXISTS relationship_proposal_id uuid
+    REFERENCES relationship_proposals(id) ON DELETE SET NULL;
+
+-- Provenance lookups ("which edge did proposal X verify?") and the ADR-0017
+-- canary's Check 2 read this back-link; index the non-null subset.
+CREATE INDEX IF NOT EXISTS idx_kg_rel_proposal_id
+  ON kg_relationships (relationship_proposal_id)
+  WHERE relationship_proposal_id IS NOT NULL;
+
+COMMIT;
+
+-- ─── DOWN ──────────────────────────────────────────────────────────────────
+-- BEGIN;
+-- DROP INDEX IF EXISTS idx_kg_rel_proposal_id;
+-- ALTER TABLE kg_relationships
+--   DROP COLUMN IF EXISTS relationship_proposal_id;
+-- COMMIT;


### PR DESCRIPTION
## P0: Hub Knowledge → Suggestions "Verify" 500s in every env (#1890)

### Root cause
`src/app/api/proposals/[id]/decide/route.ts` (verify branch) writes
`kg_relationships.relationship_proposal_id` on both the INSERT (new edge, L120)
and UPDATE (existing edge, L143) paths — the provenance back-link recording
which `relationship_proposals` row promoted a verified edge. **No migration ever
created that column**; it existed only in a comment in
`027_ai_suggestions.sql`. Live dev/staging/prod `kg_relationships` had no such
column → every **Verify** click 500'd with
`column "relationship_proposal_id" of relation "kg_relationships" does not exist`.
**Reject** took the no-kg-write path → 200, masking the gap. Same class of bug
that migration **029** fixed for `approval_state`/`proposed_by`/`evidence_summary`.

### Fix
New migration `050_kg_relationships_proposal_id.sql`:
- `ADD COLUMN IF NOT EXISTS relationship_proposal_id uuid REFERENCES relationship_proposals(id) ON DELETE SET NULL` — provenance link survives proposal deletion (the edge is its own truth once verified).
- Partial index on the non-null subset (provenance lookups + ADR-0017 canary Check 2).
- Idempotent, wrapped BEGIN/COMMIT, matches 029's shape + DOWN block.

No route changes — the route was correct, the schema was missing.

### Verified end-to-end on dev Neon (`ep-lingering-salad`)
Applied the migration, seeded a `proposed` `relationship_proposals` row (+ paired
`ai_suggestions` kg_edge + 2 `kg_entities`), POSTed the verify decision via the
real route with a minted next-auth cookie:

- ✅ `POST …/decide/` → **HTTP 200** `{"ok":true,"status":"verified"}` (was 500)
- ✅ `relationship_proposals.status` → `verified`
- ✅ `ai_suggestions.status` → `accepted` (ADR-0017 Hub lockstep)
- ✅ `kg_relationships` mirror row written: `approval_state='verified'`, `relationship_proposal_id` linked (the INSERT that used to crash)
- ✅ `GET /api/kg/graph` returns the edge as `state:"verified"` (Map "1 verified" edge)

Dev seed data cleaned up after verification.

### Rollout
- **dev**: migration applied manually (apply-migrations.yml has no dev target). ✅
- **staging → prod**: apply via `apply-migrations.yml` (dry-run then apply) after merge.

### Out of scope (separate triage issues, not touched here)
- #1893 confirmed in passing: routes live under `/hub` basePath + `trailingSlash: true`, so the client must POST `…/decide/` (trailing slash) or eat a 308. Client-side fix, separate PR.
- #1891 (ai_suggestions queue reconciliation), #1892 (pagination), #1894 (NULL-tenant leak), #1895 (polish) untouched.

Closes #1890

🤖 Generated with [Claude Code](https://claude.com/claude-code)