### PR TITLE
feat(contextualization): asset-matching engine (HubV3 P3)

### DIFF
--- a/mira-hub/src/lib/contextualization/asset-matcher.test.ts
+++ b/mira-hub/src/lib/contextualization/asset-matcher.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyAsset, fromEquipmentRow, type EquipmentRow } from "./asset-matcher";
+
+// A small fleet of existing assets to classify incoming contextualization identity against.
+const AB_DRIVE: EquipmentRow = {
+  id: "asset-ab-drive",
+  manufacturer: "Allen-Bradley",
+  model: "PowerFlex 525",
+  serialNumber: "SN-123",
+};
+
+describe("classifyAsset — PRD §6 tests 4/5/6 (strong / none / probable)", () => {
+  it("test 4: a strong (unique-id) match stages under the existing asset, still proposed", () => {
+    // serial number is an instance-unique key; normalization absorbs case/punctuation/whitespace
+    const m = classifyAsset(
+      { serialNumber: " sn-123 ", manufacturer: "allen bradley" },
+      [AB_DRIVE],
+    );
+    expect(m.strength).toBe("strong");
+    expect(m.decision).toBe("existing_asset");
+    expect(m.matchedAssetId).toBe("asset-ab-drive");
+    expect(m.matchedFields).toContain("serialNumber");
+    // NEVER auto-verify — even a strong match lands as proposed for admin approval
+    expect(m.approvalState).toBe("proposed");
+  });
+
+  it("test 5: no overlap creates a draft asset proposal (no existing asset)", () => {
+    const m = classifyAsset(
+      { manufacturer: "Siemens", model: "S7-1200", serialNumber: "XYZ-999" },
+      [AB_DRIVE],
+    );
+    expect(m.strength).toBe("none");
+    expect(m.decision).toBe("draft_asset");
+    expect(m.matchedAssetId).toBeNull();
+    expect(m.approvalState).toBe("proposed");
+  });
+
+  it("test 6: a probable (model-level only) match requires human confirmation", () => {
+    // manufacturer + model agree but there is NO instance-unique key → cannot auto-stage
+    const m = classifyAsset({ manufacturer: "Allen-Bradley", model: "PowerFlex 525" }, [
+      { id: "asset-2", manufacturer: "Allen-Bradley", model: "PowerFlex 525" },
+    ]);
+    expect(m.strength).toBe("probable");
+    expect(m.decision).toBe("needs_confirmation");
+    expect(m.matchedAssetId).toBe("asset-2");
+    expect(m.approvalState).toBe("proposed");
+  });
+
+  it("a unique UNS path match is also strong", () => {
+    const m = classifyAsset({ proposedUnsPath: "enterprise/garage/cv_101" }, [
+      { id: "asset-uns", proposedUnsPath: "enterprise.garage.cv_101" },
+    ]);
+    expect(m.strength).toBe("strong");
+    expect(m.decision).toBe("existing_asset");
+    expect(m.matchedAssetId).toBe("asset-uns");
+  });
+});
+
+describe("classifyAsset — adversarial: no false-merge, no missed-match", () => {
+  it("FALSE-MERGE GUARD: same mfr+model but a CONFLICTING serial is never strong", () => {
+    // identical drive model, different physical unit → must NOT auto-stage under the existing asset
+    const m = classifyAsset(
+      { manufacturer: "Allen-Bradley", model: "PowerFlex 525", serialNumber: "SN-BBB" },
+      [AB_DRIVE], // serial SN-123
+    );
+    expect(m.strength).not.toBe("strong");
+    expect(m.decision).not.toBe("existing_asset");
+    expect(m.strength).toBe("none"); // a conflicting instance-id means a different asset
+    expect(m.conflictFields).toContain("serialNumber");
+  });
+
+  it("AMBIGUITY GUARD: two equally-strong candidates downgrade to needs_confirmation", () => {
+    // duplicate serials in the asset registry → identity is ambiguous, do not pick one blindly
+    const m = classifyAsset({ serialNumber: "DUP" }, [
+      { id: "asset-a", serialNumber: "DUP" },
+      { id: "asset-b", serialNumber: "DUP" },
+    ]);
+    expect(m.decision).toBe("needs_confirmation");
+    expect(m.decision).not.toBe("existing_asset");
+    expect(m.strength).toBe("probable");
+  });
+
+  it("MISSED-MATCH GUARD: normalization catches formatting differences (mfr+model)", () => {
+    const m = classifyAsset(
+      { manufacturer: "allen  bradley", model: "2080 lc50 24qwb" },
+      [{ id: "asset-4", manufacturer: "Allen-Bradley", model: "2080-LC50-24QWB" }],
+    );
+    expect(m.strength).toBe("probable");
+    expect(m.matchedAssetId).toBe("asset-4");
+  });
+
+  it("FALSE-MERGE GUARD: a placeholder serial (N/A) is not a strong identity match", () => {
+    // CMMS registries are full of "N/A"/"0"/"UNKNOWN" serials — two different assets sharing a
+    // placeholder must NOT auto-merge. The placeholder carries no identity, so fall back to model-level.
+    const m = classifyAsset(
+      { manufacturer: "Allen-Bradley", model: "PowerFlex 525", serialNumber: "N/A" },
+      [{ id: "ph-1", manufacturer: "Allen-Bradley", model: "PowerFlex 525", serialNumber: "N/A" }],
+    );
+    expect(m.strength).not.toBe("strong");
+    expect(m.decision).not.toBe("existing_asset");
+    expect(m.strength).toBe("probable"); // mfr+model still corroborate → confirm, don't merge
+  });
+
+  it("FALSE-MERGE GUARD: a too-short unique id is not strong on its own", () => {
+    const m = classifyAsset({ serialNumber: "7" }, [{ id: "short-1", serialNumber: "7" }]);
+    expect(m.strength).not.toBe("strong");
+    expect(m.decision).not.toBe("existing_asset");
+  });
+
+  it("a controller IP alone is only probable; corroborated by PLC program it is strong", () => {
+    const ipOnly = classifyAsset({ controllerIp: "192.168.1.50" }, [
+      { id: "ctrl-1", controllerIp: "192.168.1.50" },
+    ]);
+    expect(ipOnly.strength).toBe("probable");
+
+    const corroborated = classifyAsset(
+      { controllerIp: "192.168.1.50", plcProgramName: "Conv_Simple" },
+      [{ id: "ctrl-1", controllerIp: "192.168.1.50", plcProgramName: "Conv_Simple" }],
+    );
+    expect(corroborated.strength).toBe("strong");
+  });
+});
+
+describe("fromEquipmentRow — maps a cmms_equipment row to the matcher shape", () => {
+  it("maps the real snake_case columns", () => {
+    const row = fromEquipmentRow({
+      id: "eq-1",
+      equipment_number: "CV-101",
+      manufacturer: "Allen-Bradley",
+      model_number: "2080-LC50-24QWB",
+      serial_number: "SN-123",
+      uns_path: "enterprise.garage.cv_101",
+    });
+    expect(row).toEqual({
+      id: "eq-1",
+      assetNumber: "CV-101",
+      manufacturer: "Allen-Bradley",
+      model: "2080-LC50-24QWB",
+      serialNumber: "SN-123",
+      proposedUnsPath: "enterprise.garage.cv_101",
+    });
+  });
+});

