### PR TITLE
feat(plc-parser): Structured Text + PLCopen XML parsers (Phase 5) + golden contract

### DIFF
--- a/mira-plc-parser/.gitignore
+++ b/mira-plc-parser/.gitignore
@@ -3,3 +3,15 @@ tests/corpus/*.L5X
 tests/corpus/*.md
 tests/corpus/*.txt
 tests/corpus/*.csv
+
+# Standalone-exe build artifacts — built on demand, never committed (see PACKAGING.md).
+# Only the spec (mira-plc-parser.spec) and PACKAGING.md are tracked; the per-platform
+# binary and PyInstaller's working dir are not.
+/build/
+/dist/
+
+# CLI report outputs written during local runs / tests (<stem>.report.md / .json).
+*.report.md
+*.report.json
+# ...EXCEPT the golden snapshots, which are the committed report@1 contract (not run output).
+!tests/fixtures/golden/*.report.json

--- a/mira-plc-parser/README.md
+++ b/mira-plc-parser/README.md
@@ -25,16 +25,19 @@ upload → detect format → vendor parser → MIRA PLC IR → deterministic ana
                                           (the neutral model)   (rule-based first; LLM explains later)
 ```
 
-## What's built (Phase 1)
+## What's built (Phase 1–2)
 
 | Stage | Status |
 |---|---|
-| File-format / vendor **detector** (content-first) | ✅ L5X, CSV, +routing stubs for PLCopen XML / Siemens / ST |
+| File-format / vendor **detector** (content-first) | ✅ L5X, CSV, PLCopen XML, ST; +routing stub for Siemens |
 | **Rockwell L5X parser** → IR (controller, datatypes, tags, programs, routines, rungs, rung logic) | ✅ |
 | **CSV tag-export** → IR (reuses the tested `tag_csv` multi-vendor parser) | ✅ |
+| **Structured Text (.st) parser** → IR (VAR decls → tags, POU body → ST routine, assignments → synthetic rungs) | ✅ |
+| **PLCopen XML parser** → IR (namespace-agnostic tc6; interface vars → tags, ST body reuses the ST lift) | ✅ |
 | **MIRA PLC IR** (Controller → Program → Routine → Rung → Tag, + provenance + confidence) | ✅ |
 | **Deterministic analysis**: tag dictionary, routine summaries, output-dependency map, fault candidates, asset candidates, VFD-signal candidates, usage cross-reference, safety **review** flags | ✅ |
-| Markdown report renderer | ✅ |
+| Name tokenizer handles **camelCase humps** (`fault` in `FaultRoutine`) as well as `_`/digit breaks | ✅ |
+| Markdown + JSON report renderers; JSON shape pinned by **golden snapshots** (`report@1`) | ✅ |
 
 ## Install & CLI
 
@@ -72,6 +75,36 @@ print(result.report.output_dependencies) # structured findings
 print(result.project.all_tags())         # the IR
 ```
 
+## Report schema (`mira-plc-parser/report@1`)
+
+`render_json(result)` returns a stable, `json.dumps`-safe dict — the contract downstream MIRA
+ingest consumes. Its shape is pinned by golden snapshots (`tests/fixtures/golden/`); any change to
+fields, counts, ordering, or candidate sets is a deliberate, reviewed bump.
+
+```jsonc
+{
+  "schema": "mira-plc-parser/report@1",
+  "detection": { "fmt": "structured_text", "confidence": "high", "reason": "...", "needs_export": "" },
+  "handled": true,                       // false for closed-project / unknown (then only the keys below it)
+  "controller": "ConveyorControl",
+  "vendor": "IEC 61131-3",
+  "counts": { "controllers": 1, "tags": 12, "programs": 1, "routines": 1, "rungs": 3,
+              "outputs": 2, "fault_candidates": 4, "asset_candidates": 3,
+              "vfd_signal_candidates": 4, "review_required": 1 },
+  "review_required":      [ {"kind","name","detail","confidence","evidence":[...]} ],
+  "output_dependencies":  [ {"kind":"output","name","detail":"true when: ...","confidence","evidence"} ],
+  "fault_candidates":     [ {"kind":"fault", ...} ],
+  "asset_candidates":     [ {"kind":"asset", ...} ],
+  "vfd_signal_candidates":[ {"kind":"vfd_signal","detail":"candidate role: frequency", ...} ],
+  "routine_summaries":    [ {"program","routine","type","rungs","outputs_controlled",...} ],
+  "tag_dictionary":       [ {"name","data_type","scope","description","address","roles","used_count",...} ],
+  "warnings": [ ... ]
+}
+```
+
+An unhandled result (`handled: false`) carries only `schema`, `detection`, `handled`, and
+`warnings` — e.g. a closed `.ACD` returns `detection.needs_export` with the precise export steps.
+
 ## Confidence grading
 
 Every extracted/inferred fact is graded (this protects you and looks professional):
@@ -90,11 +123,11 @@ product is **read-only analysis of exported programs** — safer and easier to s
 ## Roadmap
 
 1. **Phase 1 (done):** Rockwell L5X + CSV → IR + deterministic analysis.
-2. **Eval dataset:** public + synthetic L5X / OpenPLC / PLCopen / ST samples.
-3. **IR hardening:** the schema is the asset; grow it as new formats arrive.
-4. **Analysis depth:** timers→fault chains, permissives/interlocks, sequence/state extraction.
-5. **PLCopen XML + Structured Text** parsers (ST becomes the reasoning bridge).
-6. **Siemens** via TIA Portal Openness XML exports (not closed project files).
+2. **Eval dataset (done):** synthetic L5X / CSV / ST / PLCopen fixtures + golden `report@1` snapshots.
+3. **IR hardening (done):** `report@1` shape pinned by golden tests; camelCase tokenizer fix.
+4. **PLCopen XML + Structured Text (done):** ST is the reasoning bridge; PLCopen reuses the ST lift.
+5. **Analysis depth (next):** timers→fault chains, permissives/interlocks, sequence/state extraction.
+6. **Siemens** via TIA Portal Openness XML exports (not closed project files) — recognized, parser pending.
 7. **PDF / screenshot** fallback (OCR, low confidence) — last.
 
 ## Tests
@@ -103,9 +136,11 @@ product is **read-only analysis of exported programs** — safer and easier to s
 python -m pytest mira-plc-parser/tests/ -q
 ```
 
-Fixture-based: a synthetic conveyor `conveyor.L5X` (VFD tags + an e-stop to exercise the review
-path) and a Kepware-dialect `gs10_tags.csv`. 25 tests cover detection, L5X extraction, rung-logic
-parsing, the full analysis, and graceful handling of unknown/planned formats.
+Fixture-based across all four formats: a synthetic conveyor `conveyor.L5X` (VFD tags + an e-stop to
+exercise the review path), a Kepware-dialect `gs10_tags.csv`, a camelCase `conveyor.st`, and a
+`conveyor.plcopen.xml`. The suite covers detection, every parser's extraction, rung-logic parsing,
+the tokenizer's camelCase handling, the full analysis, golden `report@1` snapshots, graceful
+handling of unknown/planned/closed-project formats, and the CLI/packaging path resolution.
 
 ## Layout
 
@@ -116,7 +151,9 @@ mira_plc_parser/
   parsers/
     rockwell_l5x.py  # L5X → IR
     csv_tags.py      # CSV → IR (reuses ignition/.../diagnose/tag_csv.py)
-  analyze.py         # deterministic maintenance analysis
+    structured_text.py # IEC 61131-3 ST → IR (VAR decls + assignments → rungs)
+    plcopen_xml.py   # PLCopen tc6 XML → IR (reuses the ST body lift)
+  analyze.py         # deterministic maintenance analysis (camelCase-aware tokenizer)
   pipeline.py        # detect → parse → analyze → report (render_markdown / render_json)
   cli.py             # offline CLI (analyze → local report files)
   __main__.py        # `python -m mira_plc_parser`

--- a/mira-plc-parser/mira_plc_parser/analyze.py
+++ b/mira-plc-parser/mira_plc_parser/analyze.py
@@ -18,13 +18,23 @@ from dataclasses import dataclass, field
 
 from .ir import Confidence, PLCProject, Tag
 
-
 # --- name-pattern vocabularies (MEDIUM-confidence inference) ---
 # PLC tag names are underscore/camelCase (Motor_Run, VFD_FaultCode), so a plain \b boundary fails
-# (underscore is a \w char). _kw() builds a LETTER-boundary matcher: a keyword matches when it is
-# not flanked by other letters -- so '_' , digits, spaces, and camelCase humps all act as breaks.
+# (underscore is a \w char). _kw() builds a word matcher whose boundaries are: a non-letter neighbor
+# (`_`, digit, space, symbol, start/end) OR a camelCase hump -- a lowercase/digit -> Uppercase
+# transition. Without the hump rule, "fault" fused into "FaultRoutine"/"MotorFault" was missed.
+# The boundaries only ADD matches (each is a `non-letter OR hump` alternation), so underscore-style
+# names behave exactly as before. A keyword buried in a lowercase run ("defaulting") still won't
+# match -- there is no boundary on either side.
+# Boundaries are case-SENSITIVE (a hump is literally lowercase/digit -> Uppercase), so they must
+# not be compiled under re.I -- otherwise [a-z]/[A-Z] would match either case and "defaulting" would
+# match "fault". Case-insensitivity is scoped to just the keyword body via an inline (?i:...) group.
+_LEFT_BOUND = r"(?:(?<![A-Za-z])|(?<=[a-z0-9])(?=[A-Z]))"
+_RIGHT_BOUND = r"(?:(?![A-Za-z])|(?<=[a-z0-9])(?=[A-Z]))"
+
+
 def _kw(words):
-    return re.compile(r"(?<![A-Za-z])(?:" + "|".join(words) + r")(?![A-Za-z])", re.I)
+    return re.compile(_LEFT_BOUND + r"(?i:" + "|".join(words) + r")" + _RIGHT_BOUND)
 
 
 _FAULT_PAT = _kw(["fault", "trip", "alarm", "estop", "fail", "error", "overload", "jam"])

--- a/mira-plc-parser/mira_plc_parser/parsers/plcopen_xml.py
+++ b/mira-plc-parser/mira_plc_parser/parsers/plcopen_xml.py
@@ -1,0 +1,184 @@
+"""PLCopen XML (TC6, tc6_0200 / tc6_0201) parser -> MIRA PLC IR.
+
+PLCopen XML is the vendor-neutral interchange format that CODESYS, OpenPLC/Beremiz, and others
+export. Shape (abridged, namespaced under http://www.plcopen.org/xml/tc6_0201):
+
+  <project>
+    <fileHeader companyName="..." productName="..."/>
+    <contentHeader name="ProjectName"/>
+    <types><pous>
+      <pou name="ConveyorControl" pouType="program">
+        <interface>
+          <localVars><variable name="MotorRun"><type><BOOL/></type>
+            <documentation><xhtml>...</xhtml></documentation></variable> ... </localVars>
+          <globalVars> ... </globalVars>
+        </interface>
+        <body><ST><xhtml>IF ... THEN MotorRun := TRUE; END_IF;</xhtml></ST></body>
+      </pou>
+    </pous></types>
+
+Mapping: each <pou> -> a Program; interface variables -> Tags (globalVars -> controller scope,
+the rest -> program scope); an <ST> body -> an ST Routine whose statements are lifted into rungs
+via the shared ST helper (so a PLCopen ST body and a raw .st file analyze identically).
+
+Namespace-agnostic: we match by local element name, so tc6_0200 and tc6_0201 both parse.
+Read-only, stdlib-only (xml.etree).
+"""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+
+from ..ir import (
+    Confidence,
+    Controller,
+    PLCProject,
+    Program,
+    Provenance,
+    Routine,
+    RoutineType,
+    Tag,
+    TagScope,
+)
+from .structured_text import _statements_to_rungs
+
+FORMAT = "plcopen_xml"
+
+# interface var sections -> IR scope. globalVars are controller-wide; everything else is POU-local.
+_VAR_SECTIONS = {
+    "localVars": TagScope.PROGRAM.value,
+    "tempVars": TagScope.PROGRAM.value,
+    "inputVars": TagScope.PROGRAM.value,
+    "outputVars": TagScope.PROGRAM.value,
+    "inOutVars": TagScope.PROGRAM.value,
+    "externalVars": TagScope.PROGRAM.value,
+    "globalVars": TagScope.CONTROLLER.value,
+}
+
+
+def _ln(tag: str) -> str:
+    """Local element name (drop the {namespace} prefix ElementTree prepends)."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _child(el: ET.Element, name: str) -> ET.Element | None:
+    return next((c for c in el if _ln(c.tag) == name), None)
+
+
+def _descendants(root: ET.Element, name: str) -> list[ET.Element]:
+    return [e for e in root.iter() if _ln(e.tag) == name]
+
+
+def _prov(src: str, locator: str) -> Provenance:
+    return Provenance(source_file=src, source_format=FORMAT, locator=locator, confidence=Confidence.HIGH)
+
+
+def parse(text: str, source_file: str = "") -> PLCProject:
+    """Parse PLCopen XML into a PLCProject. Malformed XML / no pou -> a warning, never a crash."""
+    proj = PLCProject(source_format=FORMAT, source_files=[source_file] if source_file else [])
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError as e:
+        proj.warnings.append("PLCopen XML parse error: %s" % e)
+        return proj
+
+    header = _child(root, "fileHeader")
+    content = _child(root, "contentHeader")
+    vendor = (header.get("companyName") if header is not None else "") or ""
+    software = (header.get("productName") if header is not None else "") or "PLCopen XML"
+    proj_name = (content.get("name") if content is not None else "") or ""
+
+    pous = _descendants(root, "pou")
+    if not pous:
+        proj.warnings.append("no <pou> element found in PLCopen XML")
+        return proj
+
+    ctrl = Controller(
+        name=proj_name or pous[0].get("name", ""),
+        vendor=vendor or "PLCopen",
+        software=software,
+        provenance=_prov(source_file, "project[%s]" % proj_name),
+    )
+    for pou in pous:
+        _parse_pou(pou, ctrl, source_file)
+    proj.controllers.append(ctrl)
+    return proj
+
+
+def _parse_pou(pou: ET.Element, ctrl: Controller, src: str) -> None:
+    name = pou.get("name", "")
+    prog = Program(name=name)
+    iface = _child(pou, "interface")
+    if iface is not None:
+        for section in iface:
+            scope = _VAR_SECTIONS.get(_ln(section.tag))
+            if scope is None:
+                continue
+            for var_el in _descendants(section, "variable"):
+                tag = _parse_variable(var_el, scope, name, src)
+                (ctrl.tags if scope == TagScope.CONTROLLER.value else prog.tags).append(tag)
+
+    routine = _parse_body(pou, name, src)
+    if routine is not None:
+        prog.routines.append(routine)
+    ctrl.programs.append(prog)
+
+
+def _parse_variable(var_el: ET.Element, scope: str, pou: str, src: str) -> Tag:
+    name = var_el.get("name", "")
+    return Tag(
+        name=name,
+        data_type=_type_name(_child(var_el, "type")),
+        scope=scope,
+        description=_doc_text(_child(var_el, "documentation")),
+        initial_value=_initial_value(_child(var_el, "initialValue")),
+        provenance=_prov(src, "%s/Var[%s]" % (pou, name)),
+    )
+
+
+def _type_name(type_el: ET.Element | None) -> str:
+    """A <type> wraps one child: an elementary marker (<BOOL/>) or <derived name="UDT"/>."""
+    if type_el is None:
+        return ""
+    child = next(iter(type_el), None)
+    if child is None:
+        return (type_el.text or "").strip()
+    local = _ln(child.tag)
+    return child.get("name", "") if local == "derived" else local
+
+
+def _doc_text(doc_el: ET.Element | None) -> str:
+    if doc_el is None:
+        return ""
+    return " ".join(t.strip() for t in doc_el.itertext() if t.strip())
+
+
+def _initial_value(iv_el: ET.Element | None) -> str:
+    if iv_el is None:
+        return ""
+    simple = _child(iv_el, "simpleValue")
+    if simple is not None:
+        return simple.get("value", "")
+    return " ".join(t.strip() for t in iv_el.itertext() if t.strip())
+
+
+def _parse_body(pou: ET.Element, name: str, src: str) -> Routine | None:
+    body = _child(pou, "body")
+    if body is None:
+        return None
+    # PLCopen bodies: ST (text) | LD | FBD | SFC (graphical). We extract ST fully; for graphical
+    # bodies we record the language so the report still reflects the routine exists.
+    for lang in ("ST", "IL", "LD", "FBD", "SFC"):
+        el = _child(body, lang)
+        if el is None:
+            continue
+        if lang in ("ST", "IL"):
+            st_text = "\n".join(t for t in (s.strip("\n") for s in el.itertext()) if t.strip())
+            routine = Routine(
+                name=name, type=RoutineType.ST.value, st_text=st_text,
+                provenance=_prov(src, "%s/Body/ST" % name),
+            )
+            routine.rungs = _statements_to_rungs(st_text, name, src)
+            return routine
+        rtype = {"LD": RoutineType.RLL, "FBD": RoutineType.FBD, "SFC": RoutineType.SFC}[lang]
+        return Routine(name=name, type=rtype.value, provenance=_prov(src, "%s/Body/%s" % (name, lang)))
+    return None

--- a/mira-plc-parser/mira_plc_parser/parsers/structured_text.py
+++ b/mira-plc-parser/mira_plc_parser/parsers/structured_text.py
@@ -1,0 +1,179 @@
+"""IEC 61131-3 Structured Text (.st / .scl / .exp) parser -> MIRA PLC IR.
+
+ST is vendor-neutral and is the "reasoning bridge": it is the lowest-common-denominator export that
+CODESYS / OpenPLC / TwinCAT / Siemens-SCL can all produce, and it is plain text. We extract the
+structural facts only (HIGH confidence) -- interpretation stays in the analysis layer:
+
+  * VAR ... END_VAR declarations  -> IR Tags (VAR_GLOBAL -> controller scope; others -> program scope)
+  * each POU (PROGRAM / FUNCTION_BLOCK / FUNCTION) -> a Program with one ST Routine
+  * the POU body is preserved verbatim as Routine.st_text, AND each `LHS := expr;` assignment is
+    lifted into a synthetic Rung (output = LHS, condition refs = the tags in the statement) so the
+    existing rung-based analysis (output dependencies, usage x-ref) works on ST too.
+
+Read-only: parses text, never writes. No vendor SDK, no network -- stdlib only.
+"""
+from __future__ import annotations
+
+import re
+
+from ..ir import (
+    Confidence,
+    Controller,
+    PLCProject,
+    Program,
+    Provenance,
+    Routine,
+    RoutineType,
+    Rung,
+    Tag,
+    TagScope,
+)
+
+FORMAT = "structured_text"
+
+# POU block: PROGRAM/FUNCTION_BLOCK/FUNCTION <name> ... END_<kind>
+_POU_RE = re.compile(
+    r"\b(PROGRAM|FUNCTION_BLOCK|FUNCTION)\b\s+([A-Za-z_]\w*).*?\bEND_\1\b",
+    re.IGNORECASE | re.DOTALL,
+)
+# a VAR section (any flavour) up to its END_VAR
+_VAR_BLOCK_RE = re.compile(
+    r"\b(VAR(?:_INPUT|_OUTPUT|_IN_OUT|_GLOBAL|_TEMP|_EXTERNAL|_ACCESS)?)\b"
+    r"(?:\s+(?:CONSTANT|RETAIN|PERSISTENT))?\s*(.*?)\bEND_VAR\b",
+    re.IGNORECASE | re.DOTALL,
+)
+# one declaration line:  name : TYPE [:= init] ;  [(* comment *) | // comment]
+_DECL_RE = re.compile(
+    r"^\s*([A-Za-z_]\w*)\s*:\s*([A-Za-z_]\w*(?:\s*\[[^\]]*\])?)\s*"
+    r"(?::=\s*(.*?))?\s*;\s*(?:\(\*(.*?)\*\)|//(.*))?\s*$",
+    re.DOTALL,
+)
+_BLOCK_COMMENT_RE = re.compile(r"\(\*.*?\*\)", re.DOTALL)
+_LINE_COMMENT_RE = re.compile(r"//[^\n]*")
+_IDENT_RE = re.compile(r"[A-Za-z_]\w*")
+_ASSIGN_LHS_RE = re.compile(r"([A-Za-z_][\w.\[\]]*)\s*:=")
+
+# ST control keywords, boolean literals, and elementary types -- never IR tag references.
+_STOPWORDS = {
+    "IF", "THEN", "ELSE", "ELSIF", "END_IF", "CASE", "OF", "END_CASE", "FOR", "TO", "BY", "DO",
+    "END_FOR", "WHILE", "END_WHILE", "REPEAT", "UNTIL", "END_REPEAT", "RETURN", "EXIT", "CONTINUE",
+    "AND", "OR", "XOR", "NOT", "MOD", "TRUE", "FALSE", "NULL", "AT",
+    "BOOL", "SINT", "INT", "DINT", "LINT", "USINT", "UINT", "UDINT", "ULINT", "REAL", "LREAL",
+    "TIME", "DATE", "STRING", "WSTRING", "BYTE", "WORD", "DWORD", "LWORD",
+    "TON", "TOF", "TP", "CTU", "CTD", "CTUD", "R_TRIG", "F_TRIG",
+}
+
+
+def _prov(src: str, locator: str) -> Provenance:
+    return Provenance(source_file=src, source_format=FORMAT, locator=locator, confidence=Confidence.HIGH)
+
+
+def parse(text: str, source_file: str = "") -> PLCProject:
+    """Parse ST text into a PLCProject. No POU found -> a project with a warning (no crash)."""
+    proj = PLCProject(source_format=FORMAT, source_files=[source_file] if source_file else [])
+    pous = list(_POU_RE.finditer(text or ""))
+    if not pous:
+        proj.warnings.append("no PROGRAM/FUNCTION_BLOCK/FUNCTION block found in ST source")
+        return proj
+
+    ctrl = Controller(
+        name=pous[0].group(2),
+        vendor="IEC 61131-3",
+        software="Structured Text (IEC 61131-3)",
+        provenance=_prov(source_file, "POU[%s]" % pous[0].group(2)),
+    )
+    for m in pous:
+        _parse_pou(m.group(1), m.group(2), m.group(0), ctrl, source_file)
+    proj.controllers.append(ctrl)
+    return proj
+
+
+def _parse_pou(kind: str, name: str, block: str, ctrl: Controller, src: str) -> None:
+    prog = Program(name=name)
+    body = block
+    for vm in _VAR_BLOCK_RE.finditer(block):
+        section = vm.group(1).upper()
+        is_global = section == "VAR_GLOBAL"
+        scope = TagScope.CONTROLLER.value if is_global else TagScope.PROGRAM.value
+        for tag in _parse_var_block(vm.group(2), scope, name, src):
+            (ctrl.tags if is_global else prog.tags).append(tag)
+        body = body.replace(vm.group(0), "\n")   # drop declarations from the executable body
+
+    routine = Routine(
+        name=name, type=RoutineType.ST.value,
+        st_text=_body_text(kind, name, body),
+        provenance=_prov(src, "%s/Routine[%s]" % (name, name)),
+    )
+    routine.rungs = _statements_to_rungs(routine.st_text, name, src)
+    prog.routines.append(routine)
+    ctrl.programs.append(prog)
+
+
+def _parse_var_block(block: str, scope: str, pou: str, src: str) -> list[Tag]:
+    """One declaration per line (`name : TYPE [:= init];  (* comment *)`), as ST exports emit them.
+
+    Parsed line-by-line, NOT by splitting on ';': the inline comment sits *after* the ';' on the
+    same line, so a ';'-split would mis-attach each comment to the following declaration.
+    """
+    tags: list[Tag] = []
+    for raw in block.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("(*") or line.startswith("//"):
+            continue
+        m = _DECL_RE.match(line)
+        if not m:
+            continue
+        comment = (m.group(4) or m.group(5) or "").strip()
+        tags.append(Tag(
+            name=m.group(1),
+            data_type=re.sub(r"\s+", "", m.group(2)),
+            scope=scope,
+            description=comment,
+            initial_value=(m.group(3) or "").strip(),
+            provenance=_prov(src, "%s/Var[%s]" % (pou, m.group(1))),
+        ))
+    return tags
+
+
+def _body_text(kind: str, name: str, body: str) -> str:
+    """The executable statements of a POU: strip the POU header/footer keywords, keep the logic."""
+    txt = re.sub(r"^\s*%s\s+%s\b" % (kind, re.escape(name)), "", body, count=1, flags=re.IGNORECASE)
+    txt = re.sub(r"\bEND_%s\b\s*$" % kind, "", txt, count=1, flags=re.IGNORECASE)
+    return txt.strip()
+
+
+def _strip_comments(text: str) -> str:
+    return _LINE_COMMENT_RE.sub("", _BLOCK_COMMENT_RE.sub(" ", text))
+
+
+def _statements_to_rungs(st_text: str, pou: str, src: str) -> list[Rung]:
+    """Lift `LHS := expr;` assignments into synthetic rungs so rung-based analysis works on ST.
+
+    LHS is the driven output; every other identifier in the statement is a condition ref. This is a
+    deliberate, conservative model -- IF/CASE wrappers contribute their guard tags as refs, which is
+    exactly what the output-dependency view wants ("MotorRun true when: StartPB, EStopOK, ...").
+    """
+    code = _strip_comments(st_text)
+    rungs: list[Rung] = []
+    n = 0
+    for stmt in code.split(";"):
+        if ":=" not in stmt:
+            continue
+        lhs_m = _ASSIGN_LHS_RE.search(stmt)
+        if not lhs_m:
+            continue
+        output = lhs_m.group(1).split(".")[0].split("[")[0]
+        refs: list[str] = []
+        seen: set[str] = set()
+        for im in _IDENT_RE.finditer(stmt):
+            tok = im.group(0)
+            if tok.upper() in _STOPWORDS or tok in seen:
+                continue
+            seen.add(tok)
+            refs.append(tok)
+        rungs.append(Rung(
+            number=n, text=stmt.strip(), refs=refs, outputs=[output], instructions=[":="],
+            provenance=_prov(src, "%s/Rung[%d]" % (pou, n)),
+        ))
+        n += 1
+    return rungs

--- a/mira-plc-parser/mira_plc_parser/pipeline.py
+++ b/mira-plc-parser/mira_plc_parser/pipeline.py
@@ -10,15 +10,17 @@ from dataclasses import dataclass
 from . import analyze as _analyze
 from .detect import Detection, detect
 from .ir import PLCProject
-from .parsers import csv_tags, rockwell_l5x
+from .parsers import csv_tags, plcopen_xml, rockwell_l5x, structured_text
 
 # format key -> parser module (each exposes parse(text, source_file) -> PLCProject)
 _PARSERS = {
     "rockwell_l5x": rockwell_l5x,
     "csv_tags": csv_tags,
+    "structured_text": structured_text,
+    "plcopen_xml": plcopen_xml,
 }
 # recognized-but-not-yet-built parsers (routing is ready; extraction is a later phase)
-_PLANNED = {"plcopen_xml", "siemens_tia_xml", "structured_text"}
+_PLANNED = {"siemens_tia_xml"}
 
 
 @dataclass

--- a/mira-plc-parser/tests/fixtures/conveyor.plcopen.xml
+++ b/mira-plc-parser/tests/fixtures/conveyor.plcopen.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://www.plcopen.org/xml/tc6_0201">
+  <fileHeader companyName="OpenPLC" productName="OpenPLC Editor" productVersion="1.0"
+              creationDateTime="2026-06-17T08:00:00"/>
+  <contentHeader name="ConveyorCellPLCopen">
+    <coordinateInfo>
+      <fbd><scaling x="1" y="1"/></fbd><ld><scaling x="1" y="1"/></ld><sfc><scaling x="1" y="1"/></sfc>
+    </coordinateInfo>
+  </contentHeader>
+  <types>
+    <dataTypes/>
+    <pous>
+      <pou name="ConveyorControl" pouType="program">
+        <interface>
+          <localVars>
+            <variable name="StartPB"><type><BOOL/></type>
+              <documentation><xhtml xmlns="http://www.w3.org/1999/xhtml">operator start pushbutton</xhtml></documentation>
+            </variable>
+            <variable name="EStopOK"><type><BOOL/></type>
+              <documentation><xhtml xmlns="http://www.w3.org/1999/xhtml">emergency-stop circuit healthy</xhtml></documentation>
+            </variable>
+            <variable name="AutoMode"><type><BOOL/></type></variable>
+            <variable name="JamPhotoeye"><type><BOOL/></type></variable>
+            <variable name="MotorRun"><type><BOOL/></type>
+              <documentation><xhtml xmlns="http://www.w3.org/1999/xhtml">conveyor VFD run command</xhtml></documentation>
+            </variable>
+            <variable name="ConvFault"><type><BOOL/></type></variable>
+            <variable name="VFD_Frequency"><type><REAL/></type>
+              <documentation><xhtml xmlns="http://www.w3.org/1999/xhtml">drive output frequency Hz</xhtml></documentation>
+            </variable>
+            <variable name="VFD_Current"><type><REAL/></type></variable>
+            <variable name="VFD_FaultCode"><type><DINT/></type>
+              <documentation><xhtml xmlns="http://www.w3.org/1999/xhtml">active drive fault code</xhtml></documentation>
+            </variable>
+          </localVars>
+          <globalVars>
+            <variable name="LineSpeedSetpoint"><type><REAL/></type>
+              <initialValue><simpleValue value="60.0"/></initialValue>
+            </variable>
+          </globalVars>
+        </interface>
+        <body>
+          <ST>
+            <xhtml xmlns="http://www.w3.org/1999/xhtml">IF StartPB AND EStopOK AND AutoMode AND NOT ConvFault THEN
+    MotorRun := TRUE;
+END_IF;
+IF VFD_FaultCode &gt; 0 OR (MotorRun AND JamPhotoeye) THEN
+    ConvFault := TRUE;
+END_IF;</xhtml>
+          </ST>
+        </body>
+      </pou>
+    </pous>
+  </types>
+  <instances><configurations/></instances>
+</project>

--- a/mira-plc-parser/tests/fixtures/conveyor.st
+++ b/mira-plc-parser/tests/fixtures/conveyor.st
@@ -1,0 +1,35 @@
+(* Conveyor cell logic - IEC 61131-3 Structured Text export.
+   camelCase identifiers on purpose: this is how a lot of CODESYS/OpenPLC code reads, and it is
+   exactly what the tokenizer must classify (MotorRun, ConvFault, EStopOK, ...). *)
+PROGRAM ConveyorControl
+VAR
+    StartPB       : BOOL;        (* operator start pushbutton *)
+    StopPB        : BOOL;        (* operator stop pushbutton *)
+    EStopOK       : BOOL;        (* emergency-stop circuit healthy (safety) *)
+    AutoMode      : BOOL;        (* line in automatic mode *)
+    JamPhotoeye   : BOOL;        (* jam-detection photo-eye *)
+    MotorRun      : BOOL;        (* conveyor VFD run command *)
+    ConvFault     : BOOL;        (* conveyor fault latch *)
+    VFD_Frequency : REAL;        (* drive output frequency Hz *)
+    VFD_Current   : REAL;        (* drive output current amps *)
+    VFD_FaultCode : DINT;        (* active drive fault code *)
+    RunTimer      : TON;         (* conveyor run-time accumulator *)
+END_VAR
+VAR_GLOBAL
+    LineSpeedSetpoint : REAL := 60.0;   (* freq setpoint, Hz *)
+END_VAR
+
+(* run the conveyor when started, in auto, e-stop healthy, no fault *)
+IF StartPB AND EStopOK AND AutoMode AND NOT ConvFault THEN
+    MotorRun := TRUE;
+END_IF;
+
+IF StopPB OR NOT EStopOK THEN
+    MotorRun := FALSE;
+END_IF;
+
+(* latch a fault when the drive reports one or the photo-eye blocks while running *)
+IF VFD_FaultCode > 0 OR (MotorRun AND JamPhotoeye) THEN
+    ConvFault := TRUE;
+END_IF;
+END_PROGRAM

--- a/mira-plc-parser/tests/fixtures/golden/conveyor.l5x.report.json
+++ b/mira-plc-parser/tests/fixtures/golden/conveyor.l5x.report.json
@@ -1,0 +1,362 @@
+{
+  "asset_candidates": [
+    {
+      "confidence": "medium",
+      "detail": "candidate asset (keyword: conv)",
+      "evidence": [
+        "Conv_Fault"
+      ],
+      "kind": "asset",
+      "name": "Conv"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate asset (keyword: motor)",
+      "evidence": [
+        "Motor_Run"
+      ],
+      "kind": "asset",
+      "name": "Motor"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate asset (keyword: vfd)",
+      "evidence": [
+        "VFD_Frequency",
+        "VFD_Current",
+        "VFD_FaultCode"
+      ],
+      "kind": "asset",
+      "name": "VFD"
+    }
+  ],
+  "controller": "ConveyorCell",
+  "counts": {
+    "aoi_definitions": 0,
+    "aoi_local_tags": 0,
+    "aoi_parameters": 0,
+    "asset_candidates": 3,
+    "controllers": 1,
+    "fault_candidates": 4,
+    "fbd_sheets": 0,
+    "module_definitions": 0,
+    "outputs": 3,
+    "programs": 1,
+    "review_required": 1,
+    "routines": 2,
+    "rungs": 3,
+    "tags": 11,
+    "vfd_signal_candidates": 3
+  },
+  "detection": {
+    "confidence": "high",
+    "fmt": "rockwell_l5x",
+    "needs_export": "",
+    "reason": "found <RSLogix5000Content> root"
+  },
+  "fault_candidates": [
+    {
+      "confidence": "review",
+      "detail": "Emergency stop healthy (safety circuit)",
+      "evidence": [
+        "Tag[@Name='EStop_OK']"
+      ],
+      "kind": "fault",
+      "name": "EStop_OK"
+    },
+    {
+      "confidence": "medium",
+      "detail": "Jam detection photo-eye",
+      "evidence": [
+        "Tag[@Name='Photoeye_1']"
+      ],
+      "kind": "fault",
+      "name": "Photoeye_1"
+    },
+    {
+      "confidence": "medium",
+      "detail": "Conveyor fault latch",
+      "evidence": [
+        "Tag[@Name='Conv_Fault']"
+      ],
+      "kind": "fault",
+      "name": "Conv_Fault"
+    },
+    {
+      "confidence": "medium",
+      "detail": "Active drive fault code",
+      "evidence": [
+        "Tag[@Name='VFD_FaultCode']"
+      ],
+      "kind": "fault",
+      "name": "VFD_FaultCode"
+    }
+  ],
+  "handled": true,
+  "output_dependencies": [
+    {
+      "confidence": "high",
+      "detail": "true when: Motor_Run, Photoeye_1",
+      "evidence": [
+        "MainProgram/MainRoutine/Rung[2]"
+      ],
+      "kind": "output",
+      "name": "Conv_Fault"
+    },
+    {
+      "confidence": "high",
+      "detail": "true when: Start_PB, Stop_PB, EStop_OK, Auto_Mode, Conv_Fault",
+      "evidence": [
+        "MainProgram/MainRoutine/Rung[0]"
+      ],
+      "kind": "output",
+      "name": "Motor_Run"
+    },
+    {
+      "confidence": "high",
+      "detail": "true when: Motor_Run",
+      "evidence": [
+        "MainProgram/MainRoutine/Rung[1]"
+      ],
+      "kind": "output",
+      "name": "Run_Timer"
+    }
+  ],
+  "review_required": [
+    {
+      "confidence": "review",
+      "detail": "Emergency stop healthy (safety circuit)",
+      "evidence": [
+        "Tag[@Name='EStop_OK']"
+      ],
+      "kind": "safety",
+      "name": "EStop_OK"
+    }
+  ],
+  "routine_summaries": [
+    {
+      "comment_digest": [
+        "Run the conveyor motor in auto when started, no e-stop, no fault",
+        "Accumulate conveyor run time",
+        "Photo-eye blocked while running latches a jam fault"
+      ],
+      "confidence": "high",
+      "outputs_controlled": [
+        "Conv_Fault",
+        "Motor_Run",
+        "Run_Timer"
+      ],
+      "program": "MainProgram",
+      "purpose_hint": "fault / alarm handling",
+      "routine": "MainRoutine",
+      "rungs": 3,
+      "type": "RLL"
+    },
+    {
+      "comment_digest": [],
+      "confidence": "high",
+      "outputs_controlled": [],
+      "program": "MainProgram",
+      "purpose_hint": "",
+      "routine": "FaultRoutine",
+      "rungs": 0,
+      "type": "ST"
+    }
+  ],
+  "schema": "mira-plc-parser/report@1",
+  "tag_dictionary": [
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "Conveyor VFD run command",
+      "name": "Motor_Run",
+      "roles": [
+        "output"
+      ],
+      "scope": "controller",
+      "used_count": 3,
+      "used_in": [
+        "MainProgram/MainRoutine/Rung[0]",
+        "MainProgram/MainRoutine/Rung[1]",
+        "MainProgram/MainRoutine/Rung[2]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "Conveyor fault latch",
+      "name": "Conv_Fault",
+      "roles": [
+        "output",
+        "fault"
+      ],
+      "scope": "controller",
+      "used_count": 2,
+      "used_in": [
+        "MainProgram/MainRoutine/Rung[0]",
+        "MainProgram/MainRoutine/Rung[2]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "Line in automatic mode",
+      "name": "Auto_Mode",
+      "roles": [
+        "mode"
+      ],
+      "scope": "controller",
+      "used_count": 1,
+      "used_in": [
+        "MainProgram/MainRoutine/Rung[0]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "Emergency stop healthy (safety circuit)",
+      "name": "EStop_OK",
+      "roles": [
+        "fault",
+        "safety"
+      ],
+      "scope": "controller",
+      "used_count": 1,
+      "used_in": [
+        "MainProgram/MainRoutine/Rung[0]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "Jam detection photo-eye",
+      "name": "Photoeye_1",
+      "roles": [
+        "fault",
+        "input"
+      ],
+      "scope": "controller",
+      "used_count": 1,
+      "used_in": [
+        "MainProgram/MainRoutine/Rung[2]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "TIMER",
+      "description": "Conveyor run-time accumulator",
+      "name": "Run_Timer",
+      "roles": [
+        "output",
+        "timer"
+      ],
+      "scope": "controller",
+      "used_count": 1,
+      "used_in": [
+        "MainProgram/MainRoutine/Rung[1]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "Operator start pushbutton",
+      "name": "Start_PB",
+      "roles": [
+        "input"
+      ],
+      "scope": "controller",
+      "used_count": 1,
+      "used_in": [
+        "MainProgram/MainRoutine/Rung[0]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "Operator stop pushbutton",
+      "name": "Stop_PB",
+      "roles": [
+        "input"
+      ],
+      "scope": "controller",
+      "used_count": 1,
+      "used_in": [
+        "MainProgram/MainRoutine/Rung[0]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "REAL",
+      "description": "Drive output current Amps",
+      "name": "VFD_Current",
+      "roles": [],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "DINT",
+      "description": "Active drive fault code",
+      "name": "VFD_FaultCode",
+      "roles": [
+        "fault"
+      ],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "REAL",
+      "description": "Drive output frequency Hz",
+      "name": "VFD_Frequency",
+      "roles": [],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    }
+  ],
+  "vendor": "Rockwell Automation",
+  "vfd_signal_candidates": [
+    {
+      "confidence": "medium",
+      "detail": "candidate role: frequency",
+      "evidence": [
+        "Tag[@Name='VFD_Frequency']"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_Frequency"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: current_a",
+      "evidence": [
+        "Tag[@Name='VFD_Current']"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_Current"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: fault_code",
+      "evidence": [
+        "Tag[@Name='VFD_FaultCode']"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_FaultCode"
+    }
+  ],
+  "warnings": []
+}

--- a/mira-plc-parser/tests/fixtures/golden/conveyor.plcopen.report.json
+++ b/mira-plc-parser/tests/fixtures/golden/conveyor.plcopen.report.json
@@ -1,0 +1,328 @@
+{
+  "asset_candidates": [
+    {
+      "confidence": "medium",
+      "detail": "candidate asset (keyword: conv)",
+      "evidence": [
+        "ConvFault"
+      ],
+      "kind": "asset",
+      "name": "ConvFault"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate asset (keyword: motor)",
+      "evidence": [
+        "MotorRun"
+      ],
+      "kind": "asset",
+      "name": "MotorRun"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate asset (keyword: vfd)",
+      "evidence": [
+        "VFD_Frequency",
+        "VFD_Current",
+        "VFD_FaultCode"
+      ],
+      "kind": "asset",
+      "name": "VFD"
+    }
+  ],
+  "controller": "ConveyorCellPLCopen",
+  "counts": {
+    "aoi_definitions": 0,
+    "aoi_local_tags": 0,
+    "aoi_parameters": 0,
+    "asset_candidates": 3,
+    "controllers": 1,
+    "fault_candidates": 4,
+    "fbd_sheets": 0,
+    "module_definitions": 0,
+    "outputs": 2,
+    "programs": 1,
+    "review_required": 1,
+    "routines": 1,
+    "rungs": 2,
+    "tags": 10,
+    "vfd_signal_candidates": 4
+  },
+  "detection": {
+    "confidence": "high",
+    "fmt": "plcopen_xml",
+    "needs_export": "",
+    "reason": "found PLCopen XML namespace"
+  },
+  "fault_candidates": [
+    {
+      "confidence": "review",
+      "detail": "emergency-stop circuit healthy",
+      "evidence": [
+        "ConveyorControl/Var[EStopOK]"
+      ],
+      "kind": "fault",
+      "name": "EStopOK"
+    },
+    {
+      "confidence": "medium",
+      "detail": "name/desc matches fault/alarm pattern",
+      "evidence": [
+        "ConveyorControl/Var[JamPhotoeye]"
+      ],
+      "kind": "fault",
+      "name": "JamPhotoeye"
+    },
+    {
+      "confidence": "medium",
+      "detail": "name/desc matches fault/alarm pattern",
+      "evidence": [
+        "ConveyorControl/Var[ConvFault]"
+      ],
+      "kind": "fault",
+      "name": "ConvFault"
+    },
+    {
+      "confidence": "medium",
+      "detail": "active drive fault code",
+      "evidence": [
+        "ConveyorControl/Var[VFD_FaultCode]"
+      ],
+      "kind": "fault",
+      "name": "VFD_FaultCode"
+    }
+  ],
+  "handled": true,
+  "output_dependencies": [
+    {
+      "confidence": "high",
+      "detail": "true when: VFD_FaultCode, MotorRun, JamPhotoeye",
+      "evidence": [
+        "ConveyorControl/ConveyorControl/Rung[1]"
+      ],
+      "kind": "output",
+      "name": "ConvFault"
+    },
+    {
+      "confidence": "high",
+      "detail": "true when: StartPB, EStopOK, AutoMode, ConvFault",
+      "evidence": [
+        "ConveyorControl/ConveyorControl/Rung[0]"
+      ],
+      "kind": "output",
+      "name": "MotorRun"
+    }
+  ],
+  "review_required": [
+    {
+      "confidence": "review",
+      "detail": "emergency-stop circuit healthy",
+      "evidence": [
+        "ConveyorControl/Var[EStopOK]"
+      ],
+      "kind": "safety",
+      "name": "EStopOK"
+    }
+  ],
+  "routine_summaries": [
+    {
+      "comment_digest": [],
+      "confidence": "high",
+      "outputs_controlled": [
+        "ConvFault",
+        "MotorRun"
+      ],
+      "program": "ConveyorControl",
+      "purpose_hint": "",
+      "routine": "ConveyorControl",
+      "rungs": 2,
+      "type": "ST"
+    }
+  ],
+  "schema": "mira-plc-parser/report@1",
+  "tag_dictionary": [
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "",
+      "name": "ConvFault",
+      "roles": [
+        "output",
+        "fault"
+      ],
+      "scope": "program",
+      "used_count": 2,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[0]",
+        "ConveyorControl/ConveyorControl/Rung[1]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "conveyor VFD run command",
+      "name": "MotorRun",
+      "roles": [
+        "output"
+      ],
+      "scope": "program",
+      "used_count": 2,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[0]",
+        "ConveyorControl/ConveyorControl/Rung[1]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "",
+      "name": "AutoMode",
+      "roles": [
+        "mode"
+      ],
+      "scope": "program",
+      "used_count": 1,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[0]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "emergency-stop circuit healthy",
+      "name": "EStopOK",
+      "roles": [
+        "fault",
+        "safety"
+      ],
+      "scope": "program",
+      "used_count": 1,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[0]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "",
+      "name": "JamPhotoeye",
+      "roles": [
+        "fault",
+        "input"
+      ],
+      "scope": "program",
+      "used_count": 1,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[1]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "operator start pushbutton",
+      "name": "StartPB",
+      "roles": [
+        "input"
+      ],
+      "scope": "program",
+      "used_count": 1,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[0]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "DINT",
+      "description": "active drive fault code",
+      "name": "VFD_FaultCode",
+      "roles": [
+        "fault"
+      ],
+      "scope": "program",
+      "used_count": 1,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[1]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "REAL",
+      "description": "",
+      "name": "LineSpeedSetpoint",
+      "roles": [],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "REAL",
+      "description": "",
+      "name": "VFD_Current",
+      "roles": [],
+      "scope": "program",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "REAL",
+      "description": "drive output frequency Hz",
+      "name": "VFD_Frequency",
+      "roles": [],
+      "scope": "program",
+      "used_count": 0,
+      "used_in": []
+    }
+  ],
+  "vendor": "OpenPLC",
+  "vfd_signal_candidates": [
+    {
+      "confidence": "medium",
+      "detail": "candidate role: freq_setpoint",
+      "evidence": [
+        "ConveyorControl/Var[LineSpeedSetpoint]"
+      ],
+      "kind": "vfd_signal",
+      "name": "LineSpeedSetpoint"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: frequency",
+      "evidence": [
+        "ConveyorControl/Var[VFD_Frequency]"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_Frequency"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: current_a",
+      "evidence": [
+        "ConveyorControl/Var[VFD_Current]"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_Current"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: fault_code",
+      "evidence": [
+        "ConveyorControl/Var[VFD_FaultCode]"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_FaultCode"
+    }
+  ],
+  "warnings": []
+}

--- a/mira-plc-parser/tests/fixtures/golden/conveyor.st.report.json
+++ b/mira-plc-parser/tests/fixtures/golden/conveyor.st.report.json
@@ -1,0 +1,357 @@
+{
+  "asset_candidates": [
+    {
+      "confidence": "medium",
+      "detail": "candidate asset (keyword: conv)",
+      "evidence": [
+        "ConvFault"
+      ],
+      "kind": "asset",
+      "name": "ConvFault"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate asset (keyword: motor)",
+      "evidence": [
+        "MotorRun"
+      ],
+      "kind": "asset",
+      "name": "MotorRun"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate asset (keyword: vfd)",
+      "evidence": [
+        "VFD_Frequency",
+        "VFD_Current",
+        "VFD_FaultCode"
+      ],
+      "kind": "asset",
+      "name": "VFD"
+    }
+  ],
+  "controller": "ConveyorControl",
+  "counts": {
+    "aoi_definitions": 0,
+    "aoi_local_tags": 0,
+    "aoi_parameters": 0,
+    "asset_candidates": 3,
+    "controllers": 1,
+    "fault_candidates": 4,
+    "fbd_sheets": 0,
+    "module_definitions": 0,
+    "outputs": 2,
+    "programs": 1,
+    "review_required": 1,
+    "routines": 1,
+    "rungs": 3,
+    "tags": 12,
+    "vfd_signal_candidates": 4
+  },
+  "detection": {
+    "confidence": "high",
+    "fmt": "structured_text",
+    "needs_export": "",
+    "reason": "IEC 61131-3 ST program/FB keywords"
+  },
+  "fault_candidates": [
+    {
+      "confidence": "review",
+      "detail": "emergency-stop circuit healthy (safety)",
+      "evidence": [
+        "ConveyorControl/Var[EStopOK]"
+      ],
+      "kind": "fault",
+      "name": "EStopOK"
+    },
+    {
+      "confidence": "medium",
+      "detail": "jam-detection photo-eye",
+      "evidence": [
+        "ConveyorControl/Var[JamPhotoeye]"
+      ],
+      "kind": "fault",
+      "name": "JamPhotoeye"
+    },
+    {
+      "confidence": "medium",
+      "detail": "conveyor fault latch",
+      "evidence": [
+        "ConveyorControl/Var[ConvFault]"
+      ],
+      "kind": "fault",
+      "name": "ConvFault"
+    },
+    {
+      "confidence": "medium",
+      "detail": "active drive fault code",
+      "evidence": [
+        "ConveyorControl/Var[VFD_FaultCode]"
+      ],
+      "kind": "fault",
+      "name": "VFD_FaultCode"
+    }
+  ],
+  "handled": true,
+  "output_dependencies": [
+    {
+      "confidence": "high",
+      "detail": "true when: VFD_FaultCode, MotorRun, JamPhotoeye",
+      "evidence": [
+        "ConveyorControl/ConveyorControl/Rung[2]"
+      ],
+      "kind": "output",
+      "name": "ConvFault"
+    },
+    {
+      "confidence": "high",
+      "detail": "true when: StartPB, EStopOK, AutoMode, ConvFault | true when: StopPB, EStopOK",
+      "evidence": [
+        "ConveyorControl/ConveyorControl/Rung[0]",
+        "ConveyorControl/ConveyorControl/Rung[1]"
+      ],
+      "kind": "output",
+      "name": "MotorRun"
+    }
+  ],
+  "review_required": [
+    {
+      "confidence": "review",
+      "detail": "emergency-stop circuit healthy (safety)",
+      "evidence": [
+        "ConveyorControl/Var[EStopOK]"
+      ],
+      "kind": "safety",
+      "name": "EStopOK"
+    }
+  ],
+  "routine_summaries": [
+    {
+      "comment_digest": [],
+      "confidence": "high",
+      "outputs_controlled": [
+        "ConvFault",
+        "MotorRun"
+      ],
+      "program": "ConveyorControl",
+      "purpose_hint": "",
+      "routine": "ConveyorControl",
+      "rungs": 3,
+      "type": "ST"
+    }
+  ],
+  "schema": "mira-plc-parser/report@1",
+  "tag_dictionary": [
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "conveyor VFD run command",
+      "name": "MotorRun",
+      "roles": [
+        "output"
+      ],
+      "scope": "program",
+      "used_count": 3,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[0]",
+        "ConveyorControl/ConveyorControl/Rung[1]",
+        "ConveyorControl/ConveyorControl/Rung[2]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "conveyor fault latch",
+      "name": "ConvFault",
+      "roles": [
+        "output",
+        "fault"
+      ],
+      "scope": "program",
+      "used_count": 2,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[0]",
+        "ConveyorControl/ConveyorControl/Rung[2]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "emergency-stop circuit healthy (safety)",
+      "name": "EStopOK",
+      "roles": [
+        "fault",
+        "safety"
+      ],
+      "scope": "program",
+      "used_count": 2,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[0]",
+        "ConveyorControl/ConveyorControl/Rung[1]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "line in automatic mode",
+      "name": "AutoMode",
+      "roles": [
+        "mode"
+      ],
+      "scope": "program",
+      "used_count": 1,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[0]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "jam-detection photo-eye",
+      "name": "JamPhotoeye",
+      "roles": [
+        "fault",
+        "input"
+      ],
+      "scope": "program",
+      "used_count": 1,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[2]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "operator start pushbutton",
+      "name": "StartPB",
+      "roles": [
+        "input"
+      ],
+      "scope": "program",
+      "used_count": 1,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[0]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "BOOL",
+      "description": "operator stop pushbutton",
+      "name": "StopPB",
+      "roles": [
+        "input"
+      ],
+      "scope": "program",
+      "used_count": 1,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[1]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "DINT",
+      "description": "active drive fault code",
+      "name": "VFD_FaultCode",
+      "roles": [
+        "fault"
+      ],
+      "scope": "program",
+      "used_count": 1,
+      "used_in": [
+        "ConveyorControl/ConveyorControl/Rung[2]"
+      ]
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "REAL",
+      "description": "freq setpoint, Hz",
+      "name": "LineSpeedSetpoint",
+      "roles": [],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "TON",
+      "description": "conveyor run-time accumulator",
+      "name": "RunTimer",
+      "roles": [],
+      "scope": "program",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "REAL",
+      "description": "drive output current amps",
+      "name": "VFD_Current",
+      "roles": [],
+      "scope": "program",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "",
+      "confidence": "high",
+      "data_type": "REAL",
+      "description": "drive output frequency Hz",
+      "name": "VFD_Frequency",
+      "roles": [],
+      "scope": "program",
+      "used_count": 0,
+      "used_in": []
+    }
+  ],
+  "vendor": "IEC 61131-3",
+  "vfd_signal_candidates": [
+    {
+      "confidence": "medium",
+      "detail": "candidate role: frequency",
+      "evidence": [
+        "ConveyorControl/Var[LineSpeedSetpoint]"
+      ],
+      "kind": "vfd_signal",
+      "name": "LineSpeedSetpoint"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: frequency",
+      "evidence": [
+        "ConveyorControl/Var[VFD_Frequency]"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_Frequency"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: current_a",
+      "evidence": [
+        "ConveyorControl/Var[VFD_Current]"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_Current"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: fault_code",
+      "evidence": [
+        "ConveyorControl/Var[VFD_FaultCode]"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_FaultCode"
+    }
+  ],
+  "warnings": []
+}

--- a/mira-plc-parser/tests/fixtures/golden/gs10_tags.csv.report.json
+++ b/mira-plc-parser/tests/fixtures/golden/gs10_tags.csv.report.json
@@ -1,0 +1,218 @@
+{
+  "asset_candidates": [
+    {
+      "confidence": "medium",
+      "detail": "candidate asset (keyword: conveyor)",
+      "evidence": [
+        "Conveyor_Run"
+      ],
+      "kind": "asset",
+      "name": "Conveyor"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate asset (keyword: vfd)",
+      "evidence": [
+        "VFD_Frequency",
+        "VFD_Current",
+        "VFD_DCBus",
+        "VFD_FaultCode",
+        "VFD_CommOK"
+      ],
+      "kind": "asset",
+      "name": "VFD"
+    }
+  ],
+  "controller": "gs10_tags",
+  "counts": {
+    "aoi_definitions": 0,
+    "aoi_local_tags": 0,
+    "aoi_parameters": 0,
+    "asset_candidates": 2,
+    "controllers": 1,
+    "fault_candidates": 2,
+    "fbd_sheets": 0,
+    "module_definitions": 0,
+    "outputs": 0,
+    "programs": 0,
+    "review_required": 1,
+    "routines": 0,
+    "rungs": 0,
+    "tags": 7,
+    "vfd_signal_candidates": 5
+  },
+  "detection": {
+    "confidence": "high",
+    "fmt": "csv_tags",
+    "needs_export": "",
+    "reason": "delimited rows, no XML root"
+  },
+  "fault_candidates": [
+    {
+      "confidence": "medium",
+      "detail": "Active fault code",
+      "evidence": [
+        "csv:kepware"
+      ],
+      "kind": "fault",
+      "name": "VFD_FaultCode"
+    },
+    {
+      "confidence": "review",
+      "detail": "Emergency stop healthy",
+      "evidence": [
+        "csv:kepware"
+      ],
+      "kind": "fault",
+      "name": "EStop_OK"
+    }
+  ],
+  "handled": true,
+  "output_dependencies": [],
+  "review_required": [
+    {
+      "confidence": "review",
+      "detail": "Emergency stop healthy",
+      "evidence": [
+        "csv:kepware"
+      ],
+      "kind": "safety",
+      "name": "EStop_OK"
+    }
+  ],
+  "routine_summaries": [],
+  "schema": "mira-plc-parser/report@1",
+  "tag_dictionary": [
+    {
+      "address": "000002",
+      "confidence": "high",
+      "data_type": "Boolean",
+      "description": "Conveyor run command",
+      "name": "Conveyor_Run",
+      "roles": [],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "000003",
+      "confidence": "high",
+      "data_type": "Boolean",
+      "description": "Emergency stop healthy",
+      "name": "EStop_OK",
+      "roles": [
+        "fault",
+        "safety"
+      ],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "000001",
+      "confidence": "high",
+      "data_type": "Boolean",
+      "description": "Drive comms healthy",
+      "name": "VFD_CommOK",
+      "roles": [],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "40003",
+      "confidence": "high",
+      "data_type": "Float",
+      "description": "Drive output current Amps",
+      "name": "VFD_Current",
+      "roles": [],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "40005",
+      "confidence": "high",
+      "data_type": "Float",
+      "description": "DC bus voltage",
+      "name": "VFD_DCBus",
+      "roles": [],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "40007",
+      "confidence": "high",
+      "data_type": "Word",
+      "description": "Active fault code",
+      "name": "VFD_FaultCode",
+      "roles": [
+        "fault"
+      ],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    },
+    {
+      "address": "40001",
+      "confidence": "high",
+      "data_type": "Float",
+      "description": "Drive output frequency Hz",
+      "name": "VFD_Frequency",
+      "roles": [],
+      "scope": "controller",
+      "used_count": 0,
+      "used_in": []
+    }
+  ],
+  "vendor": "Kepware / PTC",
+  "vfd_signal_candidates": [
+    {
+      "confidence": "medium",
+      "detail": "candidate role: frequency",
+      "evidence": [
+        "csv:kepware"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_Frequency"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: current_a",
+      "evidence": [
+        "csv:kepware"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_Current"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: dc_bus_v",
+      "evidence": [
+        "csv:kepware"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_DCBus"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: fault_code",
+      "evidence": [
+        "csv:kepware"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_FaultCode"
+    },
+    {
+      "confidence": "medium",
+      "detail": "candidate role: comm_ok",
+      "evidence": [
+        "csv:kepware"
+      ],
+      "kind": "vfd_signal",
+      "name": "VFD_CommOK"
+    }
+  ],
+  "warnings": []
+}

--- a/mira-plc-parser/tests/test_analyze_pipeline.py
+++ b/mira-plc-parser/tests/test_analyze_pipeline.py
@@ -94,10 +94,11 @@ def test_unknown_format_handled_gracefully():
 
 
 def test_planned_format_routes_but_defers():
-    xml = '<?xml version="1.0"?><project xmlns="http://www.plcopen.org/xml/tc6_0201"></project>'
-    res = run("p.xml", xml)
+    # Siemens TIA/Openness XML is recognized but its parser is a later phase (still in _PLANNED).
+    xml = '<?xml version="1.0"?><Document><SW.Blocks.FB ID="0"></SW.Blocks.FB></Document>'
+    res = run("Block.xml", xml)
     assert not res.handled
-    assert res.detection.fmt == "plcopen_xml"
+    assert res.detection.fmt == "siemens_tia_xml"
     assert any("later phase" in w for w in res.project.warnings)
 
 

--- a/mira-plc-parser/tests/test_golden.py
+++ b/mira-plc-parser/tests/test_golden.py
@@ -1,0 +1,41 @@
+"""Golden snapshot tests -- pin the full render_json() report (schema mira-plc-parser/report@1).
+
+The JSON report is the contract downstream MIRA ingest consumes, so its exact shape is an asset:
+any drift in fields, counts, ordering, or candidate sets must be a deliberate, reviewed change.
+Each fixture has a committed golden under tests/fixtures/golden/; this test re-runs the pipeline
+and asserts byte-for-structure equality.
+
+To regenerate after an intentional change:  MIRA_REGEN_GOLDEN=1 python -m pytest tests/test_golden.py
+(then review the git diff before committing).
+"""
+import json
+import os
+
+import pytest
+
+from mira_plc_parser import render_json, run
+
+GOLDEN_DIR = "golden"
+# fixture filename -> golden filename
+CASES = {
+    "conveyor.L5X": "conveyor.l5x.report.json",
+    "gs10_tags.csv": "gs10_tags.csv.report.json",
+    "conveyor.st": "conveyor.st.report.json",
+    "conveyor.plcopen.xml": "conveyor.plcopen.report.json",
+}
+
+
+@pytest.mark.parametrize("fixture_name,golden_name", sorted(CASES.items()))
+def test_report_matches_golden(fixtures, fixture_name, golden_name):
+    text = (fixtures / fixture_name).read_text(encoding="utf-8")
+    actual = render_json(run(fixture_name, text))
+    assert actual["schema"] == "mira-plc-parser/report@1"
+
+    golden_path = fixtures / GOLDEN_DIR / golden_name
+    if os.environ.get("MIRA_REGEN_GOLDEN"):
+        golden_path.parent.mkdir(parents=True, exist_ok=True)
+        golden_path.write_text(json.dumps(actual, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        pytest.skip("regenerated %s" % golden_name)
+
+    expected = json.loads(golden_path.read_text(encoding="utf-8"))
+    assert actual == expected, "report drift vs %s (regen with MIRA_REGEN_GOLDEN=1)" % golden_name

--- a/mira-plc-parser/tests/test_plcopen_xml.py
+++ b/mira-plc-parser/tests/test_plcopen_xml.py
@@ -1,0 +1,56 @@
+"""PLCopen XML (tc6) parser + end-to-end analysis tests.
+
+PLCopen XML is the open interchange format CODESYS / OpenPLC / Beremiz export. The parser maps
+<pou> interface variables to IR tags and the <ST> body through the same statement->rung lift the
+.st parser uses, so analysis output matches between the two ST-bearing formats.
+"""
+import pytest
+
+from mira_plc_parser import analyze as A
+from mira_plc_parser import run
+from mira_plc_parser.parsers import plcopen_xml
+
+
+@pytest.fixture(scope="module")
+def conveyor_plcopen(fixtures):
+    return (fixtures / "conveyor.plcopen.xml").read_text(encoding="utf-8")
+
+
+def test_detect_and_parse_end_to_end(conveyor_plcopen):
+    res = run("conveyor.plcopen.xml", conveyor_plcopen)
+    assert res.handled
+    assert res.detection.fmt == "plcopen_xml"
+    r = res.report
+    assert r.controller == "ConveyorCellPLCopen"
+    assert r.counts["tags"] == 10         # 9 localVars + 1 globalVar
+    assert r.counts["routines"] == 1
+
+
+def test_interface_vars_become_tags(conveyor_plcopen):
+    proj = plcopen_xml.parse(conveyor_plcopen, "conveyor.plcopen.xml")
+    tags = {t.name: t for t in proj.all_tags()}
+    assert tags["MotorRun"].data_type == "BOOL"
+    assert tags["VFD_Frequency"].data_type == "REAL"
+    assert tags["VFD_FaultCode"].data_type == "DINT"
+    # <documentation> becomes the description
+    assert "frequency" in tags["VFD_Frequency"].description.lower()
+    # globalVars are controller-scoped + carry the initial value
+    assert tags["LineSpeedSetpoint"].scope == "controller"
+    assert tags["LineSpeedSetpoint"].initial_value == "60.0"
+    assert tags["StartPB"].scope == "program"
+
+
+def test_st_body_drives_analysis(conveyor_plcopen):
+    r = A.analyze(plcopen_xml.parse(conveyor_plcopen, "conveyor.plcopen.xml"))
+    outs = {f.name: f for f in r.output_dependencies}
+    assert "MotorRun" in outs and "ConvFault" in outs
+    assert "StartPB" in outs["MotorRun"].detail and "EStopOK" in outs["MotorRun"].detail
+
+
+def test_camelcase_classification(conveyor_plcopen):
+    r = A.analyze(plcopen_xml.parse(conveyor_plcopen, "conveyor.plcopen.xml"))
+    faults = {f.name for f in r.fault_candidates}
+    assert {"ConvFault", "VFD_FaultCode"} <= faults
+    assert "EStopOK" in {f.name for f in r.review_required}
+    sig = {f.name for f in r.vfd_signal_candidates}
+    assert {"VFD_Frequency", "VFD_Current"} <= sig

--- a/mira-plc-parser/tests/test_structured_text.py
+++ b/mira-plc-parser/tests/test_structured_text.py
@@ -1,0 +1,71 @@
+"""Structured Text (.st, IEC 61131-3) parser + end-to-end analysis tests.
+
+ST is the vendor-neutral reasoning bridge: VAR declarations become IR tags, assignment statements
+become synthetic rungs (LHS = driven output, expression tags = conditions), and the POU body is
+preserved as routine.st_text. The fixture is camelCase on purpose, so these tests also prove the
+tokenizer fix reaches real analysis output (ConvFault/EStopOK classify correctly).
+"""
+import pytest
+
+from mira_plc_parser import analyze as A
+from mira_plc_parser import run
+from mira_plc_parser.parsers import structured_text
+
+
+@pytest.fixture(scope="module")
+def conveyor_st(fixtures):
+    return (fixtures / "conveyor.st").read_text(encoding="utf-8")
+
+
+def test_detect_and_parse_end_to_end(conveyor_st):
+    res = run("conveyor.st", conveyor_st)
+    assert res.handled
+    assert res.detection.fmt == "structured_text"
+    r = res.report
+    assert r.controller == "ConveyorControl"
+    assert "61131" in r.vendor or "IEC" in r.vendor
+    # 11 program VARs + 1 VAR_GLOBAL
+    assert r.counts["tags"] == 12
+    assert r.counts["routines"] == 1
+
+
+def test_var_declarations_become_tags(conveyor_st):
+    proj = structured_text.parse(conveyor_st, "conveyor.st")
+    tags = {t.name: t for t in proj.all_tags()}
+    assert tags["MotorRun"].data_type == "BOOL"
+    assert tags["VFD_Frequency"].data_type == "REAL"
+    # the inline (* ... *) comment is captured as the tag description
+    assert "frequency" in tags["VFD_Frequency"].description.lower()
+    # VAR_GLOBAL is controller-scoped; POU-locals are program-scoped
+    assert tags["LineSpeedSetpoint"].scope == "controller"
+    assert tags["MotorRun"].scope == "program"
+
+
+def test_camelcase_classification_reaches_findings(conveyor_st):
+    r = A.analyze(structured_text.parse(conveyor_st, "conveyor.st"))
+    faults = {f.name for f in r.fault_candidates}
+    assert {"ConvFault", "VFD_FaultCode"} <= faults     # camelCase names, classified by the fix
+    review = {f.name for f in r.review_required}
+    assert "EStopOK" in review                          # "EStop" hump -> safety -> REVIEW
+
+
+def test_assignments_become_output_dependencies(conveyor_st):
+    r = A.analyze(structured_text.parse(conveyor_st, "conveyor.st"))
+    outs = {f.name: f for f in r.output_dependencies}
+    assert "MotorRun" in outs and "ConvFault" in outs
+    # the gating conditions of MotorRun should be surfaced from the IF expression
+    assert "StartPB" in outs["MotorRun"].detail
+    assert "EStopOK" in outs["MotorRun"].detail
+
+
+def test_vfd_signals_detected(conveyor_st):
+    r = A.analyze(structured_text.parse(conveyor_st, "conveyor.st"))
+    sig = {f.name for f in r.vfd_signal_candidates}
+    assert {"VFD_Frequency", "VFD_Current"} <= sig
+
+
+def test_body_preserved_as_st_text(conveyor_st):
+    proj = structured_text.parse(conveyor_st, "conveyor.st")
+    routine = proj.controllers[0].programs[0].routines[0]
+    assert routine.type == "ST"
+    assert ":=" in routine.st_text          # the executable body is retained for later reasoning

--- a/mira-plc-parser/tests/test_tokenizer.py
+++ b/mira-plc-parser/tests/test_tokenizer.py
@@ -1,0 +1,35 @@
+"""Tokenizer (_kw) boundary tests -- camelCase humps must act as word breaks.
+
+The name-pattern matcher used by the analysis layer originally treated only `_`, digits, spaces
+and symbols as word boundaries, so a keyword fused into a camelCase identifier was missed
+(`fault` in `FaultRoutine`). PLC names are routinely camelCase, so that was a real coverage gap.
+These tests pin both the fix (humps match) and the guard (no new false positives on fused words).
+"""
+from mira_plc_parser.analyze import _FAULT_PAT, _kw
+
+
+def test_camelcase_hump_after_keyword_matches():
+    # the canonical miss: "fault" fused before an uppercase hump
+    assert _FAULT_PAT.search("FaultRoutine")
+    assert _FAULT_PAT.search("VFD_FaultCode")   # matched on the NAME now, not just a description
+
+
+def test_camelcase_hump_before_keyword_matches():
+    # "fault" fused after a lowercase->Uppercase hump
+    assert _FAULT_PAT.search("MotorFault")
+    assert _FAULT_PAT.search("conveyorTripCount")   # "trip" between humps
+
+
+def test_classic_boundaries_still_match():
+    # underscore / digit / start / end boundaries keep working unchanged
+    assert _FAULT_PAT.search("Conv_Fault")
+    assert _FAULT_PAT.search("fault")
+    assert _FAULT_PAT.search("ALARM_1")
+
+
+def test_no_false_positive_on_fused_lowercase():
+    # not a boundary: keyword buried inside a lowercase run must NOT match (guards against
+    # the lazy fix of just dropping the boundary checks)
+    assert not _kw(["fault"]).search("defaulting")   # 'fault' inside 'defaulting'
+    assert not _kw(["trip"]).search("stripe")        # 'trip' inside 'stripe'
+    assert not _kw(["alarm"]).search("alarmist")     # trailing lowercase run, no hump


### PR DESCRIPTION
## What — Phase 5 parsers: Structured Text + PLCopen XML

Extends the read-only `mira-plc-parser` to two new vendor-neutral formats, hardens the JSON
report into a pinned golden contract, and fixes the camelCase tokenizer. Stdlib-only, offline,
no MIRA-engine deps, no UNS path building (parsers emit raw vendor/model/tag candidates only —
the UNS/i3X layer is a separate stream, #2084/#2068).

This is the parser work that was committed on the stale `feat/vfd-analyzer-auto-map` branch
(commit `f0a7f428`, which had drifted to **87 ahead / 206 behind** main). It is cherry-picked
onto **current main** and reconciled with main's newer `analyze.py` (the #2065/#2091 AOI/module/FBD
enrichment landed in parallel).

### Changes
- **Structured Text (`.st`, IEC 61131-3)** — `parsers/structured_text.py`. `VAR`/`VAR_GLOBAL`
  decls → IR tags; each POU → an ST routine with body preserved as `st_text`; every `LHS := expr;`
  assignment lifted into a synthetic rung (output = LHS, expr tags = conditions) so the existing
  rung-based analysis (output-dependency map, usage x-ref) works on ST too.
- **PLCopen XML (tc6, namespace-agnostic)** — `parsers/plcopen_xml.py`. `<pou>` interface vars →
  tags; `<ST>` body reuses the ST statement→rung lift (a `.st` file and a PLCopen ST body analyze
  identically); graphical bodies (LD/FBD/SFC) record routine + language.
- **Tokenizer fix (`analyze._kw`)** — camelCase humps (lowercase/digit → Uppercase) now act as word
  breaks, so "fault" in `FaultRoutine`/`MotorRun`/`EStopOK` classifies. Additive (superset of the
  old matches); underscore names unchanged; case-sensitive boundaries via a scoped `(?i:…)` group so
  "defaulting" still does NOT match "fault".
- **Golden report contract** — `tests/fixtures/golden/` snapshots pin `render_json` shape for all 4
  fixtures (regen via `MIRA_REGEN_GOLDEN=1`). Regenerated here against merged `analyze.py` — the only
  delta vs the original snapshots is the **additive** AOI/FBD count keys main introduced
  (`aoi_definitions`, `aoi_local_tags`, `aoi_parameters`, `fbd_sheets`, `module_definitions`),
  all `0` for these fixtures; **zero** drift in any other field.
- **Pipeline** wires both parsers; only `siemens_tia_xml` remains in `_PLANNED`.

### Reconciliation note (why this isn't a clean replay)
The `_kw()` region was independently simplified on main and re-expanded with the camelCase-hump rule
in `f0a7f428`. The 3-way cherry-pick took the hump version cleanly (main's lines matched the merge
base, so only "theirs" changed) **and** kept main's AOI/FBD count keys. Verified by the full suite
passing — including main's own `test_aoi_parsing.py` / `test_fbd_parsing.py`.

### Verification (commands + results)
```
$ python -m pytest -q
97 passed, 12 warnings

$ python -m ruff check <this PR's .py files>
All checks passed!
```
Pre-existing main lint debt (`tests/test_aoi_parsing.py`: F401 + W291) is **not** touched here —
not in this PR's scope.

### Doctrine
Read-only (no PLC writes, `.claude/rules/fieldbus-readonly.md`) · confidence + provenance on every
extracted fact · safety logic → REVIEW · no UNS path building in the parser core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
