### PR TITLE
[codex] add FactoryLM external AI context bridge

### DIFF
--- a/.agents/skills/factorylm-context-bridge/SKILL.md
+++ b/.agents/skills/factorylm-context-bridge/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: factorylm-context-bridge
+description: >
+  Use when Codex needs to query, extend, review, test, or package
+  FactoryLM's read-only external AI context bridge. Trigger on FactoryLM
+  Codex plugin work, MCP wrappers, ChatGPT connectors, approved asset context,
+  UNS/tag context, evidence citations, SimLab scenario lookup, live-read gating,
+  or mira-hub/src/lib/external-ai/context-skill.ts.
+---
+
+# FactoryLM Context Bridge
+
+FactoryLM is the governed industrial context layer. MIRA is one native client.
+External AI clients must use structured, read-only calls instead of guessing or
+duplicating MIRA chat behavior.
+
+## Start Here
+
+Read the full developer docs when the task is more than a one-line lookup:
+
+- `docs/external-ai/factorylm-codex-plugin-research.md`
+- `docs/external-ai/factorylm-external-ai-architecture.md`
+- `mira-hub/docs/developer/factorylm-external-ai-skill.md`
+
+## Rules
+
+- Do not build a chatbot.
+- Do not expose raw SQL.
+- Do not create PLC/tag/control writes.
+- Do not add hidden LLM fallback.
+- Use `mira-hub/src/lib/external-ai/context-skill.ts` first.
+- Use `POST /api/factorylm/context` for API access.
+- Keep live values gated by `approved_tags.enabled = true`.
+- Keep asset/entity/evidence reads verified or explicitly labeled draft/internal.
+- Return JSON with `evidence`, `confidence`, `approvalState`, and clear not-found behavior.
+
+## Tool Map
+
+- `find_asset`: fuzzy asset lookup
+- `get_asset_context`: asset, components, approved tags
+- `search_approved_evidence`: citations and approved evidence
+- `get_tag_context`: tag/UNS allowlist metadata
+- `list_related_assets`: verified upstream/downstream/related assets
+- `get_diagnostic_context`: verified fault/diagnostic context
+- `search_simlab_scenarios`: deterministic SimLab scenario matches
+- `get_live_value`: approved live cache value only
+
+## Verify
+
+Run from `mira-hub/`:
+
+```bash
+npx tsc --noEmit
+npx vitest run src/lib/external-ai/context-skill.test.ts src/app/api/factorylm/context/__tests__/route.test.ts
+npx eslint src/lib/external-ai/context-skill.ts src/lib/external-ai/context-skill.test.ts src/app/api/factorylm/context/route.ts src/app/api/factorylm/context/__tests__/route.test.ts
+```

--- a/.claude/skills/factorylm-context-bridge/SKILL.md
+++ b/.claude/skills/factorylm-context-bridge/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: factorylm-context-bridge
+description: >
+  Use when Codex, Claude Code, or another coding agent needs to query, extend,
+  review, test, or wrap FactoryLM's External AI Context Skill or related
+  read-only factory context access. Trigger on requests about FactoryLM external
+  AI tools, MCP/API wrappers, approved asset context, UNS/tag context, evidence
+  citations, SimLab scenario lookup, live-read gating, or preventing external
+  agents from hallucinating factory data. Also use when coding against
+  mira-hub/src/lib/external-ai/context-skill.ts.
+---
+
+# FactoryLM Context Bridge
+
+FactoryLM is the governed industrial context layer. MIRA is one native client.
+External AI clients must get context through structured, read-only calls, not by
+inventing facts or duplicating MIRA chat behavior.
+
+## Core Rule
+
+Do not build a chatbot, raw SQL endpoint, or parallel context system. Use or
+extend `mira-hub/src/lib/external-ai/context-skill.ts` first.
+
+## Workflow
+
+1. **Inspect existing context surfaces** before editing:
+   - `mira-hub/src/lib/external-ai/context-skill.ts`
+   - `mira-hub/src/app/api/factorylm/context/route.ts`
+   - `mira-hub/src/lib/i3x/data-access.ts`
+   - `mira-hub/src/lib/i3x/index.ts`
+   - `mira-hub/src/lib/manual-rag.ts`
+   - `mira-hub/src/lib/tenant-context.ts`
+   - `tests/simlab/scenarios/`
+2. **Choose the narrowest tool** for the question. See
+   `references/tool-selection.md`.
+3. **Preserve the response envelope**:
+   - `ok`
+   - `found`
+   - `tool`
+   - `data`
+   - `evidence`
+   - `confidence`
+   - `approvalState`
+   - `notFoundReason` or `refusedReason` when applicable
+4. **Keep reads gated**:
+   - KG rows exposed to agents require `approval_state = 'verified'`.
+   - live values require `approved_tags.enabled = true` before reading cache.
+   - documents default to verified/approved evidence only.
+   - draft/internal context must be explicitly labeled.
+5. **Return structured facts only**. Do not synthesize troubleshooting prose in
+   this layer.
+6. **Refuse unsafe tools** before DB access. Unknown tool names, write-like
+   names, PLC writes, tag writes, and raw SQL requests must return `ok: false`
+   with `refusedReason`.
+7. **Test with injectable dependencies**. Do not require Neon, a dev server, or
+   live credentials for unit tests.
+
+## When Coding
+
+- Add functions inside the existing skill module unless a route/MCP wrapper is
+  explicitly in scope.
+- For API work, use `POST /api/factorylm/context` and delegate to the skill
+  dispatcher. Resolve tenancy with existing i3X bearer keys first, then Hub
+  session fallback. Do not create a new API-key system in this layer.
+- Prefer pure helpers plus an injectable `runWithTenant` dependency.
+- Use `withTenantContext` for the default runtime path.
+- Reuse i3X projection helpers for related objects and live values.
+- Keep SimLab lookup file-backed and deterministic unless the caller asks for
+  simulator execution.
+- Add tests for both success and fail-closed behavior.
+
+## Verification
+
+Run from `mira-hub/`:
+
+```bash
+npx tsc --noEmit
+npx vitest run src/lib/external-ai/context-skill.test.ts src/app/api/factorylm/context/__tests__/route.test.ts
+npx eslint src/lib/external-ai/context-skill.ts src/lib/external-ai/context-skill.test.ts src/app/api/factorylm/context/route.ts src/app/api/factorylm/context/__tests__/route.test.ts
+```
+
+If adding API or MCP wrappers, also test auth boundaries and refusal of writes.
+
+## Cross-References
+
+- `mira-platform` for MIRA product and environment doctrine.
+- `mira-uns-architecture` for UNS path and confirmation-gate rules.
+- `retrieval-diagnostics` when evidence retrieval misses or cites the wrong
+  vendor.
+- `mira-industrial-safety` when a user asks for safety-critical advice.

--- a/.claude/skills/factorylm-context-bridge/agents/openai.yaml
+++ b/.claude/skills/factorylm-context-bridge/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "FactoryLM Context Bridge"
+  short_description: "Use FactoryLM context tools safely from coding agents."
+  default_prompt: "Use the FactoryLM context bridge to inspect approved factory context before answering or implementing external AI integrations."

--- a/.claude/skills/factorylm-context-bridge/references/tool-selection.md
+++ b/.claude/skills/factorylm-context-bridge/references/tool-selection.md
@@ -1,0 +1,48 @@
+# Tool Selection
+
+Use this reference after `factorylm-context-bridge` triggers.
+
+## Question To Tool
+
+| User or agent needs | Tool |
+|---|---|
+| "What asset is this?" / fuzzy lookup | `find_asset` |
+| "What is this asset?" / tags/components summary | `get_asset_context` |
+| "What evidence supports this mapping/diagnosis?" | `search_approved_evidence` |
+| "What is this tag or UNS path?" | `get_tag_context` |
+| "What is upstream/downstream/related?" | `list_related_assets` |
+| "What does FactoryLM know about this fault?" | `get_diagnostic_context` |
+| "What is the live value?" | `get_live_value` |
+| "What SimLab scenario covers this behavior?" | `search_simlab_scenarios` |
+
+## Safety Checks
+
+- If the request asks to write, update, acknowledge, reset, command, tune, or
+  control a PLC/tag/machine, refuse in this layer.
+- If no verified asset/tag/evidence is found, return `found: false`; do not
+  invent fields.
+- If evidence is draft/internal, label it draft/internal and do not present it
+  as approved.
+- If live value has no approved tag allowlist row, report that no approved
+  live-read path exists.
+
+## Coding Patterns
+
+Use this shape for new read-only tools:
+
+```ts
+async function getSomething(client: DbClient, input: Record<string, unknown>) {
+  const id = asString(input, "id");
+  if (!id) return notFound("get_something", "id is required");
+
+  const { rows } = await client.query(
+    `SELECT ... WHERE approval_state = 'verified' AND id = $1 LIMIT 1`,
+    [id],
+  );
+  if (rows.length === 0) return notFound("get_something", "verified context not found");
+
+  return ok("get_something", { ... }, evidence, "verified", "verified");
+}
+```
+
+Prefer bounded result sets and explicit status fields over free-form prose.

--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,10 @@ wiki/.smart-env/
 
 # Third-party AI tool runtime dirs (local config, not code)
 .agents/
