### PR TITLE
fix(upload): accept large PDFs end-to-end (raise size cap 20->50 MB)

### DIFF
--- a/mira-core/mira-ingest/main.py
+++ b/mira-core/mira-ingest/main.py
@@ -925,12 +925,18 @@ async def ingest_document_kb(
             detail=f"Only PDF files are supported (got mime={mime or 'unknown'}, ext={ext or 'none'})",
         )
 
-    # Validate size (20MB Telegram limit, enforced universally)
+    # Validate size. The old 20 MB cap was a Telegram-era artifact; real OEM
+    # manuals (31.5 MB GS10, 33 MB Rockwell ref) exceed it. Bounded — NOT
+    # unbounded — because this handler buffers the whole file (`await file.read()`
+    # above) before forwarding to docling, the documented 8 GB-VPS OOM path
+    # (ADR-0019). MUST match the Hub's NEXT_PUBLIC_MAX_UPLOAD_MB to avoid the
+    # Hub accepting a file ingest then rejects. True any-size needs ingest-v2.
     MB = 1024 * 1024
-    if len(raw) > 20 * MB:
+    max_upload_mb = int(os.getenv("MIRA_MAX_UPLOAD_MB", "50"))
+    if len(raw) > max_upload_mb * MB:
         raise HTTPException(
             status_code=413,
-            detail=f"File exceeds 20MB limit ({len(raw) // MB}MB)",
+            detail=f"File exceeds {max_upload_mb}MB limit ({len(raw) // MB}MB)",
         )
 
     form_tenant = (tenant_id or "").strip()

--- a/mira-core/mira-ingest/tests/test_ingest.py
+++ b/mira-core/mira-ingest/tests/test_ingest.py
@@ -175,3 +175,41 @@ def test_health_endpoint_returns_200(client):
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# document-kb upload size cap (MIRA_MAX_UPLOAD_MB, default 50)
+# Locks the 2026-06-13 fix: the Telegram-era 20 MB cap is raised to 50 MB and
+# made env-configurable, and MUST stay in sync with the Hub's
+# NEXT_PUBLIC_MAX_UPLOAD_MB. The size gate rejects before any Open WebUI
+# forward, so these need no OW mock.
+# ---------------------------------------------------------------------------
+
+
+def _post_pdf(client, size_bytes: int):
+    data = b"%PDF-1.4\n" + b"0" * max(0, size_bytes - 9)
+    return client.post(
+        "/ingest/document-kb",
+        files={"file": ("big.pdf", io.BytesIO(data), "application/pdf")},
+    )
+
+
+def test_document_kb_accepts_31mb_pdf_size_gate(client):
+    # The 31.5 MB GS10 manual that the old 20 MB cap rejected now clears the
+    # size gate (it then proceeds to the OW forward, which we don't exercise
+    # here — a 200/500 both mean the size gate passed; only 413 means rejected).
+    resp = _post_pdf(client, 31 * 1024 * 1024 + 512 * 1024)
+    assert resp.status_code != 413, resp.text
+
+
+def test_document_kb_rejects_over_default_50mb_cap(client):
+    resp = _post_pdf(client, 51 * 1024 * 1024)
+    assert resp.status_code == 413
+    assert "50MB limit" in resp.json()["detail"]
+
+
+def test_document_kb_cap_is_env_configurable(client, monkeypatch):
+    monkeypatch.setenv("MIRA_MAX_UPLOAD_MB", "1")
+    resp = _post_pdf(client, 2 * 1024 * 1024)
+    assert resp.status_code == 413
+    assert "1MB limit" in resp.json()["detail"]

--- a/mira-hub/src/app/(hub)/documents/page.tsx
+++ b/mira-hub/src/app/(hub)/documents/page.tsx
@@ -12,7 +12,7 @@ import { UploadPicker } from "@/components/UploadPicker";
 import { UploadBlock, type UploadBlockData } from "@/components/UploadBlock";
 import { useToast } from "@/providers/toast-provider";
 import { LabsStub } from "@/components/labs-stub";
