### PR TITLE
security(hub): neutralize CSV spreadsheet formula injection in exports (#1919)

### DIFF
--- a/mira-hub/src/app/api/export/route.ts
+++ b/mira-hub/src/app/api/export/route.ts
@@ -3,24 +3,13 @@ import { PassThrough } from "stream";
 import archiver from "archiver";
 import { sessionOr401 } from "@/lib/session";
 import { withTenantContext } from "@/lib/tenant-context";
+// Use the shared serialiser so this bulk export gets the same RFC 4180 quoting
+// AND spreadsheet formula-injection neutralisation as the per-table exports.
+// (Previously a local copy that quoted commas/quotes/newlines but neither
+// neutralised formulas nor handled CR — a CSV-injection hole.)
+import { toCsv } from "@/lib/csv-export";
 
 export const dynamic = "force-dynamic";
-
-function toCsv(rows: Record<string, unknown>[]): string {
-  if (rows.length === 0) return "";
-  const headers = Object.keys(rows[0]);
-  const escape = (v: unknown): string => {
-    const s = v == null ? "" : String(v);
-    return s.includes(",") || s.includes('"') || s.includes("\n")
-      ? `"${s.replace(/"/g, '""')}"`
-      : s;
-  };
-  const lines = [
-    headers.join(","),
-    ...rows.map((r) => headers.map((h) => escape(r[h])).join(",")),
-  ];
-  return lines.join("\n");
-}
 
 export async function GET() {
   if (!process.env.NEON_DATABASE_URL) {

--- a/mira-hub/src/lib/__tests__/csv-export.test.ts
+++ b/mira-hub/src/lib/__tests__/csv-export.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { csvEscape, neutralizeFormula, toCsv } from "../csv-export";
+
+describe("neutralizeFormula — CSV/spreadsheet formula injection", () => {
+  it("prefixes a single quote on every dangerous lead char", () => {
+    for (const lead of ["=", "+", "@", "\t", "\r"]) {
+      expect(neutralizeFormula(`${lead}SUM(A1)`)).toBe(`'${lead}SUM(A1)`);
+    }
+  });
+
+  it("neutralises the QA repro payloads", () => {
+    expect(neutralizeFormula('=HYPERLINK("http://evil.example","asset")')).toBe(
+      `'=HYPERLINK("http://evil.example","asset")`,
+    );
+    expect(neutralizeFormula("=2+5")).toBe("'=2+5");
+    expect(neutralizeFormula('=cmd|"/C calc"!A0')).toBe(`'=cmd|"/C calc"!A0`);
+  });
+
+  it("neutralises a '-'/'+' lead that is NOT a plain number (formula-looking)", () => {
+    expect(neutralizeFormula("-2+3")).toBe("'-2+3");
+    expect(neutralizeFormula("+SUM(1)")).toBe("'+SUM(1)");
+    expect(neutralizeFormula("-1+1+cmd")).toBe("'-1+1+cmd");
+  });
+
+  it("preserves legitimate signed numbers (a value, not a formula)", () => {
+    for (const n of ["-5", "+12", "-3.14", "-5e2", "+0", "-0.0"]) {
+      expect(neutralizeFormula(n)).toBe(n);
+    }
+  });
+
+  it("leaves ordinary text and empty strings untouched", () => {
+    for (const s of ["", "Pump 17", "PowerFlex 525", "medium", "Bay-3 East"]) {
+      expect(neutralizeFormula(s)).toBe(s);
+    }
+  });
+});
+
+describe("csvEscape — neutralise then RFC 4180 quote", () => {
+  it("neutralises a formula, then quotes it when it also has CSV specials", () => {
+    // Has commas/quotes → must be quoted AND the leading '=' neutralised.
+    expect(csvEscape('=HYPERLINK("http://evil.example","asset")')).toBe(
+      `"'=HYPERLINK(""http://evil.example"",""asset"")"`,
+    );
+  });
+
+  it("neutralises a bare formula with no CSV specials (no quoting needed)", () => {
+    expect(csvEscape("=2+5")).toBe("'=2+5");
+    expect(csvEscape("@foo")).toBe("'@foo");
+  });
+
+  it("still quotes ordinary values containing commas / quotes / newlines", () => {
+    expect(csvEscape("a,b")).toBe('"a,b"');
+    expect(csvEscape('he said "hi"')).toBe('"he said ""hi"""');
+    expect(csvEscape("line1\nline2")).toBe('"line1\nline2"');
+  });
+
+  it("a CR/TAB-led cell is neutralised AND quoted (CR forces quoting)", () => {
+    expect(csvEscape("\r=2+5")).toBe(`"'\r=2+5"`);
+    expect(csvEscape("\t=2+5")).toBe("'\t=2+5"); // TAB alone is not an RFC4180 special
+  });
+
+  it("preserves signed numbers and normal strings unquoted", () => {
+    expect(csvEscape("-5")).toBe("-5");
+    expect(csvEscape("+12")).toBe("+12");
+    expect(csvEscape("Pump 17")).toBe("Pump 17");
+  });
+
+  it("handles null and array cells", () => {
+    expect(csvEscape(null)).toBe("");
+    expect(csvEscape(undefined)).toBe("");
+    expect(csvEscape(["a", "b"])).toBe("a; b");
+    // An array whose joined value leads with a formula char is still neutralised.
+    expect(csvEscape(["=2+5", "b"])).toBe("'=2+5; b");
+  });
+});
+
+describe("toCsv — full row integration", () => {
+  it("emits a header row and neutralises hostile cells in the body", () => {
+    const out = toCsv([
+      { tag: "FORMULA_001", name: '=HYPERLINK("http://evil.example","asset")', model: "=2+5" },
+    ]);
+    const [header, body] = out.split("\n");
+    expect(header).toBe("tag,name,model");
+    // The injected formulas must NOT begin a cell with '=' anymore.
+    expect(body).toBe(`FORMULA_001,"'=HYPERLINK(""http://evil.example"",""asset"")",'=2+5`);
+    expect(body).not.toMatch(/,=/); // no cell starts a value with a bare '='
+  });
+
+  it("returns empty string for no rows", () => {
+    expect(toCsv([])).toBe("");
+  });
+});

--- a/mira-hub/src/lib/csv-export.ts
+++ b/mira-hub/src/lib/csv-export.ts
@@ -2,14 +2,38 @@
  * Lightweight CSV serialiser — no external dependencies.
  * Follows RFC 4180 quoting: fields containing commas, double-quotes,
  * or newlines are wrapped in double-quotes; embedded double-quotes are
- * doubled.
+ * doubled. Cells are first neutralised against spreadsheet formula
+ * injection (see `neutralizeFormula`).
  */
+
+// A cell whose first character is one of these is auto-evaluated as a formula
+// by Excel / Google Sheets / LibreOffice when the exported file is opened —
+// the CSV / formula-injection attack (DDE, HYPERLINK exfiltration, etc.).
+// TAB (\t) and CR (\r) are included because some spreadsheets strip a leading
+// whitespace control char and then see the formula char behind it.
+const FORMULA_LEAD = /^[=+\-@\t\r]/;
+
+/**
+ * Neutralise spreadsheet formula injection by prefixing a dangerous cell with a
+ * single quote, so the spreadsheet renders it as literal text instead of
+ * evaluating it. Legitimate signed numbers (e.g. "-5", "+12", "-3.14") are left
+ * intact — a finite number is a value, never a formula payload.
+ * OWASP: https://owasp.org/www-community/attacks/CSV_Injection
+ */
+export function neutralizeFormula(s: string): string {
+  if (s === "" || !FORMULA_LEAD.test(s)) return s;
+  // Preserve genuine signed numbers — only "-"/"+" leads can be a real number,
+  // and only when the whole cell parses as one. "=", "@", TAB, CR never can.
+  if ((s[0] === "-" || s[0] === "+") && Number.isFinite(Number(s))) return s;
+  return `'${s}`;
+}
 
 /**
  * Escape a single cell value for CSV output.
  */
 export function csvEscape(value: unknown): string {
-  const s = value == null ? "" : Array.isArray(value) ? value.join("; ") : String(value);
+  const raw = value == null ? "" : Array.isArray(value) ? value.join("; ") : String(value);
+  const s = neutralizeFormula(raw);
   if (s.includes(",") || s.includes('"') || s.includes("\n") || s.includes("\r")) {
     return `"${s.replace(/"/g, '""')}"`;
   }


### PR DESCRIPTION
## What
Closes #1919 (P1, security/hub/beta-readiness). Adversarial QA found that a user can create an asset whose `name`/`model`/`serial`/`location` *looks like a formula* (`=HYPERLINK(...)`, `=2+5`, `=cmd|…`), export the CSV, and have it **evaluated** when a maintenance manager opens it in Excel / Sheets / LibreOffice — malicious links, `WEBSERVICE` exfil, DDE.

Fix: the shared `csvEscape` now **neutralises formula-injection** — any cell beginning with `= + - @ TAB CR` is prefixed with a single quote (rendered as literal text) *before* RFC 4180 quoting. Legitimate signed numbers (`-5`, `+12`, `-3.14`) are preserved.

## Scope — every CSV-from-DB path now routes through the fixed helper
Verified with `grep -rn 'text/csv' src` + a sweep for hand-built CSV:
- `/api/assets/export.csv`, `/api/pm/export.csv`, `/api/work-orders/export.csv` — already used the shared `toCsv`/`csvEscape` → fixed centrally.
- `/api/export` (bulk ZIP: work_orders/equipment/pm_schedules/knowledge/team) had a **duplicated local serialiser** with the same hole (and also missed `\r`) — **replaced with the shared helper** so it inherits the fix and the duplication is gone.
- Remaining `text/csv` hits are a MIME *allowlist* and a raw file-download passthrough (not generated CSVs); `pm/export.ics` is calendar format. None build CSV from DB fields.
- Headers stay safe: `toCsv` headers come from fixed SQL column aliases, not attacker data.

## Why the number carve-out has no bypass
A leak would need a cell that (a) leads `-`/`+`, (b) `Number()` is finite, and (c) Excel evaluates as a formula. (c) requires a function/reference (`HYPERLINK`, `WEBSERVICE`, `cmd|…`, `A1`) — all make `Number()` return `NaN`, so they hit the `'` prefix. Only pure constants survive (b), which spreadsheets render as arithmetic values. `=`/`@`/TAB/CR never get the carve-out.

## Tests run (pasted)
```
$ npx vitest run src/lib/__tests__/csv-export.test.ts
 ✓ src/lib/__tests__/csv-export.test.ts (13 tests)
 Test Files  1 passed (1)   Tests  13 passed (13)

$ npm test            # full hub suite
 Tests  510 passed (510)

$ npx eslint src/lib/csv-export.ts src/lib/__tests__/csv-export.test.ts src/app/api/export/route.ts
 (exit 0, no findings)

$ npx tsc --noEmit    # filtered to changed files
 no type errors in changed files
```
13 new cases cover the QA repro payloads, every dangerous lead char, signed-number preservation, neutralize-then-quote ordering, CR/TAB handling, null/array cells, and full `toCsv` row integration. Unlike a deploy-gated UI fix, `csvEscape` is a pure serialiser exercised directly by these tests — **no pre-deploy verification gap**.

## Risk / blast radius
Shared helper used by 4 export routes; behaviour change is additive (only cells that would have been spreadsheet-dangerous gain a leading `'`). `/api/export` loses 15 lines of duplicated code. No schema/API-shape changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)