### PR TITLE
HubV3 — unified contextualization intake (P0–P6: contract+schema+import+matching+review+bundle+telegram)

### DIFF
--- a/contracts/contextualization/__init__.py
+++ b/contracts/contextualization/__init__.py
@@ -1,0 +1,18 @@
+"""Cross-module contextualization contracts (Hub is system of record).
+
+Neutral home for the shared Intake Contract Python twin so the offline
+Contextualizer and Telegram thin client can import it without either owning it.
+See intake_contract.py and mira-hub/src/lib/contextualization/intake-contract.ts.
+"""
+
+from .intake_contract import (  # noqa: F401
+    CONTRACT_VERSION,
+    INGEST_ROUTES,
+    SOURCE_TYPES,
+    AssetHints,
+    IntakeContract,
+    IntakeSource,
+    ProposedSignal,
+    SourceMetadata,
+    validate_envelope,
+)

--- a/contracts/contextualization/intake_contract.py
+++ b/contracts/contextualization/intake_contract.py
@@ -1,0 +1,184 @@
+"""HubV3 — Shared Contextualization Intake Contract (Python twin).
+
+The single normalized envelope every ingest route submits to the Hub. The Hub
+is the system of record; clients only collect evidence and create proposals.
+
+This is the Python twin of:
+  - mira-hub/src/lib/contextualization/intake-contract.ts  (authoritative types + validator)
+  - mira-hub/src/lib/contextualization/intake-contract.schema.json  (JSON Schema)
+
+Keep all three in lockstep — change them together. This module is intentionally
+dependency-free (stdlib only) so the offline Contextualizer (mira-contextualizer)
+and the Telegram thin client (mira-bots) can each import it without pulling a
+validation framework. Those clients are wired in HubV3 Phases 5/6; this contract
+ships first (Phase 0) so they have one shape to target.
+
+Identity model: UUIDs are identity; names / numbers / serials / models /
+controller IPs / UNS paths are MATCHING EVIDENCE, never the sole key.
+`review_status` is always "proposed" on intake — nothing is auto-approved.
+
+Spec: docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md §2
+ADR:  docs/adr/0023-hub-system-of-record-contextualization.md
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+CONTRACT_VERSION = "contextualization-intake/v1"
+
+INGEST_ROUTES = ("offline", "telegram", "hub_upload")
+SOURCE_TYPES = ("l5x", "st", "plcopen", "csv", "manual", "other")
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
+
+
+@dataclass
+class AssetHints:
+    """Identity + matching-evidence hints; never the sole key."""
+
+    name: str | None = None
+    number: str | None = None
+    manufacturer: str | None = None
+    model: str | None = None
+    serial: str | None = None
+    controller: str | None = None
+    controller_ip: str | None = None
+    uns_path: str | None = None
+
+
+@dataclass
+class SourceMetadata:
+    file_name: str
+    mime: str | None = None
+    size: int | None = None
+    captured_at: str | None = None
+    uploader: str | None = None
+    location: str | None = None
+
+
+@dataclass
+class IntakeSource:
+    source_sha256: str  # per-source dedup key (sha256 hex)
+    source_type: str  # one of SOURCE_TYPES
+    source_metadata: SourceMetadata
+    source_uuid: str | None = None  # Hub mints if absent
+
+
+@dataclass
+class ProposedSignal:
+    tag_name: str
+    roles: list[str] = field(default_factory=list)
+    uns_path: str | None = None
+    i3x_element_id: str | None = None
+    confidence: float | None = None
+    evidence: dict = field(default_factory=dict)
+    source_sha256: str | None = None
+
+
+@dataclass
+class IntakeContract:
+    """The full intake envelope (HubV3 §2)."""
+
+    ingest_route: str  # one of INGEST_ROUTES
+    sources: list[IntakeSource]
+    contract_version: str = CONTRACT_VERSION
+    review_status: str = "proposed"  # always "proposed" on intake
+    bundle_sha256: str | None = None  # whole-submission fingerprint
+    project_hint: str | None = None
+    asset_hints: AssetHints | None = None
+    evidence: list[dict] = field(default_factory=list)
+    entities: list[dict] = field(default_factory=list)
+    proposed_signals: list[ProposedSignal] = field(default_factory=list)
+    proposed_uns: list[dict] = field(default_factory=list)
+    proposed_i3x: list[dict] = field(default_factory=list)
+    proposed_faults: list[dict] = field(default_factory=list)
+    proposed_parameters: list[dict] = field(default_factory=list)
+    proposed_relationships: list[dict] = field(default_factory=list)
+    provenance: dict = field(default_factory=dict)
+    confidence: str | float | None = None
+
+    def to_envelope(self) -> dict:
+        """Serialize to the wire envelope the Hub import endpoint accepts."""
+        return {
+            "contract_version": self.contract_version,
+            "ingest_route": self.ingest_route,
+            "review_status": self.review_status,
+            "bundle_sha256": self.bundle_sha256,
+            "project_hint": self.project_hint,
+            "asset_hints": _asdict_opt(self.asset_hints),
+            "sources": [
+                {
+                    "source_sha256": s.source_sha256,
+                    "source_type": s.source_type,
+                    "source_uuid": s.source_uuid,
+                    "source_metadata": {
+                        k: v
+                        for k, v in vars(s.source_metadata).items()
+                        if v is not None
+                    },
+                }
+                for s in self.sources
+            ],
+            "evidence": self.evidence,
+            "entities": self.entities,
+            "proposed_signals": [vars(sig) for sig in self.proposed_signals],
+            "proposed_uns": self.proposed_uns,
+            "proposed_i3x": self.proposed_i3x,
+            "proposed_faults": self.proposed_faults,
+            "proposed_parameters": self.proposed_parameters,
+            "proposed_relationships": self.proposed_relationships,
+            "provenance": self.provenance,
+            "confidence": self.confidence,
+        }
+
+
+def _asdict_opt(obj) -> dict | None:
+    if obj is None:
+        return None
+    return {k: v for k, v in vars(obj).items() if v is not None}
+
+
+def validate_envelope(payload: dict) -> list[str]:
+    """Validate a raw envelope dict. Returns a list of errors ([] == valid).
+
+    Mirrors validateIntakeContract() in intake-contract.ts. Kept deliberately
+    in sync with the TS validator's rules and messages.
+    """
+    errors: list[str] = []
+    if not isinstance(payload, dict):
+        return ["intake contract must be a JSON object"]
+
+    if payload.get("contract_version") != CONTRACT_VERSION:
+        errors.append(f'contract_version must be "{CONTRACT_VERSION}"')
+
+    if payload.get("ingest_route") not in INGEST_ROUTES:
+        errors.append(f"ingest_route must be one of {', '.join(INGEST_ROUTES)}")
+
+    review_status = payload.get("review_status")
+    if review_status is not None and review_status != "proposed":
+        errors.append('review_status must be "proposed" on intake')
+
+    bundle = payload.get("bundle_sha256")
+    if bundle is not None and not (isinstance(bundle, str) and _SHA256_RE.match(bundle)):
+        errors.append("bundle_sha256 must be a 64-char hex string")
+
+    sources = payload.get("sources")
+    if not isinstance(sources, list) or len(sources) == 0:
+        errors.append("sources must be a non-empty array")
+    else:
+        for i, s in enumerate(sources):
+            if not isinstance(s, dict):
+                errors.append(f"sources[{i}] must be an object")
+                continue
+            sha = s.get("source_sha256")
+            if not (isinstance(sha, str) and _SHA256_RE.match(sha)):
+                errors.append(f"sources[{i}].source_sha256 must be a 64-char hex string")
+            if s.get("source_type") not in SOURCE_TYPES:
+                errors.append(f"sources[{i}].source_type must be one of {', '.join(SOURCE_TYPES)}")
+            meta = s.get("source_metadata")
+            if not (isinstance(meta, dict) and isinstance(meta.get("file_name"), str) and meta["file_name"].strip()):
+                errors.append(f"sources[{i}].source_metadata.file_name is required")
+
+    return errors

--- a/docs/adr/0023-hub-system-of-record-contextualization.md
+++ b/docs/adr/0023-hub-system-of-record-contextualization.md
@@ -1,0 +1,152 @@
+# ADR-0023: Hub is the System of Record for Contextualization; Offline & Telegram are Ingest Clients
+
+## Status
+
+Accepted — 2026-06-20
+
+**Related:** ADR-0013 (Hub schema canonicalization — Hub owns the product
+surface), ADR-0017 (proposal state machine — `proposed → approved` is an admin
+action), ADR-0022 (Postgres-first storage).
+**Implements:** Phase 0 + Phase 1/2 of
+[`docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md`](../plans/2026-06-20-hubv3-contextualization-intake-prd.md).
+**Builds on:** PR #2068 (`feat/plc-mapper-gui`) — migration `055_contextualization`
+and the `/api/contextualization/*` routes.
+**Artifacts:** `mira-hub/src/lib/contextualization/intake-contract.ts` (+ `.schema.json`),
+`contracts/contextualization/intake_contract.py`. **Migration:** `056_contextualization_intake`.
+
+---
+
+## Context
+
+Three ingest routes collect contextualization evidence and risk becoming three
+separate systems of record:
+
+1. **MIRA Hub / Command Center** (`app.factorylm.com/hub`).
+2. **Offline FactoryLM Contextualizer** — Windows desktop app (PR #2068).
+3. **Telegram / phone thin client** — photos, nameplates, field notes, docs.
+
+If each platform mints its own assets, sources, UNS nodes, and project models,
+the result is duplicate truth and unmergeable state. The HubV3 spec (Mike,
+2026-06-20) makes the call: **the Hub is the single system of record; the others
+become ingest clients that collect evidence and create proposals.**
+
+The PR #2068 backbone (migration 055: `contextualization_projects`,
+`ctx_sources`, `ctx_extractions`; `/import` accepting a `machine_context_bundle.zip`)
+proves the offline→Hub loop, but has four gaps for "Hub owns truth" (PRD §4.1):
+no sha256 dedup, no asset matching, no import-batch grouping, weak no-overwrite.
+This ADR fixes the contract + dedup foundation (Phases 0–2); matching (P3),
+approval/no-overwrite (P4), and client alignment (P5–P6) build on it.
+
+## Decision
+
+### 1. One shared **Contextualization Intake Contract**, authored once in three lockstep artifacts
+
+- **TypeScript** (`intake-contract.ts`) — authoritative types + a dependency-free
+  `validateIntakeContract()` (no zod; PRD §4 bans framework abstractions).
+- **JSON Schema** (`intake-contract.schema.json`) — validation + documentation.
+- **Python** (`contracts/contextualization/intake_contract.py`) — stdlib-only
+  dataclasses + `validate_envelope()`, in a **neutral top-level `contracts/`**
+  package so the offline Contextualizer (`mira-contextualizer`) and Telegram
+  client (`mira-bots`) each import it without either module owning it.
+
+The envelope (PRD §2): `contract_version`, `ingest_route ∈ {offline, telegram,
+hub_upload}`, `project_hint`, `asset_hints`, `bundle_sha256`, `sources[]` (each
+with `source_sha256`, `source_type`, `source_metadata`), `evidence`, `entities`,
+`proposed_{signals,uns,i3x,faults,parameters,relationships}`, `provenance`,
+`confidence`, and `review_status` (always `proposed` on intake).
+
+### 2. Identity is UUID-first; names are matching evidence
+
+`project_uuid · import_batch_uuid · asset_uuid · source_uuid · source_sha256 ·
+evidence_uuid · signal_uuid · uns_node_uuid · relationship_uuid` are identity.
+Names, asset numbers, tag names, serials, models, controller IPs, and UNS paths
+are **matching evidence**, never the sole key.
+
+### 3. Everything from a client enters as a proposal — nothing is auto-approved
+
+`review_status` is fixed to `proposed` on intake (the validator rejects any
+other value). Per ADR-0017, promotion to approved/verified is an admin action.
+
+**Mapping of "everything lands proposed" to the 055 schema (deliberate, surfaced):**
+the import **batch** carries `review_status = 'proposed'` (new `ctx_import_batches`
+table), and imported tags land in `ctx_extractions.status = 'pending'` — the
+existing not-yet-reviewed state. We do **not** add a 5th `'proposed'` value to
+the `ctx_extractions` status CHECK, because the review UI (tabs
+All/Pending/Accepted/Rejected) only knows `pending|accepted|rejected`; widening
+it is P4/P7 work. The invariant honored is the one that matters: **no row enters
+`accepted` on intake.** "proposed" == batch `review_status='proposed'` +
+extractions `pending`.
+
+### 4. Dedup grain (migration 056, extends 055)
+
+| Grain | Key | Mechanism |
+|---|---|---|
+| Project | `(tenant_id, bundle_sha256)` | `bundle_sha256` column + partial UNIQUE on `contextualization_projects` |
+| Import batch | `(tenant_id, bundle_sha256)` | new `ctx_import_batches` + partial UNIQUE |
+| Source file | `(tenant_id, source_sha256)` | `source_sha256` column + partial UNIQUE on `ctx_sources` |
+
+Partial (`WHERE … IS NOT NULL`) so manually-created projects / non-hashed
+sources are unaffected. The import endpoint uses `ON CONFLICT … DO NOTHING`
+against these indexes (PRD test 3: same source sha256 → no duplicate source row).
+
+`ctx_sources.import_batch_id` (FK → `ctx_import_batches`, `ON DELETE SET NULL`)
+groups a submission's sources. `ctx_extraction_asset_matches` is created now
+(RLS + grants) but populated in **P3** — its `candidate_asset_id` is a **soft
+UUID reference, no FK to `cmms_equipment`** (that full schema is upstream; a hard
+FK would couple this migration to it and break a ctx-only test DB).
+
+## Key sub-decisions
+
+1. **`source_sha256` is added to `ctx_sources` even though the task's P1 list
+   omitted it.** PRD test 3 is literally "same *source* sha256 does not
+   duplicate *source* records" — source-level dedup is impossible without the
+   column. The omission is treated as an oversight and corrected; flagged in the
+   PR.
+2. **`bundle_sha256` UNIQUE on `contextualization_projects` follows the task
+   literally** and encodes one-project-per-bundle. PRD §2's longer-term model is
+   project→many-batches; that generalization is deferred. Re-import of the same
+   bundle is a no-op (existing project + batch reused; duplicate sources skipped).
+3. **JSON contract path is additive; the existing multipart-zip path stays.**
+   `/import` branches on content-type: `application/json` → intake contract;
+   `multipart/form-data` → the existing offline bundle (`parseBundle`). P5
+   migrates the offline client to the contract; until then both work.
+4. **Hand-rolled validator, no zod.** Keeps the contract portable to the Python
+   and JSON twins and honors PRD §4 (no framework over the data path).
+
+## Alternatives considered and rejected
+
+| Alternative | Why rejected |
+|---|---|
+| Let each client keep its own ingest shape, reconcile in the Hub | Three sources of truth; the exact failure HubV3 exists to prevent. |
+| Add `'proposed'` to the `ctx_extractions` status CHECK | Breaks the review UI's `pending/accepted/rejected` model; UI change is P4/P7, out of P2 scope. |
+| Hard FK `ctx_extraction_asset_matches.candidate_asset_id → cmms_equipment(id)` | Couples 056 to an upstream schema not in 055; breaks ctx-only ephemeral test DBs. Soft UUID ref + P3 resolution instead. |
+| Use zod for validation | New dependency; can't share with the Python/JSON twins; PRD §4 bias against framework abstractions on the data path. |
+| Replace the multipart-zip `/import` path | Would break the shipped offline bundle loop before P5 aligns it. Additive content-type branch instead. |
+
+## Consequences
+
+- **Positive.** One envelope, three consumers, validated identically. Re-import
+  is idempotent (project/batch/source dedup). Nothing auto-approves. Telegram
+  (P6) and the offline client (P5) now have a single shape to target. Asset
+  matching (P3) has its staging table.
+- **Negative / deferred.** `ctx_extractions` still uses `pending` (not a literal
+  `proposed`) — a semantic, not behavioral, gap. One-project-per-bundle is a
+  simplification vs PRD §2's project→many-batches. Asset matching, approval/
+  publish, and no-overwrite enforcement are P3/P4. The Python twin has no
+  consumer until P5/P6 (ships now so they can target it).
+- **Numbering.** Migration `056` claimed for this lane; ADR `0023`. If `origin`
+  grows a competing `056` before merge, rename with the master-plan's collision
+  convention.
+
+## Verification
+
+- `intake-contract.test.ts` — validator accepts a well-formed envelope, rejects
+  bad version / route / empty sources / missing source sha256 / non-proposed
+  review_status; `intakeContractToImport` maps to insertable rows (all `pending`).
+- `import.integration.test.ts` — against ephemeral `postgres:16` with
+  `factorylm_app` role, migrations 055+056 applied, UUID tenant under
+  `SET ROLE factorylm_app`: same `source_sha256` imported twice → exactly one
+  `ctx_sources` row; batch lands `review_status='proposed'`.
+- Migration gate: `apply-migrations.yml --dry-run` on staging via the PR's
+  `migration-verify.yml` (never prod-first, never a direct staging psql from a
+  code session — `docs/environments.md`).

--- a/mira-bots/shared/contextualization_intake.py
+++ b/mira-bots/shared/contextualization_intake.py
@@ -1,0 +1,183 @@
+"""Shared contextualization intake envelope builder + Hub submit.
+
+HubV3 (`docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md`) makes the
+**Hub the single system of record** for contextualization. Offline and Telegram
+become thin *ingest clients* that collect evidence and create proposals; the Hub
+performs the final merge / approval / publish.
+
+This module builds the §2 "Shared Contextualization Intake Contract" envelope and
+POSTs it to the Hub import endpoint. It is the client half — the Hub endpoint
+accepting this JSON contract is Phase 2 (not in this module's scope).
+
+Design rules honored here:
+- **Telegram owns NO truth.** ``review_status`` is always ``proposed``; all
+  ``proposed_*`` / ``entities`` domain lists are empty (the client submits
+  evidence, the Hub derives proposals on approval).
+- **Bytes travel.** The §2 envelope is metadata-only, so the raw document/photo
+  bytes are carried alongside the JSON contract as a multipart ``file`` field —
+  the same multipart shape the Hub import endpoint already speaks.
+- **PII sanitization** (`.claude/rules/security-boundaries.md`): free-text fields
+  (caption / field notes / OCR) are scrubbed via
+  ``InferenceRouter.sanitize_text`` (IPv4 → ``[IP]``, MAC → ``[MAC]``,
+  serial → ``[SN]``). Structured ``asset_hints`` (serial, controller IP, model …)
+  are **deliberate matching evidence** and are preserved verbatim.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+
+import httpx
+
+from shared.inference.router import InferenceRouter
+
+logger = logging.getLogger("mira.contextualization_intake")
+
+# Ingest-route discriminators (§2 ``ingest_route``).
+INGEST_ROUTE_TELEGRAM = "telegram"
+INGEST_ROUTE_OFFLINE = "offline"
+INGEST_ROUTE_HUB_UPLOAD = "hub_upload"
+
+# Hub import endpoint (the offline/direct upload pipeline entry).
+HUB_IMPORT_PATH = "/api/contextualization/import"
+HUB_IMPORT_URL = os.environ.get("HUB_IMPORT_URL", "")
+HUB_IMPORT_TOKEN = os.environ.get("HUB_IMPORT_TOKEN", "")
+
+# Domain-proposal keys the client always leaves empty — it owns no truth.
+_EMPTY_PROPOSAL_KEYS = (
+    "entities",
+    "proposed_uns",
+    "proposed_i3x",
+    "proposed_faults",
+    "proposed_parameters",
+    "proposed_signals",
+    "proposed_relationships",
+)
+
+
+def _scrub(text: str | None) -> str:
+    """PII-scrub a free-text field. Empty/None → empty string."""
+    if not text:
+        return ""
+    return InferenceRouter.sanitize_text(text)
+
+
+def build_intake_envelope(
+    *,
+    raw_bytes: bytes,
+    filename: str,
+    mime: str,
+    uploader: str,
+    captured_at: str,
+    caption: str | None = None,
+    ocr_text: str | None = None,
+    location: str | None = None,
+    project_hint: str | None = None,
+    asset_hints: dict | None = None,
+    ingest_route: str = INGEST_ROUTE_TELEGRAM,
+    review_status: str = "proposed",  # accepted for signature parity; always coerced
+) -> dict:
+    """Build the §2 normalized contextualization intake envelope.
+
+    The raw bytes are *not* embedded — they travel as a multipart ``file`` field
+    in :func:`submit_intake_to_hub`. ``source_sha256`` fingerprints those bytes
+    using the same convention as mira-ingest (``hashlib.sha256(raw).hexdigest()``).
+    """
+    source_sha256 = hashlib.sha256(raw_bytes).hexdigest()
+
+    # OCR-or-raw: prefer extracted OCR text; otherwise the caption is the field
+    # note and the raw bytes themselves (carried as the multipart file) are the
+    # evidence. All free text is PII-scrubbed.
+    evidence: list[dict] = []
+    note = _scrub(caption)
+    if note:
+        evidence.append({"type": "field_note", "text": note, "ref": {"source": filename}})
+    ocr = _scrub(ocr_text)
+    if ocr:
+        evidence.append({"type": "ocr", "text": ocr, "ref": {"source": filename}})
+
+    # Telegram owns no truth → review_status is always proposed.
+    _ = review_status  # intentionally ignored; clients cannot self-approve
+
+    envelope: dict = {
+        "project_hint": project_hint or "",
+        # Structured matching evidence — preserved verbatim (NOT PII-scrubbed).
+        "asset_hints": dict(asset_hints or {}),
+        "source_metadata": {
+            "filename": filename,
+            "mime": mime,
+            "size": len(raw_bytes),
+            "captured_at": captured_at,
+            "uploader": uploader,
+            "location": location or "",
+        },
+        "source_sha256": source_sha256,
+        "evidence": evidence,
+        "provenance": {
+            "ingest_route": ingest_route,
+            "source_sha256": source_sha256,
+            "uploader": uploader,
+            "captured_at": captured_at,
+        },
+        "confidence": "low",  # unverified field capture; Hub re-scores on review
+        "review_status": "proposed",
+        "ingest_route": ingest_route,
+    }
+    for key in _EMPTY_PROPOSAL_KEYS:
+        envelope[key] = []
+    return envelope
+
+
+async def submit_intake_to_hub(
+    envelope: dict,
+    *,
+    raw_bytes: bytes,
+    filename: str,
+    mime: str,
+    tenant_id: str,
+    hub_url: str | None = None,
+    token: str | None = None,
+    timeout: float = 120,
+) -> bool:
+    """POST the §2 contract + raw bytes to the Hub import endpoint.
+
+    Multipart body: ``contract`` (the JSON envelope) + ``file`` (raw bytes) +
+    ``tenant_id`` (transport-level scoping). Returns ``True`` on a 2xx response.
+
+    Background-safe: never raises — a failing Hub POST must not break the chat
+    reply. A transport error or non-2xx is logged and reported as ``False``.
+    """
+    base = (hub_url or HUB_IMPORT_URL or "").rstrip("/")
+    if not base:
+        logger.warning("HUB_IMPORT_URL not configured — skipping Hub intake submit")
+        return False
+
+    url = f"{base}{HUB_IMPORT_PATH}"
+    headers: dict[str, str] = {}
+    bearer = token if token is not None else HUB_IMPORT_TOKEN
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                url,
+                data={"contract": json.dumps(envelope), "tenant_id": tenant_id or ""},
+                files={"file": (filename, raw_bytes, mime)},
+                headers=headers,
+            )
+            if 200 <= resp.status_code < 300:
+                logger.info(
+                    "Hub intake OK route=%s sha256=%s",
+                    envelope.get("ingest_route"),
+                    envelope.get("source_sha256", "")[:12],
+                )
+                return True
+            logger.warning("Hub intake failed %s: %s", resp.status_code, resp.text[:200])
+            return False
+    except Exception as exc:  # noqa: BLE001 - background task must never raise
+        logger.error("Hub intake submit error: %s", exc)
+        return False