-import { API_BASE } from "@/lib/config";
+import { API_BASE, MAX_UPLOAD_MB } from "@/lib/config";
 
 const NON_TERMINAL: ReadonlyArray<UploadBlockData["status"]> = [
   "queued",
@@ -121,8 +121,8 @@ export default function DocumentsPage() {
           const msg =
             body.error === "unsupported_mime"
               ? `Unsupported file type: ${(body.got as string | undefined) || file.type || "unknown"}`
-              : body.error === "exceeds_20mb_limit"
-                ? `File too large (max 20 MB): ${file.name}`
+              : body.error === "exceeds_size_limit"
+                ? `File too large (max ${MAX_UPLOAD_MB} MB): ${file.name}`
                 : typeof body.error === "string"
                   ? body.error
                   : `Upload failed (${res.status})`;

--- a/mira-hub/src/app/(hub)/knowledge/manuals/page.tsx
+++ b/mira-hub/src/app/(hub)/knowledge/manuals/page.tsx
@@ -14,7 +14,7 @@ import {
 import { useTranslations } from "next-intl";
 import { UploadPicker } from "@/components/UploadPicker";
 import { UploadBlock, type UploadBlockData } from "@/components/UploadBlock";
-import { API_BASE } from "@/lib/config";
+import { API_BASE, MAX_UPLOAD_MB } from "@/lib/config";
 import { KbGrowthDashboard } from "../KbGrowthDashboard";
 import { UploadSummaryCard } from "@/components/UploadSummaryCard";
 
@@ -319,8 +319,8 @@ export default function KnowledgePage() {
         const msg =
           body.error === "unsupported_mime"
             ? `Unsupported file type: ${(body.got as string | undefined) || file.type || "unknown"}`
-            : body.error === "exceeds_20mb_limit"
-              ? `File too large (max 20 MB): ${file.name}`
+            : body.error === "exceeds_size_limit"
+              ? `File too large (max ${MAX_UPLOAD_MB} MB): ${file.name}`
               : typeof body.error === "string"
                 ? body.error
                 : `Upload failed (${res.status})`;
@@ -896,7 +896,7 @@ export default function KnowledgePage() {
               className="text-xs"
               style={{ color: "var(--foreground-muted)" }}
             >
-              Tap to upload a PDF manual or photo — PDF, JPEG, PNG up to 20 MB.
+              Tap to upload a PDF manual or photo — PDF, JPEG, PNG up to {MAX_UPLOAD_MB} MB.
             </p>
           </button>
         )}

--- a/mira-hub/src/app/api/namespace/node/[id]/files/route.ts
+++ b/mira-hub/src/app/api/namespace/node/[id]/files/route.ts
@@ -3,6 +3,7 @@ import { sessionOr401 } from "@/lib/session";
 import { withTenantContext } from "@/lib/tenant-context";
 import { ingestPdfToNode } from "@/lib/node-knowledge-ingest";
 import pool from "@/lib/db";
+import { MAX_UPLOAD_BYTES, MAX_UPLOAD_MB } from "@/lib/config";
 
 export const dynamic = "force-dynamic";
 
@@ -15,7 +16,7 @@ const MIME_ALLOWLIST = [
   "application/vnd.openxmlformats-officedocument.",
 ];
 
-const MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+const MAX_BYTES = MAX_UPLOAD_BYTES;
 
 function isMimeAllowed(mime: string): boolean {
   return MIME_ALLOWLIST.some((prefix) => mime.startsWith(prefix));
@@ -144,7 +145,7 @@ export async function POST(
     return NextResponse.json({ error: "file field is required" }, { status: 422 });
   }
   if (file.size > MAX_BYTES) {
-    return NextResponse.json({ error: "file exceeds 10 MB limit" }, { status: 413 });
+    return NextResponse.json({ error: `file exceeds ${MAX_UPLOAD_MB} MB limit` }, { status: 413 });
   }
 
   const mimeRaw = file.type || "application/octet-stream";

--- a/mira-hub/src/app/api/uploads/route.ts
+++ b/mira-hub/src/app/api/uploads/route.ts
@@ -15,6 +15,7 @@ import { sessionOr401 } from "@/lib/session";
 import { makeUploadLogger } from "@/lib/upload-log";
 import { validateAssetTag } from "@/lib/asset-tag";
 import { runIngestPipeline } from "@/lib/upload-pipeline";
+import { MAX_UPLOAD_BYTES } from "@/lib/config";
 
 export const dynamic = "force-dynamic";
 
@@ -60,10 +61,9 @@ export async function POST(req: NextRequest) {
       { status: 400 },
     );
   }
-  const MAX = 20 * 1024 * 1024;
-  if (body.sizeBytes != null && body.sizeBytes > MAX) {
+  if (body.sizeBytes != null && body.sizeBytes > MAX_UPLOAD_BYTES) {
     return NextResponse.json(
-      { error: "exceeds_20mb_limit", got: body.sizeBytes },
+      { error: "exceeds_size_limit", got: body.sizeBytes, limitBytes: MAX_UPLOAD_BYTES },
       { status: 400 },
     );
   }

--- a/mira-hub/src/components/UploadPicker.tsx
+++ b/mira-hub/src/components/UploadPicker.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import Script from "next/script";
 import { X, Upload as UploadIcon, Search, Loader2, FolderOpen, Package, AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { API_BASE } from "@/lib/config";
+import { API_BASE, MAX_UPLOAD_MB } from "@/lib/config";
 
 export type PickResult = {
   provider: "google" | "dropbox";
@@ -429,7 +429,7 @@ export function UploadPicker({
               {uploading ? "Uploading…" : "Drop PDFs or photos here — or click to browse"}
             </span>
             <span className="text-xs" style={{ color: "var(--foreground-subtle)" }}>
-              PDF, JPEG, PNG, WebP, HEIC · Up to 20 MB each
+              PDF, JPEG, PNG, WebP, HEIC · Up to {MAX_UPLOAD_MB} MB each
             </span>
             <input
               ref={fileInputRef}

--- a/mira-hub/src/components/namespace/CreateChildCard.tsx
+++ b/mira-hub/src/components/namespace/CreateChildCard.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import Script from "next/script";
 import { Loader2, Paperclip, X, FolderOpen, Package, Smartphone } from "lucide-react";
-import { API_BASE } from "@/lib/config";
+import { API_BASE, MAX_UPLOAD_BYTES, MAX_UPLOAD_MB } from "@/lib/config";
 
 /**
  * Inline create form for a child namespace node.
@@ -127,7 +127,7 @@ const ACCEPTED_MIME = [
 ].join(",");
 
 const DROPBOX_EXTENSIONS = [".pdf", ".jpg", ".jpeg", ".png", ".webp", ".heic", ".heif"];
-const MAX_BYTES = 20 * 1024 * 1024;
+const MAX_BYTES = MAX_UPLOAD_BYTES;
 
 function mimeFromExt(name: string): string {
   const n = name.toLowerCase();
@@ -245,10 +245,10 @@ export function CreateChildCard({
       next.name = `A subsystem named "${name.trim()}" already exists here.`;
     }
     if (picked?.kind === "local" && picked.file.size > MAX_BYTES) {
-      next.file = "File is too big. Limit is 20 MB.";
+      next.file = `File is too big. Limit is ${MAX_UPLOAD_MB} MB.`;
     }
     if (picked?.kind === "cloud" && picked.sizeBytes > MAX_BYTES) {
-      next.file = "File is too big. Limit is 20 MB.";
+      next.file = `File is too big. Limit is ${MAX_UPLOAD_MB} MB.`;
     }
     setErrors(next);
     return Object.keys(next).length === 0;

--- a/mira-hub/src/lib/config.ts
+++ b/mira-hub/src/lib/config.ts
@@ -7,3 +7,20 @@ export const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "/hub";
 // Set OAUTH_BASE_PATH=/hub until all provider consoles are updated to root path.
 // The existing nginx /hub/ → / rewrite handles delivery of the callback back to hub.
 export const OAUTH_BASE = process.env.OAUTH_BASE_PATH ?? "";
+
+// Maximum upload size, in MB. Single source of truth for every upload route
+// (local, folder, cloud-pick, node-file) and the client-side pre-checks/copy.
+// NEXT_PUBLIC_ so it inlines for the browser and is also readable server-side.
+//
+// Default 50 clears real OEM manuals (the 31.5 MB GS10 PDF, the 33 MB Rockwell
+// ref manual from ADR-0019) with headroom. It is bounded BELOW nginx's 100M
+// transport ceiling on purpose: mira-ingest buffers the whole file in memory
+// (`await file.read()`) before docling, the documented 8 GB-VPS OOM path
+// (project_vps_oom_docling_incidents / ADR-0019). True any-size needs the
+// streaming ingest-v2 rebuild; until then 50 MB is the deliberate ceiling.
+//
+// MUST stay in sync with mira-ingest's MIRA_MAX_UPLOAD_MB — the ingest service
+// has its own cap, and a Hub cap above it would accept a file the Hub then
+// fails downstream. The old 20/10 MB caps were a Telegram-era artifact.
+export const MAX_UPLOAD_MB = Number(process.env.NEXT_PUBLIC_MAX_UPLOAD_MB ?? "50");
+export const MAX_UPLOAD_BYTES = MAX_UPLOAD_MB * 1024 * 1024;

--- a/mira-hub/src/lib/local-upload.ts
+++ b/mira-hub/src/lib/local-upload.ts
@@ -22,13 +22,12 @@ import {
 } from "@/lib/upload-buffer";
 import { resolveOrCreateInboxNode } from "@/lib/inbox-node";
 import { writePdfChunksForNode } from "@/lib/node-knowledge-ingest";
+import { MAX_UPLOAD_BYTES, MAX_UPLOAD_MB } from "@/lib/config";
 
 export interface UploadAuthContext {
   tenantId: string;
   userId?: string;
 }
-
-const MAX = 20 * 1024 * 1024;
 
 function extGuess(nameLower: string): string {
   if (nameLower.endsWith(".pdf")) return "application/pdf";
@@ -44,15 +43,32 @@ export async function handleLocalUpload(
   req: NextRequest,
   ctx: UploadAuthContext,
 ): Promise<NextResponse> {
-  const form = await req.formData().catch(() => null);
-  if (!form) return NextResponse.json({ error: "invalid_multipart" }, { status: 400 });
+  // Do NOT swallow the parse error. formData() throws `Failed to parse body as
+  // FormData` when the multipart body is truncated or malformed (e.g. an aborted
+  // or proxy-timed-out large upload) — which previously surfaced as a bare
+  // `invalid_multipart` with no clue why. Log the real reason + content-length so
+  // the next occurrence is diagnosable instead of guessed at.
+  let form: FormData;
+  try {
+    form = await req.formData();
+  } catch (err) {
+    console.error("[local-upload] formData parse failed", {
+      contentLength: req.headers.get("content-length"),
+      maxUploadMb: MAX_UPLOAD_MB,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json({ error: "invalid_multipart" }, { status: 400 });
+  }
 
   const file = form.get("file");
   if (!(file instanceof File)) {
     return NextResponse.json({ error: "file_field_required" }, { status: 400 });
   }
-  if (file.size > MAX) {
-    return NextResponse.json({ error: "exceeds_20mb_limit", got: file.size }, { status: 400 });
+  if (file.size > MAX_UPLOAD_BYTES) {
+    return NextResponse.json(
+      { error: "exceeds_size_limit", got: file.size, limitBytes: MAX_UPLOAD_BYTES },
+      { status: 400 },
+    );
   }
 
   const nameLower = file.name.toLowerCase();

--- a/mira-hub/src/lib/mira-ingest-client.ts
+++ b/mira-hub/src/lib/mira-ingest-client.ts
@@ -1,6 +1,7 @@
 // mira-hub/src/lib/mira-ingest-client.ts
 import { sniffMime, isMimeCompatible } from "./sniff-mime";
 import { composeTimeout, isAbortError } from "./abort-helpers";
+import { MAX_UPLOAD_BYTES, MAX_UPLOAD_MB } from "./config";
 
 const INGEST_TIMEOUT_MS = 120_000; // mira-ingest can poll OpenWebUI for ~40s+ on large PDFs
 
@@ -30,7 +31,7 @@ export interface PhotoIngestResult {
   photoPath: string | null;
 }
 
-const MAX_BYTES = 20 * 1024 * 1024;
+const MAX_BYTES = MAX_UPLOAD_BYTES;
 
 /**
  * Resolve the mira-ingest base URL, or throw a clear, user-facing error.
@@ -65,7 +66,9 @@ async function streamToBlob(
     if (done) break;
     total += value.byteLength;
     if (total > MAX_BYTES) {
-      throw new Error(`file exceeds 20 MB limit (${(total / 1024 / 1024).toFixed(1)} MB)`);
+      throw new Error(
+        `file exceeds ${MAX_UPLOAD_MB} MB limit (${(total / 1024 / 1024).toFixed(1)} MB)`,
+      );
     }
     chunks.push(value);
   }


### PR DESCRIPTION
## Problem

Large PDFs (e.g. the 31.5 MB GS10 manual, the 33 MB Rockwell ref manual from ADR-0019) cannot be uploaded to the Hub. A Telegram-era 20 MB cap (Telegram limits PDFs to 20 MB) was copied onto **both** the Hub and the `mira-ingest` service, plus a 10 MB cap on the namespace node-files route.

## Root cause

The cap, duplicated across layers:

| Layer | File | Old cap |
|---|---|---|
| Hub local/folder upload | `local-upload.ts` | 20 MB |
| Hub `streamToBlob` (forward) | `mira-ingest-client.ts` | 20 MB |
| Hub cloud-pick | `api/uploads/route.ts` | 20 MB |
| Hub node-file attach | `namespace/node/[id]/files/route.ts` | 10 MB |
| Ingest service | `mira-ingest/main.py` `/ingest/document-kb` | 20 MB |

Critically, the **Hub and ingest caps had to move together**: the Hub accepting a file that ingest then rejects (its own 20 MB cap) would mark the upload `failed` downstream. Fixing only the Hub would look fixed but still fail.

## Change

- **Single source of truth** (`lib/config.ts`): `MAX_UPLOAD_MB` / `MAX_UPLOAD_BYTES` (`NEXT_PUBLIC_MAX_UPLOAD_MB`, default **50**). Replaces every hardcoded 20/10 MB cap, plus the client pre-checks and copy (`CreateChildCard`, `UploadPicker`, documents + manuals pages).
- **Ingest** (`mira-ingest/main.py`): `/ingest/document-kb` cap is now `MIRA_MAX_UPLOAD_MB` (default 50). **Must stay in sync** with the Hub's `NEXT_PUBLIC_MAX_UPLOAD_MB`.
- **Un-swallow the `formData()` parse error**: log the real reason + content-length before returning `invalid_multipart`, so a truncated/malformed-body failure is diagnosable instead of guessed at.
- **Rename** the now-wrong error key `exceeds_20mb_limit` → `exceeds_size_limit` (+ `limitBytes`); both client consumers updated.
- **Tests**: `mira-ingest/tests/test_ingest.py` locks the cap (accepts 31.5 MB, rejects > default 50 MB, honors the env override).

## Why 50 MB, not 100 / unlimited

`mira-ingest` buffers the whole file in memory (`await file.read()`) before docling — the documented 8 GB-VPS OOM path (`project_vps_oom_docling_incidents` / ADR-0019). 50 MB clears real OEM manuals at a bounded per-file footprint. **Host-OOM-safe**: since PRs #1318/#1319/#1336 every container is `mem_limit`-bounded (docling 3g, ingest 1g, OW 1.5g), so a large upload can at worst fail a single docling job inside its cap — not take down the host as in the May outages. True any-size needs the streaming ingest-v2 rebuild (ADR-0019), which is unbuilt. To go higher, raise both env vars (and nginx `client_max_body_size`, currently 100M).

## Investigated and ruled OUT

Next 16's 10 MB request-body clone ceiling (`experimental.proxyClientMaxBodySize` / `DEFAULT_BODY_CLONE_SIZE_LIMIT`) does **not** truncate route-handler uploads. Verified against the real standalone `server.js` (plus `next start`, `next dev`, middleware-matched + unmatched routes): a 31.5 MB multipart POST arrives intact even at the default 10 MB ceiling. No `proxyClientMaxBodySize` change is included.

A prior session reported the failure as `invalid_multipart` rather than the size cap; that could not be reproduced locally as Next truncation (leading hypothesis: an nginx/client timeout on a slow large upload). **After deploy, retry the 31.5 MB upload once** — the new `[local-upload] formData parse failed` log line will name the real cause if anything beyond the cap is involved.

## Testing

- `tsc --noEmit` clean on all edited files.
- `pytest mira-ingest/tests/test_ingest.py` → 10 passed (7 existing + 3 new cap tests).
- 5-config runtime verification of the ruled-out Next truncation (standalone `server.js` included).

## Out of scope (pre-existing)

- Unbounded ingest **concurrency** to docling (this bounds per-upload size, not N concurrent uploads).
- `namespace/node/files` stores bytes as Postgres `bytea`, so its raise means a single insert can write a 50 MB blob to Neon (insert-cost profile, not streaming).
- Streaming ingest-v2 for true any-size (ADR-0019).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
