### PR TITLE
feat(hub): HubV3 Phase 7 — Hub↔offline label parity

### DIFF
--- a/docs/plans/2026-06-20-hubv3-ui-label-parity-audit.md
+++ b/docs/plans/2026-06-20-hubv3-ui-label-parity-audit.md
@@ -1,0 +1,47 @@
+# HubV3 — UI/UX Label Parity Audit (Phase 7)
+
+**Status:** DONE (Hub side) · **Date:** 2026-06-20 · **Branch:** `feat/hubv3-p7-label-parity` → `feat/plc-mapper-gui`
+**Spec:** `2026-06-20-hubv3-contextualization-intake-prd.md` §5 Phase 7 + §7. **Goal:** one mental model and one set of labels across the Hub and the offline Contextualizer — "offline is the offline experience of the Hub ingest path, not a different product."
+
+## Canonical vocabulary (PRD §5 P7 / §7)
+
+> Projects/Workspaces · Assets/Machines · Sources · Evidence · Extracted Signals · Fault Catalog · Parameters · UNS Map · Scorecard · Review Queue · Import/Export History
+
+## Key finding
+
+**The offline Contextualizer GUI is already fully canonical.** Its view registry
+(`mira-contextualizer/mira_contextualizer/gui/index.html`) reads, verbatim:
+
+```
+Dashboard · Sources · Extracted Signals · Fault Catalog · Parameters · UNS Map · Scorecard · Review Queue · Export History
+```
+…with identity fields `Machine name / Asset type / Manufacturer / … / Proposed UNS path / Hub asset id`.
+
+⇒ Phase 7 is **entirely a Hub-side conform-to-spec task.** The offline app needed
+no changes (and was out of scope to edit — owned by the P5/offline track).
+The drift was all in the Hub's pre-existing contextualization pages, which used
+PLC-tag-centric language instead of the shared "signal" vocabulary.
+
+## Parity table (Hub)
+
+| Surface | Canonical term | Hub — before | Hub — after | Status |
+|---|---|---|---|---|
+| `contextualization/page.tsx` h1 | Projects/Workspaces | **"PLC Tag Import"** | "Contextualization Projects" | ✅ fixed |
+| `contextualization/page.tsx` subtitle | Sources → Signals → promote | "Upload PLC exports… promote approved signals" | "Import equipment **sources**, review proposed UNS paths for extracted **signals**, promote approved signals" | ✅ fixed |
+| `[id]/page.tsx` h1 | Extracted Signals | **"Tag Review"** | "Extracted Signals" | ✅ fixed |
+| `[id]/page.tsx` subtitle / tooltips / toasts / empty-state | Extracted Signals | "tags" throughout | "signal(s)" throughout | ✅ fixed |
+| `[id]/page.tsx` table column | (row-level) | "Tag" | "Tag" (kept) | ✅ intentional — offline keeps `tag` at row level; "Extracted Signals" is the section, a row's PLC **tag** name is accurate |
+| `review/` (Review Queue + batch detail) | Review Queue, Sources, Evidence, Extracted Signals, Fault Catalog, Parameters, UNS Map, Scorecard | — | all canonical | ✅ already correct (shipped Phase 4) |
+| sidebar | Review Queue | (no link) | "Import Review" → `/contextualization/review` | ✅ added (PR #2136) |
+
+## Deliberate non-changes / residual gaps
+
+1. **Row-level "Tag" stays.** The offline app keeps `tag` at row level (find box "Find tag / role / UNS", per-row tag). Section heading is canonical "Extracted Signals"; the individual PLC **tag** name is the correct domain term for a row. Renaming rows to "signal" would *diverge* from offline, not converge.
+2. **"Projects" (Hub) ↔ "Machine Profiles" (offline).** The PRD pairs "Projects/Workspaces" as acceptable synonyms; a Hub *project* (workspace) can contain one or more machine profiles. Left as-is — both are canonical-list members, not drift. Revisit only if a designer wants one string everywhere.
+3. **Theme mismatch (follow-up, not label scope).** `[id]/page.tsx` is light-themed (`text-gray-900` / `bg-gray-50`) while `page.tsx` and the `review/` screens are dark. This is a visual-consistency gap, not a *label* gap; left for a focused theme pass to keep this diff label-only (surgical).
+
+## Gate (PRD §5 P7)
+
+- **Label parity audit** — this document. ✅
+- **Screenshot rule** — owed. Both contextualization screens are auth-gated and fetch live data; capturing them needs a staging deploy of `feat/plc-mapper-gui` with a seeded Garage/Micro820 batch (NeonDB SSL can't connect from the Windows dev host). Folds into the Phase 8 demo seed. ⏳
+- **Designer review** — open. ⏳

--- a/mira-hub/src/app/(hub)/contextualization/[id]/page.tsx
+++ b/mira-hub/src/app/(hub)/contextualization/[id]/page.tsx
@@ -140,9 +140,9 @@ export default function ContextualizationProjectPage() {
         setExtractions((prev) =>
           prev.map((e) => (e.id === id ? { ...e, status } : e)),
         );
-        showToast(status === "accepted" ? "Tag accepted" : "Tag rejected");
+        showToast(status === "accepted" ? "Signal accepted" : "Signal rejected");
       } catch (e) {
-        showToast(e instanceof Error ? e.message : "Error updating tag");
+        showToast(e instanceof Error ? e.message : "Error updating signal");
       } finally {
         setDeciding((d) => ({ ...d, [id]: undefined }));
       }
@@ -168,11 +168,11 @@ export default function ContextualizationProjectPage() {
       const skipped = j.skipped ?? 0;
       showToast(
         promoted + skipped === 0
-          ? "No accepted tags to promote"
+          ? "No accepted signals to promote"
           : `Promoted ${promoted} signal${promoted === 1 ? "" : "s"} to the knowledge graph${skipped ? ` (${skipped} already present)` : ""}`,
       );
     } catch (e) {
-      showToast(e instanceof Error ? e.message : "Error promoting tags");
+      showToast(e instanceof Error ? e.message : "Error promoting signals");
     } finally {
       setPromoting(false);
     }
@@ -200,7 +200,7 @@ export default function ContextualizationProjectPage() {
         if (!res.ok) throw new Error(j.error ?? "Upload failed");
         showToast(
           j.workerStarted
-            ? `Uploaded ${file.name} — parsing… tags will appear shortly`
+            ? `Uploaded ${file.name} — parsing… signals will appear shortly`
             : `Uploaded ${file.name}, but the parser didn't start (check worker)`,
         );
         // The worker writes extractions asynchronously; give it a moment, then refresh.
@@ -229,9 +229,9 @@ export default function ContextualizationProjectPage() {
     <div className="mx-auto max-w-6xl px-4 py-8">
       <div className="mb-6 flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-semibold text-gray-900">Tag Review</h1>
+          <h1 className="text-2xl font-semibold text-gray-900">Extracted Signals</h1>
           <p className="mt-1 text-sm text-gray-500">
-            Accept or reject proposed UNS paths for each extracted PLC tag.
+            Accept or reject the proposed UNS path for each extracted signal.
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -245,7 +245,7 @@ export default function ContextualizationProjectPage() {
           <button
             onClick={() => fileInputRef.current?.click()}
             disabled={uploading}
-            title="Upload a PLC export or manual to extract tags"
+            title="Upload a source (PLC export or manual) to extract signals"
             className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {uploading ? (
@@ -266,8 +266,8 @@ export default function ContextualizationProjectPage() {
             disabled={promoting || counts.accepted === 0}
             title={
               counts.accepted === 0
-                ? "Accept at least one tag before promoting"
-                : "Promote accepted tags into the knowledge graph"
+                ? "Accept at least one signal before promoting"
+                : "Promote accepted signals into the knowledge graph"
             }
             className="inline-flex items-center gap-1.5 rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
@@ -304,7 +304,7 @@ export default function ContextualizationProjectPage() {
       {loading && (
         <div className="flex items-center justify-center py-16 text-gray-400">
           <Loader2 className="mr-2 h-5 w-5 animate-spin" />
-          Loading tags…
+          Loading signals…
         </div>
       )}
 
@@ -313,7 +313,7 @@ export default function ContextualizationProjectPage() {
       )}
 
       {!loading && !error && filtered.length === 0 && (
-        <div className="py-16 text-center text-sm text-gray-400">No tags in this view.</div>
+        <div className="py-16 text-center text-sm text-gray-400">No signals in this view.</div>
       )}
 
       {!loading && !error && filtered.length > 0 && (

--- a/mira-hub/src/app/(hub)/contextualization/page.tsx
+++ b/mira-hub/src/app/(hub)/contextualization/page.tsx
@@ -95,9 +95,9 @@ export default function ContextualizationPage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-semibold text-white">PLC Tag Import</h1>
+          <h1 className="text-2xl font-semibold text-white">Contextualization Projects</h1>
           <p className="text-sm text-gray-400 mt-1">
-            Upload PLC exports, review AI-proposed UNS paths, and promote approved signals to the knowledge graph.
+            Import equipment sources, review the proposed UNS paths for extracted signals, and promote approved signals to the knowledge graph.
           </p>
         </div>
         <button


### PR DESCRIPTION
**Targets `feat/plc-mapper-gui` (HubV3 integration branch). Phase 7 — Shared UI/UX Alignment (PRD §5 P7 / §7).**

## Finding
The **offline Contextualizer GUI is already fully canonical** — its view registry reads exactly *Sources · Extracted Signals · Fault Catalog · Parameters · UNS Map · Scorecard · Review Queue · Export History*. All the drift was Hub-side, so P7 is a Hub-only conform-to-spec pass. `mira-contextualizer/` was **not** touched (already correct + owned by the offline track).

## Changes (label-only)
| Surface | Before | After |
|---|---|---|
| `contextualization/page.tsx` h1 | "PLC Tag Import" | "Contextualization Projects" |
| `[id]/page.tsx` h1 | "Tag Review" | "Extracted Signals" |
| `[id]/page.tsx` copy | "tags" (subtitle, tooltips, toasts, loading/empty) | "signals" |
| row-level "Tag" column | — | **kept** (offline keeps `tag` at row level; section = canonical "Extracted Signals") |

`review/` screens were already canonical (Phase 4); sidebar "Import Review" link added in PR #2136.

Full table + deliberate non-changes (row-level "tag"; "Projects"↔"Machine Profiles" synonym pairing; `[id]` light-theme as a separate follow-up): `docs/plans/2026-06-20-hubv3-ui-label-parity-audit.md`.

## Gate (PRD §5 P7)
- **Label parity audit** — ✅ (the doc).
- **Screenshot rule + designer review** — ⏳ owed. Both screens are auth-gated + fetch live data; capture needs a staging deploy of this branch with a seeded Garage/Micro820 batch (NeonDB SSL can't connect from the Windows dev host). Folds into the Phase 8 demo seed.

## Verification note
Edits are pure JSX **text-content** swaps — structurally incapable of changing types/behavior; the same files were `tsc` 0-errors + lint-clean before. Local `tsc`/lint couldn't run in this worktree (Windows dep-setup / NeonDB-SSL blocks); no test references the old label strings (grep-confirmed). CI typecheck/build is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)