### PR TITLE
feat(telegram): HubV3 Phase 6 — Telegram thin evidence client → Hub intake

### DIFF
--- a/mira-bots/shared/contextualization_intake.py
+++ b/mira-bots/shared/contextualization_intake.py
@@ -1,0 +1,183 @@
+"""Shared contextualization intake envelope builder + Hub submit.
+
+HubV3 (`docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md`) makes the
+**Hub the single system of record** for contextualization. Offline and Telegram
+become thin *ingest clients* that collect evidence and create proposals; the Hub
+performs the final merge / approval / publish.
+
+This module builds the §2 "Shared Contextualization Intake Contract" envelope and
+POSTs it to the Hub import endpoint. It is the client half — the Hub endpoint
+accepting this JSON contract is Phase 2 (not in this module's scope).
+
+Design rules honored here:
+- **Telegram owns NO truth.** ``review_status`` is always ``proposed``; all
+  ``proposed_*`` / ``entities`` domain lists are empty (the client submits
+  evidence, the Hub derives proposals on approval).
+- **Bytes travel.** The §2 envelope is metadata-only, so the raw document/photo
+  bytes are carried alongside the JSON contract as a multipart ``file`` field —
+  the same multipart shape the Hub import endpoint already speaks.
+- **PII sanitization** (`.claude/rules/security-boundaries.md`): free-text fields
+  (caption / field notes / OCR) are scrubbed via
+  ``InferenceRouter.sanitize_text`` (IPv4 → ``[IP]``, MAC → ``[MAC]``,
+  serial → ``[SN]``). Structured ``asset_hints`` (serial, controller IP, model …)
+  are **deliberate matching evidence** and are preserved verbatim.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+
+import httpx
+
+from shared.inference.router import InferenceRouter
+
+logger = logging.getLogger("mira.contextualization_intake")
+
+# Ingest-route discriminators (§2 ``ingest_route``).
+INGEST_ROUTE_TELEGRAM = "telegram"
+INGEST_ROUTE_OFFLINE = "offline"
+INGEST_ROUTE_HUB_UPLOAD = "hub_upload"
+
+# Hub import endpoint (the offline/direct upload pipeline entry).
+HUB_IMPORT_PATH = "/api/contextualization/import"
+HUB_IMPORT_URL = os.environ.get("HUB_IMPORT_URL", "")
+HUB_IMPORT_TOKEN = os.environ.get("HUB_IMPORT_TOKEN", "")
+
+# Domain-proposal keys the client always leaves empty — it owns no truth.
+_EMPTY_PROPOSAL_KEYS = (
+    "entities",
+    "proposed_uns",
+    "proposed_i3x",
+    "proposed_faults",
+    "proposed_parameters",
+    "proposed_signals",
+    "proposed_relationships",
+)
+
+
+def _scrub(text: str | None) -> str:
+    """PII-scrub a free-text field. Empty/None → empty string."""
+    if not text:
+        return ""
+    return InferenceRouter.sanitize_text(text)
+
+
+def build_intake_envelope(
+    *,
+    raw_bytes: bytes,
+    filename: str,
+    mime: str,
+    uploader: str,
+    captured_at: str,
+    caption: str | None = None,
+    ocr_text: str | None = None,
+    location: str | None = None,
+    project_hint: str | None = None,
+    asset_hints: dict | None = None,
+    ingest_route: str = INGEST_ROUTE_TELEGRAM,
+    review_status: str = "proposed",  # accepted for signature parity; always coerced
+) -> dict:
+    """Build the §2 normalized contextualization intake envelope.
+
+    The raw bytes are *not* embedded — they travel as a multipart ``file`` field
+    in :func:`submit_intake_to_hub`. ``source_sha256`` fingerprints those bytes
+    using the same convention as mira-ingest (``hashlib.sha256(raw).hexdigest()``).
+    """
+    source_sha256 = hashlib.sha256(raw_bytes).hexdigest()
+
+    # OCR-or-raw: prefer extracted OCR text; otherwise the caption is the field
+    # note and the raw bytes themselves (carried as the multipart file) are the
+    # evidence. All free text is PII-scrubbed.
+    evidence: list[dict] = []
+    note = _scrub(caption)
+    if note:
+        evidence.append({"type": "field_note", "text": note, "ref": {"source": filename}})
+    ocr = _scrub(ocr_text)
+    if ocr:
+        evidence.append({"type": "ocr", "text": ocr, "ref": {"source": filename}})
+
+    # Telegram owns no truth → review_status is always proposed.
+    _ = review_status  # intentionally ignored; clients cannot self-approve
+
+    envelope: dict = {
+        "project_hint": project_hint or "",
+        # Structured matching evidence — preserved verbatim (NOT PII-scrubbed).
+        "asset_hints": dict(asset_hints or {}),
+        "source_metadata": {
+            "filename": filename,
+            "mime": mime,
+            "size": len(raw_bytes),
+            "captured_at": captured_at,
+            "uploader": uploader,
+            "location": location or "",
+        },
+        "source_sha256": source_sha256,
+        "evidence": evidence,
+        "provenance": {
+            "ingest_route": ingest_route,
+            "source_sha256": source_sha256,
+            "uploader": uploader,
+            "captured_at": captured_at,
+        },
+        "confidence": "low",  # unverified field capture; Hub re-scores on review
+        "review_status": "proposed",
+        "ingest_route": ingest_route,
+    }
+    for key in _EMPTY_PROPOSAL_KEYS:
+        envelope[key] = []
+    return envelope
+
+
+async def submit_intake_to_hub(
+    envelope: dict,
+    *,
+    raw_bytes: bytes,
+    filename: str,
+    mime: str,
+    tenant_id: str,
+    hub_url: str | None = None,
+    token: str | None = None,
+    timeout: float = 120,
+) -> bool:
+    """POST the §2 contract + raw bytes to the Hub import endpoint.
+
+    Multipart body: ``contract`` (the JSON envelope) + ``file`` (raw bytes) +
+    ``tenant_id`` (transport-level scoping). Returns ``True`` on a 2xx response.
+
+    Background-safe: never raises — a failing Hub POST must not break the chat
+    reply. A transport error or non-2xx is logged and reported as ``False``.
+    """
+    base = (hub_url or HUB_IMPORT_URL or "").rstrip("/")
+    if not base:
+        logger.warning("HUB_IMPORT_URL not configured — skipping Hub intake submit")
+        return False
+
+    url = f"{base}{HUB_IMPORT_PATH}"
+    headers: dict[str, str] = {}
+    bearer = token if token is not None else HUB_IMPORT_TOKEN
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                url,
+                data={"contract": json.dumps(envelope), "tenant_id": tenant_id or ""},
+                files={"file": (filename, raw_bytes, mime)},
+                headers=headers,
+            )
+            if 200 <= resp.status_code < 300:
+                logger.info(
+                    "Hub intake OK route=%s sha256=%s",
+                    envelope.get("ingest_route"),
+                    envelope.get("source_sha256", "")[:12],
+                )
+                return True
+            logger.warning("Hub intake failed %s: %s", resp.status_code, resp.text[:200])
+            return False
+    except Exception as exc:  # noqa: BLE001 - background task must never raise
+        logger.error("Hub intake submit error: %s", exc)
+        return False

--- a/mira-bots/shared/contextualization_intake.py
+++ b/mira-bots/shared/contextualization_intake.py
@@ -14,8 +14,10 @@ Design rules honored here:
   ``proposed_*`` / ``entities`` domain lists are empty (the client submits
   evidence, the Hub derives proposals on approval).
 - **Bytes travel.** The §2 envelope is metadata-only, so the raw document/photo
-  bytes are carried alongside the JSON contract as a multipart ``file`` field —
-  the same multipart shape the Hub import endpoint already speaks.
+  bytes are carried alongside the JSON contract as a multipart ``file`` field.
+  (The import endpoint is multipart today but reads ``file`` as a *zip* and
+  ignores ``contract``/``tenant_id``; it consumes this contract field only after
+  HubV3 Phase 2.)
 - **PII sanitization** (`.claude/rules/security-boundaries.md`): free-text fields
   (caption / field notes / OCR) are scrubbed via
   ``InferenceRouter.sanitize_text`` (IPv4 → ``[IP]``, MAC → ``[MAC]``,

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -16,8 +16,13 @@ from admin_commands import (
 )
 from chat_adapter import TelegramChatAdapter
 from PIL import Image
-from shared import tts
+from shared import chat_tenant, tts
 from shared.chat.dispatcher import ChatDispatcher
+from shared.contextualization_intake import (
+    INGEST_ROUTE_TELEGRAM,
+    build_intake_envelope,
+    submit_intake_to_hub,
+)
 from shared.conversation_logger import log_turn, measure_ms
 from shared.engine import Supervisor
 from shared.identity.service import get_identity_service
@@ -66,7 +71,11 @@ MCP_REST_API_KEY = os.environ.get("MCP_REST_API_KEY", "")
 KNOWLEDGE_COLLECTION_ID = os.environ.get(
     "KNOWLEDGE_COLLECTION_ID", "dd9004b9-3af2-4751-9993-3307e478e9a3"
 )
-INGEST_SERVICE_URL = os.environ.get("INGEST_SERVICE_URL", "")
+# HubV3: Telegram is a thin evidence-capture client. Photos/docs are submitted as
+# the §2 contextualization intake contract to the Hub import endpoint (the Hub is
+# the system of record). Replaces the legacy mira-ingest {asset_tag, image} path.
+HUB_IMPORT_URL = os.environ.get("HUB_IMPORT_URL", "")
+HUB_IMPORT_TOKEN = os.environ.get("HUB_IMPORT_TOKEN", "")
 
 engine = Supervisor(
     db_path=os.environ.get("MIRA_DB_PATH", "/data/mira.db"),
@@ -181,54 +190,95 @@ def _resize_for_vision(image_bytes: bytes) -> bytes:
     return buf.getvalue()
 
 
-def _equipment_type_from_doc(filename: str, caption: str) -> str:
-    """Derive equipment type slug from filename, with caption override.
+def _intake_meta(update: Update) -> tuple[str, str, str]:
+    """(uploader_id, captured_at_iso, tenant_id) from a Telegram update.
 
-    Caption first word wins: sending 'VFD' as caption → 'vfd'.
-    Fallback: strip doc-type suffixes from filename stem.
+    Uploader is the numeric Telegram id (pseudonymous) — never a name — to keep
+    PII out of provenance. Tenant is resolved per-chat for Hub-side scoping.
     """
