### PR TITLE
chore(saas): pass display-allowlist env into mira-hub (makes PR #1960 SSRF control usable)

### DIFF
--- a/docker-compose.saas.yml
+++ b/docker-compose.saas.yml
@@ -553,6 +553,10 @@ services:
       - "127.0.0.1:3101:3000"
     environment:
       - NEON_DATABASE_URL=${NEON_DATABASE_URL:-}
+      # Command Center display registration SSRF lockdown (PR #1960): comma-separated
+      # exact hosts allowed as live-display probe targets. Empty = link-local/metadata
+      # block only (pure code). Set in Doppler factorylm/prd to bound the surface.
+      - COMMAND_CENTER_DISPLAY_HOST_ALLOWLIST=${COMMAND_CENTER_DISPLAY_HOST_ALLOWLIST:-}
       - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-https://app.factorylm.com}
       # AES-256-GCM key for at-rest encryption of OAuth tokens in hub_channel_bindings
       - OAUTH_TOKEN_ENC_KEY=${OAUTH_TOKEN_ENC_KEY:-}


### PR DESCRIPTION
Follow-up to #1960. mira-hub uses an explicit compose `environment:` block, so `COMMAND_CENTER_DISPLAY_HOST_ALLOWLIST` was never reaching the container — the allowlist SSRF control was inert in prod (the link-local/metadata block is pure code and still applies). Adds the passthrough so the control can be enabled via Doppler `factorylm/prd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)