--- a/mira-bots/shared/contextualization_intake.py
+++ b/mira-bots/shared/contextualization_intake.py
@@ -14,8 +14,10 @@ Design rules honored here:
   ``proposed_*`` / ``entities`` domain lists are empty (the client submits
   evidence, the Hub derives proposals on approval).
 - **Bytes travel.** The §2 envelope is metadata-only, so the raw document/photo
-  bytes are carried alongside the JSON contract as a multipart ``file`` field —
-  the same multipart shape the Hub import endpoint already speaks.
+  bytes are carried alongside the JSON contract as a multipart ``file`` field.
+  (The import endpoint is multipart today but reads ``file`` as a *zip* and
+  ignores ``contract``/``tenant_id``; it consumes this contract field only after
+  HubV3 Phase 2.)
 - **PII sanitization** (`.claude/rules/security-boundaries.md`): free-text fields
   (caption / field notes / OCR) are scrubbed via
   ``InferenceRouter.sanitize_text`` (IPv4 → ``[IP]``, MAC → ``[MAC]``,

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -16,8 +16,13 @@ from admin_commands import (
 )
 from chat_adapter import TelegramChatAdapter
 from PIL import Image
-from shared import tts
+from shared import chat_tenant, tts
 from shared.chat.dispatcher import ChatDispatcher
+from shared.contextualization_intake import (
+    INGEST_ROUTE_TELEGRAM,
+    build_intake_envelope,
+    submit_intake_to_hub,
+)
 from shared.conversation_logger import log_turn, measure_ms
 from shared.engine import Supervisor
 from shared.identity.service import get_identity_service
@@ -66,7 +71,11 @@ MCP_REST_API_KEY = os.environ.get("MCP_REST_API_KEY", "")
 KNOWLEDGE_COLLECTION_ID = os.environ.get(
     "KNOWLEDGE_COLLECTION_ID", "dd9004b9-3af2-4751-9993-3307e478e9a3"
 )
-INGEST_SERVICE_URL = os.environ.get("INGEST_SERVICE_URL", "")
+# HubV3: Telegram is a thin evidence-capture client. Photos/docs are submitted as
+# the §2 contextualization intake contract to the Hub import endpoint (the Hub is
+# the system of record). Replaces the legacy mira-ingest {asset_tag, image} path.
+HUB_IMPORT_URL = os.environ.get("HUB_IMPORT_URL", "")
+HUB_IMPORT_TOKEN = os.environ.get("HUB_IMPORT_TOKEN", "")
 
 engine = Supervisor(
     db_path=os.environ.get("MIRA_DB_PATH", "/data/mira.db"),
@@ -181,54 +190,95 @@ def _resize_for_vision(image_bytes: bytes) -> bytes:
     return buf.getvalue()
 
 
-def _equipment_type_from_doc(filename: str, caption: str) -> str:
-    """Derive equipment type slug from filename, with caption override.
+def _intake_meta(update: Update) -> tuple[str, str, str]:
+    """(uploader_id, captured_at_iso, tenant_id) from a Telegram update.
 
-    Caption first word wins: sending 'VFD' as caption → 'vfd'.
-    Fallback: strip doc-type suffixes from filename stem.
+    Uploader is the numeric Telegram id (pseudonymous) — never a name — to keep
+    PII out of provenance. Tenant is resolved per-chat for Hub-side scoping.
     """
-    if caption and caption.strip():
-        return caption.strip().split()[0].lower()[:40]
-    stem = os.path.splitext(filename)[0].lower()
-    for suffix in (
-        "-manual",
-        "-guide",
-        "-spec",
-        "-datasheet",
-        "-data-sheet",
-        "_manual",
-        "_guide",
-        "_spec",
-        "_datasheet",
-        "_data_sheet",
-    ):
-        if stem.endswith(suffix):
-            stem = stem[: -len(suffix)]
-            break
-    return stem[:40] or "general"
+    uploader = str(update.effective_user.id) if update.effective_user else ""
+    msg_date = getattr(update.message, "date", None)
+    captured_at = msg_date.isoformat() if msg_date else ""
+    tenant_id = chat_tenant.resolve(str(update.effective_chat.id))
+    return uploader, captured_at, tenant_id
 
 
-async def _ingest_photo_background(photo_bytes: bytes, asset_tag: str) -> None:
-    """POST photo to mira-ingest. Runs in background — never raises."""
-    if not INGEST_SERVICE_URL:
+def _asset_hints_from_caption(caption: str) -> dict:
+    """Minimal asset-identity hint from a caption (first token = asset name).
+
+    Preserves today's ``asset_tag`` behaviour. Richer hints (mfr/model/serial/
+    IP/UNS) are the Hub's job to derive from evidence — the client owns no truth.
+    """
+    tokens = caption.split() if caption else []
+    return {"name": tokens[0]} if tokens else {}
+
+
+async def _submit_photo_to_hub(raw_bytes: bytes, caption: str, update: Update) -> None:
+    """Build the §2 intake envelope for a photo and POST it to the Hub.
+
+    Runs in background — ``submit_intake_to_hub`` never raises, so a failed Hub
+    POST cannot break the chat reply. Replaces the legacy mira-ingest path.
+    """
+    if not HUB_IMPORT_URL:
         return
-    try:
-        async with httpx.AsyncClient(timeout=120) as client:
-            resp = await client.post(
-                f"{INGEST_SERVICE_URL}/ingest/photo",
-                data={"asset_tag": asset_tag},
-                files={"image": ("photo.jpg", photo_bytes, "image/jpeg")},
-            )
-            if resp.status_code == 200:
-                logger.info("Ingest OK for %s: id=%s", asset_tag, resp.json().get("id"))
-            else:
-                logger.warning("Ingest failed %s: %s", resp.status_code, resp.text[:200])
-    except Exception as e:
-        logger.error("Ingest background error: %s", e)
+    uploader, captured_at, tenant_id = _intake_meta(update)
+    envelope = build_intake_envelope(
+        raw_bytes=raw_bytes,
+        filename="photo.jpg",
+        mime="image/jpeg",
+        uploader=uploader,
+        captured_at=captured_at,
+        caption=caption,
+        asset_hints=_asset_hints_from_caption(caption),
+        ingest_route=INGEST_ROUTE_TELEGRAM,
+    )
+    await submit_intake_to_hub(
+        envelope,
+        raw_bytes=raw_bytes,
+        filename="photo.jpg",
+        mime="image/jpeg",
+        tenant_id=tenant_id,
+        token=HUB_IMPORT_TOKEN or None,
+    )
+
+
+async def _submit_doc_to_hub(
+    pdf_bytes: bytes, filename: str, caption: str, update: Update
+) -> bool:
+    """Build the §2 intake envelope for a PDF and POST it to the Hub.
+
+    Returns True on a 2xx Hub response. Never raises.
+    """
+    if not HUB_IMPORT_URL:
+        return False
+    uploader, captured_at, tenant_id = _intake_meta(update)
+    envelope = build_intake_envelope(
+        raw_bytes=pdf_bytes,
+        filename=filename,
+        mime="application/pdf",
+        uploader=uploader,
+        captured_at=captured_at,
+        caption=caption,
+        asset_hints=_asset_hints_from_caption(caption),
+        ingest_route=INGEST_ROUTE_TELEGRAM,
+    )
+    return await submit_intake_to_hub(
+        envelope,
+        raw_bytes=pdf_bytes,
+        filename=filename,
+        mime="application/pdf",
+        tenant_id=tenant_id,
+        token=HUB_IMPORT_TOKEN or None,
+    )
 
 
 async def document_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    """Receive PDF documents, index into Open WebUI KB via mira-ingest."""
+    """Receive PDF documents and submit them to the Hub as intake evidence.
+
+    HubV3: a PDF is a contextualization source. The bot builds the §2 intake
+    contract and POSTs it (+ raw bytes) to the Hub import endpoint, where it
+    lands as a ``proposed`` source for review. The bot owns no truth.
+    """
     doc = update.message.document
     filename = doc.file_name or "upload.pdf"
     caption = update.message.caption or ""
@@ -242,55 +292,31 @@ async def document_handler(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(f"{filename} is {doc.file_size // MB}MB — limit is 20MB.")
         return
 
-    if not INGEST_SERVICE_URL:
-        await update.message.reply_text("Ingest service not configured.")
+    if not HUB_IMPORT_URL:
+        await update.message.reply_text("Hub intake is not configured.")
         return
 
-    equipment_type = _equipment_type_from_doc(filename, caption)
-    await update.message.reply_text(f"Indexing {filename}...")
-    logger.info(
-        "PDF from %s: %s (type=%s)", update.effective_user.first_name, filename, equipment_type
-    )
+    await update.message.reply_text(f"Submitting {filename} to the Hub...")
+    logger.info("PDF from telegram_id=%s: %s", update.effective_user.id, filename)
 
-    async def _do_ingest_doc():
+    async def _do_submit_doc():
         try:
             tg_file = await context.bot.get_file(doc.file_id)
             pdf_bytes = bytes(await tg_file.download_as_bytearray())
-            async with httpx.AsyncClient(timeout=360) as client:
-                resp = await client.post(
-                    f"{INGEST_SERVICE_URL}/ingest/document-kb",
-                    data={"filename": filename, "equipment_type": equipment_type or ""},
-                    files={"file": (filename, pdf_bytes, "application/pdf")},
-                )
-                resp.raise_for_status()
-                data = resp.json()
-            col = data.get("collection_name", "Knowledge Base")
-            proc = data.get("processing_status", "completed")
-            if proc == "completed":
-                reply = f"Indexed *{filename}* into *{col}* collection.\nAsk me anything about it."
-            else:
+            ok = await _submit_doc_to_hub(pdf_bytes, filename, caption, update)
+            if ok:
                 reply = (
-                    f"*{filename}* uploaded to *{col}*.\n"
-                    "Extraction is still processing — RAG will be available shortly."
+                    f"Submitted *{filename}* to the Hub for review.\n"
+                    "It will appear as a proposed source once contextualized."
                 )
-            await update.message.reply_text(reply, parse_mode="Markdown")
-        except httpx.HTTPStatusError as e:
-            code = e.response.status_code
-            if code == 429:
-                msg = "Daily ingest limit reached. Try again tomorrow."
-            elif code == 413:
-                msg = f"{filename} is too large (limit 20MB)."
-            elif code == 422:
-                msg = f"Could not process {filename}: {e.response.text[:120]}"
             else:
-                msg = f"Indexing failed ({code}). Try again later."
-            logger.error("doc ingest HTTP %s: %s", code, e.response.text[:200])
-            await update.message.reply_text(msg)
+                reply = f"Couldn't submit {filename} to the Hub. Please try again later."
+            await update.message.reply_text(reply, parse_mode="Markdown")
         except Exception as exc:
-            logger.error("doc ingest error: %s", exc)
-            await update.message.reply_text(f"Indexing {filename} failed. Please try again.")
+            logger.error("doc submit error: %s", exc)
+            await update.message.reply_text(f"Submitting {filename} failed. Please try again.")
 
-    asyncio.create_task(_do_ingest_doc())
+    asyncio.create_task(_do_submit_doc())
 
 
 def _get_voice_enabled(chat_id: str) -> bool:
@@ -495,10 +521,9 @@ async def _dispatch_single_photo(
             logger.error("Photo processing error: %s", e)
             final_reply = f"MIRA error: {e}"
 
-    if INGEST_SERVICE_URL:
-        asset_tag = caption.split()[0] if caption else "UNKNOWN"
-        asyncio.create_task(_ingest_photo_background(raw_bytes, asset_tag))
-        final_reply += "\n\nPhoto queued for knowledge base."
+    if HUB_IMPORT_URL:
+        asyncio.create_task(_submit_photo_to_hub(raw_bytes, caption, update))
+        final_reply += "\n\nPhoto submitted to the Hub for review."
 
     await update.message.reply_text(final_reply)
     await _maybe_send_voice(update, context, chat_id, final_reply)
@@ -561,10 +586,9 @@ async def _enqueue_multi_photo_burst(
         await photo_queue.mark_failed(batch_id, "queue full at close_burst")
         return
 
-    if INGEST_SERVICE_URL:
-        asset_tag = caption.split()[0] if caption else "UNKNOWN"
+    if HUB_IMPORT_URL:
         for raw_bytes, _ in batches:
-            asyncio.create_task(_ingest_photo_background(raw_bytes, asset_tag))
+            asyncio.create_task(_submit_photo_to_hub(raw_bytes, caption, update))
 
 
 async def _flush_collector(

--- a/mira-bots/telegram/bot.py
+++ b/mira-bots/telegram/bot.py
@@ -194,12 +194,15 @@ def _intake_meta(update: Update) -> tuple[str, str, str]:
     """(uploader_id, captured_at_iso, tenant_id) from a Telegram update.
 
     Uploader is the numeric Telegram id (pseudonymous) — never a name — to keep
-    PII out of provenance. Tenant is resolved per-chat for Hub-side scoping.
+    PII out of provenance. Tenant is resolved by the **uploader's user id**, the
+    same key the chat adapter uses (``chat_adapter.py`` → ``chat_tenant.resolve``)
+    and that onboarding maps; ``effective_chat.id`` is the (negative) group id in
+    group chats and would miss the mapping.
     """
     uploader = str(update.effective_user.id) if update.effective_user else ""
     msg_date = getattr(update.message, "date", None)
     captured_at = msg_date.isoformat() if msg_date else ""
-    tenant_id = chat_tenant.resolve(str(update.effective_chat.id))
+    tenant_id = chat_tenant.resolve(uploader)
     return uploader, captured_at, tenant_id
 
 

--- a/mira-bots/tests/test_telegram_hub_intake.py
+++ b/mira-bots/tests/test_telegram_hub_intake.py
@@ -1,0 +1,214 @@
+"""HubV3 Phase 6 — Telegram thin evidence client → Hub import pipeline.
+
+Gating test = PRD §6 test 9: a Telegram/photo source enters the SAME
+contextualization import pipeline as an offline/direct upload, and lands
+``proposed``.
+
+Scope is the CLIENT half (the Hub endpoint accepting the JSON contract is
+Phase 2 — not exercised here). These tests assert that the shared
+envelope-builder produces the canonical §2 intake contract and that the
+Telegram submit path POSTs it to the Hub import endpoint (not mira-ingest),
+with raw bytes carried and PII scrubbed from free text.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from shared import contextualization_intake as ci
+
+# §2 "Shared Contextualization Intake Contract" — required envelope keys.
+_REQUIRED_KEYS = {
+    "project_hint",
+    "asset_hints",
+    "source_metadata",
+    "source_sha256",
+    "evidence",
+    "entities",
+    "proposed_uns",
+    "proposed_i3x",
+    "proposed_faults",
+    "proposed_parameters",
+    "proposed_signals",
+    "proposed_relationships",
+    "provenance",
+    "confidence",
+    "review_status",
+    "ingest_route",
+}
+
+
+def _build_telegram_photo_envelope() -> tuple[dict, bytes]:
+    raw = b"\xff\xd8\xff telegram nameplate jpeg; ctrl at 10.1.2.3"
+    env = ci.build_intake_envelope(
+        raw_bytes=raw,
+        filename="photo.jpg",
+        mime="image/jpeg",
+        uploader="789",  # numeric Telegram id (pseudonymous), not a name
+        captured_at="2026-06-20T12:00:00+00:00",
+        caption="conveyor-1 nameplate controller at 10.1.2.3",
+        location=None,
+        project_hint="garage-demo",
+        asset_hints={
+            "name": "conveyor-1",
+            "serial": "SN-ABC123456",
+            "controller_ip": "10.1.2.3",
+        },
+        ingest_route=ci.INGEST_ROUTE_TELEGRAM,
+        review_status="approved",  # a caller MUST NOT be able to self-approve
+    )
+    return env, raw
+
+
+def test_envelope_has_full_section2_contract_shape():
+    env, _ = _build_telegram_photo_envelope()
+    assert set(env) == _REQUIRED_KEYS, "envelope must match §2 contract exactly"
+    sm = env["source_metadata"]
+    for field in ("filename", "mime", "size", "captured_at", "uploader", "location"):
+        assert field in sm, f"source_metadata missing {field}"
+
+
+def test_source_sha256_is_content_fingerprint():
+    env, raw = _build_telegram_photo_envelope()
+    assert env["source_sha256"] == hashlib.sha256(raw).hexdigest()
+
+
+def test_review_status_forced_proposed_even_when_caller_overrides():
+    env, _ = _build_telegram_photo_envelope()
+    # Caller passed review_status="approved"; Telegram owns NO truth.
+    assert env["review_status"] == "proposed"
+
+
+def test_ingest_route_is_telegram():
+    env, _ = _build_telegram_photo_envelope()
+    assert env["ingest_route"] == "telegram"
+
+
+def test_client_owns_no_truth_domain_proposals_empty():
+    env, _ = _build_telegram_photo_envelope()
+    for key in (
+        "proposed_uns",
+        "proposed_i3x",
+        "proposed_faults",
+        "proposed_parameters",
+        "proposed_signals",
+        "proposed_relationships",
+        "entities",
+    ):
+        assert env[key] == [], f"{key} must be empty — client collects evidence only"
+
+
+def test_free_text_pii_scrubbed_but_asset_hints_preserved():
+    env, _ = _build_telegram_photo_envelope()
+    evidence_text = " ".join(b.get("text", "") for b in env["evidence"])
+    # Free-text evidence is PII-scrubbed (security-boundaries.md).
+    assert "10.1.2.3" not in evidence_text
+    assert "[IP]" in evidence_text
+    # But structured asset hints are deliberate matching evidence — preserved.
+    assert env["asset_hints"]["controller_ip"] == "10.1.2.3"
+    assert env["asset_hints"]["serial"] == "SN-ABC123456"
+
+
+def test_uploader_is_pseudonymous_id_not_a_name():
+    env, _ = _build_telegram_photo_envelope()
+    assert env["source_metadata"]["uploader"] == "789"
+
+
+async def test_telegram_source_enters_same_import_pipeline_as_offline(monkeypatch):
+    """PRD §6 test 9 (gating).
+
+    The Telegram-built envelope is the canonical §2 intake contract and is
+    POSTed to the Hub import endpoint — the same pipeline an offline/direct
+    upload uses — carrying the raw bytes, landing ``proposed``.
+    """
+    env, raw = _build_telegram_photo_envelope()
+
+    seen: dict = {}
+
+    class _Resp:
+        status_code = 201
+
+        def json(self):  # pragma: no cover - not asserted
+            return {"ok": True}
+
+        @property
+        def text(self):  # pragma: no cover
+            return ""
+
+    class _Client:
+        def __init__(self, *a, **k):
+            seen["client_kwargs"] = k
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, **kwargs):
+            seen["url"] = url
+            seen["kwargs"] = kwargs
+            return _Resp()
+
+    monkeypatch.setattr(ci.httpx, "AsyncClient", _Client)
+
+    ok = await ci.submit_intake_to_hub(
+        env,
+        raw_bytes=raw,
+        filename="photo.jpg",
+        mime="image/jpeg",
+        tenant_id="11111111-2222-3333-4444-555555555555",
+        hub_url="https://hub.example.com",
+        token="svc-token",
+    )
+
+    assert ok is True
+    # Routed to the Hub import pipeline — NOT mira-ingest.
+    assert "/api/contextualization/import" in seen["url"]
+    assert "/ingest/" not in seen["url"]
+    assert seen["url"].startswith("https://hub.example.com")
+
+    # Multipart: the §2 contract travels as JSON; raw bytes travel as `file`.
+    data = seen["kwargs"]["data"]
+    files = seen["kwargs"]["files"]
+    posted = json.loads(data["contract"])
+    assert posted["ingest_route"] == "telegram"
+    assert posted["review_status"] == "proposed"
+    assert posted["source_sha256"] == hashlib.sha256(raw).hexdigest()
+    assert files["file"][1] == raw  # bytes are carried, not dropped
+    # Tenant scoping travels at transport level.
+    assert data["tenant_id"] == "11111111-2222-3333-4444-555555555555"
+    # Forward-looking service-token auth (Phase-2 server support).
+    headers = seen["kwargs"].get("headers", {})
+    assert headers.get("Authorization") == "Bearer svc-token"
+
+
+async def test_submit_never_raises_on_transport_error(monkeypatch):
+    """Background-safe: a failing Hub POST must not break the chat reply."""
+    env, raw = _build_telegram_photo_envelope()
+
+    class _BoomClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, *a, **k):
+            raise RuntimeError("network down")
+
+    monkeypatch.setattr(ci.httpx, "AsyncClient", _BoomClient)
+
+    ok = await ci.submit_intake_to_hub(
+        env,
+        raw_bytes=raw,
+        filename="photo.jpg",
+        mime="image/jpeg",
+        tenant_id="t",
+        hub_url="https://hub.example.com",
+    )
+    assert ok is False  # swallowed, reported as failure, not raised

--- a/mira-bots/tests/test_telegram_photo_hub_wiring.py
+++ b/mira-bots/tests/test_telegram_photo_hub_wiring.py
@@ -46,10 +46,18 @@ async def test_submit_photo_to_hub_builds_telegram_envelope(monkeypatch):
 
     monkeypatch.setattr(bot, "submit_intake_to_hub", _fake_submit)
     monkeypatch.setattr(bot, "HUB_IMPORT_URL", "https://hub.example.com")
-    monkeypatch.setattr(bot.chat_tenant, "resolve", lambda cid: "tenant-x")
+
+    def _capture_resolve(cid):
+        seen["resolve_arg"] = cid
+        return "tenant-x"
+
+    monkeypatch.setattr(bot.chat_tenant, "resolve", _capture_resolve)
 
     raw = b"\xff\xd8\xff conveyor photo bytes"
-    await bot._submit_photo_to_hub(raw, "conveyor-1 nameplate", _fake_update())
+    # user_id != chat_id so a wrong resolve key is caught.
+    await bot._submit_photo_to_hub(
+        raw, "conveyor-1 nameplate", _fake_update(user_id=789, chat_id=-100200)
+    )
 
     env = seen["envelope"]
     assert env["ingest_route"] == "telegram"
@@ -59,6 +67,8 @@ async def test_submit_photo_to_hub_builds_telegram_envelope(monkeypatch):
     assert env["source_metadata"]["mime"] == "image/jpeg"
     assert seen["kwargs"]["raw_bytes"] == raw
     assert seen["kwargs"]["tenant_id"] == "tenant-x"
+    # Tenant resolves by uploader user id, NOT the (group) chat id.
+    assert seen["resolve_arg"] == "789"
 
 
 async def test_submit_doc_to_hub_builds_telegram_envelope(monkeypatch):

