### PR TITLE
test(e2e): pricing featured CTA is "Book Your Assessment" → /buy

### DIFF
--- a/mira-hub/tests/e2e/signup-flow.spec.ts
+++ b/mira-hub/tests/e2e/signup-flow.spec.ts
@@ -29,7 +29,7 @@ const HUB = (process.env.HUB_URL ?? "https://app.factorylm.com").replace(/\/$/, 
 // ---------------------------------------------------------------------------
 
 test.describe("factorylm.com/pricing — trial CTA", () => {
-  test("featured plan 'Start Free Trial' is visible and links to checkout", async ({
+  test("featured plan 'Book Your Assessment' is visible and links to /buy", async ({
     page,
   }) => {
     const res = await page.goto(WEB + "/pricing", {
@@ -37,17 +37,19 @@ test.describe("factorylm.com/pricing — trial CTA", () => {
     });
     expect(res?.status()).toBe(200);
 
-    // Production pricing uses .pricing-card.featured for the primary plan.
-    // The CTA href is /api/checkout/session — clicking it redirects to Stripe.
+    // Production pricing uses .pricing-card.featured for the primary plan. Its
+    // primary CTA is the assessment offer (data-cta="pricing-assessment") →
+    // "Book Your Assessment" → /buy. (The Stripe checkout path is exercised
+    // separately by the /api/checkout/session test below.)
     const featuredCard = page.locator(".pricing-card.featured");
     await expect(featuredCard).toBeVisible({ timeout: 10_000 });
 
-    const cta = featuredCard.locator(".card-cta");
+    const cta = featuredCard.locator('[data-cta="pricing-assessment"]');
     await expect(cta).toBeVisible();
-    await expect(cta).toContainText(/start free trial/i);
+    await expect(cta).toContainText(/book your assessment/i);
 
     const href = await cta.getAttribute("href");
-    expect(href).toMatch(/checkout/i);
+    expect(href).toMatch(/\/buy\b/);
   });
 
   test("checkout session API: 303 redirects to checkout.stripe.com", async ({


### PR DESCRIPTION
## What
Updates the `signup-flow` E2E smoke assertion to the **intended** featured-plan CTA on `factorylm.com/pricing`: **"Book Your Assessment →"** linking to **`/buy`** (stable `data-cta="pricing-assessment"`), replacing the stale "Start Free Trial → checkout" expectation.

## Why
The pricing copy was intentionally changed to the assessment offer, but `mira-hub/tests/e2e/signup-flow.spec.ts:32` still asserted the old "Start Free Trial" text + `/checkout` href — so **E2E smoke went red on every PR** (it probes live prod). The CTA is correct; the test was the stale "rule". The Stripe checkout path remains covered by the separate `/api/checkout/session` 303 test (unchanged).

## Evidence
Verified against live prod before committing:
```
$ cd mira-hub && npx playwright test --config playwright.signup.config.ts -g "Book Your Assessment"
  ✓  featured plan 'Book Your Assessment' is visible and links to /buy (475ms)
  1 passed
```
Confirmed the live featured card markup: `<a href="/buy" class="card-cta card-cta-primary" data-cta="pricing-assessment">Book Your Assessment →`.

## Risk
Minimal — one test assertion, no app/product code. Turns the E2E smoke check green.