### PR TITLE
Industry-events radar + ProveIt factory data acquired

### DIFF
--- a/docs/plans/2026-06-22-proveit-2027-demo-runbook.md
+++ b/docs/plans/2026-06-22-proveit-2027-demo-runbook.md
@@ -69,7 +69,7 @@ is the core prerequisite. The demo adds "on a foreign UNS, live." Owner: Mike. S
 | 7 | **Context package + maturity level, first-class + visible** | namespace builder (L0–L6) | 🟡 partial |
 | 8 | **Every adapter renders the same approved-context answer** | Slack/Telegram/Ignition/QR | 🟡 adapters exist; unify on approved context |
 | 9 | **Read-only violation FENCED** — remove write-to-VFD calls | Perspective view (anti-goal) | 🔴 violated — fix |
-| 10 | **Proven on ≥1 foreign plant/dataset before Feb** — the "stranger" test | design partner OR ProveIt shared spec | 🔴 never done |
+| 10 | **Proven on ≥1 foreign plant/dataset before Feb** — the "stranger" test | **acquired: the real ProveIt 2026 factory** (`../proveit-factory/`) — DMDuFresne Ent. B ~5,200-tag "Cappy Hour" beverage-bottling UNS + pilot work-orders; Flexware MIT live sim | 🟡 data in hand — run MIRA against it |
 | 11 | **Cross-tenant isolation proven** (no IDOR) | #1841 | 🟡 closing |
 | 12 | **Recorded fallback + SimLab safety net** | SimLab P0–P5 (done) + capture | 🟢 rig done; capture TODO |
 
@@ -90,10 +90,15 @@ and the ProveIt demo is real. Same finish line.
 
 ## Open decisions (Mike)
 - **Pricing** — pick one architecture before beta outreach (flagged in `NORTH_STAR.md`).
-- **Foreign-data source for item 10** — design partner plant vs. obtaining the ProveIt shared-factory
-  spec early (worth asking 4.0 Solutions for access ahead of the event).
+- **Foreign-data source — RESOLVED (2026-06-22):** the real ProveIt **2026** factory is acquired in
+  `../proveit-factory/` (verified ~5,200-tag "Cappy Hour" beverage-bottling Ignition tree = the SimLab
+  analog, + pilot work-orders/lots for grounding, + the MIT Flexware live sim). **Rehearse on this now.**
+  For the live 2027 factory: **sponsor ProveIt! (Bronze ~$7.5k)** -> spec ~16 wks out (mid-Oct 2026),
+  dry runs ~mid-Jan. Decision left to Mike: sponsor 2027 (yes/no) + when to also land a real design partner.
 - **Booth vs. main-stage slot** — confirm the format/length 4.0 Solutions offers for 2027 and tune the
   arc to the allotted time.
+- **Event calendar** — see `docs/product/2026-06-22-industry-events-radar.md` (ProveIt #1; free adds: IMC
+  award, ICC Discover Gallery, Automate Startup Challenge).
 
 ## Cross-references
 - `NORTH_STAR.md` — the wedge + competitive map this runbook executes.