--- a/mira-bots/tests/test_telegram_photo_hub_wiring.py
+++ b/mira-bots/tests/test_telegram_photo_hub_wiring.py
@@ -1,0 +1,100 @@
+"""HubV3 Phase 6 — Telegram bot wiring → Hub intake (replaces mira-ingest).
+
+Confirms the photo and document handlers build the §2 telegram-route envelope
+and submit it to the Hub import endpoint (not mira-ingest), carrying raw bytes
+and the resolved tenant. Imports the real ``bot`` module so the wiring is
+exercised, not a stand-in.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+
+# Dummy env so bot.py imports cleanly (mirrors test_image_downscale.py).
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "dummy-token-for-testing")
+os.environ.setdefault("OPENWEBUI_BASE_URL", "http://localhost:8080")
+os.environ.setdefault("OPENWEBUI_API_KEY", "")
+os.environ.setdefault("KNOWLEDGE_COLLECTION_ID", "dummy-collection")
+os.environ.setdefault("VISION_MODEL", "qwen2.5vl:7b")
+os.environ.setdefault("MIRA_DB_PATH", "/tmp/mira_hubv3_wiring_test.db")
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "telegram"))
+sys.modules.pop("chat_adapter", None)
+
+import bot  # noqa: E402
+
+
+def _fake_update(user_id=789, chat_id=42):
+    return types.SimpleNamespace(
+        effective_user=types.SimpleNamespace(id=user_id),
+        effective_chat=types.SimpleNamespace(id=chat_id),
+        message=types.SimpleNamespace(
+            date=types.SimpleNamespace(isoformat=lambda: "2026-06-20T12:00:00+00:00")
+        ),
+    )
+
+
+async def test_submit_photo_to_hub_builds_telegram_envelope(monkeypatch):
+    seen: dict = {}
+
+    async def _fake_submit(envelope, **kwargs):
+        seen["envelope"] = envelope
+        seen["kwargs"] = kwargs
+        return True
+
+    monkeypatch.setattr(bot, "submit_intake_to_hub", _fake_submit)
+    monkeypatch.setattr(bot, "HUB_IMPORT_URL", "https://hub.example.com")
+    monkeypatch.setattr(bot.chat_tenant, "resolve", lambda cid: "tenant-x")
+
+    raw = b"\xff\xd8\xff conveyor photo bytes"
+    await bot._submit_photo_to_hub(raw, "conveyor-1 nameplate", _fake_update())
+
+    env = seen["envelope"]
+    assert env["ingest_route"] == "telegram"
+    assert env["review_status"] == "proposed"
+    assert env["asset_hints"]["name"] == "conveyor-1"
+    assert env["source_metadata"]["uploader"] == "789"
+    assert env["source_metadata"]["mime"] == "image/jpeg"
+    assert seen["kwargs"]["raw_bytes"] == raw
+    assert seen["kwargs"]["tenant_id"] == "tenant-x"
+
+
+async def test_submit_doc_to_hub_builds_telegram_envelope(monkeypatch):
+    seen: dict = {}
+
+    async def _fake_submit(envelope, **kwargs):
+        seen["envelope"] = envelope
+        seen["kwargs"] = kwargs
+        return True
+
+    monkeypatch.setattr(bot, "submit_intake_to_hub", _fake_submit)
+    monkeypatch.setattr(bot, "HUB_IMPORT_URL", "https://hub.example.com")
+    monkeypatch.setattr(bot.chat_tenant, "resolve", lambda cid: "tenant-y")
+
+    pdf = b"%PDF-1.7 fake manual"
+    await bot._submit_doc_to_hub(pdf, "gs10manual.pdf", "drive manual", _fake_update())
+
+    env = seen["envelope"]
+    assert env["ingest_route"] == "telegram"
+    assert env["review_status"] == "proposed"
+    assert env["source_metadata"]["filename"] == "gs10manual.pdf"
+    assert env["source_metadata"]["mime"] == "application/pdf"
+    assert seen["kwargs"]["raw_bytes"] == pdf
+    assert seen["kwargs"]["filename"] == "gs10manual.pdf"
+    assert seen["kwargs"]["tenant_id"] == "tenant-y"
+
+
+async def test_submit_photo_to_hub_noop_when_unconfigured(monkeypatch):
+    called = {"n": 0}
+
+    async def _fake_submit(*a, **k):
+        called["n"] += 1
+        return True
+
+    monkeypatch.setattr(bot, "submit_intake_to_hub", _fake_submit)
+    monkeypatch.setattr(bot, "HUB_IMPORT_URL", "")  # not configured
+
+    await bot._submit_photo_to_hub(b"x", "cap", _fake_update())
+    assert called["n"] == 0  # no submit attempted when Hub URL absent

--- a/mira-contextualizer/mira_contextualizer/bundle.py
+++ b/mira-contextualizer/mira_contextualizer/bundle.py
@@ -5,16 +5,23 @@ back online. Built entirely from the local store (accepted extractions + extract
 deterministic projections — no network, no LLM.
 
 Contents:
-  manifest.json            tool/version/time, source list + sha256, counts
+  manifest.json            tool/version/time, mode, source list + sha256, counts
   uns.json                 accepted signals as UNS paths
-  i3x.json                 CESMII i3X objectInstances projected from the UNS hierarchy
+  i3x.json                 CESMII i3X objectInstances projected from the UNS hierarchy (uns_node_uuid)
   kg_entities.json         accepted extractions as proposed kg_entities (offline twin of Promote)
   kg_relationships.json    HAS_SIGNAL (asset→signal) + MENTIONS (document→tag) edges, status=proposed
   signals.csv              flat tag / uns / roles / confidence / source
+  evidence.json            aggregate provenance index: source(sha256) → evidence(uuid) → entity
   documents/<file>.json    extracted Document IR per uploaded document (knowledge_entries seed)
   review.json              full accept/reject audit trail with provenance
   report.md                human-readable summary
   IMPORT.md                how to load the bundle into MIRA Hub
+
+Export modes (``build_bundle(..., sanitized=…)``):
+  full       Full Evidence Bundle — raw documents/*.json + verbatim evidence text. (default)
+  sanitized  Sanitized Structured Context Bundle — derived structured context only: no raw document
+             payloads, refs-only evidence.json (uuids + source sha256, no verbatim text). NOT
+             "anonymous" — identity hints (asset_match, profile) are retained.
 
 Note (branch): the richer asset_graph/registers/edges emitters live on the parser's
 feat/vfd-analyzer-auto-map branch; bundle@1 derives signals.csv from accepted extractions and defers
@@ -27,6 +34,7 @@ import hashlib
 import io
 import json
 import re
+import uuid
 import zipfile
 from datetime import datetime, timezone
 
@@ -35,6 +43,16 @@ from . import scorecard as _scorecard
 
 SCHEMA = "mira-contextualizer/bundle@1"
 _TYPE_URI = "urn:mira:type:%s"
+
+# Fixed namespace for the UUID-first identity model (§2 of the HubV3 intake contract). Entity ids are
+# minted with uuid5 over a stable key so a re-export of the same project yields the SAME bundle — the
+# bundle's determinism property must hold for these too. ``.hex`` matches the store's uuid4().hex form.
+_NS = uuid.uuid5(uuid.NAMESPACE_URL, "urn:mira:contextualizer:bundle")
+
+
+def _eid(kind: str, *parts: object) -> str:
+    """Deterministic 32-char entity id for ``kind`` over ``parts`` (project-scoped, stable per content)."""
+    return uuid.uuid5(_NS, kind + ":" + ":".join(str(p) for p in parts)).hex
 
 
 def _safe(name: str) -> str:
@@ -45,7 +63,7 @@ def _uns_segments(path: str) -> list[str]:
     return [s for s in re.split(r"[/.]", path) if s]
 
 
-def _i3x(accepted: list[dict], quantities: dict | None = None) -> dict:
+def _i3x(accepted: list[dict], quantities: dict | None = None, project_id: str = "") -> dict:
     """Project accepted UNS paths into CESMII i3X objectInstances (containers + signal leaves).
 
     ``quantities`` maps a signal's tag name → its UCUM-coded quantity (from ``standards``); when a
@@ -70,6 +88,7 @@ def _i3x(accepted: list[dict], quantities: dict | None = None) -> dict:
                     meta["quantity"] = q
             instances[elem_id] = {
                 "elementId": elem_id,
+                "uns_node_uuid": _eid("uns_node", project_id, elem_id),
                 "name": segs[i],
                 "typeElementId": _TYPE_URI % ("signal" if is_leaf else "container"),
                 "parentId": "/".join(segs[:i]) or None,
@@ -118,6 +137,7 @@ def _kg(accepted: list[dict], project_id: str, quantities: dict | None = None) -
         node = ent("signal", path, e["tagName"],
                    {"roles": e.get("roles") or [], "confidence": e.get("confidence"),
                     "provenance": prov(e)})
+        node.setdefault("signal_uuid", _eid("signal", project_id, path))
         signal_by_tag.setdefault(e["tagName"], node)
         segs = _uns_segments(path)
         if len(segs) >= 2:
@@ -164,10 +184,16 @@ def _kg(accepted: list[dict], project_id: str, quantities: dict | None = None) -
             node = ent(primary, e["tagName"], e["tagName"],
                        {"confidence": e.get("confidence"), "provenance": prov(e)})
             if primary == "tag_reference":
-                for m in ev.get("mentions", []):
+                # one MENTIONS edge per mention; its id derives from the per-mention evidence_uuid
+                # (same key as _evidence) so the same tag mentioned N times yields N distinct, linkable
+                # edges instead of one colliding id.
+                for i, m in enumerate(ev.get("mentions", [])):
+                    euid = _eid("evidence", e["id"], i)
                     relationships.append({
                         "type": "MENTIONS", "source": "document:%s" % m.get("file"),
                         "target": e["tagName"], "approval_state": "proposed",
+                        "evidence_uuid": euid,
+                        "relationship_uuid": _eid("relationship", "MENTIONS", euid),
                         "evidence": {"page": m.get("page"), "snippet": m.get("snippet")}})
 
         # UCUM quantity: carry it on the document entity, and attach it to the matching UNS signal.
@@ -177,6 +203,11 @@ def _kg(accepted: list[dict], project_id: str, quantities: dict | None = None) -
             sig = signal_by_tag.get(e["tagName"])
             if sig:
                 sig["properties"]["quantity"] = q
+
+    # stamp a stable id on every edge that didn't already derive one (MENTIONS derives from evidence).
+    for r in relationships:
+        r.setdefault("relationship_uuid",
+                     _eid("relationship", project_id, r["type"], r["source"], r["target"]))
 
     return ({"schema": "mira-contextualizer/kg_entities@1", "entities": entities},
             {"schema": "mira-contextualizer/kg_relationships@1", "relationships": relationships})
@@ -221,6 +252,40 @@ def _parameters(accepted: list[dict], quantities: dict) -> dict:
                 entry["quantity"] = raw
         params.append(entry)
     return {"schema": "mira-contextualizer/parameters@1", "parameters": params}
+
+
+def _evidence(accepted: list[dict], src_meta: list[dict], sanitized: bool = False) -> dict:
+    """Aggregate the evidence that today is scattered across ``review.json`` + ``documents/*.json`` into
+    one provenance index: **source (sha256) → evidence (evidence_uuid) → entity (tag/extraction)**.
+
+    One block per document mention (so each is independently addressable), or one block per extraction
+    when there are no mentions (PLC/CCW signals carry their extractor evidence as ``raw``). Full mode
+    keeps the verbatim text (``snippet`` / ``raw``); the **sanitized** mode keeps only refs, uuids, and
+    the source sha256 — no verbatim document payload."""
+    sha_by_file = {s["file"]: s["sha256"] for s in src_meta}
+    blocks: list[dict] = []
+    for e in accepted:
+        ev = e.get("evidenceJson") or {}
+        mentions = ev.get("mentions") or []
+        common: dict = {"tag": e["tagName"], "roles": e.get("roles") or [],
+                        "confidence": e.get("confidence"), "extraction_id": e["id"]}
+        if mentions:
+            for i, m in enumerate(mentions):
+                src_file = m.get("file") or e.get("fileName")
+                block = dict(common, evidence_uuid=_eid("evidence", e["id"], i),
+                             source_file=src_file, source_sha256=sha_by_file.get(src_file),
+                             page=m.get("page"))
+                if not sanitized:
+                    block["snippet"] = m.get("snippet")
+                blocks.append(block)
+        else:
+            src_file = e.get("fileName")
+            block = dict(common, evidence_uuid=_eid("evidence", e["id"], 0),
+                         source_file=src_file, source_sha256=sha_by_file.get(src_file), page=None)
+            if not sanitized:
+                block["raw"] = ev
+            blocks.append(block)
+    return {"schema": "mira-contextualizer/evidence@1", "evidence": blocks}
 
 
 def _profile_json(proj: dict) -> dict:
@@ -294,8 +359,13 @@ _IMPORT_MD = (
 )
 
 
-def build_bundle(store, project_id: str) -> dict[str, str]:
-    """Return a mapping of bundle-relative path → file content (str). Caller writes or zips it."""
+def build_bundle(store, project_id: str, sanitized: bool = False) -> dict[str, str]:
+    """Return a mapping of bundle-relative path → file content (str). Caller writes or zips it.
+
+    ``sanitized=False`` → **Full Evidence Bundle**: raw ``documents/*.json`` + verbatim evidence text.
+    ``sanitized=True``  → **Sanitized Structured Context Bundle**: the derived structured context only
+    (UNS/i3X/kg/faults/parameters/scorecard + source refs/hashes), with no raw document payloads and
+    refs-only evidence. It is *not* anonymous — identity hints (asset_match, profile) are retained."""
     proj = store.get_project(project_id)
     if not proj:
         raise ValueError("project not found")
@@ -308,9 +378,9 @@ def build_bundle(store, project_id: str) -> dict[str, str]:
     for s in sources:
         full = store.get_source(s["id"])
         ir = full.get("extracted") if full else None
-        if ir:
+        if ir and not sanitized:  # raw document IR is omitted from the sanitized bundle
             files["documents/%s.json" % _safe(s["fileName"])] = json.dumps(ir, indent=2)
-        blob = json.dumps(ir or {}, sort_keys=True).encode()
+        blob = json.dumps(ir or {}, sort_keys=True).encode()  # sha is identical in both modes
         src_meta.append({"file": s["fileName"], "type": s["sourceType"], "status": s["status"],
                          "sha256": hashlib.sha256(blob).hexdigest()})
 
@@ -332,6 +402,8 @@ def build_bundle(store, project_id: str) -> dict[str, str]:
     files["manifest.json"] = json.dumps({
         "schema": SCHEMA, "tool": "mira-contextualizer", "tool_version": __version__,
         "created_at": datetime.now(timezone.utc).isoformat(),
+        # which export mode produced this bundle (raw documents + verbatim evidence, or refs-only)
+        "mode": "sanitized" if sanitized else "full",
         "project": {"id": proj["id"], "name": proj["name"], "description": proj.get("description")},
         "counts": {"sources": len(sources), "candidates": len(exts), "accepted": len(accepted),
                    "uns_signals": n_uns, "iso14224_faults": n_iso,
@@ -352,13 +424,14 @@ def build_bundle(store, project_id: str) -> dict[str, str]:
                      "confidence": e.get("confidence")}
                     for e in accepted if e.get("unsPathProposed")],
     }, indent=2)
-    files["i3x.json"] = json.dumps(_i3x(accepted, quantities), indent=2)
+    files["i3x.json"] = json.dumps(_i3x(accepted, quantities, project_id), indent=2)
     ents, rels = _kg(accepted, project_id, quantities)
     files["kg_entities.json"] = json.dumps(ents, indent=2)
     files["kg_relationships.json"] = json.dumps(rels, indent=2)
     files["signals.csv"] = _signals_csv(accepted)
     files["fault_catalog.json"] = json.dumps(_fault_catalog(accepted), indent=2)
     files["parameters.json"] = json.dumps(_parameters(accepted, quantities), indent=2)
