### PR TITLE
fix(hub): preserve /hub callback instead of redirecting unauth users to /feed (#1952)

### DIFF
--- a/mira-hub/src/middleware.test.ts
+++ b/mira-hub/src/middleware.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest, type NextFetchEvent } from "next/server";
+import middleware from "./middleware";
+
+// Next strips the `/hub` basePath before invoking middleware, so the paths the
+// middleware actually sees are basePath-relative ("/" for the bare /hub root,
+// "/feed/" for /hub/feed/). We construct requests with those stripped paths.
+// No session cookie is set → the unauthenticated branch returns before any JWE
+// decode, so these tests need no AUTH_SECRET / jose work.
+function unauth(path: string) {
+  const req = new NextRequest(new URL(`http://localhost${path}`));
+  return middleware(req, {} as NextFetchEvent);
+}
+
+function callbackOf(res: Response) {
+  const loc = res.headers.get("location");
+  if (!loc) throw new Error("expected a redirect Location header");
+  const url = new URL(loc);
+  // Strip the optional trailing slash (trailingSlash: true) so "/login" and
+  // "/login/" compare equal — only the callbackUrl value matters for this bug.
+  return { pathname: url.pathname.replace(/\/$/, "") || "/", callbackUrl: url.searchParams.get("callbackUrl") };
+}
+
+describe("middleware — unauthenticated callback preservation (#1952)", () => {
+  it("preserves the basepath root as the callback instead of /feed", async () => {
+    const res = await unauth("/");
+    const { pathname, callbackUrl } = callbackOf(res);
+    expect(pathname).toBe("/login");
+    // The bug: root was pre-redirected to /feed, so the callback became /feed.
+    expect(callbackUrl).toBe("/");
+    expect(callbackUrl).not.toBe("/feed");
+    expect(callbackUrl).not.toBe("/feed/");
+  });
+
+  it("does NOT pre-redirect an unauthenticated root request to /feed", async () => {
+    const res = await unauth("/");
+    // Must bounce to /login, never straight to /feed (which would drop the dest).
+    expect(callbackOf(res).pathname).toBe("/login");
+  });
+
+  it("still preserves /feed for the existing feed login flow", async () => {
+    const res = await unauth("/feed/");
+    const { pathname, callbackUrl } = callbackOf(res);
+    expect(pathname).toBe("/login");
+    expect(callbackUrl).toBe("/feed/");
+  });
+
+  it("preserves an arbitrary protected route as its own callback", async () => {
+    const res = await unauth("/assets/");
+    expect(callbackOf(res).callbackUrl).toBe("/assets/");
+  });
+});

--- a/mira-hub/src/middleware.ts
+++ b/mira-hub/src/middleware.ts
@@ -156,16 +156,6 @@ export default async function middleware(req: NextRequest, _ev: NextFetchEvent) 
   const nonce = b64Nonce(crypto.randomUUID());
   const csp = buildCsp(nonce, pathname);
 
-  // Basepath root → /feed. `redirect()` from a Server Component is silently
-  // swallowed in Next.js 16.2.4 standalone + basePath (response comes back
-  // chunked, 0 bytes, no Location header), so the redirect has to live here.
-  if (pathname === "/") {
-    const url = req.nextUrl.clone();
-    url.pathname = "/feed";
-    url.search = "";
-    return applySecurityHeaders(NextResponse.redirect(url), pathname, csp);
-  }
-
   const cookieValue =
     req.cookies.get(SECURE_NAME)?.value ?? req.cookies.get(REGULAR_NAME)?.value;
   const secret = process.env.AUTH_SECRET ?? process.env.NEXTAUTH_SECRET ?? "";
@@ -202,6 +192,19 @@ export default async function middleware(req: NextRequest, _ev: NextFetchEvent) 
     url.pathname = "/login";
     url.search = "";
     url.searchParams.set("callbackUrl", pathname);
