### PR TITLE
fix(hub): empty-namespace New Folder click no longer dropped pre-hydration (#1917)

### DIFF
--- a/mira-hub/src/app/(hub)/namespace/page.tsx
+++ b/mira-hub/src/app/(hub)/namespace/page.tsx
@@ -347,6 +347,14 @@ export default function NamespacePage() {
           icon={<FolderPlus className="h-3.5 w-3.5" />}
           label="New Folder"
           testId="toolbar-new-folder"
+          // #1917: keep New Folder disabled until the initial tree load resolves.
+          // `loading` starts true (so the SSR HTML renders the button disabled)
+          // and only flips false inside a post-hydration effect — so a click on a
+          // fresh empty namespace can't land before React wires up onClick and get
+          // silently dropped (the input never appeared). Native disabled blocks the
+          // early click; Playwright's .click() auto-waits for "enabled", so the
+          // first interaction always happens once the page is truly interactive.
+          disabled={loading}
           onClick={() => setNewFolder({ parentId: selected?.id ?? null, value: "" })}
         />
         <ToolbarButton

--- a/mira-hub/tests/e2e/namespace-inline-create.spec.ts
+++ b/mira-hub/tests/e2e/namespace-inline-create.spec.ts
@@ -562,6 +562,35 @@ test.describe("Namespace create + doc attach", () => {
     }
   });
 
+  test("Scenario 12 — #1917: New Folder is disabled until tree load resolves (hydration-race guard)", async ({ page }) => {
+    // Regression guard for #1917: on a fresh empty namespace the toolbar
+    // "New Folder" click was fired before React hydrated and silently dropped,
+    // so the inline input never appeared and a brand-new user couldn't create
+    // their first node. The fix gates the button on `loading` (true until the
+    // initial /api/namespace/tree fetch resolves in a post-hydration effect), so
+    // the button is non-interactive until the page is genuinely ready.
+    //
+    // Reproduce deterministically WITHOUT an empty tenant by delaying the tree
+    // fetch: while it's in flight `loading` is true and the button MUST be
+    // disabled; once it resolves the button enables and the input opens. This
+    // proves the mechanism on the existing seeded user — no race, no flake.
+    await page.route("**/api/namespace/tree", async (route) => {
+      await new Promise((r) => setTimeout(r, 1500));
+      await route.continue();
+    });
+    await page.goto(`${HUB}/namespace`, { waitUntil: "domcontentloaded", timeout: 60_000 });
+
+    const newFolder = page.getByTestId("toolbar-new-folder");
+    // During the (forced) loading window the button is disabled — an early click
+    // is natively blocked instead of dropped.
+    await expect(newFolder).toBeDisabled();
+    // Once the tree load resolves, it enables…
+    await expect(newFolder).toBeEnabled({ timeout: 10_000 });
+    // …and clicking now reliably opens the inline folder-name input.
+    await newFolder.click();
+    await expect(page.getByTestId("new-folder-input")).toBeVisible({ timeout: 10_000 });
+  });
+
   test("Scenario 9 — regression: existing tree features still work", async ({ page }) => {
     // Tree rows are drag-draggable.
     const firstRow = page.locator('[data-testid="namespace-node"]').first();


### PR DESCRIPTION
## What
On a fresh, **empty** namespace the toolbar **New Folder** button was rendered in the SSR HTML (it lives outside the `loading` gate) but its `onClick` wasn't wired until React hydrated. A click fired in that window was silently dropped, so the inline `Folder name…` input never appeared and a brand-new user could not create their first namespace node through the UI.

Fix (one line + comment): gate the button on `loading`. `loading` is `useState(true)`, so the SSR HTML renders the button **disabled**, and it only flips false inside the post-hydration tree-fetch effect. The native `disabled` attribute blocks the early click instead of dropping it; Playwright's `.click()` auto-waits for "enabled", so the existing QA retest passes unchanged once deployed.

## Why
Closes #1917 (P1, beta-readiness, hub). QA found a fresh signup could reach the Namespace page but clicking **New Folder** never showed the name input — blocking the core onboarding path (first namespace node). Root cause was already documented in this same spec's `startRootFolder` helper: *"a click fired before hydration is silently dropped … the inline input never appears."* The existing E2E sidestepped it by seeding the tenant and waiting for a node row (proof of hydration) — but an empty namespace has no node row to anchor on, so the gap shipped untested.

## How verified
- `npx eslint "src/app/(hub)/namespace/page.tsx"` → **4 problems on both `main` and this branch** (pre-existing `set-state-in-effect`/`static-components` in unrelated `ContentPanel`/`#1900` code) — **0 new**. New spec file: **0 problems**.
- `npx tsc --noEmit` → **no type errors in either changed file**.
- `npm test` (vitest) → **497 passed (53 files)**.
- **Scenario 12** (new) deterministically forces the loading window by delaying `/api/namespace/tree`, asserts the button is `toBeDisabled()` during load → `toBeEnabled()` after → click opens `new-folder-input`. Runs on the existing seeded user (no empty tenant, no race).

## Not yet verified (honest)
The Playwright E2E can't be validated pre-deploy: current prod lacks the fix, so `toBeDisabled()` would (correctly) fail there. **Live confirmation is the operator's prod re-test after deploy** (the original `retest-1915-1916.mjs` flow — its immediate click will now auto-wait for the enabled button).

## Risk / blast radius
Tiny. One JSX prop (`disabled={loading}`) on the New Folder toolbar button in `mira-hub/src/app/(hub)/namespace/page.tsx`, plus one additive E2E scenario. `loading` always flips false (the tree fetch swallows its own errors), so no stuck-disabled risk. No API, schema, or shared-module changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)