### PR TITLE
fix(hub): clamp long asset names so the Assets cards stay balanced (#1922)

### DIFF
--- a/mira-hub/src/app/(hub)/assets/page.tsx
+++ b/mira-hub/src/app/(hub)/assets/page.tsx
@@ -344,6 +344,8 @@ function AssetTile({ asset }: { asset: Asset }) {
   const StatusIcon = statusCfg.Icon;
   const Icon = TYPE_ICONS[asset.type ?? ""] ?? Cog;
   const newBadge = isNew(asset);
+  const displayName =
+    asset.name || `${asset.manufacturer ?? ""} ${asset.model ?? ""}`.trim() || "Unnamed Asset";
 
   return (
     <Link href={`/assets/${asset.id}`} className="block">
@@ -365,21 +367,29 @@ function AssetTile({ asset }: { asset: Asset }) {
           <StatusIcon className="w-4 h-4 mt-0.5" style={{ color: statusCfg.color }} />
         </div>
 
-        <div className="flex-1">
-          <p className="text-sm font-medium leading-snug" style={{ color: "var(--foreground)" }}>
-            {asset.name || `${asset.manufacturer ?? ""} ${asset.model ?? ""}`.trim() || "Unnamed Asset"}
+        <div className="flex-1 min-w-0">
+          <p
+            className="text-sm font-medium leading-snug line-clamp-2 break-words"
+            style={{ color: "var(--foreground)" }}
+            title={displayName}
+          >
+            {displayName}
           </p>
-          <p className="text-[11px] font-mono mt-0.5" style={{ color: "var(--foreground-subtle)" }}>
+          <p className="text-[11px] font-mono mt-0.5 truncate" style={{ color: "var(--foreground-subtle)" }}>
             {asset.tag}
           </p>
         </div>
 
-        <div className="flex items-center justify-between">
-          <span className="text-[11px]" style={{ color: "var(--foreground-muted)" }}>
+        <div className="flex items-center justify-between gap-2">
+          <span
+            className="text-[11px] truncate min-w-0"
+            style={{ color: "var(--foreground-muted)" }}
+            title={asset.location ?? undefined}
+          >
             {asset.location ?? "—"}
           </span>
           <span
-            className="text-[10px] font-medium px-2 py-0.5 rounded-full"
+            className="text-[10px] font-medium px-2 py-0.5 rounded-full shrink-0"
             style={{ backgroundColor: statusCfg.bg, color: statusCfg.color }}
           >
             {status}


### PR DESCRIPTION
## What
Closes #1922 (P3, hub). On the Assets tab a very long asset name rendered unclamped in the card, inflating the whole grid row's height (cards share `h-full`) and reading as messy. Clamp the name to **2 lines** (`line-clamp-2 break-words`) with a `title` tooltip for the full value, and `truncate` the tag + location to one line (`min-w-0` on the flex containers, `shrink-0` on the status badge so it isn't squeezed).

## Why
Adversarial Assets-tab QA: long / pasted / hostile-looking names (escaped safely) made the cards ugly and unbalanced. Polish, not a security issue.

## Context — the other QA follow-up (QR labels / Scan) needed no change
Investigated alongside this: the **Print QR Labels** button calls `window.print()` (the OS dialog is correctly invisible to automation — the on-screen label sheet renders and already `line-clamp-2`s names), and `/scan` handles `denied`/`unsupported`/`error` with manual-tag fallback and `encodeURIComponent` routing. No bug in either — so no code change there.

## Verified
- eslint: 4 problems on **both** `main` and this branch (1 pre-existing error + 3 pre-existing warnings — `Factory`/`FormEvent`/`loadError`, untouched by this diff) → **0 new**.
- `tsc --noEmit`: no type errors in the changed file.
- `line-clamp-2` is already proven in this app (`src/app/(hub)/assets/print-qr/page.tsx`).

## Not yet verified (honest)
CSS-only change to an authenticated hub surface — a faithful screenshot needs the running stack + a long-named asset. Visual confirmation is owed post-deploy; the QA's existing long-named assets on the retest tenant will demonstrate the clamp on `app.factorylm.com` after merge.

## Risk / blast radius
One component (`AssetTile`) in `assets/page.tsx`; presentational classes only — no data, API, or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)