### PR TITLE
feat(hub): HubV3 Phase 4 — Review Queue + approval-aware publish gate

### DIFF
--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## v2.12.0 — 2026-06-20
+- feat(hub): HubV3 Phase 4 — batch Review Queue + approval gate. New `Review Queue` screen (`/contextualization/review`) drives `ctx_import_batches.review_status` (proposed→approved|rejected|needs_review) over the shared vocabulary (Sources, Evidence, Extracted Signals, Fault Catalog, Parameters, UNS Map, Scorecard). Approve **publishes** a batch's accepted staged proposals into the live model: `kg_entities` go proposed→verified (the engine's grounding surface) with the paired `ai_suggestions` moved pending→accepted in lockstep (ADR-0017). The `/contextualization/[id]/promote` route is now approval-aware: it reads `kg_entities.approval_state` and refuses to overwrite verified/deprecated rows (returns skip reasons instead of a silent `ON CONFLICT DO NOTHING`), and uses the live `(tenant_id, entity_type, name)` conflict target (mig 026). Nothing auto-promotes — import stages `proposed`; only a human approve verifies. No migration. (HubV3 §5 Phase 4)
+
 ## v2.8.0 — 2026-06-15
 - feat(hub): onboarding now guides a fresh customer to upload their manual and ask MIRA a cited question about it; un-onboarded tenants are auto-sent to the wizard (#1901).
 

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/src/app/(hub)/contextualization/review/[batchId]/page.tsx
+++ b/mira-hub/src/app/(hub)/contextualization/review/[batchId]/page.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft, Check, Loader2, X, AlertTriangle } from "lucide-react";
+import { API_BASE } from "@/lib/config";
+
+type ReviewStatus = "proposed" | "approved" | "rejected" | "needs_review";
+type Decision = "approve" | "reject" | "needs_review";
+
+interface Signal {
+  id: string;
+  tagName: string;
+  roles: string[];
+  unsPath: string | null;
+  i3xElementId: string | null;
+  confidence: number | null;
+  status: string;
+  sourceFile: string | null;
+  evidenceCount: number;
+}
+interface Source {
+  id: string;
+  sourceType: string;
+  fileName: string;
+  status: string;
+  sha256: string | null;
+}
+interface BatchDetail {
+  batch: {
+    id: string;
+    projectName: string;
+    ingestRoute: string;
+    bundleSha256: string | null;
+    reviewStatus: ReviewStatus;
+    createdAt: string;
+  };
+  sources: Source[];
+  evidence: { tagName: string; evidenceCount: number }[];
+  extractedSignals: Signal[];
+  faultCatalog: Signal[];
+  parameters: Signal[];
+  unsMap: { tagName: string; unsPath: string | null; i3xElementId: string | null }[];
+  scorecard: {
+    sources: number;
+    signals: number;
+    mappedUns: number;
+    accepted: number;
+    avgConfidence: number | null;
+  };
+}
+
+const STATUS_STYLE: Record<ReviewStatus, string> = {
+  proposed: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+  approved: "bg-green-500/15 text-green-300 border-green-500/30",
+  rejected: "bg-red-500/15 text-red-300 border-red-500/30",
+  needs_review: "bg-blue-500/15 text-blue-300 border-blue-500/30",
+};
+
+function Section({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-white font-medium">{title}</h2>
+        <span className="text-xs text-gray-500">{count}</span>
+      </div>
+      {count === 0 ? (
+        <p className="text-sm text-gray-600 italic">None in this batch.</p>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}
+
+function confColor(c: number | null): string {
+  if (c == null) return "text-gray-500";
+  if (c >= 0.85) return "text-green-400";
+  if (c >= 0.5) return "text-amber-400";
+  return "text-gray-400";
+}
+
+export default function BatchReviewPage() {
+  const router = useRouter();
+  const params = useParams();
+  const batchId = String(params.batchId);
+
+  const [data, setData] = useState<BatchDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [acting, setActing] = useState<Decision | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const fetchDetail = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/contextualization/batches/${batchId}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load batch");
+    } finally {
+      setLoading(false);
+    }
+  }, [batchId]);
+
+  useEffect(() => {
+    fetchDetail();
+  }, [fetchDetail]);
+
+  async function decide(decision: Decision) {
+    setActing(decision);
+    setToast(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/contextualization/batches/${batchId}/review`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      if (decision === "approve") {
+        setToast(`Approved — published ${body.published} signal(s)${body.skipped ? `, ${body.skipped} kept (already approved)` : ""}.`);
+      } else {
+        setToast(decision === "reject" ? "Batch rejected." : "Marked needs-review.");
+      }
+      await fetchDetail();
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : "Action failed");
+    } finally {
+      setActing(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-gray-400 py-20 justify-center">
+        <Loader2 size={20} className="animate-spin" /> Loading batch…
+      </div>
+    );
+  }
+  if (error || !data) {
+    return <div className="text-red-400 py-20 text-center">{error ?? "Not found"}</div>;
+  }
+
+  const { batch, sources, evidence, extractedSignals, faultCatalog, parameters, unsMap, scorecard } = data;
+  const isOpen = batch.reviewStatus === "proposed" || batch.reviewStatus === "needs_review";
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <button
+        onClick={() => router.push("/contextualization/review")}
+        className="flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-200 mb-4"
+      >
+        <ArrowLeft size={15} /> Review Queue
+      </button>
+
+      {/* Header + actions */}
+      <div className="flex items-start justify-between gap-4 mb-6">
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-semibold text-white">{batch.projectName}</h1>
+            <span className={`text-[11px] px-2 py-0.5 rounded-full border ${STATUS_STYLE[batch.reviewStatus]}`}>
+              {batch.reviewStatus.replace("_", " ")}
+            </span>
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            via {batch.ingestRoute}
+            {batch.bundleSha256 ? ` · ${batch.bundleSha256.slice(0, 12)}…` : ""} · {new Date(batch.createdAt).toLocaleString()}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            onClick={() => decide("approve")}
+            disabled={!isOpen || acting !== null}
+            className="flex items-center gap-1.5 bg-green-600 hover:bg-green-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+          >
+            {acting === "approve" ? <Loader2 size={14} className="animate-spin" /> : <Check size={15} />}
+            Approve &amp; Publish
+          </button>
+          <button
+            onClick={() => decide("needs_review")}
+            disabled={!isOpen || acting !== null}
+            className="flex items-center gap-1.5 bg-gray-800 hover:bg-gray-700 disabled:opacity-40 text-gray-200 text-sm px-3 py-2 rounded-lg transition-colors"
+          >
+            {acting === "needs_review" ? <Loader2 size={14} className="animate-spin" /> : <AlertTriangle size={15} />}
+            Needs review
+          </button>
+          <button
+            onClick={() => decide("reject")}
+            disabled={!isOpen || acting !== null}
+            className="flex items-center gap-1.5 bg-gray-800 hover:bg-red-900/60 disabled:opacity-40 text-red-300 text-sm px-3 py-2 rounded-lg transition-colors"
+          >
+            {acting === "reject" ? <Loader2 size={14} className="animate-spin" /> : <X size={15} />}
+            Reject
+          </button>
+        </div>
+      </div>
+
+      {toast && (
+        <div className="mb-5 text-sm text-gray-200 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2.5">
+          {toast}
+        </div>
+      )}
+
+      {/* Scorecard */}
+      <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-5">
+        {[
+          { label: "Sources", value: scorecard.sources },
+          { label: "Extracted Signals", value: scorecard.signals },
+          { label: "UNS Map", value: scorecard.mappedUns },
+          { label: "Accepted", value: scorecard.accepted },
+          { label: "Avg confidence", value: scorecard.avgConfidence ?? "—" },
+        ].map((m) => (
+          <div key={m.label} className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+            <div className="text-xl font-semibold text-white">{m.value}</div>
+            <div className="text-[11px] text-gray-500 mt-0.5">{m.label}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid gap-4">
+        {/* Sources */}
+        <Section title="Sources" count={sources.length}>
+          <ul className="divide-y divide-gray-800">
+            {sources.map((s) => (
+              <li key={s.id} className="py-2 flex items-center justify-between text-sm">
+                <span className="text-gray-200 truncate">{s.fileName}</span>
+                <span className="text-xs text-gray-500 shrink-0 ml-3">
+                  {s.sourceType} · {s.sha256 ? `${s.sha256.slice(0, 10)}…` : "no hash"} · {s.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+
+        {/* Extracted Signals */}
+        <Section title="Extracted Signals" count={extractedSignals.length}>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs text-gray-500 border-b border-gray-800">
+                  <th className="py-2 pr-3 font-medium">Tag</th>
+                  <th className="py-2 pr-3 font-medium">Roles</th>
+                  <th className="py-2 pr-3 font-medium">Proposed UNS path</th>
+                  <th className="py-2 pr-3 font-medium">Conf.</th>
+                  <th className="py-2 font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {extractedSignals.map((s) => (
+                  <tr key={s.id} className="border-b border-gray-800/60">
+                    <td className="py-2 pr-3 text-gray-200 font-mono text-xs">{s.tagName}</td>
+                    <td className="py-2 pr-3 text-gray-400 text-xs">{s.roles.join(", ") || "—"}</td>
+                    <td className="py-2 pr-3 text-gray-400 font-mono text-xs">{s.unsPath ?? "—"}</td>
+                    <td className={`py-2 pr-3 text-xs ${confColor(s.confidence)}`}>
+                      {s.confidence != null ? s.confidence.toFixed(2) : "—"}
+                    </td>
+                    <td className="py-2 text-xs text-gray-400">{s.status}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Section>
+
+        <div className="grid sm:grid-cols-2 gap-4">
+          {/* Fault Catalog */}
+          <Section title="Fault Catalog" count={faultCatalog.length}>
+            <ul className="space-y-1.5 text-sm">
+              {faultCatalog.map((f) => (
+                <li key={f.id} className="text-gray-300 font-mono text-xs">{f.tagName}</li>
+              ))}
+            </ul>
+          </Section>
+
+          {/* Parameters */}
+          <Section title="Parameters" count={parameters.length}>
+            <ul className="space-y-1.5 text-sm">
+              {parameters.map((p) => (
+                <li key={p.id} className="text-gray-300 font-mono text-xs">{p.tagName}</li>
+              ))}
+            </ul>
+          </Section>
+        </div>
+
+        {/* UNS Map */}
+        <Section title="UNS Map" count={unsMap.length}>
+          <ul className="divide-y divide-gray-800">
+            {unsMap.map((u) => (
+              <li key={u.tagName} className="py-2 flex items-center justify-between text-xs font-mono">
+                <span className="text-gray-300">{u.tagName}</span>
+                <span className="text-gray-500 truncate ml-3">{u.unsPath}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+
+        {/* Evidence */}
+        <Section title="Evidence" count={evidence.length}>
+          <ul className="divide-y divide-gray-800">
+            {evidence.map((e) => (
+              <li key={e.tagName} className="py-2 flex items-center justify-between text-xs">
+                <span className="text-gray-300 font-mono">{e.tagName}</span>
+                <span className="text-gray-500">{e.evidenceCount} block{e.evidenceCount !== 1 ? "s" : ""}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/mira-hub/src/app/(hub)/contextualization/review/page.tsx
+++ b/mira-hub/src/app/(hub)/contextualization/review/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ClipboardList, Loader2 } from "lucide-react";
+import { API_BASE } from "@/lib/config";
+
+type ReviewStatus = "proposed" | "approved" | "rejected" | "needs_review";
+
+interface Batch {
+  id: string;
+  projectName: string;
+  ingestRoute: string;
+  reviewStatus: ReviewStatus;
+  sourceCount: number;
+  extractionCount: number;
+  acceptedCount: number;
+  createdAt: string;
+}
+
+const STATUS_STYLE: Record<ReviewStatus, string> = {
+  proposed: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+  approved: "bg-green-500/15 text-green-300 border-green-500/30",
+  rejected: "bg-red-500/15 text-red-300 border-red-500/30",
+  needs_review: "bg-blue-500/15 text-blue-300 border-blue-500/30",
+};
+const STATUS_LABEL: Record<ReviewStatus, string> = {
+  proposed: "Pending review",
+  approved: "Approved",
+  rejected: "Rejected",
+  needs_review: "Needs review",
+};
+
+export default function ReviewQueuePage() {
+  const router = useRouter();
+  const [batches, setBatches] = useState<Batch[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchBatches = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/contextualization/batches`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setBatches(data.batches ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load review queue");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchBatches();
+  }, [fetchBatches]);
+
+  const pending = batches.filter((b) => b.reviewStatus === "proposed" || b.reviewStatus === "needs_review").length;
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">Review Queue</h1>
+          <p className="text-sm text-gray-400 mt-1">
+            Imported context lands here as proposed. Approve a batch to publish its signals, UNS map, and
+            i3X objects into the project model — nothing goes live until you approve it.
+          </p>
+        </div>
+        {pending > 0 && (
+          <span className="text-xs text-amber-300 bg-amber-500/15 border border-amber-500/30 px-3 py-1.5 rounded-lg">
+            {pending} awaiting review
+          </span>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-gray-400 py-12 justify-center">
+          <Loader2 size={20} className="animate-spin" />
+          Loading review queue…
+        </div>
+      ) : error ? (
+        <div className="text-red-400 py-12 text-center">{error}</div>
+      ) : batches.length === 0 ? (
+        <div className="border border-dashed border-gray-700 rounded-xl py-20 flex flex-col items-center gap-4 text-gray-500">
+          <ClipboardList size={40} className="text-gray-600" />
+          <p className="text-sm">No import batches yet. Import an offline bundle or Telegram capture to populate the queue.</p>
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {batches.map((b) => (
+            <button
+              key={b.id}
+              onClick={() => router.push(`/contextualization/review/${b.id}`)}
+              className="w-full text-left bg-gray-900 border border-gray-800 hover:border-gray-600 rounded-xl p-5 transition-colors group"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-3">
+                    <h2 className="text-white font-medium group-hover:text-blue-300 transition-colors truncate">
+                      {b.projectName}
+                    </h2>
+                    <span className={`text-[11px] px-2 py-0.5 rounded-full border ${STATUS_STYLE[b.reviewStatus]}`}>
+                      {STATUS_LABEL[b.reviewStatus]}
+                    </span>
+                  </div>
+                  <p className="text-gray-500 text-xs mt-1">via {b.ingestRoute}</p>
+                </div>
+                <div className="flex items-center gap-4 text-xs text-gray-500 shrink-0 mt-0.5">
+                  <span>
+                    <span className="text-gray-300 font-medium">{b.sourceCount}</span> source{b.sourceCount !== 1 ? "s" : ""}
+                  </span>
+                  <span>
+                    <span className="text-gray-300 font-medium">{b.extractionCount}</span> signals
+                  </span>
+                  <span>
+                    <span className="text-green-400 font-medium">{b.acceptedCount}</span> accepted
+                  </span>
+                  <span>{new Date(b.createdAt).toLocaleDateString()}</span>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mira-hub/src/app/api/contextualization/[id]/promote/route.ts
+++ b/mira-hub/src/app/api/contextualization/[id]/promote/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from "next/server";
 import { sessionOr401 } from "@/lib/session";
 import { withTenantContext } from "@/lib/tenant-context";
+import {
+  IMPORT_APPROVAL_STATE,
+  buildEntityInsert,
+  decidePromotion,
+  type EntityApprovalState,
+} from "@/lib/contextualization/approval";
 
 export const dynamic = "force-dynamic";
 
@@ -10,16 +16,21 @@ interface ExtractionRow {
   roles: string[];
   uns_path_proposed: string | null;
   confidence: string | null;
+  import_batch_id: string | null;
 }
 
 /**
  * POST /api/contextualization/[id]/promote
  *
- * Promotes all accepted ctx_extractions for a project into kg_entities
+ * Stages all accepted ctx_extractions for a project into kg_entities
  * (type=signal, approval_state=proposed) and creates a paired ai_suggestions
- * row (type=kg_entity, status=pending) so the Hub proposals queue picks them up.
+ * row (type=kg_entity, status=pending). This is import-time STAGING — it never
+ * publishes. Publishing (proposed → verified) is a human action via the batch
+ * review-queue (POST .../batches/[batchId]/review {decision:"approve"}).
  *
- * Idempotent: ON CONFLICT DO NOTHING on both tables.
+ * Approval-aware: before writing, it reads the existing kg_entities.approval_state
+ * and REFUSES to overwrite approved data (verified/deprecated). Skipped rows are
+ * reported with a reason instead of a silent ON CONFLICT DO NOTHING.
  */
 export async function POST(
   _req: Request,
@@ -46,27 +57,31 @@ export async function POST(
       );
       if (proj.rows.length === 0) return null;
 
-      // Fetch accepted extractions with proposed UNS paths
+      // Fetch accepted extractions with proposed UNS paths + their import batch
+      // (the batch comes from the source the extraction was parsed from).
       const rows = await c
         .query<ExtractionRow>(
-          `SELECT id, tag_name, roles, uns_path_proposed, confidence::text
-             FROM ctx_extractions
-            WHERE project_id = $1
-              AND tenant_id = $2::uuid
-              AND status = 'accepted'
-              AND uns_path_proposed IS NOT NULL
-            ORDER BY tag_name`,
+          `SELECT e.id, e.tag_name, e.roles, e.uns_path_proposed,
+                  e.confidence::text AS confidence, s.import_batch_id
+             FROM ctx_extractions e
+             LEFT JOIN ctx_sources s ON s.id = e.source_id
+            WHERE e.project_id = $1
+              AND e.tenant_id = $2::uuid
+              AND e.status = 'accepted'
+              AND e.uns_path_proposed IS NOT NULL
+            ORDER BY e.tag_name`,
           [projectId, ctx.tenantId],
         )
         .then((r) => r.rows);
 
       if (rows.length === 0) {
-        return { projectName: proj.rows[0].name, promoted: 0, skipped: 0 };
+        return { projectName: proj.rows[0].name, promoted: 0, skipped: 0, skips: [] };
       }
 
       const actorLabel = `import:ctx_project:${projectId}`;
       let promoted = 0;
       let skipped = 0;
+      const skips: { tag_name: string; reason: string; protected: boolean }[] = [];
 
       for (const row of rows) {
         const unsPath = row.uns_path_proposed!;
@@ -77,31 +92,53 @@ export async function POST(
         const properties = {
           roles: row.roles ?? [],
           confidence,
-          provenance: { ctx_extraction_id: row.id, ctx_project_id: projectId },
+          provenance: {
+            ctx_extraction_id: row.id,
+            ctx_project_id: projectId,
+            ctx_import_batch_id: row.import_batch_id, // audit link, not a lookup key
+          },
         };
 
-        // Upsert kg_entities: entity_type=signal, entity_id=uns_path (unique within tenant)
-        const ent = await c.query<{ id: string; was_new: boolean }>(
-          `INSERT INTO kg_entities
-               (tenant_id, entity_type, entity_id, name, properties,
-                approval_state, uns_path)
-             VALUES ($1::uuid, 'signal', $2, $3, $4::jsonb,
-                     'proposed', $5::ltree)
-             ON CONFLICT (tenant_id, entity_type, entity_id) DO NOTHING
-             RETURNING id, TRUE AS was_new`,
-          [ctx.tenantId, unsPath, row.tag_name, JSON.stringify(properties), ltreePath],
+        // Approval gate: read existing approval_state on the live natural key
+        // (tenant_id, entity_type, name) and refuse to overwrite approved data.
+        const existing = await c.query<{ approval_state: EntityApprovalState }>(
+          `SELECT approval_state FROM kg_entities
+            WHERE tenant_id = $1::uuid AND entity_type = 'signal' AND name = $2`,
+          [ctx.tenantId, row.tag_name],
         );
+        const decision = decidePromotion(existing.rows[0] ?? null);
 
-        if (ent.rows.length === 0) {
-          // Row already existed — still wire up ai_suggestions below (idempotent)
+        if (decision.action === "skip") {
           skipped++;
-        } else {
-          promoted++;
+          skips.push({
+            tag_name: row.tag_name,
+            reason: decision.reason ?? "skipped",
+            protected: decision.protectedRow ?? false,
+          });
+          continue; // do not touch the row, do not create a new suggestion
         }
 
-        // Create an ai_suggestions row only when one doesn't exist for this extraction yet.
-        // ai_suggestions has no unique constraint beyond PK, so we check first.
-        const existing = await c.query<{ id: string }>(
+        // Stage a fresh proposed entity (correct conflict target — migration 026).
+        const ins = buildEntityInsert({
+          tenantId: ctx.tenantId,
+          name: row.tag_name,
+          unsPath,
+          ltreePath,
+          propertiesJson: JSON.stringify(properties),
+          approvalState: IMPORT_APPROVAL_STATE,
+        });
+        const ent = await c.query<{ id: string }>(ins.text, ins.values);
+        if (ent.rows.length === 0) {
+          // Lost a race to a concurrent insert — treat as already-staged.
+          skipped++;
+          skips.push({ tag_name: row.tag_name, reason: "already staged (race)", protected: false });
+          continue;
+        }
+        promoted++;
+
+        // Paired ai_suggestions row (one review surface stays in lockstep on
+        // approve — see batches/[batchId]/review). Create only when absent.
+        const existingSug = await c.query<{ id: string }>(
           `SELECT id FROM ai_suggestions
             WHERE tenant_id = $1::uuid
               AND suggestion_type = 'kg_entity'
@@ -110,7 +147,7 @@ export async function POST(
           [ctx.tenantId, row.id],
         );
 
-        if (existing.rows.length === 0) {
+        if (existingSug.rows.length === 0) {
           await c.query(
             `INSERT INTO ai_suggestions
                (tenant_id, suggestion_type, extracted_data,
@@ -138,7 +175,7 @@ export async function POST(
         }
       }
 
-      return { projectName: proj.rows[0].name, promoted, skipped, total: rows.length };
+      return { projectName: proj.rows[0].name, promoted, skipped, total: rows.length, skips };
     });
 
     if (!result) {

--- a/mira-hub/src/app/api/contextualization/batches/[batchId]/review/route.ts
+++ b/mira-hub/src/app/api/contextualization/batches/[batchId]/review/route.ts
@@ -1,0 +1,211 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { applyHubProposalTransition } from "@/lib/proposal-transition";
+import {
+  PUBLISHED_APPROVAL_STATE,
+  buildEntityInsert,
+  buildPublishEntityUpdate,
+  decideBatchReview,
+  decidePublish,
+  parseReviewDecision,
+  type EntityApprovalState,
+} from "@/lib/contextualization/approval";
+
+export const dynamic = "force-dynamic";
+
+interface PublishRow {
+  id: string;
+  tag_name: string;
+  roles: string[] | null;
+  uns_path_proposed: string | null;
+  confidence: string | null;
+}
+
+/**
+ * POST /api/contextualization/batches/[batchId]/review
+ * Body: { decision: "approve" | "reject" | "needs_review" }
+ *
+ * The Hub's batch-level approval gate (HubV3 Phase 4). Transitions
+ * ctx_import_batches.review_status. On `approve` — and ONLY on a human approve —
+ * it PUBLISHES the batch's accepted staged proposals into the live model:
+ * kg_entities go proposed → verified (the engine's grounding surface; this is
+ * the "publish to project model + UNS + i3X + MIRA KB" step), and the paired
+ * ai_suggestions move pending → accepted so the two Hub projections stay in
+ * lockstep (ADR-0017).
+ *
+ * No path here auto-promotes: import stages `proposed`; this human action is the
+ * verification. Approved/deprecated rows are never overwritten — the publish
+ * UPDATE carries a DB-level no-overwrite guard.
+ */
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ batchId: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { batchId } = await params;
+  if (!batchId || !/^[0-9a-f-]{36}$/i.test(batchId)) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const decision = parseReviewDecision(body.decision);
+  if (!decision) {
+    return NextResponse.json(
+      { error: "decision must be one of: approve, reject, needs_review" },
+      { status: 400 },
+    );
+  }
+
+  const reviewerLabel = `human:${ctx.userId}`;
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      const batch = await c.query<{ review_status: string; project_id: string }>(
+        `SELECT review_status, project_id
+           FROM ctx_import_batches
+          WHERE id = $1 AND tenant_id = $2::uuid`,
+        [batchId, ctx.tenantId],
+      );
+      if (batch.rows.length === 0) return null;
+
+      const outcome = decideBatchReview(
+        batch.rows[0].review_status as "proposed" | "approved" | "rejected" | "needs_review",
+        decision,
+      );
+
+      await c.query(
+        `UPDATE ctx_import_batches
+            SET review_status = $1, updated_at = now()
+          WHERE id = $2 AND tenant_id = $3::uuid`,
+        [outcome.status, batchId, ctx.tenantId],
+      );
+
+      if (!outcome.publish) {
+        return { reviewStatus: outcome.status, published: 0, skipped: 0, publishSkips: [] };
+      }
+
+      // Publish: accepted extractions of THIS batch (source of truth =
+      // ctx_sources.import_batch_id), upserted by the live natural key.
+      const rows = await c
+        .query<PublishRow>(
+          `SELECT e.id, e.tag_name, e.roles, e.uns_path_proposed, e.confidence::text AS confidence
+             FROM ctx_extractions e
+             JOIN ctx_sources s ON s.id = e.source_id
+            WHERE s.import_batch_id = $1
+              AND e.tenant_id = $2::uuid
+              AND e.status = 'accepted'
+              AND e.uns_path_proposed IS NOT NULL
+            ORDER BY e.tag_name`,
+          [batchId, ctx.tenantId],
+        )
+        .then((r) => r.rows);
+
+      let published = 0;
+      let skipped = 0;
+      const publishSkips: { tag_name: string; reason: string }[] = [];
+
+      for (const row of rows) {
+        const unsPath = row.uns_path_proposed!;
+        const ltreePath = unsPath.replace(/\//g, ".").replace(/[^a-z0-9_.]/gi, "_");
+        const confidence = row.confidence ? parseFloat(row.confidence) : 0.5;
+        const properties = {
+          roles: row.roles ?? [],
+          confidence,
+          provenance: {
+            ctx_extraction_id: row.id,
+            ctx_import_batch_id: batchId,
+            published_by: reviewerLabel,
+          },
+        };
+        const propsJson = JSON.stringify(properties);
+
+        // Read the live approval_state and decide insert / update / skip.
+        const existing = await c.query<{ approval_state: EntityApprovalState }>(
+          `SELECT approval_state FROM kg_entities
+            WHERE tenant_id = $1::uuid AND entity_type = 'signal' AND name = $2`,
+          [ctx.tenantId, row.tag_name],
+        );
+        const pd = decidePublish(existing.rows[0] ?? null);
+
+        if (pd.action === "skip") {
+          skipped++;
+          publishSkips.push({ tag_name: row.tag_name, reason: pd.reason ?? "skipped" });
+          continue;
+        }
+
+        let wrote = false;
+        if (pd.action === "insert") {
+          // Approval IS the verification — insert directly as verified.
+          const ins = buildEntityInsert({
+            tenantId: ctx.tenantId,
+            name: row.tag_name,
+            unsPath,
+            ltreePath,
+            propertiesJson: propsJson,
+            approvalState: PUBLISHED_APPROVAL_STATE,
+          });
+          const r = await c.query<{ id: string }>(ins.text, ins.values);
+          wrote = r.rows.length > 0;
+        }
+        if (!wrote) {
+          // update path (or lost-race fallback) — guarded so verified/deprecated
+          // rows are never overwritten.
+          const upd = buildPublishEntityUpdate({
+            tenantId: ctx.tenantId,
+            name: row.tag_name,
+            propertiesJson: propsJson,
+          });
+          const r = await c.query<{ id: string }>(upd.text, upd.values);
+          wrote = r.rows.length > 0;
+        }
+
+        if (wrote) {
+          published++;
+          // Keep the paired ai_suggestions row in lockstep (ADR-0017): the
+          // generic /proposals queue must not show this as pending forever once
+          // the Review Queue has approved it.
+          const sug = await c.query<{ id: string }>(
+            `SELECT id FROM ai_suggestions
+              WHERE tenant_id = $1::uuid
+                AND suggestion_type = 'kg_entity'
+                AND extracted_data->>'ctx_extraction_id' = $2
+                AND status = 'pending'
+              LIMIT 1`,
+            [ctx.tenantId, row.id],
+          );
+          if (sug.rows.length > 0) {
+            await applyHubProposalTransition(c, {
+              trigger: "accept",
+              aiSuggestionId: sug.rows[0].id,
+              reviewerLabel,
+            });
+          }
+        } else {
+          skipped++;
+          publishSkips.push({ tag_name: row.tag_name, reason: "protected — not overwritten" });
+        }
+      }
+
+      return { reviewStatus: outcome.status, published, skipped, total: rows.length, publishSkips };
+    });
+
+    if (!result) {
+      return NextResponse.json({ error: "batch not found" }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    console.error("[api/contextualization/batches/[batchId]/review POST]", err);
+    return NextResponse.json({ error: "Review failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/contextualization/batches/[batchId]/route.ts
+++ b/mira-hub/src/app/api/contextualization/batches/[batchId]/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+const FAULT_ROLES = new Set(["fault", "alarm", "fault_code", "diagnostic"]);
+const PARAM_ROLES = new Set(["parameter", "setpoint", "config", "limit", "threshold"]);
+
+interface BatchHeadRow {
+  id: string;
+  project_id: string;
+  project_name: string;
+  ingest_route: string;
+  bundle_sha256: string | null;
+  review_status: string;
+  created_at: string;
+  updated_at: string;
+}
+interface SourceRow {
+  id: string;
+  source_type: string;
+  file_name: string;
+  status: string;
+  source_sha256: string | null;
+  created_at: string;
+}
+interface ExtractionRow {
+  id: string;
+  tag_name: string;
+  roles: string[] | null;
+  uns_path_proposed: string | null;
+  i3x_element_id: string | null;
+  confidence: string | null;
+  status: string;
+  evidence_json: unknown;
+  source_file: string | null;
+}
+
+/**
+ * GET /api/contextualization/batches/[batchId]
+ *
+ * Full review payload for one import batch, grouped under the shared HubV3
+ * vocabulary: Sources, Evidence, Extracted Signals, Fault Catalog, Parameters,
+ * UNS Map, Scorecard. Sections the staged schema does not populate come back
+ * empty (the screen shows an honest empty-state) — never fabricated.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ batchId: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { batchId } = await params;
+  if (!batchId || !/^[0-9a-f-]{36}$/i.test(batchId)) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  try {
+    const payload = await withTenantContext(ctx.tenantId, async (c) => {
+      const head = await c.query<BatchHeadRow>(
+        `SELECT b.id, b.project_id, p.name AS project_name, b.ingest_route,
+                b.bundle_sha256, b.review_status, b.created_at, b.updated_at
+           FROM ctx_import_batches b
+           JOIN contextualization_projects p ON p.id = b.project_id
+          WHERE b.id = $1 AND b.tenant_id = $2::uuid`,
+        [batchId, ctx.tenantId],
+      );
+      if (head.rows.length === 0) return null;
+
+      const sources = await c
+        .query<SourceRow>(
+          `SELECT id, source_type, file_name, status, source_sha256, created_at
+             FROM ctx_sources
+            WHERE import_batch_id = $1 AND tenant_id = $2::uuid
+            ORDER BY file_name`,
+          [batchId, ctx.tenantId],
+        )
+        .then((r) => r.rows);
+
+      const extractions = await c
+        .query<ExtractionRow>(
+          `SELECT e.id, e.tag_name, e.roles, e.uns_path_proposed, e.i3x_element_id,
+                  e.confidence::text AS confidence, e.status, e.evidence_json,
+                  s.file_name AS source_file
+             FROM ctx_extractions e
+             JOIN ctx_sources s ON s.id = e.source_id
+            WHERE s.import_batch_id = $1 AND e.tenant_id = $2::uuid
+            ORDER BY e.tag_name`,
+          [batchId, ctx.tenantId],
+        )
+        .then((r) => r.rows);
+
+      return { head: head.rows[0], sources, extractions };
+    });
+
+    if (!payload) {
+      return NextResponse.json({ error: "batch not found" }, { status: 404 });
+    }
+
+    const { head, sources, extractions } = payload;
+
+    const signals = extractions.map((e) => ({
+      id: e.id,
+      tagName: e.tag_name,
+      roles: e.roles ?? [],
+      unsPath: e.uns_path_proposed,
+      i3xElementId: e.i3x_element_id,
+      confidence: e.confidence != null ? Number(e.confidence) : null,
+      status: e.status,
+      sourceFile: e.source_file,
+      evidenceCount: countEvidence(e.evidence_json),
+    }));
+
+    const hasRole = (e: typeof signals[number], set: Set<string>) =>
+      e.roles.some((r) => set.has(String(r).toLowerCase()));
+
+    const unsMap = signals
+      .filter((s) => s.unsPath)
+      .map((s) => ({ tagName: s.tagName, unsPath: s.unsPath, i3xElementId: s.i3xElementId }));
+
+    const accepted = signals.filter((s) => s.status === "accepted").length;
+    const confidences = signals.map((s) => s.confidence).filter((v): v is number => v != null);
+    const avgConfidence =
+      confidences.length > 0
+        ? Number((confidences.reduce((a, b) => a + b, 0) / confidences.length).toFixed(3))
+        : null;
+
+    return NextResponse.json({
+      batch: {
+        id: head.id,
+        projectId: head.project_id,
+        projectName: head.project_name,
+        ingestRoute: head.ingest_route,
+        bundleSha256: head.bundle_sha256,
+        reviewStatus: head.review_status,
+        createdAt: head.created_at,
+        updatedAt: head.updated_at,
+      },
+      sources: sources.map((s) => ({
+        id: s.id,
+        sourceType: s.source_type,
+        fileName: s.file_name,
+        status: s.status,
+        sha256: s.source_sha256,
+        createdAt: s.created_at,
+      })),
+      // Evidence is currently carried inline on each extraction; surface the
+      // aggregate count until the offline bundle ships a dedicated evidence.json.
+      evidence: signals
+        .filter((s) => s.evidenceCount > 0)
+        .map((s) => ({ tagName: s.tagName, evidenceCount: s.evidenceCount })),
+      extractedSignals: signals,
+      faultCatalog: signals.filter((s) => hasRole(s, FAULT_ROLES)),
+      parameters: signals.filter((s) => hasRole(s, PARAM_ROLES)),
+      unsMap,
+      scorecard: {
+        sources: sources.length,
+        signals: signals.length,
+        mappedUns: unsMap.length,
+        accepted,
+        avgConfidence,
+      },
+    });
+  } catch (err) {
+    console.error("[api/contextualization/batches/[batchId] GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}
+
+function countEvidence(ev: unknown): number {
+  if (Array.isArray(ev)) return ev.length;
+  if (ev && typeof ev === "object") return Object.keys(ev).length;
+  return 0;
+}

--- a/mira-hub/src/app/api/contextualization/batches/route.ts
+++ b/mira-hub/src/app/api/contextualization/batches/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+interface BatchRow {
+  id: string;
+  project_id: string;
+  project_name: string;
+  ingest_route: string;
+  bundle_sha256: string | null;
+  review_status: string;
+  source_count: string;
+  extraction_count: string;
+  accepted_count: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * GET /api/contextualization/batches
+ *
+ * The Review Queue feed. Lists every staged import batch for the tenant with
+ * its review_status (proposed | approved | rejected | needs_review) and live
+ * source / extraction / accepted counts. Newest first.
+ */
+export async function GET() {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  try {
+    const rows = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query<BatchRow>(
+          `SELECT
+              b.id,
+              b.project_id,
+              p.name AS project_name,
+              b.ingest_route,
+              b.bundle_sha256,
+              b.review_status,
+              COUNT(DISTINCT s.id)::text AS source_count,
+              COUNT(DISTINCT e.id)::text AS extraction_count,
+              COUNT(DISTINCT e.id) FILTER (WHERE e.status = 'accepted')::text AS accepted_count,
+              b.created_at,
+              b.updated_at
+           FROM ctx_import_batches b
+           JOIN contextualization_projects p ON p.id = b.project_id
+           LEFT JOIN ctx_sources s ON s.import_batch_id = b.id
+           LEFT JOIN ctx_extractions e ON e.source_id = s.id
+           WHERE b.tenant_id = $1::uuid
+           GROUP BY b.id, p.name
+           ORDER BY b.created_at DESC`,
+          [ctx.tenantId],
+        )
+        .then((r) => r.rows),
+    );
+
+    return NextResponse.json({
+      batches: rows.map((r) => ({
+        id: r.id,
+        projectId: r.project_id,
+        projectName: r.project_name,
+        ingestRoute: r.ingest_route,
+        bundleSha256: r.bundle_sha256,
+        reviewStatus: r.review_status,
+        sourceCount: Number(r.source_count),
+        extractionCount: Number(r.extraction_count),
+        acceptedCount: Number(r.accepted_count),
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      })),
+    });
+  } catch (err) {
+    console.error("[api/contextualization/batches GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/lib/contextualization/approval.test.ts
+++ b/mira-hub/src/lib/contextualization/approval.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  IMPORT_APPROVAL_STATE,
+  PUBLISHED_APPROVAL_STATE,
+  decidePromotion,
+  decidePublish,
+  decideBatchReview,
+  parseReviewDecision,
+  buildEntityInsert,
+  buildPublishEntityUpdate,
+} from "./approval";
+
+// HubV3 Phase 4 acceptance — PRD §6 test matrix.
+// These prove the *decision logic* and the *SQL no-overwrite guard*.
+// (A live re-import is an integration concern; NeonDB-SSL-on-Windows blocks it
+// locally — see PR notes. The SQL guard below is the real enforcement: delete
+// the WHERE clause and these go red.)
+
+describe("test 7 — imported proposals do not overwrite approved Hub data", () => {
+  it("import-time promote SKIPS an already-verified entity with a protected reason", () => {
+    const d = decidePromotion({ approval_state: "verified" });
+    expect(d.action).toBe("skip");
+    expect(d.protectedRow).toBe(true);
+    expect(d.reason).toMatch(/not overwrite/i);
+  });
+
+  it("import-time promote SKIPS a deprecated entity (protected)", () => {
+    const d = decidePromotion({ approval_state: "deprecated" });
+    expect(d.action).toBe("skip");
+    expect(d.protectedRow).toBe(true);
+  });
+
+  it("re-approval cannot mutate an already-verified entity", () => {
+    const d = decidePublish({ approval_state: "verified" });
+    expect(d.action).toBe("skip");
+  });
+
+  it("the publish UPDATE carries the no-overwrite SQL guard", () => {
+    const q = buildPublishEntityUpdate({
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      name: "conv_run",
+      propertiesJson: "{}",
+    });
+    // Verified/deprecated rows must be untouchable at the DB layer.
+    expect(q.text).toMatch(/approval_state\s+NOT IN\s*\(\s*'verified'\s*,\s*'deprecated'\s*\)/i);
+    expect(q.text).toMatch(/SET[\s\S]*approval_state\s*=\s*'verified'/i);
+  });
+
+  it("the stage INSERT uses the live natural-key conflict target, never entity_id", () => {
+    const q = buildEntityInsert({
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      name: "conv_run",
+      unsPath: "enterprise.garage.demo_cell.conveyor.conv_run",
+      ltreePath: "enterprise.garage.demo_cell.conveyor.conv_run",
+      propertiesJson: "{}",
+      approvalState: "proposed",
+    });
+    expect(q.text).toMatch(/ON CONFLICT\s*\(\s*tenant_id\s*,\s*entity_type\s*,\s*name\s*\)\s*DO NOTHING/i);
+    expect(q.text).not.toMatch(/ON CONFLICT[^)]*entity_id/i);
+  });
+});
+
+describe("test 8 — UNS/i3X remain proposed until approved", () => {
+  it("a freshly staged entity lands as 'proposed', never 'verified'", () => {
+    expect(IMPORT_APPROVAL_STATE).toBe("proposed");
+    const d = decidePromotion(null);
+    expect(d.action).toBe("insert");
+    expect(d.approvalState).toBe("proposed");
+  });
+
+  it("import-time promote never writes a verified entity (no auto-publish)", () => {
+    const q = buildEntityInsert({
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      name: "conv_run",
+      unsPath: "enterprise.garage.demo_cell.conveyor.conv_run",
+      ltreePath: "enterprise.garage.demo_cell.conveyor.conv_run",
+      propertiesJson: "{}",
+      approvalState: IMPORT_APPROVAL_STATE,
+    });
+    expect(q.values).toContain("proposed");
+    expect(q.values).not.toContain("verified");
+  });
+
+  it("only the approve decision publishes; reject/needs_review never publish", () => {
+    expect(PUBLISHED_APPROVAL_STATE).toBe("verified");
+    expect(decideBatchReview("proposed", "approve")).toEqual({ status: "approved", publish: true });
+    expect(decideBatchReview("proposed", "reject")).toEqual({ status: "rejected", publish: false });
+    expect(decideBatchReview("proposed", "needs_review")).toEqual({ status: "needs_review", publish: false });
+  });
+
+  it("publishing elevates a previously-proposed entity to verified", () => {
+    const d = decidePublish({ approval_state: "proposed" });
+    expect(d.action).toBe("update");
+  });
+
+  it("publishing an absent entity inserts it directly as verified (the human approval IS the verification)", () => {
+    const d = decidePublish(null);
+    expect(d.action).toBe("insert");
+  });
+});
+
+describe("parseReviewDecision — request guard", () => {
+  it("accepts the three valid decisions", () => {
+    expect(parseReviewDecision("approve")).toBe("approve");
+    expect(parseReviewDecision("reject")).toBe("reject");
+    expect(parseReviewDecision("needs_review")).toBe("needs_review");
+  });
+
+  it("rejects anything else (no auto-approve via a bogus value)", () => {
+    expect(parseReviewDecision("approved")).toBeNull();
+    expect(parseReviewDecision("verified")).toBeNull();
+    expect(parseReviewDecision("")).toBeNull();
+    expect(parseReviewDecision(undefined)).toBeNull();
+    expect(parseReviewDecision(42)).toBeNull();
+  });
+});

--- a/mira-hub/src/lib/contextualization/approval.ts
+++ b/mira-hub/src/lib/contextualization/approval.ts
@@ -1,0 +1,207 @@
+// HubV3 Phase 4 — approval gate decision logic + SQL builders.
+//
+// Hub owns truth. Imported (offline/telegram/hub_upload) proposals land as
+// `proposed`. A human approval — and ONLY a human approval — publishes them
+// (proposed → verified). Nothing here ever auto-promotes (ADR-0017; KG Iron
+// Rule: "MIRA proposes, the human verifies").
+//
+// The pure functions below are the single source of decision truth, shared by
+// the promote route (import-time staging) and the batch-review route
+// (approval-time publish). The SQL builders carry the no-overwrite guard at the
+// DB layer so verified/deprecated rows are untouchable even under a race.
+
+/** kg_entities.approval_state CHECK (migration 029). */
+export type EntityApprovalState =
+  | "proposed"
+  | "verified"
+  | "rejected"
+  | "needs_review"
+  | "deprecated";
+
+/** ctx_import_batches.review_status CHECK (migration 056). */
+export type BatchReviewStatus = "proposed" | "approved" | "rejected" | "needs_review";
+
+/** What a human can decide about a staged import batch. */
+export type ReviewDecision = "approve" | "reject" | "needs_review";
+
+const REVIEW_DECISIONS: ReadonlySet<string> = new Set([
+  "approve",
+  "reject",
+  "needs_review",
+]);
+
+/** Validate a request body's `decision` field. Returns the decision or null. */
+export function parseReviewDecision(value: unknown): ReviewDecision | null {
+  return typeof value === "string" && REVIEW_DECISIONS.has(value)
+    ? (value as ReviewDecision)
+    : null;
+}
+
+/** Everything imported lands here. Never `verified` at import time. */
+export const IMPORT_APPROVAL_STATE: EntityApprovalState = "proposed";
+
+/** The published state — only a human approval writes this. */
+export const PUBLISHED_APPROVAL_STATE: EntityApprovalState = "verified";
+
+/** Approved Hub data that import/publish must never overwrite. */
+const PROTECTED_STATES: ReadonlySet<EntityApprovalState> = new Set([
+  "verified",
+  "deprecated",
+]);
+
+export interface PromotionDecision {
+  action: "insert" | "skip";
+  /** present when action === "insert" */
+  approvalState?: EntityApprovalState;
+  /** present when action === "skip" */
+  reason?: string;
+  /** true when the skip is because the existing row is approved/protected */
+  protectedRow?: boolean;
+}
+
+/**
+ * Import-time staging decision. Stages a proposed entity when absent; refuses
+ * to overwrite approved (verified/deprecated) data; leaves other staged states
+ * untouched (idempotent re-import).
+ */
+export function decidePromotion(
+  existing: { approval_state: EntityApprovalState } | null,
+): PromotionDecision {
+  if (!existing) {
+    return { action: "insert", approvalState: IMPORT_APPROVAL_STATE };
+  }
+  if (PROTECTED_STATES.has(existing.approval_state)) {
+    return {
+      action: "skip",
+      protectedRow: true,
+      reason: `entity already ${existing.approval_state} — import will not overwrite approved data`,
+    };
+  }
+  return {
+    action: "skip",
+    protectedRow: false,
+    reason: `entity already staged (${existing.approval_state}) — left unchanged`,
+  };
+}
+
+export interface PublishDecision {
+  action: "insert" | "update" | "skip";
+  reason?: string;
+}
+
+/**
+ * Approval-time publish decision (runs inside the human approve action).
+ * - absent           → insert directly as verified (the approval IS the verification)
+ * - proposed/needs_review → update to verified
+ * - verified         → skip (idempotent re-approve)
+ * - rejected/deprecated   → skip (a human already declined/retired it)
+ */
+export function decidePublish(
+  existing: { approval_state: EntityApprovalState } | null,
+): PublishDecision {
+  if (!existing) return { action: "insert" };
+  switch (existing.approval_state) {
+    case "proposed":
+    case "needs_review":
+      return { action: "update" };
+    case "verified":
+      return { action: "skip", reason: "already verified" };
+    case "rejected":
+      return { action: "skip", reason: "previously rejected by a human" };
+    case "deprecated":
+      return { action: "skip", reason: "deprecated" };
+  }
+}
+
+export interface BatchReviewOutcome {
+  status: BatchReviewStatus;
+  publish: boolean;
+}
+
+/**
+ * Maps a human review decision to the batch's new review_status and whether it
+ * triggers publishing. Only `approve` publishes — never auto.
+ */
+export function decideBatchReview(
+  _current: BatchReviewStatus,
+  decision: ReviewDecision,
+): BatchReviewOutcome {
+  switch (decision) {
+    case "approve":
+      return { status: "approved", publish: true };
+    case "reject":
+      return { status: "rejected", publish: false };
+    case "needs_review":
+      return { status: "needs_review", publish: false };
+  }
+}
+
+// ─── SQL builders ───────────────────────────────────────────────────────────
+// Kept pure (return {text, values}) so the no-overwrite guard and the correct
+// conflict target are unit-testable without a live DB.
+
+export interface BuiltQuery {
+  text: string;
+  values: unknown[];
+}
+
+export interface EntityInsertParams {
+  tenantId: string;
+  name: string; // tag_name — the live natural key (tenant_id, entity_type, name)
+  unsPath: string;
+  ltreePath: string;
+  propertiesJson: string;
+  approvalState: EntityApprovalState;
+}
+
+/**
+ * INSERT a signal entity. Conflict target is the LIVE natural key
+ * (tenant_id, entity_type, name) — migration 026 dropped the old
+ * (tenant_id, entity_type, entity_id) unique, so the spine's entity_id-based
+ * ON CONFLICT referenced a non-existent constraint (latent runtime error).
+ */
+export function buildEntityInsert(p: EntityInsertParams): BuiltQuery {
+  return {
+    text: `INSERT INTO kg_entities
+             (tenant_id, entity_type, entity_id, name, properties,
+              approval_state, uns_path)
+           VALUES ($1::uuid, 'signal', $2, $3, $4::jsonb, $5, $6::ltree)
+           ON CONFLICT (tenant_id, entity_type, name) DO NOTHING
+           RETURNING id`,
+    values: [
+      p.tenantId,
+      p.unsPath,
+      p.name,
+      p.propertiesJson,
+      p.approvalState,
+      p.ltreePath,
+    ],
+  };
+}
+
+export interface PublishEntityUpdateParams {
+  tenantId: string;
+  name: string;
+  propertiesJson: string;
+}
+
+/**
+ * Publish (proposed → verified) a previously-staged signal entity. The WHERE
+ * guard is the real no-overwrite enforcement: verified/deprecated rows are
+ * untouchable at the DB layer. Returns 0 rows when the row is protected or
+ * absent (caller falls back to an insert when truly absent).
+ */
+export function buildPublishEntityUpdate(p: PublishEntityUpdateParams): BuiltQuery {
+  return {
+    text: `UPDATE kg_entities
+              SET approval_state = 'verified',
+                  properties = properties || $3::jsonb,
+                  updated_at = now()
+            WHERE tenant_id = $1::uuid
+              AND entity_type = 'signal'
+              AND name = $2
+              AND approval_state NOT IN ('verified', 'deprecated')
+          RETURNING id`,
+    values: [p.tenantId, p.name, p.propertiesJson],
+  };
+}


### PR DESCRIPTION
**Targets `feat/hubv3-hub-spine` (the HubV3 spine, #2126). Do NOT merge to main — stacked feature branch.**

Implements PRD §5 **Phase 4** (`docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md`): Review Queue + Approval + No-Overwrite. Hub owns truth — imported context stages as `proposed`; a human approval, and only a human approval, publishes it.

## What shipped
1. **Batch Review-Queue API**
   - `GET /api/contextualization/batches` — the queue feed (status + live counts).
   - `GET /api/contextualization/batches/[batchId]` — detail grouped under the shared vocabulary.
   - `POST /api/contextualization/batches/[batchId]/review` `{decision}` — drives `ctx_import_batches.review_status` proposed→approved|rejected|needs_review.
2. **New Hub Review Queue screen** (`/contextualization/review` + `/[batchId]`) labelled with the shared HubV3 vocabulary: **Review Queue · Sources · Evidence · Extracted Signals · Fault Catalog · Parameters · UNS Map · Scorecard**. Honest empty-states where the staged schema doesn't populate a section (no fabricated rows).
3. **Approve publishes** the batch's accepted staged proposals into the live model: `kg_entities` proposed→verified (the engine's grounding surface = "publish to project model + UNS + i3X + MIRA KB"); paired `ai_suggestions` move pending→accepted via `applyHubProposalTransition` so the two Hub projections stay in lockstep (ADR-0017) — no orphaned pending suggestions survive approval.
4. **`/contextualization/[id]/promote` is now approval-aware**: reads `kg_entities.approval_state`, **refuses to overwrite `verified`/`deprecated`** rows (returns skip reasons, not a silent `ON CONFLICT DO NOTHING`), and uses the live `(tenant_id, entity_type, name)` conflict target — mig 026 dropped the old `entity_id` unique, so the spine's `ON CONFLICT (…entity_id)` referenced a **non-existent constraint** (latent 500). Confirmed the name index is a **plain** (non-partial) unique → predicate-less `ON CONFLICT` is valid.

No migration (`review_status` in mig 056, `approval_state` in mig 029). Version `mira-hub` 2.11.0 → **2.12.0** + CHANGELOG.

## TDD / gate
`src/lib/contextualization/approval.ts` is a pure, fully-tested decision module; routes are thin callers. `approval.test.ts` encodes **PRD §6 test 7** (no overwrite of approved) + **test 8** (UNS/i3X stay proposed until approved), plus the request guard — **12/12 green**.

> **Scope of the proof (advisor-flagged):** these tests prove the **decision logic + the SQL no-overwrite guard** (`buildPublishEntityUpdate` carries `WHERE approval_state NOT IN ('verified','deprecated')` — delete it and tests go red). DB-touching routes are not unit-tested in this repo (live NeonDB; the Windows host hits the NeonDB-SSL gotcha), so a literal live re-import is **not** asserted here — a follow-up integration test (`vitest.integration.config.ts` against ephemeral postgres) would close that. The SQL guard is the real DB-level enforcement.

## Reviewer notes
- **Iron Rule letter (managing-the-knowledge-graph):** the approve route writes `approval_state='verified'` outside the `/api/proposals/[id]/decide` route. This is **spirit-compliant** — it runs **inside the human approve action** (the verification), and is PRD-mandated ("approval publishes", §5 P4). Not an auto-promote.
- **export vs grounding:** `export?format=uns|i3x` still reads `ctx_extractions.status='accepted'` — treat it as a **pre-publish preview**. Test 8's "proposed until approved" holds for the **verified-`kg_entities` grounding surface** the engine actually reads, not the export endpoint. "Publish to MIRA KB" = the KG (`kg_entities`), **not** `knowledge_entries` (untouched — different tenant law).

## Owed before this reaches main (not in this PR)
- Sidebar/nav link to `/contextualization/review`.
- Screenshot Rule: live screenshots of both screens (need a seeded batch + auth; staging-first per train-before-deploy).

## Verification
- `tsc --noEmit`: **0 errors**.
- `vitest run`: **761 passed**; 1 pre-existing failure (`sitemap-drift.test.ts`, a `.mjs` import SyntaxError) — **fails identically on the untouched spine**, not introduced here.
- `eslint` (new files): clean except the repo-wide `react-hooks/set-state-in-effect` pattern, which the existing sibling `contextualization` pages already trip (matched their convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)