### PR TITLE
fix(orchestrator): apply 3 pulse patches — D5 quorum, D4 replay seam (step 3), signup smoke gate

### DIFF
--- a/.github/workflows/eval-replay-gate.yml
+++ b/.github/workflows/eval-replay-gate.yml
@@ -1,0 +1,76 @@
+name: Eval Replay Gate (keyless)
+
+# D4 — keyless deterministic eval replay seam.
+#
+# Runs `offline_run.py --replay` with NO LLM API keys on PRs touching the
+# engine or eval harness. This is the only deterministic regression-guard for
+# the #1858 quickstart cross-vendor citation-strip (cp_citation_vendor_relevance,
+# tests/eval/grader.py) — a future commit must not be able to silently
+# re-introduce the wrong-vendor citation lie.
+#
+# INERT UNTIL THE STORE IS RECORDED. Strict replay raises on call #1 when the
+# fixture store is absent (tests/eval/llm_replay.py:install → by_scenario empty).
+# The store (tests/eval/fixtures/llm_replay/*.json) is .gitignored and must be
+# recorded with live keys + a founder PII eyeball, then committed — see
+# wiki/orchestrator/patches/2026-06-11-D4-replay-seam-activation.md steps 1-2.
+# Until then this gate SKIPS the run (emitting a loud ::warning::) so it never
+# deadlocks engine/eval PRs, and auto-activates the moment the store lands.
+# Promote it to a required check (runbook "Done when") only after step 2.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+on:
+  pull_request:
+    paths:
+      - 'mira-bots/shared/**'
+      - 'tests/eval/**'
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
+
+jobs:
+  replay-gate:
+    name: Keyless replay gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Guard BEFORE any heavy setup so the inert path is cheap. hashFiles
+      # returns '' when the store is absent (today) — the gate run is skipped.
+      - name: Check for recorded replay store
+        id: store
+        run: |
+          if [ -n "${{ hashFiles('tests/eval/fixtures/llm_replay/cascade.json') }}" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Notice — replay store not yet recorded (gate inert)
+        if: steps.store.outputs.present != 'true'
+        run: |
+          echo "::warning::Eval replay gate INERT — fixture store not recorded. \
+          Record + commit it (founder, needs live keys + PII eyeball) per \
+          wiki/orchestrator/patches/2026-06-11-D4-replay-seam-activation.md \
+          steps 1-2; this gate activates automatically once the store lands."
+
+      - uses: actions/setup-python@v6
+        if: steps.store.outputs.present == 'true'
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        if: steps.store.outputs.present == 'true'
+        run: |
+          pip install httpx pyyaml pytest-asyncio
+
+      # Keyless by construction: GROQ/GEMINI/CEREBRAS keys are intentionally
+      # UNSET. Strict replay (default) serves every cascade + retrieval response
+      # from the committed store — no network, no DB, no keys.
+      - name: Run keyless replay eval
+        if: steps.store.outputs.present == 'true'
+        run: |
+          env MIRA_EVAL_REPLAY=replay python tests/eval/offline_run.py

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -70,6 +70,13 @@ jobs:
           HUB_URL: https://app.factorylm.com
         run: npx playwright test --config playwright.smoke.config.ts
 
+      - name: Run signup money-path tests (pricing → trial CTA → checkout → magic link)
+        working-directory: mira-hub
+        env:
+          WEB_URL: https://factorylm.com
+          HUB_URL: https://app.factorylm.com
+        run: npx playwright test --config playwright.signup.config.ts
+
       - name: Upload failure screenshots
         if: failure()
         uses: actions/upload-artifact@v7

--- a/mira-bots/tools/fix_proposer.py
+++ b/mira-bots/tools/fix_proposer.py
@@ -31,6 +31,7 @@ import argparse
 import asyncio
 import json
 import logging
+import math
 import os
 import re
 import subprocess
@@ -118,6 +119,68 @@ def find_latest_scorecard(runs_dir: Path) -> Path | None:
     # Prefer judge-enabled runs (they have more signal)
     judge_first = [c for c in candidates if "judge" in c.stem]
     return (judge_first or candidates)[0] if (judge_first or candidates) else None
+
+
+def _recent_scorecards(runs_dir: Path, limit: int) -> list[Path]:
+    """Return up to `limit` most-recent scorecard .md files, newest first.
+
+    Mirrors find_latest_scorecard's ordering (lexical-desc, judge-enabled
+    runs first) so the quorum window is drawn from the same population the
+    single-scorecard path would have sampled.
+    """
+    if limit < 1 or not runs_dir.exists():
+        return []
+    candidates = sorted(runs_dir.glob("*.md"), reverse=True)
+    judge_first = [c for c in candidates if "judge" in c.stem]
+    ordered = judge_first or candidates
+    return ordered[:limit]
+
+
+def quorum_failures(
+    latest_failures: list[FailureRecord],
+    runs_dir: Path,
+    window: int,
+) -> list[FailureRecord]:
+    """Keep only failures confirmed by a median quorum across recent scorecards.
+
+    A flaky scenario that fails one scorecard but passes most others should not
+    drive a fix-PR (phantom clusters #1773/#1788). A failure from the latest
+    scorecard survives only if the same (scenario, checkpoint, reason-signature)
+    triple appears in at least ceil(window/2) of the last `window` scorecards.
+
+    Backward-compatible: if fewer than `window` scorecards exist (or window < 2),
+    the latest failures are returned unchanged — identical to the historical
+    single-scorecard behavior.
+    """
+    recent = _recent_scorecards(runs_dir, window)
+    if window < 2 or len(recent) < window:
+        return latest_failures
+
+    threshold = math.ceil(window / 2)
+    # Count, per failure signature, how many of the recent scorecards exhibit it.
+    occurrence: dict[tuple[str, str, str], int] = defaultdict(int)
+    for card in recent:
+        seen: set[tuple[str, str, str]] = set()
+        for rec in parse_scorecard(card):
+            seen.add((rec.scenario_id, rec.checkpoint, _reason_signature(rec.reason)))
+        for sig in seen:
+            occurrence[sig] += 1
+
+    confirmed = [
+        rec
+        for rec in latest_failures
+        if occurrence[(rec.scenario_id, rec.checkpoint, _reason_signature(rec.reason))] >= threshold
+    ]
+    dropped = len(latest_failures) - len(confirmed)
+    if dropped:
+        logger.info(
+            "Quorum filter: %d/%d failures dropped (need %d of last %d scorecards)",
+            dropped,
+            len(latest_failures),
+            threshold,
+            window,
+        )
+    return confirmed
 
 
 # ── Clustering: group failures by signature ─────────────────────────────────
@@ -263,6 +326,7 @@ class FixProposerConfig:
     claude_model: str = _DEFAULT_MODEL
     min_cluster_size: int = 3
     max_clusters_per_run: int = 3
+    quorum_window: int = 3
     repo: str = REPO
 
 
@@ -492,6 +556,18 @@ class FixProposer:
                 "ts": run_ts,
             }
 
