### PR TITLE
fix(hub): platform-accounts search-aware count + safer account actions (#1945)

### DIFF
--- a/mira-hub/src/app/(hub)/admin/users/account-actions.test.ts
+++ b/mira-hub/src/app/(hub)/admin/users/account-actions.test.ts
@@ -1,0 +1,67 @@
+// #1945: the platform-accounts admin surface must (a) report a search-aware
+// count so a filtered view doesn't read as the full total, (b) confirm before
+// destructive mutations, and (c) give each row action a user-specific
+// accessible name. These pure helpers back all three; cover their branches.
+
+import { it, expect, describe } from "vitest";
+import { formatCountLabel, confirmMessage, actionAriaLabel } from "./account-actions";
+
+describe("formatCountLabel", () => {
+  it("shows bare total when no query is active", () => {
+    expect(formatCountLabel({ total: 34, visible: 34, hasQuery: false, pending: 0 }))
+      .toBe("34 total");
+  });
+
+  it("appends pending review when there are pending accounts and no query", () => {
+    expect(formatCountLabel({ total: 49, visible: 49, hasQuery: false, pending: 5 }))
+      .toBe("49 total · 5 pending review");
+  });
+
+  it("leads with a singular result count when a query matches one user", () => {
+    expect(formatCountLabel({ total: 49, visible: 1, hasQuery: true, pending: 5 }))
+      .toBe("1 result · 49 total");
+  });
+
+  it("leads with a plural result count when a query matches several users", () => {
+    expect(formatCountLabel({ total: 49, visible: 3, hasQuery: true, pending: 5 }))
+      .toBe("3 results · 49 total");
+  });
+
+  it("reports zero results (still plural) when a query matches nothing", () => {
+    expect(formatCountLabel({ total: 49, visible: 0, hasQuery: true, pending: 0 }))
+      .toBe("0 results · 49 total");
+  });
+
+  it("never leaks the pending suffix into the filtered count", () => {
+    expect(formatCountLabel({ total: 49, visible: 2, hasQuery: true, pending: 5 }))
+      .not.toContain("pending");
+  });
+});
+
+describe("confirmMessage", () => {
+  it("requires confirmation for Revoke (→ pending), naming the user", () => {
+    expect(confirmMessage("pending", "Ada Probe")).toBe("Revoke access for Ada Probe?");
+  });
+
+  it("requires confirmation for Expire (→ expired), naming the user", () => {
+    expect(confirmMessage("expired", "probe@factorylm.com"))
+      .toBe("Expire trial for probe@factorylm.com?");
+  });
+
+  it("does not confirm for Approve (one-click)", () => {
+    expect(confirmMessage("approved", "Ada Probe")).toBeNull();
+  });
+});
+
+describe("actionAriaLabel", () => {
+  it("gives each action a user-specific accessible name", () => {
+    expect(actionAriaLabel("approved", "Ada Probe")).toBe("Approve Ada Probe");
+    expect(actionAriaLabel("pending", "Ada Probe")).toBe("Revoke access for Ada Probe");
+    expect(actionAriaLabel("expired", "Ada Probe")).toBe("Expire trial for Ada Probe");
+  });
+
+  it("disambiguates two rows by their distinct labels", () => {
+    expect(actionAriaLabel("approved", "alice@x.com"))
+      .not.toBe(actionAriaLabel("approved", "bob@x.com"));
+  });
+});

--- a/mira-hub/src/app/(hub)/admin/users/account-actions.ts
+++ b/mira-hub/src/app/(hub)/admin/users/account-actions.ts
@@ -1,0 +1,53 @@
+// Pure helpers for the platform-accounts admin page (#1945). Kept JSX-free so
+// the count / accessible-label / confirmation logic is unit-testable under
+// vitest's node environment (the page itself is a "use client" component).
+
+// Target status a row action moves a user to. "approved" is one-click;
+// "pending" (Revoke) and "expired" (Expire) are destructive → confirm first.
+export type MutationStatus = "approved" | "pending" | "expired";
+
+/**
+ * Header count copy. Search-aware: when a query is active, lead with the
+ * filtered result count so the operator sees how many of the total matched
+ * ("1 result · 49 total") instead of a bare, misleading unfiltered total.
+ */
+export function formatCountLabel(opts: {
+  total: number;
+  visible: number;
+  hasQuery: boolean;
+  pending: number;
+}): string {
+  const { total, visible, hasQuery, pending } = opts;
+  if (hasQuery) {
+    return `${visible} result${visible === 1 ? "" : "s"} · ${total} total`;
+  }
+  return `${total} total${pending > 0 ? ` · ${pending} pending review` : ""}`;
+}
+
+/**
+ * Confirmation prompt for a status mutation, or null when the action is
+ * non-destructive. Approval stays one-click (returns null) per the issue;
+ * Revoke and Expire return a prompt naming the target user.
+ */
+export function confirmMessage(status: MutationStatus, label: string): string | null {
+  switch (status) {
+    case "pending":
+      return `Revoke access for ${label}?`;
+    case "expired":
+      return `Expire trial for ${label}?`;
+    default:
+      return null;
+  }
+}
+
+/** Accessible name for a row action button, disambiguated by target user. */
+export function actionAriaLabel(status: MutationStatus, label: string): string {
+  switch (status) {
+    case "approved":
+      return `Approve ${label}`;
+    case "pending":
+      return `Revoke access for ${label}`;
+    case "expired":
+      return `Expire trial for ${label}`;
+  }
+}

--- a/mira-hub/src/app/(hub)/admin/users/page.tsx
+++ b/mira-hub/src/app/(hub)/admin/users/page.tsx
@@ -6,6 +6,13 @@ import { Input } from "@/components/ui/input";
 import { useTranslations } from "next-intl";
 import { API_BASE } from "@/lib/config";
 import { NoAccess } from "@/components/ui/no-access";
+import { useToast } from "@/providers/toast-provider";
+import {
+  formatCountLabel,
+  confirmMessage,
+  actionAriaLabel,
+  type MutationStatus,
+} from "./account-actions";
 
 // Platform user administration (FactoryLM staff): the cross-workspace list with
 // approve / revoke / expire actions used to gate new signups. Distinct from the
@@ -38,6 +45,7 @@ function daysLeft(isoDate: string): number {
 
 export default function AdminUsersPage() {
   const t = useTranslations("admin");
+  const { toast } = useToast();
   const [users, setUsers] = useState<ApiUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [denied, setDenied] = useState(false);
@@ -69,15 +77,33 @@ export default function AdminUsersPage() {
 
   useEffect(() => { loadUsers(); }, [loadUsers]);
 
-  async function setStatus(id: string, status: string) {
+  async function setStatus(id: string, status: MutationStatus, label: string) {
+    // Destructive transitions (Revoke / Expire) confirm before mutating;
+    // approval stays one-click. confirmMessage returns null for one-click.
+    const prompt = confirmMessage(status, label);
+    if (prompt && !window.confirm(prompt)) return;
+
     setUpdating(id);
-    await fetch(`/hub/api/admin/users/${id}`, {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ status }),
-    });
-    await loadUsers();
-    setUpdating(null);
+    try {
+      const res = await fetch(`/hub/api/admin/users/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status }),
+      });
+      if (!res.ok) {
+        // Surface the failure instead of silently reloading the old state.
+        toast(
+          `Couldn't update ${label} — ${res.status === 403 ? "not permitted" : "please try again"}`,
+          "error",
+        );
+        return;
+      }
+      await loadUsers();
+    } catch {
+      toast(`Couldn't update ${label} — network error`, "error");
+    } finally {
+      setUpdating(null);
+    }
   }
 
   if (denied) {
@@ -94,6 +120,12 @@ export default function AdminUsersPage() {
   );
 
   const pendingCount = users.filter(u => u.status === "pending").length;
+  const countLabel = formatCountLabel({
+    total: users.length,
+    visible: visible.length,
+    hasQuery: query.trim().length > 0,
+    pending: pendingCount,
+  });
 
   return (
     <div className="min-h-full" style={{ backgroundColor: "var(--background)" }}>
@@ -102,7 +134,9 @@ export default function AdminUsersPage() {
           <div>
             <h1 className="text-base font-semibold" style={{ color: "var(--foreground)" }}>{t("users.title")}</h1>
             <p className="text-xs mt-0.5" style={{ color: "var(--foreground-muted)" }}>
-              {users.length} total{pendingCount > 0 && ` · ${pendingCount} pending review`}
+              {/* Scope hint distinguishes this platform-wide approvals surface
+                  from the tenant-scoped Settings → Users (#1945). */}
+              Platform-wide account approvals · {countLabel}
             </p>
           </div>
           {(showSystem || systemHidden > 0) && (
@@ -139,6 +173,7 @@ export default function AdminUsersPage() {
             {visible.map(user => {
               const cfg = STATUS_CONFIG[user.status] ?? STATUS_CONFIG.pending;
               const StatusIcon = cfg.Icon;
+              const label = user.name ?? user.email;
               return (
                 <div key={user.id} className="card p-3 flex items-center gap-3">
                   <div className="w-9 h-9 rounded-full flex items-center justify-center text-xs font-bold flex-shrink-0"
@@ -179,7 +214,8 @@ export default function AdminUsersPage() {
                       <>
                         {user.status !== "approved" && (
                           <button
-                            onClick={() => setStatus(user.id, "approved")}
+                            onClick={() => setStatus(user.id, "approved", label)}
+                            aria-label={actionAriaLabel("approved", label)}
                             className="px-2.5 py-1 text-xs font-medium rounded-md transition-colors"
                             style={{ backgroundColor: "rgba(34,197,94,0.1)", color: "#22C55E" }}
                           >
@@ -188,7 +224,8 @@ export default function AdminUsersPage() {
                         )}
                         {user.status === "approved" && (
                           <button
-                            onClick={() => setStatus(user.id, "pending")}
+                            onClick={() => setStatus(user.id, "pending", label)}
+                            aria-label={actionAriaLabel("pending", label)}
                             className="px-2.5 py-1 text-xs font-medium rounded-md transition-colors"
                             style={{ backgroundColor: "rgba(234,179,8,0.1)", color: "#EAB308" }}
                           >
@@ -197,7 +234,8 @@ export default function AdminUsersPage() {
                         )}
                         {user.status === "trial" && (
                           <button
-                            onClick={() => setStatus(user.id, "expired")}
+                            onClick={() => setStatus(user.id, "expired", label)}
+                            aria-label={actionAriaLabel("expired", label)}
                             className="px-2.5 py-1 text-xs font-medium rounded-md transition-colors"
                             style={{ backgroundColor: "rgba(148,163,184,0.1)", color: "#94A3B8" }}
                           >

--- a/mira-hub/src/components/layout/sidebar.tsx
+++ b/mira-hub/src/components/layout/sidebar.tsx
@@ -121,7 +121,7 @@ export function Sidebar() {
       "reports":       t("reports"),
       "team":          t("team"),
       "admin-review":  "Review queue",
-      "platform-users": "Accounts",
+      "platform-users": "Platform accounts",
       // Legacy routes (still reachable, not in sidebar):
       "event-log":     t("eventLog"),
       "usage":         t("usage"),

--- a/mira-hub/src/providers/access-control.ts
+++ b/mira-hub/src/providers/access-control.ts
@@ -106,7 +106,7 @@ export const NAV_ITEMS: ReadonlyArray<{
   // approval (approve / revoke / expire). Gated to platform admins
   // (platform.users.read ← status === "admin"); distinct from the tenant-scoped
   // /settings/users. URL stays /admin/users; only platform admins see this link.
-  { key: "platform-users", label: "Accounts",     icon: "Users",         href: "/admin/users",            roles: ["admin", "owner"], group: "secondary", capability: "platform.users.read" },
+  { key: "platform-users", label: "Platform accounts", icon: "Users",     href: "/admin/users",            roles: ["admin", "owner"], group: "secondary", capability: "platform.users.read" },
 
   // ── LABS (gated on NEXT_PUBLIC_LABS_ENABLED) ───────────────────────────────
   { key: "conversations", label: "Conversations", icon: "MessageSquare", href: "/conversations", roles: [...ALL_ROLES], group: "labs" },


### PR DESCRIPTION
## What
Polishes the platform admin `/admin/users` surface (the cross-workspace signup-approval list) per dogfood QA in #1945:

1. **Search-aware count** — when a query is active the header now leads with the filtered result count (`1 result · 49 total` / `3 results · 49 total` / `0 results · 49 total`) instead of the bare unfiltered total. No query → `34 total · N pending review` as before.
2. **Accessible row-action names** — `Approve` / `Revoke` / `Expire` now carry a user-specific `aria-label` (e.g. `Approve Ada Probe`, `Revoke access for …`, `Expire trial for …`) so screen readers can disambiguate the repeated buttons.
3. **Confirm before destructive mutations** — `Revoke` and `Expire` now `window.confirm` with the target user named; `Approve` stays one-click.
4. **Surfaced failures** — a failed PATCH now raises an error toast instead of silently reloading the prior state.
5. **Scope clarity** — sidebar nav label `Accounts` → **`Platform accounts`** (both label sources) + a `Platform-wide account approvals` page subtitle, distinguishing this from tenant-scoped Settings → Users.

Count / accessible-label / confirmation logic is extracted to a JSX-free helper (`account-actions.ts`) so it's unit-testable under the repo's node-env vitest. **No account or seed data changed.**

## Why
Closes #1945 (P2, a11y + admin-surface safety). The repeated generic buttons were an a11y issue, destructive actions were one-click with no confirmation, the filtered count was misleading, and `Accounts` was ambiguous against tenant Settings → Users.

## Acceptance criteria (from #1945)
- [x] Active search shows filtered result count + total
- [x] Approve/Revoke/Expire have user-specific accessible names
- [x] Revoke/Expire require confirmation before PATCH
- [x] Mutation failure surfaced (error toast) instead of silent reload
- [x] Copy clarifies platform-wide scope (nav rename + subtitle)
- [x] Tests added for filtered count + label/confirmation behavior

## Tests run
\`\`\`
$ npx vitest run                       # full hub suite
  Test Files  57 passed (57)
       Tests  527 passed (527)
$ npx vitest run .../admin/users/account-actions.test.ts
  ✓ account-actions.test.ts (11 tests)   # count copy, confirm prompts, aria labels
\`\`\`
New test covers: singular/plural/zero result copy, pending-suffix isolation from filtered count, Revoke/Expire confirm prompts, Approve = no confirm, per-user aria-label disambiguation.

## Verification notes
- **Logic** verified via the 11 extracted-helper unit tests + full suite green.
- **Visual/rendered behavior not exercised locally**: standing up mira-hub needs a Doppler/Neon admin session, and the QA was run against **prod** (`app.factorylm.com`) where clicking these buttons mutates real accounts — deliberately not done. Diff wiring is mechanical (standard `aria-label` attrs, `window.confirm` gate, `useToast`). QA evidence PNGs confirm the sidebar fits the longer label with no overlap and console is clean.
- **Pre-existing, not introduced by this PR:** `react-hooks/set-state-in-effect` lint on `page.tsx` `useEffect(() => { loadUsers(); }, [loadUsers])` (line unchanged by this diff — verified identical hit on the pristine `origin/main` copy). Left untouched per surgical-changes.

## Risk / blast radius
Low. `account-actions.ts` is new and single-consumer. `page.tsx` is the only renderer. `access-control.ts` / `sidebar.tsx` changes are a display-label rename only (nav key, href, gating unchanged). No API, schema, engine, or data changes.