+    files["evidence.json"] = json.dumps(_evidence(accepted, src_meta, sanitized), indent=2)
     files["review.json"] = json.dumps({
         "schema": "mira-contextualizer/review@1",
         "decisions": [{"tag": e["tagName"], "roles": e.get("roles", []), "status": e["status"],

--- a/mira-contextualizer/mira_contextualizer/gui/index.html
+++ b/mira-contextualizer/mira_contextualizer/gui/index.html
@@ -112,6 +112,7 @@
       <button onclick="act('saveAs')" data-need="profile">Save As…</button>
       <button onclick="act('import')" data-need="profile">Import Files…</button>
       <button onclick="act('exportBundle')" data-need="profile">Export Bundle…</button>
+      <button onclick="act('exportSanitized')" data-need="profile">Export Sanitized Context…</button>
       <div class="sep"></div>
       <div class="sub">Recent Profiles</div>
       <div id="recentList"><button disabled>None yet</button></div>
@@ -231,7 +232,7 @@ async function act(a){
     openProfile:()=>$("profileInput").click(),
     save:saveProfile, saveAs:saveProfile,
     import:()=>$("fileInput").click(),
-    exportBundle:exportBundle,
+    exportBundle:exportBundle, exportSanitized:exportSanitized,
     exit:()=>{ window.close(); toast("You can close this window."); },
     undo:undoDecision, redo:redoDecision,
     find:()=>{ setView(VIEW); const f=$("findBox"); if(f){ f.focus(); } else { setView("signals"); } },
@@ -444,6 +445,8 @@ function openProfileFile(ev){ const f=ev.target.files[0]; ev.target.value=""; if
   r.readAsText(f); }
 function exportBundle(){ if(!CURRENT){ toast("Open a profile first"); return; }
   window.location.href=`/api/projects/${CURRENT}/export?format=bundle`; toast("Building machine_context_bundle.zip…"); }
+function exportSanitized(){ if(!CURRENT){ toast("Open a profile first"); return; }
+  window.location.href=`/api/projects/${CURRENT}/export?format=bundle-sanitized`; toast("Building sanitized structured context…"); }
 async function loadRecents(){
   try{ const j=await api("/api/recents"); const el=$("recentList");
     if(!(j.recents||[]).length){ el.innerHTML='<button disabled>None yet</button>'; return; }

--- a/mira-contextualizer/mira_contextualizer/server.py
+++ b/mira-contextualizer/mira_contextualizer/server.py
@@ -332,13 +332,16 @@ def make_handler(store: Store, gui_dir: str, recents_path: str | None = None):
                     {"tag": e["tagName"], "unsPath": e["unsPathProposed"], "roles": e["roles"],
                      "confidence": e["confidence"]} for e in accepted if e["unsPathProposed"]]})
             elif fmt == "i3x":
-                self._json(bundle._i3x(accepted))
-            elif fmt == "bundle":
-                data = bundle.zip_bytes(bundle.build_bundle(store, pid))
-                store.add_export(pid, "bundle", "machine_context_bundle.zip",
+                self._json(bundle._i3x(accepted, project_id=pid))
+            elif fmt in ("bundle", "bundle-sanitized"):
+                sanitized = fmt == "bundle-sanitized"
+                name = ("machine_context_sanitized.zip" if sanitized
+                        else "machine_context_bundle.zip")
+                data = bundle.zip_bytes(bundle.build_bundle(store, pid, sanitized=sanitized))
+                store.add_export(pid, fmt, name,
                                  {"bytes": len(data), "accepted": sum(
                                      1 for e in store.list_extractions(pid) if e["status"] == "accepted")})
-                self._send_bytes(data, "application/zip", "machine_context_bundle.zip")
+                self._send_bytes(data, "application/zip", name)
             elif fmt == "profile":
                 data = json.dumps(profile.save_profile(store, pid), indent=2).encode("utf-8")
                 store.add_export(pid, "profile", "%s%s" % (proj["name"], profile.EXT))
@@ -347,7 +350,7 @@ def make_handler(store: Store, gui_dir: str, recents_path: str | None = None):
                 self._send_bytes(data, "application/json",
                                  "%s%s" % (bundle._safe(proj["name"]), profile.EXT))
             else:
-                self._err("unsupported format (uns | i3x | bundle | profile)", 400)
+                self._err("unsupported format (uns | i3x | bundle | bundle-sanitized | profile)", 400)
 
     return Handler
 

--- a/mira-contextualizer/tests/test_bundle.py
+++ b/mira-contextualizer/tests/test_bundle.py
@@ -57,7 +57,7 @@ def test_bundle_contents(seeded):
     files = bundle.build_bundle(store, pid)
     for key in ("manifest.json", "uns.json", "i3x.json", "kg_entities.json",
                 "kg_relationships.json", "signals.csv", "review.json", "report.md", "IMPORT.md",
-                "scorecard.json"):
+                "scorecard.json", "evidence.json"):
         assert key in files, key
     sc = json.loads(files["scorecard.json"])
     assert sc["schema"] == "mira-contextualizer/scorecard@1" and "score" in sc
@@ -231,6 +231,106 @@ def test_bundle_existing_asset_intent_when_hub_asset_id_set(tmp_path):
     man = json.loads(bundle.build_bundle(s, p["id"])["manifest.json"])
     assert man["import"]["intent"] == "existing_asset"
     assert man["import"]["hub_asset_id"] == "asset-abc-123"
+    s.close()
+
+
+def test_full_bundle_emits_evidence_and_preserves_provenance(seeded):
+    """PRD test 11 — the full bundle aggregates evidence into evidence.json and keeps a walkable
+    provenance chain: an entity → its evidence block (by extraction id) → the source sha256 that
+    appears in the manifest. Full mode also carries verbatim document text + raw evidence."""
+    store, pid = seeded
+    files = bundle.build_bundle(store, pid)
+
+    # the previously-missing 16th bundle file now exists, with stable per-block UUIDs
+    assert "evidence.json" in files
+    ev = json.loads(files["evidence.json"])
+    assert ev["schema"] == "mira-contextualizer/evidence@1" and ev["evidence"]
+    assert all(b["evidence_uuid"] for b in ev["evidence"])
+
+    # full mode carries the raw document payload + the verbatim mined snippet
+    assert any(k.startswith("documents/") for k in files)
+    assert any("Conv_Run energizes" in (b.get("snippet") or "") for b in ev["evidence"])
+
+    # chain: signal entity → evidence block (same extraction id) → manifest source sha256
+    ents = json.loads(files["kg_entities.json"])["entities"]
+    sig = next(e for e in ents if e["entity_type"] == "signal" and e["entity_id"] == UNS)
+    assert sig["signal_uuid"]                                       # stable signal identity
+    xid = sig["properties"]["provenance"]["ctx_extraction_id"]
+    block = next(b for b in ev["evidence"] if b["extraction_id"] == xid)
+    man_shas = {s["sha256"] for s in json.loads(files["manifest.json"])["sources"]}
+    assert block["source_sha256"] in man_shas
+
+
+def test_sanitized_bundle_has_no_raw_document_payloads(seeded):
+    """PRD test 10 — the *sanitized structured context* bundle ships the derived structured context but
+    NO raw document payloads: no ``documents/*.json`` files, and ``evidence.json`` carries refs/uuids/
+    sha only — never verbatim mined text. Boundary (narrow §3 reading): the short provenance snippets in
+    review.json/parameters.json/fault_catalog.json are derived structured context and are retained; only
+    the raw document IR and the aggregate evidence text are stripped."""
+    store, pid = seeded
+    full = bundle.build_bundle(store, pid)
+    san = bundle.build_bundle(store, pid, sanitized=True)
+
+    # no raw document IR files, and the manifest declares the mode
+    assert any(k.startswith("documents/") for k in full)
+    assert not any(k.startswith("documents/") for k in san)
+    assert json.loads(san["manifest.json"])["mode"] == "sanitized"
+    assert json.loads(full["manifest.json"])["mode"] == "full"
+
+    # evidence.json present in both, but the verbatim mined sentence appears ONLY in the full bundle
+    SENTINEL = "Conv_Run energizes"
+    assert SENTINEL in full["evidence.json"]
+    assert SENTINEL not in san["evidence.json"]
+    san_ev = json.loads(san["evidence.json"])["evidence"]
+    assert san_ev and all("snippet" not in b and "raw" not in b for b in san_ev)
+
+    # derived structured context is still fully present (this is "sanitized", not "anonymous")
+    for key in ("uns.json", "i3x.json", "kg_entities.json", "kg_relationships.json",
+                "fault_catalog.json", "parameters.json", "scorecard.json", "signals.csv"):
+        assert key in san, key
+    # source refs + hashes survive sanitization (provenance chain still resolves)
+    assert all(b["source_sha256"] for b in san_ev)
+    assert json.loads(san["manifest.json"])["asset_match"]["source_file_hashes"]
+
+
+def test_entity_uuids_present_and_unique(tmp_path):
+    """The 4 missing identity UUIDs (§2) are minted: ``signal_uuid`` on signal entities, ``uns_node_uuid``
+    on every i3X node, ``relationship_uuid`` on every edge, ``evidence_uuid`` per evidence block.
+    Critically, a tag mentioned twice in one document yields two DISTINCT MENTIONS edges whose
+    relationship_uuid derives from (and matches) the per-mention evidence_uuid — no collisions."""
+    s = Store(str(tmp_path / "uuids.db"))
+    p = s.create_project("UUID cell")
+    plc = s.create_source(p["id"], "ccw", "ccw")
+    s.add_extractions(p["id"], plc["id"], [
+        {"tag_name": "Conv_Run", "roles": ["motor"], "uns_path_proposed": UNS,
+         "i3x_element_id": UNS, "evidence_json": {"source": "ccw_modbus"}, "confidence": 0.9}])
+    doc = s.create_source(p["id"], "manual", "m.pdf")
+    s.add_extractions(p["id"], doc["id"], [
+        {"tag_name": "Conv_Run", "roles": ["tag_reference"], "uns_path_proposed": None,
+         "evidence_json": {"source": "document", "entity_type": "tag_reference", "mentions": [
+             {"file": "m.pdf", "page": 2, "snippet": "Conv_Run energizes the motor"},
+             {"file": "m.pdf", "page": 7, "snippet": "Conv_Run de-energizes on stop"}]},
+         "confidence": 0.9}])
+    for e in s.list_extractions(p["id"]):
+        s.set_extraction_status(e["id"], "accepted")
+    files = bundle.build_bundle(s, p["id"])
+
+    nodes = json.loads(files["i3x.json"])["objectInstances"]
+    assert nodes and all(n["uns_node_uuid"] for n in nodes)
+    assert len({n["uns_node_uuid"] for n in nodes}) == len(nodes)   # one stable id per UNS node
+
+    rels = json.loads(files["kg_relationships.json"])["relationships"]
+    assert rels and all(r["relationship_uuid"] for r in rels)
+    assert len({r["relationship_uuid"] for r in rels}) == len(rels)  # no edge-id collisions
+
+    mentions = [r for r in rels if r["type"] == "MENTIONS" and r["target"] == "Conv_Run"]
+    assert len(mentions) == 2                                        # two distinct mention edges
+    assert mentions[0]["relationship_uuid"] != mentions[1]["relationship_uuid"]
+
+    # each MENTIONS edge links back to a real evidence block (relationship_uuid derives from evidence)
+    ev_uuids = {b["evidence_uuid"] for b in json.loads(files["evidence.json"])["evidence"]}
+    for r in mentions:
+        assert r["evidence_uuid"] in ev_uuids
     s.close()
 
 

--- a/mira-contextualizer/tests/test_server.py
+++ b/mira-contextualizer/tests/test_server.py
@@ -85,6 +85,29 @@ def test_bundle_and_i3x_export(base):
         assert "manifest.json" in zf.namelist() and "uns.json" in zf.namelist()
 
 
+def test_sanitized_bundle_export(base):
+    """The sanitized structured-context bundle is reachable over the API and ships no raw documents."""
+    import io
+    import json as _json
+    import zipfile
+    _, j = _req(f"{base}/api/projects", "POST", {"name": "Sanitized Co"})
+    pid = j["project"]["id"]
+    _req(f"{base}/api/projects/{pid}/sources", "POST",
+         {"fileName": FIXTURE.name, "text": FIXTURE.read_text(encoding="utf-8")})
+    _, ext = _req(f"{base}/api/projects/{pid}/extractions")
+    target = next(e for e in ext["extractions"] if e["unsPathProposed"])
+    _req(f"{base}/api/extractions/{target['id']}", "PATCH", {"status": "accepted"})
+
+    with urllib.request.urlopen(f"{base}/api/projects/{pid}/export?format=bundle-sanitized") as r:
+        assert r.status == 200 and r.headers["Content-Type"] == "application/zip"
+        data = r.read()
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        names = zf.namelist()
+        assert "manifest.json" in names and "evidence.json" in names
+        assert not any(n.startswith("documents/") for n in names)
+        assert _json.loads(zf.read("manifest.json"))["mode"] == "sanitized"
+
+
 def test_ccw_project_import_json_and_zip(base):
     import io
     import zipfile

--- a/mira-hub/CHANGELOG.md
+++ b/mira-hub/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to mira-hub. Format follows the project's Versioning Discipline rule: one line per release, namespaced semver tag at merge.
 
+## v2.12.0 — 2026-06-20
+- feat(hub): HubV3 Phase 4 — batch Review Queue + approval gate. New `Review Queue` screen (`/contextualization/review`) drives `ctx_import_batches.review_status` (proposed→approved|rejected|needs_review) over the shared vocabulary (Sources, Evidence, Extracted Signals, Fault Catalog, Parameters, UNS Map, Scorecard). Approve **publishes** a batch's accepted staged proposals into the live model: `kg_entities` go proposed→verified (the engine's grounding surface) with the paired `ai_suggestions` moved pending→accepted in lockstep (ADR-0017). The `/contextualization/[id]/promote` route is now approval-aware: it reads `kg_entities.approval_state` and refuses to overwrite verified/deprecated rows (returns skip reasons instead of a silent `ON CONFLICT DO NOTHING`), and uses the live `(tenant_id, entity_type, name)` conflict target (mig 026). Nothing auto-promotes — import stages `proposed`; only a human approve verifies. No migration. (HubV3 §5 Phase 4)
+
 ## v2.8.0 — 2026-06-15
 - feat(hub): onboarding now guides a fresh customer to upload their manual and ask MIRA a cited question about it; un-onboarded tenants are auto-sent to the wizard (#1901).
 

--- a/mira-hub/db/migrations/056_contextualization_intake.sql
+++ b/mira-hub/db/migrations/056_contextualization_intake.sql
@@ -1,0 +1,144 @@
+-- Migration 056: contextualization intake — extend 055 for the shared HubV3
+-- Intake Contract (Hub as system of record; offline/Telegram are ingest clients).
+--
+-- Builds on 055_contextualization. Adds:
+--   * contextualization_projects.bundle_sha256   (+ partial UNIQUE per tenant) — project dedup
+--   * ctx_import_batches                          — one row per import submission, review_status
+--   * ctx_sources.source_sha256                   (+ partial UNIQUE per tenant) — source dedup (PRD test 3)
+--   * ctx_sources.import_batch_id                 (FK → ctx_import_batches)
+--   * ctx_extraction_asset_matches                — P3 asset-matching staging (created now, populated later)
+--
+-- Tenant: UUID (matches 055; Hub auth 401s non-UUID sessions). RLS pattern, GRANT
+-- to factorylm_app, and the touch_ctx_updated_at() trigger fn are reused verbatim
+-- from 055. Idempotent (IF NOT EXISTS / DROP POLICY|TRIGGER IF EXISTS). Single txn.
+--
+-- ADR: docs/adr/0023-hub-system-of-record-contextualization.md
+-- Spec: docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md §2, §5 P1/P2
+-- Rule: .claude/rules/mira-hub-migrations.md (UUID tenant family, RLS in-type, GRANT, idempotency)
+
+BEGIN;
+
+-- ── ctx_import_batches ─────────────────────────────────────────────────────────
+-- One row per import submission. Groups the sources/extractions of a single
+-- intake. review_status holds the batch at 'proposed' on intake — nothing is
+-- auto-approved (ADR-0017). Per-bundle idempotency via the partial UNIQUE index.
+
+CREATE TABLE IF NOT EXISTS ctx_import_batches (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id     UUID NOT NULL,
+  project_id    UUID NOT NULL REFERENCES contextualization_projects(id) ON DELETE CASCADE,
+  ingest_route  TEXT NOT NULL
+    CHECK (ingest_route IN ('offline', 'telegram', 'hub_upload')),
+  bundle_sha256 TEXT,
+  source_count     INTEGER NOT NULL DEFAULT 0,
+  extraction_count INTEGER NOT NULL DEFAULT 0,
+  review_status TEXT NOT NULL DEFAULT 'proposed'
+    CHECK (review_status IN ('proposed', 'approved', 'rejected', 'needs_review')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ctx_import_batches_project
+  ON ctx_import_batches(project_id);
+CREATE INDEX IF NOT EXISTS idx_ctx_import_batches_tenant
+  ON ctx_import_batches(tenant_id);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ctx_import_batches_bundle_sha
+  ON ctx_import_batches(tenant_id, bundle_sha256)
+  WHERE bundle_sha256 IS NOT NULL;
+
+ALTER TABLE ctx_import_batches ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_ctx_import_batches ON ctx_import_batches;
+CREATE POLICY tenant_isolation_ctx_import_batches ON ctx_import_batches
+  FOR ALL TO factorylm_app
+  USING (tenant_id = current_setting('app.tenant_id', TRUE)::UUID);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ctx_import_batches TO factorylm_app;
+
+DROP TRIGGER IF EXISTS trg_ctx_import_batches_updated_at ON ctx_import_batches;
+CREATE TRIGGER trg_ctx_import_batches_updated_at
+  BEFORE UPDATE ON ctx_import_batches
+  FOR EACH ROW EXECUTE FUNCTION touch_ctx_updated_at();
+
+-- ── contextualization_projects: bundle_sha256 (project dedup) ───────────────────
+ALTER TABLE contextualization_projects
+  ADD COLUMN IF NOT EXISTS bundle_sha256 TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ctx_projects_bundle_sha
+  ON contextualization_projects(tenant_id, bundle_sha256)
+  WHERE bundle_sha256 IS NOT NULL;
+
+-- ── ctx_sources: source_sha256 (source dedup) + import_batch_id ─────────────────
+ALTER TABLE ctx_sources
+  ADD COLUMN IF NOT EXISTS source_sha256 TEXT;
+ALTER TABLE ctx_sources
+  ADD COLUMN IF NOT EXISTS import_batch_id UUID REFERENCES ctx_import_batches(id) ON DELETE SET NULL;
+
+-- PRD §6 test 3: same source sha256 must not duplicate source records. Partial
+-- so manually-added sources (no hash) are unaffected; the import route's
+-- ON CONFLICT (tenant_id, source_sha256) WHERE source_sha256 IS NOT NULL infers it.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ctx_sources_source_sha
+  ON ctx_sources(tenant_id, source_sha256)
+  WHERE source_sha256 IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_ctx_sources_batch
+  ON ctx_sources(import_batch_id);
+
+-- ── ctx_extraction_asset_matches (P3 staging — created now, populated later) ─────
+-- Links a staged extraction (or a whole batch) to a candidate cmms_equipment
+-- asset with a match strength. candidate_asset_id is a SOFT reference (no FK to
+-- cmms_equipment — that full schema is upstream of 055; a hard FK would couple
+-- this migration to it and break a ctx-only test DB). P3's asset-matcher resolves it.
+
+CREATE TABLE IF NOT EXISTS ctx_extraction_asset_matches (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id          UUID NOT NULL,
+  project_id         UUID NOT NULL REFERENCES contextualization_projects(id) ON DELETE CASCADE,
+  import_batch_id    UUID REFERENCES ctx_import_batches(id) ON DELETE SET NULL,
+  extraction_id      UUID REFERENCES ctx_extractions(id) ON DELETE CASCADE,
+  candidate_asset_id UUID,                                  -- soft ref → cmms_equipment.id (resolved in P3)
+  match_strength     TEXT NOT NULL
+    CHECK (match_strength IN ('strong', 'probable', 'none')),
+  match_evidence     JSONB NOT NULL DEFAULT '{}',
+  status             TEXT NOT NULL DEFAULT 'proposed'
+    CHECK (status IN ('proposed', 'confirmed', 'rejected')),
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ctx_asset_matches_project
+  ON ctx_extraction_asset_matches(project_id);
+CREATE INDEX IF NOT EXISTS idx_ctx_asset_matches_tenant
+  ON ctx_extraction_asset_matches(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_ctx_asset_matches_extraction
+  ON ctx_extraction_asset_matches(extraction_id);
+CREATE INDEX IF NOT EXISTS idx_ctx_asset_matches_candidate
+  ON ctx_extraction_asset_matches(candidate_asset_id);
+
+ALTER TABLE ctx_extraction_asset_matches ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_isolation_ctx_asset_matches ON ctx_extraction_asset_matches;
+CREATE POLICY tenant_isolation_ctx_asset_matches ON ctx_extraction_asset_matches
+  FOR ALL TO factorylm_app
+  USING (tenant_id = current_setting('app.tenant_id', TRUE)::UUID);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ctx_extraction_asset_matches TO factorylm_app;
+
+DROP TRIGGER IF EXISTS trg_ctx_asset_matches_updated_at ON ctx_extraction_asset_matches;
+CREATE TRIGGER trg_ctx_asset_matches_updated_at
+  BEFORE UPDATE ON ctx_extraction_asset_matches
+  FOR EACH ROW EXECUTE FUNCTION touch_ctx_updated_at();
+
+COMMIT;
+
+-- Verification:
+--   \d+ ctx_import_batches
+--   \d+ ctx_extraction_asset_matches
+--   \d  contextualization_projects   (bundle_sha256 + uq_ctx_projects_bundle_sha)
+--   \d  ctx_sources                  (source_sha256, import_batch_id + uq_ctx_sources_source_sha)
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS ctx_extraction_asset_matches CASCADE;
+--   ALTER TABLE ctx_sources DROP COLUMN IF EXISTS import_batch_id, DROP COLUMN IF EXISTS source_sha256;
+--   DROP TABLE IF EXISTS ctx_import_batches CASCADE;
+--   ALTER TABLE contextualization_projects DROP COLUMN IF EXISTS bundle_sha256;

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-hub",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mira-hub/package.json
+++ b/mira-hub/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:integration": "vitest run --testTimeout 30000 '**/*.integration.test.ts'",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "db:check-order": "node db/check-migration-order.mjs",
     "sitemap": "node scripts/sitemap.mjs",
     "sitemap:check": "node scripts/sitemap.mjs --check",

--- a/mira-hub/src/app/(hub)/contextualization/review/[batchId]/page.tsx
+++ b/mira-hub/src/app/(hub)/contextualization/review/[batchId]/page.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { ArrowLeft, Check, Loader2, X, AlertTriangle } from "lucide-react";
+import { API_BASE } from "@/lib/config";
+
+type ReviewStatus = "proposed" | "approved" | "rejected" | "needs_review";
+type Decision = "approve" | "reject" | "needs_review";
+
+interface Signal {
+  id: string;
+  tagName: string;
+  roles: string[];
+  unsPath: string | null;
+  i3xElementId: string | null;
+  confidence: number | null;
+  status: string;
+  sourceFile: string | null;
+  evidenceCount: number;
+}
+interface Source {
+  id: string;
+  sourceType: string;
+  fileName: string;
+  status: string;
+  sha256: string | null;
+}
+interface BatchDetail {
+  batch: {
+    id: string;
+    projectName: string;
+    ingestRoute: string;
+    bundleSha256: string | null;
+    reviewStatus: ReviewStatus;
+    createdAt: string;
+  };
+  sources: Source[];
+  evidence: { tagName: string; evidenceCount: number }[];
+  extractedSignals: Signal[];
+  faultCatalog: Signal[];
+  parameters: Signal[];
+  unsMap: { tagName: string; unsPath: string | null; i3xElementId: string | null }[];
+  scorecard: {
+    sources: number;
+    signals: number;
+    mappedUns: number;
+    accepted: number;
+    avgConfidence: number | null;
+  };
+}
+
+const STATUS_STYLE: Record<ReviewStatus, string> = {
+  proposed: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+  approved: "bg-green-500/15 text-green-300 border-green-500/30",
+  rejected: "bg-red-500/15 text-red-300 border-red-500/30",
+  needs_review: "bg-blue-500/15 text-blue-300 border-blue-500/30",
+};
+
+function Section({ title, count, children }: { title: string; count: number; children: React.ReactNode }) {
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-5">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-white font-medium">{title}</h2>
+        <span className="text-xs text-gray-500">{count}</span>
+      </div>
+      {count === 0 ? (
+        <p className="text-sm text-gray-600 italic">None in this batch.</p>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}
+
+function confColor(c: number | null): string {
+  if (c == null) return "text-gray-500";
+  if (c >= 0.85) return "text-green-400";
+  if (c >= 0.5) return "text-amber-400";
+  return "text-gray-400";
+}
+
+export default function BatchReviewPage() {
+  const router = useRouter();
+  const params = useParams();
+  const batchId = String(params.batchId);
+
+  const [data, setData] = useState<BatchDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [acting, setActing] = useState<Decision | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const fetchDetail = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/contextualization/batches/${batchId}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData(await res.json());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load batch");
+    } finally {
+      setLoading(false);
+    }
+  }, [batchId]);
+
+  useEffect(() => {
+    fetchDetail();
+  }, [fetchDetail]);
+
+  async function decide(decision: Decision) {
+    setActing(decision);
+    setToast(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/contextualization/batches/${batchId}/review`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ decision }),
+      });
+      const body = await res.json();
+      if (!res.ok) throw new Error(body.error ?? `HTTP ${res.status}`);
+      if (decision === "approve") {
+        setToast(`Approved — published ${body.published} signal(s)${body.skipped ? `, ${body.skipped} kept (already approved)` : ""}.`);
+      } else {
+        setToast(decision === "reject" ? "Batch rejected." : "Marked needs-review.");
+      }
+      await fetchDetail();
+    } catch (e) {
+      setToast(e instanceof Error ? e.message : "Action failed");
+    } finally {
+      setActing(null);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-gray-400 py-20 justify-center">
+        <Loader2 size={20} className="animate-spin" /> Loading batch…
+      </div>
+    );
+  }
+  if (error || !data) {
+    return <div className="text-red-400 py-20 text-center">{error ?? "Not found"}</div>;
+  }
+
+  const { batch, sources, evidence, extractedSignals, faultCatalog, parameters, unsMap, scorecard } = data;
+  const isOpen = batch.reviewStatus === "proposed" || batch.reviewStatus === "needs_review";
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <button
+        onClick={() => router.push("/contextualization/review")}
+        className="flex items-center gap-1.5 text-sm text-gray-400 hover:text-gray-200 mb-4"
+      >
+        <ArrowLeft size={15} /> Review Queue
+      </button>
+
+      {/* Header + actions */}
+      <div className="flex items-start justify-between gap-4 mb-6">
+        <div>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-semibold text-white">{batch.projectName}</h1>
+            <span className={`text-[11px] px-2 py-0.5 rounded-full border ${STATUS_STYLE[batch.reviewStatus]}`}>
+              {batch.reviewStatus.replace("_", " ")}
+            </span>
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            via {batch.ingestRoute}
+            {batch.bundleSha256 ? ` · ${batch.bundleSha256.slice(0, 12)}…` : ""} · {new Date(batch.createdAt).toLocaleString()}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            onClick={() => decide("approve")}
+            disabled={!isOpen || acting !== null}
+            className="flex items-center gap-1.5 bg-green-600 hover:bg-green-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+          >
+            {acting === "approve" ? <Loader2 size={14} className="animate-spin" /> : <Check size={15} />}
+            Approve &amp; Publish
+          </button>
+          <button
+            onClick={() => decide("needs_review")}
+            disabled={!isOpen || acting !== null}
+            className="flex items-center gap-1.5 bg-gray-800 hover:bg-gray-700 disabled:opacity-40 text-gray-200 text-sm px-3 py-2 rounded-lg transition-colors"
+          >
+            {acting === "needs_review" ? <Loader2 size={14} className="animate-spin" /> : <AlertTriangle size={15} />}
+            Needs review
+          </button>
+          <button
+            onClick={() => decide("reject")}
+            disabled={!isOpen || acting !== null}
+            className="flex items-center gap-1.5 bg-gray-800 hover:bg-red-900/60 disabled:opacity-40 text-red-300 text-sm px-3 py-2 rounded-lg transition-colors"
+          >
+            {acting === "reject" ? <Loader2 size={14} className="animate-spin" /> : <X size={15} />}
+            Reject
+          </button>
+        </div>
+      </div>
+
+      {toast && (
+        <div className="mb-5 text-sm text-gray-200 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2.5">
+          {toast}
+        </div>
+      )}
+
+      {/* Scorecard */}
+      <div className="grid grid-cols-2 sm:grid-cols-5 gap-3 mb-5">
+        {[
+          { label: "Sources", value: scorecard.sources },
+          { label: "Extracted Signals", value: scorecard.signals },
+          { label: "UNS Map", value: scorecard.mappedUns },
+          { label: "Accepted", value: scorecard.accepted },
+          { label: "Avg confidence", value: scorecard.avgConfidence ?? "—" },
+        ].map((m) => (
+          <div key={m.label} className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+            <div className="text-xl font-semibold text-white">{m.value}</div>
+            <div className="text-[11px] text-gray-500 mt-0.5">{m.label}</div>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid gap-4">
+        {/* Sources */}
+        <Section title="Sources" count={sources.length}>
+          <ul className="divide-y divide-gray-800">
+            {sources.map((s) => (
+              <li key={s.id} className="py-2 flex items-center justify-between text-sm">
+                <span className="text-gray-200 truncate">{s.fileName}</span>
+                <span className="text-xs text-gray-500 shrink-0 ml-3">
+                  {s.sourceType} · {s.sha256 ? `${s.sha256.slice(0, 10)}…` : "no hash"} · {s.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+
+        {/* Extracted Signals */}
+        <Section title="Extracted Signals" count={extractedSignals.length}>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs text-gray-500 border-b border-gray-800">
+                  <th className="py-2 pr-3 font-medium">Tag</th>
+                  <th className="py-2 pr-3 font-medium">Roles</th>
+                  <th className="py-2 pr-3 font-medium">Proposed UNS path</th>
+                  <th className="py-2 pr-3 font-medium">Conf.</th>
+                  <th className="py-2 font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {extractedSignals.map((s) => (
+                  <tr key={s.id} className="border-b border-gray-800/60">
+                    <td className="py-2 pr-3 text-gray-200 font-mono text-xs">{s.tagName}</td>
+                    <td className="py-2 pr-3 text-gray-400 text-xs">{s.roles.join(", ") || "—"}</td>
+                    <td className="py-2 pr-3 text-gray-400 font-mono text-xs">{s.unsPath ?? "—"}</td>
+                    <td className={`py-2 pr-3 text-xs ${confColor(s.confidence)}`}>
+                      {s.confidence != null ? s.confidence.toFixed(2) : "—"}
+                    </td>
+                    <td className="py-2 text-xs text-gray-400">{s.status}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Section>
+
+        <div className="grid sm:grid-cols-2 gap-4">
+          {/* Fault Catalog */}
+          <Section title="Fault Catalog" count={faultCatalog.length}>
+            <ul className="space-y-1.5 text-sm">
+              {faultCatalog.map((f) => (
+                <li key={f.id} className="text-gray-300 font-mono text-xs">{f.tagName}</li>
+              ))}
+            </ul>
+          </Section>
+
+          {/* Parameters */}
+          <Section title="Parameters" count={parameters.length}>
+            <ul className="space-y-1.5 text-sm">
+              {parameters.map((p) => (
+                <li key={p.id} className="text-gray-300 font-mono text-xs">{p.tagName}</li>
+              ))}
+            </ul>
+          </Section>
+        </div>
+
+        {/* UNS Map */}
+        <Section title="UNS Map" count={unsMap.length}>
+          <ul className="divide-y divide-gray-800">
+            {unsMap.map((u) => (
+              <li key={u.tagName} className="py-2 flex items-center justify-between text-xs font-mono">
+                <span className="text-gray-300">{u.tagName}</span>
+                <span className="text-gray-500 truncate ml-3">{u.unsPath}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+
+        {/* Evidence */}
+        <Section title="Evidence" count={evidence.length}>
+          <ul className="divide-y divide-gray-800">
+            {evidence.map((e) => (
+              <li key={e.tagName} className="py-2 flex items-center justify-between text-xs">
+                <span className="text-gray-300 font-mono">{e.tagName}</span>
+                <span className="text-gray-500">{e.evidenceCount} block{e.evidenceCount !== 1 ? "s" : ""}</span>
+              </li>
+            ))}
+          </ul>
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/mira-hub/src/app/(hub)/contextualization/review/page.tsx
+++ b/mira-hub/src/app/(hub)/contextualization/review/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ClipboardList, Loader2 } from "lucide-react";
+import { API_BASE } from "@/lib/config";
+
+type ReviewStatus = "proposed" | "approved" | "rejected" | "needs_review";
+
+interface Batch {
+  id: string;
+  projectName: string;
+  ingestRoute: string;
+  reviewStatus: ReviewStatus;
+  sourceCount: number;
+  extractionCount: number;
+  acceptedCount: number;
+  createdAt: string;
+}
+
+const STATUS_STYLE: Record<ReviewStatus, string> = {
+  proposed: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+  approved: "bg-green-500/15 text-green-300 border-green-500/30",
+  rejected: "bg-red-500/15 text-red-300 border-red-500/30",
+  needs_review: "bg-blue-500/15 text-blue-300 border-blue-500/30",
+};
+const STATUS_LABEL: Record<ReviewStatus, string> = {
+  proposed: "Pending review",
+  approved: "Approved",
+  rejected: "Rejected",
+  needs_review: "Needs review",
+};
+
+export default function ReviewQueuePage() {
+  const router = useRouter();
+  const [batches, setBatches] = useState<Batch[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchBatches = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`${API_BASE}/api/contextualization/batches`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      setBatches(data.batches ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load review queue");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchBatches();
+  }, [fetchBatches]);
+
+  const pending = batches.filter((b) => b.reviewStatus === "proposed" || b.reviewStatus === "needs_review").length;
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">Review Queue</h1>
+          <p className="text-sm text-gray-400 mt-1">
+            Imported context lands here as proposed. Approve a batch to publish its signals, UNS map, and
+            i3X objects into the project model — nothing goes live until you approve it.
+          </p>
+        </div>
+        {pending > 0 && (
+          <span className="text-xs text-amber-300 bg-amber-500/15 border border-amber-500/30 px-3 py-1.5 rounded-lg">
+            {pending} awaiting review
+          </span>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-gray-400 py-12 justify-center">
+          <Loader2 size={20} className="animate-spin" />
+          Loading review queue…
+        </div>
+      ) : error ? (
+        <div className="text-red-400 py-12 text-center">{error}</div>
+      ) : batches.length === 0 ? (
+        <div className="border border-dashed border-gray-700 rounded-xl py-20 flex flex-col items-center gap-4 text-gray-500">
+          <ClipboardList size={40} className="text-gray-600" />
+          <p className="text-sm">No import batches yet. Import an offline bundle or Telegram capture to populate the queue.</p>
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {batches.map((b) => (
+            <button
+              key={b.id}
+              onClick={() => router.push(`/contextualization/review/${b.id}`)}
+              className="w-full text-left bg-gray-900 border border-gray-800 hover:border-gray-600 rounded-xl p-5 transition-colors group"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-3">
+                    <h2 className="text-white font-medium group-hover:text-blue-300 transition-colors truncate">
+                      {b.projectName}
+                    </h2>
+                    <span className={`text-[11px] px-2 py-0.5 rounded-full border ${STATUS_STYLE[b.reviewStatus]}`}>
+                      {STATUS_LABEL[b.reviewStatus]}
+                    </span>
+                  </div>
+                  <p className="text-gray-500 text-xs mt-1">via {b.ingestRoute}</p>
+                </div>
+                <div className="flex items-center gap-4 text-xs text-gray-500 shrink-0 mt-0.5">
+                  <span>
+                    <span className="text-gray-300 font-medium">{b.sourceCount}</span> source{b.sourceCount !== 1 ? "s" : ""}
+                  </span>
+                  <span>
+                    <span className="text-gray-300 font-medium">{b.extractionCount}</span> signals
+                  </span>
+                  <span>
+                    <span className="text-green-400 font-medium">{b.acceptedCount}</span> accepted
+                  </span>
+                  <span>{new Date(b.createdAt).toLocaleDateString()}</span>
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mira-hub/src/app/api/contextualization/[id]/promote/route.ts
+++ b/mira-hub/src/app/api/contextualization/[id]/promote/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from "next/server";
 import { sessionOr401 } from "@/lib/session";
 import { withTenantContext } from "@/lib/tenant-context";
+import {
+  IMPORT_APPROVAL_STATE,
+  buildEntityInsert,
+  decidePromotion,
+  type EntityApprovalState,
+} from "@/lib/contextualization/approval";
 
 export const dynamic = "force-dynamic";
 
@@ -10,16 +16,21 @@ interface ExtractionRow {
   roles: string[];
   uns_path_proposed: string | null;
   confidence: string | null;
+  import_batch_id: string | null;
 }
 
 /**
  * POST /api/contextualization/[id]/promote
  *
- * Promotes all accepted ctx_extractions for a project into kg_entities
+ * Stages all accepted ctx_extractions for a project into kg_entities
  * (type=signal, approval_state=proposed) and creates a paired ai_suggestions
- * row (type=kg_entity, status=pending) so the Hub proposals queue picks them up.
+ * row (type=kg_entity, status=pending). This is import-time STAGING — it never
+ * publishes. Publishing (proposed → verified) is a human action via the batch
+ * review-queue (POST .../batches/[batchId]/review {decision:"approve"}).
  *
- * Idempotent: ON CONFLICT DO NOTHING on both tables.
+ * Approval-aware: before writing, it reads the existing kg_entities.approval_state
+ * and REFUSES to overwrite approved data (verified/deprecated). Skipped rows are
+ * reported with a reason instead of a silent ON CONFLICT DO NOTHING.
  */
 export async function POST(
   _req: Request,
@@ -46,27 +57,31 @@ export async function POST(
       );
       if (proj.rows.length === 0) return null;
 
-      // Fetch accepted extractions with proposed UNS paths
+      // Fetch accepted extractions with proposed UNS paths + their import batch
+      // (the batch comes from the source the extraction was parsed from).
       const rows = await c
         .query<ExtractionRow>(
-          `SELECT id, tag_name, roles, uns_path_proposed, confidence::text
-             FROM ctx_extractions
-            WHERE project_id = $1
-              AND tenant_id = $2::uuid
-              AND status = 'accepted'
-              AND uns_path_proposed IS NOT NULL
-            ORDER BY tag_name`,
+          `SELECT e.id, e.tag_name, e.roles, e.uns_path_proposed,
+                  e.confidence::text AS confidence, s.import_batch_id
+             FROM ctx_extractions e
+             LEFT JOIN ctx_sources s ON s.id = e.source_id
+            WHERE e.project_id = $1
+              AND e.tenant_id = $2::uuid
+              AND e.status = 'accepted'
+              AND e.uns_path_proposed IS NOT NULL
+            ORDER BY e.tag_name`,
           [projectId, ctx.tenantId],
         )
         .then((r) => r.rows);
 
       if (rows.length === 0) {
-        return { projectName: proj.rows[0].name, promoted: 0, skipped: 0 };
+        return { projectName: proj.rows[0].name, promoted: 0, skipped: 0, skips: [] };
       }
 
       const actorLabel = `import:ctx_project:${projectId}`;
       let promoted = 0;
       let skipped = 0;
+      const skips: { tag_name: string; reason: string; protected: boolean }[] = [];
 
       for (const row of rows) {
         const unsPath = row.uns_path_proposed!;
@@ -77,31 +92,53 @@ export async function POST(
         const properties = {
           roles: row.roles ?? [],
           confidence,
-          provenance: { ctx_extraction_id: row.id, ctx_project_id: projectId },
+          provenance: {
+            ctx_extraction_id: row.id,
+            ctx_project_id: projectId,
+            ctx_import_batch_id: row.import_batch_id, // audit link, not a lookup key
+          },
         };
 
-        // Upsert kg_entities: entity_type=signal, entity_id=uns_path (unique within tenant)
-        const ent = await c.query<{ id: string; was_new: boolean }>(
-          `INSERT INTO kg_entities
-               (tenant_id, entity_type, entity_id, name, properties,
-                approval_state, uns_path)
-             VALUES ($1::uuid, 'signal', $2, $3, $4::jsonb,
-                     'proposed', $5::ltree)
-             ON CONFLICT (tenant_id, entity_type, entity_id) DO NOTHING
-             RETURNING id, TRUE AS was_new`,
-          [ctx.tenantId, unsPath, row.tag_name, JSON.stringify(properties), ltreePath],
+        // Approval gate: read existing approval_state on the live natural key
+        // (tenant_id, entity_type, name) and refuse to overwrite approved data.
+        const existing = await c.query<{ approval_state: EntityApprovalState }>(
+          `SELECT approval_state FROM kg_entities
+            WHERE tenant_id = $1::uuid AND entity_type = 'signal' AND name = $2`,
+          [ctx.tenantId, row.tag_name],
         );
+        const decision = decidePromotion(existing.rows[0] ?? null);
 
-        if (ent.rows.length === 0) {
-          // Row already existed — still wire up ai_suggestions below (idempotent)
+        if (decision.action === "skip") {
           skipped++;
-        } else {
-          promoted++;
+          skips.push({
+            tag_name: row.tag_name,
+            reason: decision.reason ?? "skipped",
+            protected: decision.protectedRow ?? false,
+          });
+          continue; // do not touch the row, do not create a new suggestion
         }
 
-        // Create an ai_suggestions row only when one doesn't exist for this extraction yet.
-        // ai_suggestions has no unique constraint beyond PK, so we check first.
-        const existing = await c.query<{ id: string }>(
+        // Stage a fresh proposed entity (correct conflict target — migration 026).
+        const ins = buildEntityInsert({
+          tenantId: ctx.tenantId,
+          name: row.tag_name,
+          unsPath,
+          ltreePath,
+          propertiesJson: JSON.stringify(properties),
+          approvalState: IMPORT_APPROVAL_STATE,
+        });
+        const ent = await c.query<{ id: string }>(ins.text, ins.values);
+        if (ent.rows.length === 0) {
+          // Lost a race to a concurrent insert — treat as already-staged.
+          skipped++;
+          skips.push({ tag_name: row.tag_name, reason: "already staged (race)", protected: false });
+          continue;
+        }
+        promoted++;
+
+        // Paired ai_suggestions row (one review surface stays in lockstep on
+        // approve — see batches/[batchId]/review). Create only when absent.
+        const existingSug = await c.query<{ id: string }>(
           `SELECT id FROM ai_suggestions
             WHERE tenant_id = $1::uuid
               AND suggestion_type = 'kg_entity'
@@ -110,7 +147,7 @@ export async function POST(
           [ctx.tenantId, row.id],
         );
 
-        if (existing.rows.length === 0) {
+        if (existingSug.rows.length === 0) {
           await c.query(
             `INSERT INTO ai_suggestions
                (tenant_id, suggestion_type, extracted_data,
@@ -138,7 +175,7 @@ export async function POST(
         }
       }
 
-      return { projectName: proj.rows[0].name, promoted, skipped, total: rows.length };
+      return { projectName: proj.rows[0].name, promoted, skipped, total: rows.length, skips };
     });
 
     if (!result) {

--- a/mira-hub/src/app/api/contextualization/batches/[batchId]/review/route.ts
+++ b/mira-hub/src/app/api/contextualization/batches/[batchId]/review/route.ts
@@ -1,0 +1,211 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { applyHubProposalTransition } from "@/lib/proposal-transition";
+import {
+  PUBLISHED_APPROVAL_STATE,
+  buildEntityInsert,
+  buildPublishEntityUpdate,
+  decideBatchReview,
+  decidePublish,
+  parseReviewDecision,
+  type EntityApprovalState,
+} from "@/lib/contextualization/approval";
+
+export const dynamic = "force-dynamic";
+
+interface PublishRow {
+  id: string;
+  tag_name: string;
+  roles: string[] | null;
+  uns_path_proposed: string | null;
+  confidence: string | null;
+}
+
+/**
+ * POST /api/contextualization/batches/[batchId]/review
+ * Body: { decision: "approve" | "reject" | "needs_review" }
+ *
+ * The Hub's batch-level approval gate (HubV3 Phase 4). Transitions
+ * ctx_import_batches.review_status. On `approve` — and ONLY on a human approve —
+ * it PUBLISHES the batch's accepted staged proposals into the live model:
+ * kg_entities go proposed → verified (the engine's grounding surface; this is
+ * the "publish to project model + UNS + i3X + MIRA KB" step), and the paired
+ * ai_suggestions move pending → accepted so the two Hub projections stay in
+ * lockstep (ADR-0017).
+ *
+ * No path here auto-promotes: import stages `proposed`; this human action is the
+ * verification. Approved/deprecated rows are never overwritten — the publish
+ * UPDATE carries a DB-level no-overwrite guard.
+ */
+export async function POST(
+  req: Request,
+  { params }: { params: Promise<{ batchId: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { batchId } = await params;
+  if (!batchId || !/^[0-9a-f-]{36}$/i.test(batchId)) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  const decision = parseReviewDecision(body.decision);
+  if (!decision) {
+    return NextResponse.json(
+      { error: "decision must be one of: approve, reject, needs_review" },
+      { status: 400 },
+    );
+  }
+
+  const reviewerLabel = `human:${ctx.userId}`;
+
+  try {
+    const result = await withTenantContext(ctx.tenantId, async (c) => {
+      const batch = await c.query<{ review_status: string; project_id: string }>(
+        `SELECT review_status, project_id
+           FROM ctx_import_batches
+          WHERE id = $1 AND tenant_id = $2::uuid`,
+        [batchId, ctx.tenantId],
+      );
+      if (batch.rows.length === 0) return null;
+
+      const outcome = decideBatchReview(
+        batch.rows[0].review_status as "proposed" | "approved" | "rejected" | "needs_review",
+        decision,
+      );
+
+      await c.query(
+        `UPDATE ctx_import_batches
+            SET review_status = $1, updated_at = now()
+          WHERE id = $2 AND tenant_id = $3::uuid`,
+        [outcome.status, batchId, ctx.tenantId],
+      );
+
+      if (!outcome.publish) {
+        return { reviewStatus: outcome.status, published: 0, skipped: 0, publishSkips: [] };
+      }
+
+      // Publish: accepted extractions of THIS batch (source of truth =
+      // ctx_sources.import_batch_id), upserted by the live natural key.
+      const rows = await c
+        .query<PublishRow>(
+          `SELECT e.id, e.tag_name, e.roles, e.uns_path_proposed, e.confidence::text AS confidence
+             FROM ctx_extractions e
+             JOIN ctx_sources s ON s.id = e.source_id
+            WHERE s.import_batch_id = $1
+              AND e.tenant_id = $2::uuid
+              AND e.status = 'accepted'
+              AND e.uns_path_proposed IS NOT NULL
+            ORDER BY e.tag_name`,
+          [batchId, ctx.tenantId],
+        )
+        .then((r) => r.rows);
+
+      let published = 0;
+      let skipped = 0;
+      const publishSkips: { tag_name: string; reason: string }[] = [];
+
+      for (const row of rows) {
+        const unsPath = row.uns_path_proposed!;
+        const ltreePath = unsPath.replace(/\//g, ".").replace(/[^a-z0-9_.]/gi, "_");
+        const confidence = row.confidence ? parseFloat(row.confidence) : 0.5;
+        const properties = {
+          roles: row.roles ?? [],
+          confidence,
+          provenance: {
+            ctx_extraction_id: row.id,
+            ctx_import_batch_id: batchId,
+            published_by: reviewerLabel,
+          },
+        };
+        const propsJson = JSON.stringify(properties);
+
+        // Read the live approval_state and decide insert / update / skip.
+        const existing = await c.query<{ approval_state: EntityApprovalState }>(
+          `SELECT approval_state FROM kg_entities
+            WHERE tenant_id = $1::uuid AND entity_type = 'signal' AND name = $2`,
+          [ctx.tenantId, row.tag_name],
+        );
+        const pd = decidePublish(existing.rows[0] ?? null);
+
+        if (pd.action === "skip") {
+          skipped++;
+          publishSkips.push({ tag_name: row.tag_name, reason: pd.reason ?? "skipped" });
+          continue;
+        }
+
+        let wrote = false;
+        if (pd.action === "insert") {
+          // Approval IS the verification — insert directly as verified.
+          const ins = buildEntityInsert({
+            tenantId: ctx.tenantId,
+            name: row.tag_name,
+            unsPath,
+            ltreePath,
+            propertiesJson: propsJson,
+            approvalState: PUBLISHED_APPROVAL_STATE,
+          });
+          const r = await c.query<{ id: string }>(ins.text, ins.values);
+          wrote = r.rows.length > 0;
+        }
+        if (!wrote) {
+          // update path (or lost-race fallback) — guarded so verified/deprecated
+          // rows are never overwritten.
+          const upd = buildPublishEntityUpdate({
+            tenantId: ctx.tenantId,
+            name: row.tag_name,
+            propertiesJson: propsJson,
+          });
+          const r = await c.query<{ id: string }>(upd.text, upd.values);
+          wrote = r.rows.length > 0;
+        }
+
+        if (wrote) {
+          published++;
+          // Keep the paired ai_suggestions row in lockstep (ADR-0017): the
+          // generic /proposals queue must not show this as pending forever once
+          // the Review Queue has approved it.
+          const sug = await c.query<{ id: string }>(
+            `SELECT id FROM ai_suggestions
+              WHERE tenant_id = $1::uuid
+                AND suggestion_type = 'kg_entity'
+                AND extracted_data->>'ctx_extraction_id' = $2
+                AND status = 'pending'
+              LIMIT 1`,
+            [ctx.tenantId, row.id],
+          );
+          if (sug.rows.length > 0) {
+            await applyHubProposalTransition(c, {
+              trigger: "accept",
+              aiSuggestionId: sug.rows[0].id,
+              reviewerLabel,
+            });
+          }
+        } else {
+          skipped++;
+          publishSkips.push({ tag_name: row.tag_name, reason: "protected — not overwritten" });
+        }
+      }
+
+      return { reviewStatus: outcome.status, published, skipped, total: rows.length, publishSkips };
+    });
+
+    if (!result) {
+      return NextResponse.json({ error: "batch not found" }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    console.error("[api/contextualization/batches/[batchId]/review POST]", err);
+    return NextResponse.json({ error: "Review failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/contextualization/batches/[batchId]/route.ts
+++ b/mira-hub/src/app/api/contextualization/batches/[batchId]/route.ts
@@ -1,0 +1,179 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+const FAULT_ROLES = new Set(["fault", "alarm", "fault_code", "diagnostic"]);
+const PARAM_ROLES = new Set(["parameter", "setpoint", "config", "limit", "threshold"]);
+
+interface BatchHeadRow {
+  id: string;
+  project_id: string;
+  project_name: string;
+  ingest_route: string;
+  bundle_sha256: string | null;
+  review_status: string;
+  created_at: string;
+  updated_at: string;
+}
+interface SourceRow {
+  id: string;
+  source_type: string;
+  file_name: string;
+  status: string;
+  source_sha256: string | null;
+  created_at: string;
+}
+interface ExtractionRow {
+  id: string;
+  tag_name: string;
+  roles: string[] | null;
+  uns_path_proposed: string | null;
+  i3x_element_id: string | null;
+  confidence: string | null;
+  status: string;
+  evidence_json: unknown;
+  source_file: string | null;
+}
+
+/**
+ * GET /api/contextualization/batches/[batchId]
+ *
+ * Full review payload for one import batch, grouped under the shared HubV3
+ * vocabulary: Sources, Evidence, Extracted Signals, Fault Catalog, Parameters,
+ * UNS Map, Scorecard. Sections the staged schema does not populate come back
+ * empty (the screen shows an honest empty-state) — never fabricated.
+ */
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ batchId: string }> },
+) {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  const { batchId } = await params;
+  if (!batchId || !/^[0-9a-f-]{36}$/i.test(batchId)) {
+    return NextResponse.json({ error: "invalid id" }, { status: 400 });
+  }
+
+  try {
+    const payload = await withTenantContext(ctx.tenantId, async (c) => {
+      const head = await c.query<BatchHeadRow>(
+        `SELECT b.id, b.project_id, p.name AS project_name, b.ingest_route,
+                b.bundle_sha256, b.review_status, b.created_at, b.updated_at
+           FROM ctx_import_batches b
+           JOIN contextualization_projects p ON p.id = b.project_id
+          WHERE b.id = $1 AND b.tenant_id = $2::uuid`,
+        [batchId, ctx.tenantId],
+      );
+      if (head.rows.length === 0) return null;
+
+      const sources = await c
+        .query<SourceRow>(
+          `SELECT id, source_type, file_name, status, source_sha256, created_at
+             FROM ctx_sources
+            WHERE import_batch_id = $1 AND tenant_id = $2::uuid
+            ORDER BY file_name`,
+          [batchId, ctx.tenantId],
+        )
+        .then((r) => r.rows);
+
+      const extractions = await c
+        .query<ExtractionRow>(
+          `SELECT e.id, e.tag_name, e.roles, e.uns_path_proposed, e.i3x_element_id,
+                  e.confidence::text AS confidence, e.status, e.evidence_json,
+                  s.file_name AS source_file
+             FROM ctx_extractions e
+             JOIN ctx_sources s ON s.id = e.source_id
+            WHERE s.import_batch_id = $1 AND e.tenant_id = $2::uuid
+            ORDER BY e.tag_name`,
+          [batchId, ctx.tenantId],
+        )
+        .then((r) => r.rows);
+
+      return { head: head.rows[0], sources, extractions };
+    });
+
+    if (!payload) {
+      return NextResponse.json({ error: "batch not found" }, { status: 404 });
+    }
+
+    const { head, sources, extractions } = payload;
+
+    const signals = extractions.map((e) => ({
+      id: e.id,
+      tagName: e.tag_name,
+      roles: e.roles ?? [],
+      unsPath: e.uns_path_proposed,
+      i3xElementId: e.i3x_element_id,
+      confidence: e.confidence != null ? Number(e.confidence) : null,
+      status: e.status,
+      sourceFile: e.source_file,
+      evidenceCount: countEvidence(e.evidence_json),
+    }));
+
+    const hasRole = (e: typeof signals[number], set: Set<string>) =>
+      e.roles.some((r) => set.has(String(r).toLowerCase()));
+
+    const unsMap = signals
+      .filter((s) => s.unsPath)
+      .map((s) => ({ tagName: s.tagName, unsPath: s.unsPath, i3xElementId: s.i3xElementId }));
+
+    const accepted = signals.filter((s) => s.status === "accepted").length;
+    const confidences = signals.map((s) => s.confidence).filter((v): v is number => v != null);
+    const avgConfidence =
+      confidences.length > 0
+        ? Number((confidences.reduce((a, b) => a + b, 0) / confidences.length).toFixed(3))
+        : null;
+
+    return NextResponse.json({
+      batch: {
+        id: head.id,
+        projectId: head.project_id,
+        projectName: head.project_name,
+        ingestRoute: head.ingest_route,
+        bundleSha256: head.bundle_sha256,
+        reviewStatus: head.review_status,
+        createdAt: head.created_at,
+        updatedAt: head.updated_at,
+      },
+      sources: sources.map((s) => ({
+        id: s.id,
+        sourceType: s.source_type,
+        fileName: s.file_name,
+        status: s.status,
+        sha256: s.source_sha256,
+        createdAt: s.created_at,
+      })),
+      // Evidence is currently carried inline on each extraction; surface the
+      // aggregate count until the offline bundle ships a dedicated evidence.json.
+      evidence: signals
+        .filter((s) => s.evidenceCount > 0)
+        .map((s) => ({ tagName: s.tagName, evidenceCount: s.evidenceCount })),
+      extractedSignals: signals,
+      faultCatalog: signals.filter((s) => hasRole(s, FAULT_ROLES)),
+      parameters: signals.filter((s) => hasRole(s, PARAM_ROLES)),
+      unsMap,
+      scorecard: {
+        sources: sources.length,
+        signals: signals.length,
+        mappedUns: unsMap.length,
+        accepted,
+        avgConfidence,
+      },
+    });
+  } catch (err) {
+    console.error("[api/contextualization/batches/[batchId] GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}
+
+function countEvidence(ev: unknown): number {
+  if (Array.isArray(ev)) return ev.length;
+  if (ev && typeof ev === "object") return Object.keys(ev).length;
+  return 0;
+}

--- a/mira-hub/src/app/api/contextualization/batches/route.ts
+++ b/mira-hub/src/app/api/contextualization/batches/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from "next/server";
+import { sessionOr401 } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+
+export const dynamic = "force-dynamic";
+
+interface BatchRow {
+  id: string;
+  project_id: string;
+  project_name: string;
+  ingest_route: string;
+  bundle_sha256: string | null;
+  review_status: string;
+  source_count: string;
+  extraction_count: string;
+  accepted_count: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * GET /api/contextualization/batches
+ *
+ * The Review Queue feed. Lists every staged import batch for the tenant with
+ * its review_status (proposed | approved | rejected | needs_review) and live
+ * source / extraction / accepted counts. Newest first.
+ */
+export async function GET() {
+  if (!process.env.NEON_DATABASE_URL) {
+    return NextResponse.json({ error: "DB not configured" }, { status: 503 });
+  }
+  const ctx = await sessionOr401();
+  if (ctx instanceof NextResponse) return ctx;
+
+  try {
+    const rows = await withTenantContext(ctx.tenantId, (c) =>
+      c
+        .query<BatchRow>(
+          `SELECT
+              b.id,
+              b.project_id,
+              p.name AS project_name,
+              b.ingest_route,
+              b.bundle_sha256,
+              b.review_status,
+              COUNT(DISTINCT s.id)::text AS source_count,
+              COUNT(DISTINCT e.id)::text AS extraction_count,
+              COUNT(DISTINCT e.id) FILTER (WHERE e.status = 'accepted')::text AS accepted_count,
+              b.created_at,
+              b.updated_at
+           FROM ctx_import_batches b
+           JOIN contextualization_projects p ON p.id = b.project_id
+           LEFT JOIN ctx_sources s ON s.import_batch_id = b.id
+           LEFT JOIN ctx_extractions e ON e.source_id = s.id
+           WHERE b.tenant_id = $1::uuid
+           GROUP BY b.id, p.name
+           ORDER BY b.created_at DESC`,
+          [ctx.tenantId],
+        )
+        .then((r) => r.rows),
+    );
+
+    return NextResponse.json({
+      batches: rows.map((r) => ({
+        id: r.id,
+        projectId: r.project_id,
+        projectName: r.project_name,
+        ingestRoute: r.ingest_route,
+        bundleSha256: r.bundle_sha256,
+        reviewStatus: r.review_status,
+        sourceCount: Number(r.source_count),
+        extractionCount: Number(r.extraction_count),
+        acceptedCount: Number(r.accepted_count),
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+      })),
+    });
+  } catch (err) {
+    console.error("[api/contextualization/batches GET]", err);
+    return NextResponse.json({ error: "Query failed" }, { status: 500 });
+  }
+}

--- a/mira-hub/src/app/api/contextualization/import/import.integration.test.ts
+++ b/mira-hub/src/app/api/contextualization/import/import.integration.test.ts
@@ -1,0 +1,139 @@
+// Integration test: the contextualization import endpoint accepts the shared
+// HubV3 Intake Contract (PRD §2) and dedups sources by sha256 (PRD §6 test 1 + 3).
+//
+// Requires a Postgres test DB with migrations 055 + 056 applied and a
+// `factorylm_app` role present. Provide via env:
+//   TEST_DATABASE_URL=postgres://postgres:test@localhost:5440/postgres
+//
+// Local setup (see also docs/adr/0023-...):
+//   docker run --rm -d -p 5440:5432 -e POSTGRES_PASSWORD=test --name mira-ctx-test postgres:16
+//   psql ... -c "CREATE ROLE factorylm_app NOLOGIN; GRANT USAGE ON SCHEMA public TO factorylm_app;"
+//   psql ... -f mira-hub/db/migrations/055_contextualization.sql
+//   psql ... -f mira-hub/db/migrations/056_contextualization_intake.sql
+//   TEST_DATABASE_URL=... bunx vitest run --config vitest.config.ts \
+//     src/app/api/contextualization/import/import.integration.test.ts
+//
+// This file is *.integration.test.ts → excluded from the default `vitest run`
+// (vitest.config.ts), run via the integration lane.
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from "vitest";
+import type { Pool } from "pg";
+
+// Build the test pool (no SSL — the lib's default pool forces SSL, which a local
+// postgres:16 rejects) before imports, and inject it as the @/lib/db default so
+// withTenantContext runs against the test DB. require() in vi.hoisted is fine in vitest.
+const { testPool } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { Pool: PgPool } = require("pg");
+  return { testPool: new PgPool({ connectionString: process.env.TEST_DATABASE_URL }) as Pool };
+});
+vi.mock("@/lib/db", () => ({ default: testPool }));
+vi.mock("@/lib/session", () => ({ sessionOr401: vi.fn() }));
+
+import { POST } from "./route";
+import { sessionOr401 } from "@/lib/session";
+
+const TENANT = "000000c1-0000-0000-0000-0000000000c1";
+const SHA_A = "a".repeat(64);
+const SHA_SRC = "c".repeat(64);
+
+const sessionOr401Mock = vi.mocked(sessionOr401);
+
+function envelope(): Record<string, unknown> {
+  return {
+    contract_version: "contextualization-intake/v1",
+    ingest_route: "offline",
+    project_hint: "Garage Demo / Micro820 Conveyor",
+    bundle_sha256: SHA_A,
+    review_status: "proposed",
+    sources: [
+      {
+        source_sha256: SHA_SRC,
+        source_type: "st",
+        source_metadata: { file_name: "Micro820.st", mime: "text/plain", uploader: "mike" },
+      },
+    ],
+    proposed_signals: [
+      { tag_name: "Conv_Run", roles: ["output"], uns_path: "enterprise.garage.demo.conv.run", confidence: 0.9, source_sha256: SHA_SRC },
+    ],
+  };
+}
+
+function jsonReq(body: unknown): Request {
+  return new Request("http://test/api/contextualization/import", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeAll(() => {
+  if (!process.env.TEST_DATABASE_URL) {
+    throw new Error("TEST_DATABASE_URL is required for the import integration test. See header.");
+  }
+  process.env.NEON_DATABASE_URL = process.env.TEST_DATABASE_URL; // satisfy the route's 503 guard
+});
+
+afterAll(async () => {
+  await testPool.end();
+});
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  // superuser connection bypasses RLS for cleanup; CASCADE clears sources/batches/extractions.
+  await testPool.query("DELETE FROM contextualization_projects WHERE tenant_id = $1", [TENANT]);
+  sessionOr401Mock.mockResolvedValue({
+    userId: "u_test",
+    tenantId: TENANT,
+    email: "tester@example.com",
+    status: "active",
+    trialExpiresAt: null,
+  });
+});
+
+describe("POST /api/contextualization/import — intake contract", () => {
+  it("accepts the intake contract and stages a project + source + extraction (test 1)", async () => {
+    const res = await POST(jsonReq(envelope()));
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.sources).toBe(1);
+    expect(body.extractions).toBe(1);
+
+    const proj = await testPool.query("SELECT count(*)::int AS n FROM contextualization_projects WHERE tenant_id=$1", [TENANT]);
+    expect(proj.rows[0].n).toBe(1);
+  });
+
+  it("does not duplicate a source with the same sha256 on re-import (test 3)", async () => {
+    const first = await POST(jsonReq(envelope()));
+    expect(first.status).toBe(201);
+    const second = await POST(jsonReq(envelope()));
+    expect(second.status).toBe(201);
+
+    const src = await testPool.query(
+      "SELECT count(*)::int AS n FROM ctx_sources WHERE tenant_id=$1 AND source_sha256=$2",
+      [TENANT, SHA_SRC],
+    );
+    expect(src.rows[0].n).toBe(1); // deduped — exactly one source row.
+
+    const proj = await testPool.query("SELECT count(*)::int AS n FROM contextualization_projects WHERE tenant_id=$1", [TENANT]);
+    expect(proj.rows[0].n).toBe(1); // bundle dedup — one project.
+  });
+
+  it("everything lands proposed — batch review_status=proposed, no accepted extraction", async () => {
+    await POST(jsonReq(envelope()));
+    const batch = await testPool.query("SELECT review_status FROM ctx_import_batches WHERE tenant_id=$1", [TENANT]);
+    expect(batch.rows[0].review_status).toBe("proposed");
+    const accepted = await testPool.query(
+      "SELECT count(*)::int AS n FROM ctx_extractions WHERE tenant_id=$1 AND status='accepted'",
+      [TENANT],
+    );
+    expect(accepted.rows[0].n).toBe(0);
+  });
+
+  it("rejects a malformed contract with 400", async () => {
+    const bad = { ...envelope(), ingest_route: "pigeon" };
+    const res = await POST(jsonReq(bad));
+    expect(res.status).toBe(400);
+  });
+});

--- a/mira-hub/src/app/api/contextualization/import/route.ts
+++ b/mira-hub/src/app/api/contextualization/import/route.ts
@@ -1,8 +1,14 @@
 import { NextResponse } from "next/server";
+import type { PoolClient } from "pg";
 import { sessionOr401 } from "@/lib/session";
 import { withTenantContext } from "@/lib/tenant-context";
 import { readZipEntries } from "@/lib/contextualization/unzip";
 import { parseBundle } from "@/lib/contextualization/bundle-import";
+import {
+  validateIntakeContract,
+  intakeContractToImport,
+  type ContractImport,
+} from "@/lib/contextualization/intake-contract";
 
 export const dynamic = "force-dynamic";
 
@@ -11,14 +17,16 @@ const SRC_STATUS = new Set(["pending", "processing", "done", "error"]);
 /**
  * POST /api/contextualization/import
  *
- * Closes the floor→cloud loop: ingest a Factory Context Bundle (bundle@1) produced offline by the
- * desktop FactoryLM Contextualizer, recreating a project + ctx_sources + ctx_extractions (preserving
- * the offline accept/reject status). The existing /promote flow then lands accepted signals in the
- * knowledge graph for admin review.
+ * Two intake shapes, chosen by content-type (HubV3 — Hub is system of record):
+ *  - application/json  → the shared Intake Contract (ADR-0023, PRD §2). Dedups
+ *    project/batch by bundle_sha256 and sources by source_sha256; everything
+ *    lands proposed (batch review_status='proposed', extractions 'pending').
+ *  - multipart/form-data (file=<bundle>.zip) → the offline Factory Context
+ *    Bundle (bundle@1), recreated into a project + ctx_sources + ctx_extractions
+ *    (legacy path; P5 migrates the offline client onto the contract).
  *
- * Multipart: file=<bundle>.zip. Document/knowledge_entries seeding is intentionally out of scope here
- * (that hybrid table has tenant-scoping footguns — see .claude/rules/knowledge-entries-tenant-scoping);
- * a follow-up wires it behind is_private=true once validated on staging.
+ * Document/knowledge_entries seeding stays out of scope here (that hybrid table
+ * has tenant-scoping footguns — see .claude/rules/knowledge-entries-tenant-scoping).
  */
 export async function POST(req: Request) {
   if (!process.env.NEON_DATABASE_URL) {
@@ -27,6 +35,162 @@ export async function POST(req: Request) {
   const ctx = await sessionOr401();
   if (ctx instanceof NextResponse) return ctx;
 
+  const contentType = req.headers.get("content-type") || "";
+  if (contentType.includes("application/json")) {
+    return importFromContract(ctx.tenantId, req);
+  }
+  return importFromBundle(ctx.tenantId, req);
+}
+
+// ── Intake Contract path (HubV3 §2) ─────────────────────────────────────────
+
+async function importFromContract(tenantId: string, req: Request) {
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Expected a JSON intake contract body" }, { status: 400 });
+  }
+
+  const { ok, errors, value } = validateIntakeContract(raw);
+  if (!ok || !value) {
+    return NextResponse.json({ error: "invalid intake contract", details: errors }, { status: 400 });
+  }
+  const imp = intakeContractToImport(value);
+
+  try {
+    const result = await withTenantContext(tenantId, async (c) => {
+      const projectId = await upsertProject(c, tenantId, imp);
+      const { batchId, isNew } = await upsertBatch(c, tenantId, projectId, imp);
+
+      // Re-import of an already-staged bundle is an idempotent no-op: the source
+      // ON CONFLICT below would dedup anyway, but skipping avoids re-inserting
+      // extractions (which have no natural unique key).
+      if (!isNew) {
+        return {
+          projectId,
+          importBatchId: batchId,
+          sources: imp.sources.length,
+          extractions: imp.extractions.length,
+          deduped: true,
+        };
+      }
+
+      // Insert sources (sha256 dedup), mapping each sha → its source row id so
+      // extractions attach to the right source even when a source was deduped.
+      const shaToSource = new Map<string, string>();
+      for (const s of imp.sources) {
+        const status = SRC_STATUS.has(s.status) ? s.status : "done";
+        const ins = await c.query<{ id: string }>(
+          `INSERT INTO ctx_sources
+             (tenant_id, project_id, import_batch_id, source_type, file_name, source_sha256, status)
+           VALUES ($1::uuid, $2, $3, $4, $5, $6, $7)
+           ON CONFLICT (tenant_id, source_sha256) WHERE source_sha256 IS NOT NULL DO NOTHING
+           RETURNING id`,
+          [tenantId, projectId, batchId, s.sourceType, s.fileName, s.sourceSha256, status],
+        );
+        let sid = ins.rows[0]?.id;
+        if (!sid) {
+          const sel = await c.query<{ id: string }>(
+            `SELECT id FROM ctx_sources WHERE tenant_id = $1::uuid AND source_sha256 = $2`,
+            [tenantId, s.sourceSha256],
+          );
+          sid = sel.rows[0].id;
+        }
+        shaToSource.set(s.sourceSha256, sid);
+      }
+      const defaultSource = shaToSource.values().next().value as string;
+
+      let extractions = 0;
+      for (const e of imp.extractions) {
+        const sid = (e.sourceSha256 && shaToSource.get(e.sourceSha256)) || defaultSource;
+        await c.query(
+          `INSERT INTO ctx_extractions
+             (tenant_id, project_id, source_id, tag_name, roles, uns_path_proposed,
+              i3x_element_id, evidence_json, confidence, status)
+           VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10)`,
+          [
+            tenantId, projectId, sid, e.tagName, e.roles, e.unsPathProposed,
+            e.i3xElementId, JSON.stringify(e.evidenceJson), e.confidence, e.status,
+          ],
+        );
+        extractions++;
+      }
+
+      await c.query(
+        `UPDATE ctx_import_batches SET source_count = $2, extraction_count = $3 WHERE id = $1`,
+        [batchId, imp.sources.length, extractions],
+      );
+
+      return { projectId, importBatchId: batchId, sources: imp.sources.length, extractions, deduped: false };
+    });
+
+    return NextResponse.json({ ok: true, ...result }, { status: 201 });
+  } catch (err) {
+    console.error("[api/contextualization/import POST contract]", err);
+    return NextResponse.json({ error: "Import failed" }, { status: 500 });
+  }
+}
+
+/** Upsert a project by (tenant_id, bundle_sha256); returns its id. */
+async function upsertProject(c: PoolClient, tenantId: string, imp: ContractImport): Promise<string> {
+  const name = `${imp.projectName} (imported)`;
+  if (imp.bundleSha256) {
+    const ins = await c.query<{ id: string }>(
+      `INSERT INTO contextualization_projects (tenant_id, name, description, bundle_sha256)
+         VALUES ($1::uuid, $2, $3, $4)
+         ON CONFLICT (tenant_id, bundle_sha256) WHERE bundle_sha256 IS NOT NULL DO NOTHING
+         RETURNING id`,
+      [tenantId, name, imp.description, imp.bundleSha256],
+    );
+    if (ins.rows[0]) return ins.rows[0].id;
+    const sel = await c.query<{ id: string }>(
+      `SELECT id FROM contextualization_projects WHERE tenant_id = $1::uuid AND bundle_sha256 = $2`,
+      [tenantId, imp.bundleSha256],
+    );
+    return sel.rows[0].id;
+  }
+  const ins = await c.query<{ id: string }>(
+    `INSERT INTO contextualization_projects (tenant_id, name, description)
+       VALUES ($1::uuid, $2, $3) RETURNING id`,
+    [tenantId, name, imp.description],
+  );
+  return ins.rows[0].id;
+}
+
+/** Upsert an import batch by (tenant_id, bundle_sha256); isNew=false means the bundle was already imported. */
+async function upsertBatch(
+  c: PoolClient,
+  tenantId: string,
+  projectId: string,
+  imp: ContractImport,
+): Promise<{ batchId: string; isNew: boolean }> {
+  if (imp.bundleSha256) {
+    const ins = await c.query<{ id: string }>(
+      `INSERT INTO ctx_import_batches (tenant_id, project_id, ingest_route, bundle_sha256)
+         VALUES ($1::uuid, $2, $3, $4)
+         ON CONFLICT (tenant_id, bundle_sha256) WHERE bundle_sha256 IS NOT NULL DO NOTHING
+         RETURNING id`,
+      [tenantId, projectId, imp.ingestRoute, imp.bundleSha256],
+    );
+    if (ins.rows[0]) return { batchId: ins.rows[0].id, isNew: true };
+    const sel = await c.query<{ id: string }>(
+      `SELECT id FROM ctx_import_batches WHERE tenant_id = $1::uuid AND bundle_sha256 = $2`,
+      [tenantId, imp.bundleSha256],
+    );
+    return { batchId: sel.rows[0].id, isNew: false };
+  }
+  const ins = await c.query<{ id: string }>(
+    `INSERT INTO ctx_import_batches (tenant_id, project_id, ingest_route)
+       VALUES ($1::uuid, $2, $3) RETURNING id`,
+    [tenantId, projectId, imp.ingestRoute],
+  );
+  return { batchId: ins.rows[0].id, isNew: true };
+}
+
+// ── Offline bundle path (legacy, multipart) ─────────────────────────────────
+
+async function importFromBundle(tenantId: string, req: Request) {
   let form: FormData;
   try {
     form = await req.formData();
@@ -55,12 +219,12 @@ export async function POST(req: Request) {
   }
 
   try {
-    const result = await withTenantContext(ctx.tenantId, async (c) => {
+    const result = await withTenantContext(tenantId, async (c) => {
       const proj = await c
         .query<{ id: string }>(
           `INSERT INTO contextualization_projects (tenant_id, name, description)
              VALUES ($1::uuid, $2, $3) RETURNING id`,
-          [ctx.tenantId, `${parsed.projectName} (imported)`, parsed.description],
+          [tenantId, `${parsed.projectName} (imported)`, parsed.description],
         )
         .then((r) => r.rows[0]);
       const projectId = proj.id;
@@ -73,7 +237,7 @@ export async function POST(req: Request) {
           .query<{ id: string }>(
             `INSERT INTO ctx_sources (tenant_id, project_id, source_type, file_name, status)
                VALUES ($1::uuid, $2, $3, $4, $5) RETURNING id`,
-            [ctx.tenantId, projectId, s.sourceType, s.fileName, status],
+            [tenantId, projectId, s.sourceType, s.fileName, status],
           )
           .then((r) => r.rows[0]);
         fileToSource.set(s.fileName, row.id);
@@ -85,7 +249,7 @@ export async function POST(req: Request) {
           .query<{ id: string }>(
             `INSERT INTO ctx_sources (tenant_id, project_id, source_type, file_name, status)
                VALUES ($1::uuid, $2, 'other', 'imported', 'done') RETURNING id`,
-            [ctx.tenantId, projectId],
+            [tenantId, projectId],
           )
           .then((r) => r.rows[0].id);
       }
@@ -99,7 +263,7 @@ export async function POST(req: Request) {
               i3x_element_id, evidence_json, confidence, status)
            VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10)`,
           [
-            ctx.tenantId, projectId, sid, e.tagName, e.roles, e.unsPathProposed,
+            tenantId, projectId, sid, e.tagName, e.roles, e.unsPathProposed,
             e.i3xElementId, JSON.stringify(e.evidenceJson), e.confidence, e.status,
           ],
         );

--- a/mira-hub/src/lib/contextualization/approval.test.ts
+++ b/mira-hub/src/lib/contextualization/approval.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  IMPORT_APPROVAL_STATE,
+  PUBLISHED_APPROVAL_STATE,
+  decidePromotion,
+  decidePublish,
+  decideBatchReview,
+  parseReviewDecision,
+  buildEntityInsert,
+  buildPublishEntityUpdate,
+} from "./approval";
+
+// HubV3 Phase 4 acceptance — PRD §6 test matrix.
+// These prove the *decision logic* and the *SQL no-overwrite guard*.
+// (A live re-import is an integration concern; NeonDB-SSL-on-Windows blocks it
+// locally — see PR notes. The SQL guard below is the real enforcement: delete
+// the WHERE clause and these go red.)
+
+describe("test 7 — imported proposals do not overwrite approved Hub data", () => {
+  it("import-time promote SKIPS an already-verified entity with a protected reason", () => {
+    const d = decidePromotion({ approval_state: "verified" });
+    expect(d.action).toBe("skip");
+    expect(d.protectedRow).toBe(true);
+    expect(d.reason).toMatch(/not overwrite/i);
+  });
+
+  it("import-time promote SKIPS a deprecated entity (protected)", () => {
+    const d = decidePromotion({ approval_state: "deprecated" });
+    expect(d.action).toBe("skip");
+    expect(d.protectedRow).toBe(true);
+  });
+
+  it("re-approval cannot mutate an already-verified entity", () => {
+    const d = decidePublish({ approval_state: "verified" });
+    expect(d.action).toBe("skip");
+  });
+
+  it("the publish UPDATE carries the no-overwrite SQL guard", () => {
+    const q = buildPublishEntityUpdate({
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      name: "conv_run",
+      propertiesJson: "{}",
+    });
+    // Verified/deprecated rows must be untouchable at the DB layer.
+    expect(q.text).toMatch(/approval_state\s+NOT IN\s*\(\s*'verified'\s*,\s*'deprecated'\s*\)/i);
+    expect(q.text).toMatch(/SET[\s\S]*approval_state\s*=\s*'verified'/i);
+  });
+
+  it("the stage INSERT uses the live natural-key conflict target, never entity_id", () => {
+    const q = buildEntityInsert({
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      name: "conv_run",
+      unsPath: "enterprise.garage.demo_cell.conveyor.conv_run",
+      ltreePath: "enterprise.garage.demo_cell.conveyor.conv_run",
+      propertiesJson: "{}",
+      approvalState: "proposed",
+    });
+    expect(q.text).toMatch(/ON CONFLICT\s*\(\s*tenant_id\s*,\s*entity_type\s*,\s*name\s*\)\s*DO NOTHING/i);
+    expect(q.text).not.toMatch(/ON CONFLICT[^)]*entity_id/i);
+  });
+});
+
+describe("test 8 — UNS/i3X remain proposed until approved", () => {
+  it("a freshly staged entity lands as 'proposed', never 'verified'", () => {
+    expect(IMPORT_APPROVAL_STATE).toBe("proposed");
+    const d = decidePromotion(null);
+    expect(d.action).toBe("insert");
+    expect(d.approvalState).toBe("proposed");
+  });
+
+  it("import-time promote never writes a verified entity (no auto-publish)", () => {
+    const q = buildEntityInsert({
+      tenantId: "11111111-1111-1111-1111-111111111111",
+      name: "conv_run",
+      unsPath: "enterprise.garage.demo_cell.conveyor.conv_run",
+      ltreePath: "enterprise.garage.demo_cell.conveyor.conv_run",
+      propertiesJson: "{}",
+      approvalState: IMPORT_APPROVAL_STATE,
+    });
+    expect(q.values).toContain("proposed");
+    expect(q.values).not.toContain("verified");
+  });
+
+  it("only the approve decision publishes; reject/needs_review never publish", () => {
+    expect(PUBLISHED_APPROVAL_STATE).toBe("verified");
+    expect(decideBatchReview("proposed", "approve")).toEqual({ status: "approved", publish: true });
+    expect(decideBatchReview("proposed", "reject")).toEqual({ status: "rejected", publish: false });
+    expect(decideBatchReview("proposed", "needs_review")).toEqual({ status: "needs_review", publish: false });
+  });
+
+  it("publishing elevates a previously-proposed entity to verified", () => {
+    const d = decidePublish({ approval_state: "proposed" });
+    expect(d.action).toBe("update");
+  });
+
+  it("publishing an absent entity inserts it directly as verified (the human approval IS the verification)", () => {
+    const d = decidePublish(null);
+    expect(d.action).toBe("insert");
+  });
+});
+
+describe("parseReviewDecision — request guard", () => {
+  it("accepts the three valid decisions", () => {
+    expect(parseReviewDecision("approve")).toBe("approve");
+    expect(parseReviewDecision("reject")).toBe("reject");
+    expect(parseReviewDecision("needs_review")).toBe("needs_review");
+  });
+
+  it("rejects anything else (no auto-approve via a bogus value)", () => {
+    expect(parseReviewDecision("approved")).toBeNull();
+    expect(parseReviewDecision("verified")).toBeNull();
+    expect(parseReviewDecision("")).toBeNull();
+    expect(parseReviewDecision(undefined)).toBeNull();
+    expect(parseReviewDecision(42)).toBeNull();
+  });
+});

--- a/mira-hub/src/lib/contextualization/approval.ts
+++ b/mira-hub/src/lib/contextualization/approval.ts
@@ -1,0 +1,207 @@
+// HubV3 Phase 4 — approval gate decision logic + SQL builders.
+//
+// Hub owns truth. Imported (offline/telegram/hub_upload) proposals land as
+// `proposed`. A human approval — and ONLY a human approval — publishes them
+// (proposed → verified). Nothing here ever auto-promotes (ADR-0017; KG Iron
+// Rule: "MIRA proposes, the human verifies").
+//
+// The pure functions below are the single source of decision truth, shared by
+// the promote route (import-time staging) and the batch-review route
+// (approval-time publish). The SQL builders carry the no-overwrite guard at the
+// DB layer so verified/deprecated rows are untouchable even under a race.
+
+/** kg_entities.approval_state CHECK (migration 029). */
+export type EntityApprovalState =
+  | "proposed"
+  | "verified"
+  | "rejected"
+  | "needs_review"
+  | "deprecated";
+
+/** ctx_import_batches.review_status CHECK (migration 056). */
+export type BatchReviewStatus = "proposed" | "approved" | "rejected" | "needs_review";
+
+/** What a human can decide about a staged import batch. */
+export type ReviewDecision = "approve" | "reject" | "needs_review";
+
+const REVIEW_DECISIONS: ReadonlySet<string> = new Set([
+  "approve",
+  "reject",
+  "needs_review",
+]);
+
+/** Validate a request body's `decision` field. Returns the decision or null. */
+export function parseReviewDecision(value: unknown): ReviewDecision | null {
+  return typeof value === "string" && REVIEW_DECISIONS.has(value)
+    ? (value as ReviewDecision)
+    : null;
+}
+
+/** Everything imported lands here. Never `verified` at import time. */
+export const IMPORT_APPROVAL_STATE: EntityApprovalState = "proposed";
+
+/** The published state — only a human approval writes this. */
+export const PUBLISHED_APPROVAL_STATE: EntityApprovalState = "verified";
+
+/** Approved Hub data that import/publish must never overwrite. */
+const PROTECTED_STATES: ReadonlySet<EntityApprovalState> = new Set([
+  "verified",
+  "deprecated",
+]);
+
+export interface PromotionDecision {
+  action: "insert" | "skip";
+  /** present when action === "insert" */
+  approvalState?: EntityApprovalState;
+  /** present when action === "skip" */
+  reason?: string;
+  /** true when the skip is because the existing row is approved/protected */
+  protectedRow?: boolean;
+}
+
+/**
+ * Import-time staging decision. Stages a proposed entity when absent; refuses
+ * to overwrite approved (verified/deprecated) data; leaves other staged states
+ * untouched (idempotent re-import).
+ */
+export function decidePromotion(
+  existing: { approval_state: EntityApprovalState } | null,
+): PromotionDecision {
+  if (!existing) {
+    return { action: "insert", approvalState: IMPORT_APPROVAL_STATE };
+  }
+  if (PROTECTED_STATES.has(existing.approval_state)) {
+    return {
+      action: "skip",
+      protectedRow: true,
+      reason: `entity already ${existing.approval_state} — import will not overwrite approved data`,
+    };
+  }
+  return {
+    action: "skip",
+    protectedRow: false,
+    reason: `entity already staged (${existing.approval_state}) — left unchanged`,
+  };
+}
+
+export interface PublishDecision {
+  action: "insert" | "update" | "skip";
+  reason?: string;
+}
+
+/**
+ * Approval-time publish decision (runs inside the human approve action).
+ * - absent           → insert directly as verified (the approval IS the verification)
+ * - proposed/needs_review → update to verified
+ * - verified         → skip (idempotent re-approve)
+ * - rejected/deprecated   → skip (a human already declined/retired it)
+ */
+export function decidePublish(
+  existing: { approval_state: EntityApprovalState } | null,
+): PublishDecision {
+  if (!existing) return { action: "insert" };
+  switch (existing.approval_state) {
+    case "proposed":
+    case "needs_review":
+      return { action: "update" };
+    case "verified":
+      return { action: "skip", reason: "already verified" };
+    case "rejected":
+      return { action: "skip", reason: "previously rejected by a human" };
+    case "deprecated":
+      return { action: "skip", reason: "deprecated" };
+  }
+}
+
+export interface BatchReviewOutcome {
+  status: BatchReviewStatus;
+  publish: boolean;
+}
+
+/**
+ * Maps a human review decision to the batch's new review_status and whether it
+ * triggers publishing. Only `approve` publishes — never auto.
+ */
+export function decideBatchReview(
+  _current: BatchReviewStatus,
+  decision: ReviewDecision,
+): BatchReviewOutcome {
+  switch (decision) {
+    case "approve":
+      return { status: "approved", publish: true };
+    case "reject":
+      return { status: "rejected", publish: false };
+    case "needs_review":
+      return { status: "needs_review", publish: false };
+  }
+}
+
+// ─── SQL builders ───────────────────────────────────────────────────────────
+// Kept pure (return {text, values}) so the no-overwrite guard and the correct
+// conflict target are unit-testable without a live DB.
+
+export interface BuiltQuery {
+  text: string;
+  values: unknown[];
+}
+
+export interface EntityInsertParams {
+  tenantId: string;
+  name: string; // tag_name — the live natural key (tenant_id, entity_type, name)
+  unsPath: string;
+  ltreePath: string;
+  propertiesJson: string;
+  approvalState: EntityApprovalState;
+}
+
+/**
+ * INSERT a signal entity. Conflict target is the LIVE natural key
+ * (tenant_id, entity_type, name) — migration 026 dropped the old
+ * (tenant_id, entity_type, entity_id) unique, so the spine's entity_id-based
+ * ON CONFLICT referenced a non-existent constraint (latent runtime error).
+ */
+export function buildEntityInsert(p: EntityInsertParams): BuiltQuery {
+  return {
+    text: `INSERT INTO kg_entities
+             (tenant_id, entity_type, entity_id, name, properties,
+              approval_state, uns_path)
+           VALUES ($1::uuid, 'signal', $2, $3, $4::jsonb, $5, $6::ltree)
+           ON CONFLICT (tenant_id, entity_type, name) DO NOTHING
+           RETURNING id`,
+    values: [
+      p.tenantId,
+      p.unsPath,
+      p.name,
+      p.propertiesJson,
+      p.approvalState,
+      p.ltreePath,
+    ],
+  };
+}
+
+export interface PublishEntityUpdateParams {
+  tenantId: string;
+  name: string;
+  propertiesJson: string;
+}
+
+/**
+ * Publish (proposed → verified) a previously-staged signal entity. The WHERE
+ * guard is the real no-overwrite enforcement: verified/deprecated rows are
+ * untouchable at the DB layer. Returns 0 rows when the row is protected or
+ * absent (caller falls back to an insert when truly absent).
+ */
+export function buildPublishEntityUpdate(p: PublishEntityUpdateParams): BuiltQuery {
+  return {
+    text: `UPDATE kg_entities
+              SET approval_state = 'verified',
+                  properties = properties || $3::jsonb,
+                  updated_at = now()
+            WHERE tenant_id = $1::uuid
+              AND entity_type = 'signal'
+              AND name = $2
+              AND approval_state NOT IN ('verified', 'deprecated')
+          RETURNING id`,
+    values: [p.tenantId, p.name, p.propertiesJson],
+  };
+}

--- a/mira-hub/src/lib/contextualization/asset-matcher.test.ts
+++ b/mira-hub/src/lib/contextualization/asset-matcher.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyAsset, fromEquipmentRow, type EquipmentRow } from "./asset-matcher";
+
+// A small fleet of existing assets to classify incoming contextualization identity against.
+const AB_DRIVE: EquipmentRow = {
+  id: "asset-ab-drive",
+  manufacturer: "Allen-Bradley",
+  model: "PowerFlex 525",
+  serialNumber: "SN-123",
+};
+
+describe("classifyAsset — PRD §6 tests 4/5/6 (strong / none / probable)", () => {
+  it("test 4: a strong (unique-id) match stages under the existing asset, still proposed", () => {
+    // serial number is an instance-unique key; normalization absorbs case/punctuation/whitespace
+    const m = classifyAsset(
+      { serialNumber: " sn-123 ", manufacturer: "allen bradley" },
+      [AB_DRIVE],
+    );
+    expect(m.strength).toBe("strong");
+    expect(m.decision).toBe("existing_asset");
+    expect(m.matchedAssetId).toBe("asset-ab-drive");
+    expect(m.matchedFields).toContain("serialNumber");
+    // NEVER auto-verify — even a strong match lands as proposed for admin approval
+    expect(m.approvalState).toBe("proposed");
+  });
+
+  it("test 5: no overlap creates a draft asset proposal (no existing asset)", () => {
+    const m = classifyAsset(
+      { manufacturer: "Siemens", model: "S7-1200", serialNumber: "XYZ-999" },
+      [AB_DRIVE],
+    );
+    expect(m.strength).toBe("none");
+    expect(m.decision).toBe("draft_asset");
+    expect(m.matchedAssetId).toBeNull();
+    expect(m.approvalState).toBe("proposed");
+  });
+
+  it("test 6: a probable (model-level only) match requires human confirmation", () => {
+    // manufacturer + model agree but there is NO instance-unique key → cannot auto-stage
+    const m = classifyAsset({ manufacturer: "Allen-Bradley", model: "PowerFlex 525" }, [
+      { id: "asset-2", manufacturer: "Allen-Bradley", model: "PowerFlex 525" },
+    ]);
+    expect(m.strength).toBe("probable");
+    expect(m.decision).toBe("needs_confirmation");
+    expect(m.matchedAssetId).toBe("asset-2");
+    expect(m.approvalState).toBe("proposed");
+  });
+
+  it("a unique UNS path match is also strong", () => {
+    const m = classifyAsset({ proposedUnsPath: "enterprise/garage/cv_101" }, [
+      { id: "asset-uns", proposedUnsPath: "enterprise.garage.cv_101" },
+    ]);
+    expect(m.strength).toBe("strong");
+    expect(m.decision).toBe("existing_asset");
+    expect(m.matchedAssetId).toBe("asset-uns");
+  });
+});
+
+describe("classifyAsset — adversarial: no false-merge, no missed-match", () => {
+  it("FALSE-MERGE GUARD: same mfr+model but a CONFLICTING serial is never strong", () => {
+    // identical drive model, different physical unit → must NOT auto-stage under the existing asset
+    const m = classifyAsset(
+      { manufacturer: "Allen-Bradley", model: "PowerFlex 525", serialNumber: "SN-BBB" },
+      [AB_DRIVE], // serial SN-123
+    );
+    expect(m.strength).not.toBe("strong");
+    expect(m.decision).not.toBe("existing_asset");
+    expect(m.strength).toBe("none"); // a conflicting instance-id means a different asset
+    expect(m.conflictFields).toContain("serialNumber");
+  });
+
+  it("AMBIGUITY GUARD: two equally-strong candidates downgrade to needs_confirmation", () => {
+    // duplicate serials in the asset registry → identity is ambiguous, do not pick one blindly
+    const m = classifyAsset({ serialNumber: "DUP" }, [
+      { id: "asset-a", serialNumber: "DUP" },
+      { id: "asset-b", serialNumber: "DUP" },
+    ]);
+    expect(m.decision).toBe("needs_confirmation");
+    expect(m.decision).not.toBe("existing_asset");
+    expect(m.strength).toBe("probable");
+  });
+
+  it("MISSED-MATCH GUARD: normalization catches formatting differences (mfr+model)", () => {
+    const m = classifyAsset(
+      { manufacturer: "allen  bradley", model: "2080 lc50 24qwb" },
+      [{ id: "asset-4", manufacturer: "Allen-Bradley", model: "2080-LC50-24QWB" }],
+    );
+    expect(m.strength).toBe("probable");
+    expect(m.matchedAssetId).toBe("asset-4");
+  });
+
+  it("FALSE-MERGE GUARD: a placeholder serial (N/A) is not a strong identity match", () => {
+    // CMMS registries are full of "N/A"/"0"/"UNKNOWN" serials — two different assets sharing a
+    // placeholder must NOT auto-merge. The placeholder carries no identity, so fall back to model-level.
+    const m = classifyAsset(
+      { manufacturer: "Allen-Bradley", model: "PowerFlex 525", serialNumber: "N/A" },
+      [{ id: "ph-1", manufacturer: "Allen-Bradley", model: "PowerFlex 525", serialNumber: "N/A" }],
+    );
+    expect(m.strength).not.toBe("strong");
+    expect(m.decision).not.toBe("existing_asset");
+    expect(m.strength).toBe("probable"); // mfr+model still corroborate → confirm, don't merge
+  });
+
+  it("FALSE-MERGE GUARD: a too-short unique id is not strong on its own", () => {
+    const m = classifyAsset({ serialNumber: "7" }, [{ id: "short-1", serialNumber: "7" }]);
+    expect(m.strength).not.toBe("strong");
+    expect(m.decision).not.toBe("existing_asset");
+  });
+
+  it("a controller IP alone is only probable; corroborated by PLC program it is strong", () => {
+    const ipOnly = classifyAsset({ controllerIp: "192.168.1.50" }, [
+      { id: "ctrl-1", controllerIp: "192.168.1.50" },
+    ]);
+    expect(ipOnly.strength).toBe("probable");
+
+    const corroborated = classifyAsset(
+      { controllerIp: "192.168.1.50", plcProgramName: "Conv_Simple" },
+      [{ id: "ctrl-1", controllerIp: "192.168.1.50", plcProgramName: "Conv_Simple" }],
+    );
+    expect(corroborated.strength).toBe("strong");
+  });
+});
+
+describe("fromEquipmentRow — maps a cmms_equipment row to the matcher shape", () => {
+  it("maps the real snake_case columns", () => {
+    const row = fromEquipmentRow({
+      id: "eq-1",
+      equipment_number: "CV-101",
+      manufacturer: "Allen-Bradley",
+      model_number: "2080-LC50-24QWB",
+      serial_number: "SN-123",
+      uns_path: "enterprise.garage.cv_101",
+    });
+    expect(row).toEqual({
+      id: "eq-1",
+      assetNumber: "CV-101",
+      manufacturer: "Allen-Bradley",
+      model: "2080-LC50-24QWB",
+      serialNumber: "SN-123",
+      proposedUnsPath: "enterprise.garage.cv_101",
+    });
+  });
+});

--- a/mira-hub/src/lib/contextualization/asset-matcher.ts
+++ b/mira-hub/src/lib/contextualization/asset-matcher.ts
@@ -1,0 +1,282 @@
+/**
+ * Asset matching for HubV3 contextualization intake (PRD §2 "Import behavior", §5 Phase 3).
+ *
+ * Classifies an incoming asset identity (the manifest `asset_match` block / project profile of an
+ * imported bundle) against the tenant's existing `cmms_equipment` rows as `strong | probable | none`,
+ * and maps that to a staging decision:
+ *   strong   → stage proposals under the existing asset   (`existing_asset`)
+ *   probable → require human confirmation                 (`needs_confirmation`)
+ *   none     → create a draft asset proposal              (`draft_asset`)
+ *
+ * Design goals (the adversarial bar): no FALSE-MERGE (never auto-stage under the wrong asset) and no
+ * MISSED-MATCH (formatting noise must not hide a real match). Two ideas carry that weight:
+ *   - Tiered evidence: only INSTANCE-unique keys (serial, asset number, proposed UNS path, or a
+ *     controller IP corroborated by another field) can make a match `strong`. MODEL-level descriptors
+ *     (manufacturer, model, controller type, PLC program, name) only ever reach `probable` — two
+ *     identical drives must not merge.
+ *   - Conflict guard: if BOTH sides carry a unique instance id and they disagree, the row is a
+ *     different asset → capped at `none` (the safe direction: a draft a human can still merge).
+ *   - Ambiguity guard: two equally-strong candidates downgrade to `needs_confirmation`.
+ *
+ * Everything lands `approval_state = "proposed"` — matching NEVER auto-verifies (ADR-0017). This module
+ * is pure + DB-free so it is unit-testable without migration 056; `persistAssetMatches` is the thin
+ * writer that lands rows in `ctx_extraction_asset_matches` (shape owned by migration 056, PRD §4.1).
+ */
+
+export type MatchStrength = "strong" | "probable" | "none";
+export type StagingDecision = "existing_asset" | "needs_confirmation" | "draft_asset";
+
+/** Asset-identity hints from an imported bundle (manifest `asset_match` / project profile). */
+export interface AssetHints {
+  assetNumber?: string | null;
+  name?: string | null;
+  manufacturer?: string | null;
+  model?: string | null;
+  serialNumber?: string | null;
+  controllerType?: string | null;
+  controllerIp?: string | null;
+  plcProgramName?: string | null;
+  proposedUnsPath?: string | null;
+}
+
+/** An existing asset to match against (normalized projection of a `cmms_equipment` row). */
+export interface EquipmentRow extends AssetHints {
+  id: string;
+}
+
+export interface AssetMatch {
+  strength: MatchStrength;
+  decision: StagingDecision;
+  /** The existing asset to stage under (strong) or confirm against (probable); null for a draft. */
+  matchedAssetId: string | null;
+  confidence: number; // 0..1, banded by strength
+  matchedFields: string[]; // evidence: which identity fields agreed
+  conflictFields: string[]; // unique-id fields that disagreed (drove a downgrade)
+  /** Imported matches are never auto-verified — admin approval promotes them later. */
+  approvalState: "proposed";
+}
+
+// Instance-unique identity keys: an exact agreement identifies the SAME physical asset; a
+// disagreement identifies a DIFFERENT one. These can make a match strong and can veto one.
+const UNIQUE_KEYS = ["serialNumber", "assetNumber", "proposedUnsPath"] as const;
+// Model-level descriptors: corroborating evidence only — never strong on their own.
+const DESCRIPTOR_KEYS = ["manufacturer", "model", "controllerType", "plcProgramName", "name"] as const;
+
+type Field = keyof AssetHints;
+
+// Sentinel "I don't know" values that pollute CMMS registries. They carry NO identity, so a match on
+// one must never merge two assets — treat them as absent everywhere (normalize to null).
+const PLACEHOLDERS = new Set([
+  "na", "nan", "none", "null", "nil", "unknown", "unk", "tbd", "tba", "pending", "default",
+  "notavailable", "notapplicable", "placeholder", "xxx", "xxxx", "xxxxx",
+  "0", "00", "000", "0000", "00000",
+]);
+// A strong (auto-merge) decision needs an instance-unique id with real entropy. 1–2 char "serials"
+// are implausibly unique and a frequent data-entry artifact, so they can corroborate but never merge.
+const MIN_STRONG_ID_LEN = 3;
+
+/** Normalize for comparison: lowercase, separators/punctuation → nothing, whitespace collapsed.
+ * Absorbs "Allen-Bradley" vs "allen bradley" and "enterprise/garage/cv_101" vs "enterprise.garage.cv_101".
+ * Returns null for empty and for known placeholder/sentinel values (which convey no identity). */
+function norm(v: string | null | undefined): string | null {
+  if (v == null) return null;
+  const s = v.toLowerCase().replace(/[^a-z0-9]+/g, "");
+  if (!s.length || PLACEHOLDERS.has(s)) return null;
+  return s;
+}
+
+function fieldsAgree(a: AssetHints, b: AssetHints, field: Field): boolean | null {
+  const na = norm(a[field]);
+  const nb = norm(b[field]);
+  if (na == null || nb == null) return null; // not comparable (one side absent)
+  return na === nb;
+}
+
+function band(strength: MatchStrength): number {
+  return strength === "strong" ? 0.9 : strength === "probable" ? 0.6 : 0;
+}
+
+function decisionFor(strength: MatchStrength): StagingDecision {
+  return strength === "strong"
+    ? "existing_asset"
+    : strength === "probable"
+      ? "needs_confirmation"
+      : "draft_asset";
+}
+
+interface RowVerdict {
+  strength: MatchStrength;
+  matchedFields: string[];
+  conflictFields: string[];
+}
+
+/** Classify the hints against a single equipment row. */
+function classifyRow(hints: AssetHints, row: EquipmentRow): RowVerdict {
+  const matched: string[] = [];
+  const conflict: string[] = [];
+
+  for (const k of [...UNIQUE_KEYS, ...DESCRIPTOR_KEYS]) {
+    const agree = fieldsAgree(hints, row, k);
+    if (agree === true) matched.push(k);
+    else if (agree === false && (UNIQUE_KEYS as readonly string[]).includes(k)) conflict.push(k);
+  }
+
+  // A disagreeing instance-unique id means a DIFFERENT asset — never merge. (Controller IP is not in
+  // UNIQUE_KEYS: IPs get reassigned, so an IP mismatch is not proof of a different asset.)
+  if (conflict.length) return { strength: "none", matchedFields: matched, conflictFields: conflict };
+
+  const has = (k: Field) => matched.includes(k);
+  // A unique-id only makes a match STRONG when its agreed value has real entropy (≥ MIN_STRONG_ID_LEN
+  // after normalization) — guards against ultra-short artifacts auto-merging distinct assets.
+  const strongId = (k: Field) => has(k) && (norm(hints[k])?.length ?? 0) >= MIN_STRONG_ID_LEN;
+  const strongUniqueHit = strongId("serialNumber") || strongId("assetNumber") || strongId("proposedUnsPath");
+  // A controller IP corroborated by a second field (PLC program / model / controller type) is strong;
+  // IP alone is only probable.
+  const ipAgree = fieldsAgree(hints, row, "controllerIp") === true;
+  const ipCorroborated =
+    ipAgree && (has("plcProgramName") || has("model") || has("controllerType"));
+
+  if (strongUniqueHit || ipCorroborated) {
+    return { strength: "strong", matchedFields: matched, conflictFields: conflict };
+  }
+
+  const modelLevel =
+    (has("manufacturer") && has("model")) || has("name") || has("plcProgramName") || ipAgree;
+  if (modelLevel) return { strength: "probable", matchedFields: matched, conflictFields: conflict };
+
+  return { strength: "none", matchedFields: matched, conflictFields: conflict };
+}
+
+const RANK: Record<MatchStrength, number> = { strong: 2, probable: 1, none: 0 };
+
+/**
+ * Classify an asset identity against the existing fleet and decide how to stage it.
+ * `equipmentRows` should already be scoped to the caller's tenant.
+ */
+export function classifyAsset(hints: AssetHints, equipmentRows: EquipmentRow[]): AssetMatch {
+  let best: (RowVerdict & { id: string }) | null = null;
+  let strongCount = 0;
+
+  for (const row of equipmentRows) {
+    const v = classifyRow(hints, row);
+    if (v.strength === "strong") strongCount += 1;
+    const better =
+      !best ||
+      RANK[v.strength] > RANK[best.strength] ||
+      (RANK[v.strength] === RANK[best.strength] && v.matchedFields.length > best.matchedFields.length);
+    if (better) best = { ...v, id: row.id };
+  }
+
+  if (!best || best.strength === "none") {
+    return {
+      strength: "none",
+      decision: "draft_asset",
+      matchedAssetId: null,
+      confidence: 0,
+      matchedFields: best?.matchedFields ?? [],
+      conflictFields: best?.conflictFields ?? [],
+      approvalState: "proposed",
+    };
+  }
+
+  // Ambiguity guard: more than one equally-strong candidate → don't pick blindly, ask a human.
+  let strength = best.strength;
+  if (strength === "strong" && strongCount > 1) strength = "probable";
+
+  return {
+    strength,
+    decision: decisionFor(strength),
+    matchedAssetId: best.id,
+    confidence: band(strength),
+    matchedFields: best.matchedFields,
+    conflictFields: best.conflictFields,
+    approvalState: "proposed",
+  };
+}
+
+/** A raw `cmms_equipment` row (the snake_case columns this matcher reads). */
+export interface CmmsEquipmentRow {
+  id: string;
+  equipment_number?: string | null;
+  manufacturer?: string | null;
+  model_number?: string | null;
+  serial_number?: string | null;
+  uns_path?: string | null;
+}
+
+/** Map a `cmms_equipment` DB row to the matcher's normalized shape. Only sets the fields present
+ * so an absent column never masquerades as a matchable empty string. */
+export function fromEquipmentRow(row: CmmsEquipmentRow): EquipmentRow {
+  const out: EquipmentRow = { id: row.id };
+  if (row.equipment_number != null) out.assetNumber = row.equipment_number;
+  if (row.manufacturer != null) out.manufacturer = row.manufacturer;
+  if (row.model_number != null) out.model = row.model_number;
+  if (row.serial_number != null) out.serialNumber = row.serial_number;
+  if (row.uns_path != null) out.proposedUnsPath = row.uns_path;
+  return out;
+}
+
+/** A staged extraction→asset match row, ready to insert into `ctx_extraction_asset_matches`. */
+export interface ExtractionAssetMatch {
+  extractionId: string;
+  matchedAssetId: string | null;
+  strength: MatchStrength;
+  decision: StagingDecision;
+  confidence: number;
+  matchedFields: string[];
+  approvalState: "proposed";
+}
+
+/** Apply one asset-level match to each extraction of the imported asset (one row per extraction). */
+export function buildExtractionMatches(
+  extractionIds: string[],
+  match: AssetMatch,
+): ExtractionAssetMatch[] {
+  return extractionIds.map((extractionId) => ({
+    extractionId,
+    matchedAssetId: match.matchedAssetId,
+    strength: match.strength,
+    decision: match.decision,
+    confidence: match.confidence,
+    matchedFields: match.matchedFields,
+    approvalState: match.approvalState,
+  }));
+}
+
+/** Minimal `pg` client surface used by the writer (matches `withTenantContext`'s PoolClient). */
+interface QueryClient {
+  query: (text: string, params?: unknown[]) => Promise<unknown>;
+}
+
+/**
+ * Persist staged matches into `ctx_extraction_asset_matches`.
+ *
+ * NOTE: the table is owned by migration 056 (PRD §4.1) and is not in 055 yet — this writer assumes
+ * that shape and is exercised only once 056 lands (integration-tested then). It is intentionally
+ * INSERT-only and lands every row `approval_state = 'proposed'`; promotion is a separate admin action.
+ * The caller supplies a client already inside `withTenantContext(tenantId, …)` so RLS scopes the write.
+ */
+export async function persistAssetMatches(
+  client: QueryClient,
+  tenantId: string,
+  rows: ExtractionAssetMatch[],
+): Promise<void> {
+  for (const r of rows) {
+    await client.query(
+      `INSERT INTO ctx_extraction_asset_matches
+         (tenant_id, extraction_id, matched_equipment_id, match_strength, decision,
+          confidence, matched_fields, approval_state)
+       VALUES ($1::uuid, $2::uuid, $3::uuid, $4, $5, $6, $7::jsonb, $8)`,
+      [
+        tenantId,
+        r.extractionId,
+        r.matchedAssetId,
+        r.strength,
+        r.decision,
+        r.confidence,
+        JSON.stringify(r.matchedFields),
+        r.approvalState,
+      ],
+    );
+  }
+}

--- a/mira-hub/src/lib/contextualization/intake-contract.schema.json
+++ b/mira-hub/src/lib/contextualization/intake-contract.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://factorylm.com/schemas/contextualization-intake/v1.json",
+  "title": "Contextualization Intake Contract",
+  "description": "HubV3 §2 — the single normalized envelope every ingest route (offline Contextualizer, Telegram thin client, Hub upload) submits to the Hub. Kept in lockstep with intake-contract.ts and contracts/contextualization/intake_contract.py. UUIDs are identity; names/serials/models/IPs/UNS paths are matching evidence. review_status is always 'proposed' on intake.",
+  "type": "object",
+  "required": ["contract_version", "ingest_route", "sources"],
+  "additionalProperties": true,
+  "properties": {
+    "contract_version": { "const": "contextualization-intake/v1" },
+    "ingest_route": { "enum": ["offline", "telegram", "hub_upload"] },
+    "review_status": {
+      "const": "proposed",
+      "description": "Always 'proposed' on intake — nothing is auto-approved (ADR-0017)."
+    },
+    "bundle_sha256": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-fA-F]{64}$",
+      "description": "Whole-submission fingerprint — project/batch dedup key."
+    },
+    "project_hint": { "type": ["string", "null"] },
+    "asset_hints": {
+      "type": "object",
+      "description": "Identity + matching-evidence hints; never the sole key.",
+      "additionalProperties": true,
+      "properties": {
+        "name": { "type": "string" },
+        "number": { "type": "string" },
+        "manufacturer": { "type": "string" },
+        "model": { "type": "string" },
+        "serial": { "type": "string" },
+        "controller": { "type": "string" },
+        "controller_ip": { "type": "string" },
+        "uns_path": { "type": "string" }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["source_sha256", "source_type", "source_metadata"],
+        "additionalProperties": true,
+        "properties": {
+          "source_sha256": { "type": "string", "pattern": "^[0-9a-fA-F]{64}$" },
+          "source_type": { "enum": ["l5x", "st", "plcopen", "csv", "manual", "other"] },
+          "source_uuid": { "type": "string" },
+          "source_metadata": {
+            "type": "object",
+            "required": ["file_name"],
+            "additionalProperties": true,
+            "properties": {
+              "file_name": { "type": "string", "minLength": 1 },
+              "mime": { "type": "string" },
+              "size": { "type": "number" },
+              "captured_at": { "type": "string" },
+              "uploader": { "type": "string" },
+              "location": { "type": "string" }
+            }
+          }
+        }
+      }
+    },
+    "evidence": { "type": "array", "items": { "type": "object" } },
+    "entities": { "type": "array", "items": { "type": "object" } },
+    "proposed_signals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["tag_name"],
+        "additionalProperties": true,
+        "properties": {
+          "tag_name": { "type": "string" },
+          "roles": { "type": "array", "items": { "type": "string" } },
+          "uns_path": { "type": ["string", "null"] },
+          "i3x_element_id": { "type": ["string", "null"] },
+          "confidence": { "type": ["number", "null"] },
+          "evidence": { "type": "object" },
+          "source_sha256": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "proposed_uns": { "type": "array", "items": { "type": "object" } },
+    "proposed_i3x": { "type": "array", "items": { "type": "object" } },
+    "proposed_faults": { "type": "array", "items": { "type": "object" } },
+    "proposed_parameters": { "type": "array", "items": { "type": "object" } },
+    "proposed_relationships": { "type": "array", "items": { "type": "object" } },
+    "provenance": { "type": "object" },
+    "confidence": { "type": ["string", "number", "null"] }
+  }
+}

--- a/mira-hub/src/lib/contextualization/intake-contract.test.ts
+++ b/mira-hub/src/lib/contextualization/intake-contract.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTRACT_VERSION,
+  validateIntakeContract,
+  intakeContractToImport,
+  type IntakeContract,
+} from "./intake-contract";
+
+// A minimal-but-valid envelope per HubV3 PRD §2. Names/serials/paths are
+// matching evidence, never identity; review_status is always "proposed" on intake.
+function validEnvelope(): Record<string, unknown> {
+  return {
+    contract_version: CONTRACT_VERSION,
+    ingest_route: "offline",
+    project_hint: "Garage Demo / Micro820 Conveyor",
+    bundle_sha256: "a".repeat(64),
+    review_status: "proposed",
+    asset_hints: { name: "Conveyor 1", model: "Micro820", controller_ip: "192.168.1.20" },
+    sources: [
+      {
+        source_sha256: "b".repeat(64),
+        source_type: "st",
+        source_metadata: { file_name: "Micro820.st", mime: "text/plain", uploader: "mike" },
+      },
+    ],
+    evidence: [],
+    entities: [],
+    proposed_signals: [
+      { tag_name: "Conv_Run", roles: ["output"], uns_path: "enterprise.garage.demo.conv.run", confidence: 0.9, source_sha256: "b".repeat(64) },
+    ],
+    proposed_uns: [],
+    proposed_i3x: [],
+    proposed_faults: [],
+    proposed_parameters: [],
+    proposed_relationships: [],
+  };
+}
+
+describe("validateIntakeContract", () => {
+  it("accepts a well-formed intake envelope", () => {
+    const res = validateIntakeContract(validEnvelope());
+    expect(res.ok).toBe(true);
+    expect(res.errors).toEqual([]);
+    expect(res.value?.ingest_route).toBe("offline");
+  });
+
+  it("rejects a wrong contract_version", () => {
+    const env = { ...validEnvelope(), contract_version: "nope/v9" };
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(" ")).toMatch(/contract_version/);
+  });
+
+  it("rejects an unknown ingest_route", () => {
+    const env = { ...validEnvelope(), ingest_route: "carrier-pigeon" };
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(" ")).toMatch(/ingest_route/);
+  });
+
+  it("rejects an empty sources array", () => {
+    const env = { ...validEnvelope(), sources: [] };
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(" ")).toMatch(/sources/);
+  });
+
+  it("rejects a source missing its sha256", () => {
+    const env = validEnvelope();
+    (env.sources as Record<string, unknown>[])[0].source_sha256 = undefined;
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(" ")).toMatch(/source_sha256/);
+  });
+
+  it("rejects review_status other than proposed on intake", () => {
+    const env = { ...validEnvelope(), review_status: "approved" };
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(false);
+    expect(res.errors.join(" ")).toMatch(/review_status/);
+  });
+
+  it("defaults review_status to proposed when omitted", () => {
+    const env = validEnvelope();
+    delete (env as Record<string, unknown>).review_status;
+    const res = validateIntakeContract(env);
+    expect(res.ok).toBe(true);
+    expect(res.value?.review_status).toBe("proposed");
+  });
+});
+
+describe("intakeContractToImport", () => {
+  it("maps the envelope to insertable project/source/extraction rows", () => {
+    const contract = validateIntakeContract(validEnvelope()).value as IntakeContract;
+    const imp = intakeContractToImport(contract);
+    expect(imp.bundleSha256).toBe("a".repeat(64));
+    expect(imp.ingestRoute).toBe("offline");
+    expect(imp.sources).toHaveLength(1);
+    expect(imp.sources[0].sourceSha256).toBe("b".repeat(64));
+    expect(imp.sources[0].sourceType).toBe("st");
+    // proposed_signals become extractions; nothing lands "accepted" on intake.
+    expect(imp.extractions).toHaveLength(1);
+    expect(imp.extractions[0].tagName).toBe("Conv_Run");
+    expect(imp.extractions[0].status).toBe("pending");
+  });
+});

--- a/mira-hub/src/lib/contextualization/intake-contract.ts
+++ b/mira-hub/src/lib/contextualization/intake-contract.ts
@@ -1,0 +1,271 @@
+/**
+ * HubV3 — Shared Contextualization Intake Contract (TypeScript).
+ *
+ * The single normalized envelope every ingest route (offline Contextualizer,
+ * Telegram thin client, Hub upload) submits to the Hub. The Hub is the system
+ * of record; clients only collect evidence and create proposals. See
+ * `docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md` §2 and
+ * `docs/adr/0023-hub-system-of-record-contextualization.md`.
+ *
+ * Three artifacts are kept in lockstep — change all three together:
+ *   - this file (TypeScript types + validator),
+ *   - `intake-contract.schema.json` (JSON Schema, co-located),
+ *   - `contracts/contextualization/intake_contract.py` (Python dataclass).
+ *
+ * Identity model: UUIDs are identity; names / numbers / serials / model
+ * numbers / controller IPs / UNS paths are MATCHING EVIDENCE, never the key.
+ * `review_status` is always "proposed" on intake — nothing is auto-approved.
+ *
+ * Pure + dependency-free (no zod — PRD §4 bans framework abstractions, and a
+ * hand-rolled validator keeps the contract portable to the Python/JSON twins).
+ */
+
+export const CONTRACT_VERSION = "contextualization-intake/v1";
+
+export type IngestRoute = "offline" | "telegram" | "hub_upload";
+
+/** ctx_sources.source_type domain (matches migration 055). */
+export type SourceType = "l5x" | "st" | "plcopen" | "csv" | "manual" | "other";
+
+export const INGEST_ROUTES: readonly IngestRoute[] = ["offline", "telegram", "hub_upload"];
+export const SOURCE_TYPES: readonly SourceType[] = ["l5x", "st", "plcopen", "csv", "manual", "other"];
+
+/** Identity + matching-evidence hints for the asset this submission describes. */
+export interface AssetHints {
+  name?: string;
+  number?: string;
+  manufacturer?: string;
+  model?: string;
+  serial?: string;
+  controller?: string;
+  controller_ip?: string;
+  uns_path?: string;
+}
+
+export interface SourceMetadata {
+  file_name: string;
+  mime?: string;
+  size?: number;
+  captured_at?: string;
+  uploader?: string;
+  location?: string;
+}
+
+export interface IntakeSource {
+  /** Content fingerprint — the per-source dedup key (sha256 hex). */
+  source_sha256: string;
+  source_type: SourceType;
+  source_metadata: SourceMetadata;
+  /** Optional client-minted UUID; the Hub mints its own if absent. */
+  source_uuid?: string;
+}
+
+/** A proposed signal/tag. Lands as a ctx_extractions row (status "pending"). */
+export interface ProposedSignal {
+  tag_name: string;
+  roles?: string[];
+  uns_path?: string | null;
+  i3x_element_id?: string | null;
+  confidence?: number | null;
+  evidence?: Record<string, unknown>;
+  /** Which source (by sha256) this signal came from. */
+  source_sha256?: string | null;
+}
+
+/**
+ * The full intake envelope. Proposal arrays beyond `proposed_signals` are
+ * carried verbatim for downstream phases (P3 matching, P4 publish); P2 only
+ * stages sources + signals. All proposal arrays default to [].
+ */
+export interface IntakeContract {
+  contract_version: typeof CONTRACT_VERSION;
+  ingest_route: IngestRoute;
+  /** Always "proposed" on intake. */
+  review_status: "proposed";
+  /** Whole-submission fingerprint — the project/batch dedup key (sha256 hex). */
+  bundle_sha256?: string | null;
+  project_hint?: string | null;
+  asset_hints?: AssetHints;
+  sources: IntakeSource[];
+  evidence?: Record<string, unknown>[];
+  entities?: Record<string, unknown>[];
+  proposed_signals?: ProposedSignal[];
+  proposed_uns?: Record<string, unknown>[];
+  proposed_i3x?: Record<string, unknown>[];
+  proposed_faults?: Record<string, unknown>[];
+  proposed_parameters?: Record<string, unknown>[];
+  proposed_relationships?: Record<string, unknown>[];
+  provenance?: Record<string, unknown>;
+  confidence?: string | number | null;
+}
+
+export interface ValidationResult {
+  ok: boolean;
+  errors: string[];
+  value?: IntakeContract;
+}
+
+const SHA256_RE = /^[0-9a-f]{64}$/i;
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Validate + normalize an unknown payload into an IntakeContract. Returns
+ * `{ ok, errors, value? }`. `value` is only set when `ok` is true. Optional
+ * proposal arrays are defaulted to []; `review_status` defaults to "proposed".
+ */
+export function validateIntakeContract(input: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (!isObject(input)) {
+    return { ok: false, errors: ["intake contract must be a JSON object"] };
+  }
+
+  if (input.contract_version !== CONTRACT_VERSION) {
+    errors.push(`contract_version must be "${CONTRACT_VERSION}"`);
+  }
+
+  const ingestRoute = input.ingest_route;
+  if (typeof ingestRoute !== "string" || !INGEST_ROUTES.includes(ingestRoute as IngestRoute)) {
+    errors.push(`ingest_route must be one of ${INGEST_ROUTES.join(", ")}`);
+  }
+
+  if (input.review_status !== undefined && input.review_status !== "proposed") {
+    errors.push('review_status must be "proposed" on intake');
+  }
+
+  if (input.bundle_sha256 !== undefined && input.bundle_sha256 !== null) {
+    if (typeof input.bundle_sha256 !== "string" || !SHA256_RE.test(input.bundle_sha256)) {
+      errors.push("bundle_sha256 must be a 64-char hex string");
+    }
+  }
+
+  const sources = input.sources;
+  if (!Array.isArray(sources) || sources.length === 0) {
+    errors.push("sources must be a non-empty array");
+  } else {
+    sources.forEach((s, i) => {
+      if (!isObject(s)) {
+        errors.push(`sources[${i}] must be an object`);
+        return;
+      }
+      if (typeof s.source_sha256 !== "string" || !SHA256_RE.test(s.source_sha256)) {
+        errors.push(`sources[${i}].source_sha256 must be a 64-char hex string`);
+      }
+      if (typeof s.source_type !== "string" || !SOURCE_TYPES.includes(s.source_type as SourceType)) {
+        errors.push(`sources[${i}].source_type must be one of ${SOURCE_TYPES.join(", ")}`);
+      }
+      const meta = s.source_metadata;
+      if (!isObject(meta) || typeof meta.file_name !== "string" || !meta.file_name.trim()) {
+        errors.push(`sources[${i}].source_metadata.file_name is required`);
+      }
+    });
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  const value: IntakeContract = {
+    contract_version: CONTRACT_VERSION,
+    ingest_route: ingestRoute as IngestRoute,
+    review_status: "proposed",
+    bundle_sha256: (input.bundle_sha256 as string | undefined) ?? null,
+    project_hint: typeof input.project_hint === "string" ? input.project_hint : null,
+    asset_hints: isObject(input.asset_hints) ? (input.asset_hints as AssetHints) : undefined,
+    sources: (sources as IntakeSource[]).map((s) => ({
+      source_sha256: String(s.source_sha256),
+      source_type: s.source_type,
+      source_metadata: s.source_metadata,
+      source_uuid: typeof s.source_uuid === "string" ? s.source_uuid : undefined,
+    })),
+    evidence: Array.isArray(input.evidence) ? (input.evidence as Record<string, unknown>[]) : [],
+    entities: Array.isArray(input.entities) ? (input.entities as Record<string, unknown>[]) : [],
+    proposed_signals: Array.isArray(input.proposed_signals)
+      ? (input.proposed_signals as ProposedSignal[])
+      : [],
+    proposed_uns: Array.isArray(input.proposed_uns) ? (input.proposed_uns as Record<string, unknown>[]) : [],
+    proposed_i3x: Array.isArray(input.proposed_i3x) ? (input.proposed_i3x as Record<string, unknown>[]) : [],
+    proposed_faults: Array.isArray(input.proposed_faults)
+      ? (input.proposed_faults as Record<string, unknown>[])
+      : [],
+    proposed_parameters: Array.isArray(input.proposed_parameters)
+      ? (input.proposed_parameters as Record<string, unknown>[])
+      : [],
+    proposed_relationships: Array.isArray(input.proposed_relationships)
+      ? (input.proposed_relationships as Record<string, unknown>[])
+      : [],
+    provenance: isObject(input.provenance) ? (input.provenance as Record<string, unknown>) : undefined,
+    confidence:
+      typeof input.confidence === "string" || typeof input.confidence === "number"
+        ? input.confidence
+        : null,
+  };
+
+  return { ok: true, errors: [], value };
+}
+
+// ── Mapping to insertable rows (consumed by the import route) ────────────────
+
+export interface ImportSourceRow {
+  fileName: string;
+  sourceType: SourceType;
+  sourceSha256: string;
+  status: string;
+}
+
+export interface ImportExtractionRow {
+  tagName: string;
+  roles: string[];
+  unsPathProposed: string | null;
+  i3xElementId: string | null;
+  evidenceJson: Record<string, unknown>;
+  confidence: number | null;
+  /** Nothing lands "accepted" on intake — proposed == pending in ctx_extractions. */
+  status: "pending";
+  sourceSha256: string | null;
+}
+
+export interface ContractImport {
+  projectName: string;
+  description: string | null;
+  ingestRoute: IngestRoute;
+  bundleSha256: string | null;
+  sources: ImportSourceRow[];
+  extractions: ImportExtractionRow[];
+}
+
+/**
+ * Map a validated IntakeContract into the project/source/extraction rows the
+ * import route inserts. Mirrors ParsedBundle (bundle-import.ts) so the route's
+ * insert path is shared. proposed_signals → ctx_extractions, all "pending".
+ */
+export function intakeContractToImport(contract: IntakeContract): ContractImport {
+  const sources: ImportSourceRow[] = contract.sources.map((s) => ({
+    fileName: s.source_metadata.file_name,
+    sourceType: s.source_type,
+    sourceSha256: s.source_sha256,
+    status: "done",
+  }));
+
+  const extractions: ImportExtractionRow[] = (contract.proposed_signals ?? [])
+    .map((sig) => ({
+      tagName: String(sig.tag_name ?? "").trim(),
+      roles: Array.isArray(sig.roles) ? sig.roles.map(String) : [],
+      unsPathProposed: typeof sig.uns_path === "string" ? sig.uns_path : null,
+      i3xElementId: typeof sig.i3x_element_id === "string" ? sig.i3x_element_id : null,
+      evidenceJson: isObject(sig.evidence) ? sig.evidence : {},
+      confidence: typeof sig.confidence === "number" ? sig.confidence : null,
+      status: "pending" as const,
+      sourceSha256: typeof sig.source_sha256 === "string" ? sig.source_sha256 : null,
+    }))
+    .filter((e) => e.tagName);
+
+  return {
+    projectName: contract.project_hint?.trim() || "Imported project",
+    description: null,
+    ingestRoute: contract.ingest_route,
+    bundleSha256: contract.bundle_sha256 ?? null,
+    sources,
+    extractions,
+  };
+}

--- a/mira-hub/vitest.integration.config.ts
+++ b/mira-hub/vitest.integration.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+// Integration-test config: runs *.integration.test.ts (real Postgres via
+// TEST_DATABASE_URL). The default vitest.config.ts excludes these so unit `test`
+// stays DB-free; this config includes them. Used by `bun run test:integration`.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.integration.test.ts"],
+    exclude: ["node_modules/**", "tests/e2e/**"],
+    testTimeout: 30000,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
Unifies the HubV3 phase branches into one integrated branch. **Hub = system of record**; offline Contextualizer + Telegram are ingest clients submitting the shared Contextualization Intake Contract.

PRD: `docs/plans/2026-06-20-hubv3-contextualization-intake-prd.md` · Plan: `docs/plans/2026-06-20-hubv3-build-plan.md`

## Folds in (all merged clean — `merge-tree` showed zero conflicts)
- **P0** intake contract (TS + Python dataclass + JSON Schema) + ADR-0023 — from #2126
- **P1** migration `056` — `ctx_import_batches`, `ctx_extraction_asset_matches`, sha256 dedup, RLS, grants — from #2126
- **P2** `/api/contextualization/import` accepts contract + sha256 dedup, all rows `proposed` — from #2126
- **P3** asset-matcher.ts (strong/probable/none vs cmms_equipment) — from #2131
- **P4** batch Review Queue + approval-aware promote (no overwrite of verified) — from #2133
- **P5** bundle: evidence.json + entity UUIDs + sanitized export mode — from #2125
- **P6** Telegram thin client → Hub intake (sha256 + hints + uploader, lands proposed) — from #2132

## Not yet included (still missing from origin)
- **P7** UI label parity — never pushed
- **P8** garage-conveyor demo + §6 test matrix — never reached origin (PLC push didn't land)

## Base
Targets `feat/plc-mapper-gui` (#2068) — carries 055 + the contextualizer. When #2068 merges to main, retarget this to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)