### PR TITLE
fix(rag): drop embedding-not-null filter from kb_has_pair_coverage (parity with #1308)

### DIFF
--- a/mira-bots/shared/neon_recall.py
+++ b/mira-bots/shared/neon_recall.py
@@ -912,6 +912,21 @@ def kb_has_coverage(vendor: str, model: str, tenant_id: str) -> tuple[bool, str]
 
 KB_PAIR_COVERAGE_MIN_CHUNKS = int(os.getenv("MIRA_KB_PAIR_COVERAGE_MIN_CHUNKS", "1"))
 
+# No ``embedding IS NOT NULL`` filter — kept in parity with ``kb_has_coverage``
+# (#1308). A row reachable only via BM25 (content_tsv) is still KB coverage, and
+# a freshly-seeded (vendor, model) pair whose embeddings haven't been backfilled
+# yet must NOT be judged "not covered": that makes the resolver drop the model
+# (UNS_PAIR_DROPPED), degrading the UNS path, the product-name rerank stream, and
+# the citation label for a product the KB does cover lexically. See the sibling's
+# rationale comment above and the retrieval-grounding audit (2026-06-21).
+_KB_PAIR_COVERAGE_SQL = """
+    SELECT COUNT(*) AS cnt
+    FROM knowledge_entries
+    WHERE (tenant_id = :tid OR tenant_id = :shared_tid)
+      AND LOWER(manufacturer) LIKE LOWER(:vendor_pat)
+      AND LOWER(model_number) LIKE LOWER(:model_pat)
+"""
+
 
 def kb_has_pair_coverage(vendor: str, model: str, tenant_id: str) -> tuple[bool, int]:
     """Strict-pair coverage probe — does the KB have chunks tagged with BOTH
@@ -952,16 +967,7 @@ def kb_has_pair_coverage(vendor: str, model: str, tenant_id: str) -> tuple[bool,
         )
         with engine.connect() as conn:
             row = conn.execute(
-                text(
-                    """
-                    SELECT COUNT(*) AS cnt
-                    FROM knowledge_entries
-                    WHERE (tenant_id = :tid OR tenant_id = :shared_tid)
-                      AND LOWER(manufacturer) LIKE LOWER(:vendor_pat)
-                      AND LOWER(model_number) LIKE LOWER(:model_pat)
-                      AND embedding IS NOT NULL
-                    """
-                ),
+                text(_KB_PAIR_COVERAGE_SQL),
                 {
                     "tid": tenant_id,
                     "shared_tid": SHARED_TENANT_ID,

--- a/tests/test_kb_pair_coverage_sql.py
+++ b/tests/test_kb_pair_coverage_sql.py
@@ -1,0 +1,28 @@
+"""Offline contract test for kb_has_pair_coverage's SQL (no NeonDB).
+
+The pair-coverage probe must stay in parity with kb_has_coverage (#1308): NO
+`embedding IS NOT NULL` filter. A freshly-seeded (vendor, model) pair whose
+embeddings aren't backfilled yet is still KB coverage (reachable via BM25); the
+filter made the resolver drop the model (UNS_PAIR_DROPPED) for a product the KB
+does cover. Regression guard for the 2026-06-21 retrieval-grounding audit.
+"""
+
+from shared.neon_recall import _KB_PAIR_COVERAGE_SQL
+
+
+def test_pair_coverage_sql_has_no_embedding_filter():
+    assert "embedding is not null" not in _KB_PAIR_COVERAGE_SQL.lower()
+    assert "embedding" not in _KB_PAIR_COVERAGE_SQL.lower()
+
+
+def test_pair_coverage_sql_is_still_pair_scoped():
+    sql = _KB_PAIR_COVERAGE_SQL.lower()
+    assert "manufacturer" in sql
+    assert "model_number" in sql
+    assert ":vendor_pat" in sql
+    assert ":model_pat" in sql
+
+
+def test_pair_coverage_sql_keeps_tenant_predicate():
+    sql = _KB_PAIR_COVERAGE_SQL.lower()
+    assert ":tid" in sql and ":shared_tid" in sql


### PR DESCRIPTION
## Why
From the 2026-06-21 retrieval-grounding investigation (issues #2207–#2212). This is the **safe, correct-by-construction** finding — the rest are filed for the staging-gated work.

`kb_has_coverage` deliberately dropped `AND embedding IS NOT NULL` in **#1308** (a BM25-reachable row is still coverage; seeded-but-unembedded rows were invisible → Modbus questions routed to the hallucination fallback). Its sibling **`kb_has_pair_coverage` kept the filter** (`neon_recall.py:962`). So a real `(vendor, model)` pair whose chunks are seeded but not yet embedded (the #2083/#2085/#2117 NULL-embedding class) is judged "not covered" → the resolver **drops the model** (`UNS_PAIR_DROPPED`), degrading the UNS path, the product-name rerank stream, and the citation label — for a product the KB *does* cover lexically.

## What
- Removed `AND embedding IS NOT NULL` from `kb_has_pair_coverage`, restoring parity with `kb_has_coverage`.
- Extracted the query to `_KB_PAIR_COVERAGE_SQL` so it's unit-testable without NeonDB.
- `tests/test_kb_pair_coverage_sql.py` — asserts no embedding filter + still pair/tenant-scoped.

## Verification
`pytest tests/test_kb_pair_coverage_sql.py` → 3 passed; `ruff` clean; module imports. No DB needed (the fix is a contract change, the sibling already proved the behavior in #1308).

## Deploy gate
Engine/RAG path — **run the staging eval (garage_conveyor_field --live, #2202) before prod deploy.** Low risk (aligns to an already-proven sibling), but it changes coverage judgments.

## Related (filed this session, not in this PR)
#2207 (dead 0.70-floor relaxation), #2208 (chat query poisoning), #2209 (follow-up context loss), #2210 (bot recall hybrid filter, P0), #2211 (extraction precision bundle), #2212 (non-GS10 corpus seeding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)