### PR TITLE
fix(hub): fresh-tenant Feed shows real user, not hardcoded 'Mike Harper' (#1904)

### DIFF
--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## v2.2.6 — 2026-06-12
+- fix(hub): fresh-tenant Feed header no longer shows a hardcoded "Mike Harper · Admin" — it now renders the real signed-in user (name + role) from `/api/me`, the same source as the sidebar, and renders nothing until loaded. Also replaced the leftover "Mike Harper" placeholder in the labs-only Conversations/Team mock data with a generic name. No real cross-tenant data was leaking — the strings were hardcoded. (#1904)
+
 ## v2.2.5 — 2026-06-12
 - security(hub): node-attachment manual chunks are now written `is_private = true` (`writePdfChunksForNode`). They were inserted without it → defaulted `false` → a tenant's uploaded manual could surface in other tenants' library/aggregate views via the hybrid read filter `(is_private = false OR tenant_id = $caller)` (#1833 leak class). Migration 052 backfills existing v2 node_attachment chunks to private; shared OEM corpus untouched. Adds a regression test pinning the INSERT to `is_private = true`. (#1903)
 

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/app/(hub)/conversations/page.tsx
+++ b/mira-hub/src/app/(hub)/conversations/page.tsx
@@ -67,7 +67,7 @@ const CONVERSATIONS: Conversation[] = [
     ],
   },
   {
-    id: "c005", tech: "Mike Harper", techInitials: "MH",
+    id: "c005", tech: "Alex Rivera", techInitials: "AR",
     channel: "Open WebUI", channelEmoji: "🖥️",
     lastMessage: "Show me the weekly wrench time breakdown by tech",
     ts: "Yesterday", asset: null, unread: 0,

--- a/mira-hub/src/app/(hub)/feed/page.tsx
+++ b/mira-hub/src/app/(hub)/feed/page.tsx
@@ -166,7 +166,17 @@ export default function FeedPage() {
   const [wos, setWos] = useState<WOApi[]>([]);
   const [pms, setPms] = useState<PMApi[]>([]);
   const [loading, setLoading] = useState(true);
+  // #1904: the header showed a hardcoded "Mike Harper · Admin" to every tenant.
+  // Show the real signed-in user instead (same /api/me source as the sidebar).
+  const [me, setMe] = useState<{ name: string; role: string } | null>(null);
   const { speaking, speak } = useSpeech();
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/me`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: { name: string; role: string } | null) => d && setMe(d))
+      .catch(() => {});
+  }, []);
 
   const KPI_LABEL_MAP: Record<string, string> = {
     "Open Work Orders": tFeed("kpi.openWorkOrders"),
@@ -245,9 +255,11 @@ export default function FeedPage() {
               <h1 className="text-base font-semibold" style={{ color: "var(--foreground)" }}>{tFeed("title")}</h1>
               <Badge variant="secondary" className="text-[10px]">Live</Badge>
             </div>
-            <p className="text-xs mt-0.5" style={{ color: "var(--foreground-muted)" }}>
-              Mike Harper · <span className="capitalize font-medium" style={{ color: "var(--brand-blue)" }}>Admin</span>
-            </p>
+            {me && (
+              <p className="text-xs mt-0.5" style={{ color: "var(--foreground-muted)" }}>
+                {me.name} · <span className="capitalize font-medium" style={{ color: "var(--brand-blue)" }}>{me.role}</span>
+              </p>
+            )}
           </div>
           <Button variant="ghost" size="icon" onClick={handleRefresh}>
             <RefreshCw className={`w-4 h-4 ${refreshing ? "animate-spin" : ""}`} style={{ color: "var(--foreground-muted)" }} />

--- a/mira-hub/src/app/(hub)/team/page.tsx
+++ b/mira-hub/src/app/(hub)/team/page.tsx
@@ -38,7 +38,7 @@ type TeamMember = {
 
 const TEAM: TeamMember[] = [
   {
-    id: "T-001", name: "Mike Harper", initials: "MH", role: "Maintenance Lead", dept: "Maintenance",
+    id: "T-001", name: "Alex Rivera", initials: "AR", role: "Maintenance Lead", dept: "Maintenance",
     shift: "Day (6AM–2PM)", shiftStatus: "on-shift", phone: "(863) 555-0101",
     currentAssignment: "WO-2026-009 — Air Compressor PM",
     todayActivity: ["Completed PM-008 (Oil Change)", "Reviewed 2 maintenance requests", "Ordered parts PO-2026-044"],


### PR DESCRIPTION
Closes #1904.

## Triage result
The "Mike Harper · Admin" a fresh tenant saw on `/feed/` was a **hardcoded string** (`feed/page.tsx:249`), **not** a cross-tenant identity leak (so not the P0 the issue flagged as a possibility). Same for the `conversations`/`team` occurrences — literal strings in **labs-only mock arrays** (hidden in prod via `NEXT_PUBLIC_LABS_ENABLED`, ADR-0014).

## Fix
- **`feed/page.tsx`** — the header now fetches `/api/me` (same source as the sidebar) and renders the **real signed-in user's** name + role; renders nothing until loaded. No more "Mike Harper" for anyone.
- **`conversations/page.tsx` + `team/page.tsx`** — replaced the leftover "Mike Harper" mock placeholder with a generic name (these are hidden labs surfaces; real data isn't wired, so a neutral placeholder is the right call there).
- Bump `2.2.5 → 2.2.6` + CHANGELOG.

## Note (out of scope, tracked)
The issue's second ask — labeling the shared OEM corpus stats distinctly from a tenant's own uploads on the Knowledge page — overlaps #1900 (upload-path/ownership clarity) and is left to that issue.

## Verification
- The three files typecheck clean; `/api/me` returns `{name, role, …}` (verified live during #1899 — sidebar already renders it correctly, e.g. "Dale Tech Final / owner").

🤖 Generated with [Claude Code](https://claude.com/claude-code)