+        # Require a median quorum across recent scorecards before clustering, so a
+        # single flaky scorecard can't spawn a phantom fix-PR (#1773/#1788).
+        failures = quorum_failures(failures, self.cfg.runs_dir, self.cfg.quorum_window)
+        if not failures:
+            logger.info("No quorum-confirmed failures — nothing to propose")
+            return {
+                "status": "ok",
+                "reason": "no_quorum_failures",
+                "scorecard": str(scorecard),
+                "ts": run_ts,
+            }
+
         clusters = cluster_failures(failures, self.cfg.min_cluster_size)
         if not clusters:
             logger.info("No clusters ≥%d failures — nothing to propose", self.cfg.min_cluster_size)
@@ -566,6 +642,7 @@ def _build_proposer() -> FixProposer:
             claude_model=os.getenv("CLAUDE_MODEL", _DEFAULT_MODEL),
             min_cluster_size=int(os.getenv("FIX_PROPOSER_MIN_CLUSTER", "3")),
             max_clusters_per_run=int(os.getenv("FIX_PROPOSER_MAX_CLUSTERS", "3")),
+            quorum_window=int(os.getenv("FIX_PROPOSER_QUORUM_WINDOW", "3")),
         )
     )
 

--- a/tests/eval/fix_proposer_tasks.py
+++ b/tests/eval/fix_proposer_tasks.py
@@ -18,6 +18,7 @@ Environment variables required:
 Optional tuning:
     FIX_PROPOSER_MIN_CLUSTER       Min failures per cluster (default: 3)
     FIX_PROPOSER_MAX_CLUSTERS      Max clusters per run (default: 3)
+    FIX_PROPOSER_QUORUM_WINDOW     Scorecards in the flakiness quorum (default: 3)
     FIX_PROPOSER_STATE_PATH        State JSON (default: /opt/mira/data/fix_proposer_state.json)
     FIX_PROPOSER_RUNS_DIR          Scorecards directory (default: /opt/mira/tests/eval/runs)
     CLAUDE_MODEL                   Model override (default: claude-sonnet-4-6)