+    return applySecurityHeaders(NextResponse.redirect(url), pathname, csp);
+  }
+
+  // Authenticated. Basepath root → /feed (the default landing surface).
+  // Placed AFTER the auth gate, not before it: an UNAUTHENTICATED root request
+  // must preserve "/" as its login callback, not be pre-redirected to /feed and
+  // come back with callbackUrl=/feed, losing the destination (#1952). `redirect()`
+  // from a Server Component is silently swallowed in Next.js 16.2.4 standalone +
+  // basePath (chunked 0-byte response, no Location header), so it lives here.
+  if (pathname === "/") {
+    const url = req.nextUrl.clone();
+    url.pathname = "/feed";
+    url.search = "";
     return applySecurityHeaders(NextResponse.redirect(url), pathname, csp);
   }
 


### PR DESCRIPTION
## What
Unauthenticated visits to `/hub` redirected to `/login/?callbackUrl=%2Ffeed%2F`, losing the requested destination. Now the requested route is preserved as the callback.

## Root cause
`mira-hub` runs with `basePath: '/hub'` + `trailingSlash: true`, so the bare `/hub` URL reaches `middleware.ts` as the basePath-stripped pathname `"/"`. The middleware redirected `"/" → /feed` **before** the auth gate. So for an unauthenticated user:
1. `/hub` (internal `/`) → pre-redirected to `/feed`
2. the follow-up `/feed` request hits the no-cookie branch → `callbackUrl=/feed`

The original destination was gone before auth ever ran.

## Fix
Move the root → `/feed` redirect to **after** the cookie/token auth checks, so it only applies to **authenticated** users. An unauthenticated root request now falls through to the login bounce and preserves `"/"` as its callback — basePath-stripped, exactly like the existing `/feed` callback appears as `%2Ffeed%2F` (the consumer, `login-form.tsx`'s `router.push(callbackUrl)`, re-adds the `/hub` basePath). After login the user returns to `/hub`, which forwards to `/feed` as designed.

> Note on the issue's literal `%2Fhub%2F`: `/hub` is the basePath **root**, which Next strips to `"/"` before middleware sees it — so the correct, convention-consistent callback is `"/"` (it round-trips back to `/hub`). Emitting a literal `/hub/` callback would double-prefix to `/hub/hub/` once `router.push` re-adds the basePath. The behavioral intent — *preserve the requested route, don't hardcode `/feed`* — is fully met.

## Behavior matrix
| Request (unauth unless noted) | Before | After |
|---|---|---|
| `/hub` (root) | `/login?callbackUrl=/feed` ❌ | `/login?callbackUrl=/` ✅ |
| `/hub/feed` | `/login?callbackUrl=/feed` | `/login?callbackUrl=/feed` (unchanged) |
| `/hub/assets` | `/login?callbackUrl=/assets` | `/login?callbackUrl=/assets` (unchanged) |
| `/hub` (authenticated) | → `/feed` | → `/feed` (unchanged) |

## Acceptance criteria (#1952)
- [x] Visiting `/hub` unauthenticated preserves the root (`/`) as the callback, not `/feed`
- [x] Successful login returns to `/hub` (which forwards to `/feed` as designed)
- [x] Existing `/feed` login flow still works (callback unchanged)
- [x] Regression coverage added — `src/middleware.test.ts` (first middleware unit test)

## Tests
```
$ npx vitest run src/middleware.test.ts   # 4/4 passed
$ npx vitest run                          # 538 passed
$ npx tsc --noEmit                        # no errors in middleware files
$ npx eslint src/middleware.ts src/middleware.test.ts
```
The new test constructs basePath-stripped `NextRequest`s with no session cookie (the unauth branch returns before any JWE decode, so no `AUTH_SECRET`/jose needed) and asserts the `callbackUrl`.

**Pre-existing, not introduced here:** the one failing test file (`src/lib/knowledge-graph/analysis.ts`) fails to import `graphology` — a missing-dep artifact untouched by this PR. The single eslint warning (`_ev` unused in the middleware signature) is pre-existing on the original function signature; left per surgical-changes.

## Verification notes
Logic verified via the 4 unit tests + full suite. **Rendered/browser flow not exercised locally** (needs a Doppler/Neon session; prod auth is real). The change is a control-flow reorder with no new dependencies. Recommend a reviewer confirm the unauthenticated `app.factorylm.com/hub` → `/login/?callbackUrl=%2F` → post-login lands on the Hub.

## Risk / blast radius
Low. One control-flow reorder in `middleware.ts` (no API/schema/data changes). The authenticated root→feed redirect and all existing protected-route callbacks are unchanged; only the unauthenticated *root* path changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)