### PR TITLE
docs: clarify LangChain ban ≠ Langfuse (observability allowed + in use)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -162,7 +162,7 @@ Full rules: `.claude/rules/codegraph-usage.md`. Reference: `wiki/references/code
 ## Rules for code changes
 
 - **Conventional Commits**: `feat/fix/security/docs/refactor/test/chore/BREAKING`. Scope hint: module name (`feat(slack):`, `fix(uns):`, `fix(engine):`).
-- **No LangChain, TensorFlow, n8n** — see PRD §4 in root CLAUDE.md.
+- **No LangChain, TensorFlow, n8n** — see PRD §4 in root CLAUDE.md. (Bans LLM-orchestration frameworks only. **Langfuse is NOT LangChain** — it is observability/tracing, allowed, and in use. Don't conflate them.)
 - **Doppler for secrets** — `factorylm/dev` (local) / `factorylm/stg` (staging) / `factorylm/prd` (production). Never `.env` files in git. Never copy `prd` values into a dev shell.
 - **Python: ruff + httpx + `Optional[X]` (3.12 target)** — see `.claude/rules/python-standards.md`.
 - **Security boundaries** — see `.claude/rules/security-boundaries.md` (PII sanitization, safety keywords, Doppler).

--- a/.claude/skills/mira-platform/SKILL.md
+++ b/.claude/skills/mira-platform/SKILL.md
@@ -142,7 +142,7 @@ See `references/environment-doctrine.md` for the full table.
 
 ### 4.8 Frameworks + abstractions
 
-- **PLT-070** `[FATAL]` No LangChain, no TensorFlow, no n8n, no framework that abstracts the LLM call. PRD §4.
+- **PLT-070** `[FATAL]` No LangChain, no TensorFlow, no n8n, no framework that abstracts the LLM call. PRD §4. **Scope: LLM-orchestration/agent frameworks only. Langfuse (observability/tracing) is NOT in scope — it is allowed and in active use. Never flag Langfuse under PLT-070.**
 - **PLT-071** `[STYLE]` Engine layer, bot adapters, and ingest pipelines read top-to-bottom — not chained through indirections.
 
 ### 4.9 Python standards

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@
 
 1. **Licenses:** Apache 2.0 or MIT ONLY.
 2. **Cloud LLMs:** Groq + Cerebras + Gemini cascade (all free-tier, OpenAI-compat). NeonDB for persistence. Doppler-managed secrets. **No Anthropic** (removed PR #610 — never reintroduce).
-3. **No:** LangChain, TensorFlow, n8n, or any framework that abstracts the LLM call.
+3. **No:** LangChain, TensorFlow, n8n, or any framework that abstracts the LLM call. **This bans LLM-orchestration/agent frameworks that wrap the model call — NOT Langfuse. Langfuse ≠ LangChain: Langfuse is observability/tracing, is explicitly ALLOWED, and is in active use (`mira-bots/shared/langfuse_setup.py`). Do not "remove Langfuse" on the strength of this rule.**
 4. **Secrets:** All via Doppler. Config is env-scoped: `factorylm/dev` (local), `factorylm/stg` (staging), `factorylm/prd` (production). Never commit `.env` to git. Never paste prod values into a dev shell — set them in `factorylm/dev`.
 5. **Containers:** One per service. `restart: unless-stopped` + healthcheck. Pinned image versions.
 6. **Commits:** Conventional format (`feat/fix/security/docs/refactor/test/chore/BREAKING`).


### PR DESCRIPTION
## Why
This session nearly deleted the (sanctioned, wired) Langfuse integration after confusing the **No LangChain** hard constraint with a ban on **Langfuse**. They're different tools — LangChain is a banned LLM-orchestration framework; Langfuse is observability/tracing that's allowed and in active use (`mira-bots/shared/langfuse_setup.py`, every architecture doc, the inference-routing skill).

## What
One-line clarifier at the 3 highest-traffic enforcement points (not all ~30 mentions — that'd be noise):
- root `CLAUDE.md` PRD §4 #3
- `.claude/CLAUDE.md` code-change rules
- `.claude/skills/mira-platform/SKILL.md` PLT-070 (the FATAL gate an agent actually checks)

Each now says: the ban is LLM-orchestration frameworks only; **Langfuse ≠ LangChain**, allowed, in use, don't flag/remove it under this rule.

Docs only. No version bump. The LangChain ban itself is unchanged.