### PR TITLE
feat(contextualizer): sanitized structured-context export mode (HubV3 P5)

### DIFF
--- a/mira-contextualizer/mira_contextualizer/bundle.py
+++ b/mira-contextualizer/mira_contextualizer/bundle.py
@@ -294,8 +294,20 @@ _IMPORT_MD = (
 )
 
 
-def build_bundle(store, project_id: str) -> dict[str, str]:
-    """Return a mapping of bundle-relative path → file content (str). Caller writes or zips it."""
+# Export modes (PRD §3). "full" = raw document IR + rich provenance; "sanitized" = the same derived
+# structured context (hashes, source refs, UNS/i3X, faults, params, scorecard) WITHOUT raw documents.
+# Never "anonymous" — it isn't (asset identity + hashes remain).
+EXPORT_MODES = ("full", "sanitized")
+
+
+def build_bundle(store, project_id: str, mode: str = "full") -> dict[str, str]:
+    """Return a mapping of bundle-relative path → file content (str). Caller writes or zips it.
+
+    ``mode`` selects the export contract: ``"full"`` (default) ships raw ``documents/*.json`` payloads
+    alongside the derived structured context; ``"sanitized"`` ships only the derived structured context
+    (kept hashes/source-refs/UNS/i3X/faults/params/scorecard) and omits the raw document payloads."""
+    if mode not in EXPORT_MODES:
+        raise ValueError("unknown export mode %r (expected one of %r)" % (mode, EXPORT_MODES))
     proj = store.get_project(project_id)
     if not proj:
         raise ValueError("project not found")
@@ -308,7 +320,7 @@ def build_bundle(store, project_id: str) -> dict[str, str]:
     for s in sources:
         full = store.get_source(s["id"])
         ir = full.get("extracted") if full else None
-        if ir:
+        if ir and mode == "full":  # sanitized mode keeps the source hash below but drops the raw IR
             files["documents/%s.json" % _safe(s["fileName"])] = json.dumps(ir, indent=2)
         blob = json.dumps(ir or {}, sort_keys=True).encode()
         src_meta.append({"file": s["fileName"], "type": s["sourceType"], "status": s["status"],
@@ -338,6 +350,8 @@ def build_bundle(store, project_id: str) -> dict[str, str]:
                    "ucum_quantities": len(quantities)},
         # answerability snapshot so a consumer can gate on it without re-deriving
         "scorecard": {"score": sc["score"], "grade": sc["grade"]},
+        # export contract: "full" carries raw documents/*.json; "sanitized" is derived context only
+        "export": {"mode": mode, "raw_documents": mode == "full"},
         # how the Hub should land this: match an existing asset or create a draft (proposed only)
         "asset_match": asset_match,
         "import": import_intent,

--- a/mira-contextualizer/mira_contextualizer/server.py
+++ b/mira-contextualizer/mira_contextualizer/server.py
@@ -333,12 +333,15 @@ def make_handler(store: Store, gui_dir: str, recents_path: str | None = None):
                      "confidence": e["confidence"]} for e in accepted if e["unsPathProposed"]]})
             elif fmt == "i3x":
                 self._json(bundle._i3x(accepted))
