### PR TITLE
fix(hub): make a Knowledge-uploaded manual one click from Ask MIRA (#1900)

### DIFF
--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## v2.2.7 — 2026-06-12
+- fix(hub): a manual uploaded via Knowledge → Upload is now one click from being asked about. The PDF was already chunked + attached to the per-tenant Inbox node and citable (#1806), but nothing pointed the user there: the post-upload card said "Parsed", the Inbox folder read "0 files", and the user's own folder's Ask MIRA structurally can't reach Inbox docs (subtree-scoped retrieval) → felt broken. Now (1) the upload summary card shows an **"Ask MIRA about this manual"** CTA deep-linking to `/namespace?node=<inbox>&chat=1`; (2) `namespace?node=&chat=1` selects + expands the target node and auto-opens Ask MIRA; (3) node `files_count` + the folder Files list now include v2-indexed PDFs (`hub_uploads.kg_entity_id`), shown as read-only "indexed" entries — killing the "0 files" lie. No schema change. (The reported "Knowledge upload hits the demo `/api/documents/upload`" was stale — it's hit `/api/uploads/local` since the Knowledge-tab unification; that demo endpoint is now-orphaned dead code, noted for separate cleanup.) (#1900)
+
 ## v2.2.6 — 2026-06-12
 - fix(hub): fresh-tenant Feed header no longer shows a hardcoded "Mike Harper · Admin" — it now renders the real signed-in user (name + role) from `/api/me`, the same source as the sidebar, and renders nothing until loaded. Also replaced the leftover "Mike Harper" placeholder in the labs-only Conversations/Team mock data with a generic name. No real cross-tenant data was leaking — the strings were hardcoded. (#1904)
 

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/app/(hub)/namespace/page.tsx
+++ b/mira-hub/src/app/(hub)/namespace/page.tsx
@@ -89,6 +89,8 @@ export default function NamespacePage() {
   const [uploadState, setUploadState] = useState<UploadState>(null);
   const [nodeFiles, setNodeFiles] = useState<Record<string, FileRecord[]>>({});
   const [ctxMenu, setCtxMenu] = useState<{ node: NamespaceNode; x: number; y: number } | null>(null);
+  const [pendingChat, setPendingChat] = useState(false);
+  const [deepLinkApplied, setDeepLinkApplied] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const showToast = useCallback((msg: string) => {
@@ -150,6 +152,28 @@ export default function NamespacePage() {
     setSelected(node);
     void loadFiles(node.id);
   }, [loadFiles]);
+
+  // #1900 deep-link: `/namespace?node=<id|inbox>&chat=1` selects a node (used by
+  // the post-upload "Ask MIRA about this manual" CTA — lands the user straight on
+  // the Inbox node that holds their just-uploaded manual) and optionally opens its
+  // Ask MIRA panel. Read once, after the tree has loaded so the target exists.
+  useEffect(() => {
+    if (deepLinkApplied || loading || tree.length === 0) return;
+    setDeepLinkApplied(true);
+    const params = new URLSearchParams(window.location.search);
+    const nodeParam = params.get("node");
+    if (!nodeParam) return;
+    const chain =
+      nodeParam === "inbox"
+        ? findChain(tree, (n) => n.unsPath === "inbox")
+        : findChain(tree, (n) => n.id === nodeParam);
+    if (!chain || chain.length === 0) return;
+    const target = chain[chain.length - 1];
+    setExpandedIds((prev) => new Set([...prev, ...chain.map((n) => n.id)]));
+    setSelected(target);
+    void loadFiles(target.id);
+    if (params.get("chat") === "1") setPendingChat(true);
+  }, [deepLinkApplied, loading, tree, loadFiles]);
 
   // ── Node drag-and-drop (reparent) ──────────────────────────────────────────
 
@@ -458,6 +482,8 @@ export default function NamespacePage() {
               node={selected}
               files={nodeFiles[selected.id]}
               uploadState={uploadState}
+              openChat={pendingChat}
+              onChatOpened={() => setPendingChat(false)}
               onSelect={handleSelect}
               onDeleteFile={(fileId) => handleDeleteFile(fileId, selected.id)}
               onUpload={() => fileInputRef.current?.click()}
@@ -731,12 +757,14 @@ function TreeNode({
 // ── ContentPanel ──────────────────────────────────────────────────────────────
 
 function ContentPanel({
-  node, files, uploadState,
+  node, files, uploadState, openChat, onChatOpened,
   onSelect, onDeleteFile, onUpload,
 }: {
   node: NamespaceNode;
   files: FileRecord[] | undefined;
   uploadState: UploadState;
+  openChat: boolean;
+  onChatOpened: () => void;
   onSelect: (n: NamespaceNode) => void;
   onDeleteFile: (fileId: string) => void;
   onUpload: () => void;
@@ -754,6 +782,15 @@ function ContentPanel({
   // folder=brain: "Ask MIRA" is available at every node — the answer is grounded in
   // the docs attached to this node and everything beneath it (subtree retrieval).
   const [showChat, setShowChat] = useState(false);
+
+  // #1900: a deep-link (`?chat=1`) auto-opens Ask MIRA after upload. Fire once per
+  // signal so the user can still close it; the parent resets `openChat` immediately.
+  useEffect(() => {
+    if (openChat) {
+      setShowChat(true);
+      onChatOpened();
+    }
+  }, [openChat, onChatOpened]);
 
   return (
     <div className="flex flex-col h-full">
@@ -931,14 +968,27 @@ function FilesSection({ nodeId, files, uploadState, onDeleteFile, onUpload }: {
             {files.map((f) => (
               <tr key={f.id} className="group hover:bg-[#e8e8f8]">
                 <td className="py-0.5 pr-4">
-                  <a
-                    href={`${API_BASE}/api/namespace/files/${f.id}`}
-                    className="flex items-center gap-1.5 text-blue-700 hover:underline"
-                    download={f.filename}
-                  >
-                    <FileText className="h-3.5 w-3.5 shrink-0 text-gray-400" />
-                    {f.filename}
-                  </a>
+                  {f.source === "upload" ? (
+                    // #1900: an indexed PDF (chunked into knowledge_entries, citable
+                    // by Ask MIRA) — no raw bytes are parked here to download, so show
+                    // it as a read-only "indexed" entry rather than a broken link.
+                    <span className="flex items-center gap-1.5 text-gray-800">
+                      <FileText className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+                      {f.filename}
+                      <span className="ml-1 rounded bg-green-100 px-1 text-[10px] text-green-700">
+                        indexed
+                      </span>
+                    </span>
+                  ) : (
+                    <a
+                      href={`${API_BASE}/api/namespace/files/${f.id}`}
+                      className="flex items-center gap-1.5 text-blue-700 hover:underline"
+                      download={f.filename}
+                    >
+                      <FileText className="h-3.5 w-3.5 shrink-0 text-gray-400" />
+                      {f.filename}
+                    </a>
+                  )}
                 </td>
                 <td className="py-0.5 pr-4 text-gray-500">{formatBytes(f.size_bytes)}</td>
                 <td className="py-0.5 pr-4 text-gray-400">{formatDate(f.created_at)}</td>
@@ -1125,6 +1175,23 @@ function findNode(nodes: NamespaceNode[], id: string): NamespaceNode | null {
     if (n.id === id) return n;
     const found = findNode(n.children, id);
     if (found) return found;
+  }
+  return null;
+}
+
+/** Return the root→match chain (inclusive) for the first node matching `pred`, so
+ *  the caller can expand every ancestor and select the target. Used by the #1900
+ *  deep-link. */
+function findChain(
+  nodes: NamespaceNode[],
+  pred: (n: NamespaceNode) => boolean,
+  trail: NamespaceNode[] = [],
+): NamespaceNode[] | null {
+  for (const n of nodes) {
+    const next = [...trail, n];
+    if (pred(n)) return next;
+    const deeper = findChain(n.children, pred, next);
+    if (deeper) return deeper;
   }
   return null;
 }

--- a/mira-hub/src/app/api/namespace/node/[id]/files/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/namespace/node/[id]/files/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+// Vitest coverage for GET /api/namespace/node/[id]/files — specifically the
+// #1900 change: a PDF indexed into a node (hub_uploads.kg_entity_id, chunked into
+// knowledge_entries) must appear in the node's file list as a read-only "indexed"
+// entry, so a folder holding a citable manual no longer reads "0 files".
+//
+// Run: cd mira-hub && npx vitest run src/app/api/namespace/node/[id]/files
+//
+// Mocks the session helper, the tenant-context wrapper (direct uploads), and the
+// owner pool (the v2 hub_uploads read). Issue: #1900
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/session", () => ({ sessionOr401: vi.fn() }));
+vi.mock("@/lib/tenant-context", () => ({ withTenantContext: vi.fn() }));
+vi.mock("@/lib/db", () => ({ default: { query: vi.fn() } }));
+// Pull node-knowledge-ingest in as a no-op — GET never touches it, but importing
+// the route module loads it, and it must not hit a real DB at import time.
+vi.mock("@/lib/node-knowledge-ingest", () => ({ ingestPdfToNode: vi.fn() }));
+
+import { GET } from "../route";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import pool from "@/lib/db";
+
+const VALID_UUID = "11111111-2222-3333-4444-555555555555";
+const TENANT_ID = "tenant-aaaa-bbbb";
+
+const goodSession = {
+  userId: "u_1",
+  tenantId: TENANT_ID,
+  email: "x@y",
+  status: "trial",
+  trialExpiresAt: null,
+};
+
+const makeReq = () =>
+  new Request(`https://hub.test/api/namespace/node/${VALID_UUID}/files`, { method: "GET" });
+const makeParams = (id: string) => ({ params: Promise.resolve({ id }) });
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  process.env.NEON_DATABASE_URL = "postgres://test-only-not-used";
+});
+
+describe("GET /api/namespace/node/[id]/files — v2 indexed uploads (#1900)", () => {
+  it("merges hub_uploads v2 docs as read-only 'upload' entries ahead of direct files", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    // Node exists, one direct (raw) file attached.
+    vi.mocked(withTenantContext).mockResolvedValue([
+      {
+        id: "direct-1",
+        filename: "wiring.png",
+        mime_type: "image/png",
+        size_bytes: 2048,
+        source: "direct",
+        created_at: "2026-06-12T00:00:00Z",
+      },
+    ]);
+    // One indexed PDF attached to this node via hub_uploads.kg_entity_id.
+    vi.mocked(pool.query).mockResolvedValue({
+      rows: [
+        {
+          id: "upload-1",
+          filename: "pump-manual.pdf",
+          mime_type: "application/pdf",
+          size_bytes: "51200",
+          created_at: "2026-06-12T01:00:00Z",
+        },
+      ],
+    } as never);
+
+    const res = await GET(makeReq(), makeParams(VALID_UUID));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { files: Array<Record<string, unknown>> };
+    expect(body.files).toHaveLength(2);
+    // Indexed entries lead, tagged source 'upload' (no download/delete on the client).
+    expect(body.files[0]).toMatchObject({
+      filename: "pump-manual.pdf",
+      source: "upload",
+      size_bytes: 51200,
+    });
+    expect(body.files[1]).toMatchObject({ filename: "wiring.png", source: "direct" });
+    // The v2 read is scoped to tenant + this node id.
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining("FROM hub_uploads"),
+      [TENANT_ID, VALID_UUID],
+    );
+  });
+
+  it("degrades to direct files alone when the hub_uploads read fails (never 500s)", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    vi.mocked(withTenantContext).mockResolvedValue([]);
+    vi.mocked(pool.query).mockRejectedValue(new Error("relation hub_uploads does not exist"));
+
+    const res = await GET(makeReq(), makeParams(VALID_UUID));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { files: unknown[] };
+    expect(body.files).toEqual([]);
+  });
+
+  it("returns 404 when the node does not belong to the tenant", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    vi.mocked(withTenantContext).mockResolvedValue(null);
+    const res = await GET(makeReq(), makeParams(VALID_UUID));
+    expect(res.status).toBe(404);
+  });
+
+  it("propagates a 401 from the session helper", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await GET(makeReq(), makeParams(VALID_UUID));
+    expect(res.status).toBe(401);
+  });
+});

--- a/mira-hub/src/app/api/namespace/node/[id]/files/route.ts
+++ b/mira-hub/src/app/api/namespace/node/[id]/files/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { sessionOr401 } from "@/lib/session";
 import { withTenantContext } from "@/lib/tenant-context";
 import { ingestPdfToNode } from "@/lib/node-knowledge-ingest";
+import pool from "@/lib/db";
 
 export const dynamic = "force-dynamic";
 
@@ -69,7 +70,47 @@ export async function GET(
       return NextResponse.json({ error: "node not found" }, { status: 404 });
     }
 
-    return NextResponse.json({ files });
+    // #1900: also list PDFs indexed into this node (hub_uploads v2 attach) so a
+    // folder holding a citable manual doesn't read "0 files / No files attached".
+    // hub_uploads is an app-pool table (no RLS) — query on the owner pool. These
+    // are read-only here (source 'upload'): no raw bytes are parked in
+    // namespace_direct_uploads, so the client renders them as indexed entries with
+    // no download/delete. A failure must never break the panel.
+    let indexed: Array<Omit<FileRow, "size_bytes"> & { size_bytes: number }> = [];
+    try {
+      const r = await pool.query<{
+        id: string;
+        filename: string;
+        mime_type: string;
+        size_bytes: string;
+        created_at: string;
+      }>(
+        `SELECT id::text AS id,
+                filename,
+                COALESCE(mime_type, 'application/pdf') AS mime_type,
+                COALESCE(size_bytes, 0)::text AS size_bytes,
+                created_at
+           FROM hub_uploads
+          WHERE tenant_id = $1
+            AND kg_entity_id = $2
+            AND status = 'parsed'
+            AND kind = 'document'
+          ORDER BY created_at DESC`,
+        [ctx.tenantId, id],
+      );
+      indexed = r.rows.map((row) => ({
+        id: row.id,
+        filename: row.filename,
+        mime_type: row.mime_type,
+        size_bytes: Number(row.size_bytes),
+        source: "upload" as const,
+        created_at: row.created_at,
+      }));
+    } catch (err) {
+      console.warn("[api/namespace/node/:id/files] indexed list skipped", err);
+    }
+
+    return NextResponse.json({ files: [...indexed, ...files] });
   } catch (err) {
     console.error("[api/namespace/node/:id/files GET]", err);
     return NextResponse.json({ error: "Query failed" }, { status: 500 });

--- a/mira-hub/src/app/api/namespace/tree/route.ts
+++ b/mira-hub/src/app/api/namespace/tree/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { sessionOr401 } from "@/lib/session";
 import { withTenantContext } from "@/lib/tenant-context";
+import pool from "@/lib/db";
 
 export const dynamic = "force-dynamic";
 
@@ -92,6 +93,33 @@ export async function GET() {
 
       return { entities: entitiesRes.rows, proposals: proposalsRes.rows };
     });
+
+    // #1900: a PDF uploaded via Knowledge / a folder is chunked into
+    // knowledge_entries and attached to its node (hub_uploads.kg_entity_id) — it
+    // is NOT a namespace_direct_uploads row, so files_count above counts 0 and the
+    // node looks empty even though the manual is citable. Fold in the v2-attached
+    // upload count. hub_uploads is an app-pool table with no RLS, so query it on
+    // the owner pool (not the tenant RLS context); a failure here must never break
+    // the tree, so it degrades to the direct-upload count alone.
+    try {
+      const { rows } = await pool.query<{ kg_entity_id: string; n: string }>(
+        `SELECT kg_entity_id, COUNT(*)::text AS n
+           FROM hub_uploads
+          WHERE tenant_id = $1
+            AND kg_entity_id IS NOT NULL
+            AND status = 'parsed'
+            AND kind = 'document'
+          GROUP BY kg_entity_id`,
+        [ctx.tenantId],
+      );
+      const v2Counts = new Map(rows.map((r) => [r.kg_entity_id, Number(r.n) || 0]));
+      for (const e of result.entities) {
+        const extra = v2Counts.get(e.id);
+        if (extra) e.files_count = String((Number(e.files_count) || 0) + extra);
+      }
+    } catch (err) {
+      console.warn("[api/namespace/tree] v2 upload count skipped", err);
+    }
 
     const nodes = buildTree(result.entities, result.proposals);
     return NextResponse.json({ nodes, total: result.entities.length });

--- a/mira-hub/src/components/UploadSummaryCard.tsx
+++ b/mira-hub/src/components/UploadSummaryCard.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { CheckCircle2, Loader2, AlertCircle, CalendarDays, BookOpen, Wrench } from "lucide-react";
+import { CheckCircle2, Loader2, AlertCircle, CalendarDays, BookOpen, Wrench, Bot } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { API_BASE } from "@/lib/config";
 
@@ -16,6 +16,11 @@ interface UploadSummaryData {
   pm_tasks_count: number;
   fault_codes_count: number;
   knowledge_chunks_count: number;
+  // #1900: where the chunks landed + whether they're citable. A 'v2' upload is
+  // attached to a kg_entities node (the per-tenant Inbox for blind PDFs) and is
+  // answerable by that node's Ask MIRA. kgEntityId is the deep-link target.
+  kgEntityId: string | null;
+  ingestRoute: string | null;
 }
 
 const POLLING_INTERVAL_MS = 3_000;
@@ -183,19 +188,37 @@ export function UploadSummaryCard({ uploadId }: { uploadId: string }) {
 
       {/* CTAs — only shown once processing is done */}
       {!processing && !failed && (
-        <div className="flex gap-2 pt-1">
-          <Button asChild size="sm" variant="outline" className="flex-1 text-xs gap-1.5">
-            <Link href="/schedule">
-              <CalendarDays className="w-3.5 h-3.5" />
-              View PM Schedule
-            </Link>
-          </Button>
-          <Button asChild size="sm" variant="outline" className="flex-1 text-xs gap-1.5">
-            <Link href="/knowledge/manuals">
-              <BookOpen className="w-3.5 h-3.5" />
-              View Knowledge Base
-            </Link>
-          </Button>
+        <div className="space-y-2 pt-1">
+          {/* #1900 keystone: a manual that "Parsed" is useless until the user can
+              ASK about it. When the upload is citable (v2, attached to a node),
+              lead with a deep-link straight into that node's Ask MIRA so the
+              obvious next action — ask a question — is one click, not a hunt
+              through Namespace → folder → Ask MIRA. */}
+          {data.ingestRoute === "v2" && data.knowledge_chunks_count > 0 && (
+            <Button asChild size="sm" className="w-full text-xs gap-1.5">
+              <Link
+                href={`/namespace?node=${data.kgEntityId ?? "inbox"}&chat=1`}
+                data-testid="upload-ask-mira-cta"
+              >
+                <Bot className="w-3.5 h-3.5" />
+                Ask MIRA about this manual
+              </Link>
+            </Button>
+          )}
+          <div className="flex gap-2">
+            <Button asChild size="sm" variant="outline" className="flex-1 text-xs gap-1.5">
+              <Link href="/schedule">
+                <CalendarDays className="w-3.5 h-3.5" />
+                View PM Schedule
+              </Link>
+            </Button>
+            <Button asChild size="sm" variant="outline" className="flex-1 text-xs gap-1.5">
+              <Link href="/knowledge/manuals">
+                <BookOpen className="w-3.5 h-3.5" />
+                View Knowledge Base
+              </Link>
+            </Button>
+          </div>
         </div>
       )}
     </div>

--- a/mira-hub/src/lib/uploads.ts
+++ b/mira-hub/src/lib/uploads.ts
@@ -31,6 +31,10 @@ export interface Upload {
   kbChunkCount: number | null;
   assetTag: string | null;
   unsPath: string | null;
+  /** Confirmed kg_entities node this drop is attached to (Inbox node for blind PDFs, #1806). */
+  kgEntityId: string | null;
+  /** 'v2' = chunks written to knowledge_entries (citable); null/'ow' = legacy OW-only. */
+  ingestRoute: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -144,6 +148,8 @@ function rowToUpload(r: Record<string, unknown>): Upload {
     kbChunkCount: r.kb_chunk_count != null ? Number(r.kb_chunk_count) : null,
     assetTag: (r.asset_tag as string | null) ?? null,
     unsPath: (r.uns_path as string | null) ?? null,
+    kgEntityId: (r.kg_entity_id as string | null) ?? null,
+    ingestRoute: (r.ingest_route as string | null) ?? null,
     createdAt: r.created_at as string,
     updatedAt: r.updated_at as string,
   };


### PR DESCRIPTION
Closes #1900.

## The real bug (post-#1899)
A manual uploaded via **Knowledge → Upload** is already chunked + attached to the per-tenant **Inbox** node and citable (#1806). But nothing pointed the user there, so it *felt* broken:
- post-upload card says **"Parsed"**, then nothing;
- **Namespace → Inbox** reads **"0 files"** (the files list/count only counted `namespace_direct_uploads`, never the v2 `knowledge_entries` chunks);
- the user's *own* folder's Ask MIRA structurally **can't** reach Inbox docs — `retrieveForNode` is subtree-scoped by `metadata.node_id`, and Inbox sits at top-level `uns_path='inbox'`.

Net: "Parsed" → ask on your folder → "no coverage" → looks broken even though ingest worked.

> ⚠️ **Stale premise corrected:** the issue says Knowledge → Upload hits the demo `POST /api/documents/upload`. It hasn't since the Knowledge-tab unification (`84b43e73`) — it hits `/api/uploads/local` (verified by `git log -S` + grep: **zero** callers of the demo endpoint remain). The demo endpoint is now-orphaned dead code; noted for separate cleanup, **not** touched here.

## The fix (one UX-clarity PR — #1806's split made legible; no schema change)
1. **`UploadSummaryCard`** — when the upload is citable (`ingest_route='v2'`, chunks>0), lead with an **"Ask MIRA about this manual"** CTA deep-linking into the holding node's chat: `/namespace?node=<kgEntityId|inbox>&chat=1`.
2. **namespace page** — `?node=&chat=1` selects + expands the target node (`findChain`) and auto-opens its Ask MIRA panel.
3. **node `files_count` (tree) + folder Files list** — now include v2-indexed PDFs (`hub_uploads.kg_entity_id`), shown as read-only **"indexed"** entries (no raw bytes to download/delete) → kills the **"0 files"** lie.
4. **`uploads.ts`** — expose `kgEntityId` + `ingestRoute` on the `Upload` row (auto-surfaces on the list + single GET; powers the CTA gate + deep-link target).

### Safety
`hub_uploads` is an app-pool table with **no RLS** → both new reads run on the **owner pool**, never inside the tenant RLS context (avoids the grant landmine, mira-hub-migrations rule #3). Both filter `tenant_id = $1`; the files route's 404-on-unowned-node check runs **before** the `hub_uploads` read (no IDOR). Any failure degrades to the direct-upload count/list alone — never breaks the tree or panel.

## Verification
- `tsc --noEmit` clean for the diff (3 remaining errors — `route.test.ts` fixtures, 2 `@ts-expect-error` — are **pre-existing on `c3f871e0`**, not the CI gate).
- Full hub `vitest run`: **493 pass**. One pre-existing/environmental failure (`sitemap-drift.test.ts`, `.mjs` import parse — byte-identical to CI-green `main`, `git diff c3f871e0 HEAD` empty for those files).
- New unit test: `files/__tests__/route.test.ts` — asserts the v2 merge, read-only `source:"upload"`, graceful-degrade, 404, 401.
- Bumps `mira-hub` 2.2.6 → **2.2.7** + CHANGELOG.

### Post-deploy live-verify (owed, matching #1904)
The upload→Inbox→citable **foundation** is already on prod (#1806/#1899) and I code-confirmed the chain (CTA → deep-link → Inbox node → `retrieveForNode` `node_id` scope). I have **not** yet observed an end-to-end Inbox-chat citation myself — after merge + deploy I'll run the live pass (Knowledge upload → click CTA → confirm the Inbox node's Ask MIRA cites the manual) + screenshots, like #1904.

🤖 Generated with [Claude Code](https://claude.com/claude-code)