-    if caption and caption.strip():
-        return caption.strip().split()[0].lower()[:40]
-    stem = os.path.splitext(filename)[0].lower()
-    for suffix in (
-        "-manual",
-        "-guide",
-        "-spec",
-        "-datasheet",
-        "-data-sheet",
-        "_manual",
-        "_guide",
-        "_spec",
-        "_datasheet",
-        "_data_sheet",
-    ):
-        if stem.endswith(suffix):
-            stem = stem[: -len(suffix)]
-            break
-    return stem[:40] or "general"
+    uploader = str(update.effective_user.id) if update.effective_user else ""
+    msg_date = getattr(update.message, "date", None)
+    captured_at = msg_date.isoformat() if msg_date else ""
+    tenant_id = chat_tenant.resolve(str(update.effective_chat.id))
+    return uploader, captured_at, tenant_id
 
 
-async def _ingest_photo_background(photo_bytes: bytes, asset_tag: str) -> None:
-    """POST photo to mira-ingest. Runs in background — never raises."""
-    if not INGEST_SERVICE_URL:
+def _asset_hints_from_caption(caption: str) -> dict:
+    """Minimal asset-identity hint from a caption (first token = asset name).
+
+    Preserves today's ``asset_tag`` behaviour. Richer hints (mfr/model/serial/
+    IP/UNS) are the Hub's job to derive from evidence — the client owns no truth.
+    """
+    tokens = caption.split() if caption else []
+    return {"name": tokens[0]} if tokens else {}
+
+
+async def _submit_photo_to_hub(raw_bytes: bytes, caption: str, update: Update) -> None:
+    """Build the §2 intake envelope for a photo and POST it to the Hub.
+
+    Runs in background — ``submit_intake_to_hub`` never raises, so a failed Hub
+    POST cannot break the chat reply. Replaces the legacy mira-ingest path.
+    """
+    if not HUB_IMPORT_URL:
         return
