### PR TITLE
fix(migrations): 057 — add ingest columns to tag_events (additive drift repair)

### DIFF
--- a/mira-hub/db/migrations/057_tag_events_ingest_columns.sql
+++ b/mira-hub/db/migrations/057_tag_events_ingest_columns.sql
@@ -1,0 +1,53 @@
+BEGIN;
+
+-- Migration 057: backfill the ingest columns onto tag_events (drift repair).
+--
+-- WHY THIS EXISTS
+--   `mira-relay/tag_ingest.py` (ingest_batch -> NeonTagStore.persist_batch)
+--   INSERTs tag_events with the columns defined by 033_tag_events.sql:
+--     value, value_type, quality, source_system, source_connection_id,
+--     equipment_entity_id, metadata.
+--   On environments where an EARLIER, diff-style `tag_events` (event_type /
+--   prev_value / new_value / threshold / window_start|end / severity ...) was
+--   created before the current 033, `CREATE TABLE IF NOT EXISTS` in 033 SKIPPED
+--   the table, so those ingest columns were never added. The SimLab->relay
+--   ingest landing then fails with `column "source_system" does not exist`.
+--   (Confirmed on STAGING 2026-06-24: tag_events was missing all 7 columns;
+--   live_signal_cache was already correct.) This is the CREATE-TABLE-IF-NOT-EXISTS
+--   drift hazard documented in .claude/rules/mira-hub-migrations.md.
+--
+-- WHAT THIS DOES
+--   Purely ADDITIVE: ALTER TABLE ... ADD COLUMN IF NOT EXISTS for each of the 7
+--   columns, with the EXACT types / defaults / CHECKs from 033_tag_events.sql.
+--   It does NOT drop, rename, rewrite, truncate, or backfill any existing
+--   column, and it does not change runtime behavior beyond making the documented
+--   ingest write path schema-valid. Idempotent (IF NOT EXISTS) and safe to
+--   re-run. On a tag_events that already matches 033, every statement is a no-op.
+--
+--   NOTE on source_system (NOT NULL, no default — matching 033): this is safe
+--   because the only environments needing this migration have an EMPTY tag_events
+--   (verified 0 rows on staging). If a target env ever has rows in a drifted
+--   tag_events, add a one-off DEFAULT for the ADD COLUMN there — do not weaken
+--   the column shape here.
+--
+-- PROMOTION: dev -> staging -> prod via apply-migrations.yml (dry-run then
+--   apply). Applied to STAGING directly 2026-06-24 to unblock the SimLab->UNS
+--   ingest staging validation; this file is the durable artifact for prod.
+
+ALTER TABLE tag_events ADD COLUMN IF NOT EXISTS equipment_entity_id UUID;
+
+ALTER TABLE tag_events ADD COLUMN IF NOT EXISTS value TEXT;
+
+ALTER TABLE tag_events ADD COLUMN IF NOT EXISTS value_type TEXT NOT NULL DEFAULT 'string'
+    CHECK (value_type IN ('bool', 'int', 'float', 'string', 'enum'));
+
+ALTER TABLE tag_events ADD COLUMN IF NOT EXISTS quality TEXT NOT NULL DEFAULT 'good'
+    CHECK (quality IN ('good', 'bad', 'stale', 'uncertain'));
+
+ALTER TABLE tag_events ADD COLUMN IF NOT EXISTS source_system TEXT NOT NULL;
+
+ALTER TABLE tag_events ADD COLUMN IF NOT EXISTS source_connection_id TEXT;
+
+ALTER TABLE tag_events ADD COLUMN IF NOT EXISTS metadata JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Additive migration repairing a **schema drift** on `tag_events` discovered during the SimLab→UNS ingest staging validation.

`mira-relay/tag_ingest.py` (the relay ingest landing) INSERTs `tag_events` with the columns from `033_tag_events.sql` — `value, value_type, quality, source_system, source_connection_id, equipment_entity_id, metadata`. On environments where an **earlier diff-style `tag_events`** pre-existed, `033`'s `CREATE TABLE IF NOT EXISTS` **skipped** it, so those columns were never added → landing fails with `column "source_system" does not exist`. This is the `CREATE TABLE IF NOT EXISTS` hazard in `.claude/rules/mira-hub-migrations.md`.

**Confirmed on staging 2026-06-24:** all 7 columns missing on `tag_events` (`live_signal_cache` was already correct, 0 missing).

## What it does
Purely **additive**: `ALTER TABLE tag_events ADD COLUMN IF NOT EXISTS` ×7, with the **exact** 033 types/defaults/CHECKs. No drop / rename / rewrite / truncate / backfill. Idempotent — a no-op where `tag_events` already matches 033. `source_system TEXT NOT NULL` (no default) is safe because the only drifted env has an **empty** `tag_events` (verified 0 rows on staging).

## Status
- **Dry-run on staging:** ✅ rollback-verified (columns appear in-txn, gone after rollback, no errors).
- **Applied to staging:** ✅ all 7 columns now present (done directly to unblock the validation).
- **Prod:** likely the same drift (shared migration lineage) — applying 057 via `apply-migrations.yml` is safe regardless (`IF NOT EXISTS`). Do **not** merge until reviewed; promote dev→staging→prod via the normal gate.

Not for immediate merge — opened as the durable artifact for the prod path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)