@@ -104,6 +105,7 @@ def run_nightly() -> dict:
             claude_model=os.getenv("CLAUDE_MODEL", "claude-sonnet-4-6"),
             min_cluster_size=int(os.getenv("FIX_PROPOSER_MIN_CLUSTER", "3")),
             max_clusters_per_run=int(os.getenv("FIX_PROPOSER_MAX_CLUSTERS", "3")),
+            quorum_window=int(os.getenv("FIX_PROPOSER_QUORUM_WINDOW", "3")),
         ))
 
         result = asyncio.run(proposer.run(dry_run=False))

--- a/tests/eval/test_fix_proposer.py
+++ b/tests/eval/test_fix_proposer.py
@@ -26,6 +26,7 @@ from tools.fix_proposer import (
     cluster_failures,
     find_latest_scorecard,
     parse_scorecard,
+    quorum_failures,
 )
 
 
@@ -277,3 +278,73 @@ def test_state_missing_returns_defaults(tmp_path):
     proposer = _make_proposer(tmp_path)
     state = proposer._load_state()
     assert state["last_run_ts"] is None
+
+
+# ── Quorum filter tests (median-across-N scorecards) ───────────────────────
+
+
+def _write_scorecard(runs_dir: Path, name: str, scenario_ids: list[str]) -> None:
+    """Write a minimal scorecard whose Failures section lists the given scenarios."""
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    blocks = "\n\n".join(
+        f"### {sid}\n- **cp_keyword_match** FAILED: No match from ['x']" for sid in scenario_ids
+    )
+    (runs_dir / name).write_text(f"# Scorecard\n\n## Failures\n\n{blocks}\n\n## Summary\n")
+
+
+def test_quorum_passthrough_when_fewer_than_window(tmp_path):
+    """Fewer than `window` scorecards → latest failures returned unchanged."""
+    runs = tmp_path / "runs"
+    _write_scorecard(runs, "2026-04-14.md", ["flaky_01"])
+    latest = parse_scorecard(runs / "2026-04-14.md")
+    # window=3 but only 1 scorecard exists → no filtering
+    out = quorum_failures(latest, runs, window=3)
+    assert {r.scenario_id for r in out} == {"flaky_01"}
+
+
+def test_quorum_passthrough_when_window_below_two(tmp_path):
+    """window < 2 disables the quorum (single-scorecard behavior)."""
+    runs = tmp_path / "runs"
+    _write_scorecard(runs, "2026-04-14.md", ["a", "b"])
+    latest = parse_scorecard(runs / "2026-04-14.md")
+    out = quorum_failures(latest, runs, window=1)
+    assert len(out) == 2
+
+
+def test_quorum_drops_flaky_keeps_persistent(tmp_path):
+    """A 1-of-3 flaky scenario is dropped; a 2-of-3 persistent one survives."""
+    runs = tmp_path / "runs"
+    # 3 scorecards. `persistent_02` fails in 2 of 3 (>= ceil(3/2)=2 → kept).
+    # `flaky_01` fails only in the latest (1 of 3 < 2 → dropped).
+    _write_scorecard(runs, "2026-04-12.md", ["persistent_02"])
+    _write_scorecard(runs, "2026-04-13.md", ["other_03"])
+    _write_scorecard(runs, "2026-04-14.md", ["flaky_01", "persistent_02"])
+    latest = parse_scorecard(runs / "2026-04-14.md")
+    out = quorum_failures(latest, runs, window=3)
+    ids = {r.scenario_id for r in out}
+    assert ids == {"persistent_02"}
+
+
+def test_quorum_keeps_failure_meeting_threshold(tmp_path):
+    """A scenario failing in exactly ceil(N/2) of N scorecards is retained."""
+    runs = tmp_path / "runs"
+    _write_scorecard(runs, "2026-04-13.md", ["edge_01"])
+    _write_scorecard(runs, "2026-04-14.md", ["edge_01"])
+    latest = parse_scorecard(runs / "2026-04-14.md")
+    # window=2 → threshold ceil(2/2)=1; edge_01 appears in both → kept
+    out = quorum_failures(latest, runs, window=2)
+    assert {r.scenario_id for r in out} == {"edge_01"}
+
+
+def test_run_phantom_cluster_suppressed_by_quorum(tmp_path):
+    """End-to-end: a phantom cluster present only in the latest scorecard is suppressed."""
+    proposer = _make_proposer(tmp_path)
+    proposer.cfg.quorum_window = 3
+    runs = proposer.cfg.runs_dir
+    # Older two scorecards have no failures; latest has a 3-member phantom cluster.
+    _write_scorecard(runs, "2026-04-12.md", [])
+    _write_scorecard(runs, "2026-04-13.md", [])
+    _write_scorecard(runs, "2026-04-14.md", ["ph_a", "ph_b", "ph_c"])
+    result = asyncio.run(proposer.run(dry_run=True))
+    assert result["status"] == "ok"
+    assert result["reason"] == "no_quorum_failures"