-    try:
-        async with httpx.AsyncClient(timeout=120) as client:
-            resp = await client.post(
-                f"{INGEST_SERVICE_URL}/ingest/photo",
-                data={"asset_tag": asset_tag},
-                files={"image": ("photo.jpg", photo_bytes, "image/jpeg")},
-            )
-            if resp.status_code == 200:
-                logger.info("Ingest OK for %s: id=%s", asset_tag, resp.json().get("id"))
-            else:
-                logger.warning("Ingest failed %s: %s", resp.status_code, resp.text[:200])
-    except Exception as e:
-        logger.error("Ingest background error: %s", e)
+    uploader, captured_at, tenant_id = _intake_meta(update)
+    envelope = build_intake_envelope(
+        raw_bytes=raw_bytes,
+        filename="photo.jpg",
+        mime="image/jpeg",
+        uploader=uploader,
+        captured_at=captured_at,
+        caption=caption,
+        asset_hints=_asset_hints_from_caption(caption),
+        ingest_route=INGEST_ROUTE_TELEGRAM,
+    )
+    await submit_intake_to_hub(
+        envelope,
+        raw_bytes=raw_bytes,
+        filename="photo.jpg",
+        mime="image/jpeg",
+        tenant_id=tenant_id,
+        token=HUB_IMPORT_TOKEN or None,
+    )
+
+
+async def _submit_doc_to_hub(
+    pdf_bytes: bytes, filename: str, caption: str, update: Update
+) -> bool:
+    """Build the §2 intake envelope for a PDF and POST it to the Hub.
+
+    Returns True on a 2xx Hub response. Never raises.
+    """
+    if not HUB_IMPORT_URL:
+        return False
+    uploader, captured_at, tenant_id = _intake_meta(update)
+    envelope = build_intake_envelope(
+        raw_bytes=pdf_bytes,
+        filename=filename,
+        mime="application/pdf",
+        uploader=uploader,
+        captured_at=captured_at,
+        caption=caption,
+        asset_hints=_asset_hints_from_caption(caption),
+        ingest_route=INGEST_ROUTE_TELEGRAM,
+    )
+    return await submit_intake_to_hub(
+        envelope,
+        raw_bytes=pdf_bytes,
+        filename=filename,
+        mime="application/pdf",
+        tenant_id=tenant_id,
+        token=HUB_IMPORT_TOKEN or None,
+    )
 
 
 async def document_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Receive PDF documents, index into Open WebUI KB via mira-ingest."""
+    """Receive PDF documents and submit them to the Hub as intake evidence.
+
+    HubV3: a PDF is a contextualization source. The bot builds the §2 intake
+    contract and POSTs it (+ raw bytes) to the Hub import endpoint, where it
+    lands as a ``proposed`` source for review. The bot owns no truth.
+    """
     doc = update.message.document
     filename = doc.file_name or "upload.pdf"
     caption = update.message.caption or ""
@@ -242,55 +292,31 @@ async def document_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(f"{filename} is {doc.file_size // MB}MB — limit is 20MB.")
         return
 
-    if not INGEST_SERVICE_URL:
-        await update.message.reply_text("Ingest service not configured.")
+    if not HUB_IMPORT_URL:
+        await update.message.reply_text("Hub intake is not configured.")
         return
 
-    equipment_type = _equipment_type_from_doc(filename, caption)
-    await update.message.reply_text(f"Indexing {filename}...")
-    logger.info(
-        "PDF from %s: %s (type=%s)", update.effective_user.first_name, filename, equipment_type
-    )
+    await update.message.reply_text(f"Submitting {filename} to the Hub...")
+    logger.info("PDF from telegram_id=%s: %s", update.effective_user.id, filename)
 
-    async def _do_ingest_doc():
+    async def _do_submit_doc():
         try:
             tg_file = await context.bot.get_file(doc.file_id)
             pdf_bytes = bytes(await tg_file.download_as_bytearray())
-            async with httpx.AsyncClient(timeout=360) as client:
-                resp = await client.post(
-                    f"{INGEST_SERVICE_URL}/ingest/document-kb",
-                    data={"filename": filename, "equipment_type": equipment_type or ""},
-                    files={"file": (filename, pdf_bytes, "application/pdf")},
-                )
-                resp.raise_for_status()
-                data = resp.json()
-            col = data.get("collection_name", "Knowledge Base")
-            proc = data.get("processing_status", "completed")
-            if proc == "completed":
-                reply = f"Indexed *{filename}* into *{col}* collection.\nAsk me anything about it."
-            else:
+            ok = await _submit_doc_to_hub(pdf_bytes, filename, caption, update)
+            if ok:
                 reply = (
-                    f"*{filename}* uploaded to *{col}*.\n"
-                    "Extraction is still processing — RAG will be available shortly."
+                    f"Submitted *{filename}* to the Hub for review.\n"
+                    "It will appear as a proposed source once contextualized."
                 )
-            await update.message.reply_text(reply, parse_mode="Markdown")
-        except httpx.HTTPStatusError as e:
-            code = e.response.status_code
-            if code == 429:
-                msg = "Daily ingest limit reached. Try again tomorrow."
-            elif code == 413:
-                msg = f"{filename} is too large (limit 20MB)."
-            elif code == 422:
-                msg = f"Could not process {filename}: {e.response.text[:120]}"
             else:
-                msg = f"Indexing failed ({code}). Try again later."
-            logger.error("doc ingest HTTP %s: %s", code, e.response.text[:200])
-            await update.message.reply_text(msg)
+                reply = f"Couldn't submit {filename} to the Hub. Please try again later."
+            await update.message.reply_text(reply, parse_mode="Markdown")
         except Exception as exc:
-            logger.error("doc ingest error: %s", exc)
-            await update.message.reply_text(f"Indexing {filename} failed. Please try again.")
+            logger.error("doc submit error: %s", exc)
+            await update.message.reply_text(f"Submitting {filename} failed. Please try again.")
 
-    asyncio.create_task(_do_ingest_doc())
+    asyncio.create_task(_do_submit_doc())
 
 
 def _get_voice_enabled(chat_id: str) -> bool:
@@ -495,10 +521,9 @@ async def _dispatch_single_photo(
             logger.error("Photo processing error: %s", e)
             final_reply = f"MIRA error: {e}"
 
-    if INGEST_SERVICE_URL:
-        asset_tag = caption.split()[0] if caption else "UNKNOWN"
-        asyncio.create_task(_ingest_photo_background(raw_bytes, asset_tag))
-        final_reply += "\n\nPhoto queued for knowledge base."
+    if HUB_IMPORT_URL:
+        asyncio.create_task(_submit_photo_to_hub(raw_bytes, caption, update))
+        final_reply += "\n\nPhoto submitted to the Hub for review."
 
     await update.message.reply_text(final_reply)
     await _maybe_send_voice(update, context, chat_id, final_reply)
@@ -561,10 +586,9 @@ async def _enqueue_multi_photo_burst(
         await photo_queue.mark_failed(batch_id, "queue full at close_burst")
         return
 
-    if INGEST_SERVICE_URL:
-        asset_tag = caption.split()[0] if caption else "UNKNOWN"
+    if HUB_IMPORT_URL:
         for raw_bytes, _ in batches:
-            asyncio.create_task(_ingest_photo_background(raw_bytes, asset_tag))
+            asyncio.create_task(_submit_photo_to_hub(raw_bytes, caption, update))
 
 
 async def _flush_collector(

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -194,12 +194,15 @@ def _intake_meta(update: Update) -> tuple[str, str, str]:
     """(uploader_id, captured_at_iso, tenant_id) from a Telegram update.
 
     Uploader is the numeric Telegram id (pseudonymous) — never a name — to keep
