### PR TITLE
security(hub): node-attachment chunks written is_private=true (#1903)

### DIFF
--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## v2.2.5 — 2026-06-12
+- security(hub): node-attachment manual chunks are now written `is_private = true` (`writePdfChunksForNode`). They were inserted without it → defaulted `false` → a tenant's uploaded manual could surface in other tenants' library/aggregate views via the hybrid read filter `(is_private = false OR tenant_id = $caller)` (#1833 leak class). Migration 052 backfills existing v2 node_attachment chunks to private; shared OEM corpus untouched. Adds a regression test pinning the INSERT to `is_private = true`. (#1903)
+
 ## v2.2.4 — 2026-06-12
 - fix(hub): folder=brain PDF upload 500 — second cause. Signup created only the auth-side `hub_tenants` row, never the data-side `tenants` row that `knowledge_entries.tenant_id` FK-references, so a fresh tenant's first manual upload threw `23503 knowledge_entries_tenant_id_fkey` ("Server storage error") even after the unpdf fix. `createUser` now creates the `tenants` row (id, name, contact_email) at signup; migration 051 backfills existing fresh tenants. Verified against the live prod FK + reproduced fixed on staging. Closes the upload→retrieval gap for strangers. (#1899)
 

--- a/mira-hub/db/migrations/052_privatize_node_attachment_chunks.sql
+++ b/mira-hub/db/migrations/052_privatize_node_attachment_chunks.sql
@@ -1,0 +1,27 @@
+-- Migration 052: privatize existing node-attachment chunks (is_private = true).
+--
+-- #1903 — node=brain chunk writer inserted per-tenant manual chunks into
+-- knowledge_entries WITHOUT is_private, so they defaulted to false. Per
+-- `.claude/rules/knowledge-entries-tenant-scoping.md`, a per-tenant row left
+-- is_private = false leaks to every tenant through the hybrid read filter
+-- `(is_private = false OR tenant_id = $caller)` and the universal library /
+-- aggregate surfaces (the #1833 leak class).
+--
+-- `writePdfChunksForNode` now pins is_private = true for new uploads. This
+-- migration closes the EXISTING leak: every v2 node_attachment chunk already in
+-- the table is, by definition, a per-tenant upload and must be private. This is
+-- narrowly scoped to ingest_route = 'v2' AND source_type = 'node_attachment', so
+-- the shared OEM corpus (ingest_route NULL/'ow', is_private = false by design)
+-- is untouched.
+--
+-- Idempotent: re-running only flips rows still at false; already-true rows are skipped.
+
+BEGIN;
+
+UPDATE knowledge_entries
+   SET is_private = true
+ WHERE ingest_route = 'v2'
+   AND source_type = 'node_attachment'
+   AND is_private = false;
+
+COMMIT;

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/lib/__tests__/node-knowledge-ingest-is-private.test.ts
+++ b/mira-hub/src/lib/__tests__/node-knowledge-ingest-is-private.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * #1903 regression — node-attachment chunks MUST be written is_private = true.
+ *
+ * A PDF attached to a namespace node is a PER-TENANT upload, not shared OEM
+ * corpus. Per `.claude/rules/knowledge-entries-tenant-scoping.md`, a per-tenant
+ * row left is_private = false (the column default) leaks to every other tenant
+ * through the hybrid read filter `(is_private = false OR tenant_id = $caller)`
+ * and the universal library/aggregate surfaces (#1833). This test mocks the DB
+ * client and unpdf, runs the real writePdfChunksForNode, and asserts the chunk
+ * INSERT pins is_private = true (so removing it fails loudly, no DB required).
+ */
+
+const captured: { sql: string; params: unknown[] }[] = [];
+
+vi.mock("unpdf", () => ({
+  getDocumentProxy: vi.fn(async () => ({})),
+  extractText: vi.fn(async () => ({
+    text: ["Fault ZX-451 — recalibrate the PT-7 pressure transducer."],
+  })),
+}));
+
+vi.mock("@/lib/tenant-context", () => ({
+  withTenantContext: vi.fn(
+    async (_tenantId: string, fn: (c: { query: (sql: string, params: unknown[]) => Promise<{ rows: [] }> }) => Promise<unknown>) =>
+      fn({
+        query: async (sql: string, params: unknown[]) => {
+          captured.push({ sql, params });
+          return { rows: [] as [] };
+        },
+      }),
+  ),
+}));
+
+describe("#1903 node-attachment chunks are is_private = true", () => {
+  beforeEach(() => {
+    captured.length = 0;
+  });
+
+  it("the knowledge_entries INSERT pins is_private = true", async () => {
+    const { writePdfChunksForNode } = await import("../node-knowledge-ingest");
+    const count = await writePdfChunksForNode({
+      tenantId: "tenant-a",
+      uploadId: "upload-1",
+      nodeId: "node-1",
+      unsPath: "enterprise.site.line.press",
+      filename: "zephyr.pdf",
+      buffer: Buffer.from("%PDF-1.4 stub"),
+    });
+
+    expect(count).toBeGreaterThan(0);
+    const insert = captured.find((c) => c.sql.includes("INSERT INTO knowledge_entries"));
+    expect(insert, "no knowledge_entries INSERT was issued").toBeTruthy();
+
+    // Column list includes is_private, and it is the literal `true` (not a default,
+    // not a bound param that could be flipped).
+    expect(insert!.sql).toMatch(/\bis_private\b/);
+    expect(insert!.sql).toMatch(/'v2',\s*\$7,\s*\$7,\s*\$8,\s*true\b/);
+    // Belt + suspenders: the params never carry a `false` for privacy.
+    expect(insert!.params).not.toContain(false);
+  });
+});

--- a/mira-hub/src/lib/node-knowledge-ingest.ts
+++ b/mira-hub/src/lib/node-knowledge-ingest.ts
@@ -91,10 +91,15 @@ export async function writePdfChunksForNode(opts: {
     await withTenantContext(tenantId, async (c) => {
       for (const r of rows) {
         await c.query(
+          // #1903: a node attachment is a per-tenant upload, NOT shared OEM corpus.
+          // is_private = true keeps it out of the universal/library aggregate surfaces
+          // and the hybrid read filter `(is_private = false OR tenant_id = $caller)`, so
+          // tenant A's manual is never visible to tenant B. The column defaults to false,
+          // so relying on the default would leak (see .claude/rules/knowledge-entries-tenant-scoping.md #1833).
           `INSERT INTO knowledge_entries
              (id, tenant_id, source_type, content, source_url, source_page,
-              doc_id, ingest_route, page_start, page_end, metadata)
-           VALUES ($1, $2, 'node_attachment', $3, $4, $5, $6, 'v2', $7, $7, $8)
+              doc_id, ingest_route, page_start, page_end, metadata, is_private)
+           VALUES ($1, $2, 'node_attachment', $3, $4, $5, $6, 'v2', $7, $7, $8, true)
            ON CONFLICT (tenant_id, source_url, ((metadata->>'chunk_index')::int))
              WHERE (metadata->>'chunk_index') IS NOT NULL
              DO NOTHING`,


### PR DESCRIPTION
Closes #1903.

## The leak
`writePdfChunksForNode` (`mira-hub/src/lib/node-knowledge-ingest.ts`) inserted per-tenant manual chunks into `knowledge_entries` **without `is_private`**, so they defaulted to `false`. Per `.claude/rules/knowledge-entries-tenant-scoping.md`, a per-tenant row left `is_private = false` is visible to **every** tenant through the hybrid read filter `(is_private = false OR tenant_id = $caller)` and the universal library/aggregate surfaces (the #1833 leak class). Contrast `/api/documents/upload`, which correctly sets `is_private = true`.

Now that #1899 landed and the upload path actually writes rows (it previously 500'd, so the leak was latent), this is live — including the chunk my own beta-gate verification just uploaded.

## Fix
1. **`writePdfChunksForNode`** pins `is_private = true` in the INSERT (literal `true`, not a default or flippable param).
2. **Migration 052** backfills existing `ingest_route = 'v2' AND source_type = 'node_attachment'` chunks to `is_private = true`. Narrowly scoped — the shared OEM corpus (`ingest_route` NULL/`'ow'`, private = false by design) is untouched. Idempotent.
3. **Regression test** (`node-knowledge-ingest-is-private.test.ts`) mocks unpdf + the tenant DB client, runs the real writer, and asserts the INSERT pins `is_private = true` (no DB needed).
4. Bump `2.2.4 → 2.2.5` + CHANGELOG.

## Verification
- New regression test green; node-knowledge lib suite green.
- `is_private`/`ingest_route`/`source_type` columns confirmed present on prod (earlier `db-inspect` probe).
- Owed after merge: apply migration 052 (dev→staging→prod) + redeploy hub, then confirm a tenant-A node upload is NOT visible to tenant B in `/api/knowledge`, `/api/library/*`, `/api/documents`.

> Note: the `staging-gate`/`apply-and-verify` chain is red for the same **unrelated, pre-existing** `ai_suggestions` RLS failure on the shared staging branch that affected #1910 (diff-proven not this change; blocks all migration PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)