-            elif fmt == "bundle":
-                data = bundle.zip_bytes(bundle.build_bundle(store, pid))
-                store.add_export(pid, "bundle", "machine_context_bundle.zip",
-                                 {"bytes": len(data), "accepted": sum(
+            elif fmt in ("bundle", "bundle-sanitized"):
+                mode = "sanitized" if fmt == "bundle-sanitized" else "full"
+                fname = ("machine_context_bundle.sanitized.zip" if mode == "sanitized"
+                         else "machine_context_bundle.zip")
+                data = bundle.zip_bytes(bundle.build_bundle(store, pid, mode=mode))
+                store.add_export(pid, fmt, fname,
+                                 {"bytes": len(data), "mode": mode, "accepted": sum(
                                      1 for e in store.list_extractions(pid) if e["status"] == "accepted")})
-                self._send_bytes(data, "application/zip", "machine_context_bundle.zip")
+                self._send_bytes(data, "application/zip", fname)
             elif fmt == "profile":
                 data = json.dumps(profile.save_profile(store, pid), indent=2).encode("utf-8")
                 store.add_export(pid, "profile", "%s%s" % (proj["name"], profile.EXT))
@@ -347,7 +350,7 @@ def make_handler(store: Store, gui_dir: str, recents_path: str | None = None):
                 self._send_bytes(data, "application/json",
                                  "%s%s" % (bundle._safe(proj["name"]), profile.EXT))
             else:
-                self._err("unsupported format (uns | i3x | bundle | profile)", 400)
+                self._err("unsupported format (uns | i3x | bundle | bundle-sanitized | profile)", 400)
 
     return Handler
 

--- a/mira-contextualizer/tests/test_bundle.py
+++ b/mira-contextualizer/tests/test_bundle.py
@@ -248,3 +248,64 @@ def test_build_unknown_project_raises(seeded):
     store, _ = seeded
     with pytest.raises(ValueError):
         bundle.build_bundle(store, "deadbeef")
+
+
+# --- Export modes: full (default) vs sanitized structured context (PRD §3, §6 tests 10/11) ---
+
+# The derived structured context a sanitized bundle keeps — Hub-importable without raw documents.
+_STRUCTURED = ("manifest.json", "profile.json", "sources.json", "uns.json", "i3x.json",
+               "kg_entities.json", "kg_relationships.json", "signals.csv",
+               "fault_catalog.json", "parameters.json", "scorecard.json", "report.md", "IMPORT.md")
+
+
+def test_sanitized_bundle_omits_raw_document_payloads(seeded):
+    """PRD §6 test 10 — the sanitized structured-context mode ships derived context (UNS, i3X, kg,
+    faults, params, hashes) but NO raw ``documents/*.json`` payloads."""
+    store, pid = seeded
+    # the seeded project has a manual source whose IR would emit a documents/ payload in full mode
+    full = bundle.build_bundle(store, pid, mode="full")
+    assert any(k.startswith("documents/") for k in full), "fixture must exercise a raw document"
+
+    files = bundle.build_bundle(store, pid, mode="sanitized")
+    assert not any(k.startswith("documents/") for k in files), "sanitized must drop raw documents"
+    for key in _STRUCTURED:
+        assert key in files, "sanitized must keep derived structured context: %s" % key
+
+    man = json.loads(files["manifest.json"])
+    assert man["export"]["mode"] == "sanitized"
+    assert man["export"]["raw_documents"] is False
+    # derived context survives: UNS signal, i3X leaf, proposed kg entities
+    assert json.loads(files["uns.json"])["signals"][0]["unsPath"] == UNS
+    assert json.loads(files["kg_entities.json"])["entities"]
+
+
+def test_full_bundle_preserves_provenance(seeded):
+    """PRD §6 test 11 — the full evidence bundle keeps the raw documents AND the source→evidence→
+    entity provenance chain (kg provenance, MENTIONS evidence, review audit)."""
+    store, pid = seeded
+    files = bundle.build_bundle(store, pid)  # default mode is full
+    assert any(k.startswith("documents/") for k in files), "full keeps raw document payloads"
+
+    man = json.loads(files["manifest.json"])
+    assert man["export"]["mode"] == "full" and man["export"]["raw_documents"] is True
+
+    # entity provenance: every accepted signal carries its ctx extraction id + evidence
+    ents = json.loads(files["kg_entities.json"])["entities"]
+    sig = next(e for e in ents if e["entity_type"] == "signal" and e["entity_id"] == UNS)
+    prov = sig["properties"]["provenance"]
+    assert prov["ctx_project_id"] == pid and prov["ctx_extraction_id"]
+
+    # relationship provenance: the document→tag MENTIONS edge keeps page + snippet
+    rels = json.loads(files["kg_relationships.json"])["relationships"]
+    mention = next(r for r in rels if r["type"] == "MENTIONS" and r["target"] == "Conv_Run")
+    assert mention["evidence"]["page"] == 2 and mention["evidence"]["snippet"]
+
+    # review audit: per-decision evidence is retained
+    review = json.loads(files["review.json"])["decisions"]
+    assert any(d["evidence"] for d in review)
+
+
+def test_build_rejects_unknown_mode(seeded):
+    store, pid = seeded
+    with pytest.raises(ValueError):
+        bundle.build_bundle(store, pid, mode="anonymous")

--- a/mira-contextualizer/tests/test_server.py
+++ b/mira-contextualizer/tests/test_server.py
@@ -83,6 +83,19 @@ def test_bundle_and_i3x_export(base):
         data = r.read()
     with zipfile.ZipFile(io.BytesIO(data)) as zf:
         assert "manifest.json" in zf.namelist() and "uns.json" in zf.namelist()
+        full_man = json.loads(zf.read("manifest.json"))
+        assert full_man["export"]["mode"] == "full"
+
+    # sanitized structured-context bundle: same derived context, no raw documents/*.json
+    with urllib.request.urlopen(f"{base}/api/projects/{pid}/export?format=bundle-sanitized") as r:
+        assert r.status == 200 and r.headers["Content-Type"] == "application/zip"
+        assert "sanitized" in r.headers.get("Content-Disposition", "")
+        sdata = r.read()
+    with zipfile.ZipFile(io.BytesIO(sdata)) as zf:
+        names = zf.namelist()
+        assert "manifest.json" in names and "uns.json" in names
+        assert not any(n.startswith("documents/") for n in names)
+        assert json.loads(zf.read("manifest.json"))["export"]["mode"] == "sanitized"
 
 
 def test_ccw_project_import_json_and_zip(base):


### PR DESCRIPTION
## HubV3 Phase 5 (MAC-1) — offline bundle: full vs sanitized export mode

Implements the **sanitized structured-context export mode** for the offline
Contextualizer bundle, per `docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md`
§3 (Bundle/Export Contract) and §5 Phase 5.

### What changed (scope: `mira-contextualizer/` only)
- **`bundle.build_bundle(store, pid, mode="full"|"sanitized")`**
  - `full` (default, unchanged behavior): ships raw `documents/*.json` IR + rich provenance.
  - `sanitized`: ships the **same derived structured context** (source hashes, source refs,
    UNS, i3X, ISO-14224 fault catalog, UCUM parameters, scorecard, `asset_match`,
    `import{intent,policy}`, kg entities/relationships, review audit) **without** raw
    document payloads.
  - Manifest now records `export.{mode, raw_documents}`.
  - Unknown mode → `ValueError`.
- **`server.py` `/export?format=bundle-sanitized`** exposes the new mode; downloads as
  `machine_context_bundle.sanitized.zip`. Existing `format=bundle` unchanged.

### Naming
Called **"sanitized structured context"** — *not* "anonymous" (asset identity, model,
serial, controller IP, and source hashes remain). Matches PRD §3 / §9 guardrail.

### Out of scope (deliberately)
- `evidence.json` aggregate + the 4 missing entity UUIDs (other Phase-5 items) — not part
  of this mode change; can follow in a separate commit/PR.
- GUI affordance for the sanitized download — belongs to Phase 7 (UI/UX alignment).
- No changes to `mira-hub/` or `mira-bots/`.

### TDD / evidence
- **Test 10** (`test_sanitized_bundle_omits_raw_document_payloads`): sanitized bundle has
  no `documents/*` keys, keeps all derived structured files, `export.mode == "sanitized"`.
- **Test 11** (`test_full_bundle_preserves_provenance`): full bundle keeps raw documents +
  kg/relationship/review provenance chains, `export.mode == "full"`.
- Plus `test_build_rejects_unknown_mode` and a server-route test for `bundle-sanitized`.
- Each test written **red-first**, watched fail, then made green.

**Gate:**
- `pytest` → **80 passed** (77 baseline preserved + 3 new).
- Frozen exe rebuilt (`pyinstaller MIRA-Contextualizer.spec`) → `FactoryLM-Contextualizer.exe --selftest` **exit 0**; `--version` → `2.2.0`.
- `ruff check` clean on changed production files.

⚠️ Targets `feat/plc-mapper-gui` (where 055 + the contextualizer live), not `main`. **Do not merge** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)