### PR TITLE
fix(hub): NodeChat citation [n] markers match rendered source chips (#1912)

### DIFF
--- a/mira-hub/src/lib/__tests__/manual-rag.test.ts
+++ b/mira-hub/src/lib/__tests__/manual-rag.test.ts
@@ -232,6 +232,65 @@ describe("chunksToSources", () => {
     expect(sources[0].title).toBe("AB PF525");
     expect(sources[1].page).toBe(8);
   });
+
+  it("numbers chips contiguously even after a dedupe (#1912)", () => {
+    const c: ManualChunk = {
+      content: "a", manufacturer: "AB", modelNumber: "PF525",
+      sourceUrl: "https://x/y.pdf", sourcePage: 1, title: "", rank: 1,
+    };
+    // 2nd chunk is a same-(url,page) duplicate; 3rd is a new page.
+    const sources = chunksToSources([c, { ...c, content: "b" }, { ...c, sourcePage: 2 }]);
+    expect(sources.map((s) => s.index)).toEqual([1, 2]); // not [1, 3]
+  });
+});
+
+// #1912 — the answer cited [2] but only chip [1] rendered. Root cause: the LLM
+// context blocks were numbered per-chunk while the chips were deduped by
+// (url, page). This locks the invariant: every block number the model can cite
+// has a matching chip with the same index.
+describe("citation numbering matches between context and chips (#1912)", () => {
+  it("collapses same-page excerpts to one [n] in BOTH the prompt and the chips", () => {
+    // Two excerpts of the same PDF page (the PowerFlex sample, p.1) — exactly the
+    // shape that produced the bug.
+    const base: ManualChunk = {
+      content: "F004 UnderVoltage: check incoming line voltage.",
+      manufacturer: "", modelNumber: "",
+      sourceUrl: "https://x/powerflex-fault-code-sample.pdf",
+      sourcePage: 1, title: "powerflex-fault-code-sample.pdf", rank: 1,
+    };
+    const chunks: ManualChunk[] = [
+      base,
+      { ...base, content: "F005 OverVoltage: increase decel time." },
+    ];
+
+    const ctx = buildGroundedContext(chunks);
+    const sources = chunksToSources(chunks);
+
+    // Both excerpts cite source [1]; there is NO [2] block for the model to cite.
+    expect(ctx).toContain("[1] powerflex-fault-code-sample.pdf, p.1");
+    expect(ctx).not.toContain("[2]");
+    expect(sources).toHaveLength(1);
+    expect(sources[0].index).toBe(1);
+
+    // Invariant: every [n] the prompt exposes has a matching chip index.
+    const blockNums = [...ctx.matchAll(/\[(\d+)\]/g)].map((m) => Number(m[1]));
+    const chipNums = new Set(sources.map((s) => s.index));
+    for (const n of blockNums) expect(chipNums.has(n)).toBe(true);
+  });
+
+  it("keeps distinct pages as distinct, matching [n]s", () => {
+    const p1: ManualChunk = {
+      content: "page one", manufacturer: "AB", modelNumber: "PF525",
+      sourceUrl: "https://x/m.pdf", sourcePage: 1, title: "m.pdf", rank: 1,
+    };
+    const chunks: ManualChunk[] = [p1, { ...p1, content: "page two", sourcePage: 2 }];
+    const ctx = buildGroundedContext(chunks);
+    const sources = chunksToSources(chunks);
+    expect(ctx).toContain("[1] AB PF525, p.1");
+    expect(ctx).toContain("[2] AB PF525, p.2");
+    expect(sources.map((s) => s.index)).toEqual([1, 2]);
+    expect(sources.map((s) => s.page)).toEqual([1, 2]);
+  });
 });
 
 const tokenCount = (s: string) => s.split(/\s+/).filter(Boolean).length;