--- a/docs/product/2026-06-22-industry-events-radar.md
+++ b/docs/product/2026-06-22-industry-events-radar.md
@@ -1,0 +1,64 @@
+# Industry Events Radar — where to show MIRA (2026–2027)
+
+> Companion to `NORTH_STAR.md` + `docs/plans/2026-06-22-proveit-2027-demo-runbook.md`.
+> ICP reminder: **plant maintenance & reliability leaders at SMB/mid-market manufacturers.**
+> Demo asset: a beverage/juice-bottling line on a UNS (= the ProveIt "Cappy Hour" enterprise shape).
+
+## The strategic read
+No single event gives you **both** the pure maintenance/reliability buyer **and** a winnable pitch
+competition. So **split the motion**: win *buyers + credibility* at ProveIt! + IMC; win *capital +
+validation* at the cash shark-tanks (Automate) and ecosystem accelerators (SE Ventures / ABB). It is
+June 2026 — many 2026 windows have passed; 2027 targets noted.
+
+## Top picks for MIRA (ranked)
+
+1. **ProveIt! 2027** — Feb 9-12, Dallas. *The shared-UNS live-demo format IS our thesis* (~76% end-users
+   watch you diagnose a live factory). Reputational win, not cash. Bronze ~$7.5k; spec ~16 wks out.
+   **#1 priority** — and we now hold the 2026 factory data to rehearse on (`../proveit-factory/`).
+2. **IMC — International Maintenance Conference** — Dec 7-10, 2026, Marco Island, FL. *Exact buyer + a
+   winnable, cheap award:* "Best AI Innovation" / People's Choice (an AI chatbot has already won).
+   Solution Awards **$999, free if exhibiting.** Judged award (not cash).
+3. **Automate Startup Challenge 2027** — May 10-13, Las Vegas. The one **free, winnable cash shark-tank**
+   ($10k + NVIDIA/Microsoft + VC validation). Eligibility <5yr/<$5M — we qualify. Frame as
+   "industrial-AI software with downtime ROI," not "a chatbot."
+4. **SMRP Annual 2026** — Sep 28-Oct 1, Raleigh. *Purest, most concentrated SMB maintenance/reliability
+   buyer room.* No competition; best pure pipeline. Pair with cheap regional chapter demos.
+5. **ICC — Ignition Community Conference 2026** — Sep 22-24, Sacramento. Our **Ignition integrator/resale
+   channel** + a FREE juried **Discover Gallery / Firebrand** showcase (MIRA ships on Ignition; submit).
+   UNS/Sparkplug-literate room. Submission deadline ~Apr 30 — start the writeup early.
+6. **PACK EXPO International 2026** — Oct 18-21, Chicago. Biggest in-context stage for the bottling-line
+   demo at a **cheap booth (~$3,425, 10x10)** + Innovation Stage. Maintenance is a secondary persona here
+   — go for thematic splash, not buyer density.
+7. **Ecosystem accelerators (free capital, buyers in their network):** **SE Ventures** ($100k SAFE; thesis
+   literally "Agentic AI for Industrial Workflows") · **ABB Startup Challenge** ($30k + 6-mo pilot — 2026
+   Motion winner was a hardware-free predictive-maintenance startup, near-exact space).
+
+*Honorable mention:* **MaximoWorld** (Aug 17-20, 2026, Nashville — judged AI award, but enterprise/EAM
+buyer) · **FA&M / Food Innovation & Manufacturing Forum** (small but the food-side automation+reliability+
+IT-OT core in one room) · **ARC Industry Forum** (exec credibility, ~ProveIt week/corridor).
+
+## Skip / wrong room
+BevNET Live New Beverage Showdown (CPG brands, not OT) · IFT FIRST (food science) · ProFood Tech (defunct)
+· drinktec (next ~2028) · pure broad shows (Hannover/IMTS) — too diffuse for a niche maintenance wedge.
+
+## Plannable calendar (next ~18 months)
+
+| When | Event | Action |
+|---|---|---|
+| Aug 17-20, 2026 | MaximoWorld, Nashville | Attend; line up a Maximo-shop pilot for a co-submitted award |
+| Sep 22-24, 2026 | **ICC, Sacramento** | Submit Discover Gallery (FREE, deadline ~Apr 30) |
+| Sep 28-Oct 1, 2026 | **SMRP Annual, Raleigh** | Work the bullseye buyer floor + chapters |
+| Oct 18-21, 2026 | **PACK EXPO Intl, Chicago** | 10x10 (~$3,425) bottling-line demo + Innovation Stage |
+| ~mid-Oct 2026 | **ProveIt! spec drops** (if sponsoring) | The official 2027 factory spec + UNS access |
+| Dec 7-10, 2026 | **IMC, Marco Island** | Enter Solution Awards (~$999/free) -> "Best AI Innovation" |
+| ~Jan 2027 | ABB Startup Challenge apps | Apply ($30k + pilot) |
+| ~mid-Jan 2027 | **ProveIt! dry runs** | Validated by the technical committee |
+| **Feb 9-12, 2027** | **ProveIt!, Dallas** | **#1 — the live diagnosis demo (rehearsed since June)** |
+| May 10-13, 2027 | **Automate, Las Vegas** | Enter the Startup Challenge (FREE, $10k) |
+| H2-2026 (watch) | SE Ventures apps | $100k SAFE, "Agentic AI for Industrial Workflows" |
+
+## Decision
+- **Sponsor ProveIt! 2027 (Bronze) now** to lock the spec + UNS access (and the rehearsal corpus is already
+  in hand). It is the single highest-fit event on the list.
+- **Free, high-leverage adds:** IMC award entry, ICC Discover Gallery, Automate Startup Challenge — all
+  cheap/free and winnable; stack them around the ProveIt anchor.


### PR DESCRIPTION
Adds the events radar (`docs/product/2026-06-22-industry-events-radar.md` — where to demo MIRA: ProveIt #1, IMC award, Automate cash shark-tank, SMRP, ICC, PACK EXPO, SE Ventures/ABB + an 18-month calendar) and resolves the runbook's foreign-data decision: the real ProveIt 2026 factory (~5,200-tag 'Cappy Hour' beverage-bottling UNS + pilot work-orders + MIT Flexware sim) is acquired locally in `../proveit-factory/` for rehearsal. Markdown-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)