-    PII out of provenance. Tenant is resolved per-chat for Hub-side scoping.
+    PII out of provenance. Tenant is resolved by the **uploader's user id**, the
+    same key the chat adapter uses (``chat_adapter.py`` → ``chat_tenant.resolve``)
+    and that onboarding maps; ``effective_chat.id`` is the (negative) group id in
+    group chats and would miss the mapping.
     """
     uploader = str(update.effective_user.id) if update.effective_user else ""
     msg_date = getattr(update.message, "date", None)
     captured_at = msg_date.isoformat() if msg_date else ""
-    tenant_id = chat_tenant.resolve(str(update.effective_chat.id))
+    tenant_id = chat_tenant.resolve(uploader)
     return uploader, captured_at, tenant_id
 
 

--- a/mira-bots/tests/test_telegram_hub_intake.py
+++ b/mira-bots/tests/test_telegram_hub_intake.py
@@ -1,0 +1,214 @@
+"""HubV3 Phase 6 — Telegram thin evidence client → Hub import pipeline.
+
+Gating test = PRD §6 test 9: a Telegram/photo source enters the SAME
+contextualization import pipeline as an offline/direct upload, and lands
+``proposed``.
+
+Scope is the CLIENT half (the Hub endpoint accepting the JSON contract is
+Phase 2 — not exercised here). These tests assert that the shared
+envelope-builder produces the canonical §2 intake contract and that the
+Telegram submit path POSTs it to the Hub import endpoint (not mira-ingest),
+with raw bytes carried and PII scrubbed from free text.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from shared import contextualization_intake as ci
+
+# §2 "Shared Contextualization Intake Contract" — required envelope keys.
+_REQUIRED_KEYS = {
+    "project_hint",
+    "asset_hints",
+    "source_metadata",
+    "source_sha256",
+    "evidence",
+    "entities",
+    "proposed_uns",
+    "proposed_i3x",
+    "proposed_faults",
+    "proposed_parameters",
+    "proposed_signals",
+    "proposed_relationships",
+    "provenance",
+    "confidence",
+    "review_status",
+    "ingest_route",
+}
+
+
+def _build_telegram_photo_envelope() -> tuple[dict, bytes]:
+    raw = b"\xff\xd8\xff telegram nameplate jpeg; ctrl at 10.1.2.3"
+    env = ci.build_intake_envelope(
+        raw_bytes=raw,
+        filename="photo.jpg",
+        mime="image/jpeg",
+        uploader="789",  # numeric Telegram id (pseudonymous), not a name
+        captured_at="2026-06-20T12:00:00+00:00",
+        caption="conveyor-1 nameplate controller at 10.1.2.3",
+        location=None,
+        project_hint="garage-demo",
+        asset_hints={
+            "name": "conveyor-1",
+            "serial": "SN-ABC123456",
+            "controller_ip": "10.1.2.3",
+        },
+        ingest_route=ci.INGEST_ROUTE_TELEGRAM,
+        review_status="approved",  # a caller MUST NOT be able to self-approve
+    )
+    return env, raw
+
+
+def test_envelope_has_full_section2_contract_shape():
+    env, _ = _build_telegram_photo_envelope()
+    assert set(env) == _REQUIRED_KEYS, "envelope must match §2 contract exactly"
+    sm = env["source_metadata"]
+    for field in ("filename", "mime", "size", "captured_at", "uploader", "location"):
+        assert field in sm, f"source_metadata missing {field}"
+
+
+def test_source_sha256_is_content_fingerprint():
+    env, raw = _build_telegram_photo_envelope()
+    assert env["source_sha256"] == hashlib.sha256(raw).hexdigest()
+
+
+def test_review_status_forced_proposed_even_when_caller_overrides():
+    env, _ = _build_telegram_photo_envelope()
+    # Caller passed review_status="approved"; Telegram owns NO truth.
+    assert env["review_status"] == "proposed"
+
+
+def test_ingest_route_is_telegram():
+    env, _ = _build_telegram_photo_envelope()
+    assert env["ingest_route"] == "telegram"
+
+
+def test_client_owns_no_truth_domain_proposals_empty():
+    env, _ = _build_telegram_photo_envelope()
+    for key in (
+        "proposed_uns",
+        "proposed_i3x",
+        "proposed_faults",
+        "proposed_parameters",
+        "proposed_signals",
+        "proposed_relationships",
+        "entities",
+    ):
+        assert env[key] == [], f"{key} must be empty — client collects evidence only"
+
+
+def test_free_text_pii_scrubbed_but_asset_hints_preserved():
+    env, _ = _build_telegram_photo_envelope()
+    evidence_text = " ".join(b.get("text", "") for b in env["evidence"])
+    # Free-text evidence is PII-scrubbed (security-boundaries.md).
+    assert "10.1.2.3" not in evidence_text
+    assert "[IP]" in evidence_text
+    # But structured asset hints are deliberate matching evidence — preserved.
+    assert env["asset_hints"]["controller_ip"] == "10.1.2.3"
+    assert env["asset_hints"]["serial"] == "SN-ABC123456"
+
+
+def test_uploader_is_pseudonymous_id_not_a_name():
+    env, _ = _build_telegram_photo_envelope()
+    assert env["source_metadata"]["uploader"] == "789"
+
+
+async def test_telegram_source_enters_same_import_pipeline_as_offline(monkeypatch):
+    """PRD §6 test 9 (gating).
+
+    The Telegram-built envelope is the canonical §2 intake contract and is
+    POSTed to the Hub import endpoint — the same pipeline an offline/direct
+    upload uses — carrying the raw bytes, landing ``proposed``.
+    """
+    env, raw = _build_telegram_photo_envelope()
+
+    seen: dict = {}
+
+    class _Resp:
+        status_code = 201
+
+        def json(self):  # pragma: no cover - not asserted
+            return {"ok": True}
+
+        @property
+        def text(self):  # pragma: no cover
+            return ""
+
+    class _Client:
+        def __init__(self, *a, **k):
+            seen["client_kwargs"] = k
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, **kwargs):
+            seen["url"] = url
+            seen["kwargs"] = kwargs
+            return _Resp()
+
+    monkeypatch.setattr(ci.httpx, "AsyncClient", _Client)
+
+    ok = await ci.submit_intake_to_hub(
+        env,
+        raw_bytes=raw,
+        filename="photo.jpg",
+        mime="image/jpeg",
+        tenant_id="11111111-2222-3333-4444-555555555555",
+        hub_url="https://hub.example.com",
+        token="svc-token",
+    )
+
+    assert ok is True
+    # Routed to the Hub import pipeline — NOT mira-ingest.
+    assert "/api/contextualization/import" in seen["url"]
+    assert "/ingest/" not in seen["url"]
+    assert seen["url"].startswith("https://hub.example.com")
+
+    # Multipart: the §2 contract travels as JSON; raw bytes travel as `file`.
+    data = seen["kwargs"]["data"]
+    files = seen["kwargs"]["files"]
+    posted = json.loads(data["contract"])
+    assert posted["ingest_route"] == "telegram"
+    assert posted["review_status"] == "proposed"
+    assert posted["source_sha256"] == hashlib.sha256(raw).hexdigest()
+    assert files["file"][1] == raw  # bytes are carried, not dropped
+    # Tenant scoping travels at transport level.
+    assert data["tenant_id"] == "11111111-2222-3333-4444-555555555555"
+    # Forward-looking service-token auth (Phase-2 server support).
+    headers = seen["kwargs"].get("headers", {})
+    assert headers.get("Authorization") == "Bearer svc-token"
+
+
+async def test_submit_never_raises_on_transport_error(monkeypatch):
+    """Background-safe: a failing Hub POST must not break the chat reply."""
+    env, raw = _build_telegram_photo_envelope()
+
+    class _BoomClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, *a, **k):
+            raise RuntimeError("network down")
+
+    monkeypatch.setattr(ci.httpx, "AsyncClient", _BoomClient)
+
+    ok = await ci.submit_intake_to_hub(
+        env,
+        raw_bytes=raw,
+        filename="photo.jpg",
+        mime="image/jpeg",
+        tenant_id="t",
+        hub_url="https://hub.example.com",
+    )
+    assert ok is False  # swallowed, reported as failure, not raised