--- a/mira-hub/src/lib/manual-rag.ts
+++ b/mira-hub/src/lib/manual-rag.ts
@@ -360,19 +360,48 @@ export async function retrieveNodeChunks(
 }
 
 /**
- * Build the grounded context block for the system prompt. Chunks are
- * numbered so the model can cite with `[n]` markers.
+ * Stable citation key for a chunk's source. Two chunks from the same document
+ * page share one key (and therefore one citation number + one UI chip).
+ */
+function sourceKey(c: Pick<ManualChunk, "sourceUrl" | "sourcePage">): string {
+  return `${c.sourceUrl}::${c.sourcePage ?? ""}`;
+}
+
+/**
+ * Assign every unique source (url, page) a stable 1-based citation number in
+ * first-appearance order. #1912: buildGroundedContext (the blocks the model
+ * cites) and chunksToSources (the chips the UI renders) MUST share this numbering
+ * — otherwise the model cites a per-chunk block number (e.g. two excerpts of the
+ * same page → blocks [1] and [2]) while the deduped chip list only shows [1], and
+ * the answer's `[2]` has no matching chip. Numbering by source key makes both
+ * spaces identical: every inline `[n]` has a rendered `[n]` chip.
+ */
+function citationIndex(chunks: ManualChunk[]): Map<string, number> {
+  const idx = new Map<string, number>();
+  for (const c of chunks) {
+    const key = sourceKey(c);
+    if (!idx.has(key)) idx.set(key, idx.size + 1);
+  }
+  return idx;
+}
+
+/**
+ * Build the grounded context block for the system prompt. Each chunk is labelled
+ * with its SOURCE citation number (#1912): excerpts from the same document page
+ * share one `[n]`, matching the single chip chunksToSources renders for them.
  */
 export function buildGroundedContext(chunks: ManualChunk[]): string {
   if (chunks.length === 0) return "";
-  const blocks = chunks.map((c, i) => {
+  const idx = citationIndex(chunks);
+  const blocks = chunks.map((c) => {
+    const n = idx.get(sourceKey(c))!;
     const headBits = [c.manufacturer, c.modelNumber].filter(Boolean);
     const head = headBits.join(" ") || c.title || "OEM document";
     const page = c.sourcePage != null ? `, p.${c.sourcePage}` : "";
     const content = c.content.length > MAX_CONTENT_CHARS
       ? `${c.content.slice(0, MAX_CONTENT_CHARS)}…`
       : c.content;
-    return `[${i + 1}] ${head}${page}\n${content}`;
+    return `[${n}] ${head}${page}\n${content}`;
   });
   return blocks.join("\n\n---\n\n");
 }
@@ -400,23 +429,28 @@ ${buildGroundedContext(chunks)}`;
 }
 
 /**
- * Public source descriptors for the UI. Dedupes by (url, page).
+ * Public source descriptors for the UI. Dedupes by (url, page) and numbers each
+ * chip with the SAME citation index the model is shown (#1912) — so an inline
+ * `[n]` in the answer always maps to a rendered `[n]` chip. Indices are
+ * contiguous 1..M over the unique sources (previously `i + 1` used the pre-dedupe
+ * position, which could emit a non-contiguous [3] for the 2nd unique chip).
  */
 export function chunksToSources(chunks: ManualChunk[]): ManualSource[] {
+  const idx = citationIndex(chunks);
   const seen = new Set<string>();
   const out: ManualSource[] = [];
-  chunks.forEach((c, i) => {
-    const key = `${c.sourceUrl}::${c.sourcePage ?? ""}`;
-    if (seen.has(key)) return;
+  for (const c of chunks) {
+    const key = sourceKey(c);
+    if (seen.has(key)) continue;
     seen.add(key);
     const titleBits = [c.manufacturer, c.modelNumber].filter(Boolean);
     const title = titleBits.join(" ") || c.title || c.sourceUrl || "OEM document";
     out.push({
-      index: i + 1,
+      index: idx.get(key)!,
       title,
       url: c.sourceUrl || null,
       page: c.sourcePage,
     });
-  });
+  }
   return out;
 }


### PR DESCRIPTION
Fixes the citation-numbering bug found in the new-maintenance-manager beta flow (upload PowerFlex manual → Ask MIRA about F004/F005). Found via Hermes outside-in QA.

Closes #1912

> **Scope note:** this PR originally also carried a namespace file-count/visibility fix (#1914). That bug was independently fixed by **#1915** (merged to main while this was in review), so this branch was rebased to **drop** the duplicate and now contains **only the citation fix** (`manual-rag.ts`). #1914 is closed as resolved by #1915.

## FIX — citation `[n]` markers now match the rendered source chips (#1912, P1)
`buildGroundedContext` numbered the LLM's context blocks `[1..N]` over **every chunk**, while `chunksToSources` deduped the UI chips by `(url, page)`. Two excerpts of the same manual page became blocks `[1]`/`[2]` (model cited `[2]`) but collapsed to a single chip `[1]` — the answer pointed at a source the user couldn't see (the exact observed symptom: answer cites `[2]`, only chip `[1]` renders).

Both functions now share one `citationIndex` keyed by `(url, page)`: same-page excerpts collapse to one `[n]` in **both** the prompt and the chips, and chip indices are contiguous (previously `chunksToSources` could emit a non-contiguous `[3]` for the 2nd unique chip). Every inline `[n]` now has a matching chip. Improves node, asset, and quickstart chat (all import these helpers).

The observed evidence (model citing `[2]` while exactly one chip `[1]` rendered) is only possible with ≥2 chunks sharing one `(url,page)` — precisely the case this collapses (the 1-page sample PDF chunks to ~2 same-page blocks).

## Tests
- `manual-rag` suite: 33 pass, incl. 3 new #1912 regression tests asserting block `[n]` ⊆ chip indices and same-page collapse.
- Changed files lint clean (`eslint` exit 0).

## Owed at deploy
- This is RAG-adjacent → staging gate (`smoke-test.yml` + eval) before prod, per `docs/environments.md`.

## Tooling note
CodeGraph index was missing in this checkout (fresh clone) — navigation used grep + Read for the TypeScript paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