+!.agents/
+!.agents/skills/
+!.agents/skills/factorylm-context-bridge/
+!.agents/skills/factorylm-context-bridge/**
 .codex/
 .serena/
 

--- a/docs/external-ai/README.md
+++ b/docs/external-ai/README.md
@@ -1,0 +1,70 @@
+# FactoryLM External AI Developer Usage
+
+FactoryLM external AI access is private/local first.
+
+## Use With Codex Today
+
+Start in the MIRA repo and invoke the repo skill:
+
+```text
+$factorylm-context-bridge
+Find the conveyor asset and show approved evidence.
+```
+
+The skill points Codex at:
+
+- `mira-hub/src/lib/external-ai/context-skill.ts`
+- `mira-hub/src/app/api/factorylm/context/route.ts`
+- `mira-hub/docs/developer/factorylm-external-ai-skill.md`
+
+## Use The Internal API
+
+From an authenticated Hub session or with an existing i3X bearer key:
+
+```bash
+curl -sS https://app.example.com/api/factorylm/context \
+  -H "content-type: application/json" \
+  -H "authorization: Bearer $I3X_API_KEY" \
+  -d '{
+    "tool": "find_asset",
+    "input": { "query": "conveyor" }
+  }'
+```
+
+Local development can call the library directly in tests:
+
+```ts
+import { factoryLmContextSkill } from "@/lib/external-ai/context-skill";
+
+const result = await factoryLmContextSkill.call({
+  tool: "get_asset_context",
+  input: { asset_id: "filler01" },
+  context: { tenantId },
+});
+```
+
+## Private Codex Plugin Draft
+
+The private plugin package lives at:
+
+```text
+plugins/factorylm-context/
+```
+
+It currently bundles the `factorylm-context-bridge` skill only. MCP config is
+intentionally absent until the dedicated read-only MCP server exists.
+
+## Expected Result Style
+
+Answers should be grounded in returned JSON, not model memory:
+
+- cite `evidence`
+- report `approvalState`
+- preserve `notFoundReason`
+- say when live data is unavailable or not approved
+- do not invent tags, assets, documents, fault codes, or live values
+
+## Next Developer Milestone
+
+Build the local MCP server wrapper for `POST /api/factorylm/context`, then add
+that server to the private Codex plugin as `.mcp.json`.

--- a/docs/external-ai/factorylm-codex-plugin-research.md
+++ b/docs/external-ai/factorylm-codex-plugin-research.md
@@ -1,0 +1,209 @@
+# FactoryLM Codex Plugin And ChatGPT MCP Research
+
+Date: 2026-06-25
+
+Status: private/internal research note. This is the decision record for moving
+from the local FactoryLM context skill toward a Codex plugin and later a
+ChatGPT MCP app/connector.
+
+## Official Sources Checked
+
+- OpenAI Codex skills: `https://developers.openai.com/codex/skills`
+- OpenAI Codex plugins overview: `https://developers.openai.com/codex/plugins`
+- OpenAI Codex plugin authoring: `https://developers.openai.com/codex/plugins/build`
+- OpenAI Codex MCP configuration: `https://developers.openai.com/codex/mcp`
+- OpenAI Apps SDK quickstart: `https://developers.openai.com/apps-sdk/quickstart`
+- OpenAI Apps SDK MCP server guide: `https://developers.openai.com/apps-sdk/build/mcp-server`
+- OpenAI Apps SDK connect from ChatGPT: `https://developers.openai.com/apps-sdk/deploy/connect-chatgpt`
+- OpenAI Apps SDK authentication: `https://developers.openai.com/apps-sdk/build/auth`
+- OpenAI Apps SDK security/privacy: `https://developers.openai.com/apps-sdk/guides/security-privacy`
+- OpenAI remote MCP guide for ChatGPT/API integrations: `https://developers.openai.com/api/docs/mcp`
+
+## 1. Skill Vs Plugin Vs MCP Server Vs ChatGPT Custom MCP App
+
+**Codex skill:** a local or bundled workflow made of `SKILL.md` plus optional
+references/scripts/assets. Codex loads skill metadata first and only reads the
+full instructions when triggered. Skills are best for proving repeatable agent
+behavior, like "query FactoryLM context before answering."
+
+**Codex plugin:** an installable distribution unit for Codex. OpenAI documents
+plugins as bundles that can contain skills, app integrations, and MCP servers.
+Use a plugin when the workflow needs to be shared, installed, bundled with MCP
+configuration, or presented as a stable package.
+
+**MCP server:** a service that exposes tools and context over the Model Context
+Protocol. For Codex, MCP servers can be stdio or streamable HTTP, and Codex can
+configure bearer-token or OAuth auth for HTTP servers. For ChatGPT Apps, MCP is
+the required backend protocol: the server lists tools, handles tool calls,
+returns structured content, and may point to optional UI resources.
+
+**ChatGPT custom MCP app/connector:** current OpenAI docs use "apps" for the
+ChatGPT product surface, with older "connector" terminology still relevant for
+data-only apps. A ChatGPT app needs a remote HTTPS MCP server. If no UI is
+needed, it can be a data-only app exposing tools; if UI is needed, it can also
+serve a widget resource rendered inside ChatGPT.
+
+## 2. What Files/Config Does A Codex Plugin Require?
+
+Minimum plugin structure:
+
+```text
+factorylm-context/
+  .codex-plugin/
+    plugin.json
+  skills/
+    factorylm-context-bridge/
+      SKILL.md
+```
+
+Required manifest path:
+
+```text
+.codex-plugin/plugin.json
+```
+
+Minimum manifest fields from the OpenAI plugin docs:
+
+```json
+{
+  "name": "factorylm-context",
+  "version": "0.1.0",
+  "description": "Read-only FactoryLM context access for external AI tools.",
+  "skills": "./skills/"
+}
+```
+
+For usable presentation and validation, include author/interface metadata. MCP
+configuration can be a sibling `.mcp.json` and referenced by `mcpServers`, but
+only after an actual MCP server exists.
+
+## 3. Can A Codex Plugin Bundle A Skill And MCP Server Config?
+
+Yes. OpenAI's Codex docs state that plugins can bundle skills and may also
+bundle MCP server configuration. Codex MCP docs also describe plugin-provided
+MCP servers controlled through user `config.toml` under `plugins.*.mcp_servers`.
+
+For FactoryLM, the safe order is:
+
+1. Bundle the proven skill now.
+2. Add local MCP config only after a working MCP server exists.
+3. Add remote MCP config only after HTTPS auth, tenant scope, and audit logging
+   are implemented.
+
+## 4. What Would FactoryLM Need To Expose Through MCP?
+
+The MCP server should wrap the internal FactoryLM context API, not database
+tables. Initial tools should mirror the current context skill:
+
+- `find_asset(query)`
+- `get_asset_context(asset_id)`
+- `search_approved_evidence(asset_id, query)`
+- `get_tag_context(tag_or_uns_path)`
+- `list_related_assets(asset_id)`
+- `get_diagnostic_context(asset_id?, fault_code?)`
+- `search_simlab_scenarios(query)`
+- `get_live_value(tag_or_uns_path)` only through approved live-read paths
+
+For ChatGPT company knowledge/deep research compatibility, OpenAI's remote MCP
+guide also expects read-only `search` and `fetch` tools with structured result
+objects. FactoryLM should add those as a compatibility layer over approved
+evidence and asset/document context.
+
+## 5. What Is Required For A ChatGPT Custom MCP Connector/App?
+
+The ChatGPT-facing version requires:
+
+- A remote HTTPS MCP endpoint, typically `/mcp`.
+- Tool descriptors with clear names, descriptions, input schemas, and output
+  schemas.
+- Structured tool results, preferably `structuredContent`.
+- Authentication for customer-specific data. OpenAI's Apps SDK auth docs expect
+  OAuth 2.1 conforming to the MCP authorization spec for protected resources.
+- Protected resource metadata at
+  `/.well-known/oauth-protected-resource` or equivalent `WWW-Authenticate`
+  discovery.
+- OAuth authorization server metadata, PKCE support, scopes, redirect URI
+  allowlisting, token audience/resource validation, and per-request bearer token
+  verification.
+- For ChatGPT development setup, create a connector in ChatGPT settings using
+  the public `/mcp` endpoint. For local development, use a secure tunnel.
+- Optional UI bundle only if FactoryLM wants a richer app experience. Data-only
+  context access can skip UI.
+
+## 6. What Can Be Built Privately Before Public Submission?
+
+Build now:
+
+- Repo-local Codex skill.
+- Internal read-only FactoryLM context API.
+- Private Codex plugin bundling the skill.
+- Local MCP server wrapping the internal API.
+- Local or private marketplace entry for testing.
+- Remote MCP prototype behind non-public auth.
+- Admin-only customer API-key/OAuth experiments.
+- Security tests, tenant-boundary tests, prompt-injection tests, and audit logs.
+
+Do not assume public/plugin-store acceptance yet. OpenAI docs currently point
+ChatGPT public distribution through app submission guidelines, while Codex
+plugins can be local, marketplace-backed, or workspace-shared. Treat public
+distribution as a later packaging/review phase.
+
+## 7. Mandatory Security Requirements For Factory Data
+
+FactoryLM's external AI bridge must enforce:
+
+- Read-only only.
+- No PLC writes.
+- No tag writes.
+- No control actions.
+- No raw SQL exposure.
+- No database dump endpoints.
+- No unapproved document leakage unless explicitly marked draft/internal.
+- No cross-tenant leakage.
+- No hallucinated fields or hidden LLM fallback.
+- Tenant/site boundaries via existing RLS/session/API-key patterns.
+- Least-privilege scopes for remote OAuth/API keys.
+- Tool descriptions that discourage misuse.
+- Server-side input validation for every tool call.
+- Audit logs for who called which tool, tenant/site, arguments summary,
+  result status, and correlation ID.
+- PII/secret redaction in logs.
+- Explicit stale/draft/unapproved warnings in tool output.
+
+OpenAI's Apps SDK security guidance also emphasizes least privilege, explicit
+consent, defense in depth, prompt-injection assumptions, input validation, and
+audit logging. Those map directly to FactoryLM's factory-data safety model.
+
+## Repo Inspection Summary
+
+Existing reusable pieces:
+
+- `mira-hub/src/lib/external-ai/context-skill.ts`:
+  internal dispatcher for read-only structured FactoryLM context.
+- `mira-hub/src/app/api/factorylm/context/route.ts`:
+  current internal API wrapper using i3X bearer auth or Hub session fallback.
+- `mira-hub/src/lib/i3x/data-access.ts` and `mira-hub/src/lib/i3x/*`:
+  verified-entity projection, related objects, approved-tag live reads.
+- `mira-hub/src/lib/manual-rag.ts`:
+  approved document retrieval and citation/source helpers.
+- `mira-hub/src/lib/tenant-context.ts`:
+  app-role RLS tenant isolation.
+- `mira-hub/src/lib/session.ts` and `mira-hub/src/lib/i3x/auth.ts`:
+  session and bearer-key tenant resolution patterns.
+- `mira-hub/src/app/api/mira/ask/route.ts` and
+  `mira-hub/src/app/api/namespace/node/[id]/chat/route.ts`:
+  MIRA chat surfaces to reuse conceptually but not duplicate.
+- `tests/simlab/scenarios/*.yaml` and `simlab/`:
+  deterministic diagnostic scenario context.
+- `mira-mcp/server.py`:
+  existing MCP server, but it includes write-capable CMMS/diagnostic tools and
+  should not be reused directly for this read-only bridge.
+- `.claude/skills/*`:
+  repo-local agent skill pattern.
+
+Current gap:
+
+- No dedicated read-only FactoryLM MCP server yet.
+- No Codex plugin package yet.
+- No customer-scoped OAuth/API-key model for ChatGPT remote MCP yet.
+- No shared audit helper for external AI tool calls yet.

--- a/docs/external-ai/factorylm-external-ai-architecture.md
+++ b/docs/external-ai/factorylm-external-ai-architecture.md
@@ -1,0 +1,201 @@
+# FactoryLM External AI Architecture
+
+Date: 2026-06-25
+
+## Principle
+
+FactoryLM is the governed industrial context layer. MIRA is one native client.
+External AI tools should query FactoryLM context through safe, structured,
+read-only calls. They should not duplicate MIRA, become a chatbot, or infer
+factory facts from model memory.
+
+## Phases
+
+### Phase 1: Local FactoryLM Codex Skill
+
+Status: started.
+
+Repo skill:
+
+- `.claude/skills/factorylm-context-bridge/SKILL.md`
+
+Purpose:
+
+- Teach Codex/Claude Code how to use FactoryLM context safely.
+- Keep future coding sessions from adding raw SQL, write tools, or duplicate
+  MIRA chat flows.
+
+### Phase 2: Internal Read-Only FactoryLM Context API
+
+Status: started.
+
+Files:
+
+- `mira-hub/src/lib/external-ai/context-skill.ts`
+- `mira-hub/src/app/api/factorylm/context/route.ts`
+- `mira-hub/docs/developer/factorylm-external-ai-skill.md`
+
+Auth:
+
+- Existing i3X bearer key first.
+- Hub session fallback for internal/dev usage.
+- No new customer API-key system yet.
+
+Endpoint:
+
+```http
+POST /api/factorylm/context
+Content-Type: application/json
+Authorization: Bearer <existing i3X key>
+```
+
+Request:
+
+```json
+{
+  "tool": "get_asset_context",
+  "input": { "asset_id": "filler01" }
+}
+```
+
+### Phase 3: Local MCP Server Wrapping The API
+
+Status: planned.
+
+Shape:
+
+- Local stdio or streamable HTTP MCP server.
+- Calls `/api/factorylm/context`.
+- Exposes only read-only tools.
+- Returns structured content and matching JSON text content for broad MCP
+  compatibility.
+
+Tool set:
+
+- `find_asset`
+- `get_asset_context`
+- `search_approved_evidence`
+- `get_tag_context`
+- `list_related_assets`
+- `get_diagnostic_context`
+- `search_simlab_scenarios`
+- `get_live_value`
+
+Compatibility tools for ChatGPT/deep research later:
+
+- `search`
+- `fetch`
+
+### Phase 4: Codex Plugin Bundling Skill And MCP Config
+
+Status: start private/internal.
+
+Initial plugin should bundle only the skill until the MCP server exists. Once
+Phase 3 is real, add `mcpServers` to `.codex-plugin/plugin.json`.
+
+Private plugin structure:
+
+```text
+plugins/factorylm-context/
+  .codex-plugin/plugin.json
+  skills/factorylm-context-bridge/SKILL.md
+  skills/factorylm-context-bridge/references/tool-selection.md
+```
+
+Later:
+
+```text
+plugins/factorylm-context/.mcp.json
+```
+
+### Phase 5: Remote MCP Server For ChatGPT Custom Connector/App
+
+Status: planned.
+
+Requirements:
+
+- HTTPS `/mcp` endpoint.
+- OAuth 2.1 / MCP authorization spec support for customer data.
+- Tenant/site scopes.
+- Tool schemas and output schemas.
+- `search`/`fetch` compatibility if targeting company knowledge/deep research.
+- Optional ChatGPT UI only after data-only mode works.
+
+### Phase 6: Customer-Scoped API Keys/OAuth, Audit Logs, Admin Controls
+
+Status: planned.
+
+Required before customer rollout:
+
+- Customer-managed connector enable/disable.
+- Scoped OAuth or API-key issuance.
+- Scope model: tenant, site, asset namespace subtree, live value permission,
+  draft/internal permission.
+- Audit log for each tool call.
+- Admin visibility into connected clients.
+- Revocation and rotation.
+- Rate limits.
+
+### Phase 7: Publishable Plugin/App Package
+
+Status: later.
+
+Do not assume public acceptance. Build so it is publishable:
+
+- Accurate metadata.
+- Privacy policy and terms URLs.
+- Screenshots if UI exists.
+- Test prompts/responses.
+- Security review materials.
+- Tenant-boundary test evidence.
+
+## Response Contract
+
+Every FactoryLM external AI response should include:
+
+- `ok`
+- `found`
+- `tool`
+- `data`
+- `evidence`
+- `confidence`
+- `approvalState`
+- `notFoundReason` or `refusedReason` where relevant
+
+Data should include, where available:
+
+- asset ID
+- asset name
+- UNS path
+- tenant/site context
+- approval status
+- citations/source references
+- related tags
+- related documents
+- stale/draft/unapproved warnings
+
+## Security Rules
+
+- Read-only only.
+- No PLC writes.
+- No tag writes.
+- No control actions.
+- No raw SQL exposed.
+- No database dumps.
+- No unapproved document leakage unless explicitly marked internal/draft.
+- No cross-tenant leakage.
+- No hidden LLM fallback.
+- No hallucinated fields.
+- Evidence missing must be explicit.
+
+## Immediate Backlog
+
+1. Package current skill into `plugins/factorylm-context`.
+2. Add local plugin validation to CI or a developer command.
+3. Build a local MCP server that wraps `/api/factorylm/context`.
+4. Add MCP tests for read-only tool schema and refusal behavior.
+5. Add audit helper/table for external AI tool calls.
+6. Add `search`/`fetch` compatibility tools over approved evidence.
+7. Design OAuth scopes for ChatGPT remote MCP.
+8. Add admin controls for connected external AI clients.
+9. Add security review checklist and prompt-injection tests.

--- a/mira-hub/docs/developer/factorylm-external-ai-skill.md
+++ b/mira-hub/docs/developer/factorylm-external-ai-skill.md
@@ -1,0 +1,146 @@
+# FactoryLM External AI Context Skill
+
+FactoryLM is the governed industrial context layer. MIRA is one native client.
+External AI tools such as Codex, Claude Code, future MCP clients, or scoped API
+connectors should query FactoryLM through small, structured, read-only calls.
+
+This skill is the first internal developer-facing bridge. It is not a chatbot
+and does not generate troubleshooting prose. It returns JSON context that a
+caller can cite or inspect before deciding what to do next.
+
+## Location
+
+- Library: `src/lib/external-ai/context-skill.ts`
+- API route: `src/app/api/factorylm/context/route.ts`
+- Tests: `src/lib/external-ai/context-skill.test.ts`
+  and `src/app/api/factorylm/context/__tests__/route.test.ts`
+
+## Tool Surface
+
+Call `factoryLmContextSkill.call(...)` or create an injectable instance with
+`createFactoryLmContextSkill(...)`.
+
+```ts
+import { factoryLmContextSkill } from "@/lib/external-ai/context-skill";
+
+const result = await factoryLmContextSkill.call({
+  tool: "get_asset_context",
+  context: { tenantId },
+  input: { asset_id: "filler01" },
+});
+```
+
+Supported tools:
+
+- `find_asset({ query, limit? })`
+- `get_asset_context({ asset_id | assetId | uns_path })`
+- `search_approved_evidence({ asset_id, query, limit?, includeDraft? })`
+- `get_tag_context({ tag_or_uns_path })`
+- `list_related_assets({ asset_id })`
+- `get_diagnostic_context({ asset_id?, fault_code? })`
+- `get_live_value({ tag_or_uns_path })`
+- `search_simlab_scenarios({ query, limit? })`
+
+## API Surface
+
+The first API wrapper is:
+
+```http
+POST /api/factorylm/context
+Content-Type: application/json
+Authorization: Bearer <existing i3X API key>
+```
+
+Request:
+
+```json
+{
+  "tool": "get_asset_context",
+  "input": { "asset_id": "filler01" }
+}
+```
+
+The route resolves tenancy with existing auth only:
+
+1. Existing i3X bearer key via `i3x_api_keys`
+2. Hub session cookie fallback for internal/developer use
+
+It does not create a new customer API-key system. It delegates to the same
+internal skill dispatcher, so unsupported or write-like tool names return the
+standard refusal envelope.
+
+Every response uses a consistent envelope:
+
+```json
+{
+  "ok": true,
+  "found": true,
+  "tool": "get_asset_context",
+  "data": {},
+  "evidence": [],
+  "confidence": "verified",
+  "approvalState": "verified"
+}
+```
+
+When nothing is found, `found` is `false` and `notFoundReason` is set. Unknown
+or unsafe tool names return `ok: false` with `refusedReason`.
+
+## Reused FactoryLM/MIRA Surfaces
+
+- Tenant boundaries use `withTenantContext`, which drops into the app role and
+  sets tenant RLS variables.
+- Asset/entity reads use `kg_entities` and require `approval_state = 'verified'`.
+- Related assets reuse the i3X relationship helpers in `src/lib/i3x/data-access.ts`.
+- Live values are gated through `approved_tags` before reading
+  `live_signal_cache`.
+- Evidence search reads `knowledge_entries` under the asset namespace subtree
+  and defaults to `verified = true`.
+- SimLab search reads deterministic scenario YAML fixtures and marks them
+  `internal`.
+
+## Safety Rules
+
+- Read-only only.
+- No PLC writes.
+- No tag writes.
+- No direct SQL exposed to callers.
+- No raw database dumping.
+- No unapproved documents by default.
+- Tenant/site boundaries must be supplied by the trusted caller context.
+- Draft evidence is only returned when the caller explicitly passes
+  `includeDraft: true`; those records remain marked `draft`.
+
+## Example Usage By External AI Tools
+
+Before answering "What is this asset?":
+
+1. Call `find_asset({ query })`.
+2. If a single high-confidence candidate returns, call `get_asset_context`.
+3. Use `evidence` and `approvalState` fields in the final answer.
+4. If `found: false`, ask the operator for a better asset, tag, or UNS path.
+
+Before answering "What tags belong to it?":
+
+1. Call `get_asset_context({ asset_id })`.
+2. Read `data.approvedTags`.
+3. Never invent tags that are not returned.
+
+Before answering "What evidence supports this mapping?":
+
+1. Call `search_approved_evidence({ asset_id, query })`.
+2. Cite only returned evidence references.
+
+Before answering "What is the live value?":
+
+1. Call `get_live_value({ tag_or_uns_path })`.
+2. If the result is not found, report that no approved live-read path exists.
+
+## Follow-Up Backlog
+
+- Add audit logging for tool calls if/when a shared tool-call audit helper exists.
+- Add a FastMCP wrapper that delegates to this library rather than duplicating SQL.
+- Add scoped customer connector/API-key support on top of the i3X key model.
+- Add richer diagnostic context by reusing or refactoring
+  `maintenanceContext` without exposing write-capable KG dispatch operations.
+- Add pagination/cursors for large namespace searches.

--- a/mira-hub/src/app/api/factorylm/context/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/factorylm/context/__tests__/route.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  call: vi.fn(),
+  resolveI3xTenant: vi.fn(),
+  sessionOr401: vi.fn(),
+}));
+
+vi.mock("@/lib/external-ai/context-skill", () => ({
+  factoryLmContextSkill: {
+    call: mocks.call,
+  },
+}));
+
+vi.mock("@/lib/i3x/auth", () => ({
+  resolveI3xTenant: mocks.resolveI3xTenant,
+}));
+
+vi.mock("@/lib/session", () => ({
+  sessionOr401: mocks.sessionOr401,
+}));
+
+import { POST } from "@/app/api/factorylm/context/route";
+
+function req(body: unknown, init: RequestInit = {}) {
+  return new Request("http://x/api/factorylm/context", {
+    method: "POST",
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(init.headers ?? {}),
+    },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/factorylm/context", () => {
+  beforeEach(() => {
+    mocks.call.mockReset();
+    mocks.resolveI3xTenant.mockReset();
+    mocks.sessionOr401.mockReset();
+  });
+
+  it("401s when neither bearer auth nor Hub session resolves a tenant", async () => {
+    mocks.resolveI3xTenant.mockResolvedValue(null);
+    mocks.sessionOr401.mockResolvedValue(NextResponse.json({ error: "Unauthorized" }, { status: 401 }));
+
+    const res = await POST(req({ tool: "find_asset", input: { query: "filler" } }));
+
+    expect(res.status).toBe(401);
+    expect(mocks.call).not.toHaveBeenCalled();
+  });
+
+  it("uses existing i3X bearer auth when present", async () => {
+    mocks.resolveI3xTenant.mockResolvedValue("tenant-i3x");
+    mocks.call.mockResolvedValue({
+      ok: true,
+      found: true,
+      tool: "find_asset",
+      data: { results: [] },
+      evidence: [],
+      confidence: "medium",
+      approvalState: "verified",
+    });
+
+    const res = await POST(req({ tool: "find_asset", input: { query: "filler" } }, {
+      headers: { authorization: "Bearer good" },
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(mocks.sessionOr401).not.toHaveBeenCalled();
+    expect(mocks.call).toHaveBeenCalledWith({
+      tool: "find_asset",
+      input: { query: "filler" },
+      context: { tenantId: "tenant-i3x" },
+    });
+  });
+
+  it("falls back to the Hub session for internal/dev usage", async () => {
+    mocks.resolveI3xTenant.mockResolvedValue(null);
+    mocks.sessionOr401.mockResolvedValue({ tenantId: "tenant-session", userId: "u1", email: "a@example.com" });
+    mocks.call.mockResolvedValue({
+      ok: true,
+      found: false,
+      tool: "get_live_value",
+      data: null,
+      evidence: [],
+      confidence: "none",
+      approvalState: "not_found",
+      notFoundReason: "no approved live-read tag matched",
+    });
+
+    const res = await POST(req({ tool: "get_live_value", input: { tag_or_uns_path: "line.tag" } }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.found).toBe(false);
+    expect(mocks.call).toHaveBeenCalledWith({
+      tool: "get_live_value",
+      input: { tag_or_uns_path: "line.tag" },
+      context: { tenantId: "tenant-session" },
+    });
+  });
+
+  it("400s malformed JSON and missing tool before dispatch", async () => {
+    mocks.resolveI3xTenant.mockResolvedValue("tenant-i3x");
+
+    const malformed = await POST(req("{"));
+    expect(malformed.status).toBe(400);
+
+    const missingTool = await POST(req({ input: {} }));
+    expect(missingTool.status).toBe(400);
+    expect(mocks.call).not.toHaveBeenCalled();
+  });
+
+  it("surfaces read-only refusals as 400 without hiding the envelope", async () => {
+    mocks.resolveI3xTenant.mockResolvedValue("tenant-i3x");
+    mocks.call.mockResolvedValue({
+      ok: false,
+      found: false,
+      tool: "write_tag",
+      data: null,
+      evidence: [],
+      confidence: "none",
+      approvalState: "unknown",
+      refusedReason: "unsupported or unsafe tool; FactoryLM external AI skill is read-only",
+    });
+
+    const res = await POST(req({ tool: "write_tag", input: { tag: "x", value: 1 } }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.refusedReason).toMatch(/read-only/i);
+  });
+});

--- a/mira-hub/src/app/api/factorylm/context/route.ts
+++ b/mira-hub/src/app/api/factorylm/context/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { factoryLmContextSkill } from "@/lib/external-ai/context-skill";
+import { resolveI3xTenant } from "@/lib/i3x/auth";
+import { sessionOr401 } from "@/lib/session";
+
+export const dynamic = "force-dynamic";
+
+interface ContextApiBody {
+  tool?: unknown;
+  input?: unknown;
+}
+
+function badRequest(detail: string) {
+  return NextResponse.json({ error: "Bad Request", detail }, { status: 400 });
+}
+
+async function resolveTenant(req: Request): Promise<string | NextResponse> {
+  const i3xTenant = await resolveI3xTenant(req);
+  if (i3xTenant) return i3xTenant;
+
+  const session = await sessionOr401();
+  if (session instanceof NextResponse) return session;
+  return session.tenantId;
+}
+
+export async function POST(req: Request) {
+  let body: ContextApiBody;
+  try {
+    body = (await req.json()) as ContextApiBody;
+  } catch {
+    return badRequest("invalid JSON body");
+  }
+
+  if (!body || typeof body.tool !== "string" || body.tool.trim().length === 0) {
+    return badRequest("tool is required");
+  }
+  if (body.input !== undefined && (typeof body.input !== "object" || body.input === null || Array.isArray(body.input))) {
+    return badRequest("input must be an object when provided");
+  }
+
+  const tenant = await resolveTenant(req);
+  if (tenant instanceof NextResponse) return tenant;
+
+  const result = await factoryLmContextSkill.call({
+    tool: body.tool.trim(),
+    input: (body.input ?? {}) as Record<string, unknown>,
+    context: { tenantId: tenant },
+  });
+
+  return NextResponse.json(result, { status: result.ok ? 200 : 400 });
+}

--- a/mira-hub/src/lib/external-ai/context-skill.test.ts
+++ b/mira-hub/src/lib/external-ai/context-skill.test.ts
@@ -1,0 +1,349 @@
+import { describe, expect, it, vi } from "vitest";
+import { createFactoryLmContextSkill, type FactoryLmToolCall } from "./context-skill";
+import type { DbClient } from "@/lib/i3x/data-access";
+
+const TENANT_ID = "11111111-1111-4111-8111-111111111111";
+
+function mockClient(handlers: Array<[RegExp, unknown[]]>): DbClient & { calls: Array<{ sql: string; params?: unknown[] }> } {
+  const calls: Array<{ sql: string; params?: unknown[] }> = [];
+  const query: DbClient["query"] = async <T = Record<string, unknown>>(sql: string, params?: unknown[]) => {
+    calls.push({ sql, params });
+    const hit = handlers.find(([pattern]) => pattern.test(sql));
+    if (!hit) throw new Error(`unhandled query: ${sql}`);
+    return { rows: hit[1] as T[] };
+  };
+  return {
+    calls,
+    query,
+  };
+}
+
+function skillFor(client: DbClient) {
+  return createFactoryLmContextSkill({
+    runWithTenant: async (tenantId, fn) => {
+      expect(tenantId).toBe(TENANT_ID);
+      return fn(client);
+    },
+  });
+}
+
+function call(tool: string, input: Record<string, unknown> = {}): FactoryLmToolCall {
+  return { tool, input, context: { tenantId: TENANT_ID } };
+}
+
+describe("FactoryLM external AI context skill", () => {
+  it("refuses unsupported/write-like tools before touching the database", async () => {
+    const runWithTenant = vi.fn();
+    const skill = createFactoryLmContextSkill({ runWithTenant });
+
+    const res = await skill.call(call("write_tag", { tag: "pump01.speed", value: 100 }));
+
+    expect(res.ok).toBe(false);
+    expect(res.found).toBe(false);
+    expect(res.refusedReason).toMatch(/read-only/i);
+    expect(runWithTenant).not.toHaveBeenCalled();
+  });
+
+  it("find_asset returns verified structured asset candidates with evidence", async () => {
+    const client = mockClient([
+      [/FROM kg_entities[\s\S]*approval_state = 'verified'[\s\S]*ORDER BY/, [
+        {
+          id: "asset-1",
+          entity_id: "filler01",
+          entity_type: "equipment",
+          name: "Filler 01",
+          approval_state: "verified",
+          uns_path: "enterprise.demo.plant.line01.filler01",
+          properties: { manufacturer: "Acme", model: "F100" },
+        },
+      ]],
+    ]);
+
+    const res = await skillFor(client).call(call("find_asset", { query: "filler" }));
+
+    expect(res.ok).toBe(true);
+    expect(res.found).toBe(true);
+    expect(res.approvalState).toBe("verified");
+    expect(res.data).toMatchObject({
+      query: "filler",
+      results: [
+        {
+          assetId: "asset-1",
+          entityId: "filler01",
+          unsPath: "enterprise.demo.plant.line01.filler01",
+          approvalState: "verified",
+        },
+      ],
+    });
+    expect(res.evidence[0]).toMatchObject({
+      sourceType: "kg_entity",
+      sourceId: "asset-1",
+      approvalState: "verified",
+    });
+  });
+
+  it("get_live_value is fail-closed behind approved_tags and projects an i3X current value", async () => {
+    const client = mockClient([
+      [/FROM approved_tags[\s\S]*LIMIT 1/, [
+        {
+          uns_path: "enterprise.demo.line01.filler01.bowl_pressure",
+          source_system: "ignition",
+          source_tag_path: "Line01/Filler01/BowlPressure",
+          normalized_tag_path: "line01.filler01.bowl_pressure",
+          enabled: true,
+        },
+      ]],
+      [/FROM live_signal_cache/, [
+        {
+          uns_path: "enterprise.demo.line01.filler01.bowl_pressure",
+          last_value_text: null,
+          last_value_numeric: 5.2,
+          last_value_bool: null,
+          latest_quality: "good",
+          freshness_status: "live",
+          last_seen_at: "2026-06-24T12:00:00.000Z",
+        },
+      ]],
+    ]);
+
+    const res = await skillFor(client).call(call("get_live_value", {
+      tag_or_uns_path: "enterprise.demo.line01.filler01.bowl_pressure",
+    }));
+
+    expect(res.ok).toBe(true);
+    expect(res.approvalState).toBe("approved");
+    expect(res.data).toMatchObject({
+      unsPath: "enterprise.demo.line01.filler01.bowl_pressure",
+      currentValue: {
+        value: 5.2,
+        quality: "Good",
+        timestamp: "2026-06-24T12:00:00.000Z",
+      },
+    });
+    expect(res.evidence.map((e) => e.sourceType)).toEqual(["approved_tag", "live_signal_cache"]);
+  });
+
+  it("get_live_value returns a clear not-found when a tag is not approved", async () => {
+    const client = mockClient([[/FROM approved_tags[\s\S]*LIMIT 1/, []]]);
+
+    const res = await skillFor(client).call(call("get_live_value", { tag_or_uns_path: "raw.plc.secret" }));
+
+    expect(res.ok).toBe(true);
+    expect(res.found).toBe(false);
+    expect(res.notFoundReason).toMatch(/approved/i);
+  });
+
+  it("search_approved_evidence defaults to verified chunks only", async () => {
+    const client = mockClient([
+      [/FROM kg_entities[\s\S]*entity_type IN/, [
+        {
+          id: "asset-1",
+          entity_id: "filler01",
+          entity_type: "equipment",
+          name: "Filler 01",
+          approval_state: "verified",
+          uns_path: "enterprise.demo.line01.filler01",
+          properties: {},
+        },
+      ]],
+      [/FROM knowledge_entries/, [
+        {
+          id: "chunk-1",
+          content: "F010 indicates low filler bowl pressure.",
+          source_url: "manuals/filler.pdf",
+          source_page: 42,
+          page_start: null,
+          title: "Filler troubleshooting",
+          filename: "troubleshooting.md",
+          verified: true,
+          rank: 1,
+        },
+      ]],
+    ]);
+
+    const res = await skillFor(client).call(call("search_approved_evidence", {
+      asset_id: "asset-1",
+      query: "F010 bowl pressure",
+    }));
+
+    expect(res.ok).toBe(true);
+    expect(res.approvalState).toBe("verified");
+    expect(res.data).toMatchObject({
+      results: [{ content: "F010 indicates low filler bowl pressure.", approvalState: "verified" }],
+    });
+    const evidenceQuery = client.calls.find((c) => /FROM knowledge_entries/.test(c.sql));
+    expect(evidenceQuery?.params?.[4]).toBe(false);
+    expect(evidenceQuery?.sql).toMatch(/verified = true/);
+  });
+
+  it("get_asset_context returns asset metadata, verified components, and approved tags", async () => {
+    const client = mockClient([
+      [/FROM kg_entities[\s\S]*entity_type IN/, [
+        {
+          id: "asset-1",
+          entity_id: "filler01",
+          entity_type: "equipment",
+          name: "Filler 01",
+          approval_state: "verified",
+          uns_path: "enterprise.demo.line01.filler01",
+          properties: { model_number: "F100" },
+        },
+      ]],
+      [/FROM kg_relationships r[\s\S]*relationship_type IN/, [
+        {
+          id: "component-1",
+          entity_id: "filler01_regulator",
+          entity_type: "component",
+          name: "Bowl Pressure Regulator",
+          approval_state: "verified",
+          uns_path: "enterprise.demo.line01.filler01.regulator",
+          properties: {},
+          relationship_type: "has_component",
+        },
+      ]],
+      [/FROM approved_tags[\s\S]*uns_path <@/, [
+        {
+          uns_path: "enterprise.demo.line01.filler01.bowl_pressure",
+          source_system: "ignition",
+          source_tag_path: "Line01/Filler01/BowlPressure",
+          normalized_tag_path: "line01.filler01.bowl_pressure",
+          enabled: true,
+        },
+      ]],
+    ]);
+
+    const res = await skillFor(client).call(call("get_asset_context", { asset_id: "asset-1" }));
+
+    expect(res.ok).toBe(true);
+    expect(res.data).toMatchObject({
+      asset: { assetId: "asset-1", unsPath: "enterprise.demo.line01.filler01", model: "F100" },
+      components: [{ assetId: "component-1", relationshipType: "has_component" }],
+      approvedTags: [{ unsPath: "enterprise.demo.line01.filler01.bowl_pressure" }],
+    });
+    expect(res.evidence.some((e) => e.sourceType === "approved_tag")).toBe(true);
+  });
+
+  it("list_related_assets uses verified i3X relationship helpers", async () => {
+    const client = mockClient([
+      [/FROM kg_entities[\s\S]*entity_type IN/, [
+        {
+          id: "asset-1",
+          entity_id: "casepacker01",
+          entity_type: "equipment",
+          name: "Case Packer 01",
+          approval_state: "verified",
+          uns_path: "enterprise.demo.line01.casepacker01",
+          properties: {},
+        },
+      ]],
+      [/FROM kg_relationships[\s\S]*source_id = \$1 OR target_id = \$1/, [
+        {
+          source_id: "asset-1",
+          target_id: "asset-2",
+          relationship_type: "feeds",
+          approval_state: "verified",
+        },
+      ]],
+      [/WHERE id = ANY/, [
+        {
+          id: "asset-2",
+          entity_type: "equipment",
+          name: "Palletizer 01",
+          approval_state: "verified",
+          uns_path: "enterprise.demo.line01.palletizer01",
+          properties: {},
+        },
+      ]],
+    ]);
+
+    const res = await skillFor(client).call(call("list_related_assets", { asset_id: "casepacker01" }));
+
+    expect(res.ok).toBe(true);
+    expect(res.data).toMatchObject({
+      related: [
+        {
+          relationship: "feeds",
+          assetId: "asset-2",
+          name: "Palletizer 01",
+          unsPath: "enterprise.demo.line01.palletizer01",
+        },
+      ],
+    });
+    expect(res.evidence).toContainEqual(expect.objectContaining({
+      sourceType: "kg_relationship",
+      approvalState: "verified",
+    }));
+  });
+
+  it("get_diagnostic_context returns verified fault context without prose generation", async () => {
+    const client = mockClient([
+      [/FROM kg_entities e[\s\S]*entity_type IN \('fault'/, [
+        {
+          id: "fault-1",
+          entity_id: "F010",
+          entity_type: "fault_code",
+          name: "Low Bowl Pressure",
+          approval_state: "verified",
+          uns_path: "enterprise.demo.line01.filler01.fault_codes.f010",
+          properties: { expected_action: "Inspect bowl pressure regulator" },
+          relationship_type: "had_fault",
+        },
+      ]],
+    ]);
+
+    const res = await skillFor(client).call(call("get_diagnostic_context", { fault_code: "F010" }));
+
+    expect(res.ok).toBe(true);
+    expect(res.data).toMatchObject({
+      faultCode: "F010",
+      results: [
+        {
+          id: "fault-1",
+          entityId: "F010",
+          entityType: "fault_code",
+          approvalState: "verified",
+        },
+      ],
+    });
+    expect(JSON.stringify(res.data)).not.toMatch(/you should/i);
+  });
+
+  it("search_simlab_scenarios reads local deterministic scenario fixtures", async () => {
+    const skill = createFactoryLmContextSkill({
+      readDir: vi.fn(async () => ["juice_filler_underfill_01.yaml"] as never),
+      readTextFile: vi.fn(async () => `id: juice_filler_underfill_01
+name: "Filler 01 - Underfill from Low Bowl Pressure"
+machine_type: rotary_filler
+tags: [underfill, bowl_pressure, juice_bottling]
+simlab_scenario_id: filler_underfill_low_bowl_pressure
+simlab_asset_id: filler01
+machine_context:
+  uns_path: "enterprise.demo.line01"
+fault:
+  root_cause: low_filler_bowl_pressure
+  root_cause_component: filler01
+` as never),
+    });
+
+    const res = await skill.call(call("search_simlab_scenarios", { query: "bowl pressure underfill" }));
+
+    expect(res.ok).toBe(true);
+    expect(res.approvalState).toBe("internal");
+    expect(res.data).toMatchObject({
+      results: [
+        {
+          scenarioId: "juice_filler_underfill_01",
+          simlabScenarioId: "filler_underfill_low_bowl_pressure",
+          simlabAssetId: "filler01",
+          rootCause: "low_filler_bowl_pressure",
+          rootCauseComponent: "filler01",
+          citation: "juice_filler_underfill_01.yaml",
+        },
+      ],
+    });
+    expect(res.evidence[0]).toMatchObject({
+      sourceType: "simlab_scenario",
+      approvalState: "internal",
+    });
+  });
+});

--- a/mira-hub/src/lib/external-ai/context-skill.ts
+++ b/mira-hub/src/lib/external-ai/context-skill.ts
@@ -1,0 +1,705 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { withTenantContext } from "@/lib/tenant-context";
+import type { DbClient } from "@/lib/i3x/data-access";
+import { relationshipsForElement, loadEntitiesByIds } from "@/lib/i3x/data-access";
+import { kgEntityToObjectInstance, relatedFromEdge, toCurrentValueResult } from "@/lib/i3x";
+
+export const FACTORYLM_CONTEXT_TOOLS = [
+  "find_asset",
+  "get_asset_context",
+  "search_approved_evidence",
+  "get_tag_context",
+  "list_related_assets",
+  "get_diagnostic_context",
+  "get_live_value",
+  "search_simlab_scenarios",
+] as const;
+
+export type FactoryLmContextTool = (typeof FACTORYLM_CONTEXT_TOOLS)[number];
+export type ApprovalState = "verified" | "approved" | "draft" | "internal" | "not_found" | "unknown";
+export type ConfidenceBand = "verified" | "high" | "medium" | "low" | "none";
+
+export interface FactoryLmToolContext {
+  tenantId: string;
+}
+
+export interface FactoryLmToolCall {
+  tool: string;
+  input?: Record<string, unknown>;
+  context: FactoryLmToolContext;
+}
+
+export interface FactoryLmEvidenceRef {
+  sourceType: "kg_entity" | "kg_relationship" | "knowledge_entry" | "approved_tag" | "live_signal_cache" | "simlab_scenario";
+  sourceId: string;
+  title?: string | null;
+  url?: string | null;
+  page?: number | null;
+  approvalState: ApprovalState;
+  citation?: string | null;
+}
+
+export interface FactoryLmToolResponse<T = unknown> {
+  ok: boolean;
+  found: boolean;
+  tool: string;
+  data: T | null;
+  evidence: FactoryLmEvidenceRef[];
+  confidence: ConfidenceBand;
+  approvalState: ApprovalState;
+  notFoundReason?: string;
+  refusedReason?: string;
+}
+
+interface AssetRow {
+  id: string;
+  entity_id: string | null;
+  entity_type: string;
+  name: string;
+  approval_state: string | null;
+  uns_path: string | null;
+  properties: Record<string, unknown> | null;
+}
+
+interface ComponentRow {
+  id: string;
+  entity_id: string | null;
+  entity_type: string;
+  name: string;
+  approval_state: string | null;
+  uns_path: string | null;
+  properties: Record<string, unknown> | null;
+  relationship_type?: string | null;
+}
+
+interface ApprovedTagRow {
+  id?: string | null;
+  uns_path: string | null;
+  source_system: string | null;
+  source_tag_path: string | null;
+  normalized_tag_path: string | null;
+  enabled: boolean;
+}
+
+interface LiveValueRow {
+  uns_path: string | null;
+  last_value_text: string | null;
+  last_value_numeric: number | null;
+  last_value_bool: boolean | null;
+  latest_quality: string | null;
+  freshness_status: string | null;
+  last_seen_at: string | Date;
+}
+
+interface EvidenceRow {
+  id: string | null;
+  content: string;
+  source_url: string | null;
+  source_page: number | null;
+  page_start: number | null;
+  title: string | null;
+  filename: string | null;
+  verified: boolean;
+  rank: number | null;
+}
+
+interface SkillDeps {
+  runWithTenant?: <T>(tenantId: string, fn: (client: DbClient) => Promise<T>) => Promise<T>;
+  simlabScenarioDir?: string;
+  readDir?: typeof readdir;
+  readTextFile?: typeof readFile;
+}
+
+const DEFAULT_SIMLAB_SCENARIO_DIR = path.resolve(process.cwd(), "../tests/simlab/scenarios");
+
+function ok<T>(
+  tool: string,
+  data: T,
+  evidence: FactoryLmEvidenceRef[],
+  confidence: ConfidenceBand,
+  approvalState: ApprovalState,
+): FactoryLmToolResponse<T> {
+  return { ok: true, found: true, tool, data, evidence, confidence, approvalState };
+}
+
+function notFound(tool: string, reason: string): FactoryLmToolResponse<null> {
+  return {
+    ok: true,
+    found: false,
+    tool,
+    data: null,
+    evidence: [],
+    confidence: "none",
+    approvalState: "not_found",
+    notFoundReason: reason,
+  };
+}
+
+function refused(tool: string, reason: string): FactoryLmToolResponse<null> {
+  return {
+    ok: false,
+    found: false,
+    tool,
+    data: null,
+    evidence: [],
+    confidence: "none",
+    approvalState: "unknown",
+    refusedReason: reason,
+  };
+}
+
+function asString(input: Record<string, unknown>, key: string): string {
+  const value = input[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function asLimit(input: Record<string, unknown>, fallback = 5, max = 20): number {
+  const raw = input.limit;
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(1, Math.min(max, Math.trunc(n)));
+}
+
+function sqlLike(s: string): string {
+  return `%${s.replace(/[\\%_]/g, "\\$&")}%`;
+}
+
+function assetEvidence(row: Pick<AssetRow, "id" | "approval_state">): FactoryLmEvidenceRef {
+  return {
+    sourceType: "kg_entity",
+    sourceId: row.id,
+    approvalState: row.approval_state === "verified" ? "verified" : "draft",
+  };
+}
+
+function projectAsset(row: AssetRow) {
+  const props = row.properties ?? {};
+  return {
+    assetId: row.id,
+    entityId: row.entity_id,
+    name: row.name,
+    entityType: row.entity_type,
+    unsPath: row.uns_path,
+    manufacturer: props.manufacturer ?? props.manufacturer_name ?? null,
+    model: props.model ?? props.model_number ?? null,
+    approvalState: row.approval_state ?? "unknown",
+  };
+}
+
+function projectComponent(row: ComponentRow) {
+  return {
+    assetId: row.id,
+    entityId: row.entity_id,
+    name: row.name,
+    entityType: row.entity_type,
+    unsPath: row.uns_path,
+    relationshipType: row.relationship_type ?? null,
+    approvalState: row.approval_state ?? "unknown",
+  };
+}
+
+function normalizeLiveValue(row: LiveValueRow) {
+  if (row.last_value_bool !== null) {
+    return {
+      value: row.last_value_bool,
+      valueType: "bool" as const,
+      quality: row.latest_quality ?? "uncertain",
+      freshness: row.freshness_status ?? "live",
+      timestamp: row.last_seen_at,
+    };
+  }
+  if (row.last_value_numeric !== null) {
+    return {
+      value: row.last_value_numeric,
+      valueType: Number.isInteger(row.last_value_numeric) ? "int" as const : "float" as const,
+      quality: row.latest_quality ?? "uncertain",
+      freshness: row.freshness_status ?? "live",
+      timestamp: row.last_seen_at,
+    };
+  }
+  return {
+    value: row.last_value_text,
+    valueType: "string" as const,
+    quality: row.latest_quality ?? "uncertain",
+    freshness: row.freshness_status ?? "live",
+    timestamp: row.last_seen_at,
+  };
+}
+
+async function resolveVerifiedAsset(client: DbClient, assetId: string): Promise<AssetRow | null> {
+  const { rows } = await client.query<AssetRow>(
+    `SELECT id, entity_id, entity_type, name, approval_state, uns_path::text AS uns_path, properties
+       FROM kg_entities
+      WHERE (id::text = $1 OR entity_id = $1 OR uns_path::text = $1)
+        AND entity_type IN ('equipment', 'asset', 'component')
+        AND approval_state = 'verified'
+      LIMIT 1`,
+    [assetId],
+  );
+  return rows[0] ?? null;
+}
+
+async function findAsset(client: DbClient, input: Record<string, unknown>) {
+  const query = asString(input, "query");
+  if (!query) return notFound("find_asset", "query is required");
+  const limit = asLimit(input);
+
+  const { rows } = await client.query<AssetRow>(
+    `SELECT id, entity_id, entity_type, name, approval_state, uns_path::text AS uns_path, properties
+       FROM kg_entities
+      WHERE approval_state = 'verified'
+        AND entity_type IN ('equipment', 'asset', 'component')
+        AND (
+          name ILIKE $1 ESCAPE '\\'
+          OR entity_id ILIKE $1 ESCAPE '\\'
+          OR uns_path::text ILIKE $1 ESCAPE '\\'
+          OR properties::text ILIKE $1 ESCAPE '\\'
+        )
+      ORDER BY
+        CASE
+          WHEN entity_id = $2 THEN 0
+          WHEN uns_path::text = $2 THEN 1
+          WHEN name ILIKE $1 ESCAPE '\\' THEN 2
+          ELSE 3
+        END,
+        name
+      LIMIT $3`,
+    [sqlLike(query), query, limit],
+  );
+
+  if (rows.length === 0) return notFound("find_asset", `no verified asset matched "${query}"`);
+  return ok(
+    "find_asset",
+    { query, results: rows.map(projectAsset) },
+    rows.map(assetEvidence),
+    rows.length === 1 ? "high" : "medium",
+    "verified",
+  );
+}
+
+async function getAssetContext(client: DbClient, input: Record<string, unknown>) {
+  const assetId = asString(input, "asset_id") || asString(input, "assetId") || asString(input, "uns_path");
+  if (!assetId) return notFound("get_asset_context", "asset_id or uns_path is required");
+
+  const asset = await resolveVerifiedAsset(client, assetId);
+  if (!asset) return notFound("get_asset_context", "verified asset not found");
+
+  const [components, tags] = await Promise.all([
+    client.query<ComponentRow>(
+      `SELECT e.id, e.entity_id, e.entity_type, e.name, e.approval_state,
+              e.uns_path::text AS uns_path, e.properties, r.relationship_type
+         FROM kg_relationships r
+         JOIN kg_entities e ON e.id = r.target_id
+        WHERE r.source_id = $1
+          AND r.approval_state = 'verified'
+          AND e.approval_state = 'verified'
+          AND r.relationship_type IN ('has_component', 'controlled_by', 'monitors', 'drives')
+        ORDER BY e.name
+        LIMIT 50`,
+      [asset.id],
+    ),
+    client.query<ApprovedTagRow>(
+      `SELECT uns_path::text AS uns_path, source_system, source_tag_path,
+              normalized_tag_path, enabled
+         FROM approved_tags
+        WHERE enabled = true
+          AND ($1::ltree IS NULL OR uns_path <@ $1::ltree)
+        ORDER BY uns_path::text
+        LIMIT 100`,
+      [asset.uns_path],
+    ),
+  ]);
+
+  return ok(
+    "get_asset_context",
+    {
+      asset: projectAsset(asset),
+      components: components.rows.map(projectComponent),
+      approvedTags: tags.rows.map((tag) => ({
+        unsPath: tag.uns_path,
+        sourceSystem: tag.source_system,
+        sourceTagPath: tag.source_tag_path,
+        normalizedTagPath: tag.normalized_tag_path,
+        approvalState: "approved",
+      })),
+    },
+    [
+      assetEvidence(asset),
+      ...components.rows.map(assetEvidence),
+      ...tags.rows.map((tag) => ({
+        sourceType: "approved_tag" as const,
+        sourceId: tag.uns_path ?? tag.normalized_tag_path ?? "approved_tag",
+        approvalState: "approved" as const,
+      })),
+    ],
+    "verified",
+    "verified",
+  );
+}
+
+async function searchApprovedEvidence(client: DbClient, input: Record<string, unknown>) {
+  const assetId = asString(input, "asset_id") || asString(input, "assetId");
+  const query = asString(input, "query");
+  const includeDraft = input.includeDraft === true;
+  if (!assetId || !query) {
+    return notFound("search_approved_evidence", "asset_id and query are required");
+  }
+
+  const asset = await resolveVerifiedAsset(client, assetId);
+  if (!asset) return notFound("search_approved_evidence", "verified asset not found");
+  const limit = asLimit(input, 6, 12);
+
+  const { rows } = await client.query<EvidenceRow>(
+    `WITH scoped_nodes AS (
+       SELECT id::text AS id
+         FROM kg_entities
+        WHERE ($1::ltree IS NULL AND id = $2)
+           OR ($1::ltree IS NOT NULL AND uns_path <@ $1::ltree)
+     )
+     SELECT id::text AS id, content, source_url, source_page, page_start,
+            metadata->>'title' AS title, metadata->>'filename' AS filename,
+            verified, ts_rank_cd(content_tsv, plainto_tsquery('english', $3)) AS rank
+       FROM knowledge_entries
+      WHERE tenant_id = $4
+        AND (metadata->>'node_id') = ANY(SELECT id FROM scoped_nodes)
+        AND ($5::boolean = true OR verified = true)
+        AND content_tsv @@ plainto_tsquery('english', $3)
+      ORDER BY verified DESC, rank DESC
+      LIMIT $6`,
+    [asset.uns_path, asset.id, query, input.tenantId, includeDraft, limit],
+  );
+
+  if (rows.length === 0) {
+    return notFound("search_approved_evidence", "no approved evidence matched this asset/query");
+  }
+
+  return ok(
+    "search_approved_evidence",
+    {
+      asset: projectAsset(asset),
+      query,
+      results: rows.map((row) => ({
+        content: row.content,
+        title: row.title ?? row.filename ?? row.source_url ?? "FactoryLM evidence",
+        url: row.source_url,
+        page: row.page_start ?? row.source_page,
+        approvalState: row.verified ? "verified" : "draft",
+      })),
+    },
+    rows.map((row, index) => ({
+      sourceType: "knowledge_entry",
+      sourceId: row.id ?? `knowledge_entry:${index}`,
+      title: row.title ?? row.filename ?? null,
+      url: row.source_url,
+      page: row.page_start ?? row.source_page,
+      approvalState: row.verified ? "verified" : "draft",
+    })),
+    "high",
+    rows.every((r) => r.verified) ? "verified" : "draft",
+  );
+}
+
+async function getTagContext(client: DbClient, input: Record<string, unknown>) {
+  const tag = asString(input, "tag_or_uns_path") || asString(input, "tagOrUnsPath") || asString(input, "tag");
+  if (!tag) return notFound("get_tag_context", "tag_or_uns_path is required");
+
+  const { rows } = await client.query<ApprovedTagRow & { entity_id: string | null; entity_name: string | null }>(
+    `SELECT t.uns_path::text AS uns_path, t.source_system, t.source_tag_path,
+            t.normalized_tag_path, t.enabled, e.id::text AS entity_id, e.name AS entity_name
+       FROM approved_tags t
+       LEFT JOIN kg_entities e ON e.uns_path = t.uns_path AND e.approval_state = 'verified'
+      WHERE t.enabled = true
+        AND (
+          t.uns_path::text = $1
+          OR t.normalized_tag_path = $1
+          OR t.source_tag_path = $1
+        )
+      LIMIT 1`,
+    [tag],
+  );
+  const row = rows[0];
+  if (!row) return notFound("get_tag_context", "tag is not on the approved read allowlist");
+
+  return ok(
+    "get_tag_context",
+    {
+      unsPath: row.uns_path,
+      sourceSystem: row.source_system,
+      sourceTagPath: row.source_tag_path,
+      normalizedTagPath: row.normalized_tag_path,
+      linkedEntity: row.entity_id ? { assetId: row.entity_id, name: row.entity_name } : null,
+      approvalState: "approved",
+    },
+    [{
+      sourceType: "approved_tag",
+      sourceId: row.uns_path ?? tag,
+      approvalState: "approved",
+    }],
+    "verified",
+    "approved",
+  );
+}
+
+async function getLiveValue(client: DbClient, input: Record<string, unknown>) {
+  const tag = asString(input, "tag_or_uns_path") || asString(input, "tagOrUnsPath") || asString(input, "tag");
+  if (!tag) return notFound("get_live_value", "tag_or_uns_path is required");
+
+  const allowed = await client.query<ApprovedTagRow>(
+    `SELECT uns_path::text AS uns_path, source_system, source_tag_path,
+            normalized_tag_path, enabled
+       FROM approved_tags
+      WHERE enabled = true
+        AND (
+          uns_path::text = $1
+          OR normalized_tag_path = $1
+          OR source_tag_path = $1
+        )
+      LIMIT 1`,
+    [tag],
+  );
+  const approved = allowed.rows[0];
+  if (!approved?.uns_path) return notFound("get_live_value", "no approved live-read tag matched");
+
+  const live = await client.query<LiveValueRow>(
+    `SELECT uns_path::text AS uns_path, last_value_text, last_value_numeric,
+            last_value_bool, latest_quality, freshness_status, last_seen_at
+       FROM live_signal_cache
+      WHERE uns_path = $1::ltree
+      LIMIT 1`,
+    [approved.uns_path],
+  );
+  const row = live.rows[0];
+  if (!row) return notFound("get_live_value", "approved tag has no cached live value");
+
+  const reading = normalizeLiveValue(row);
+  return ok(
+    "get_live_value",
+    {
+      unsPath: approved.uns_path,
+      sourceSystem: approved.source_system,
+      sourceTagPath: approved.source_tag_path,
+      currentValue: toCurrentValueResult(reading),
+      approvalState: "approved",
+    },
+    [
+      { sourceType: "approved_tag", sourceId: approved.uns_path, approvalState: "approved" },
+      { sourceType: "live_signal_cache", sourceId: approved.uns_path, approvalState: "approved" },
+    ],
+    "verified",
+    "approved",
+  );
+}
+
+async function listRelatedAssets(client: DbClient, input: Record<string, unknown>) {
+  const assetId = asString(input, "asset_id") || asString(input, "assetId");
+  if (!assetId) return notFound("list_related_assets", "asset_id is required");
+
+  const asset = await resolveVerifiedAsset(client, assetId);
+  if (!asset) return notFound("list_related_assets", "verified asset not found");
+
+  const edges = await relationshipsForElement(client, asset.id);
+  const otherIds = edges.map((e) => (e.source_id === asset.id ? e.target_id : e.source_id));
+  const others = await loadEntitiesByIds(client, otherIds);
+  const byId = new Map(others.map((o) => [o.id, kgEntityToObjectInstance(o)]));
+  const related = edges.map((e) => relatedFromEdge(e, asset.id, byId)).filter((r) => r !== null);
+
+  if (related.length === 0) return notFound("list_related_assets", "no verified related assets found");
+  return ok(
+    "list_related_assets",
+    {
+      asset: projectAsset(asset),
+      related: related.map((r) => ({
+        relationship: r.sourceRelationship,
+        assetId: r.object.elementId,
+        name: r.object.displayName,
+        typeElementId: r.object.typeElementId,
+        unsPath: r.object.metadata?.system?.uns_path ?? null,
+        approvalState: "verified",
+      })),
+    },
+    [
+      assetEvidence(asset),
+      ...edges.map((edge) => ({
+        sourceType: "kg_relationship" as const,
+        sourceId: `${edge.source_id}:${edge.relationship_type}:${edge.target_id}`,
+        approvalState: "verified" as const,
+      })),
+    ],
+    "verified",
+    "verified",
+  );
+}
+
+async function getDiagnosticContext(client: DbClient, input: Record<string, unknown>) {
+  const assetId = asString(input, "asset_id") || asString(input, "assetId");
+  const faultCode = asString(input, "fault_code") || asString(input, "faultCode");
+  if (!assetId && !faultCode) {
+    return notFound("get_diagnostic_context", "asset_id or fault_code is required");
+  }
+
+  const { rows } = await client.query<{
+    id: string;
+    entity_id: string | null;
+    entity_type: string;
+    name: string;
+    approval_state: string | null;
+    uns_path: string | null;
+    properties: Record<string, unknown> | null;
+    relationship_type: string | null;
+  }>(
+    `SELECT e.id, e.entity_id, e.entity_type, e.name, e.approval_state,
+            e.uns_path::text AS uns_path, e.properties, r.relationship_type
+       FROM kg_entities e
+       LEFT JOIN kg_relationships r
+         ON r.target_id = e.id
+        AND r.approval_state = 'verified'
+      WHERE e.approval_state = 'verified'
+        AND (
+          ($1::text <> '' AND (e.id::text = $1 OR r.source_id::text = $1))
+          OR ($2::text <> '' AND (e.entity_id ILIKE $2 OR e.name ILIKE $2 OR e.properties::text ILIKE $2))
+        )
+        AND e.entity_type IN ('fault', 'fault_code', 'diagnostic', 'manual', 'work_order', 'component')
+      ORDER BY e.entity_type, e.name
+      LIMIT 30`,
+    [assetId, faultCode ? sqlLike(faultCode) : ""],
+  );
+
+  if (rows.length === 0) return notFound("get_diagnostic_context", "no verified diagnostic context found");
+  return ok(
+    "get_diagnostic_context",
+    {
+      assetId: assetId || null,
+      faultCode: faultCode || null,
+      results: rows.map((row) => ({
+        id: row.id,
+        entityId: row.entity_id,
+        entityType: row.entity_type,
+        name: row.name,
+        unsPath: row.uns_path,
+        relationshipType: row.relationship_type,
+        properties: row.properties ?? {},
+        approvalState: row.approval_state ?? "unknown",
+      })),
+    },
+    rows.map((row) => ({
+      sourceType: "kg_entity",
+      sourceId: row.id,
+      approvalState: row.approval_state === "verified" ? "verified" : "draft",
+    })),
+    "high",
+    "verified",
+  );
+}
+
+function yamlString(body: string, key: string): string | null {
+  const m = body.match(new RegExp(`^${key}:\\s*["']?([^"'\\n]+)["']?\\s*$`, "m"));
+  return m ? m[1].trim() : null;
+}
+
+function yamlList(body: string, key: string): string[] {
+  const oneLine = body.match(new RegExp(`^${key}:\\s*\\[([^\\]]*)\\]\\s*$`, "m"));
+  if (oneLine) {
+    return oneLine[1].split(",").map((s) => s.trim().replace(/^["']|["']$/g, "")).filter(Boolean);
+  }
+  const block = body.match(new RegExp(`^${key}:\\s*\\n((?:\\s+-\\s+[^\\n]+\\n?)+)`, "m"));
+  if (!block) return [];
+  return block[1].split("\n").map((line) => line.replace(/^\s+-\s+/, "").trim()).filter(Boolean);
+}
+
+function scenarioEvidence(file: string, id: string): FactoryLmEvidenceRef {
+  return {
+    sourceType: "simlab_scenario",
+    sourceId: id,
+    title: file,
+    approvalState: "internal",
+    citation: file,
+  };
+}
+
+async function searchSimlabScenarios(input: Record<string, unknown>, deps: SkillDeps) {
+  const query = asString(input, "query");
+  if (!query) return notFound("search_simlab_scenarios", "query is required");
+  const dir = deps.simlabScenarioDir ?? DEFAULT_SIMLAB_SCENARIO_DIR;
+  const readDir = deps.readDir ?? readdir;
+  const readTextFile = deps.readTextFile ?? readFile;
+  const limit = asLimit(input, 5, 20);
+
+  const files = (await readDir(dir)).filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"));
+  const q = query.toLowerCase();
+  const matches = [];
+  for (const file of files) {
+    const fullPath = path.join(dir, file);
+    const body = await readTextFile(fullPath, "utf8");
+    const haystack = body.toLowerCase();
+    if (!haystack.includes(q) && !q.split(/\s+/).some((term) => term.length > 2 && haystack.includes(term))) {
+      continue;
+    }
+    const id = yamlString(body, "id") ?? file.replace(/\.ya?ml$/, "");
+    matches.push({
+      scenarioId: id,
+      name: yamlString(body, "name"),
+      machineType: yamlString(body, "machine_type"),
+      simlabScenarioId: yamlString(body, "simlab_scenario_id"),
+      simlabAssetId: yamlString(body, "simlab_asset_id"),
+      unsPath: yamlString(body, "\\s+uns_path"),
+      rootCause: yamlString(body, "\\s+root_cause"),
+      rootCauseComponent: yamlString(body, "\\s+root_cause_component"),
+      tags: yamlList(body, "tags"),
+      citation: file,
+    });
+    if (matches.length >= limit) break;
+  }
+
+  if (matches.length === 0) return notFound("search_simlab_scenarios", "no SimLab scenario matched query");
+  return ok(
+    "search_simlab_scenarios",
+    { query, results: matches },
+    matches.map((m) => scenarioEvidence(m.citation, m.scenarioId)),
+    "medium",
+    "internal",
+  );
+}
+
+export function createFactoryLmContextSkill(deps: SkillDeps = {}) {
+  const runWithTenant = deps.runWithTenant ?? withTenantContext;
+
+  return {
+    async call(call: FactoryLmToolCall): Promise<FactoryLmToolResponse> {
+      if (!call.context?.tenantId) {
+        return refused(call.tool, "tenantId is required");
+      }
+      if (!FACTORYLM_CONTEXT_TOOLS.includes(call.tool as FactoryLmContextTool)) {
+        return refused(call.tool, "unsupported or unsafe tool; FactoryLM external AI skill is read-only");
+      }
+
+      const input = { ...(call.input ?? {}), tenantId: call.context.tenantId };
+      if (call.tool === "search_simlab_scenarios") {
+        return searchSimlabScenarios(input, deps);
+      }
+
+      return runWithTenant(call.context.tenantId, async (client) => {
+        switch (call.tool) {
+          case "find_asset":
+            return findAsset(client, input);
+          case "get_asset_context":
+            return getAssetContext(client, input);
+          case "search_approved_evidence":
+            return searchApprovedEvidence(client, input);
+          case "get_tag_context":
+            return getTagContext(client, input);
+          case "list_related_assets":
+            return listRelatedAssets(client, input);
+          case "get_diagnostic_context":
+            return getDiagnosticContext(client, input);
+          case "get_live_value":
+            return getLiveValue(client, input);
+          default:
+            return refused(call.tool, "unsupported tool");
+        }
+      });
+    },
+  };
+}
+
+export const factoryLmContextSkill = createFactoryLmContextSkill();

--- a/plugins/factorylm-context/.codex-plugin/plugin.json
+++ b/plugins/factorylm-context/.codex-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "factorylm-context",
+  "version": "0.1.0",
+  "description": "Read-only FactoryLM context workflows for external AI development.",
+  "author": {
+    "name": "FactoryLM"
+  },
+  "homepage": "https://factorylm.com",
+  "keywords": ["factorylm", "mira", "context", "mcp", "codex"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "FactoryLM Context",
+    "shortDescription": "Query approved FactoryLM factory context safely.",
+    "longDescription": "Private/internal Codex plugin package for the FactoryLM context bridge. Bundles the coding-agent skill for read-only asset, UNS, evidence, tag, live-value, and SimLab context access. MCP server configuration will be added after the local MCP wrapper is implemented.",
+    "developerName": "FactoryLM",
+    "category": "Productivity",
+    "capabilities": ["Context", "Read-only"],
+    "defaultPrompt": [
+      "Use FactoryLM context before answering.",
+      "Find approved evidence for this asset.",
+      "Inspect FactoryLM tag context safely."
+    ]
+  }
+}

--- a/plugins/factorylm-context/README.md
+++ b/plugins/factorylm-context/README.md
@@ -1,0 +1,20 @@
+# FactoryLM Context Codex Plugin
+
+Private/internal plugin package for FactoryLM external AI development.
+
+This plugin currently bundles the `factorylm-context-bridge` skill. It does not
+yet bundle MCP server configuration because the dedicated read-only MCP server
+has not been implemented.
+
+Current contents:
+
+- `.codex-plugin/plugin.json`
+- `skills/factorylm-context-bridge/SKILL.md`
+- `skills/factorylm-context-bridge/references/tool-selection.md`
+
+Next packaging step:
+
+1. Build local MCP server wrapping `POST /api/factorylm/context`.
+2. Add plugin `.mcp.json`.
+3. Add `mcpServers` to `.codex-plugin/plugin.json`.
+4. Validate local install through a private marketplace.

--- a/plugins/factorylm-context/skills/factorylm-context-bridge/SKILL.md
+++ b/plugins/factorylm-context/skills/factorylm-context-bridge/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: factorylm-context-bridge
+description: >
+  Use when Codex, Claude Code, or another coding agent needs to query, extend,
+  review, test, or wrap FactoryLM's External AI Context Skill or related
+  read-only factory context access. Trigger on requests about FactoryLM external
+  AI tools, MCP/API wrappers, approved asset context, UNS/tag context, evidence
+  citations, SimLab scenario lookup, live-read gating, or preventing external
+  agents from hallucinating factory data. Also use when coding against
+  mira-hub/src/lib/external-ai/context-skill.ts.
+---
+
+# FactoryLM Context Bridge
+
+FactoryLM is the governed industrial context layer. MIRA is one native client.
+External AI clients must get context through structured, read-only calls, not by
+inventing facts or duplicating MIRA chat behavior.
+
+## Core Rule
+
+Do not build a chatbot, raw SQL endpoint, or parallel context system. Use or
+extend `mira-hub/src/lib/external-ai/context-skill.ts` first.
+
+## Workflow
+
+1. **Inspect existing context surfaces** before editing:
+   - `mira-hub/src/lib/external-ai/context-skill.ts`
+   - `mira-hub/src/app/api/factorylm/context/route.ts`
+   - `mira-hub/src/lib/i3x/data-access.ts`
+   - `mira-hub/src/lib/i3x/index.ts`
+   - `mira-hub/src/lib/manual-rag.ts`
+   - `mira-hub/src/lib/tenant-context.ts`
+   - `tests/simlab/scenarios/`
+2. **Choose the narrowest tool** for the question. See
+   `references/tool-selection.md`.
+3. **Preserve the response envelope**:
+   - `ok`
+   - `found`
+   - `tool`
+   - `data`
+   - `evidence`
+   - `confidence`
+   - `approvalState`
+   - `notFoundReason` or `refusedReason` when applicable
+4. **Keep reads gated**:
+   - KG rows exposed to agents require `approval_state = 'verified'`.
+   - live values require `approved_tags.enabled = true` before reading cache.
+   - documents default to verified/approved evidence only.
+   - draft/internal context must be explicitly labeled.
+5. **Return structured facts only**. Do not synthesize troubleshooting prose in
+   this layer.
+6. **Refuse unsafe tools** before DB access. Unknown tool names, write-like
+   names, PLC writes, tag writes, and raw SQL requests must return `ok: false`
+   with `refusedReason`.
+7. **Test with injectable dependencies**. Do not require Neon, a dev server, or
+   live credentials for unit tests.
+
+## When Coding
+
+- Add functions inside the existing skill module unless a route/MCP wrapper is
+  explicitly in scope.
+- For API work, use `POST /api/factorylm/context` and delegate to the skill
+  dispatcher. Resolve tenancy with existing i3X bearer keys first, then Hub
+  session fallback. Do not create a new API-key system in this layer.
+- Prefer pure helpers plus an injectable `runWithTenant` dependency.
+- Use `withTenantContext` for the default runtime path.
+- Reuse i3X projection helpers for related objects and live values.
+- Keep SimLab lookup file-backed and deterministic unless the caller asks for
+  simulator execution.
+- Add tests for both success and fail-closed behavior.
+
+## Verification
+
+Run from `mira-hub/`:
+
+```bash
+npx tsc --noEmit
+npx vitest run src/lib/external-ai/context-skill.test.ts src/app/api/factorylm/context/__tests__/route.test.ts
+npx eslint src/lib/external-ai/context-skill.ts src/lib/external-ai/context-skill.test.ts src/app/api/factorylm/context/route.ts src/app/api/factorylm/context/__tests__/route.test.ts
+```
+
+If adding API or MCP wrappers, also test auth boundaries and refusal of writes.
+
+## Cross-References
+
+- `mira-platform` for MIRA product and environment doctrine.
+- `mira-uns-architecture` for UNS path and confirmation-gate rules.
+- `retrieval-diagnostics` when evidence retrieval misses or cites the wrong
+  vendor.
+- `mira-industrial-safety` when a user asks for safety-critical advice.

--- a/plugins/factorylm-context/skills/factorylm-context-bridge/references/tool-selection.md
+++ b/plugins/factorylm-context/skills/factorylm-context-bridge/references/tool-selection.md
@@ -1,0 +1,48 @@
+# Tool Selection
+
+Use this reference after `factorylm-context-bridge` triggers.
+
+## Question To Tool
+
+| User or agent needs | Tool |
+|---|---|
+| "What asset is this?" / fuzzy lookup | `find_asset` |
+| "What is this asset?" / tags/components summary | `get_asset_context` |
+| "What evidence supports this mapping/diagnosis?" | `search_approved_evidence` |
+| "What is this tag or UNS path?" | `get_tag_context` |
+| "What is upstream/downstream/related?" | `list_related_assets` |
+| "What does FactoryLM know about this fault?" | `get_diagnostic_context` |
+| "What is the live value?" | `get_live_value` |
+| "What SimLab scenario covers this behavior?" | `search_simlab_scenarios` |
+
+## Safety Checks
+
+- If the request asks to write, update, acknowledge, reset, command, tune, or
+  control a PLC/tag/machine, refuse in this layer.
+- If no verified asset/tag/evidence is found, return `found: false`; do not
+  invent fields.
+- If evidence is draft/internal, label it draft/internal and do not present it
+  as approved.
+- If live value has no approved tag allowlist row, report that no approved
+  live-read path exists.
+
+## Coding Patterns
+
+Use this shape for new read-only tools:
+
+```ts
+async function getSomething(client: DbClient, input: Record<string, unknown>) {
+  const id = asString(input, "id");
+  if (!id) return notFound("get_something", "id is required");
+
+  const { rows } = await client.query(
+    `SELECT ... WHERE approval_state = 'verified' AND id = $1 LIMIT 1`,
+    [id],
+  );
+  if (rows.length === 0) return notFound("get_something", "verified context not found");
+
+  return ok("get_something", { ... }, evidence, "verified", "verified");
+}
+```
+
+Prefer bounded result sets and explicit status fields over free-form prose.


### PR DESCRIPTION
## Summary

- Adds a read-only FactoryLM external AI context skill/client layer in Hub for structured context calls.
- Adds `POST /api/factorylm/context` using existing i3X bearer auth with Hub session fallback.
- Adds Codex/Claude repo skills, a private Codex plugin draft, and research/architecture docs for the path toward Codex plugin + ChatGPT MCP connector.

## Scope

This PR intentionally starts private/local and does not claim the full connector stack is complete. It proves the internal skill/API contract and packages the first Codex-facing workflow.

Completed in this PR:

- Local FactoryLM context skill/tool dispatcher
- Internal read-only API wrapper
- Tests for structured responses, approved live reads, read-only refusals, auth behavior, SimLab fixture search, and evidence gating
- Repo-local Codex skill under `.agents/skills`
- Claude-style companion skill under `.claude/skills`
- Private Codex plugin draft under `plugins/factorylm-context`
- Research and architecture docs for Codex plugin + ChatGPT MCP path

Still backlog:

- Dedicated local MCP server wrapping `/api/factorylm/context`
- Plugin `.mcp.json` bundled after the MCP server exists
- Remote MCP server for ChatGPT custom connector/app
- Customer-scoped OAuth/API-key model
- Audit logs/admin controls/rate limits for external AI tool calls
- Public marketplace/app submission package

## Validation

- `npx tsc --noEmit`
- `npx vitest run src/lib/external-ai/context-skill.test.ts src/app/api/factorylm/context/__tests__/route.test.ts`
- `npx eslint src/lib/external-ai/context-skill.ts src/lib/external-ai/context-skill.test.ts src/app/api/factorylm/context/route.ts src/app/api/factorylm/context/__tests__/route.test.ts`
- `python3 /Users/charlienode/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/factorylm-context`
- `python3 /Users/charlienode/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/factorylm-context-bridge`
- `python3 /Users/charlienode/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/factorylm-context-bridge`
- `python3 /Users/charlienode/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/factorylm-context/skills/factorylm-context-bridge`