--- a/mira-bots/tests/test_telegram_photo_hub_wiring.py
+++ b/mira-bots/tests/test_telegram_photo_hub_wiring.py
@@ -46,10 +46,18 @@ async def test_submit_photo_to_hub_builds_telegram_envelope(monkeypatch):
 
     monkeypatch.setattr(bot, "submit_intake_to_hub", _fake_submit)
     monkeypatch.setattr(bot, "HUB_IMPORT_URL", "https://hub.example.com")
-    monkeypatch.setattr(bot.chat_tenant, "resolve", lambda cid: "tenant-x")
+
+    def _capture_resolve(cid):
+        seen["resolve_arg"] = cid
+        return "tenant-x"
+
+    monkeypatch.setattr(bot.chat_tenant, "resolve", _capture_resolve)
 
     raw = b"\xff\xd8\xff conveyor photo bytes"
-    await bot._submit_photo_to_hub(raw, "conveyor-1 nameplate", _fake_update())
+    # user_id != chat_id so a wrong resolve key is caught.
+    await bot._submit_photo_to_hub(
+        raw, "conveyor-1 nameplate", _fake_update(user_id=789, chat_id=-100200)
+    )
 
     env = seen["envelope"]
     assert env["ingest_route"] == "telegram"
@@ -59,6 +67,8 @@ async def test_submit_photo_to_hub_builds_telegram_envelope(monkeypatch):
     assert env["source_metadata"]["mime"] == "image/jpeg"
     assert seen["kwargs"]["raw_bytes"] == raw
     assert seen["kwargs"]["tenant_id"] == "tenant-x"
