### PR TITLE
fix(scan): honest UX when GS10 docs missing; no more config error (#1928)

### DIFF
--- a/mira-scan-monday/backend/mira_rag.py
+++ b/mira-scan-monday/backend/mira_rag.py
@@ -188,7 +188,8 @@ async def chat(
 
     if not MIRA_KB_BASE_URL:
         return (
-            "MIRA knowledge base is not configured. Set MIRA_KB_BASE_URL to enable grounded chat.",
+            "Grounded chat is not available for this equipment right now. "
+            "Contact your MIRA administrator to enable it.",
             [],
         )
 

--- a/mira-scan-monday/backend/tests/test_vendor_rag.py
+++ b/mira-scan-monday/backend/tests/test_vendor_rag.py
@@ -92,6 +92,37 @@ async def test_vendor_chat_returns_none_when_no_patterns():
 
 
 @pytest.mark.asyncio
+async def test_vendor_chat_no_chunks_returns_no_docs_message(monkeypatch):
+    """Known asset in the allowlist but no KB chunks — should return a
+    deterministic 'no documentation' message, NOT None (which would fall
+    through to the raw MIRA_KB_BASE_URL config error).
+    """
+
+    async def empty_chunks(_patterns, _query, **_kwargs):  # noqa: ARG001
+        return []
+
+    monkeypatch.setattr(vendor_rag, "retrieve_vendor_chunks", empty_chunks)
+    monkeypatch.setattr(
+        vendor_rag,
+        "_providers",
+        lambda: [{"name": "stub", "url": "x", "key": "x", "model": "x"}],
+    )
+
+    result = await vendor_rag.vendor_chat(
+        message="What does fault code F12 mean?",
+        asset_id="automationdirect-gs10",
+        asset_label="AutomationDirect GS10",
+        history=[],
+    )
+    # Must NOT return None — returning None exposes the config-error string to users.
+    assert result is not None
+    reply, sources = result
+    assert "AutomationDirect GS10" in reply
+    assert "knowledge base" in reply.lower()
+    assert sources == []
+
+
+@pytest.mark.asyncio
 async def test_vendor_chat_filters_by_manufacturer(monkeypatch):
     """The retrieval SQL must restrict by manufacturer ILIKE — never
     return chunks from unrelated vendors. We assert by inspecting the

--- a/mira-scan-monday/backend/vendor_rag.py
+++ b/mira-scan-monday/backend/vendor_rag.py
@@ -13,6 +13,10 @@ Falls back to mira_rag.chat()'s existing mira-pipeline path when:
 - the asset isn't in the curated allowlist (no manufacturer patterns),
 - NeonDB is unavailable,
 - or all LLM providers fail.
+
+Returns a deterministic "no documentation indexed" message (instead of falling
+back) when the asset IS in the allowlist but has no KB chunks — this prevents
+the cross-vendor contamination that the mira-pipeline path would cause.
 """
 
 from __future__ import annotations
@@ -254,11 +258,17 @@ async def vendor_chat(
     chunks = await retrieve_vendor_chunks(patterns, message)
     if not chunks:
         logger.info(
-            "vendor RAG: no chunks for asset=%s patterns=%r — falling back",
+            "vendor RAG: no chunks for asset=%s patterns=%r — no documentation indexed",
             asset_id,
             patterns,
         )
-        return None
+        label = asset_label or (asset_id or "").replace("-", " ").strip() or "this equipment"
+        return (
+            f"I don't have documentation for **{label}** in the knowledge base yet. "
+            "Once the OEM manual is indexed, I'll be able to answer grounded questions "
+            "about fault codes, parameters, and procedures.",
+            [],
+        )
 
     if not _providers():
         logger.warning(

--- a/mira-scan-monday/backend/vendor_rag.py
+++ b/mira-scan-monday/backend/vendor_rag.py
@@ -265,8 +265,8 @@ async def vendor_chat(
         label = asset_label or (asset_id or "").replace("-", " ").strip() or "this equipment"
         return (
             f"I don't have documentation for **{label}** in the knowledge base yet. "
-            "Once the OEM manual is indexed, I'll be able to answer grounded questions "
-            "about fault codes, parameters, and procedures.",
+            "Your MIRA administrator can add the OEM manual to unlock grounded fault "
+            "code and parameter answers.",
             [],
         )
 

--- a/mira-scan-monday/frontend/src/App.jsx
+++ b/mira-scan-monday/frontend/src/App.jsx
@@ -40,11 +40,9 @@ export default function App() {
     <div className="app-shell">
       <header className="row" style={{ justifyContent: "space-between" }}>
         <h1 style={{ margin: 0, fontSize: 20 }}>MIRA Scan</h1>
-        <span className="muted">
-          {mondayCtx?.itemId
-            ? `Item ${mondayCtx.itemId}`
-            : "monday context loading…"}
-        </span>
+        {mondayCtx?.itemId && (
+          <span className="muted">Item {mondayCtx.itemId}</span>
+        )}
       </header>
 
       <ScanPanel sessionToken={sessionToken} onResult={setPlate} />

--- a/mira-scan-monday/frontend/src/components/MiraChat.jsx
+++ b/mira-scan-monday/frontend/src/components/MiraChat.jsx
@@ -39,7 +39,7 @@ export default function MiraChat({ assetId, assetLabel, sessionToken }) {
     <div className="card">
       <h3 style={{ margin: 0, fontSize: 16 }}>Ask MIRA</h3>
       <p className="muted" style={{ marginTop: 4 }}>
-        Grounded in the OEM manual for this asset.
+        Ask questions about fault codes, procedures, and parameters for this asset.
       </p>
       <div className="chat-log" role="log">
         {history.length === 0 && (


### PR DESCRIPTION
## Summary

- **Bug #1928** (P1): Asking "What does fault code F12 mean?" after scanning an AutomationDirect GS1-45P0 nameplate returned the raw dev string `"MIRA knowledge base is not configured. Set MIRA_KB_BASE_URL to enable grounded chat."` — now returns a user-facing message explaining the manual isn't indexed yet.
- **Bug #2**: Scan page always showed `"monday context loading…"` even when running outside monday.com — fixed by only rendering the item badge when `mondayCtx.itemId` is present.

## Root causes fixed

1. **`vendor_rag.vendor_chat()`** — when a known-allowlist asset (e.g. `automationdirect-gs10`) has no KB chunks, it returned `None`. `mira_rag.chat()` then hit the empty `MIRA_KB_BASE_URL` check and returned the raw config string. Fix: return a deterministic "no documentation indexed" message from `vendor_chat()` instead of `None`, preventing cross-vendor contamination AND the config error.
2. **`mira_rag.chat()` fallback path** — three other `vendor_chat() → None` branches (unknown asset, no LLM providers, empty cascade) still hit the same raw string. Fix: replaced with a user-facing "contact your MIRA administrator" message.
3. **`App.jsx` loading indicator** — `mondayCtx` transitions `null → {}` outside monday.com; the ternary only tested `itemId`, treating both states as "loading". Fix: conditional render — item badge only appears when `itemId` is present.
4. **`MiraChat.jsx` subtitle** — "Grounded in the OEM manual for this asset." was inaccurate when no manual was indexed. Fix: neutral wording that stays honest in both states.

## Test plan

- [ ] `python3.12 -m pytest backend/tests/test_vendor_rag.py -v` — all 7 pass, including new `test_vendor_chat_no_chunks_returns_no_docs_message`
- [ ] After deploying mira-scan-monday to VPS: scan GS1-45P0 nameplate → ask "What does fault code F12 mean?" → should see "I don't have documentation for **AutomationDirect GS10**…" not the config error
- [ ] Access scan app standalone (outside monday.com) — no "monday context loading…" in header

## Pending (requires human action)

- Set `MIRA_KB_BASE_URL=http://mira-pipeline:9099` in Doppler `factorylm/prd` — enables the generic fallback path for assets not in the curated allowlist
- Ingest the GS10 manual into `knowledge_entries` — once done, vendor_rag will return grounded F12 answers with citations
- Rebuild and redeploy `mira-scan-monday` on VPS (separate compose, not in `deploy-vps.yml`): `doppler run --project factorylm --config prd -- docker compose build && docker compose up -d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)