--- a/mira-hub/src/lib/contextualization/asset-matcher.ts
+++ b/mira-hub/src/lib/contextualization/asset-matcher.ts
@@ -1,0 +1,282 @@
+/**
+ * Asset matching for HubV3 contextualization intake (PRD §2 "Import behavior", §5 Phase 3).
+ *
+ * Classifies an incoming asset identity (the manifest `asset_match` block / project profile of an
+ * imported bundle) against the tenant's existing `cmms_equipment` rows as `strong | probable | none`,
+ * and maps that to a staging decision:
+ *   strong   → stage proposals under the existing asset   (`existing_asset`)
+ *   probable → require human confirmation                 (`needs_confirmation`)
+ *   none     → create a draft asset proposal              (`draft_asset`)
+ *
+ * Design goals (the adversarial bar): no FALSE-MERGE (never auto-stage under the wrong asset) and no
+ * MISSED-MATCH (formatting noise must not hide a real match). Two ideas carry that weight:
+ *   - Tiered evidence: only INSTANCE-unique keys (serial, asset number, proposed UNS path, or a
+ *     controller IP corroborated by another field) can make a match `strong`. MODEL-level descriptors
+ *     (manufacturer, model, controller type, PLC program, name) only ever reach `probable` — two
+ *     identical drives must not merge.
+ *   - Conflict guard: if BOTH sides carry a unique instance id and they disagree, the row is a
+ *     different asset → capped at `none` (the safe direction: a draft a human can still merge).
+ *   - Ambiguity guard: two equally-strong candidates downgrade to `needs_confirmation`.
+ *
+ * Everything lands `approval_state = "proposed"` — matching NEVER auto-verifies (ADR-0017). This module
+ * is pure + DB-free so it is unit-testable without migration 056; `persistAssetMatches` is the thin
+ * writer that lands rows in `ctx_extraction_asset_matches` (shape owned by migration 056, PRD §4.1).
+ */
+
+export type MatchStrength = "strong" | "probable" | "none";
+export type StagingDecision = "existing_asset" | "needs_confirmation" | "draft_asset";
+
+/** Asset-identity hints from an imported bundle (manifest `asset_match` / project profile). */
+export interface AssetHints {
+  assetNumber?: string | null;
+  name?: string | null;
+  manufacturer?: string | null;
+  model?: string | null;
+  serialNumber?: string | null;
+  controllerType?: string | null;
+  controllerIp?: string | null;
+  plcProgramName?: string | null;
+  proposedUnsPath?: string | null;
+}
+
+/** An existing asset to match against (normalized projection of a `cmms_equipment` row). */
+export interface EquipmentRow extends AssetHints {
+  id: string;
+}
+
+export interface AssetMatch {
+  strength: MatchStrength;
+  decision: StagingDecision;
+  /** The existing asset to stage under (strong) or confirm against (probable); null for a draft. */
+  matchedAssetId: string | null;
+  confidence: number; // 0..1, banded by strength
+  matchedFields: string[]; // evidence: which identity fields agreed
+  conflictFields: string[]; // unique-id fields that disagreed (drove a downgrade)
+  /** Imported matches are never auto-verified — admin approval promotes them later. */
+  approvalState: "proposed";
+}
+
+// Instance-unique identity keys: an exact agreement identifies the SAME physical asset; a
+// disagreement identifies a DIFFERENT one. These can make a match strong and can veto one.
+const UNIQUE_KEYS = ["serialNumber", "assetNumber", "proposedUnsPath"] as const;
+// Model-level descriptors: corroborating evidence only — never strong on their own.
+const DESCRIPTOR_KEYS = ["manufacturer", "model", "controllerType", "plcProgramName", "name"] as const;
+
+type Field = keyof AssetHints;
+
+// Sentinel "I don't know" values that pollute CMMS registries. They carry NO identity, so a match on
+// one must never merge two assets — treat them as absent everywhere (normalize to null).
+const PLACEHOLDERS = new Set([
+  "na", "nan", "none", "null", "nil", "unknown", "unk", "tbd", "tba", "pending", "default",
+  "notavailable", "notapplicable", "placeholder", "xxx", "xxxx", "xxxxx",
+  "0", "00", "000", "0000", "00000",
+]);
+// A strong (auto-merge) decision needs an instance-unique id with real entropy. 1–2 char "serials"
+// are implausibly unique and a frequent data-entry artifact, so they can corroborate but never merge.
+const MIN_STRONG_ID_LEN = 3;
+
+/** Normalize for comparison: lowercase, separators/punctuation → nothing, whitespace collapsed.
+ * Absorbs "Allen-Bradley" vs "allen bradley" and "enterprise/garage/cv_101" vs "enterprise.garage.cv_101".
+ * Returns null for empty and for known placeholder/sentinel values (which convey no identity). */
+function norm(v: string | null | undefined): string | null {
+  if (v == null) return null;
+  const s = v.toLowerCase().replace(/[^a-z0-9]+/g, "");
+  if (!s.length || PLACEHOLDERS.has(s)) return null;
+  return s;
+}
+
+function fieldsAgree(a: AssetHints, b: AssetHints, field: Field): boolean | null {
+  const na = norm(a[field]);
+  const nb = norm(b[field]);
+  if (na == null || nb == null) return null; // not comparable (one side absent)
+  return na === nb;
+}
+
+function band(strength: MatchStrength): number {
+  return strength === "strong" ? 0.9 : strength === "probable" ? 0.6 : 0;
+}
+
+function decisionFor(strength: MatchStrength): StagingDecision {
+  return strength === "strong"
+    ? "existing_asset"
+    : strength === "probable"
+      ? "needs_confirmation"
+      : "draft_asset";
+}
+
+interface RowVerdict {
+  strength: MatchStrength;
+  matchedFields: string[];
+  conflictFields: string[];
+}
+
+/** Classify the hints against a single equipment row. */
+function classifyRow(hints: AssetHints, row: EquipmentRow): RowVerdict {
+  const matched: string[] = [];
+  const conflict: string[] = [];
+
+  for (const k of [...UNIQUE_KEYS, ...DESCRIPTOR_KEYS]) {
+    const agree = fieldsAgree(hints, row, k);
+    if (agree === true) matched.push(k);
+    else if (agree === false && (UNIQUE_KEYS as readonly string[]).includes(k)) conflict.push(k);
+  }
+
+  // A disagreeing instance-unique id means a DIFFERENT asset — never merge. (Controller IP is not in
+  // UNIQUE_KEYS: IPs get reassigned, so an IP mismatch is not proof of a different asset.)
+  if (conflict.length) return { strength: "none", matchedFields: matched, conflictFields: conflict };
+
+  const has = (k: Field) => matched.includes(k);
+  // A unique-id only makes a match STRONG when its agreed value has real entropy (≥ MIN_STRONG_ID_LEN
+  // after normalization) — guards against ultra-short artifacts auto-merging distinct assets.
+  const strongId = (k: Field) => has(k) && (norm(hints[k])?.length ?? 0) >= MIN_STRONG_ID_LEN;
+  const strongUniqueHit = strongId("serialNumber") || strongId("assetNumber") || strongId("proposedUnsPath");
+  // A controller IP corroborated by a second field (PLC program / model / controller type) is strong;
+  // IP alone is only probable.
+  const ipAgree = fieldsAgree(hints, row, "controllerIp") === true;
+  const ipCorroborated =
+    ipAgree && (has("plcProgramName") || has("model") || has("controllerType"));
+
+  if (strongUniqueHit || ipCorroborated) {
+    return { strength: "strong", matchedFields: matched, conflictFields: conflict };
+  }
+
+  const modelLevel =
+    (has("manufacturer") && has("model")) || has("name") || has("plcProgramName") || ipAgree;
+  if (modelLevel) return { strength: "probable", matchedFields: matched, conflictFields: conflict };
+
+  return { strength: "none", matchedFields: matched, conflictFields: conflict };
+}
+
+const RANK: Record<MatchStrength, number> = { strong: 2, probable: 1, none: 0 };
+
+/**
+ * Classify an asset identity against the existing fleet and decide how to stage it.
+ * `equipmentRows` should already be scoped to the caller's tenant.
+ */
+export function classifyAsset(hints: AssetHints, equipmentRows: EquipmentRow[]): AssetMatch {
+  let best: (RowVerdict & { id: string }) | null = null;
+  let strongCount = 0;
+
+  for (const row of equipmentRows) {
+    const v = classifyRow(hints, row);
+    if (v.strength === "strong") strongCount += 1;
+    const better =
+      !best ||
+      RANK[v.strength] > RANK[best.strength] ||
+      (RANK[v.strength] === RANK[best.strength] && v.matchedFields.length > best.matchedFields.length);
+    if (better) best = { ...v, id: row.id };
+  }
+
+  if (!best || best.strength === "none") {
+    return {
+      strength: "none",
+      decision: "draft_asset",
+      matchedAssetId: null,
+      confidence: 0,
+      matchedFields: best?.matchedFields ?? [],
+      conflictFields: best?.conflictFields ?? [],
+      approvalState: "proposed",
+    };
+  }
+
+  // Ambiguity guard: more than one equally-strong candidate → don't pick blindly, ask a human.
+  let strength = best.strength;
+  if (strength === "strong" && strongCount > 1) strength = "probable";
+
+  return {
+    strength,
+    decision: decisionFor(strength),
+    matchedAssetId: best.id,
+    confidence: band(strength),
+    matchedFields: best.matchedFields,
+    conflictFields: best.conflictFields,
+    approvalState: "proposed",
+  };
+}
+
+/** A raw `cmms_equipment` row (the snake_case columns this matcher reads). */
+export interface CmmsEquipmentRow {
+  id: string;
+  equipment_number?: string | null;
+  manufacturer?: string | null;
+  model_number?: string | null;
+  serial_number?: string | null;
+  uns_path?: string | null;
+}
+
+/** Map a `cmms_equipment` DB row to the matcher's normalized shape. Only sets the fields present
+ * so an absent column never masquerades as a matchable empty string. */
+export function fromEquipmentRow(row: CmmsEquipmentRow): EquipmentRow {
+  const out: EquipmentRow = { id: row.id };
+  if (row.equipment_number != null) out.assetNumber = row.equipment_number;
+  if (row.manufacturer != null) out.manufacturer = row.manufacturer;
+  if (row.model_number != null) out.model = row.model_number;
+  if (row.serial_number != null) out.serialNumber = row.serial_number;
+  if (row.uns_path != null) out.proposedUnsPath = row.uns_path;
+  return out;
+}
+
+/** A staged extraction→asset match row, ready to insert into `ctx_extraction_asset_matches`. */
+export interface ExtractionAssetMatch {
+  extractionId: string;
+  matchedAssetId: string | null;
+  strength: MatchStrength;
+  decision: StagingDecision;
+  confidence: number;
+  matchedFields: string[];
+  approvalState: "proposed";
+}
+
+/** Apply one asset-level match to each extraction of the imported asset (one row per extraction). */
+export function buildExtractionMatches(
+  extractionIds: string[],
+  match: AssetMatch,
+): ExtractionAssetMatch[] {
+  return extractionIds.map((extractionId) => ({
+    extractionId,
+    matchedAssetId: match.matchedAssetId,
+    strength: match.strength,
+    decision: match.decision,
+    confidence: match.confidence,
+    matchedFields: match.matchedFields,
+    approvalState: match.approvalState,
+  }));
+}
+
+/** Minimal `pg` client surface used by the writer (matches `withTenantContext`'s PoolClient). */
+interface QueryClient {
+  query: (text: string, params?: unknown[]) => Promise<unknown>;
+}
+
+/**
+ * Persist staged matches into `ctx_extraction_asset_matches`.
+ *
+ * NOTE: the table is owned by migration 056 (PRD §4.1) and is not in 055 yet — this writer assumes
+ * that shape and is exercised only once 056 lands (integration-tested then). It is intentionally
+ * INSERT-only and lands every row `approval_state = 'proposed'`; promotion is a separate admin action.
+ * The caller supplies a client already inside `withTenantContext(tenantId, …)` so RLS scopes the write.
+ */
+export async function persistAssetMatches(
+  client: QueryClient,
+  tenantId: string,
+  rows: ExtractionAssetMatch[],
+): Promise<void> {
+  for (const r of rows) {
+    await client.query(
+      `INSERT INTO ctx_extraction_asset_matches
+         (tenant_id, extraction_id, matched_equipment_id, match_strength, decision,
+          confidence, matched_fields, approval_state)
+       VALUES ($1::uuid, $2::uuid, $3::uuid, $4, $5, $6, $7::jsonb, $8)`,
+      [
+        tenantId,
+        r.extractionId,
+        r.matchedAssetId,
+        r.strength,
+        r.decision,
+        r.confidence,
+        JSON.stringify(r.matchedFields),
+        r.approvalState,
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## HubV3 Phase 3 (WIN‑2) — asset matching: strong / probable / none

New, greenfield matching engine per `docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md`
§2 (import behavior), §4.1 (greenfield gap), §5 Phase 3.

### What it does (scope: one new file + its tests)
`src/lib/contextualization/asset-matcher.ts` — `classifyAsset(hints, cmms_equipment_rows)` classifies
an imported asset identity and maps it to a staging decision:

| Strength | Evidence | Decision |
|---|---|---|
| **strong** | an instance-unique key agrees (serial / asset number / proposed UNS path, or controller‑IP **corroborated** by PLC program / model / controller type) | `existing_asset` — stage under it |
| **probable** | model-level only (mfr+model, name, PLC program, or IP alone) | `needs_confirmation` |
| **none** | no overlap, or a conflicting unique id | `draft_asset` |

Everything lands **`approval_state = "proposed"` — never auto-verified** (ADR-0017), even on a strong match.

### No false-merge (the adversarial bar)
- **Tiered evidence:** model-level descriptors can *never* reach strong → two identical drives don't merge.
- **Conflict guard:** a disagreeing unique id (serial/asset#/UNS) caps the row at `none` — the safe direction (draft a human can still merge), never a silent overwrite.
- **Ambiguity guard:** ≥2 equally-strong candidates downgrade to `needs_confirmation`.
- **Placeholder/low-entropy guard:** sentinel ids (`N/A`, `0`, `UNKNOWN`, …) and `<3`-char ids carry no identity and cannot auto-merge — a common real-world CMMS false-merge vector.
- An **adversarial reviewer subagent** traced all six false-merge vectors and found **no false-merge path**; the placeholder/short-id vectors it didn't cover are closed here with explicit tests.

### Boundaries honored
- `fromEquipmentRow` maps the real `cmms_equipment` snake_case columns (`equipment_number`, `manufacturer`, `model_number`, `serial_number`, `uns_path`).
- `persistAssetMatches` writes `ctx_extraction_asset_matches` **assuming the migration‑056 shape** (PRD §4.1) — **no migration written here** (owned by Win‑1). Its DB path is integration-tested once 056 lands; the classify core is pure + DB-free and fully tested now.
- Did **not** touch the import route, migrations, `mira-contextualizer/`, or `mira-bots/`.

### TDD / evidence
- **Test 4** (strong → existing), **Test 5** (none → draft), **Test 6** (probable → confirm) — written red-first.
- Adversarial: conflicting serial, duplicate-serial ambiguity, normalization formatting, IP corroboration, placeholder serial, too-short id.
- **`vitest` → 11/11** in `asset-matcher.test.ts`; **full unit suite 752 passed**. The one failing suite (`src/lib/sitemap-drift.test.ts`) is **pre-existing and unrelated** — a `SyntaxError` importing a `.mjs` sibling, identical to the base branch (`git diff` empty), nothing in contextualization.
- `tsc --noEmit` clean for the new file; `eslint` clean.

⚠️ Targets `feat/plc-mapper-gui`, not `main`. **Do not merge** — for review. Soft dep: the writer's table arrives with Win‑1's migration 056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)