+    # Tenant resolves by uploader user id, NOT the (group) chat id.
+    assert seen["resolve_arg"] == "789"
 
 
 async def test_submit_doc_to_hub_builds_telegram_envelope(monkeypatch):

--- a/mira-bots/tests/test_telegram_photo_hub_wiring.py
+++ b/mira-bots/tests/test_telegram_photo_hub_wiring.py
@@ -1,0 +1,100 @@
+"""HubV3 Phase 6 — Telegram bot wiring → Hub intake (replaces mira-ingest).
+
+Confirms the photo and document handlers build the §2 telegram-route envelope
+and submit it to the Hub import endpoint (not mira-ingest), carrying raw bytes
+and the resolved tenant. Imports the real ``bot`` module so the wiring is
+exercised, not a stand-in.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+# Dummy env so bot.py imports cleanly (mirrors test_image_downscale.py).
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy-token-for-testing")
+os.environ.setdefault("OPENWEBUI_BASE_URL", "http://localhost:8080")
+os.environ.setdefault("OPENWEBUI_API_KEY", "")
+os.environ.setdefault("KNOWLEDGE_COLLECTION_ID", "dummy-collection")
+os.environ.setdefault("VISION_MODEL", "qwen2.5vl:7b")
+os.environ.setdefault("MIRA_DB_PATH", "/tmp/mira_hubv3_wiring_test.db")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "telegram"))
+sys.modules.pop("chat_adapter", None)
+
+import bot  # noqa: E402
+
+
+def _fake_update(user_id=789, chat_id=42):
+    return types.SimpleNamespace(
+        effective_user=types.SimpleNamespace(id=user_id),
+        effective_chat=types.SimpleNamespace(id=chat_id),
+        message=types.SimpleNamespace(
+            date=types.SimpleNamespace(isoformat=lambda: "2026-06-20T12:00:00+00:00")
+        ),
+    )
+
+
+async def test_submit_photo_to_hub_builds_telegram_envelope(monkeypatch):
+    seen: dict = {}
+
+    async def _fake_submit(envelope, **kwargs):
+        seen["envelope"] = envelope
+        seen["kwargs"] = kwargs
+        return True
+
+    monkeypatch.setattr(bot, "submit_intake_to_hub", _fake_submit)
+    monkeypatch.setattr(bot, "HUB_IMPORT_URL", "https://hub.example.com")
+    monkeypatch.setattr(bot.chat_tenant, "resolve", lambda cid: "tenant-x")
+
+    raw = b"\xff\xd8\xff conveyor photo bytes"
+    await bot._submit_photo_to_hub(raw, "conveyor-1 nameplate", _fake_update())
+
+    env = seen["envelope"]
+    assert env["ingest_route"] == "telegram"
+    assert env["review_status"] == "proposed"
+    assert env["asset_hints"]["name"] == "conveyor-1"
+    assert env["source_metadata"]["uploader"] == "789"
+    assert env["source_metadata"]["mime"] == "image/jpeg"
+    assert seen["kwargs"]["raw_bytes"] == raw
+    assert seen["kwargs"]["tenant_id"] == "tenant-x"
+
+
+async def test_submit_doc_to_hub_builds_telegram_envelope(monkeypatch):
+    seen: dict = {}
+
+    async def _fake_submit(envelope, **kwargs):
+        seen["envelope"] = envelope
+        seen["kwargs"] = kwargs
+        return True
+
+    monkeypatch.setattr(bot, "submit_intake_to_hub", _fake_submit)
+    monkeypatch.setattr(bot, "HUB_IMPORT_URL", "https://hub.example.com")
+    monkeypatch.setattr(bot.chat_tenant, "resolve", lambda cid: "tenant-y")
+
+    pdf = b"%PDF-1.7 fake manual"
+    await bot._submit_doc_to_hub(pdf, "gs10manual.pdf", "drive manual", _fake_update())
+
+    env = seen["envelope"]
+    assert env["ingest_route"] == "telegram"
+    assert env["review_status"] == "proposed"
+    assert env["source_metadata"]["filename"] == "gs10manual.pdf"
+    assert env["source_metadata"]["mime"] == "application/pdf"
+    assert seen["kwargs"]["raw_bytes"] == pdf
+    assert seen["kwargs"]["filename"] == "gs10manual.pdf"
+    assert seen["kwargs"]["tenant_id"] == "tenant-y"
+
+
+async def test_submit_photo_to_hub_noop_when_unconfigured(monkeypatch):
+    called = {"n": 0}
+
+    async def _fake_submit(*a, **k):
+        called["n"] += 1
+        return True
+
+    monkeypatch.setattr(bot, "submit_intake_to_hub", _fake_submit)
+    monkeypatch.setattr(bot, "HUB_IMPORT_URL", "")  # not configured
+
+    await bot._submit_photo_to_hub(b"x", "cap", _fake_update())
+    assert called["n"] == 0  # no submit attempted when Hub URL absent


### PR DESCRIPTION
## What

Makes **Telegram a HubV3 evidence-capture client** (PRD §4.3 / §5 Phase 6, `docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md`). Photos and PDFs are submitted to the **Hub** as the **§2 "Shared Contextualization Intake Contract"** — replacing the legacy mira-ingest `{asset_tag, image}` / `document-kb` path. The Hub is the system of record; **Telegram owns no truth** — everything lands `review_status="proposed"`.

## How

- **`mira-bots/shared/contextualization_intake.py`** (new shared envelope-builder):
  - `build_intake_envelope()` emits the §2 envelope: `source_sha256` (same `hashlib.sha256(raw).hexdigest()` convention as mira-ingest), `asset_hints`, `source_metadata{filename,mime,size,captured_at,uploader,location}`, `evidence` (OCR-or-raw), `provenance`, `confidence`, `ingest_route="telegram"`. `review_status` is **always coerced to `proposed`** (a caller cannot self-approve).
  - `submit_intake_to_hub()` POSTs **multipart** (`contract` JSON + raw-byte `file` + `tenant_id`, `Bearer` token) to `/api/contextualization/import`. **Background-safe — never raises.**
- **`mira-bots/telegram/bot.py`**: photo (single + multi-photo burst) and document handlers build the envelope and submit to the Hub. Uploader = numeric Telegram id (pseudonymous, no name leak). Retired `INGEST_SERVICE_URL`, `_ingest_photo_background`, `_equipment_type_from_doc` (orphaned by the change).
- **PII** (`.claude/rules/security-boundaries.md`): free-text evidence scrubbed via `InferenceRouter.sanitize_text` (IPv4/MAC/serial); structured `asset_hints` (serial, controller IP) **preserved** as deliberate matching evidence.

## Bytes transport decision

The §2 envelope is metadata-only. A pure-JSON POST would silently drop the image/PDF, so the raw bytes travel as a multipart `file` field alongside the `contract` JSON — the same multipart shape the Hub import endpoint already speaks.

## Tests (TDD — §6 test 9 first, RED→GREEN)

- `test_telegram_hub_intake.py` (9) — gating **test 9**: telegram source enters the same import pipeline as offline/direct upload, lands `proposed`; sha256 fingerprint; `proposed` forced on override; `ingest_route="telegram"`; routed to Hub **not** mira-ingest; bytes carried; PII scrubbed in evidence but asset_hints serial/IP preserved; background-safe.
- `test_telegram_photo_hub_wiring.py` (3) — photo + document handlers build the telegram-route envelope and submit with raw bytes + resolved tenant; no-op when `HUB_IMPORT_URL` unset.
- **12 new tests green**; existing telegram adapter + image suites green (27 passed). `ruff check`/`format` clean.

## ⚠️ Cross-phase dependency — do NOT merge ahead of Phase 2

This is the **client half**. The Hub import endpoint is **multipart-zip-only today**; it accepts this JSON contract only after **HubV3 Phase 2** (import endpoint + sha256 dedup). Test 9 is therefore **client-scoped** (envelope shape + Hub-routing), not end-to-end. Auth uses a forward-looking `HUB_IMPORT_TOKEN` Bearer (service-token path is Phase-2 server work).

## Scope / guardrails honored

- Touched **only** `mira-bots/telegram/` + a shared envelope-builder in `mira-bots/shared/`. **No** changes to `mira-hub/`, migrations, or `mira-contextualizer/`.
- The shared contract here is the client artifact; Phase 0 may relocate/dedupe it against a TS type in `mira-hub` (out of scope here).

New env vars: `HUB_IMPORT_URL`, `HUB_IMPORT_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)