### PR TITLE
feat(hub): "Import Review" sidebar link → contextualization Review Queue

### DIFF
--- a/mira-hub/src/components/layout/sidebar.tsx
+++ b/mira-hub/src/components/layout/sidebar.tsx
@@ -122,6 +122,7 @@ export function Sidebar() {
       "reports":       t("reports"),
       "team":          t("team"),
       "admin-review":  "Review queue",
+      "ctx-review":    "Import Review",
       "platform-users": "Platform accounts",
       // Legacy routes (still reachable, not in sidebar):
       "event-log":     t("eventLog"),

--- a/mira-hub/src/providers/access-control.ts
+++ b/mira-hub/src/providers/access-control.ts
@@ -95,6 +95,10 @@ export const NAV_ITEMS: ReadonlyArray<{
   { key: "assets",        label: "Assets",        icon: "Wrench",        href: "/assets",        roles: [...ALL_ROLES], group: "secondary" },
   { key: "workorders",    label: "CMMS",          icon: "ClipboardList", href: "/workorders",    roles: [...ALL_ROLES], group: "secondary" },
   { key: "scan",          label: "Scan",          icon: "Cpu",           href: "/scan",          roles: [...ALL_ROLES], group: "secondary" },
+  // HubV3 contextualization Review Queue — approve imported (offline/Telegram)
+  // context batches; approval publishes proposed → verified. Distinct from the
+  // internal staff "Review queue" (admin-review) above.
+  { key: "ctx-review",    label: "Import Review", icon: "Network",       href: "/contextualization/review", roles: [...ADMIN_ROLES], group: "secondary" },
   // Customer-facing workspace admin. Visible to every authenticated tenant user
   // (workspace caps); the page itself shows only what each capability allows.
   { key: "settings",      label: "Settings",      icon: "Settings",      href: "/settings",      roles: [...ALL_ROLES], group: "secondary" },


### PR DESCRIPTION
Re-lands a stranded 5-line nav change onto the HubV3 integration branch.

**Context:** my Phase-4 review/approve work was folded into the unified HubV3 branch (PR #2134, merged to `feat/plc-mapper-gui`), but the follow-up nav commit landed *after* the fold and was orphaned when PR #2133 was closed. Without this, nothing in the sidebar links to the new `/contextualization/review` Review Queue screen.

**Change:** one secondary-group `NAV_ITEM` (`ctx-review`, icon Network, admin roles) labelled **"Import Review"** → `/contextualization/review`, plus its `navLabel` entry. Named distinct from the internal-staff "Review queue" (`admin-review`). No new capability — matches the existing ungated contextualization surface.

Verified clean cherry-pick (nav files unchanged between spine and `feat/plc-mapper-gui`); `ctx-review` was confirmed absent on the integration branch. tsc 0 errors + lint clean on the original commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)