### PR DESCRIPTION
Applies the three orchestrator-pulse patches from `wiki/orchestrator/patches/`, in the pulse-recommended order. Worked in an isolated worktree off `origin/main` (`2337a116`) to keep the main checkout clean.

## Commits

### 1. `fix(eval): median-quorum gate — kills phantom fix-PRs` (D5, keyless)
From `2026-06-12-D5-fixproposer-median-quorum.patch` — applied clean.
`quorum_failures()` keeps a failure only if its `(scenario, checkpoint, reason-signature)` triple recurs in ≥ `ceil(window/2)` of the last `window` committed scorecards (default 3, env `FIX_PROPOSER_QUORUM_WINDOW`). Stops one flaky scorecard from minting a phantom fix-PR (#1773/#1788). Backward-compatible: fewer than `window` scorecards (or `window<2`) returns the latest failures unchanged.
**Verified:** `pytest tests/eval/test_fix_proposer.py` → **22 passed** (17 existing + 5 new quorum tests) on the repo's 3.12 venv.

### 2. `feat(eval): wire keyless replay seam into CI` (D4 — step 3 only)
From the runbook `2026-06-11-D4-replay-seam-activation.md`. Adds a dedicated `pull_request` workflow `.github/workflows/eval-replay-gate.yml` that runs `offline_run.py --replay` with **no LLM keys** on PRs touching `mira-bots/shared/**` or `tests/eval/**` — the only deterministic regression-guard for the #1858 cross-vendor citation-strip.

> **⚠️ This gate is INERT today and does not yet flip Lens D to GREEN.** Strict replay raises on call #1 when the fixture store is absent, and the store (`tests/eval/fixtures/llm_replay/*.json`) is `.gitignore`d. A native `hashFiles()` guard **skips** the run and emits a loud `::warning::` while the store is absent, so the gate never deadlocks engine/eval PRs and **activates automatically** once the store lands. It is **not** marked a required check.

**Deliberately NOT done here (founder judgment calls, per the runbook's own "no code patch is staged" note):**
- **Steps 1–2** — record + commit the replay store. Needs live LLM keys (`doppler … MIRA_EVAL_REPLAY=record`) and a human PII eyeball before committing model outputs + un-gitignoring the path. I did not record or commit it.
- **Step 4** — the 3-run median gate on eval-fixer **is** the D5 patch in commit 1.
- Promoting this gate to a **required** check is a branch-protection action for the founder, valid only after step 2.

### 3. `feat(ci): smoke gate for signup → upload → cite money-path`
From `2026-06-09-smoke-gate-signup-moneypath.patch` — applied clean. Adds a signup money-path step (pricing → trial CTA → checkout → magic link) to the post-deploy smoke job, running `mira-hub/playwright.signup.config.ts` (verified present) against production.

## Verification
- D5 unit tests: **22/22 green** (3.12 venv).
- Both workflow files are **actionlint-clean** (`eval-replay-gate.yml` clean; my smoke-test.yml addition clean). A pre-existing `SC2129` style note at `smoke-test.yml:90` is in the untouched "Annotate PR" step — left per surgical-change discipline.
- `tsc --noEmit`: **N/A** — this PR touches only YAML workflows + Python (no TypeScript).
- The pre-existing `print()` at `fix_proposer.py:664` (CLI `main`) is untouched.

## Remaining patches in `wiki/orchestrator/patches/` (NOT applied — out of scope)
Discriminated with `git apply --check` against this branch.

**Genuinely pending (apply clean on this branch):**
- `2026-06-10-canary-reverse-drift-check.patch` (+ `.md`)
- `c6-engine-docstring-direct-connection.patch` (+ `.md`)

**Will-not-apply (likely already on `origin/main`, or conflict — needs review before applying):**
- `2026-06-07-quickstart-rate-limit.patch`
- `2026-06-08-quickstart-rate-limit.patch`
- `2026-06-08-documents-tenant-filter.patch`
- `2026-06-10-quickstart-wrong-vendor-refuse.patch` (+ `.md`)

**Runbook `.md`s (no git patch staged — founder/manual):**
- `2026-06-11-A5-inmem-limiter-pattern.md`
- `2026-06-11-E4-migration-tree-coverage.md`
- `2026-06-11-D4-replay-seam-activation.md` (step 3 done here; steps 1–2/4 as noted above)
- `2026-06-12-D5-fixproposer-median-quorum.md` (companion to the applied D5 patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
