### PR TITLE
feat(contextualizer): HubV3 Phase 5 — evidence.json + entity UUIDs + sanitized export

### DIFF
--- a/mira-contextualizer/mira_contextualizer/bundle.py
+++ b/mira-contextualizer/mira_contextualizer/bundle.py
@@ -5,16 +5,23 @@ back online. Built entirely from the local store (accepted extractions + extract
 deterministic projections — no network, no LLM.
 
 Contents:
-  manifest.json            tool/version/time, source list + sha256, counts
+  manifest.json            tool/version/time, mode, source list + sha256, counts
   uns.json                 accepted signals as UNS paths
-  i3x.json                 CESMII i3X objectInstances projected from the UNS hierarchy
+  i3x.json                 CESMII i3X objectInstances projected from the UNS hierarchy (uns_node_uuid)
   kg_entities.json         accepted extractions as proposed kg_entities (offline twin of Promote)
   kg_relationships.json    HAS_SIGNAL (asset→signal) + MENTIONS (document→tag) edges, status=proposed
   signals.csv              flat tag / uns / roles / confidence / source
+  evidence.json            aggregate provenance index: source(sha256) → evidence(uuid) → entity
   documents/<file>.json    extracted Document IR per uploaded document (knowledge_entries seed)
   review.json              full accept/reject audit trail with provenance
   report.md                human-readable summary
   IMPORT.md                how to load the bundle into MIRA Hub
+
+Export modes (``build_bundle(..., sanitized=…)``):
+  full       Full Evidence Bundle — raw documents/*.json + verbatim evidence text. (default)
+  sanitized  Sanitized Structured Context Bundle — derived structured context only: no raw document
+             payloads, refs-only evidence.json (uuids + source sha256, no verbatim text). NOT
+             "anonymous" — identity hints (asset_match, profile) are retained.
 
 Note (branch): the richer asset_graph/registers/edges emitters live on the parser's
 feat/vfd-analyzer-auto-map branch; bundle@1 derives signals.csv from accepted extractions and defers
@@ -27,6 +34,7 @@ import hashlib
 import io
 import json
 import re
+import uuid
 import zipfile
 from datetime import datetime, timezone
 
@@ -35,6 +43,16 @@ from . import scorecard as _scorecard
 
 SCHEMA = "mira-contextualizer/bundle@1"
 _TYPE_URI = "urn:mira:type:%s"
+
+# Fixed namespace for the UUID-first identity model (§2 of the HubV3 intake contract). Entity ids are
+# minted with uuid5 over a stable key so a re-export of the same project yields the SAME bundle — the
+# bundle's determinism property must hold for these too. ``.hex`` matches the store's uuid4().hex form.
+_NS = uuid.uuid5(uuid.NAMESPACE_URL, "urn:mira:contextualizer:bundle")
+
+
+def _eid(kind: str, *parts: object) -> str:
+    """Deterministic 32-char entity id for ``kind`` over ``parts`` (project-scoped, stable per content)."""
+    return uuid.uuid5(_NS, kind + ":" + ":".join(str(p) for p in parts)).hex
 
 
 def _safe(name: str) -> str:
@@ -45,7 +63,7 @@ def _uns_segments(path: str) -> list[str]:
     return [s for s in re.split(r"[/.]", path) if s]
 
 
-def _i3x(accepted: list[dict], quantities: dict | None = None) -> dict:
+def _i3x(accepted: list[dict], quantities: dict | None = None, project_id: str = "") -> dict:
     """Project accepted UNS paths into CESMII i3X objectInstances (containers + signal leaves).
 
     ``quantities`` maps a signal's tag name → its UCUM-coded quantity (from ``standards``); when a
@@ -70,6 +88,7 @@ def _i3x(accepted: list[dict], quantities: dict | None = None) -> dict:
                     meta["quantity"] = q
             instances[elem_id] = {
                 "elementId": elem_id,
+                "uns_node_uuid": _eid("uns_node", project_id, elem_id),
                 "name": segs[i],
                 "typeElementId": _TYPE_URI % ("signal" if is_leaf else "container"),
                 "parentId": "/".join(segs[:i]) or None,
@@ -118,6 +137,7 @@ def _kg(accepted: list[dict], project_id: str, quantities: dict | None = None) -
         node = ent("signal", path, e["tagName"],
                    {"roles": e.get("roles") or [], "confidence": e.get("confidence"),
                     "provenance": prov(e)})
+        node.setdefault("signal_uuid", _eid("signal", project_id, path))
         signal_by_tag.setdefault(e["tagName"], node)
         segs = _uns_segments(path)
         if len(segs) >= 2:
@@ -164,10 +184,16 @@ def _kg(accepted: list[dict], project_id: str, quantities: dict | None = None) -
             node = ent(primary, e["tagName"], e["tagName"],
                        {"confidence": e.get("confidence"), "provenance": prov(e)})
             if primary == "tag_reference":
-                for m in ev.get("mentions", []):
+                # one MENTIONS edge per mention; its id derives from the per-mention evidence_uuid
+                # (same key as _evidence) so the same tag mentioned N times yields N distinct, linkable
+                # edges instead of one colliding id.
+                for i, m in enumerate(ev.get("mentions", [])):
+                    euid = _eid("evidence", e["id"], i)
                     relationships.append({
                         "type": "MENTIONS", "source": "document:%s" % m.get("file"),
                         "target": e["tagName"], "approval_state": "proposed",
+                        "evidence_uuid": euid,
+                        "relationship_uuid": _eid("relationship", "MENTIONS", euid),
                         "evidence": {"page": m.get("page"), "snippet": m.get("snippet")}})
 
         # UCUM quantity: carry it on the document entity, and attach it to the matching UNS signal.
@@ -177,6 +203,11 @@ def _kg(accepted: list[dict], project_id: str, quantities: dict | None = None) -
             sig = signal_by_tag.get(e["tagName"])
             if sig:
                 sig["properties"]["quantity"] = q
+
+    # stamp a stable id on every edge that didn't already derive one (MENTIONS derives from evidence).
+    for r in relationships:
+        r.setdefault("relationship_uuid",
+                     _eid("relationship", project_id, r["type"], r["source"], r["target"]))
 
     return ({"schema": "mira-contextualizer/kg_entities@1", "entities": entities},
             {"schema": "mira-contextualizer/kg_relationships@1", "relationships": relationships})
@@ -221,6 +252,40 @@ def _parameters(accepted: list[dict], quantities: dict) -> dict:
                 entry["quantity"] = raw
         params.append(entry)
     return {"schema": "mira-contextualizer/parameters@1", "parameters": params}
+
+
+def _evidence(accepted: list[dict], src_meta: list[dict], sanitized: bool = False) -> dict:
+    """Aggregate the evidence that today is scattered across ``review.json`` + ``documents/*.json`` into
+    one provenance index: **source (sha256) → evidence (evidence_uuid) → entity (tag/extraction)**.
+
+    One block per document mention (so each is independently addressable), or one block per extraction
+    when there are no mentions (PLC/CCW signals carry their extractor evidence as ``raw``). Full mode
+    keeps the verbatim text (``snippet`` / ``raw``); the **sanitized** mode keeps only refs, uuids, and
+    the source sha256 — no verbatim document payload."""
+    sha_by_file = {s["file"]: s["sha256"] for s in src_meta}
+    blocks: list[dict] = []
+    for e in accepted:
+        ev = e.get("evidenceJson") or {}
+        mentions = ev.get("mentions") or []
+        common: dict = {"tag": e["tagName"], "roles": e.get("roles") or [],
+                        "confidence": e.get("confidence"), "extraction_id": e["id"]}
+        if mentions:
+            for i, m in enumerate(mentions):
+                src_file = m.get("file") or e.get("fileName")
+                block = dict(common, evidence_uuid=_eid("evidence", e["id"], i),
+                             source_file=src_file, source_sha256=sha_by_file.get(src_file),
+                             page=m.get("page"))
+                if not sanitized:
+                    block["snippet"] = m.get("snippet")
+                blocks.append(block)
+        else:
+            src_file = e.get("fileName")
+            block = dict(common, evidence_uuid=_eid("evidence", e["id"], 0),
+                         source_file=src_file, source_sha256=sha_by_file.get(src_file), page=None)
+            if not sanitized:
+                block["raw"] = ev
+            blocks.append(block)
+    return {"schema": "mira-contextualizer/evidence@1", "evidence": blocks}
 
 
 def _profile_json(proj: dict) -> dict:
@@ -294,8 +359,13 @@ _IMPORT_MD = (
 )
 
 
-def build_bundle(store, project_id: str) -> dict[str, str]:
-    """Return a mapping of bundle-relative path → file content (str). Caller writes or zips it."""
+def build_bundle(store, project_id: str, sanitized: bool = False) -> dict[str, str]:
+    """Return a mapping of bundle-relative path → file content (str). Caller writes or zips it.
+
+    ``sanitized=False`` → **Full Evidence Bundle**: raw ``documents/*.json`` + verbatim evidence text.
+    ``sanitized=True``  → **Sanitized Structured Context Bundle**: the derived structured context only
+    (UNS/i3X/kg/faults/parameters/scorecard + source refs/hashes), with no raw document payloads and
+    refs-only evidence. It is *not* anonymous — identity hints (asset_match, profile) are retained."""
     proj = store.get_project(project_id)
     if not proj:
         raise ValueError("project not found")
@@ -308,9 +378,9 @@ def build_bundle(store, project_id: str) -> dict[str, str]:
     for s in sources:
         full = store.get_source(s["id"])
         ir = full.get("extracted") if full else None
-        if ir:
+        if ir and not sanitized:  # raw document IR is omitted from the sanitized bundle
             files["documents/%s.json" % _safe(s["fileName"])] = json.dumps(ir, indent=2)
-        blob = json.dumps(ir or {}, sort_keys=True).encode()
+        blob = json.dumps(ir or {}, sort_keys=True).encode()  # sha is identical in both modes
         src_meta.append({"file": s["fileName"], "type": s["sourceType"], "status": s["status"],
                          "sha256": hashlib.sha256(blob).hexdigest()})
 
@@ -332,6 +402,8 @@ def build_bundle(store, project_id: str) -> dict[str, str]:
     files["manifest.json"] = json.dumps({
         "schema": SCHEMA, "tool": "mira-contextualizer", "tool_version": __version__,
         "created_at": datetime.now(timezone.utc).isoformat(),
+        # which export mode produced this bundle (raw documents + verbatim evidence, or refs-only)
+        "mode": "sanitized" if sanitized else "full",
         "project": {"id": proj["id"], "name": proj["name"], "description": proj.get("description")},
         "counts": {"sources": len(sources), "candidates": len(exts), "accepted": len(accepted),
                    "uns_signals": n_uns, "iso14224_faults": n_iso,
@@ -352,13 +424,14 @@ def build_bundle(store, project_id: str) -> dict[str, str]:
                      "confidence": e.get("confidence")}
                     for e in accepted if e.get("unsPathProposed")],
     }, indent=2)
-    files["i3x.json"] = json.dumps(_i3x(accepted, quantities), indent=2)
+    files["i3x.json"] = json.dumps(_i3x(accepted, quantities, project_id), indent=2)
     ents, rels = _kg(accepted, project_id, quantities)
     files["kg_entities.json"] = json.dumps(ents, indent=2)
     files["kg_relationships.json"] = json.dumps(rels, indent=2)
     files["signals.csv"] = _signals_csv(accepted)
     files["fault_catalog.json"] = json.dumps(_fault_catalog(accepted), indent=2)
     files["parameters.json"] = json.dumps(_parameters(accepted, quantities), indent=2)
+    files["evidence.json"] = json.dumps(_evidence(accepted, src_meta, sanitized), indent=2)
     files["review.json"] = json.dumps({
         "schema": "mira-contextualizer/review@1",
         "decisions": [{"tag": e["tagName"], "roles": e.get("roles", []), "status": e["status"],

--- a/mira-contextualizer/mira_contextualizer/gui/index.html
+++ b/mira-contextualizer/mira_contextualizer/gui/index.html
@@ -112,6 +112,7 @@
       <button onclick="act('saveAs')" data-need="profile">Save As…</button>
       <button onclick="act('import')" data-need="profile">Import Files…</button>
       <button onclick="act('exportBundle')" data-need="profile">Export Bundle…</button>
+      <button onclick="act('exportSanitized')" data-need="profile">Export Sanitized Context…</button>
       <div class="sep"></div>
       <div class="sub">Recent Profiles</div>
       <div id="recentList"><button disabled>None yet</button></div>
@@ -231,7 +232,7 @@ async function act(a){
     openProfile:()=>$("profileInput").click(),
     save:saveProfile, saveAs:saveProfile,
     import:()=>$("fileInput").click(),
-    exportBundle:exportBundle,
+    exportBundle:exportBundle, exportSanitized:exportSanitized,
     exit:()=>{ window.close(); toast("You can close this window."); },
     undo:undoDecision, redo:redoDecision,
     find:()=>{ setView(VIEW); const f=$("findBox"); if(f){ f.focus(); } else { setView("signals"); } },
@@ -444,6 +445,8 @@ function openProfileFile(ev){ const f=ev.target.files[0]; ev.target.value=""; if
   r.readAsText(f); }
 function exportBundle(){ if(!CURRENT){ toast("Open a profile first"); return; }
   window.location.href=`/api/projects/${CURRENT}/export?format=bundle`; toast("Building machine_context_bundle.zip…"); }
+function exportSanitized(){ if(!CURRENT){ toast("Open a profile first"); return; }
+  window.location.href=`/api/projects/${CURRENT}/export?format=bundle-sanitized`; toast("Building sanitized structured context…"); }
 async function loadRecents(){
   try{ const j=await api("/api/recents"); const el=$("recentList");
     if(!(j.recents||[]).length){ el.innerHTML='<button disabled>None yet</button>'; return; }

--- a/mira-contextualizer/mira_contextualizer/server.py
+++ b/mira-contextualizer/mira_contextualizer/server.py
@@ -332,13 +332,16 @@ def make_handler(store: Store, gui_dir: str, recents_path: str | None = None):
                     {"tag": e["tagName"], "unsPath": e["unsPathProposed"], "roles": e["roles"],
                      "confidence": e["confidence"]} for e in accepted if e["unsPathProposed"]]})
             elif fmt == "i3x":
-                self._json(bundle._i3x(accepted))
-            elif fmt == "bundle":
-                data = bundle.zip_bytes(bundle.build_bundle(store, pid))
-                store.add_export(pid, "bundle", "machine_context_bundle.zip",
+                self._json(bundle._i3x(accepted, project_id=pid))
+            elif fmt in ("bundle", "bundle-sanitized"):
+                sanitized = fmt == "bundle-sanitized"
+                name = ("machine_context_sanitized.zip" if sanitized
+                        else "machine_context_bundle.zip")
+                data = bundle.zip_bytes(bundle.build_bundle(store, pid, sanitized=sanitized))
+                store.add_export(pid, fmt, name,
                                  {"bytes": len(data), "accepted": sum(
                                      1 for e in store.list_extractions(pid) if e["status"] == "accepted")})
-                self._send_bytes(data, "application/zip", "machine_context_bundle.zip")
+                self._send_bytes(data, "application/zip", name)
             elif fmt == "profile":
                 data = json.dumps(profile.save_profile(store, pid), indent=2).encode("utf-8")
                 store.add_export(pid, "profile", "%s%s" % (proj["name"], profile.EXT))
@@ -347,7 +350,7 @@ def make_handler(store: Store, gui_dir: str, recents_path: str | None = None):
                 self._send_bytes(data, "application/json",
                                  "%s%s" % (bundle._safe(proj["name"]), profile.EXT))
             else:
-                self._err("unsupported format (uns | i3x | bundle | profile)", 400)
+                self._err("unsupported format (uns | i3x | bundle | bundle-sanitized | profile)", 400)
 
     return Handler
 

--- a/mira-contextualizer/tests/test_bundle.py
+++ b/mira-contextualizer/tests/test_bundle.py
@@ -57,7 +57,7 @@ def test_bundle_contents(seeded):
     files = bundle.build_bundle(store, pid)
     for key in ("manifest.json", "uns.json", "i3x.json", "kg_entities.json",
                 "kg_relationships.json", "signals.csv", "review.json", "report.md", "IMPORT.md",
-                "scorecard.json"):
+                "scorecard.json", "evidence.json"):
         assert key in files, key
     sc = json.loads(files["scorecard.json"])
     assert sc["schema"] == "mira-contextualizer/scorecard@1" and "score" in sc
@@ -231,6 +231,106 @@ def test_bundle_existing_asset_intent_when_hub_asset_id_set(tmp_path):
     man = json.loads(bundle.build_bundle(s, p["id"])["manifest.json"])
     assert man["import"]["intent"] == "existing_asset"
     assert man["import"]["hub_asset_id"] == "asset-abc-123"
+    s.close()
+
+
+def test_full_bundle_emits_evidence_and_preserves_provenance(seeded):
+    """PRD test 11 — the full bundle aggregates evidence into evidence.json and keeps a walkable
+    provenance chain: an entity → its evidence block (by extraction id) → the source sha256 that
+    appears in the manifest. Full mode also carries verbatim document text + raw evidence."""
+    store, pid = seeded
+    files = bundle.build_bundle(store, pid)
+
+    # the previously-missing 16th bundle file now exists, with stable per-block UUIDs
+    assert "evidence.json" in files
+    ev = json.loads(files["evidence.json"])
+    assert ev["schema"] == "mira-contextualizer/evidence@1" and ev["evidence"]
+    assert all(b["evidence_uuid"] for b in ev["evidence"])
+
+    # full mode carries the raw document payload + the verbatim mined snippet
+    assert any(k.startswith("documents/") for k in files)
+    assert any("Conv_Run energizes" in (b.get("snippet") or "") for b in ev["evidence"])
+
+    # chain: signal entity → evidence block (same extraction id) → manifest source sha256
+    ents = json.loads(files["kg_entities.json"])["entities"]
+    sig = next(e for e in ents if e["entity_type"] == "signal" and e["entity_id"] == UNS)
+    assert sig["signal_uuid"]                                       # stable signal identity
+    xid = sig["properties"]["provenance"]["ctx_extraction_id"]
+    block = next(b for b in ev["evidence"] if b["extraction_id"] == xid)
+    man_shas = {s["sha256"] for s in json.loads(files["manifest.json"])["sources"]}
+    assert block["source_sha256"] in man_shas
+
+
+def test_sanitized_bundle_has_no_raw_document_payloads(seeded):
+    """PRD test 10 — the *sanitized structured context* bundle ships the derived structured context but
+    NO raw document payloads: no ``documents/*.json`` files, and ``evidence.json`` carries refs/uuids/
+    sha only — never verbatim mined text. Boundary (narrow §3 reading): the short provenance snippets in
+    review.json/parameters.json/fault_catalog.json are derived structured context and are retained; only
+    the raw document IR and the aggregate evidence text are stripped."""
+    store, pid = seeded
+    full = bundle.build_bundle(store, pid)
+    san = bundle.build_bundle(store, pid, sanitized=True)
+
+    # no raw document IR files, and the manifest declares the mode
+    assert any(k.startswith("documents/") for k in full)
+    assert not any(k.startswith("documents/") for k in san)
+    assert json.loads(san["manifest.json"])["mode"] == "sanitized"
+    assert json.loads(full["manifest.json"])["mode"] == "full"
+
+    # evidence.json present in both, but the verbatim mined sentence appears ONLY in the full bundle
+    SENTINEL = "Conv_Run energizes"
+    assert SENTINEL in full["evidence.json"]
+    assert SENTINEL not in san["evidence.json"]
+    san_ev = json.loads(san["evidence.json"])["evidence"]
+    assert san_ev and all("snippet" not in b and "raw" not in b for b in san_ev)
+
+    # derived structured context is still fully present (this is "sanitized", not "anonymous")
+    for key in ("uns.json", "i3x.json", "kg_entities.json", "kg_relationships.json",
+                "fault_catalog.json", "parameters.json", "scorecard.json", "signals.csv"):
+        assert key in san, key
+    # source refs + hashes survive sanitization (provenance chain still resolves)
+    assert all(b["source_sha256"] for b in san_ev)
+    assert json.loads(san["manifest.json"])["asset_match"]["source_file_hashes"]
+
+
+def test_entity_uuids_present_and_unique(tmp_path):
+    """The 4 missing identity UUIDs (§2) are minted: ``signal_uuid`` on signal entities, ``uns_node_uuid``
+    on every i3X node, ``relationship_uuid`` on every edge, ``evidence_uuid`` per evidence block.
+    Critically, a tag mentioned twice in one document yields two DISTINCT MENTIONS edges whose
+    relationship_uuid derives from (and matches) the per-mention evidence_uuid — no collisions."""
+    s = Store(str(tmp_path / "uuids.db"))
+    p = s.create_project("UUID cell")
+    plc = s.create_source(p["id"], "ccw", "ccw")
+    s.add_extractions(p["id"], plc["id"], [
+        {"tag_name": "Conv_Run", "roles": ["motor"], "uns_path_proposed": UNS,
+         "i3x_element_id": UNS, "evidence_json": {"source": "ccw_modbus"}, "confidence": 0.9}])
+    doc = s.create_source(p["id"], "manual", "m.pdf")
+    s.add_extractions(p["id"], doc["id"], [
+        {"tag_name": "Conv_Run", "roles": ["tag_reference"], "uns_path_proposed": None,
+         "evidence_json": {"source": "document", "entity_type": "tag_reference", "mentions": [
+             {"file": "m.pdf", "page": 2, "snippet": "Conv_Run energizes the motor"},
+             {"file": "m.pdf", "page": 7, "snippet": "Conv_Run de-energizes on stop"}]},
+         "confidence": 0.9}])
+    for e in s.list_extractions(p["id"]):
+        s.set_extraction_status(e["id"], "accepted")
+    files = bundle.build_bundle(s, p["id"])
+
+    nodes = json.loads(files["i3x.json"])["objectInstances"]
+    assert nodes and all(n["uns_node_uuid"] for n in nodes)
+    assert len({n["uns_node_uuid"] for n in nodes}) == len(nodes)   # one stable id per UNS node
+
+    rels = json.loads(files["kg_relationships.json"])["relationships"]
+    assert rels and all(r["relationship_uuid"] for r in rels)
+    assert len({r["relationship_uuid"] for r in rels}) == len(rels)  # no edge-id collisions
+
+    mentions = [r for r in rels if r["type"] == "MENTIONS" and r["target"] == "Conv_Run"]
+    assert len(mentions) == 2                                        # two distinct mention edges
+    assert mentions[0]["relationship_uuid"] != mentions[1]["relationship_uuid"]
+
+    # each MENTIONS edge links back to a real evidence block (relationship_uuid derives from evidence)
+    ev_uuids = {b["evidence_uuid"] for b in json.loads(files["evidence.json"])["evidence"]}
+    for r in mentions:
+        assert r["evidence_uuid"] in ev_uuids
     s.close()
 
 

--- a/mira-contextualizer/tests/test_server.py
+++ b/mira-contextualizer/tests/test_server.py
@@ -85,6 +85,29 @@ def test_bundle_and_i3x_export(base):
         assert "manifest.json" in zf.namelist() and "uns.json" in zf.namelist()
 
 
+def test_sanitized_bundle_export(base):
+    """The sanitized structured-context bundle is reachable over the API and ships no raw documents."""
+    import io
+    import json as _json
+    import zipfile
+    _, j = _req(f"{base}/api/projects", "POST", {"name": "Sanitized Co"})
+    pid = j["project"]["id"]
+    _req(f"{base}/api/projects/{pid}/sources", "POST",
+         {"fileName": FIXTURE.name, "text": FIXTURE.read_text(encoding="utf-8")})
+    _, ext = _req(f"{base}/api/projects/{pid}/extractions")
+    target = next(e for e in ext["extractions"] if e["unsPathProposed"])
+    _req(f"{base}/api/extractions/{target['id']}", "PATCH", {"status": "accepted"})
+
+    with urllib.request.urlopen(f"{base}/api/projects/{pid}/export?format=bundle-sanitized") as r:
+        assert r.status == 200 and r.headers["Content-Type"] == "application/zip"
+        data = r.read()
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        names = zf.namelist()
+        assert "manifest.json" in names and "evidence.json" in names
+        assert not any(n.startswith("documents/") for n in names)
+        assert _json.loads(zf.read("manifest.json"))["mode"] == "sanitized"
+
+
 def test_ccw_project_import_json_and_zip(base):
     import io
     import zipfile


### PR DESCRIPTION
## What

Completes the offline Contextualizer bundle (15/16 → **16/16**) per `docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md` §5 **Phase 5**. Scope is strictly `mira-contextualizer/` — **no `mira-hub/` or `mira-bots/` changes**.

Three Phase-5 deliverables:

1. **`evidence.json`** — the previously-missing 16th bundle file. Aggregates the evidence that today is scattered across `review.json` + `documents/*.json` into one provenance index: **source(sha256) → evidence(`evidence_uuid`) → entity(tag/extraction)**. One block per document mention (independently addressable) or per extraction when there are none.
2. **The 4 missing identity UUIDs** (§2 UUID-first model), minted deterministically with `uuid5` (`.hex`, matching the store's `uuid4().hex` form) so a re-export of the same project stays reproducible:
   - `evidence_uuid` (per mention), `signal_uuid` (signal entities), `uns_node_uuid` (i3X nodes), `relationship_uuid` (every edge).
   - **MENTIONS edges derive `relationship_uuid` from their `evidence_uuid`**, so a tag mentioned N times yields N distinct, linkable edges instead of one colliding id.
3. **Sanitized Structured Context export mode** (greenfield) — `build_bundle(sanitized=True)` drops raw `documents/*.json` and ships **refs-only** `evidence.json` (uuids + source sha256, no verbatim text). Reachable via `?format=bundle-sanitized` and a GUI button. It is **not "anonymous"** — `asset_match`/profile identity hints are retained (per §9 guardrail).

`scorecard.json`, `asset_match`, `import{intent,policy}`, and source sha256 already existed and were **not** rebuilt.

## Sanitized boundary (conscious decision — please read)

Narrow but PRD-sanctioned reading of §3 ("*optionally* strips sensitive snippets"): sanitized mode strips the **raw document IR** (`documents/*.json`) and the **verbatim text in `evidence.json`**. Short provenance snippets still ship in `review.json`, `parameters.json`, and `fault_catalog.json` (they embed `mentions[].snippet`) — these are derived structured context. If fully text-free output is wanted, the extension is to also strip the `snippet` fields in those three emitters. `sha256` is identical in both modes (computed from the IR regardless of the `documents/` skip), so the provenance chain resolves in both.

## Tests (TDD)

PRD §6 **test 10** (sanitized has no raw document payloads) and **test 11** (full bundle preserves provenance — walkable entity → evidence → manifest sha chain) written first, red, then green. Plus UUID uniqueness + MENTIONS-collision test, and a server-route test for `?format=bundle-sanitized`.

- Full suite: **78 passed, 3 skipped** — the 77 pre-existing tests intact.
- Frozen onedir rebuilt on macOS; binary `--selftest` **exit 0**.
- Changed files: `bundle.py`, `server.py`, `gui/index.html`, `tests/test_bundle.py`, `tests/test_server.py`.

## Relation to `feat/hubv3-offline-bundle` (peer branch)

A concurrent session pushed `feat/hubv3-offline-bundle` (commit `8349959a`) implementing **only** the sanitized-export subset — no `evidence.json`, no entity UUIDs. **This PR is a complete superset of all three Phase-5 deliverables** and includes a more complete sanitized mode (manifest `mode` marker, refs-only `evidence.json`, GUI button). I did not touch the peer branch; suggest closing it in favor of this one.

**Do not merge** — targets `feat/plc-mapper-gui` for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)