### PR TITLE
fix(ui): clarify sun-readable toggle label + hub feed FAB quick actions

### DIFF
--- a/mira-hub/src/app/(hub)/feed/page.tsx
+++ b/mira-hub/src/app/(hub)/feed/page.tsx
@@ -158,7 +158,6 @@ function useSpeech() {
 
 export default function FeedPage() {
   const tFeed = useTranslations("feed");
-  const tWorkorders = useTranslations("workorders");
   const [fabOpen, setFabOpen] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
   const [dismissed, setDismissed] = useState<Set<number>>(new Set());
@@ -317,15 +316,15 @@ export default function FeedPage() {
         )}
       </div>
 
-      {/* FAB */}
+      {/* FAB — "Scan asset QR" first: most field-relevant quick action */}
       <div className="fixed bottom-20 right-5 md:bottom-6 z-30 flex flex-col items-end gap-2">
         {fabOpen && (
           <div className="flex flex-col items-end gap-2 mb-1 animate-in fade-in slide-in-from-bottom-2 duration-150">
             {[
-              { label: tWorkorders("new"), icon: ClipboardList,     href: "/workorders/new" },
-              { label: tFeed("scanQr"),    icon: QrCode,            href: "/scan" },
-              { label: tFeed("newRequest"), icon: MessageSquarePlus, href: "/requests/new" },
-              { label: "New Asset",        icon: Cog,               href: "/assets?create=1" },
+              { label: tFeed("scanQr"),          icon: QrCode,            href: "/scan" },
+              { label: tFeed("createWorkOrder"), icon: ClipboardList,     href: "/workorders/new" },
+              { label: tFeed("newRequest"),      icon: MessageSquarePlus, href: "/requests/new" },
+              { label: tFeed("newAsset"),        icon: Cog,               href: "/assets?create=1" },
             ].map((action) => (
               <Link key={action.label} href={action.href}
                 className="flex items-center gap-2 rounded-full px-4 py-2 text-sm font-medium text-white shadow-lg"
@@ -337,6 +336,8 @@ export default function FeedPage() {
           </div>
         )}
         <button onClick={() => setFabOpen(v => !v)}
+          aria-expanded={fabOpen}
+          aria-label={fabOpen ? "Close quick actions" : "Open quick actions"}
           className="w-14 h-14 rounded-full text-white flex items-center justify-center transition-all duration-200"
           style={{ background: "linear-gradient(135deg, #2563EB, #0891B2)", boxShadow: "var(--shadow-fab)", transform: fabOpen ? "rotate(45deg)" : "none" }}>
           {fabOpen ? <X className="w-6 h-6" /> : <Plus className="w-6 h-6" />}

--- a/mira-hub/src/messages/en.json
+++ b/mira-hub/src/messages/en.json
@@ -118,7 +118,7 @@
   },
   "feed": {
     "title": "Activity Feed",
-    "newRequest": "New Request",
+    "newRequest": "Submit maintenance request",
     "allCaughtUp": "All caught up!",
     "noActivity": "No new activity",
     "markRead": "Mark as read",
@@ -130,7 +130,9 @@
     "auditTrail": "Audit Trail",
     "acknowledge": "Acknowledge",
     "addNote": "Add Note",
-    "scanQr": "Scan QR Code",
+    "scanQr": "Scan asset QR",
+    "createWorkOrder": "Create work order",
+    "newAsset": "Add new asset",
     "kpi": {
       "openWorkOrders": "Open Work Orders",
       "overduePMs": "Overdue PMs",

--- a/mira-hub/src/messages/es.json
+++ b/mira-hub/src/messages/es.json
@@ -119,7 +119,7 @@
   },
   "feed": {
     "title": "Registro de actividad",
-    "newRequest": "Nueva solicitud",
+    "newRequest": "Enviar solicitud de mantenimiento",
     "allCaughtUp": "¡Todo al día!",
     "noActivity": "Sin actividad nueva",
     "markRead": "Marcar como leído",
@@ -131,7 +131,9 @@
     "auditTrail": "Historial de auditoría",
     "acknowledge": "Confirmar",
     "addNote": "Agregar nota",
-    "scanQr": "Escanear código QR",
+    "scanQr": "Escanear QR del activo",
+    "createWorkOrder": "Crear orden de trabajo",
+    "newAsset": "Agregar nuevo activo",
     "kpi": {
       "openWorkOrders": "Órdenes abiertas",
       "overduePMs": "MPs vencidos",

--- a/mira-hub/src/messages/hi.json
+++ b/mira-hub/src/messages/hi.json
@@ -119,7 +119,7 @@
   },
   "feed": {
     "title": "गतिविधि फ़ीड",
-    "newRequest": "नया अनुरोध",
+    "newRequest": "रखरखाव अनुरोध सबमिट करें",
     "allCaughtUp": "सब अद्यतन है!",
     "noActivity": "कोई नई गतिविधि नहीं",
     "markRead": "पढ़ा हुआ चिह्नित करें",
@@ -131,7 +131,9 @@
     "auditTrail": "ऑडिट ट्रेल",
     "acknowledge": "स्वीकार करें",
     "addNote": "नोट जोड़ें",
-    "scanQr": "QR कोड स्कैन करें",
+    "scanQr": "एसेट QR स्कैन करें",
+    "createWorkOrder": "कार्य आदेश बनाएं",
+    "newAsset": "नया एसेट जोड़ें",
     "kpi": {
       "openWorkOrders": "खुले कार्य आदेश",
       "overduePMs": "विलंबित PM",

--- a/mira-hub/src/messages/zh.json
+++ b/mira-hub/src/messages/zh.json
@@ -119,7 +119,7 @@
   },
   "feed": {
     "title": "动态",
-    "newRequest": "新报修",
+    "newRequest": "提交维护请求",
     "allCaughtUp": "全部处理完毕！",
     "noActivity": "暂无新动态",
     "markRead": "标记为已读",
@@ -131,7 +131,9 @@
     "auditTrail": "审计记录",
     "acknowledge": "确认",
     "addNote": "添加备注",
-    "scanQr": "扫描QR码",
+    "scanQr": "扫描资产二维码",
+    "createWorkOrder": "创建工单",
+    "newAsset": "添加新资产",
     "kpi": {
       "openWorkOrders": "待处理工单",
       "overduePMs": "逾期预防维护",

--- a/mira-web/public/sun-toggle.js
+++ b/mira-web/public/sun-toggle.js
@@ -1,20 +1,32 @@
 (function () {
   var KEY = "fl_sun_mode";
 
+  // Label reflects the NEXT action, not the current state — so it's always
+  // clear what clicking will do. OFF → offers sun-readable; ON → offers dark.
+  var LABEL_OFF = "☀ Sun-readable";          // ☀ Sun-readable
+  var LABEL_ON = "🌙 Dark mode";        // 🌙 Dark mode
+  var ARIA_OFF = "Switch to sun-readable high-contrast mode";
+  var ARIA_ON = "Switch back to dark mode";
+
+  function setLabel(btn, on) {
+    if (!btn) return;
+    btn.textContent = on ? LABEL_ON : LABEL_OFF;
+    btn.setAttribute("aria-pressed", on ? "true" : "false");
+    btn.setAttribute("aria-label", on ? ARIA_ON : ARIA_OFF);
+  }
+
   function applyState() {
+    var on = false;
     try {
-      if (localStorage.getItem(KEY) === "1") {
-        document.body.classList.add("sun");
-        var btn = document.getElementById("fl-sun-toggle");
-        if (btn) btn.setAttribute("aria-pressed", "true");
-      }
+      on = localStorage.getItem(KEY) === "1";
     } catch (e) { /* localStorage blocked */ }
+    if (on) document.body.classList.add("sun");
+    setLabel(document.getElementById("fl-sun-toggle"), on);
   }
 
   window.flToggleSun = function () {
     var on = document.body.classList.toggle("sun");
-    var btn = document.getElementById("fl-sun-toggle");
-    if (btn) btn.setAttribute("aria-pressed", on ? "true" : "false");
+    setLabel(document.getElementById("fl-sun-toggle"), on);
     try { localStorage.setItem(KEY, on ? "1" : "0"); } catch (e) { /* blocked */ }
   };
 

--- a/mira-web/src/views/_topbar.ts
+++ b/mira-web/src/views/_topbar.ts
@@ -92,7 +92,7 @@ export function footer(opts: TopbarOpts = {}): string {
     <ul class="fl-footer-links">
 ${items}
     </ul>
-    <button type="button" id="fl-sun-toggle" class="fl-sun-toggle" aria-pressed="false" aria-label="&#9728; Sun-readable" data-cta="sun-toggle">&#9728; Sun-readable</button>
+    <button type="button" id="fl-sun-toggle" class="fl-sun-toggle" aria-pressed="false" aria-label="Switch to sun-readable high-contrast mode" data-cta="sun-toggle">&#9728; Sun-readable</button>
   </div>
 </footer>`;
 }


### PR DESCRIPTION
## What & why
QA feedback on two floating buttons.

### 1. Public homepage "Sun-readable" toggle (`mira-web`)
The label stayed "☀ Sun-readable" even after enabling sun mode — confusing. Now it reflects the **next** action:
- **OFF** → `☀ Sun-readable` (`aria-pressed="false"`, aria-label "Switch to sun-readable high-contrast mode")
- **ON** → `🌙 Dark mode` (`aria-pressed="true"`, aria-label "Switch back to dark mode")

`applyState()` now sets the label on load for both states; `localStorage` (`fl_sun_mode`) persistence and the `body.sun` high-contrast styling are unchanged. Server-rendered `aria-label` in `_topbar.ts` made action-oriented (visible text/id/class/data-cta untouched).

### 2. Hub feed FAB (`mira-hub`)
- Reordered: **Scan asset QR** first (most field-relevant), then Create work order → Submit maintenance request → Add new asset.
- Clearer labels moved fully into the `feed` i18n namespace (en/es/hi/zh); replaces the hardcoded "New Asset" and drops the now-unused `tWorkorders` hook.
- Toggle button gains `aria-expanded` + `aria-label` ("Open/Close quick actions") — it previously had no accessible name.
- Hrefs (`/scan`, `/workorders/new`, `/requests/new`, `/assets?create=1`), overlay-to-close, and mobile positioning unchanged.

## Verification
- `node --check public/sun-toggle.js` → OK; logic sim confirmed label/aria/localStorage flip both directions.
- `npx tsc --noEmit` (mira-hub): `feed/page.tsx` **zero errors** (remaining errors are pre-existing, in unrelated test files + generated `.next` stubs).
- `bun test` (mira-web view suites): **14 failures, all pre-existing** — verified identical on a stash-baseline of `origin/main`. Sun-toggle tests (AC8, topbar footer) pass. **No regressions introduced.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)