### PR TITLE
feat(hub): HubV3 Hub spine — intake contract + migration 056 + import dedup (P0–P2)

### DIFF
--- a/contracts/contextualization/__init__.py
+++ b/contracts/contextualization/__init__.py
@@ -1,0 +1,18 @@
+"""Cross-module contextualization contracts (Hub is system of record).
+
+Neutral home for the shared Intake Contract Python twin so the offline
+Contextualizer and Telegram thin client can import it without either owning it.
+See intake_contract.py and mira-hub/src/lib/contextualization/intake-contract.ts.
+"""
+
+from .intake_contract import (  # noqa: F401
+    CONTRACT_VERSION,
+    INGEST_ROUTES,
+    SOURCE_TYPES,
+    AssetHints,
+    IntakeContract,
+    IntakeSource,
+    ProposedSignal,
+    SourceMetadata,
+    validate_envelope,
+)

--- a/contracts/contextualization/intake_contract.py
+++ b/contracts/contextualization/intake_contract.py
@@ -1,0 +1,184 @@
+"""HubV3 — Shared Contextualization Intake Contract (Python twin).
+
+The single normalized envelope every ingest route submits to the Hub. The Hub
+is the system of record; clients only collect evidence and create proposals.
+
+This is the Python twin of:
+  - mira-hub/src/lib/contextualization/intake-contract.ts  (authoritative types + validator)
+  - mira-hub/src/lib/contextualization/intake-contract.schema.json  (JSON Schema)
+
+Keep all three in lockstep — change them together. This module is intentionally
+dependency-free (stdlib only) so the offline Contextualizer (mira-contextualizer)
+and the Telegram thin client (mira-bots) can each import it without pulling a
+validation framework. Those clients are wired in HubV3 Phases 5/6; this contract
+ships first (Phase 0) so they have one shape to target.
+
+Identity model: UUIDs are identity; names / numbers / serials / models /
+controller IPs / UNS paths are MATCHING EVIDENCE, never the sole key.
+`review_status` is always "proposed" on intake — nothing is auto-approved.
+
+Spec: docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md §2
+ADR:  docs/adr/0023-hub-system-of-record-contextualization.md
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+CONTRACT_VERSION = "contextualization-intake/v1"
+
+INGEST_ROUTES = ("offline", "telegram", "hub_upload")
+SOURCE_TYPES = ("l5x", "st", "plcopen", "csv", "manual", "other")
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
+
+
+@dataclass
+class AssetHints:
+    """Identity + matching-evidence hints; never the sole key."""
+
+    name: str | None = None
+    number: str | None = None
+    manufacturer: str | None = None
+    model: str | None = None
+    serial: str | None = None
+    controller: str | None = None
+    controller_ip: str | None = None
+    uns_path: str | None = None
+
+
+@dataclass
+class SourceMetadata:
+    file_name: str
+    mime: str | None = None
+    size: int | None = None
+    captured_at: str | None = None
+    uploader: str | None = None
+    location: str | None = None
+
+
+@dataclass
+class IntakeSource:
+    source_sha256: str  # per-source dedup key (sha256 hex)
+    source_type: str  # one of SOURCE_TYPES
+    source_metadata: SourceMetadata
+    source_uuid: str | None = None  # Hub mints if absent
+
+
+@dataclass
+class ProposedSignal:
+    tag_name: str
+    roles: list[str] = field(default_factory=list)
+    uns_path: str | None = None
+    i3x_element_id: str | None = None
+    confidence: float | None = None
+    evidence: dict = field(default_factory=dict)
+    source_sha256: str | None = None
+
+
+@dataclass
+class IntakeContract:
+    """The full intake envelope (HubV3 §2)."""
+
+    ingest_route: str  # one of INGEST_ROUTES
+    sources: list[IntakeSource]
+    contract_version: str = CONTRACT_VERSION
+    review_status: str = "proposed"  # always "proposed" on intake
+    bundle_sha256: str | None = None  # whole-submission fingerprint
+    project_hint: str | None = None
+    asset_hints: AssetHints | None = None
+    evidence: list[dict] = field(default_factory=list)
+    entities: list[dict] = field(default_factory=list)
+    proposed_signals: list[ProposedSignal] = field(default_factory=list)
+    proposed_uns: list[dict] = field(default_factory=list)
+    proposed_i3x: list[dict] = field(default_factory=list)
+    proposed_faults: list[dict] = field(default_factory=list)
+    proposed_parameters: list[dict] = field(default_factory=list)
+    proposed_relationships: list[dict] = field(default_factory=list)
+    provenance: dict = field(default_factory=dict)
+    confidence: str | float | None = None
+
+    def to_envelope(self) -> dict:
+        """Serialize to the wire envelope the Hub import endpoint accepts."""
+        return {
+            "contract_version": self.contract_version,
+            "ingest_route": self.ingest_route,
+            "review_status": self.review_status,
+            "bundle_sha256": self.bundle_sha256,
+            "project_hint": self.project_hint,
+            "asset_hints": _asdict_opt(self.asset_hints),
+            "sources": [
+                {
+                    "source_sha256": s.source_sha256,
+                    "source_type": s.source_type,
+                    "source_uuid": s.source_uuid,
+                    "source_metadata": {
+                        k: v
+                        for k, v in vars(s.source_metadata).items()
+                        if v is not None
+                    },
+                }
+                for s in self.sources
+            ],
+            "evidence": self.evidence,
+            "entities": self.entities,
+            "proposed_signals": [vars(sig) for sig in self.proposed_signals],
+            "proposed_uns": self.proposed_uns,
+            "proposed_i3x": self.proposed_i3x,
+            "proposed_faults": self.proposed_faults,
+            "proposed_parameters": self.proposed_parameters,
+            "proposed_relationships": self.proposed_relationships,
+            "provenance": self.provenance,
+            "confidence": self.confidence,
+        }
+
+
+def _asdict_opt(obj) -> dict | None:
+    if obj is None:
+        return None
+    return {k: v for k, v in vars(obj).items() if v is not None}
+
+
+def validate_envelope(payload: dict) -> list[str]:
+    """Validate a raw envelope dict. Returns a list of errors ([] == valid).
+
+    Mirrors validateIntakeContract() in intake-contract.ts. Kept deliberately
+    in sync with the TS validator's rules and messages.
+    """
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return ["intake contract must be a JSON object"]
+
+    if payload.get("contract_version") != CONTRACT_VERSION:
+        errors.append(f'contract_version must be "{CONTRACT_VERSION}"')
+
+    if payload.get("ingest_route") not in INGEST_ROUTES:
+        errors.append(f"ingest_route must be one of {', '.join(INGEST_ROUTES)}")
+
+    review_status = payload.get("review_status")
+    if review_status is not None and review_status != "proposed":
+        errors.append('review_status must be "proposed" on intake')
+
+    bundle = payload.get("bundle_sha256")
+    if bundle is not None and not (isinstance(bundle, str) and _SHA256_RE.match(bundle)):
+        errors.append("bundle_sha256 must be a 64-char hex string")
+
+    sources = payload.get("sources")
+    if not isinstance(sources, list) or len(sources) == 0:
+        errors.append("sources must be a non-empty array")
+    else:
+        for i, s in enumerate(sources):
+            if not isinstance(s, dict):
+                errors.append(f"sources[{i}] must be an object")
+                continue
+            sha = s.get("source_sha256")
+            if not (isinstance(sha, str) and _SHA256_RE.match(sha)):
+                errors.append(f"sources[{i}].source_sha256 must be a 64-char hex string")
+            if s.get("source_type") not in SOURCE_TYPES:
+                errors.append(f"sources[{i}].source_type must be one of {', '.join(SOURCE_TYPES)}")
+            meta = s.get("source_metadata")
+            if not (isinstance(meta, dict) and isinstance(meta.get("file_name"), str) and meta["file_name"].strip()):
+                errors.append(f"sources[{i}].source_metadata.file_name is required")
+
+    return errors

--- a/docs/adr/0023-hub-system-of-record-contextualization.md
+++ b/docs/adr/0023-hub-system-of-record-contextualization.md
@@ -1,0 +1,152 @@
+# ADR-0023: Hub is the System of Record for Contextualization; Offline & Telegram are Ingest Clients
+
+## Status
+
+Accepted — 2026-06-20
+
+**Related:** ADR-0013 (Hub schema canonicalization — Hub owns the product
+surface), ADR-0017 (proposal state machine — `proposed → approved` is an admin
+action), ADR-0022 (Postgres-first storage).
+**Implements:** Phase 0 + Phase 1/2 of
+[`docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md`](../plans/2026-06-20-hubv3-contextualization-intake-prd.md).
+**Builds on:** PR #2068 (`feat/plc-mapper-gui`) — migration `055_contextualization`
+and the `/api/contextualization/*` routes.
+**Artifacts:** `mira-hub/src/lib/contextualization/intake-contract.ts` (+ `.schema.json`),
+`contracts/contextualization/intake_contract.py`. **Migration:** `056_contextualization_intake`.
+
+---
+
+## Context
+
+Three ingest routes collect contextualization evidence and risk becoming three
+separate systems of record:
+
+1. **MIRA Hub / Command Center** (`app.factorylm.com/hub`).
+2. **Offline FactoryLM Contextualizer** — Windows desktop app (PR #2068).
+3. **Telegram / phone thin client** — photos, nameplates, field notes, docs.
+
+If each platform mints its own assets, sources, UNS nodes, and project models,
+the result is duplicate truth and unmergeable state. The HubV3 spec (Mike,
+2026-06-20) makes the call: **the Hub is the single system of record; the others
+become ingest clients that collect evidence and create proposals.**
+
+The PR #2068 backbone (migration 055: `contextualization_projects`,
+`ctx_sources`, `ctx_extractions`; `/import` accepting a `machine_context_bundle.zip`)
+proves the offline→Hub loop, but has four gaps for "Hub owns truth" (PRD §4.1):
+no sha256 dedup, no asset matching, no import-batch grouping, weak no-overwrite.
+This ADR fixes the contract + dedup foundation (Phases 0–2); matching (P3),
+approval/no-overwrite (P4), and client alignment (P5–P6) build on it.
+
+## Decision
+
+### 1. One shared **Contextualization Intake Contract**, authored once in three lockstep artifacts
+
+- **TypeScript** (`intake-contract.ts`) — authoritative types + a dependency-free
+  `validateIntakeContract()` (no zod; PRD §4 bans framework abstractions).
+- **JSON Schema** (`intake-contract.schema.json`) — validation + documentation.
+- **Python** (`contracts/contextualization/intake_contract.py`) — stdlib-only
+  dataclasses + `validate_envelope()`, in a **neutral top-level `contracts/`**
+  package so the offline Contextualizer (`mira-contextualizer`) and Telegram
+  client (`mira-bots`) each import it without either module owning it.
+
+The envelope (PRD §2): `contract_version`, `ingest_route ∈ {offline, telegram,
+hub_upload}`, `project_hint`, `asset_hints`, `bundle_sha256`, `sources[]` (each
+with `source_sha256`, `source_type`, `source_metadata`), `evidence`, `entities`,
+`proposed_{signals,uns,i3x,faults,parameters,relationships}`, `provenance`,
+`confidence`, and `review_status` (always `proposed` on intake).
+
+### 2. Identity is UUID-first; names are matching evidence
+
+`project_uuid · import_batch_uuid · asset_uuid · source_uuid · source_sha256 ·
+evidence_uuid · signal_uuid · uns_node_uuid · relationship_uuid` are identity.
+Names, asset numbers, tag names, serials, models, controller IPs, and UNS paths
+are **matching evidence**, never the sole key.
+
+### 3. Everything from a client enters as a proposal — nothing is auto-approved
+
+`review_status` is fixed to `proposed` on intake (the validator rejects any
+other value). Per ADR-0017, promotion to approved/verified is an admin action.
+
+**Mapping of "everything lands proposed" to the 055 schema (deliberate, surfaced):**
+the import **batch** carries `review_status = 'proposed'` (new `ctx_import_batches`
+table), and imported tags land in `ctx_extractions.status = 'pending'` — the
+existing not-yet-reviewed state. We do **not** add a 5th `'proposed'` value to
+the `ctx_extractions` status CHECK, because the review UI (tabs
+All/Pending/Accepted/Rejected) only knows `pending|accepted|rejected`; widening
+it is P4/P7 work. The invariant honored is the one that matters: **no row enters
+`accepted` on intake.** "proposed" == batch `review_status='proposed'` +
+extractions `pending`.
+
+### 4. Dedup grain (migration 056, extends 055)
+
+| Grain | Key | Mechanism |
+|---|---|---|
+| Project | `(tenant_id, bundle_sha256)` | `bundle_sha256` column + partial UNIQUE on `contextualization_projects` |
+| Import batch | `(tenant_id, bundle_sha256)` | new `ctx_import_batches` + partial UNIQUE |
+| Source file | `(tenant_id, source_sha256)` | `source_sha256` column + partial UNIQUE on `ctx_sources` |
+
+Partial (`WHERE … IS NOT NULL`) so manually-created projects / non-hashed
+sources are unaffected. The import endpoint uses `ON CONFLICT … DO NOTHING`
+against these indexes (PRD test 3: same source sha256 → no duplicate source row).
+
+`ctx_sources.import_batch_id` (FK → `ctx_import_batches`, `ON DELETE SET NULL`)
+groups a submission's sources. `ctx_extraction_asset_matches` is created now
+(RLS + grants) but populated in **P3** — its `candidate_asset_id` is a **soft
+UUID reference, no FK to `cmms_equipment`** (that full schema is upstream; a hard
+FK would couple this migration to it and break a ctx-only test DB).
+
+## Key sub-decisions
+
+1. **`source_sha256` is added to `ctx_sources` even though the task's P1 list
+   omitted it.** PRD test 3 is literally "same *source* sha256 does not
+   duplicate *source* records" — source-level dedup is impossible without the
+   column. The omission is treated as an oversight and corrected; flagged in the
+   PR.
+2. **`bundle_sha256` UNIQUE on `contextualization_projects` follows the task
+   literally** and encodes one-project-per-bundle. PRD §2's longer-term model is
+   project→many-batches; that generalization is deferred. Re-import of the same
+   bundle is a no-op (existing project + batch reused; duplicate sources skipped).
+3. **JSON contract path is additive; the existing multipart-zip path stays.**
+   `/import` branches on content-type: `application/json` → intake contract;
+   `multipart/form-data` → the existing offline bundle (`parseBundle`). P5
+   migrates the offline client to the contract; until then both work.
+4. **Hand-rolled validator, no zod.** Keeps the contract portable to the Python
+   and JSON twins and honors PRD §4 (no framework over the data path).
+
+## Alternatives considered and rejected
+
+| Alternative | Why rejected |
+|---|---|
+| Let each client keep its own ingest shape, reconcile in the Hub | Three sources of truth; the exact failure HubV3 exists to prevent. |
+| Add `'proposed'` to the `ctx_extractions` status CHECK | Breaks the review UI's `pending/accepted/rejected` model; UI change is P4/P7, out of P2 scope. |
+| Hard FK `ctx_extraction_asset_matches.candidate_asset_id → cmms_equipment(id)` | Couples 056 to an upstream schema not in 055; breaks ctx-only ephemeral test DBs. Soft UUID ref + P3 resolution instead. |
+| Use zod for validation | New dependency; can't share with the Python/JSON twins; PRD §4 bias against framework abstractions on the data path. |
+| Replace the multipart-zip `/import` path | Would break the shipped offline bundle loop before P5 aligns it. Additive content-type branch instead. |
+
+## Consequences
+
+- **Positive.** One envelope, three consumers, validated identically. Re-import
+  is idempotent (project/batch/source dedup). Nothing auto-approves. Telegram
+  (P6) and the offline client (P5) now have a single shape to target. Asset
+  matching (P3) has its staging table.
+- **Negative / deferred.** `ctx_extractions` still uses `pending` (not a literal
+  `proposed`) — a semantic, not behavioral, gap. One-project-per-bundle is a
+  simplification vs PRD §2's project→many-batches. Asset matching, approval/
+  publish, and no-overwrite enforcement are P3/P4. The Python twin has no
+  consumer until P5/P6 (ships now so they can target it).
+- **Numbering.** Migration `056` claimed for this lane; ADR `0023`. If `origin`
+  grows a competing `056` before merge, rename with the master-plan's collision
+  convention.
+
+## Verification
+
+- `intake-contract.test.ts` — validator accepts a well-formed envelope, rejects
+  bad version / route / empty sources / missing source sha256 / non-proposed
+  review_status; `intakeContractToImport` maps to insertable rows (all `pending`).
+- `import.integration.test.ts` — against ephemeral `postgres:16` with
+  `factorylm_app` role, migrations 055+056 applied, UUID tenant under
+  `SET ROLE factorylm_app`: same `source_sha256` imported twice → exactly one
+  `ctx_sources` row; batch lands `review_status='proposed'`.
+- Migration gate: `apply-migrations.yml --dry-run` on staging via the PR's
+  `migration-verify.yml` (never prod-first, never a direct staging psql from a
+  code session — `docs/environments.md`).

--- a/mira-hub/db/migrations/056_contextualization_intake.sql
+++ b/mira-hub/db/migrations/056_contextualization_intake.sql
@@ -1,0 +1,144 @@
+-- Migration 056: contextualization intake — extend 055 for the shared HubV3
+-- Intake Contract (Hub as system of record; offline/Telegram are ingest clients).
+--
+-- Builds on 055_contextualization. Adds:
+--   * contextualization_projects.bundle_sha256   (+ partial UNIQUE per tenant) — project dedup
+--   * ctx_import_batches                          — one row per import submission, review_status
+--   * ctx_sources.source_sha256                   (+ partial UNIQUE per tenant) — source dedup (PRD test 3)
+--   * ctx_sources.import_batch_id                 (FK → ctx_import_batches)
+--   * ctx_extraction_asset_matches                — P3 asset-matching staging (created now, populated later)
+--
+-- Tenant: UUID (matches 055; Hub auth 401s non-UUID sessions). RLS pattern, GRANT
+-- to factorylm_app, and the touch_ctx_updated_at() trigger fn are reused verbatim
+-- from 055. Idempotent (IF NOT EXISTS / DROP POLICY|TRIGGER IF EXISTS). Single txn.
+--
+-- ADR: docs/adr/0023-hub-system-of-record-contextualization.md
+-- Spec: docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md §2, §5 P1/P2
+-- Rule: .claude/rules/mira-hub-migrations.md (UUID tenant family, RLS in-type, GRANT, idempotency)
+
+BEGIN;
+
+-- ── ctx_import_batches ─────────────────────────────────────────────────────────
+-- One row per import submission. Groups the sources/extractions of a single
+-- intake. review_status holds the batch at 'proposed' on intake — nothing is
+-- auto-approved (ADR-0017). Per-bundle idempotency via the partial UNIQUE index.
+
+CREATE TABLE IF NOT EXISTS ctx_import_batches (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id     UUID NOT NULL,
+  project_id    UUID NOT NULL REFERENCES contextualization_projects(id) ON DELETE CASCADE,
+  ingest_route  TEXT NOT NULL
+    CHECK (ingest_route IN ('offline', 'telegram', 'hub_upload')),
+  bundle_sha256 TEXT,
+  source_count     INTEGER NOT NULL DEFAULT 0,
+  extraction_count INTEGER NOT NULL DEFAULT 0,
+  review_status TEXT NOT NULL DEFAULT 'proposed'
+    CHECK (review_status IN ('proposed', 'approved', 'rejected', 'needs_review')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ctx_import_batches_project
+  ON ctx_import_batches(project_id);
+CREATE INDEX IF NOT EXISTS idx_ctx_import_batches_tenant
+  ON ctx_import_batches(tenant_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ctx_import_batches_bundle_sha
+  ON ctx_import_batches(tenant_id, bundle_sha256)
+  WHERE bundle_sha256 IS NOT NULL;
+
+ALTER TABLE ctx_import_batches ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_ctx_import_batches ON ctx_import_batches;
+CREATE POLICY tenant_isolation_ctx_import_batches ON ctx_import_batches
+  FOR ALL TO factorylm_app
+  USING (tenant_id = current_setting('app.tenant_id', TRUE)::UUID);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ctx_import_batches TO factorylm_app;
+
+DROP TRIGGER IF EXISTS trg_ctx_import_batches_updated_at ON ctx_import_batches;
+CREATE TRIGGER trg_ctx_import_batches_updated_at
+  BEFORE UPDATE ON ctx_import_batches
+  FOR EACH ROW EXECUTE FUNCTION touch_ctx_updated_at();
+
+-- ── contextualization_projects: bundle_sha256 (project dedup) ───────────────────
+ALTER TABLE contextualization_projects
+  ADD COLUMN IF NOT EXISTS bundle_sha256 TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ctx_projects_bundle_sha
+  ON contextualization_projects(tenant_id, bundle_sha256)
+  WHERE bundle_sha256 IS NOT NULL;
+
+-- ── ctx_sources: source_sha256 (source dedup) + import_batch_id ─────────────────
+ALTER TABLE ctx_sources
+  ADD COLUMN IF NOT EXISTS source_sha256 TEXT;
+ALTER TABLE ctx_sources
+  ADD COLUMN IF NOT EXISTS import_batch_id UUID REFERENCES ctx_import_batches(id) ON DELETE SET NULL;
+
+-- PRD §6 test 3: same source sha256 must not duplicate source records. Partial
+-- so manually-added sources (no hash) are unaffected; the import route's
+-- ON CONFLICT (tenant_id, source_sha256) WHERE source_sha256 IS NOT NULL infers it.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ctx_sources_source_sha
+  ON ctx_sources(tenant_id, source_sha256)
+  WHERE source_sha256 IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ctx_sources_batch
+  ON ctx_sources(import_batch_id);
+
+-- ── ctx_extraction_asset_matches (P3 staging — created now, populated later) ─────
+-- Links a staged extraction (or a whole batch) to a candidate cmms_equipment
+-- asset with a match strength. candidate_asset_id is a SOFT reference (no FK to
+-- cmms_equipment — that full schema is upstream of 055; a hard FK would couple
+-- this migration to it and break a ctx-only test DB). P3's asset-matcher resolves it.
+
+CREATE TABLE IF NOT EXISTS ctx_extraction_asset_matches (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id          UUID NOT NULL,
+  project_id         UUID NOT NULL REFERENCES contextualization_projects(id) ON DELETE CASCADE,
+  import_batch_id    UUID REFERENCES ctx_import_batches(id) ON DELETE SET NULL,
+  extraction_id      UUID REFERENCES ctx_extractions(id) ON DELETE CASCADE,
+  candidate_asset_id UUID,                                  -- soft ref → cmms_equipment.id (resolved in P3)
+  match_strength     TEXT NOT NULL
+    CHECK (match_strength IN ('strong', 'probable', 'none')),
+  match_evidence     JSONB NOT NULL DEFAULT '{}',
+  status             TEXT NOT NULL DEFAULT 'proposed'
+    CHECK (status IN ('proposed', 'confirmed', 'rejected')),
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ctx_asset_matches_project
+  ON ctx_extraction_asset_matches(project_id);
+CREATE INDEX IF NOT EXISTS idx_ctx_asset_matches_tenant
+  ON ctx_extraction_asset_matches(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_ctx_asset_matches_extraction
+  ON ctx_extraction_asset_matches(extraction_id);
+CREATE INDEX IF NOT EXISTS idx_ctx_asset_matches_candidate
+  ON ctx_extraction_asset_matches(candidate_asset_id);
+
+ALTER TABLE ctx_extraction_asset_matches ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_ctx_asset_matches ON ctx_extraction_asset_matches;
+CREATE POLICY tenant_isolation_ctx_asset_matches ON ctx_extraction_asset_matches
+  FOR ALL TO factorylm_app
+  USING (tenant_id = current_setting('app.tenant_id', TRUE)::UUID);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ctx_extraction_asset_matches TO factorylm_app;
+
+DROP TRIGGER IF EXISTS trg_ctx_asset_matches_updated_at ON ctx_extraction_asset_matches;
+CREATE TRIGGER trg_ctx_asset_matches_updated_at
+  BEFORE UPDATE ON ctx_extraction_asset_matches
+  FOR EACH ROW EXECUTE FUNCTION touch_ctx_updated_at();
+
+COMMIT;
+
+-- Verification:
+--   \d+ ctx_import_batches
+--   \d+ ctx_extraction_asset_matches
+--   \d  contextualization_projects   (bundle_sha256 + uq_ctx_projects_bundle_sha)
+--   \d  ctx_sources                  (source_sha256, import_batch_id + uq_ctx_sources_source_sha)
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS ctx_extraction_asset_matches CASCADE;
+--   ALTER TABLE ctx_sources DROP COLUMN IF EXISTS import_batch_id, DROP COLUMN IF EXISTS source_sha256;
+--   DROP TABLE IF EXISTS ctx_import_batches CASCADE;
+--   ALTER TABLE contextualization_projects DROP COLUMN IF EXISTS bundle_sha256;

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:integration": "vitest run --testTimeout 30000 '**/*.integration.test.ts'",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "db:check-order": "node db/check-migration-order.mjs",
     "sitemap": "node scripts/sitemap.mjs",
     "sitemap:check": "node scripts/sitemap.mjs --check",

--- a/mira-hub/src/app/api/contextualization/import/import.integration.test.ts
+++ b/mira-hub/src/app/api/contextualization/import/import.integration.test.ts
@@ -1,0 +1,139 @@
+// Integration test: the contextualization import endpoint accepts the shared
+// HubV3 Intake Contract (PRD §2) and dedups sources by sha256 (PRD §6 test 1 + 3).
+//
+// Requires a Postgres test DB with migrations 055 + 056 applied and a
+// `factorylm_app` role present. Provide via env:
+//   TEST_DATABASE_URL=postgres://postgres:test@localhost:5440/postgres
+//
+// Local setup (see also docs/adr/0023-...):
+//   docker run --rm -d -p 5440:5432 -e POSTGRES_PASSWORD=test --name mira-ctx-test postgres:16
+//   psql ... -c "CREATE ROLE factorylm_app NOLOGIN; GRANT USAGE ON SCHEMA public TO factorylm_app;"
+//   psql ... -f mira-hub/db/migrations/055_contextualization.sql
+//   psql ... -f mira-hub/db/migrations/056_contextualization_intake.sql
+//   TEST_DATABASE_URL=... bunx vitest run --config vitest.config.ts \
+//     src/app/api/contextualization/import/import.integration.test.ts
+//
+// This file is *.integration.test.ts → excluded from the default `vitest run`
+// (vitest.config.ts), run via the integration lane.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import type { Pool } from "pg";
+
+// Build the test pool (no SSL — the lib's default pool forces SSL, which a local
+// postgres:16 rejects) before imports, and inject it as the @/lib/db default so
+// withTenantContext runs against the test DB. require() in vi.hoisted is fine in vitest.
+const { testPool } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Pool: PgPool } = require("pg");
+  return { testPool: new PgPool({ connectionString: process.env.TEST_DATABASE_URL }) as Pool };
+});
+vi.mock("@/lib/db", () => ({ default: testPool }));
+vi.mock("@/lib/session", () => ({ sessionOr401: vi.fn() }));
+
+import { POST } from "./route";
+import { sessionOr401 } from "@/lib/session";
+
+const TENANT = "000000c1-0000-0000-0000-0000000000c1";
+const SHA_A = "a".repeat(64);
+const SHA_SRC = "c".repeat(64);
+
+const sessionOr401Mock = vi.mocked(sessionOr401);
+
+function envelope(): Record<string, unknown> {
+  return {
+    contract_version: "contextualization-intake/v1",
+    ingest_route: "offline",
+    project_hint: "Garage Demo / Micro820 Conveyor",
+    bundle_sha256: SHA_A,
+    review_status: "proposed",
+    sources: [
+      {
+        source_sha256: SHA_SRC,
+        source_type: "st",
+        source_metadata: { file_name: "Micro820.st", mime: "text/plain", uploader: "mike" },
+      },
+    ],
+    proposed_signals: [
+      { tag_name: "Conv_Run", roles: ["output"], uns_path: "enterprise.garage.demo.conv.run", confidence: 0.9, source_sha256: SHA_SRC },
+    ],
+  };
+}
+
+function jsonReq(body: unknown): Request {
+  return new Request("http://test/api/contextualization/import", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeAll(() => {
+  if (!process.env.TEST_DATABASE_URL) {
+    throw new Error("TEST_DATABASE_URL is required for the import integration test. See header.");
+  }
+  process.env.NEON_DATABASE_URL = process.env.TEST_DATABASE_URL; // satisfy the route's 503 guard
+});
+
+afterAll(async () => {
+  await testPool.end();
+});
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  // superuser connection bypasses RLS for cleanup; CASCADE clears sources/batches/extractions.
+  await testPool.query("DELETE FROM contextualization_projects WHERE tenant_id = $1", [TENANT]);
+  sessionOr401Mock.mockResolvedValue({
+    userId: "u_test",
+    tenantId: TENANT,
+    email: "tester@example.com",
+    status: "active",
+    trialExpiresAt: null,
+  });
+});
+
+describe("POST /api/contextualization/import — intake contract", () => {
+  it("accepts the intake contract and stages a project + source + extraction (test 1)", async () => {
+    const res = await POST(jsonReq(envelope()));
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.sources).toBe(1);
+    expect(body.extractions).toBe(1);
+
+    const proj = await testPool.query("SELECT count(*)::int AS n FROM contextualization_projects WHERE tenant_id=$1", [TENANT]);
+    expect(proj.rows[0].n).toBe(1);
+  });
+
+  it("does not duplicate a source with the same sha256 on re-import (test 3)", async () => {
+    const first = await POST(jsonReq(envelope()));
+    expect(first.status).toBe(201);
+    const second = await POST(jsonReq(envelope()));
+    expect(second.status).toBe(201);
+
+    const src = await testPool.query(
+      "SELECT count(*)::int AS n FROM ctx_sources WHERE tenant_id=$1 AND source_sha256=$2",
+      [TENANT, SHA_SRC],
+    );
+    expect(src.rows[0].n).toBe(1); // deduped — exactly one source row.
+
+    const proj = await testPool.query("SELECT count(*)::int AS n FROM contextualization_projects WHERE tenant_id=$1", [TENANT]);
+    expect(proj.rows[0].n).toBe(1); // bundle dedup — one project.
+  });
+
+  it("everything lands proposed — batch review_status=proposed, no accepted extraction", async () => {
+    await POST(jsonReq(envelope()));
+    const batch = await testPool.query("SELECT review_status FROM ctx_import_batches WHERE tenant_id=$1", [TENANT]);
+    expect(batch.rows[0].review_status).toBe("proposed");
+    const accepted = await testPool.query(
+      "SELECT count(*)::int AS n FROM ctx_extractions WHERE tenant_id=$1 AND status='accepted'",
+      [TENANT],
+    );
+    expect(accepted.rows[0].n).toBe(0);
+  });
+
+  it("rejects a malformed contract with 400", async () => {
+    const bad = { ...envelope(), ingest_route: "pigeon" };
+    const res = await POST(jsonReq(bad));
+    expect(res.status).toBe(400);
+  });
+});

--- a/mira-hub/src/app/api/contextualization/import/route.ts
+++ b/mira-hub/src/app/api/contextualization/import/route.ts
@@ -1,8 +1,14 @@
 import { NextResponse } from "next/server";
+import type { PoolClient } from "pg";
 import { sessionOr401 } from "@/lib/session";
 import { withTenantContext } from "@/lib/tenant-context";
 import { readZipEntries } from "@/lib/contextualization/unzip";
 import { parseBundle } from "@/lib/contextualization/bundle-import";
+import {
+  validateIntakeContract,
+  intakeContractToImport,
+  type ContractImport,
+} from "@/lib/contextualization/intake-contract";
 
 export const dynamic = "force-dynamic";
 
@@ -11,14 +17,16 @@ const SRC_STATUS = new Set(["pending", "processing", "done", "error"]);
 /**
  * POST /api/contextualization/import
  *
- * Closes the floor→cloud loop: ingest a Factory Context Bundle (bundle@1) produced offline by the
- * desktop FactoryLM Contextualizer, recreating a project + ctx_sources + ctx_extractions (preserving
- * the offline accept/reject status). The existing /promote flow then lands accepted signals in the
- * knowledge graph for admin review.
+ * Two intake shapes, chosen by content-type (HubV3 — Hub is system of record):
+ *  - application/json  → the shared Intake Contract (ADR-0023, PRD §2). Dedups
+ *    project/batch by bundle_sha256 and sources by source_sha256; everything
+ *    lands proposed (batch review_status='proposed', extractions 'pending').
+ *  - multipart/form-data (file=<bundle>.zip) → the offline Factory Context
+ *    Bundle (bundle@1), recreated into a project + ctx_sources + ctx_extractions
+ *    (legacy path; P5 migrates the offline client onto the contract).
  *
- * Multipart: file=<bundle>.zip. Document/knowledge_entries seeding is intentionally out of scope here
- * (that hybrid table has tenant-scoping footguns — see .claude/rules/knowledge-entries-tenant-scoping);
- * a follow-up wires it behind is_private=true once validated on staging.
+ * Document/knowledge_entries seeding stays out of scope here (that hybrid table
+ * has tenant-scoping footguns — see .claude/rules/knowledge-entries-tenant-scoping).
  */
 export async function POST(req: Request) {
   if (!process.env.NEON_DATABASE_URL) {
@@ -27,6 +35,162 @@ export async function POST(req: Request) {
   const ctx = await sessionOr401();
   if (ctx instanceof NextResponse) return ctx;
 
+  const contentType = req.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    return importFromContract(ctx.tenantId, req);
+  }
+  return importFromBundle(ctx.tenantId, req);
+}
+
+// ── Intake Contract path (HubV3 §2) ─────────────────────────────────────────
+
+async function importFromContract(tenantId: string, req: Request) {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Expected a JSON intake contract body" }, { status: 400 });
+  }
+
+  const { ok, errors, value } = validateIntakeContract(raw);
+  if (!ok || !value) {
+    return NextResponse.json({ error: "invalid intake contract", details: errors }, { status: 400 });
+  }
+  const imp = intakeContractToImport(value);
+
+  try {
+    const result = await withTenantContext(tenantId, async (c) => {
+      const projectId = await upsertProject(c, tenantId, imp);
+      const { batchId, isNew } = await upsertBatch(c, tenantId, projectId, imp);
+
+      // Re-import of an already-staged bundle is an idempotent no-op: the source
+      // ON CONFLICT below would dedup anyway, but skipping avoids re-inserting
+      // extractions (which have no natural unique key).
+      if (!isNew) {
+        return {
+          projectId,
+          importBatchId: batchId,
+          sources: imp.sources.length,
+          extractions: imp.extractions.length,
+          deduped: true,
+        };
+      }
+
+      // Insert sources (sha256 dedup), mapping each sha → its source row id so
+      // extractions attach to the right source even when a source was deduped.
+      const shaToSource = new Map<string, string>();
+      for (const s of imp.sources) {
+        const status = SRC_STATUS.has(s.status) ? s.status : "done";
+        const ins = await c.query<{ id: string }>(
+          `INSERT INTO ctx_sources
+             (tenant_id, project_id, import_batch_id, source_type, file_name, source_sha256, status)
+           VALUES ($1::uuid, $2, $3, $4, $5, $6, $7)
+           ON CONFLICT (tenant_id, source_sha256) WHERE source_sha256 IS NOT NULL DO NOTHING
+           RETURNING id`,
+          [tenantId, projectId, batchId, s.sourceType, s.fileName, s.sourceSha256, status],
+        );
+        let sid = ins.rows[0]?.id;
+        if (!sid) {
+          const sel = await c.query<{ id: string }>(
+            `SELECT id FROM ctx_sources WHERE tenant_id = $1::uuid AND source_sha256 = $2`,
+            [tenantId, s.sourceSha256],
+          );
+          sid = sel.rows[0].id;
+        }
+        shaToSource.set(s.sourceSha256, sid);
+      }
+      const defaultSource = shaToSource.values().next().value as string;
+
+      let extractions = 0;
+      for (const e of imp.extractions) {
+        const sid = (e.sourceSha256 && shaToSource.get(e.sourceSha256)) || defaultSource;
+        await c.query(
+          `INSERT INTO ctx_extractions
+             (tenant_id, project_id, source_id, tag_name, roles, uns_path_proposed,
+              i3x_element_id, evidence_json, confidence, status)
+           VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10)`,
+          [
+            tenantId, projectId, sid, e.tagName, e.roles, e.unsPathProposed,
+            e.i3xElementId, JSON.stringify(e.evidenceJson), e.confidence, e.status,
+          ],
+        );
+        extractions++;
+      }
+
+      await c.query(
+        `UPDATE ctx_import_batches SET source_count = $2, extraction_count = $3 WHERE id = $1`,
+        [batchId, imp.sources.length, extractions],
+      );
+
+      return { projectId, importBatchId: batchId, sources: imp.sources.length, extractions, deduped: false };
+    });
+
+    return NextResponse.json({ ok: true, ...result }, { status: 201 });
+  } catch (err) {
+    console.error("[api/contextualization/import POST contract]", err);
+    return NextResponse.json({ error: "Import failed" }, { status: 500 });
+  }
+}
+
+/** Upsert a project by (tenant_id, bundle_sha256); returns its id. */
+async function upsertProject(c: PoolClient, tenantId: string, imp: ContractImport): Promise<string> {
+  const name = `${imp.projectName} (imported)`;
+  if (imp.bundleSha256) {
+    const ins = await c.query<{ id: string }>(
+      `INSERT INTO contextualization_projects (tenant_id, name, description, bundle_sha256)
+         VALUES ($1::uuid, $2, $3, $4)
+         ON CONFLICT (tenant_id, bundle_sha256) WHERE bundle_sha256 IS NOT NULL DO NOTHING
+         RETURNING id`,
+      [tenantId, name, imp.description, imp.bundleSha256],
+    );
+    if (ins.rows[0]) return ins.rows[0].id;
+    const sel = await c.query<{ id: string }>(
+      `SELECT id FROM contextualization_projects WHERE tenant_id = $1::uuid AND bundle_sha256 = $2`,
+      [tenantId, imp.bundleSha256],
+    );
+    return sel.rows[0].id;
+  }
+  const ins = await c.query<{ id: string }>(
+    `INSERT INTO contextualization_projects (tenant_id, name, description)
+       VALUES ($1::uuid, $2, $3) RETURNING id`,
+    [tenantId, name, imp.description],
+  );
+  return ins.rows[0].id;
+}
+
+/** Upsert an import batch by (tenant_id, bundle_sha256); isNew=false means the bundle was already imported. */
+async function upsertBatch(
+  c: PoolClient,
+  tenantId: string,
+  projectId: string,
+  imp: ContractImport,
+): Promise<{ batchId: string; isNew: boolean }> {
+  if (imp.bundleSha256) {
+    const ins = await c.query<{ id: string }>(
+      `INSERT INTO ctx_import_batches (tenant_id, project_id, ingest_route, bundle_sha256)
+         VALUES ($1::uuid, $2, $3, $4)
+         ON CONFLICT (tenant_id, bundle_sha256) WHERE bundle_sha256 IS NOT NULL DO NOTHING
+         RETURNING id`,
+      [tenantId, projectId, imp.ingestRoute, imp.bundleSha256],
+    );
+    if (ins.rows[0]) return { batchId: ins.rows[0].id, isNew: true };
+    const sel = await c.query<{ id: string }>(
+      `SELECT id FROM ctx_import_batches WHERE tenant_id = $1::uuid AND bundle_sha256 = $2`,
+      [tenantId, imp.bundleSha256],
+    );
+    return { batchId: sel.rows[0].id, isNew: false };
+  }
+  const ins = await c.query<{ id: string }>(
+    `INSERT INTO ctx_import_batches (tenant_id, project_id, ingest_route)
+       VALUES ($1::uuid, $2, $3) RETURNING id`,
+    [tenantId, projectId, imp.ingestRoute],
+  );
+  return { batchId: ins.rows[0].id, isNew: true };
+}
+
+// ── Offline bundle path (legacy, multipart) ─────────────────────────────────
+
+async function importFromBundle(tenantId: string, req: Request) {
   let form: FormData;
   try {
     form = await req.formData();
@@ -55,12 +219,12 @@ export async function POST(req: Request) {
   }
 
   try {
-    const result = await withTenantContext(ctx.tenantId, async (c) => {
+    const result = await withTenantContext(tenantId, async (c) => {
       const proj = await c
         .query<{ id: string }>(
           `INSERT INTO contextualization_projects (tenant_id, name, description)
              VALUES ($1::uuid, $2, $3) RETURNING id`,
-          [ctx.tenantId, `${parsed.projectName} (imported)`, parsed.description],
+          [tenantId, `${parsed.projectName} (imported)`, parsed.description],
         )
         .then((r) => r.rows[0]);
       const projectId = proj.id;
@@ -73,7 +237,7 @@ export async function POST(req: Request) {
           .query<{ id: string }>(
             `INSERT INTO ctx_sources (tenant_id, project_id, source_type, file_name, status)
                VALUES ($1::uuid, $2, $3, $4, $5) RETURNING id`,
-            [ctx.tenantId, projectId, s.sourceType, s.fileName, status],
+            [tenantId, projectId, s.sourceType, s.fileName, status],
           )
           .then((r) => r.rows[0]);
         fileToSource.set(s.fileName, row.id);
@@ -85,7 +249,7 @@ export async function POST(req: Request) {
           .query<{ id: string }>(
             `INSERT INTO ctx_sources (tenant_id, project_id, source_type, file_name, status)
                VALUES ($1::uuid, $2, 'other', 'imported', 'done') RETURNING id`,
-            [ctx.tenantId, projectId],
+            [tenantId, projectId],
           )
           .then((r) => r.rows[0].id);
       }
@@ -99,7 +263,7 @@ export async function POST(req: Request) {
               i3x_element_id, evidence_json, confidence, status)
            VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10)`,
           [
-            ctx.tenantId, projectId, sid, e.tagName, e.roles, e.unsPathProposed,
+            tenantId, projectId, sid, e.tagName, e.roles, e.unsPathProposed,
             e.i3xElementId, JSON.stringify(e.evidenceJson), e.confidence, e.status,
           ],
         );

--- a/mira-hub/src/lib/contextualization/intake-contract.schema.json
+++ b/mira-hub/src/lib/contextualization/intake-contract.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://factorylm.com/schemas/contextualization-intake/v1.json",
+  "title": "Contextualization Intake Contract",
+  "description": "HubV3 §2 — the single normalized envelope every ingest route (offline Contextualizer, Telegram thin client, Hub upload) submits to the Hub. Kept in lockstep with intake-contract.ts and contracts/contextualization/intake_contract.py. UUIDs are identity; names/serials/models/IPs/UNS paths are matching evidence. review_status is always 'proposed' on intake.",
+  "type": "object",
+  "required": ["contract_version", "ingest_route", "sources"],
+  "additionalProperties": true,
+  "properties": {
+    "contract_version": { "const": "contextualization-intake/v1" },
+    "ingest_route": { "enum": ["offline", "telegram", "hub_upload"] },
+    "review_status": {
+      "const": "proposed",
+      "description": "Always 'proposed' on intake — nothing is auto-approved (ADR-0017)."
+    },
+    "bundle_sha256": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-fA-F]{64}$",
+      "description": "Whole-submission fingerprint — project/batch dedup key."
+    },
+    "project_hint": { "type": ["string", "null"] },
+    "asset_hints": {
+      "type": "object",
+      "description": "Identity + matching-evidence hints; never the sole key.",
+      "additionalProperties": true,
+      "properties": {
+        "name": { "type": "string" },
+        "number": { "type": "string" },
+        "manufacturer": { "type": "string" },
+        "model": { "type": "string" },
+        "serial": { "type": "string" },
+        "controller": { "type": "string" },
+        "controller_ip": { "type": "string" },
+        "uns_path": { "type": "string" }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["source_sha256", "source_type", "source_metadata"],
+        "additionalProperties": true,
+        "properties": {
+          "source_sha256": { "type": "string", "pattern": "^[0-9a-fA-F]{64}$" },
+          "source_type": { "enum": ["l5x", "st", "plcopen", "csv", "manual", "other"] },
+          "source_uuid": { "type": "string" },
+          "source_metadata": {
+            "type": "object",
+            "required": ["file_name"],
+            "additionalProperties": true,
+            "properties": {
+              "file_name": { "type": "string", "minLength": 1 },
+              "mime": { "type": "string" },
+              "size": { "type": "number" },
+              "captured_at": { "type": "string" },
+              "uploader": { "type": "string" },
+              "location": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "evidence": { "type": "array", "items": { "type": "object" } },
+    "entities": { "type": "array", "items": { "type": "object" } },
+    "proposed_signals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["tag_name"],
+        "additionalProperties": true,
+        "properties": {
+          "tag_name": { "type": "string" },
+          "roles": { "type": "array", "items": { "type": "string" } },
+          "uns_path": { "type": ["string", "null"] },
+          "i3x_element_id": { "type": ["string", "null"] },
+          "confidence": { "type": ["number", "null"] },
+          "evidence": { "type": "object" },
+          "source_sha256": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "proposed_uns": { "type": "array", "items": { "type": "object" } },
+    "proposed_i3x": { "type": "array", "items": { "type": "object" } },
+    "proposed_faults": { "type": "array", "items": { "type": "object" } },
+    "proposed_parameters": { "type": "array", "items": { "type": "object" } },
+    "proposed_relationships": { "type": "array", "items": { "type": "object" } },
+    "provenance": { "type": "object" },
+    "confidence": { "type": ["string", "number", "null"] }
+  }
+}

--- a/mira-hub/src/lib/contextualization/intake-contract.test.ts
+++ b/mira-hub/src/lib/contextualization/intake-contract.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTRACT_VERSION,
+  validateIntakeContract,
+  intakeContractToImport,
+  type IntakeContract,
+} from "./intake-contract";
+
+// A minimal-but-valid envelope per HubV3 PRD §2. Names/serials/paths are
+// matching evidence, never identity; review_status is always "proposed" on intake.
+function validEnvelope(): Record<string, unknown> {
+  return {
+    contract_version: CONTRACT_VERSION,
+    ingest_route: "offline",
+    project_hint: "Garage Demo / Micro820 Conveyor",
+    bundle_sha256: "a".repeat(64),
+    review_status: "proposed",
+    asset_hints: { name: "Conveyor 1", model: "Micro820", controller_ip: "192.168.1.20" },
+    sources: [
+      {
+        source_sha256: "b".repeat(64),
+        source_type: "st",
+        source_metadata: { file_name: "Micro820.st", mime: "text/plain", uploader: "mike" },
+      },
+    ],
+    evidence: [],
+    entities: [],
+    proposed_signals: [
+      { tag_name: "Conv_Run", roles: ["output"], uns_path: "enterprise.garage.demo.conv.run", confidence: 0.9, source_sha256: "b".repeat(64) },
+    ],
+    proposed_uns: [],
+    proposed_i3x: [],
+    proposed_faults: [],
+    proposed_parameters: [],
+    proposed_relationships: [],
+  };
+}
+
+describe("validateIntakeContract", () => {
+  it("accepts a well-formed intake envelope", () => {
+    const res = validateIntakeContract(validEnvelope());
+    expect(res.ok).toBe(true);
+    expect(res.errors).toEqual([]);
+    expect(res.value?.ingest_route).toBe("offline");
+  });
+
+  it("rejects a wrong contract_version", () => {
+    const env = { ...validEnvelope(), contract_version: "nope/v9" };
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(" ")).toMatch(/contract_version/);
+  });
+
+  it("rejects an unknown ingest_route", () => {
+    const env = { ...validEnvelope(), ingest_route: "carrier-pigeon" };
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(" ")).toMatch(/ingest_route/);
+  });
+
+  it("rejects an empty sources array", () => {
+    const env = { ...validEnvelope(), sources: [] };
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(" ")).toMatch(/sources/);
+  });
+
+  it("rejects a source missing its sha256", () => {
+    const env = validEnvelope();
+    (env.sources as Record<string, unknown>[])[0].source_sha256 = undefined;
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(" ")).toMatch(/source_sha256/);
+  });
+
+  it("rejects review_status other than proposed on intake", () => {
+    const env = { ...validEnvelope(), review_status: "approved" };
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(" ")).toMatch(/review_status/);
+  });
+
+  it("defaults review_status to proposed when omitted", () => {
+    const env = validEnvelope();
+    delete (env as Record<string, unknown>).review_status;
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(true);
+    expect(res.value?.review_status).toBe("proposed");
+  });
+});
+
+describe("intakeContractToImport", () => {
+  it("maps the envelope to insertable project/source/extraction rows", () => {
+    const contract = validateIntakeContract(validEnvelope()).value as IntakeContract;
+    const imp = intakeContractToImport(contract);
+    expect(imp.bundleSha256).toBe("a".repeat(64));
+    expect(imp.ingestRoute).toBe("offline");
+    expect(imp.sources).toHaveLength(1);
+    expect(imp.sources[0].sourceSha256).toBe("b".repeat(64));
+    expect(imp.sources[0].sourceType).toBe("st");
+    // proposed_signals become extractions; nothing lands "accepted" on intake.
+    expect(imp.extractions).toHaveLength(1);
+    expect(imp.extractions[0].tagName).toBe("Conv_Run");
+    expect(imp.extractions[0].status).toBe("pending");
+  });
+});

--- a/mira-hub/src/lib/contextualization/intake-contract.ts
+++ b/mira-hub/src/lib/contextualization/intake-contract.ts
@@ -1,0 +1,271 @@
+/**
+ * HubV3 — Shared Contextualization Intake Contract (TypeScript).
+ *
+ * The single normalized envelope every ingest route (offline Contextualizer,
+ * Telegram thin client, Hub upload) submits to the Hub. The Hub is the system
+ * of record; clients only collect evidence and create proposals. See
+ * `docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md` §2 and
+ * `docs/adr/0023-hub-system-of-record-contextualization.md`.
+ *
+ * Three artifacts are kept in lockstep — change all three together:
+ *   - this file (TypeScript types + validator),
+ *   - `intake-contract.schema.json` (JSON Schema, co-located),
+ *   - `contracts/contextualization/intake_contract.py` (Python dataclass).
+ *
+ * Identity model: UUIDs are identity; names / numbers / serials / model
+ * numbers / controller IPs / UNS paths are MATCHING EVIDENCE, never the key.
+ * `review_status` is always "proposed" on intake — nothing is auto-approved.
+ *
+ * Pure + dependency-free (no zod — PRD §4 bans framework abstractions, and a
+ * hand-rolled validator keeps the contract portable to the Python/JSON twins).
+ */
+
+export const CONTRACT_VERSION = "contextualization-intake/v1";
+
+export type IngestRoute = "offline" | "telegram" | "hub_upload";
+
+/** ctx_sources.source_type domain (matches migration 055). */
+export type SourceType = "l5x" | "st" | "plcopen" | "csv" | "manual" | "other";
+
+export const INGEST_ROUTES: readonly IngestRoute[] = ["offline", "telegram", "hub_upload"];
+export const SOURCE_TYPES: readonly SourceType[] = ["l5x", "st", "plcopen", "csv", "manual", "other"];
+
+/** Identity + matching-evidence hints for the asset this submission describes. */
+export interface AssetHints {
+  name?: string;
+  number?: string;
+  manufacturer?: string;
+  model?: string;
+  serial?: string;
+  controller?: string;
+  controller_ip?: string;
+  uns_path?: string;
+}
+
+export interface SourceMetadata {
+  file_name: string;
+  mime?: string;
+  size?: number;
+  captured_at?: string;
+  uploader?: string;
+  location?: string;
+}
+
+export interface IntakeSource {
+  /** Content fingerprint — the per-source dedup key (sha256 hex). */
+  source_sha256: string;
+  source_type: SourceType;
+  source_metadata: SourceMetadata;
+  /** Optional client-minted UUID; the Hub mints its own if absent. */
+  source_uuid?: string;
+}
+
+/** A proposed signal/tag. Lands as a ctx_extractions row (status "pending"). */
+export interface ProposedSignal {
+  tag_name: string;
+  roles?: string[];
+  uns_path?: string | null;
+  i3x_element_id?: string | null;
+  confidence?: number | null;
+  evidence?: Record<string, unknown>;
+  /** Which source (by sha256) this signal came from. */
+  source_sha256?: string | null;
+}
+
+/**
+ * The full intake envelope. Proposal arrays beyond `proposed_signals` are
+ * carried verbatim for downstream phases (P3 matching, P4 publish); P2 only
+ * stages sources + signals. All proposal arrays default to [].
+ */
+export interface IntakeContract {
+  contract_version: typeof CONTRACT_VERSION;
+  ingest_route: IngestRoute;
+  /** Always "proposed" on intake. */
+  review_status: "proposed";
+  /** Whole-submission fingerprint — the project/batch dedup key (sha256 hex). */
+  bundle_sha256?: string | null;
+  project_hint?: string | null;
+  asset_hints?: AssetHints;
+  sources: IntakeSource[];
+  evidence?: Record<string, unknown>[];
+  entities?: Record<string, unknown>[];
+  proposed_signals?: ProposedSignal[];
+  proposed_uns?: Record<string, unknown>[];
+  proposed_i3x?: Record<string, unknown>[];
+  proposed_faults?: Record<string, unknown>[];
+  proposed_parameters?: Record<string, unknown>[];
+  proposed_relationships?: Record<string, unknown>[];
+  provenance?: Record<string, unknown>;
+  confidence?: string | number | null;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: string[];
+  value?: IntakeContract;
+}
+
+const SHA256_RE = /^[0-9a-f]{64}$/i;
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Validate + normalize an unknown payload into an IntakeContract. Returns
+ * `{ ok, errors, value? }`. `value` is only set when `ok` is true. Optional
+ * proposal arrays are defaulted to []; `review_status` defaults to "proposed".
+ */
+export function validateIntakeContract(input: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (!isObject(input)) {
+    return { ok: false, errors: ["intake contract must be a JSON object"] };
+  }
+
+  if (input.contract_version !== CONTRACT_VERSION) {
+    errors.push(`contract_version must be "${CONTRACT_VERSION}"`);
+  }
+
+  const ingestRoute = input.ingest_route;
+  if (typeof ingestRoute !== "string" || !INGEST_ROUTES.includes(ingestRoute as IngestRoute)) {
+    errors.push(`ingest_route must be one of ${INGEST_ROUTES.join(", ")}`);
+  }
+
+  if (input.review_status !== undefined && input.review_status !== "proposed") {
+    errors.push('review_status must be "proposed" on intake');
+  }
+
+  if (input.bundle_sha256 !== undefined && input.bundle_sha256 !== null) {
+    if (typeof input.bundle_sha256 !== "string" || !SHA256_RE.test(input.bundle_sha256)) {
+      errors.push("bundle_sha256 must be a 64-char hex string");
+    }
+  }
+
+  const sources = input.sources;
+  if (!Array.isArray(sources) || sources.length === 0) {
+    errors.push("sources must be a non-empty array");
+  } else {
+    sources.forEach((s, i) => {
+      if (!isObject(s)) {
+        errors.push(`sources[${i}] must be an object`);
+        return;
+      }
+      if (typeof s.source_sha256 !== "string" || !SHA256_RE.test(s.source_sha256)) {
+        errors.push(`sources[${i}].source_sha256 must be a 64-char hex string`);
+      }
+      if (typeof s.source_type !== "string" || !SOURCE_TYPES.includes(s.source_type as SourceType)) {
+        errors.push(`sources[${i}].source_type must be one of ${SOURCE_TYPES.join(", ")}`);
+      }
+      const meta = s.source_metadata;
+      if (!isObject(meta) || typeof meta.file_name !== "string" || !meta.file_name.trim()) {
+        errors.push(`sources[${i}].source_metadata.file_name is required`);
+      }
+    });
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  const value: IntakeContract = {
+    contract_version: CONTRACT_VERSION,
+    ingest_route: ingestRoute as IngestRoute,
+    review_status: "proposed",
+    bundle_sha256: (input.bundle_sha256 as string | undefined) ?? null,
+    project_hint: typeof input.project_hint === "string" ? input.project_hint : null,
+    asset_hints: isObject(input.asset_hints) ? (input.asset_hints as AssetHints) : undefined,
+    sources: (sources as IntakeSource[]).map((s) => ({
+      source_sha256: String(s.source_sha256),
+      source_type: s.source_type,
+      source_metadata: s.source_metadata,
+      source_uuid: typeof s.source_uuid === "string" ? s.source_uuid : undefined,
+    })),
+    evidence: Array.isArray(input.evidence) ? (input.evidence as Record<string, unknown>[]) : [],
+    entities: Array.isArray(input.entities) ? (input.entities as Record<string, unknown>[]) : [],
+    proposed_signals: Array.isArray(input.proposed_signals)
+      ? (input.proposed_signals as ProposedSignal[])
+      : [],
+    proposed_uns: Array.isArray(input.proposed_uns) ? (input.proposed_uns as Record<string, unknown>[]) : [],
+    proposed_i3x: Array.isArray(input.proposed_i3x) ? (input.proposed_i3x as Record<string, unknown>[]) : [],
+    proposed_faults: Array.isArray(input.proposed_faults)
+      ? (input.proposed_faults as Record<string, unknown>[])
+      : [],
+    proposed_parameters: Array.isArray(input.proposed_parameters)
+      ? (input.proposed_parameters as Record<string, unknown>[])
+      : [],
+    proposed_relationships: Array.isArray(input.proposed_relationships)
+      ? (input.proposed_relationships as Record<string, unknown>[])
+      : [],
+    provenance: isObject(input.provenance) ? (input.provenance as Record<string, unknown>) : undefined,
+    confidence:
+      typeof input.confidence === "string" || typeof input.confidence === "number"
+        ? input.confidence
+        : null,
+  };
+
+  return { ok: true, errors: [], value };
+}
+
+// ── Mapping to insertable rows (consumed by the import route) ────────────────
+
+export interface ImportSourceRow {
+  fileName: string;
+  sourceType: SourceType;
+  sourceSha256: string;
+  status: string;
+}
+
+export interface ImportExtractionRow {
+  tagName: string;
+  roles: string[];
+  unsPathProposed: string | null;
+  i3xElementId: string | null;
+  evidenceJson: Record<string, unknown>;
+  confidence: number | null;
+  /** Nothing lands "accepted" on intake — proposed == pending in ctx_extractions. */
+  status: "pending";
+  sourceSha256: string | null;
+}
+
+export interface ContractImport {
+  projectName: string;
+  description: string | null;
+  ingestRoute: IngestRoute;
+  bundleSha256: string | null;
+  sources: ImportSourceRow[];
+  extractions: ImportExtractionRow[];
+}
+
+/**
+ * Map a validated IntakeContract into the project/source/extraction rows the
+ * import route inserts. Mirrors ParsedBundle (bundle-import.ts) so the route's
+ * insert path is shared. proposed_signals → ctx_extractions, all "pending".
+ */
+export function intakeContractToImport(contract: IntakeContract): ContractImport {
+  const sources: ImportSourceRow[] = contract.sources.map((s) => ({
+    fileName: s.source_metadata.file_name,
+    sourceType: s.source_type,
+    sourceSha256: s.source_sha256,
+    status: "done",
+  }));
+
+  const extractions: ImportExtractionRow[] = (contract.proposed_signals ?? [])
+    .map((sig) => ({
+      tagName: String(sig.tag_name ?? "").trim(),
+      roles: Array.isArray(sig.roles) ? sig.roles.map(String) : [],
+      unsPathProposed: typeof sig.uns_path === "string" ? sig.uns_path : null,
+      i3xElementId: typeof sig.i3x_element_id === "string" ? sig.i3x_element_id : null,
+      evidenceJson: isObject(sig.evidence) ? sig.evidence : {},
+      confidence: typeof sig.confidence === "number" ? sig.confidence : null,
+      status: "pending" as const,
+      sourceSha256: typeof sig.source_sha256 === "string" ? sig.source_sha256 : null,
+    }))
+    .filter((e) => e.tagName);
+
+  return {
+    projectName: contract.project_hint?.trim() || "Imported project",
+    description: null,
+    ingestRoute: contract.ingest_route,
+    bundleSha256: contract.bundle_sha256 ?? null,
+    sources,
+    extractions,
+  };
+}

--- a/mira-hub/vitest.integration.config.ts
+++ b/mira-hub/vitest.integration.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+// Integration-test config: runs *.integration.test.ts (real Postgres via
+// TEST_DATABASE_URL). The default vitest.config.ts excludes these so unit `test`
+// stays DB-free; this config includes them. Used by `bun run test:integration`.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.integration.test.ts"],
+    exclude: ["node_modules/**", "tests/e2e/**"],
+    testTimeout: 30000,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## What

HubV3 Hub spine, scoped to PRD **P0/P1/P2** (`docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md`). Hub becomes the system of record for contextualization; offline/Telegram become ingest clients submitting one shared envelope. Extends PR #2068's migration 055 + `/api/contextualization/*` — **does not restart it**. Targets `feat/plc-mapper-gui` (not `main`).

### P0 — Shared Intake Contract (one shape, three lockstep artifacts)
- `mira-hub/src/lib/contextualization/intake-contract.ts` — types + dependency-free `validateIntakeContract` + `intakeContractToImport` (no zod, per PRD §4).
- `intake-contract.schema.json` — JSON Schema twin.
- `contracts/contextualization/intake_contract.py` — stdlib Python twin in a **neutral** package (offline/Telegram import it without owning it; they're out of scope here — P5/P6).
- `docs/adr/0023-hub-system-of-record-contextualization.md`.

### P1 — Migration 056 (extends 055)
`bundle_sha256` + partial UNIQUE on `contextualization_projects`; new `ctx_import_batches` (`review_status` default `proposed`); `source_sha256` + `import_batch_id` on `ctx_sources` (partial UNIQUE → source dedup); `ctx_extraction_asset_matches` (P3 staging; `candidate_asset_id` is a soft ref — no FK to `cmms_equipment`). RLS + `GRANT … factorylm_app`, UUID tenant, idempotent, per `.claude/rules/mira-hub-migrations.md`.

### P2 — Import endpoint
`/api/contextualization/import` accepts the contract via `application/json` (the multipart offline-bundle path is preserved). Project/batch dedup by `bundle_sha256`, source dedup by `source_sha256` (`ON CONFLICT`); everything lands **proposed**.

## Tests (TDD, red→green)
- `intake-contract.test.ts` (8) — validator. **Runs in default CI** → covers **PRD test 1**.
- `import.integration.test.ts` (4) — real Postgres through the real route: contract accepted (**test 1**), same-sha256 no-dup (**test 3**), all-proposed, malformed→400. **Integration-only**: excluded from default `vitest run`; run via `bun run test:integration` with `TEST_DATABASE_URL` (see file header). Also adds `vitest.integration.config.ts` and fixes the `test:integration` script (the old glob matched nothing under the default exclude).

## Gate status
- **Migration verified locally** on ephemeral `postgres:16` (UUID tenant, `SET ROLE factorylm_app`): RLS cross-tenant isolation (0 rows), sha256 source dedup (`INSERT 0 0`, count=1), batch `review_status='proposed'`, 056 idempotent re-apply.
- **Staging dry-run pending** via `migration-verify.yml` (CI; never a direct staging/prod psql from a code session, per `docs/environments.md`).
- Full `vitest run`: 749 pass. One **pre-existing, unrelated** failure (`sitemap-drift.test.ts`, unused `@ts-expect-error`) — file identical to base, untouched here. 2 pre-existing `tsc` warnings in untouched files; no typecheck script in CI.

## Deviations (also in ADR-0023)
1. `source_sha256` added to `ctx_sources` — **not** in the task's P1 column list, but PRD test 3 is source-level dedup → required.
2. "everything proposed" == batch `review_status='proposed'` + extractions `pending` (no 5th `proposed` value on the `ctx_extractions` CHECK → no review-UI break; that's P4/P7).
3. One-project-per-bundle (`bundle_sha256` UNIQUE) follows the task literally; PRD §2's project→many-batches generalization deferred.
4. `test:integration` script fix (was a no-op glob).

## Scope guardrails honored
No changes to `mira-contextualizer/`, `mira-bots/`, or `asset-matcher.ts`. Migration number **056** claimed. **Do not merge** — open for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
