### PR TITLE
[codex] Gate Ask MIRA on approved context

### DIFF
--- a/docs/superpowers/plans/2026-06-26-approved-context-ask-mira-plan.md
+++ b/docs/superpowers/plans/2026-06-26-approved-context-ask-mira-plan.md
@@ -504,8 +504,8 @@ Use `uns_path` when present, with normalized tag path fallback for existing rows
              ON at.tenant_id = e.tenant_id
             AND at.enabled = true
             AND (
-              at.uns_path = e.uns_path
-              OR at.normalized_tag_path = e.plc_tag
+              at.normalized_tag_path = e.plc_tag
+              OR at.source_tag_path = e.plc_tag
             )
 ```
 
@@ -518,10 +518,11 @@ and:
             AND (
               at.uns_path = cache.uns_path
               OR at.normalized_tag_path = cache.plc_tag
+              OR at.source_tag_path = cache.plc_tag
             )
 ```
 
-If the concrete columns in `live_signal_events` differ, verify them from the migrations or `mira-hub/src/lib/signal-recorder.ts:179` through `mira-hub/src/lib/signal-recorder.ts:210` before editing. UNKNOWN: this plan has not re-read the live signal table migration in this turn.
+Schema evidence: `live_signal_events` has `component_id` and `plc_tag`, but no `uns_path`, in `mira-hub/db/migrations/019_sessions_and_signals.sql:79` through `mira-hub/db/migrations/019_sessions_and_signals.sql:112`. `live_signal_cache` has `plc_tag` in `mira-hub/db/migrations/020_signal_cache_and_trends.sql:44` through `mira-hub/db/migrations/020_signal_cache_and_trends.sql:80`, and migration 036 adds `uns_path` at `mira-hub/db/migrations/036_current_tag_state_freshness.sql:45`. Do not reference `e.uns_path` in the event query.
 
 - [ ] **Step 4: Run the route test**
 

--- a/docs/superpowers/plans/2026-06-26-approved-context-ask-mira-plan.md
+++ b/docs/superpowers/plans/2026-06-26-approved-context-ask-mira-plan.md
@@ -1,0 +1,864 @@
+# Approved Context Ask MIRA Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make answer-facing Ask MIRA paths use only approved/verified asset context, or return a missing-context refusal before any model/provider call.
+
+**Architecture:** Reuse the existing approval spine instead of adding a new store or retrieval system. `kg_entities`/`kg_relationships` expose only `approval_state = 'verified'`, manual retrieval exposes only `knowledge_entries.verified = true` when the existing flag is enabled, and live telemetry is exposed only through `approved_tags.enabled = true`. The PR adds a small reusable approved-context gate, then wires existing Hub answer routes through that gate under feature flags.
+
+**Tech Stack:** Next.js App Router, TypeScript, Vitest, Postgres/Neon, existing `manual-rag`, `health-score`, i3X approval helpers, and Hub SQL migrations.
+
+## Global Constraints
+
+- Do not introduce a new database, graph store, vector store, or answer architecture.
+- Do not bypass approval gates; anything not explicitly approved fails closed.
+- Do not add live write/control paths; live telemetry remains read-only.
+- Prefer existing feature flags and add only a narrow flag alias if needed.
+- Keep PR stacked after `codex/context-spine-readiness-checklist` unless #2307/#2308 are rebased first.
+- Every new behavior needs a failing test before implementation.
+- Mark unverified or unknown context as unavailable instead of asking the model to infer.
+
+---
+
+## Research Snapshot
+
+- Last completed objective is PR #2308, `[codex] Add readiness missing-context checklist`, stacked on `codex/context-spine-db-integration`; local `gh pr view 2308` reported open draft with `mergeStateStatus: CLEAN` on 2026-06-26. This is command evidence, not a source file.
+- Base PR #2307, `[codex] Wire contextualizer imports into Hub DB spine`, is still open draft; local `gh pr view 2307` reported `mergeStateStatus: DIRTY` on 2026-06-26. This is command evidence, not a source file.
+- The Phase 4 product requirement is already documented as "Make MIRA Answer Only From Approved Asset Context" in `docs/plans/2026-06-25-context-spine-unification-plan.md:120`; it calls out `MIRA_ENFORCE_APPROVED_RETRIEVAL` at `docs/plans/2026-06-25-context-spine-unification-plan.md:126` and zero approved-source refusal at `docs/plans/2026-06-25-context-spine-unification-plan.md:128`.
+- `/api/mira/ask` already has a namespace/session gate: it loads a troubleshooting session at `mira-hub/src/app/api/mira/ask/route.ts:130` and returns a 412 namespace gate unless the session is confirmed with an asset at `mira-hub/src/app/api/mira/ask/route.ts:149`.
+- `/api/mira/ask` reads KG relationships at `mira-hub/src/app/api/mira/ask/route.ts:189`, but the SQL only filters by tenant and ids at `mira-hub/src/app/api/mira/ask/route.ts:197`; the prompt then labels those rows "Verified relationships" at `mira-hub/src/app/api/mira/ask/route.ts:331`.
+- `/api/mira/ask` calls `cascadeComplete` after prompt construction at `mira-hub/src/app/api/mira/ask/route.ts:393`; the approved-context refusal must occur before that line.
+- `/api/mira/ask` reads recent live events at `mira-hub/src/app/api/mira/ask/route.ts:205` and current live cache at `mira-hub/src/app/api/mira/ask/route.ts:221`; neither query currently joins `approved_tags`.
+- `approved_tags` is the existing live telemetry allowlist table, with `enabled BOOLEAN NOT NULL DEFAULT true` at `mira-hub/db/migrations/035_approved_tags.sql:60` and an enabled index at `mira-hub/db/migrations/035_approved_tags.sql:116`.
+- Manual retrieval already has the feature flag `MIRA_ENFORCE_APPROVED_RETRIEVAL` at `mira-hub/src/lib/manual-rag.ts:50` and emits `AND verified = true` when enabled at `mira-hub/src/lib/manual-rag.ts:54`.
+- Manual and node retrieval already apply that filter in SQL at `mira-hub/src/lib/manual-rag.ts:315` and `mira-hub/src/lib/manual-rag.ts:422`.
+- Manual no-doc fallback already tells the model not to guess at `mira-hub/src/lib/manual-rag.ts:510` through `mira-hub/src/lib/manual-rag.ts:514`.
+- Asset chat counts verified manual sources at `mira-hub/src/app/api/assets/[id]/chat/route.ts:307` through `mira-hub/src/app/api/assets/[id]/chat/route.ts:308` and emits `approved_source_count` at `mira-hub/src/app/api/assets/[id]/chat/route.ts:337`, but it does not refuse before provider calls.
+- Node chat counts verified manual sources at `mira-hub/src/app/api/namespace/node/[id]/chat/route.ts:285` through `mira-hub/src/app/api/namespace/node/[id]/chat/route.ts:286` and emits `approved_source_count` at `mira-hub/src/app/api/namespace/node/[id]/chat/route.ts:307`, but it does not refuse before provider calls.
+- The canonical exposure state is `EXPOSABLE_APPROVAL_STATE = "verified"` in `mira-hub/src/lib/i3x/approval.ts:16`; `isExposable` fails closed unless that state is present at `mira-hub/src/lib/i3x/approval.ts:23`.
+- Migration 029 added `kg_relationships.approval_state` with default `proposed` at `mira-hub/db/migrations/029_kg_approval_state.sql:23` and `kg_entities.approval_state` at `mira-hub/db/migrations/029_kg_approval_state.sql:29`.
+- Existing i3X data access requires verified entities and approved live tags for readings at `mira-hub/src/lib/i3x/data-access.ts:103` and `mira-hub/src/lib/i3x/data-access.ts:110`.
+- Existing KG context builder reads entities and relationships without approval filters at `mira-hub/src/lib/knowledge-graph/context-builder.ts:90`, `mira-hub/src/lib/knowledge-graph/context-builder.ts:118`, and `mira-hub/src/lib/knowledge-graph/context-builder.ts:131`.
+- Existing KG traversal paths join `kg_relationships` without approval filters at `mira-hub/src/lib/knowledge-graph/traversal.ts:157`, `mira-hub/src/lib/knowledge-graph/traversal.ts:416`, `mira-hub/src/lib/knowledge-graph/traversal.ts:450`, `mira-hub/src/lib/knowledge-graph/traversal.ts:460`, `mira-hub/src/lib/knowledge-graph/traversal.ts:473`, `mira-hub/src/lib/knowledge-graph/traversal.ts:481`, `mira-hub/src/lib/knowledge-graph/traversal.ts:489`, `mira-hub/src/lib/knowledge-graph/traversal.ts:499`, and `mira-hub/src/lib/knowledge-graph/traversal.ts:508`.
+- Readiness has an existing missing-context item type at `mira-hub/src/lib/health-score.ts:47` and existing checklist keys for approved documents and verified relationships at `mira-hub/src/lib/health-score.ts:153` and `mira-hub/src/lib/health-score.ts:174`.
+- UNKNOWN: there is no direct `/api/mira/ask` test file in the inspected tree.
+- UNKNOWN: no DB-backed traversal/context-builder approval-state integration test was found; current context-builder/traversal tests are formatter/classifier oriented.
+
+---
+
+## Files To Create Or Modify
+
+- Create `mira-hub/src/lib/approved-context.ts`: a pure helper for feature flag checks, approved-context summaries, and refusal payloads.
+- Create `mira-hub/src/lib/__tests__/approved-context.test.ts`: pure unit coverage for the helper.
+- Create `mira-hub/src/app/api/mira/ask/__tests__/route.test.ts`: route-level tests for verified KG filters, approved live-tag filters, and pre-provider refusal.
+- Modify `mira-hub/src/app/api/mira/ask/route.ts`: add verified KG filters, approved-tag joins, approved-context summary, and refusal before `cascadeComplete`.
+- Modify `mira-hub/src/app/api/namespace/node/[id]/chat/route.ts`: when enforcement is enabled, return approved-context refusal before opening a stream if `approvedSourceCount === 0`.
+- Modify `mira-hub/src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts`: add route coverage for zero-approved-source refusal and no provider call.
+- Modify `mira-hub/src/app/api/assets/[id]/chat/route.ts`: when enforcement is enabled, return approved-context refusal before opening a stream if no approved manual/KG context exists.
+- Create `mira-hub/src/app/api/assets/[id]/chat/__tests__/route.test.ts`: add a minimal route test seam if no asset-chat test exists.
+- Modify `mira-hub/src/lib/knowledge-graph/context-builder.ts`: require verified entities/relationships for answer-facing KG context.
+- Modify `mira-hub/src/lib/knowledge-graph/traversal.ts`: require verified entities/relationships in answer-facing traversal helpers used by `buildGraphContext`.
+- Modify `mira-hub/src/lib/knowledge-graph/__tests__/context-builder.test.ts` and `mira-hub/src/lib/knowledge-graph/__tests__/traversal.test.ts`: add query-capture tests or extracted SQL helper tests for verified filters.
+- Do not modify graph visualization APIs in this PR unless a test proves they are used for Ask MIRA answer grounding. `mira-hub/src/app/api/kg/graph/route.ts:45` is a discovered gap, but it is not the smallest answer-path PR.
+
+---
+
+### Task 1: Shared Approved-Context Gate
+
+**Files:**
+- Create: `mira-hub/src/lib/approved-context.ts`
+- Test: `mira-hub/src/lib/__tests__/approved-context.test.ts`
+
+**Interfaces:**
+- Consumes: `MissingContextItem` from `mira-hub/src/lib/health-score.ts:47`.
+- Produces:
+  - `approvedAskEnforcementEnabled(env?: NodeJS.ProcessEnv): boolean`
+  - `ApprovedContextSummary`
+  - `approvedContextReady(summary: ApprovedContextSummary): boolean`
+  - `buildApprovedContextRefusal(summary: ApprovedContextSummary): ApprovedContextRefusal`
+
+- [ ] **Step 1: Write the failing helper tests**
+
+Create `mira-hub/src/lib/__tests__/approved-context.test.ts`:
+
+```ts
+import {
+  approvedAskEnforcementEnabled,
+  approvedContextReady,
+  buildApprovedContextRefusal,
+} from "../approved-context";
+
+describe("approved context gate", () => {
+  it("is enabled by the dedicated Ask flag", () => {
+    expect(approvedAskEnforcementEnabled({ MIRA_ENFORCE_APPROVED_ASK: "true" })).toBe(true);
+  });
+
+  it("is enabled by the existing retrieval flag", () => {
+    expect(approvedAskEnforcementEnabled({ MIRA_ENFORCE_APPROVED_RETRIEVAL: "true" })).toBe(true);
+  });
+
+  it("is disabled when both flags are absent", () => {
+    expect(approvedAskEnforcementEnabled({})).toBe(false);
+  });
+
+  it("treats any approved source, verified relationship, or approved live signal as answer context", () => {
+    expect(approvedContextReady({ approvedSourceCount: 1, verifiedRelationshipCount: 0, approvedLiveSignalCount: 0 })).toBe(true);
+    expect(approvedContextReady({ approvedSourceCount: 0, verifiedRelationshipCount: 1, approvedLiveSignalCount: 0 })).toBe(true);
+    expect(approvedContextReady({ approvedSourceCount: 0, verifiedRelationshipCount: 0, approvedLiveSignalCount: 1 })).toBe(true);
+    expect(approvedContextReady({ approvedSourceCount: 0, verifiedRelationshipCount: 0, approvedLiveSignalCount: 0 })).toBe(false);
+  });
+
+  it("builds the existing missing-context checklist shape for refusal", () => {
+    const refusal = buildApprovedContextRefusal({
+      approvedSourceCount: 0,
+      verifiedRelationshipCount: 0,
+      approvedLiveSignalCount: 0,
+    });
+
+    expect(refusal).toMatchObject({
+      gate: "approved_context",
+      reason: "MIRA needs approved asset context before answering.",
+    });
+    expect(refusal.missingContext).toContainEqual(
+      expect.objectContaining({
+        key: "approved_documents",
+        status: "missing",
+        required: 1,
+      }),
+    );
+    expect(refusal.missingContext).toContainEqual(
+      expect.objectContaining({
+        key: "verified_relationships",
+        status: "needs_review",
+        required: 1,
+      }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- src/lib/__tests__/approved-context.test.ts
+```
+
+Expected: FAIL because `../approved-context` does not exist.
+
+- [ ] **Step 3: Implement the pure helper**
+
+Create `mira-hub/src/lib/approved-context.ts`:
+
+```ts
+import type { MissingContextItem } from "./health-score";
+
+export interface ApprovedContextSummary {
+  approvedSourceCount: number;
+  verifiedRelationshipCount: number;
+  approvedLiveSignalCount: number;
+}
+
+export interface ApprovedContextRefusal {
+  gate: "approved_context";
+  reason: string;
+  approved_source_count: number;
+  verified_relationship_count: number;
+  approved_live_signal_count: number;
+  missingContext: MissingContextItem[];
+}
+
+export function approvedAskEnforcementEnabled(
+  env: Pick<NodeJS.ProcessEnv, "MIRA_ENFORCE_APPROVED_ASK" | "MIRA_ENFORCE_APPROVED_RETRIEVAL"> = process.env,
+): boolean {
+  return env.MIRA_ENFORCE_APPROVED_ASK === "true" || env.MIRA_ENFORCE_APPROVED_RETRIEVAL === "true";
+}
+
+export function approvedContextReady(summary: ApprovedContextSummary): boolean {
+  return (
+    summary.approvedSourceCount > 0 ||
+    summary.verifiedRelationshipCount > 0 ||
+    summary.approvedLiveSignalCount > 0
+  );
+}
+
+export function buildApprovedContextRefusal(summary: ApprovedContextSummary): ApprovedContextRefusal {
+  return {
+    gate: "approved_context",
+    reason: "MIRA needs approved asset context before answering.",
+    approved_source_count: summary.approvedSourceCount,
+    verified_relationship_count: summary.verifiedRelationshipCount,
+    approved_live_signal_count: summary.approvedLiveSignalCount,
+    missingContext: [
+      {
+        key: "approved_documents",
+        label: "Approved document context",
+        status: summary.approvedSourceCount > 0 ? "ready" : "missing",
+        count: summary.approvedSourceCount,
+        required: 1,
+        action: "Upload and approve a manual, PLC tag list, or evidence document.",
+      },
+      {
+        key: "verified_relationships",
+        label: "Verified relationships",
+        status: summary.verifiedRelationshipCount > 0 ? "ready" : "needs_review",
+        count: summary.verifiedRelationshipCount,
+        required: 1,
+        action: "Accept grounded proposals until at least one relationship is verified.",
+      },
+    ],
+  };
+}
+```
+
+- [ ] **Step 4: Run the helper test and verify it passes**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- src/lib/__tests__/approved-context.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 1**
+
+```powershell
+git add mira-hub/src/lib/approved-context.ts mira-hub/src/lib/__tests__/approved-context.test.ts
+git commit -m "test: add approved context gate helper"
+```
+
+---
+
+### Task 2: `/api/mira/ask` Verified KG Refusal Gate
+
+**Files:**
+- Create: `mira-hub/src/app/api/mira/ask/__tests__/route.test.ts`
+- Modify: `mira-hub/src/app/api/mira/ask/route.ts:189-203`, `mira-hub/src/app/api/mira/ask/route.ts:330-393`
+
+**Interfaces:**
+- Consumes: `approvedAskEnforcementEnabled`, `approvedContextReady`, and `buildApprovedContextRefusal` from Task 1.
+- Produces: a 412 JSON response with `gate: "approved_context"` before `cascadeComplete` when enforcement is enabled and no approved context is present.
+
+- [ ] **Step 1: Write the route test for verified KG filtering and refusal**
+
+Create `mira-hub/src/app/api/mira/ask/__tests__/route.test.ts` with a mock style matching `mira-hub/src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts:17` through `mira-hub/src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts:53`:
+
+```ts
+import { NextResponse } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/session", () => ({ sessionOrDemo: vi.fn() }));
+vi.mock("@/lib/tenant-context", () => ({ withTenantContext: vi.fn() }));
+vi.mock("@/lib/llm/cascade", () => ({ cascadeComplete: vi.fn() }));
+vi.mock("@/lib/rate-limit", () => ({
+  clientIpHash: vi.fn(() => "ip-hash"),
+  rateLimited: vi.fn(() => false),
+}));
+vi.mock("@/lib/signal-recorder", () => ({ countTransitions: vi.fn() }));
+
+import { cascadeComplete } from "@/lib/llm/cascade";
+import { sessionOrDemo } from "@/lib/session";
+import { withTenantContext } from "@/lib/tenant-context";
+import { POST } from "../route";
+
+const tenantId = "tenant-1";
+const sessionId = "11111111-1111-1111-1111-111111111111";
+const assetId = "22222222-2222-2222-2222-222222222222";
+
+function req(question = "What fails when this conveyor stops?") {
+  return new Request("http://localhost/api/mira/ask", {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId, question }),
+  });
+}
+
+function mockClient(rowsBySql: Array<{ match: string; rows: Array<Record<string, unknown>> }>, calls: string[]) {
+  return {
+    query: vi.fn(async (sql: string) => {
+      calls.push(sql);
+      const hit = rowsBySql.find((entry) => sql.includes(entry.match));
+      return { rows: hit?.rows ?? [] };
+    }),
+  };
+}
+
+describe("POST /api/mira/ask approved-context gate", () => {
+  const oldEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...oldEnv, NEON_DATABASE_URL: "postgres://test", MIRA_ENFORCE_APPROVED_ASK: "true" };
+    vi.mocked(sessionOrDemo).mockResolvedValue({ tenantId, userId: "user-1" });
+    vi.mocked(cascadeComplete).mockResolvedValue({ content: "answer", provider: "mock", latencyMs: 1 });
+  });
+
+  afterEach(() => {
+    process.env = oldEnv;
+    vi.clearAllMocks();
+  });
+
+  it("requires verified KG state in the relationship grounding query", async () => {
+    const calls: string[] = [];
+    const client = mockClient(
+      [
+        {
+          match: "FROM troubleshooting_sessions",
+          rows: [{
+            id: sessionId,
+            status: "confirmed",
+            asset_id: assetId,
+            component_id: null,
+            transcript: [],
+            asset_name: "Conveyor",
+            asset_tag: "Plant.Line.Conveyor",
+          }],
+        },
+        { match: "FROM kg_relationships r", rows: [{ relationship_type: "feeds", confidence: 1, s_type: "asset", s_name: "A", t_type: "asset", t_name: "B" }] },
+        { match: "FROM live_signal_events e", rows: [] },
+        { match: "FROM live_signal_cache cache", rows: [] },
+      ],
+      calls,
+    );
+    vi.mocked(withTenantContext).mockImplementation(async (_tenant, fn) => fn(client));
+
+    const res = await POST(req());
+
+    expect(res.status).toBe(200);
+    const relationshipSql = calls.find((sql) => sql.includes("FROM kg_relationships r")) ?? "";
+    expect(relationshipSql).toMatch(/r\.approval_state\s*=\s*'verified'/i);
+    expect(relationshipSql).toMatch(/src\.approval_state\s*=\s*'verified'/i);
+    expect(relationshipSql).toMatch(/tgt\.approval_state\s*=\s*'verified'/i);
+  });
+
+  it("returns approved_context without calling cascade when no approved context exists", async () => {
+    const calls: string[] = [];
+    const client = mockClient(
+      [
+        {
+          match: "FROM troubleshooting_sessions",
+          rows: [{
+            id: sessionId,
+            status: "confirmed",
+            asset_id: assetId,
+            component_id: null,
+            transcript: [],
+            asset_name: "Conveyor",
+            asset_tag: "Plant.Line.Conveyor",
+          }],
+        },
+      ],
+      calls,
+    );
+    vi.mocked(withTenantContext).mockImplementation(async (_tenant, fn) => fn(client));
+
+    const res = await POST(req());
+    const body = await res.json();
+
+    expect(res.status).toBe(412);
+    expect(body.gate).toBe("approved_context");
+    expect(body.missingContext).toEqual(expect.any(Array));
+    expect(cascadeComplete).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the new route test and verify it fails**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- src/app/api/mira/ask/__tests__/route.test.ts
+```
+
+Expected: FAIL because the relationship SQL does not include verified filters and the route still calls `cascadeComplete` with zero approved context.
+
+- [ ] **Step 3: Add verified filters and pre-provider refusal**
+
+Modify `mira-hub/src/app/api/mira/ask/route.ts`:
+
+```ts
+import {
+  approvedAskEnforcementEnabled,
+  approvedContextReady,
+  buildApprovedContextRefusal,
+} from "@/lib/approved-context";
+```
+
+Add verified filters to the relationship query:
+
+```sql
+          WHERE r.tenant_id = $1
+            AND r.approval_state = 'verified'
+            AND src.approval_state = 'verified'
+            AND tgt.approval_state = 'verified'
+            AND (r.source_id = $2 OR r.target_id = $2 OR r.source_id = ANY($3::uuid[]))
+```
+
+After `grounding` is built and before `const messages: CascadeMessage[] = [`:
+
+```ts
+  const approvedSummary = {
+    approvedSourceCount: 0,
+    verifiedRelationshipCount: grounding.edges.length,
+    approvedLiveSignalCount:
+      ((grounding.currentSignals as Array<Record<string, unknown>> | undefined)?.length ?? 0) +
+      (grounding.recentSignals.length ?? 0),
+  };
+
+  if (approvedAskEnforcementEnabled() && !approvedContextReady(approvedSummary)) {
+    return NextResponse.json(buildApprovedContextRefusal(approvedSummary), { status: 412 });
+  }
+```
+
+- [ ] **Step 4: Run the route test and helper test**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- src/lib/__tests__/approved-context.test.ts src/app/api/mira/ask/__tests__/route.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 2**
+
+```powershell
+git add mira-hub/src/app/api/mira/ask/route.ts mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
+git commit -m "feat: gate ask mira on verified kg context"
+```
+
+---
+
+### Task 3: Approved Live Telemetry Filters For `/api/mira/ask`
+
+**Files:**
+- Modify: `mira-hub/src/app/api/mira/ask/route.ts:205-234`
+- Test: `mira-hub/src/app/api/mira/ask/__tests__/route.test.ts`
+
+**Interfaces:**
+- Consumes: `approved_tags` schema from `mira-hub/db/migrations/035_approved_tags.sql:39` through `mira-hub/db/migrations/035_approved_tags.sql:60`.
+- Produces: live event/cache grounding that only includes `approved_tags.enabled = true`.
+
+- [ ] **Step 1: Add failing assertions for approved live tag joins**
+
+Append to the existing `/api/mira/ask` route test:
+
+```ts
+  it("requires approved_tags for recent and current live grounding", async () => {
+    const calls: string[] = [];
+    const client = mockClient(
+      [
+        {
+          match: "FROM troubleshooting_sessions",
+          rows: [{
+            id: sessionId,
+            status: "confirmed",
+            asset_id: assetId,
+            component_id: null,
+            transcript: [],
+            asset_name: "Conveyor",
+            asset_tag: "Plant.Line.Conveyor",
+          }],
+        },
+        { match: "FROM kg_relationships r", rows: [{ relationship_type: "feeds", confidence: 1, s_type: "asset", s_name: "A", t_type: "asset", t_name: "B" }] },
+        { match: "FROM live_signal_events e", rows: [] },
+        { match: "FROM live_signal_cache cache", rows: [] },
+      ],
+      calls,
+    );
+    vi.mocked(withTenantContext).mockImplementation(async (_tenant, fn) => fn(client));
+
+    await POST(req());
+
+    const recentSql = calls.find((sql) => sql.includes("FROM live_signal_events e")) ?? "";
+    const currentSql = calls.find((sql) => sql.includes("FROM live_signal_cache cache")) ?? "";
+    expect(recentSql).toMatch(/JOIN approved_tags/i);
+    expect(recentSql).toMatch(/approved_tags[\s\S]+enabled\s*=\s*true/i);
+    expect(currentSql).toMatch(/JOIN approved_tags/i);
+    expect(currentSql).toMatch(/approved_tags[\s\S]+enabled\s*=\s*true/i);
+  });
+```
+
+- [ ] **Step 2: Run the route test and verify it fails**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- src/app/api/mira/ask/__tests__/route.test.ts
+```
+
+Expected: FAIL because recent/current live SQL does not join `approved_tags`.
+
+- [ ] **Step 3: Add approved-tag joins to recent and current signal SQL**
+
+Use `uns_path` when present, with normalized tag path fallback for existing rows:
+
+```sql
+           JOIN approved_tags at
+             ON at.tenant_id = e.tenant_id
+            AND at.enabled = true
+            AND (
+              at.uns_path = e.uns_path
+              OR at.normalized_tag_path = e.plc_tag
+            )
+```
+
+and:
+
+```sql
+           JOIN approved_tags at
+             ON at.tenant_id = cache.tenant_id
+            AND at.enabled = true
+            AND (
+              at.uns_path = cache.uns_path
+              OR at.normalized_tag_path = cache.plc_tag
+            )
+```
+
+If the concrete columns in `live_signal_events` differ, verify them from the migrations or `mira-hub/src/lib/signal-recorder.ts:179` through `mira-hub/src/lib/signal-recorder.ts:210` before editing. UNKNOWN: this plan has not re-read the live signal table migration in this turn.
+
+- [ ] **Step 4: Run the route test**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- src/app/api/mira/ask/__tests__/route.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Task 3**
+
+```powershell
+git add mira-hub/src/app/api/mira/ask/route.ts mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
+git commit -m "feat: filter ask mira live context to approved tags"
+```
+
+---
+
+### Task 4: Node And Asset Chat Zero-Approved-Source Refusal
+
+**Files:**
+- Modify: `mira-hub/src/app/api/namespace/node/[id]/chat/route.ts:284-286`
+- Modify: `mira-hub/src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts`
+- Modify: `mira-hub/src/app/api/assets/[id]/chat/route.ts:306-308`
+- Create: `mira-hub/src/app/api/assets/[id]/chat/__tests__/route.test.ts`
+
+**Interfaces:**
+- Consumes: `approvedAskEnforcementEnabled`, `approvedContextReady`, and `buildApprovedContextRefusal`.
+- Produces: answer routes that return 412 JSON before provider calls when enforcement is enabled and approved source count is zero.
+
+- [ ] **Step 1: Add a node chat failing test**
+
+Append to `mira-hub/src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts`:
+
+```ts
+  it("returns approved_context without calling providers when enforced and no verified node docs exist", async () => {
+    process.env.NEON_DATABASE_URL = "postgres://test";
+    process.env.MIRA_ENFORCE_APPROVED_ASK = "true";
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    vi.mocked(withTenantContext).mockImplementation(async (_tenantId, fn) =>
+      fn({
+        query: vi.fn(async (sql: string) => {
+          if (sql.includes("FROM kg_entities")) return { rows: [{ name: "Motor", uns_path: "Plant.Line.Motor" }] };
+          return { rows: [] };
+        }),
+      }),
+    );
+
+    const res = await POST(makeReq(userMsg("what does this fault mean?")), makeParams(VALID_UUID));
+    const body = await res.json();
+
+    expect(res.status).toBe(412);
+    expect(body.gate).toBe("approved_context");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+```
+
+- [ ] **Step 2: Create the smallest asset chat test**
+
+Create `mira-hub/src/app/api/assets/[id]/chat/__tests__/route.test.ts` by copying only the session, tenant-context, and fetch mock pattern from the node chat test. The test must assert:
+
+```ts
+expect(res.status).toBe(412);
+expect(body.gate).toBe("approved_context");
+expect(fetchSpy).not.toHaveBeenCalled();
+```
+
+The asset test should mock `pool.connect().query()` so the `cmms_equipment` lookup returns one row and `retrieveManualChunks` returns no rows. If mocking the raw `pool` is too broad, extract a tiny helper in the asset route first and test that helper in the same task.
+
+- [ ] **Step 3: Run the node and asset route tests and verify they fail**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- "src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts" "src/app/api/assets/[id]/chat/__tests__/route.test.ts"
+```
+
+Expected: FAIL because routes continue to stream and call providers with zero approved sources.
+
+- [ ] **Step 4: Add refusal before stream construction**
+
+In node chat, after `approvedSourceCount` is computed at `mira-hub/src/app/api/namespace/node/[id]/chat/route.ts:286` and before `const fullMessages`:
+
+```ts
+  const approvedSummary = {
+    approvedSourceCount,
+    verifiedRelationshipCount: 0,
+    approvedLiveSignalCount: 0,
+  };
+
+  if (approvedAskEnforcementEnabled() && !approvedContextReady(approvedSummary)) {
+    return NextResponse.json(buildApprovedContextRefusal(approvedSummary), { status: 412 });
+  }
+```
+
+In asset chat, after `approvedSourceCount` is computed at `mira-hub/src/app/api/assets/[id]/chat/route.ts:308` and before `const fullMessages`:
+
+```ts
+  const approvedSummary = {
+    approvedSourceCount,
+    verifiedRelationshipCount: graphContext ? 1 : 0,
+    approvedLiveSignalCount: 0,
+  };
+
+  if (approvedAskEnforcementEnabled() && !approvedContextReady(approvedSummary)) {
+    return NextResponse.json(buildApprovedContextRefusal(approvedSummary), { status: 412 });
+  }
+```
+
+Import the helper functions in both routes.
+
+- [ ] **Step 5: Run the route tests**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- src/lib/__tests__/approved-context.test.ts "src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts" "src/app/api/assets/[id]/chat/__tests__/route.test.ts"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 4**
+
+```powershell
+git add mira-hub/src/app/api/namespace/node/[id]/chat/route.ts mira-hub/src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts mira-hub/src/app/api/assets/[id]/chat/route.ts mira-hub/src/app/api/assets/[id]/chat/__tests__/route.test.ts
+git commit -m "feat: refuse unapproved asset chat context"
+```
+
+---
+
+### Task 5: Answer-Facing KG Context Filters
+
+**Files:**
+- Modify: `mira-hub/src/lib/knowledge-graph/context-builder.ts:90`, `mira-hub/src/lib/knowledge-graph/context-builder.ts:118`, `mira-hub/src/lib/knowledge-graph/context-builder.ts:131`
+- Modify: `mira-hub/src/lib/knowledge-graph/traversal.ts:95`, `mira-hub/src/lib/knowledge-graph/traversal.ts:157`, `mira-hub/src/lib/knowledge-graph/traversal.ts:416`, `mira-hub/src/lib/knowledge-graph/traversal.ts:450`, `mira-hub/src/lib/knowledge-graph/traversal.ts:460`, `mira-hub/src/lib/knowledge-graph/traversal.ts:473`, `mira-hub/src/lib/knowledge-graph/traversal.ts:481`, `mira-hub/src/lib/knowledge-graph/traversal.ts:489`, `mira-hub/src/lib/knowledge-graph/traversal.ts:499`, `mira-hub/src/lib/knowledge-graph/traversal.ts:508`
+- Test: `mira-hub/src/lib/knowledge-graph/__tests__/context-builder.test.ts`
+- Test: `mira-hub/src/lib/knowledge-graph/__tests__/traversal.test.ts`
+
+**Interfaces:**
+- Consumes: canonical verified state from `mira-hub/src/lib/i3x/approval.ts:16`.
+- Produces: KG context used by asset chat that excludes proposed/rejected/missing approval rows.
+
+- [ ] **Step 1: Add query-capture tests**
+
+Add a context-builder test that calls the exported function with a mocked DB client and asserts any query reading `kg_entities` for an answer anchor includes:
+
+```ts
+expect(sql).toMatch(/approval_state\s*=\s*'verified'/i);
+```
+
+Add a relationship query assertion:
+
+```ts
+expect(sql).toMatch(/r\.approval_state\s*=\s*'verified'/i);
+```
+
+Add traversal query assertions for each helper used by `buildGraphContext`:
+
+```ts
+expect(sqlBlob).toMatch(/kg_relationships[\s\S]+approval_state\s*=\s*'verified'/i);
+expect(sqlBlob).not.toMatch(/approval_state\s+IS\s+NULL/i);
+```
+
+- [ ] **Step 2: Run context-builder and traversal tests and verify they fail**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- src/lib/knowledge-graph/__tests__/context-builder.test.ts src/lib/knowledge-graph/__tests__/traversal.test.ts
+```
+
+Expected: FAIL because the current queries are unfiltered.
+
+- [ ] **Step 3: Add verified filters to answer-facing KG queries**
+
+Use the literal value `'verified'` in SQL to align with the partial index created at `mira-hub/db/migrations/029_kg_approval_state.sql:33`.
+
+For entity lookups:
+
+```sql
+WHERE tenant_id = $1
+  AND approval_state = 'verified'
+```
+
+For relationship joins:
+
+```sql
+JOIN kg_relationships r
+  ON ...
+ AND r.approval_state = 'verified'
+```
+
+For joined entities:
+
+```sql
+JOIN kg_entities e
+  ON ...
+ AND e.approval_state = 'verified'
+```
+
+Do not change proposal writers or graph extraction writers in this task; those already route proposed context through proposals rather than directly to verified KG rows.
+
+- [ ] **Step 4: Run the KG tests**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- src/lib/knowledge-graph/__tests__/context-builder.test.ts src/lib/knowledge-graph/__tests__/traversal.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run answer-route tests that depend on KG context**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- src/app/api/assets/[id]/chat/__tests__/route.test.ts src/app/api/mira/ask/__tests__/route.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 5**
+
+```powershell
+git add mira-hub/src/lib/knowledge-graph/context-builder.ts mira-hub/src/lib/knowledge-graph/traversal.ts mira-hub/src/lib/knowledge-graph/__tests__/context-builder.test.ts mira-hub/src/lib/knowledge-graph/__tests__/traversal.test.ts
+git commit -m "feat: restrict answer kg context to verified edges"
+```
+
+---
+
+### Task 6: Verification, Stack Hygiene, And Draft PR
+
+**Files:**
+- Modify only if needed: `docs/plans/2026-06-25-context-spine-unification-plan.md`
+
+**Interfaces:**
+- Consumes: commits from Tasks 1-5.
+- Produces: a draft PR stacked after #2308 with test evidence.
+
+- [ ] **Step 1: Run targeted unit and route tests**
+
+Run:
+
+```powershell
+cd mira-hub
+npm test -- src/lib/__tests__/approved-context.test.ts src/lib/__tests__/manual-rag.test.ts src/lib/knowledge-graph/__tests__/context-builder.test.ts src/lib/knowledge-graph/__tests__/traversal.test.ts src/app/api/mira/ask/__tests__/route.test.ts "src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts" "src/app/api/assets/[id]/chat/__tests__/route.test.ts"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run lint**
+
+Run:
+
+```powershell
+cd mira-hub
+npm run lint
+```
+
+Expected: PASS or only pre-existing unrelated warnings. If lint fails in touched files, fix before PR.
+
+- [ ] **Step 3: Run build if targeted tests pass**
+
+Run:
+
+```powershell
+cd mira-hub
+npm run build
+```
+
+Expected: PASS. If build is blocked by an external service/env requirement, capture the exact failure in the PR body.
+
+- [ ] **Step 4: Check stack state**
+
+Run:
+
+```powershell
+git status --short --branch
+gh pr view 2308 --json number,state,isDraft,mergeStateStatus,baseRefName,headRefName,url
+gh pr view 2307 --json number,state,isDraft,mergeStateStatus,baseRefName,headRefName,url
+```
+
+Expected: working tree has only intentional changes; #2308 remains the intended base or has been merged/rebased.
+
+- [ ] **Step 5: Create a stacked draft PR**
+
+Use the branch name:
+
+```powershell
+git switch -c codex/context-spine-approved-ask-mira
+git push -u origin codex/context-spine-approved-ask-mira
+gh pr create --draft --base codex/context-spine-readiness-checklist --head codex/context-spine-approved-ask-mira --title "[codex] Gate Ask MIRA on approved context" --body-file .superpowers/pr-approved-context-ask-mira.md
+```
+
+PR body must include:
+
+```markdown
+## Summary
+- Gates `/api/mira/ask` before provider calls unless approved context exists.
+- Restricts answer-facing KG relationships/entities to `approval_state = 'verified'`.
+- Restricts live Ask MIRA grounding to `approved_tags.enabled = true`.
+- Uses existing missing-context checklist shape for refusal.
+
+## Tests
+- `npm test -- src/lib/__tests__/approved-context.test.ts ...`
+- `npm run lint`
+- `npm run build`
+
+## Safety
+- No new database or graph store.
+- No live write/control paths.
+- Enforcement remains feature-flagged through `MIRA_ENFORCE_APPROVED_ASK` or `MIRA_ENFORCE_APPROVED_RETRIEVAL`.
+```
+
+---
+
+## Risks And Follow-Ups
+
+- `MIRA_ENFORCE_APPROVED_RETRIEVAL` already changes manual retrieval behavior at `mira-hub/src/lib/manual-rag.ts:51`; adding `MIRA_ENFORCE_APPROVED_ASK` as an alias keeps answer refusal explicit without breaking existing environments.
+- `approved_tags` joins in Task 3 must be checked against the actual live signal table columns before editing. The plan found signal cache writes in `mira-hub/src/lib/signal-recorder.ts:179`, but did not re-read the table migration in this planning pass.
+- Graph UI and namespace node read APIs have unfiltered gaps, including `mira-hub/src/app/api/kg/graph/route.ts:45` and `mira-hub/src/app/api/namespace/node/[id]/route.ts:146`. Keep them out of this PR unless answer-path tests prove they feed MIRA responses.
+- `mira-hub/src/lib/knowledge-graph/graph-view.ts:86` currently defaults null approval state to `verified`; that should be a follow-up PR because it may affect UI visualization semantics outside Ask MIRA.
+- If #2307 remains dirty against `main`, refresh that base before marking any stacked PR ready for review.
+
+## Smallest Possible PR Plan
+
+1. Add the approved-context helper and tests.
+2. Add `/api/mira/ask` route tests and enforce verified KG plus approved live telemetry under flags.
+3. Add zero-approved-source refusal to node/asset chat using existing counts.
+4. Filter answer-facing KG context builder/traversal paths to verified rows.
+5. Open a draft PR stacked on #2308 with targeted test, lint, and build evidence.

--- a/mira-hub/src/app/api/assets/[id]/chat/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/assets/[id]/chat/__tests__/route.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/session", () => ({ sessionOr401: vi.fn() }));
+vi.mock("@/lib/tenant-context", () => ({ withTenantContext: vi.fn() }));
+vi.mock("@/lib/db", () => ({ default: { connect: vi.fn() } }));
+vi.mock("@/lib/knowledge-graph/extractor", () => ({ extractAndStore: vi.fn() }));
+vi.mock("@/lib/knowledge-graph/context-builder", () => ({ buildGraphContext: vi.fn() }));
+vi.mock("@/lib/manual-rag", () => ({
+  retrieveManualChunks: vi.fn(),
+  appendManualContext: vi.fn((prompt: string) => prompt),
+  chunksToSources: vi.fn(() => []),
+}));
+
+import { POST } from "../route";
+import { sessionOr401 } from "@/lib/session";
+import pool from "@/lib/db";
+import { buildGraphContext } from "@/lib/knowledge-graph/context-builder";
+import { retrieveManualChunks } from "@/lib/manual-rag";
+
+const VALID_UUID = "11111111-2222-3333-4444-555555555555";
+const TENANT_ID = "tenant-aaaa-bbbb";
+
+const goodSession = {
+  userId: "u_1",
+  tenantId: TENANT_ID,
+  email: "x@y",
+  status: "trial",
+  trialExpiresAt: null,
+};
+
+const makeReq = (body: unknown) =>
+  new Request(`https://hub.test/api/assets/${VALID_UUID}/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const makeParams = (id: string) => ({ params: Promise.resolve({ id }) });
+
+const userMsg = (content: string) => ({ messages: [{ role: "user", content }] });
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  process.env.NEON_DATABASE_URL = "postgres://test-only-not-used";
+  process.env.GROQ_API_KEY = "test-key";
+  process.env.MIRA_ENFORCE_APPROVED_ASK = "true";
+  fetchSpy = vi.fn();
+  vi.stubGlobal("fetch", fetchSpy);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.MIRA_ENFORCE_APPROVED_ASK;
+});
+
+describe("POST /api/assets/[id]/chat", () => {
+  it("returns approved_context without calling providers when enforced and no approved asset context exists", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    vi.mocked(buildGraphContext).mockResolvedValue("");
+    vi.mocked(retrieveManualChunks).mockResolvedValue([]);
+
+    const release = vi.fn();
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("FROM cmms_equipment")) {
+        return {
+          rows: [
+            {
+              equipment_number: "MTR-101",
+              manufacturer: "FactoryLM",
+              model_number: "M100",
+              serial_number: "S100",
+              equipment_type: "Motor",
+              location: "Plant.Line",
+              criticality: "high",
+              description: "Line Motor",
+              installation_date: null,
+              last_maintenance_date: null,
+              last_reported_fault: null,
+              work_order_count: 0,
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+    vi.mocked(pool.connect).mockResolvedValue({ query, release } as never);
+
+    const res = await POST(makeReq(userMsg("what does this fault mean?")), makeParams(VALID_UUID));
+    const body = await res.json();
+
+    expect(res.status).toBe(412);
+    expect(body.gate).toBe("approved_context");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("propagates a 401 from the session helper", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+
+    const res = await POST(makeReq(userMsg("hi")), makeParams(VALID_UUID));
+
+    expect(res.status).toBe(401);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/mira-hub/src/app/api/assets/[id]/chat/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/assets/[id]/chat/__tests__/route.test.ts
@@ -9,14 +9,22 @@ vi.mock("@/lib/knowledge-graph/context-builder", () => ({ buildGraphContext: vi.
 vi.mock("@/lib/manual-rag", () => ({
   retrieveManualChunks: vi.fn(),
   appendManualContext: vi.fn((prompt: string) => prompt),
-  chunksToSources: vi.fn(() => []),
+  chunksToSources: vi.fn((chunks: Array<{ title?: string; sourceUrl?: string; sourcePage?: number | null; verified?: boolean }>) =>
+    chunks.map((chunk, index) => ({
+      index: index + 1,
+      title: chunk.title ?? "manual",
+      url: chunk.sourceUrl ?? null,
+      page: chunk.sourcePage ?? null,
+      verified: chunk.verified === true,
+    })),
+  ),
 }));
 
 import { POST } from "../route";
 import { sessionOr401 } from "@/lib/session";
 import pool from "@/lib/db";
 import { buildGraphContext } from "@/lib/knowledge-graph/context-builder";
-import { retrieveManualChunks } from "@/lib/manual-rag";
+import { appendManualContext, retrieveManualChunks } from "@/lib/manual-rag";
 
 const VALID_UUID = "11111111-2222-3333-4444-555555555555";
 const TENANT_ID = "tenant-aaaa-bbbb";
@@ -94,6 +102,65 @@ describe("POST /api/assets/[id]/chat", () => {
     expect(res.status).toBe(412);
     expect(body.gate).toBe("approved_context");
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("filters unverified manual chunks before building the provider prompt", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    vi.mocked(buildGraphContext).mockResolvedValue("");
+    vi.mocked(retrieveManualChunks).mockResolvedValue([
+      {
+        content: "Approved bearing reset steps",
+        manufacturer: "FactoryLM",
+        modelNumber: "M100",
+        sourceUrl: "https://docs.test/approved",
+        sourcePage: 2,
+        title: "Approved Manual",
+        rank: 0.9,
+        verified: true,
+      },
+      {
+        content: "Draft-only bypass procedure",
+        manufacturer: "FactoryLM",
+        modelNumber: "M100",
+        sourceUrl: "https://docs.test/draft",
+        sourcePage: 3,
+        title: "Draft Manual",
+        rank: 0.8,
+        verified: false,
+      },
+    ]);
+
+    const release = vi.fn();
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("FROM cmms_equipment")) {
+        return {
+          rows: [
+            {
+              equipment_number: "MTR-101",
+              manufacturer: "FactoryLM",
+              model_number: "M100",
+              serial_number: "S100",
+              equipment_type: "Motor",
+              location: "Plant.Line",
+              criticality: "high",
+              description: "Line Motor",
+              installation_date: null,
+              last_maintenance_date: null,
+              last_reported_fault: null,
+              work_order_count: 0,
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+    vi.mocked(pool.connect).mockResolvedValue({ query, release } as never);
+
+    await POST(makeReq(userMsg("what does this fault mean?")), makeParams(VALID_UUID));
+
+    expect(appendManualContext).toHaveBeenCalled();
+    const chunks = vi.mocked(appendManualContext).mock.calls[0]?.[1] ?? [];
+    expect(chunks.map((chunk) => chunk.content)).toEqual(["Approved bearing reset steps"]);
   });
 
   it("propagates a 401 from the session helper", async () => {

--- a/mira-hub/src/app/api/assets/[id]/chat/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/assets/[id]/chat/__tests__/route.test.ts
@@ -50,6 +50,15 @@ const userMsg = (content: string) => ({ messages: [{ role: "user", content }] })
 
 let fetchSpy: ReturnType<typeof vi.fn>;
 
+async function drain(res: Response): Promise<void> {
+  const reader = res.body?.getReader();
+  if (!reader) return;
+  for (;;) {
+    const { done } = await reader.read();
+    if (done) return;
+  }
+}
+
 beforeEach(() => {
   vi.resetAllMocks();
   process.env.NEON_DATABASE_URL = "postgres://test-only-not-used";
@@ -161,6 +170,50 @@ describe("POST /api/assets/[id]/chat", () => {
     expect(appendManualContext).toHaveBeenCalled();
     const chunks = vi.mocked(appendManualContext).mock.calls[0]?.[1] ?? [];
     expect(chunks.map((chunk) => chunk.content)).toEqual(["Approved bearing reset steps"]);
+  });
+
+  it("allows verified KG relationship context without requiring manual chunks", async () => {
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    vi.mocked(buildGraphContext).mockResolvedValue("[KG] verified relationship context");
+    vi.mocked(retrieveManualChunks).mockResolvedValue([]);
+    fetchSpy.mockResolvedValue(
+      new Response('data: {"choices":[{"delta":{"content":"ok"}}]}\n\ndata: [DONE]\n\n', {
+        status: 200,
+      }),
+    );
+
+    const release = vi.fn();
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("FROM cmms_equipment")) {
+        return {
+          rows: [
+            {
+              equipment_number: "MTR-101",
+              manufacturer: "FactoryLM",
+              model_number: "M100",
+              serial_number: "S100",
+              equipment_type: "Motor",
+              location: "Plant.Line",
+              criticality: "high",
+              description: "Line Motor",
+              installation_date: null,
+              last_maintenance_date: null,
+              last_reported_fault: null,
+              work_order_count: 0,
+            },
+          ],
+        };
+      }
+      if (sql.includes("FROM kg_relationships r")) return { rows: [{ count: 1 }] };
+      return { rows: [] };
+    });
+    vi.mocked(pool.connect).mockResolvedValue({ query, release } as never);
+
+    const res = await POST(makeReq(userMsg("what does this fault mean?")), makeParams(VALID_UUID));
+
+    expect(res.status).toBe(200);
+    await drain(res);
+    expect(fetchSpy).toHaveBeenCalled();
   });
 
   it("propagates a 401 from the session helper", async () => {

--- a/mira-hub/src/app/api/assets/[id]/chat/route.ts
+++ b/mira-hub/src/app/api/assets/[id]/chat/route.ts
@@ -267,6 +267,7 @@ export async function POST(
   // `.claude/rules/knowledge-entries-tenant-scoping.md`.
   let assetRow: Record<string, unknown> | null = null;
   let manualChunks: ManualChunk[] = [];
+  let verifiedRelationshipCount = 0;
   try {
     const c = await pool.connect();
     try {
@@ -290,6 +291,31 @@ export async function POST(
       if (approvedAskEnforcementEnabled()) {
         manualChunks = manualChunks.filter((chunk) => chunk.verified === true);
       }
+      const relRes = await c.query(
+        `WITH anchor AS (
+           SELECT id
+             FROM kg_entities
+            WHERE tenant_id = $1
+              AND approval_state = 'verified'
+              AND (id::text = $2 OR entity_id = $2)
+            LIMIT 1
+         )
+         SELECT COUNT(*)::int AS count
+           FROM kg_relationships r
+           JOIN anchor a ON (r.source_id = a.id OR r.target_id = a.id)
+           JOIN kg_entities src
+             ON src.id = r.source_id
+            AND src.tenant_id = r.tenant_id
+            AND src.approval_state = 'verified'
+           JOIN kg_entities tgt
+             ON tgt.id = r.target_id
+            AND tgt.tenant_id = r.tenant_id
+            AND tgt.approval_state = 'verified'
+          WHERE r.tenant_id = $1
+            AND r.approval_state = 'verified'`,
+        [ctx.tenantId, id],
+      );
+      verifiedRelationshipCount = Number(relRes.rows[0]?.count ?? 0);
     } finally {
       c.release();
     }
@@ -297,6 +323,7 @@ export async function POST(
     // Non-fatal: continue without DB context (graceful degradation)
     assetRow = null;
     manualChunks = [];
+    verifiedRelationshipCount = 0;
   }
 
   // KG graph context — fetch in parallel with (already completed) asset DB fetch
@@ -316,7 +343,7 @@ export async function POST(
   const approvedSourceCount = manualSources.filter((s) => s.verified).length;
   const approvedSummary = {
     approvedSourceCount,
-    verifiedRelationshipCount: 0,
+    verifiedRelationshipCount,
     approvedLiveSignalCount: 0,
   };
 

--- a/mira-hub/src/app/api/assets/[id]/chat/route.ts
+++ b/mira-hub/src/app/api/assets/[id]/chat/route.ts
@@ -287,6 +287,9 @@ export async function POST(
         manufacturer: mfr,
         allowTenantFallback: false,
       });
+      if (approvedAskEnforcementEnabled()) {
+        manualChunks = manualChunks.filter((chunk) => chunk.verified === true);
+      }
     } finally {
       c.release();
     }
@@ -313,7 +316,7 @@ export async function POST(
   const approvedSourceCount = manualSources.filter((s) => s.verified).length;
   const approvedSummary = {
     approvedSourceCount,
-    verifiedRelationshipCount: graphContext ? 1 : 0,
+    verifiedRelationshipCount: 0,
     approvedLiveSignalCount: 0,
   };
 

--- a/mira-hub/src/app/api/assets/[id]/chat/route.ts
+++ b/mira-hub/src/app/api/assets/[id]/chat/route.ts
@@ -12,6 +12,11 @@ import {
   type ManualChunk,
   type ManualSource,
 } from "@/lib/manual-rag";
+import {
+  approvedAskEnforcementEnabled,
+  approvedContextReady,
+  buildApprovedContextRefusal,
+} from "@/lib/approved-context";
 
 export const dynamic = "force-dynamic";
 
@@ -306,6 +311,15 @@ export async function POST(
   const systemPrompt = appendManualContext(withGraph, manualChunks);
   const manualSources: ManualSource[] = chunksToSources(manualChunks);
   const approvedSourceCount = manualSources.filter((s) => s.verified).length;
+  const approvedSummary = {
+    approvedSourceCount,
+    verifiedRelationshipCount: graphContext ? 1 : 0,
+    approvedLiveSignalCount: 0,
+  };
+
+  if (approvedAskEnforcementEnabled() && !approvedContextReady(approvedSummary)) {
+    return NextResponse.json(buildApprovedContextRefusal(approvedSummary), { status: 412 });
+  }
 
   const fullMessages: ChatMessage[] = [
     { role: "system", content: systemPrompt },

--- a/mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
@@ -113,8 +113,10 @@ describe("POST /api/mira/ask approved-context gate", () => {
     const currentSql = calls.find((sql) => sql.includes("FROM live_signal_cache cache")) ?? "";
     expect(recentSql).toMatch(/JOIN approved_tags/i);
     expect(recentSql).toMatch(/approved_tags[\s\S]+enabled\s*=\s*true/i);
+    expect(recentSql).toMatch(/at\.source_system\s*=/i);
     expect(currentSql).toMatch(/JOIN approved_tags/i);
     expect(currentSql).toMatch(/approved_tags[\s\S]+enabled\s*=\s*true/i);
+    expect(currentSql).toMatch(/at\.source_system\s*=/i);
     expect(currentSql).not.toMatch(/component_id\s+IS\s+NULL/i);
   });
 
@@ -154,6 +156,54 @@ describe("POST /api/mira/ask approved-context gate", () => {
     const cascadeMessages = vi.mocked(cascadeComplete).mock.calls[0]?.[0] ?? [];
     const systemPrompt = cascadeMessages[0]?.content ?? "";
     expect(systemPrompt).not.toContain("## Transition count");
+  });
+
+  it("passes the approved source system into transition grounding", async () => {
+    const calls: string[] = [];
+    vi.mocked(countTransitions).mockResolvedValue({
+      transitions: 2,
+      windowSeconds: 30,
+      windowStart: "start",
+      windowEnd: "end",
+      topic: "PE001",
+    });
+    const client = mockClient(
+      [
+        {
+          match: "FROM troubleshooting_sessions",
+          rows: [{
+            id: sessionId,
+            status: "confirmed",
+            asset_id: assetId,
+            component_id: null,
+            transcript: [],
+            asset_name: "Conveyor",
+            asset_tag: "Plant.Line.Conveyor",
+          }],
+        },
+        {
+          match: "FROM installed_component_instances i",
+          rows: [{ id: "cmp-1", component_name: "Photoeye", plc_tag: "PE001" }],
+        },
+        { match: "FROM kg_relationships r", rows: [{ relationship_type: "feeds", confidence: 1, s_type: "asset", s_name: "A", t_type: "asset", t_name: "B" }] },
+        { match: "FROM live_signal_events e", rows: [] },
+        { match: "FROM live_signal_cache cache", rows: [] },
+        { match: "FROM approved_tags", rows: [{ source_system: "ignition" }] },
+      ],
+      calls,
+    );
+    vi.mocked(withTenantContext).mockImplementation(async (_tenant, fn) => fn(client));
+
+    const res = await POST(req("How many times did PE001 change in the last 30 seconds?"));
+
+    expect(res.status).toBe(200);
+    expect(countTransitions).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ plcTag: "PE001", sourceSystem: "ignition" }),
+    );
+    const cascadeMessages = vi.mocked(cascadeComplete).mock.calls[0]?.[0] ?? [];
+    const systemPrompt = cascadeMessages[0]?.content ?? "";
+    expect(systemPrompt).toContain("## Transition count");
   });
 
   it("returns approved_context without calling cascade when no approved context exists", async () => {

--- a/mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/lib/signal-recorder", () => ({ countTransitions: vi.fn() }));
 import { cascadeComplete } from "@/lib/llm/cascade";
 import { sessionOrDemo } from "@/lib/demo-auth";
 import { withTenantContext } from "@/lib/tenant-context";
+import { countTransitions } from "@/lib/signal-recorder";
 import { POST } from "../route";
 
 const tenantId = "tenant-1";
@@ -114,6 +115,45 @@ describe("POST /api/mira/ask approved-context gate", () => {
     expect(recentSql).toMatch(/approved_tags[\s\S]+enabled\s*=\s*true/i);
     expect(currentSql).toMatch(/JOIN approved_tags/i);
     expect(currentSql).toMatch(/approved_tags[\s\S]+enabled\s*=\s*true/i);
+    expect(currentSql).not.toMatch(/component_id\s+IS\s+NULL/i);
+  });
+
+  it("does not add transition grounding unless the focus PLC tag is approved", async () => {
+    const calls: string[] = [];
+    const client = mockClient(
+      [
+        {
+          match: "FROM troubleshooting_sessions",
+          rows: [{
+            id: sessionId,
+            status: "confirmed",
+            asset_id: assetId,
+            component_id: null,
+            transcript: [],
+            asset_name: "Conveyor",
+            asset_tag: "Plant.Line.Conveyor",
+          }],
+        },
+        {
+          match: "FROM installed_component_instances i",
+          rows: [{ id: "cmp-1", component_name: "Photoeye", plc_tag: "PE001" }],
+        },
+        { match: "FROM kg_relationships r", rows: [{ relationship_type: "feeds", confidence: 1, s_type: "asset", s_name: "A", t_type: "asset", t_name: "B" }] },
+        { match: "FROM live_signal_events e", rows: [] },
+        { match: "FROM live_signal_cache cache", rows: [] },
+        { match: "FROM approved_tags", rows: [] },
+      ],
+      calls,
+    );
+    vi.mocked(withTenantContext).mockImplementation(async (_tenant, fn) => fn(client));
+
+    const res = await POST(req("How many times did PE001 change in the last 30 seconds?"));
+
+    expect(res.status).toBe(200);
+    expect(countTransitions).not.toHaveBeenCalled();
+    const cascadeMessages = vi.mocked(cascadeComplete).mock.calls[0]?.[0] ?? [];
+    const systemPrompt = cascadeMessages[0]?.content ?? "";
+    expect(systemPrompt).not.toContain("## Transition count");
   });
 
   it("returns approved_context without calling cascade when no approved context exists", async () => {

--- a/mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/demo-auth", () => ({ sessionOrDemo: vi.fn() }));
+vi.mock("@/lib/tenant-context", () => ({ withTenantContext: vi.fn() }));
+vi.mock("@/lib/llm/cascade", () => ({ cascadeComplete: vi.fn() }));
+vi.mock("@/lib/ip-rate-limit", () => ({
+  clientIpHash: vi.fn(() => "ip-hash"),
+  rateLimited: vi.fn(() => false),
+}));
+vi.mock("@/lib/signal-recorder", () => ({ countTransitions: vi.fn() }));
+
+import { cascadeComplete } from "@/lib/llm/cascade";
+import { sessionOrDemo } from "@/lib/demo-auth";
+import { withTenantContext } from "@/lib/tenant-context";
+import { POST } from "../route";
+
+const tenantId = "tenant-1";
+const sessionId = "11111111-1111-1111-1111-111111111111";
+const assetId = "22222222-2222-2222-2222-222222222222";
+
+function req(question = "What fails when this conveyor stops?") {
+  return new Request("http://localhost/api/mira/ask", {
+    method: "POST",
+    body: JSON.stringify({ session_id: sessionId, question }),
+  });
+}
+
+function mockClient(rowsBySql: Array<{ match: string; rows: Array<Record<string, unknown>> }>, calls: string[]) {
+  return {
+    query: vi.fn(async (sql: string) => {
+      calls.push(sql);
+      const hit = rowsBySql.find((entry) => sql.includes(entry.match));
+      return { rows: hit?.rows ?? [] };
+    }),
+  };
+}
+
+describe("POST /api/mira/ask approved-context gate", () => {
+  const oldEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...oldEnv, NEON_DATABASE_URL: "postgres://test", MIRA_ENFORCE_APPROVED_ASK: "true" };
+    vi.mocked(sessionOrDemo).mockResolvedValue({ tenantId, userId: "user-1" });
+    vi.mocked(cascadeComplete).mockResolvedValue({ content: "answer", provider: "mock", latencyMs: 1 });
+  });
+
+  afterEach(() => {
+    process.env = oldEnv;
+    vi.clearAllMocks();
+  });
+
+  it("requires verified KG state in the relationship grounding query", async () => {
+    const calls: string[] = [];
+    const client = mockClient(
+      [
+        {
+          match: "FROM troubleshooting_sessions",
+          rows: [{
+            id: sessionId,
+            status: "confirmed",
+            asset_id: assetId,
+            component_id: null,
+            transcript: [],
+            asset_name: "Conveyor",
+            asset_tag: "Plant.Line.Conveyor",
+          }],
+        },
+        { match: "FROM kg_relationships r", rows: [{ relationship_type: "feeds", confidence: 1, s_type: "asset", s_name: "A", t_type: "asset", t_name: "B" }] },
+        { match: "FROM live_signal_events e", rows: [] },
+        { match: "FROM live_signal_cache cache", rows: [] },
+      ],
+      calls,
+    );
+    vi.mocked(withTenantContext).mockImplementation(async (_tenant, fn) => fn(client));
+
+    const res = await POST(req());
+
+    expect(res.status).toBe(200);
+    const relationshipSql = calls.find((sql) => sql.includes("FROM kg_relationships r")) ?? "";
+    expect(relationshipSql).toMatch(/r\.approval_state\s*=\s*'verified'/i);
+    expect(relationshipSql).toMatch(/src\.approval_state\s*=\s*'verified'/i);
+    expect(relationshipSql).toMatch(/tgt\.approval_state\s*=\s*'verified'/i);
+  });
+
+  it("returns approved_context without calling cascade when no approved context exists", async () => {
+    const calls: string[] = [];
+    const client = mockClient(
+      [
+        {
+          match: "FROM troubleshooting_sessions",
+          rows: [{
+            id: sessionId,
+            status: "confirmed",
+            asset_id: assetId,
+            component_id: null,
+            transcript: [],
+            asset_name: "Conveyor",
+            asset_tag: "Plant.Line.Conveyor",
+          }],
+        },
+      ],
+      calls,
+    );
+    vi.mocked(withTenantContext).mockImplementation(async (_tenant, fn) => fn(client));
+
+    const res = await POST(req());
+    const body = await res.json();
+
+    expect(res.status).toBe(412);
+    expect(body.gate).toBe("approved_context");
+    expect(body.missingContext).toEqual(expect.any(Array));
+    expect(cascadeComplete).not.toHaveBeenCalled();
+  });
+});

--- a/mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
@@ -1,4 +1,3 @@
-import { NextResponse } from "next/server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/demo-auth", () => ({ sessionOrDemo: vi.fn() }));
@@ -81,6 +80,40 @@ describe("POST /api/mira/ask approved-context gate", () => {
     expect(relationshipSql).toMatch(/r\.approval_state\s*=\s*'verified'/i);
     expect(relationshipSql).toMatch(/src\.approval_state\s*=\s*'verified'/i);
     expect(relationshipSql).toMatch(/tgt\.approval_state\s*=\s*'verified'/i);
+  });
+
+  it("requires approved_tags for recent and current live grounding", async () => {
+    const calls: string[] = [];
+    const client = mockClient(
+      [
+        {
+          match: "FROM troubleshooting_sessions",
+          rows: [{
+            id: sessionId,
+            status: "confirmed",
+            asset_id: assetId,
+            component_id: null,
+            transcript: [],
+            asset_name: "Conveyor",
+            asset_tag: "Plant.Line.Conveyor",
+          }],
+        },
+        { match: "FROM kg_relationships r", rows: [{ relationship_type: "feeds", confidence: 1, s_type: "asset", s_name: "A", t_type: "asset", t_name: "B" }] },
+        { match: "FROM live_signal_events e", rows: [] },
+        { match: "FROM live_signal_cache cache", rows: [] },
+      ],
+      calls,
+    );
+    vi.mocked(withTenantContext).mockImplementation(async (_tenant, fn) => fn(client));
+
+    await POST(req());
+
+    const recentSql = calls.find((sql) => sql.includes("FROM live_signal_events e")) ?? "";
+    const currentSql = calls.find((sql) => sql.includes("FROM live_signal_cache cache")) ?? "";
+    expect(recentSql).toMatch(/JOIN approved_tags/i);
+    expect(recentSql).toMatch(/approved_tags[\s\S]+enabled\s*=\s*true/i);
+    expect(currentSql).toMatch(/JOIN approved_tags/i);
+    expect(currentSql).toMatch(/approved_tags[\s\S]+enabled\s*=\s*true/i);
   });
 
   it("returns approved_context without calling cascade when no approved context exists", async () => {

--- a/mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/mira/ask/__tests__/route.test.ts
@@ -187,8 +187,8 @@ describe("POST /api/mira/ask approved-context gate", () => {
         },
         { match: "FROM kg_relationships r", rows: [{ relationship_type: "feeds", confidence: 1, s_type: "asset", s_name: "A", t_type: "asset", t_name: "B" }] },
         { match: "FROM live_signal_events e", rows: [] },
+        { match: "approved_live_sources", rows: [{ source_system: "ignition" }] },
         { match: "FROM live_signal_cache cache", rows: [] },
-        { match: "FROM approved_tags", rows: [{ source_system: "ignition" }] },
       ],
       calls,
     );
@@ -204,6 +204,44 @@ describe("POST /api/mira/ask approved-context gate", () => {
     const cascadeMessages = vi.mocked(cascadeComplete).mock.calls[0]?.[0] ?? [];
     const systemPrompt = cascadeMessages[0]?.content ?? "";
     expect(systemPrompt).toContain("## Transition count");
+  });
+
+  it("omits transition grounding when a focus tag has multiple approved live sources", async () => {
+    const calls: string[] = [];
+    const client = mockClient(
+      [
+        {
+          match: "FROM troubleshooting_sessions",
+          rows: [{
+            id: sessionId,
+            status: "confirmed",
+            asset_id: assetId,
+            component_id: null,
+            transcript: [],
+            asset_name: "Conveyor",
+            asset_tag: "Plant.Line.Conveyor",
+          }],
+        },
+        {
+          match: "FROM installed_component_instances i",
+          rows: [{ id: "cmp-1", component_name: "Photoeye", plc_tag: "PE001" }],
+        },
+        { match: "FROM kg_relationships r", rows: [{ relationship_type: "feeds", confidence: 1, s_type: "asset", s_name: "A", t_type: "asset", t_name: "B" }] },
+        { match: "FROM live_signal_events e", rows: [] },
+        { match: "FROM live_signal_cache cache", rows: [] },
+        { match: "approved_live_sources", rows: [{ source_system: "ignition" }, { source_system: "simulator" }] },
+      ],
+      calls,
+    );
+    vi.mocked(withTenantContext).mockImplementation(async (_tenant, fn) => fn(client));
+
+    const res = await POST(req("How many times did PE001 change in the last 30 seconds?"));
+
+    expect(res.status).toBe(200);
+    expect(countTransitions).not.toHaveBeenCalled();
+    const cascadeMessages = vi.mocked(cascadeComplete).mock.calls[0]?.[0] ?? [];
+    const systemPrompt = cascadeMessages[0]?.content ?? "";
+    expect(systemPrompt).not.toContain("## Transition count");
   });
 
   it("returns approved_context without calling cascade when no approved context exists", async () => {

--- a/mira-hub/src/app/api/mira/ask/route.ts
+++ b/mira-hub/src/app/api/mira/ask/route.ts
@@ -219,6 +219,9 @@ export async function POST(req: Request) {
            JOIN approved_tags at
              ON at.tenant_id = e.tenant_id
             AND at.enabled = true
+            AND at.source_system = (
+              CASE WHEN e.source IN ('demo_simulator', 'simulator') THEN 'simulator' ELSE e.source END
+            )
             AND (
               at.normalized_tag_path = e.plc_tag
               OR at.source_tag_path = e.plc_tag
@@ -244,6 +247,10 @@ export async function POST(req: Request) {
            JOIN approved_tags at
              ON at.tenant_id = cache.tenant_id
             AND at.enabled = true
+            AND at.source_system = COALESCE(
+              NULLIF(cache.source_system, ''),
+              CASE WHEN cache.source IN ('demo_simulator', 'simulator') THEN 'simulator' ELSE cache.source END
+            )
             AND (
               at.uns_path = cache.uns_path
               OR at.normalized_tag_path = cache.plc_tag
@@ -271,10 +278,10 @@ export async function POST(req: Request) {
           (cmp) => cmp.id === component,
         ) ?? (components as Array<Record<string, unknown>>)[0];
       const focusTag = (focus?.plc_tag as string | null) ?? null;
-      let approvedFocusTag = false;
+      let approvedFocusSourceSystem: string | null = null;
       if (focusTag) {
         const approvedTagRes = await c.query(
-          `SELECT 1
+          `SELECT source_system
              FROM approved_tags
             WHERE tenant_id = $1
               AND enabled = true
@@ -282,14 +289,15 @@ export async function POST(req: Request) {
             LIMIT 1`,
           [ctx.tenantId, focusTag],
         );
-        approvedFocusTag = approvedTagRes.rows.length > 0;
+        approvedFocusSourceSystem = (approvedTagRes.rows[0]?.source_system as string | null) ?? null;
       }
-      if (focusTag && approvedFocusTag) {
+      if (focusTag && approvedFocusSourceSystem) {
         try {
           const tc = await countTransitions(c, {
             tenantId: ctx.tenantId,
             plcTag: focusTag,
             componentId: null,
+            sourceSystem: approvedFocusSourceSystem,
             windowSeconds: transitionWindowSec,
           });
           transitionFact = {

--- a/mira-hub/src/app/api/mira/ask/route.ts
+++ b/mira-hub/src/app/api/mira/ask/route.ts
@@ -282,14 +282,35 @@ export async function POST(req: Request) {
       if (focusTag) {
         const approvedTagRes = await c.query(
           `SELECT source_system
-             FROM approved_tags
-            WHERE tenant_id = $1
-              AND enabled = true
-              AND (normalized_tag_path = $2 OR source_tag_path = $2)
-            LIMIT 1`,
-          [ctx.tenantId, focusTag],
+             FROM (
+               SELECT DISTINCT at.source_system,
+                      MAX(cache.last_seen_at) AS last_seen_at
+                 FROM live_signal_cache cache
+                 JOIN installed_component_instances i ON i.id = cache.component_id
+                 JOIN approved_tags at
+                   ON at.tenant_id = cache.tenant_id
+                  AND at.enabled = true
+                  AND at.source_system = COALESCE(
+                    NULLIF(cache.source_system, ''),
+                    CASE WHEN cache.source IN ('demo_simulator', 'simulator') THEN 'simulator' ELSE cache.source END
+                  )
+                  AND (
+                    at.uns_path = cache.uns_path
+                    OR at.normalized_tag_path = cache.plc_tag
+                    OR at.source_tag_path = cache.plc_tag
+                  )
+                WHERE cache.tenant_id = $1
+                  AND i.asset_id = $2
+                  AND cache.plc_tag = $3
+                GROUP BY at.source_system
+             ) approved_live_sources
+            ORDER BY last_seen_at DESC
+            LIMIT 2`,
+          [ctx.tenantId, asset, focusTag],
         );
-        approvedFocusSourceSystem = (approvedTagRes.rows[0]?.source_system as string | null) ?? null;
+        approvedFocusSourceSystem = approvedTagRes.rows.length === 1
+          ? ((approvedTagRes.rows[0]?.source_system as string | null) ?? null)
+          : null;
       }
       if (focusTag && approvedFocusSourceSystem) {
         try {

--- a/mira-hub/src/app/api/mira/ask/route.ts
+++ b/mira-hub/src/app/api/mira/ask/route.ts
@@ -5,6 +5,11 @@ import { cascadeComplete, type CascadeMessage } from "@/lib/llm/cascade";
 import { countTransitions } from "@/lib/signal-recorder";
 import { extractTrace, recordQueryTrace, type TraceGroundingLike } from "@/lib/knowledge-graph/trace";
 import { clientIpHash, rateLimited } from "@/lib/ip-rate-limit";
+import {
+  approvedAskEnforcementEnabled,
+  approvedContextReady,
+  buildApprovedContextRefusal,
+} from "@/lib/approved-context";
 
 export const dynamic = "force-dynamic";
 
@@ -192,9 +197,12 @@ export async function POST(req: Request) {
                 src.entity_type AS s_type, src.name AS s_name,
                 tgt.entity_type AS t_type, tgt.name AS t_name
            FROM kg_relationships r
-           JOIN kg_entities src ON src.id = r.source_id
-           JOIN kg_entities tgt ON tgt.id = r.target_id
+          JOIN kg_entities src ON src.id = r.source_id
+          JOIN kg_entities tgt ON tgt.id = r.target_id
           WHERE r.tenant_id = $1
+            AND r.approval_state = 'verified'
+            AND src.approval_state = 'verified'
+            AND tgt.approval_state = 'verified'
             AND (r.source_id = $2 OR r.target_id = $2 OR r.source_id = ANY($3::uuid[]))
           ORDER BY r.confidence DESC
           LIMIT 30`,
@@ -280,6 +288,18 @@ export async function POST(req: Request) {
   });
 
   // ── 3. Compose system prompt with citations available to model ────────
+  const approvedSummary = {
+    approvedSourceCount: 0,
+    verifiedRelationshipCount: grounding.edges.length,
+    approvedLiveSignalCount:
+      ((grounding.currentSignals as Array<Record<string, unknown>> | undefined)?.length ?? 0) +
+      (grounding.recentSignals.length ?? 0),
+  };
+
+  if (approvedAskEnforcementEnabled() && !approvedContextReady(approvedSummary)) {
+    return NextResponse.json(buildApprovedContextRefusal(approvedSummary), { status: 412 });
+  }
+
   const focusCmp = (grounding.components as Array<Record<string, unknown>>).find(
     (cmp) => cmp.id === grounding.focusComponentId,
   );

--- a/mira-hub/src/app/api/mira/ask/route.ts
+++ b/mira-hub/src/app/api/mira/ask/route.ts
@@ -250,7 +250,7 @@ export async function POST(req: Request) {
               OR at.source_tag_path = cache.plc_tag
             )
           WHERE cache.tenant_id = $1
-            AND (i.asset_id = $2 OR cache.component_id IS NULL)
+            AND i.asset_id = $2
           ORDER BY cache.last_changed_at DESC`,
         [ctx.tenantId, asset],
       )
@@ -271,17 +271,29 @@ export async function POST(req: Request) {
           (cmp) => cmp.id === component,
         ) ?? (components as Array<Record<string, unknown>>)[0];
       const focusTag = (focus?.plc_tag as string | null) ?? null;
-      const focusId = (focus?.id as string | null) ?? null;
-      if (focusTag || focusId) {
+      let approvedFocusTag = false;
+      if (focusTag) {
+        const approvedTagRes = await c.query(
+          `SELECT 1
+             FROM approved_tags
+            WHERE tenant_id = $1
+              AND enabled = true
+              AND (normalized_tag_path = $2 OR source_tag_path = $2)
+            LIMIT 1`,
+          [ctx.tenantId, focusTag],
+        );
+        approvedFocusTag = approvedTagRes.rows.length > 0;
+      }
+      if (focusTag && approvedFocusTag) {
         try {
           const tc = await countTransitions(c, {
             tenantId: ctx.tenantId,
             plcTag: focusTag,
-            componentId: focusTag ? null : focusId,
+            componentId: null,
             windowSeconds: transitionWindowSec,
           });
           transitionFact = {
-            topic: focusTag ?? focusId ?? "",
+            topic: focusTag,
             component_name: (focus?.component_name as string | null) ?? null,
             count: tc.transitions,
             window_seconds: tc.windowSeconds,

--- a/mira-hub/src/app/api/mira/ask/route.ts
+++ b/mira-hub/src/app/api/mira/ask/route.ts
@@ -216,6 +216,13 @@ export async function POST(req: Request) {
                 e.simulated, i.component_name, i.plc_tag
            FROM live_signal_events e
            JOIN installed_component_instances i ON i.id = e.component_id
+           JOIN approved_tags at
+             ON at.tenant_id = e.tenant_id
+            AND at.enabled = true
+            AND (
+              at.normalized_tag_path = e.plc_tag
+              OR at.source_tag_path = e.plc_tag
+            )
           WHERE e.tenant_id = $1 AND i.asset_id = $2
           ORDER BY e.created_at DESC
           LIMIT 10`,
@@ -234,6 +241,14 @@ export async function POST(req: Request) {
                 i.component_name
            FROM live_signal_cache cache
            LEFT JOIN installed_component_instances i ON i.id = cache.component_id
+           JOIN approved_tags at
+             ON at.tenant_id = cache.tenant_id
+            AND at.enabled = true
+            AND (
+              at.uns_path = cache.uns_path
+              OR at.normalized_tag_path = cache.plc_tag
+              OR at.source_tag_path = cache.plc_tag
+            )
           WHERE cache.tenant_id = $1
             AND (i.asset_id = $2 OR cache.component_id IS NULL)
           ORDER BY cache.last_changed_at DESC`,

--- a/mira-hub/src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts
@@ -146,4 +146,25 @@ describe("POST /api/namespace/node/[id]/chat", () => {
     // No provider should be hit when there's no node context.
     expect(fetchSpy).not.toHaveBeenCalled();
   });
+
+  it("returns approved_context without calling providers when enforced and no verified node docs exist", async () => {
+    process.env.NEON_DATABASE_URL = "postgres://test";
+    process.env.MIRA_ENFORCE_APPROVED_ASK = "true";
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    vi.mocked(withTenantContext).mockImplementation(async (_tenantId, fn) =>
+      fn({
+        query: vi.fn(async (sql: string) => {
+          if (sql.includes("FROM kg_entities")) return { rows: [{ name: "Motor", uns_path: "Plant.Line.Motor" }] };
+          return { rows: [] };
+        }),
+      }),
+    );
+
+    const res = await POST(makeReq(userMsg("what does this fault mean?")), makeParams(VALID_UUID));
+    const body = await res.json();
+
+    expect(res.status).toBe(412);
+    expect(body.gate).toBe("approved_context");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
 });

--- a/mira-hub/src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts
+++ b/mira-hub/src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts
@@ -16,10 +16,24 @@ import { NextResponse } from "next/server";
 
 vi.mock("@/lib/session", () => ({ sessionOr401: vi.fn() }));
 vi.mock("@/lib/tenant-context", () => ({ withTenantContext: vi.fn() }));
+vi.mock("@/lib/manual-rag", () => ({
+  retrieveNodeChunks: vi.fn(),
+  appendManualContext: vi.fn((prompt: string) => prompt),
+  chunksToSources: vi.fn((chunks: Array<{ title?: string; sourceUrl?: string; sourcePage?: number | null; verified?: boolean }>) =>
+    chunks.map((chunk, index) => ({
+      index: index + 1,
+      title: chunk.title ?? "manual",
+      url: chunk.sourceUrl ?? null,
+      page: chunk.sourcePage ?? null,
+      verified: chunk.verified === true,
+    })),
+  ),
+}));
 
 import { POST } from "../route";
 import { sessionOr401 } from "@/lib/session";
 import { withTenantContext } from "@/lib/tenant-context";
+import { appendManualContext, retrieveNodeChunks } from "@/lib/manual-rag";
 
 const VALID_UUID = "11111111-2222-3333-4444-555555555555";
 const TENANT_ID = "tenant-aaaa-bbbb";
@@ -49,12 +63,14 @@ beforeEach(() => {
   vi.resetAllMocks();
   process.env.NEON_DATABASE_URL = "postgres://test-only-not-used";
   process.env.GROQ_API_KEY = "test-key"; // so a non-safety path WOULD try to fetch
+  vi.mocked(retrieveNodeChunks).mockResolvedValue([]);
   fetchSpy = vi.fn();
   vi.stubGlobal("fetch", fetchSpy);
 });
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  delete process.env.MIRA_ENFORCE_APPROVED_ASK;
 });
 
 // Drain an SSE ReadableStream Response, returning both the raw text and the
@@ -166,5 +182,68 @@ describe("POST /api/namespace/node/[id]/chat", () => {
     expect(res.status).toBe(412);
     expect(body.gate).toBe("approved_context");
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("requires the selected KG node itself to be verified", async () => {
+    process.env.NEON_DATABASE_URL = "postgres://test";
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    const calls: string[] = [];
+    vi.mocked(withTenantContext).mockImplementation(async (_tenantId, fn) =>
+      fn({
+        query: vi.fn(async (sql: string) => {
+          calls.push(sql);
+          return { rows: [] };
+        }),
+      }),
+    );
+
+    const res = await POST(makeReq(userMsg("what does this fault mean?")), makeParams(VALID_UUID));
+
+    expect(res.status).toBe(404);
+    const nodeSql = calls.find((sql) => sql.includes("FROM kg_entities")) ?? "";
+    expect(nodeSql).toMatch(/approval_state\s*=\s*'verified'/i);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("filters unverified node chunks before building the provider prompt", async () => {
+    process.env.NEON_DATABASE_URL = "postgres://test";
+    process.env.MIRA_ENFORCE_APPROVED_ASK = "true";
+    vi.mocked(sessionOr401).mockResolvedValue(goodSession);
+    vi.mocked(retrieveNodeChunks).mockResolvedValue([
+      {
+        content: "Approved node context",
+        manufacturer: "FactoryLM",
+        modelNumber: "N100",
+        sourceUrl: "https://docs.test/approved-node",
+        sourcePage: 4,
+        title: "Approved Node Manual",
+        rank: 0.9,
+        verified: true,
+      },
+      {
+        content: "Draft node context",
+        manufacturer: "FactoryLM",
+        modelNumber: "N100",
+        sourceUrl: "https://docs.test/draft-node",
+        sourcePage: 5,
+        title: "Draft Node Manual",
+        rank: 0.8,
+        verified: false,
+      },
+    ]);
+    vi.mocked(withTenantContext).mockImplementation(async (_tenantId, fn) =>
+      fn({
+        query: vi.fn(async (sql: string) => {
+          if (sql.includes("FROM kg_entities")) return { rows: [{ name: "Motor", uns_path: "Plant.Line.Motor" }] };
+          return { rows: [] };
+        }),
+      }),
+    );
+
+    await POST(makeReq(userMsg("what does this fault mean?")), makeParams(VALID_UUID));
+
+    expect(appendManualContext).toHaveBeenCalled();
+    const chunks = vi.mocked(appendManualContext).mock.calls[0]?.[1] ?? [];
+    expect(chunks.map((chunk) => chunk.content)).toEqual(["Approved node context"]);
   });
 });

--- a/mira-hub/src/app/api/namespace/node/[id]/chat/route.ts
+++ b/mira-hub/src/app/api/namespace/node/[id]/chat/route.ts
@@ -259,6 +259,7 @@ export async function POST(
         `SELECT name, uns_path::text AS uns_path
            FROM kg_entities
           WHERE id = $1 AND tenant_id = $2
+            AND approval_state = 'verified'
           LIMIT 1`,
         [id, ctx.tenantId],
       );
@@ -268,7 +269,10 @@ export async function POST(
         nodeId: id,
         unsPath: row.uns_path,
       });
-      return { row, chunks };
+      const approvedChunks = approvedAskEnforcementEnabled()
+        ? chunks.filter((chunk) => chunk.verified === true)
+        : chunks;
+      return { row, chunks: approvedChunks };
     });
     nodeRow = fetched.row;
     nodeChunks = fetched.chunks;

--- a/mira-hub/src/app/api/namespace/node/[id]/chat/route.ts
+++ b/mira-hub/src/app/api/namespace/node/[id]/chat/route.ts
@@ -25,6 +25,11 @@ import {
   type ManualChunk,
   type ManualSource,
 } from "@/lib/manual-rag";
+import {
+  approvedAskEnforcementEnabled,
+  approvedContextReady,
+  buildApprovedContextRefusal,
+} from "@/lib/approved-context";
 
 export const dynamic = "force-dynamic";
 
@@ -285,6 +290,15 @@ export async function POST(
   const nodeSources: ManualSource[] = chunksToSources(nodeChunks);
   const approvedSourceCount = nodeSources.filter((s) => s.verified).length;
   const safetyLabel = nodeRow.name || id;
+  const approvedSummary = {
+    approvedSourceCount,
+    verifiedRelationshipCount: 0,
+    approvedLiveSignalCount: 0,
+  };
+
+  if (approvedAskEnforcementEnabled() && !approvedContextReady(approvedSummary)) {
+    return NextResponse.json(buildApprovedContextRefusal(approvedSummary), { status: 412 });
+  }
 
   const fullMessages: ChatMessage[] = [
     { role: "system", content: systemPrompt },

--- a/mira-hub/src/lib/__tests__/approved-context.test.ts
+++ b/mira-hub/src/lib/__tests__/approved-context.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  approvedAskEnforcementEnabled,
+  approvedContextReady,
+  buildApprovedContextRefusal,
+} from "../approved-context";
+
+describe("approved context gate", () => {
+  it("is enabled by the dedicated Ask flag", () => {
+    expect(approvedAskEnforcementEnabled({ MIRA_ENFORCE_APPROVED_ASK: "true" })).toBe(true);
+  });
+
+  it("is enabled by the existing retrieval flag", () => {
+    expect(approvedAskEnforcementEnabled({ MIRA_ENFORCE_APPROVED_RETRIEVAL: "true" })).toBe(true);
+  });
+
+  it("is disabled when both flags are absent", () => {
+    expect(approvedAskEnforcementEnabled({})).toBe(false);
+  });
+
+  it("treats any approved source, verified relationship, or approved live signal as answer context", () => {
+    expect(approvedContextReady({ approvedSourceCount: 1, verifiedRelationshipCount: 0, approvedLiveSignalCount: 0 })).toBe(true);
+    expect(approvedContextReady({ approvedSourceCount: 0, verifiedRelationshipCount: 1, approvedLiveSignalCount: 0 })).toBe(true);
+    expect(approvedContextReady({ approvedSourceCount: 0, verifiedRelationshipCount: 0, approvedLiveSignalCount: 1 })).toBe(true);
+    expect(approvedContextReady({ approvedSourceCount: 0, verifiedRelationshipCount: 0, approvedLiveSignalCount: 0 })).toBe(false);
+  });
+
+  it("builds the existing missing-context checklist shape for refusal", () => {
+    const refusal = buildApprovedContextRefusal({
+      approvedSourceCount: 0,
+      verifiedRelationshipCount: 0,
+      approvedLiveSignalCount: 0,
+    });
+
+    expect(refusal).toMatchObject({
+      gate: "approved_context",
+      reason: "MIRA needs approved asset context before answering.",
+    });
+    expect(refusal.missingContext).toContainEqual(
+      expect.objectContaining({
+        key: "approved_documents",
+        status: "missing",
+        required: 1,
+      }),
+    );
+    expect(refusal.missingContext).toContainEqual(
+      expect.objectContaining({
+        key: "verified_relationships",
+        status: "needs_review",
+        required: 1,
+      }),
+    );
+  });
+});

--- a/mira-hub/src/lib/approved-context.ts
+++ b/mira-hub/src/lib/approved-context.ts
@@ -15,8 +15,10 @@ export interface ApprovedContextRefusal {
   missingContext: MissingContextItem[];
 }
 
+type ApprovedAskEnv = Record<string, string | undefined>;
+
 export function approvedAskEnforcementEnabled(
-  env: Pick<NodeJS.ProcessEnv, "MIRA_ENFORCE_APPROVED_ASK" | "MIRA_ENFORCE_APPROVED_RETRIEVAL"> = process.env,
+  env: ApprovedAskEnv = process.env,
 ): boolean {
   return env.MIRA_ENFORCE_APPROVED_ASK === "true" || env.MIRA_ENFORCE_APPROVED_RETRIEVAL === "true";
 }

--- a/mira-hub/src/lib/approved-context.ts
+++ b/mira-hub/src/lib/approved-context.ts
@@ -1,0 +1,58 @@
+import type { MissingContextItem } from "./health-score";
+
+export interface ApprovedContextSummary {
+  approvedSourceCount: number;
+  verifiedRelationshipCount: number;
+  approvedLiveSignalCount: number;
+}
+
+export interface ApprovedContextRefusal {
+  gate: "approved_context";
+  reason: string;
+  approved_source_count: number;
+  verified_relationship_count: number;
+  approved_live_signal_count: number;
+  missingContext: MissingContextItem[];
+}
+
+export function approvedAskEnforcementEnabled(
+  env: Pick<NodeJS.ProcessEnv, "MIRA_ENFORCE_APPROVED_ASK" | "MIRA_ENFORCE_APPROVED_RETRIEVAL"> = process.env,
+): boolean {
+  return env.MIRA_ENFORCE_APPROVED_ASK === "true" || env.MIRA_ENFORCE_APPROVED_RETRIEVAL === "true";
+}
+
+export function approvedContextReady(summary: ApprovedContextSummary): boolean {
+  return (
+    summary.approvedSourceCount > 0 ||
+    summary.verifiedRelationshipCount > 0 ||
+    summary.approvedLiveSignalCount > 0
+  );
+}
+
+export function buildApprovedContextRefusal(summary: ApprovedContextSummary): ApprovedContextRefusal {
+  return {
+    gate: "approved_context",
+    reason: "MIRA needs approved asset context before answering.",
+    approved_source_count: summary.approvedSourceCount,
+    verified_relationship_count: summary.verifiedRelationshipCount,
+    approved_live_signal_count: summary.approvedLiveSignalCount,
+    missingContext: [
+      {
+        key: "approved_documents",
+        label: "Approved document context",
+        status: summary.approvedSourceCount > 0 ? "ready" : "missing",
+        count: summary.approvedSourceCount,
+        required: 1,
+        action: "Upload and approve a manual, PLC tag list, or evidence document.",
+      },
+      {
+        key: "verified_relationships",
+        label: "Verified relationships",
+        status: summary.verifiedRelationshipCount > 0 ? "ready" : "needs_review",
+        count: summary.verifiedRelationshipCount,
+        required: 1,
+        action: "Accept grounded proposals until at least one relationship is verified.",
+      },
+    ],
+  };
+}

--- a/mira-hub/src/lib/knowledge-graph/__tests__/context-builder.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/context-builder.test.ts
@@ -1,5 +1,23 @@
-import { describe, test, expect } from "vitest";
-import { formatEntityContext } from "../context-builder";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { buildGraphContext, formatEntityContext } from "../context-builder";
+
+const { connectMock, queryMock } = vi.hoisted(() => {
+  const queryMock = vi.fn();
+  const client = {
+    query: queryMock,
+    release: vi.fn(),
+  };
+  return {
+    connectMock: vi.fn(async () => client),
+    queryMock,
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  default: {
+    connect: connectMock,
+  },
+}));
 
 // formatEntityContext is pure — no DB required.
 
@@ -23,6 +41,51 @@ const BASE_FULL = {
   incoming: [],
   triples: [],
 };
+
+const sqlCalls = () =>
+  queryMock.mock.calls
+    .map(([sql]) => (typeof sql === "string" ? sql : ""))
+    .filter(Boolean);
+
+describe("buildGraphContext answer-facing SQL filters", () => {
+  beforeEach(() => {
+    process.env.NEON_DATABASE_URL = "postgres://unit-test";
+    connectMock.mockClear();
+    queryMock.mockReset();
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM kg_entities") && sql.includes("entity_id = ANY")) {
+        return {
+          rows: [
+            {
+              id: "uuid-fault-1",
+              entity_type: "fault_code",
+              entity_id: "F004",
+              name: "F004",
+              properties: {},
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+  });
+
+  test("entity and relationship lookups only expose verified KG context", async () => {
+    await buildGraphContext("tenant-1", "Explain F004");
+
+    const entitySql = sqlCalls().find(
+      (sql) => sql.includes("FROM kg_entities") && sql.includes("entity_id = ANY"),
+    );
+    expect(entitySql).toMatch(/approval_state\s*=\s*'verified'/i);
+
+    const relationshipSql = sqlCalls()
+      .filter((sql) => sql.includes("FROM kg_relationships r"))
+      .join("\n");
+    expect(relationshipSql).toMatch(/r\.approval_state\s*=\s*'verified'/i);
+    expect(relationshipSql).toMatch(/src\.approval_state\s*=\s*'verified'/i);
+    expect(relationshipSql).toMatch(/tgt\.approval_state\s*=\s*'verified'/i);
+  });
+});
 
 describe("formatEntityContext — header", () => {
   test("includes entity_id in header", () => {

--- a/mira-hub/src/lib/knowledge-graph/__tests__/context-builder.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/context-builder.test.ts
@@ -85,6 +85,43 @@ describe("buildGraphContext answer-facing SQL filters", () => {
     expect(relationshipSql).toMatch(/src\.approval_state\s*=\s*'verified'/i);
     expect(relationshipSql).toMatch(/tgt\.approval_state\s*=\s*'verified'/i);
   });
+
+  test("does not read kg_triples_log or expose triple-log-only facts in answer context", async () => {
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM kg_entities") && sql.includes("entity_id = ANY")) {
+        return {
+          rows: [
+            {
+              id: "uuid-fault-1",
+              entity_type: "fault_code",
+              entity_id: "F004",
+              name: "F004",
+              properties: {},
+            },
+          ],
+        };
+      }
+      if (sql.includes("FROM kg_triples_log")) {
+        return {
+          rows: [
+            {
+              subject: "F004",
+              predicate: "exhibited_fault",
+              object: "UNAPPROVED_TRIPLE_LOG_ONLY_FAULT",
+              extracted_at: "2026-06-25T12:00:00Z",
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const ctx = await buildGraphContext("tenant-1", "Explain F004");
+
+    expect(sqlCalls().join("\n")).not.toMatch(/kg_triples_log/i);
+    expect(ctx).not.toContain("UNAPPROVED_TRIPLE_LOG_ONLY_FAULT");
+    expect(ctx).not.toContain("Recent faults:");
+  });
 });
 
 describe("formatEntityContext — header", () => {

--- a/mira-hub/src/lib/knowledge-graph/__tests__/traversal.test.ts
+++ b/mira-hub/src/lib/knowledge-graph/__tests__/traversal.test.ts
@@ -1,9 +1,81 @@
-import { describe, test, expect } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { classifyKgIntent, formatMaintenanceContext } from "../context-builder";
-import type { MaintenanceContext } from "../traversal";
+import {
+  impactAnalysis,
+  maintenanceContext,
+  rootCauseChain,
+  traverseChain,
+  type MaintenanceContext,
+} from "../traversal";
 
-// Pure functions only — no DB. Integration tests for the SQL traversals
-// run separately against a Neon dev branch.
+const { connectMock, queryMock } = vi.hoisted(() => {
+  const queryMock = vi.fn();
+  const client = {
+    query: queryMock,
+    release: vi.fn(),
+  };
+  return {
+    connectMock: vi.fn(async () => client),
+    queryMock,
+  };
+});
+
+vi.mock("@/lib/db", () => ({
+  default: {
+    connect: connectMock,
+  },
+}));
+
+vi.mock("../plan-vs-actual", () => ({
+  flagPmMismatches: vi.fn(async () => []),
+}));
+
+// SQL-shape tests use a mocked DB client. Live traversal behavior still runs
+// separately against a Neon dev branch.
+
+const EQUIPMENT_ROW = {
+  id: "uuid-eq-1",
+  tenant_id: "tenant-1",
+  entity_type: "equipment",
+  entity_id: "VFD-07",
+  name: "PowerFlex 525",
+  properties: {},
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const sqlBlob = () =>
+  queryMock.mock.calls
+    .map(([sql]) => (typeof sql === "string" ? sql : ""))
+    .join("\n\n");
+
+describe("answer-facing traversal SQL filters", () => {
+  beforeEach(() => {
+    process.env.NEON_DATABASE_URL = "postgres://unit-test";
+    connectMock.mockClear();
+    queryMock.mockReset();
+    queryMock.mockImplementation(async (sql: string) => {
+      if (sql.includes("FROM kg_entities") && sql.includes("entity_type = 'equipment'")) {
+        return { rows: [EQUIPMENT_ROW] };
+      }
+      return { rows: [] };
+    });
+  });
+
+  test.each([
+    ["traverseChain", () => traverseChain("tenant-1", "uuid-eq-1", ["parent_of"])],
+    ["impactAnalysis", () => impactAnalysis("tenant-1", "uuid-eq-1")],
+    ["rootCauseChain", () => rootCauseChain("tenant-1", "uuid-fault-1")],
+    ["maintenanceContext", () => maintenanceContext("tenant-1", "VFD-07", { includeSimilar: true })],
+  ])("%s queries only verified relationships and entities", async (_name, runTraversal) => {
+    await runTraversal();
+
+    const sql = sqlBlob();
+    expect(sql).toMatch(/kg_relationships[\s\S]+approval_state\s*=\s*'verified'/i);
+    expect(sql).toMatch(/JOIN\s+kg_entities\s+e[\s\S]+e\.approval_state\s*=\s*'verified'/i);
+    expect(sql).not.toMatch(/approval_state\s+IS\s+NULL/i);
+  });
+});
 
 describe("classifyKgIntent", () => {
   test("flags causal phrasing", () => {

--- a/mira-hub/src/lib/knowledge-graph/context-builder.ts
+++ b/mira-hub/src/lib/knowledge-graph/context-builder.ts
@@ -7,7 +7,7 @@
  * Pipeline:
  *   1. Extract entity mentions from question (equipment tags, fault codes, parts)
  *   2. Batch-lookup those entity_ids in kg_entities (single transaction)
- *   3. Fetch relationships + recent triples for each found entity
+ *   3. Fetch approved relationships for each found entity
  *   4. Format into human-readable context blocks
  *   5. Return "" if nothing found (graceful fallback to vector-only)
  */
@@ -105,9 +105,8 @@ async function fetchEntityFull(
   client: PoolClient,
   tenantId: string,
   entityUuid: string,
-  entityName: string,
 ): Promise<{ outgoing: RelRow[]; incoming: RelRow[]; triples: TripleRow[] }> {
-  const [outRes, inRes, triRes] = await Promise.all([
+  const [outRes, inRes] = await Promise.all([
     // Outgoing: join target entity for its name and entity_id
     client.query<RelRow>(
       `SELECT r.id, r.source_id, r.target_id, r.relationship_type,
@@ -148,19 +147,9 @@ async function fetchEntityFull(
        LIMIT 30`,
       [tenantId, entityUuid],
     ),
-    // Recent triples mentioning this entity by name
-    client.query<TripleRow>(
-      `SELECT subject, predicate, object, extracted_at::text
-       FROM kg_triples_log
-       WHERE tenant_id = $1
-         AND (subject = $2 OR object = $2)
-       ORDER BY extracted_at DESC
-       LIMIT 40`,
-      [tenantId, entityName],
-    ),
   ]);
 
-  return { outgoing: outRes.rows, incoming: inRes.rows, triples: triRes.rows };
+  return { outgoing: outRes.rows, incoming: inRes.rows, triples: [] };
 }
 
 // ── Formatting ─────────────────────────────────────────────────────────────
@@ -493,9 +482,7 @@ export async function buildGraphContext(
       ]);
       const out: string[] = [];
       for (const entity of [...faultRows, ...partRows].slice(0, 4)) {
-        const { outgoing, incoming, triples } = await fetchEntityFull(
-          client, tenantId, entity.id, entity.name,
-        );
+        const { outgoing, incoming, triples } = await fetchEntityFull(client, tenantId, entity.id);
         out.push(formatEntityContext({ entity, outgoing, incoming, triples }));
       }
       return out;

--- a/mira-hub/src/lib/knowledge-graph/context-builder.ts
+++ b/mira-hub/src/lib/knowledge-graph/context-builder.ts
@@ -92,6 +92,7 @@ async function fetchEntitiesByIds(
             COALESCE(properties, '{}')::jsonb AS properties
      FROM kg_entities
      WHERE tenant_id = $1
+       AND approval_state = 'verified'
        AND entity_id = ANY($2)
        AND entity_type = ANY($3)
      LIMIT 20`,
@@ -113,9 +114,16 @@ async function fetchEntityFull(
               src.entity_id AS source_entity_id, tgt.entity_id AS target_entity_id,
               tgt.name AS target_name, src.name AS source_name
        FROM kg_relationships r
-       LEFT JOIN kg_entities src ON src.id = r.source_id
-       LEFT JOIN kg_entities tgt ON tgt.id = r.target_id
+       JOIN kg_entities src
+         ON src.id = r.source_id
+        AND src.tenant_id = r.tenant_id
+        AND src.approval_state = 'verified'
+       JOIN kg_entities tgt
+         ON tgt.id = r.target_id
+        AND tgt.tenant_id = r.tenant_id
+        AND tgt.approval_state = 'verified'
        WHERE r.tenant_id = $1 AND r.source_id = $2
+         AND r.approval_state = 'verified'
        ORDER BY r.created_at DESC
        LIMIT 30`,
       [tenantId, entityUuid],
@@ -126,9 +134,16 @@ async function fetchEntityFull(
               src.entity_id AS source_entity_id, tgt.entity_id AS target_entity_id,
               tgt.name AS target_name, src.name AS source_name
        FROM kg_relationships r
-       LEFT JOIN kg_entities src ON src.id = r.source_id
-       LEFT JOIN kg_entities tgt ON tgt.id = r.target_id
+       JOIN kg_entities src
+         ON src.id = r.source_id
+        AND src.tenant_id = r.tenant_id
+        AND src.approval_state = 'verified'
+       JOIN kg_entities tgt
+         ON tgt.id = r.target_id
+        AND tgt.tenant_id = r.tenant_id
+        AND tgt.approval_state = 'verified'
        WHERE r.tenant_id = $1 AND r.target_id = $2
+         AND r.approval_state = 'verified'
        ORDER BY r.created_at DESC
        LIMIT 30`,
       [tenantId, entityUuid],

--- a/mira-hub/src/lib/knowledge-graph/traversal.ts
+++ b/mira-hub/src/lib/knowledge-graph/traversal.ts
@@ -96,7 +96,9 @@ export async function resolveEntityByUnsPath(
       `SELECT id, tenant_id, entity_type, entity_id, name, properties,
               uns_path::text AS uns_path, created_at, updated_at
          FROM kg_entities
-         WHERE tenant_id = $1 AND uns_path = $2::ltree
+         WHERE tenant_id = $1
+           AND approval_state = 'verified'
+           AND uns_path = $2::ltree
          LIMIT 1`,
       [tenantId, unsPath],
     );
@@ -120,6 +122,7 @@ export async function entitiesUnderUnsPath(
               uns_path::text AS uns_path, created_at, updated_at
          FROM kg_entities
          WHERE tenant_id = $1
+           AND approval_state = 'verified'
            AND uns_path <@ $2::ltree
          ORDER BY nlevel(uns_path), name
          LIMIT $3`,
@@ -160,7 +163,9 @@ export async function traverseChain(
          SELECT e.id, e.tenant_id, e.entity_type, e.entity_id, e.name, e.properties,
                 e.created_at, e.updated_at, 0, ARRAY[e.id::text]
            FROM kg_entities e
-           WHERE e.id = $1 AND e.tenant_id = $2
+           WHERE e.id = $1
+             AND e.tenant_id = $2
+             AND e.approval_state = 'verified'
          UNION ALL
          SELECT e.id, e.tenant_id, e.entity_type, e.entity_id, e.name, e.properties,
                 e.created_at, e.updated_at, w.depth + 1, w.path || e.id::text
@@ -169,9 +174,11 @@ export async function traverseChain(
              ON r.source_id = w.id
             AND r.tenant_id = $2
             AND r.relationship_type = ($3::text[])[w.depth + 1]
+            AND r.approval_state = 'verified'
            JOIN kg_entities e
              ON e.id = r.target_id
             AND e.tenant_id = $2
+            AND e.approval_state = 'verified'
           WHERE w.depth < $4
             AND NOT (e.id::text = ANY(w.path))
        )
@@ -213,7 +220,9 @@ export async function impactAnalysis(
          SELECT e.id, e.tenant_id, e.entity_type, e.entity_id, e.name, e.properties,
                 e.created_at, e.updated_at, 0, ARRAY[e.id::text]
            FROM kg_entities e
-           WHERE e.id = $1 AND e.tenant_id = $2
+           WHERE e.id = $1
+             AND e.tenant_id = $2
+             AND e.approval_state = 'verified'
          UNION ALL
          SELECT e.id, e.tenant_id, e.entity_type, e.entity_id, e.name, e.properties,
                 e.created_at, e.updated_at, d.depth + 1, d.path || e.id::text
@@ -222,9 +231,11 @@ export async function impactAnalysis(
              ON r.source_id = d.id
             AND r.tenant_id = $2
             AND r.relationship_type = 'feeds'
+            AND r.approval_state = 'verified'
            JOIN kg_entities e
              ON e.id = r.target_id
             AND e.tenant_id = $2
+            AND e.approval_state = 'verified'
           WHERE d.depth < $3
             AND NOT (e.id::text = ANY(d.path))
        )
@@ -241,8 +252,13 @@ export async function impactAnalysis(
       const { rows: altRows } = await client.query<{ target_id: string }>(
         `SELECT DISTINCT r.target_id
            FROM kg_relationships r
+           JOIN kg_entities src
+             ON src.id = r.source_id
+            AND src.tenant_id = r.tenant_id
+            AND src.approval_state = 'verified'
            WHERE r.tenant_id = $1
              AND r.relationship_type = 'feeds'
+             AND r.approval_state = 'verified'
              AND r.target_id = ANY($2)
              AND r.source_id <> $3
              AND NOT (r.source_id = ANY($2))`,
@@ -302,7 +318,9 @@ export async function rootCauseChain(
          SELECT e.id, e.tenant_id, e.entity_type, e.entity_id, e.name, e.properties,
                 e.created_at, e.updated_at, 0, ARRAY[e.id::text], 1.0
            FROM kg_entities e
-           WHERE e.id = $1 AND e.tenant_id = $2
+           WHERE e.id = $1
+             AND e.tenant_id = $2
+             AND e.approval_state = 'verified'
          UNION ALL
          SELECT e.id, e.tenant_id, e.entity_type, e.entity_id, e.name, e.properties,
                 e.created_at, e.updated_at, c.depth + 1, c.path || e.id::text,
@@ -312,9 +330,11 @@ export async function rootCauseChain(
              ON r.source_id = c.id
             AND r.tenant_id = $2
             AND r.relationship_type = 'caused_by'
+            AND r.approval_state = 'verified'
            JOIN kg_entities e
              ON e.id = r.target_id
             AND e.tenant_id = $2
+            AND e.approval_state = 'verified'
           WHERE c.depth < $3
             AND NOT (e.id::text = ANY(c.path))
        )
@@ -326,10 +346,14 @@ export async function rootCauseChain(
     const { rows: altRows } = await client.query<EntityRow>(
       `SELECT e.*
          FROM kg_relationships r
-         JOIN kg_entities e ON e.id = r.target_id AND e.tenant_id = r.tenant_id
+         JOIN kg_entities e
+           ON e.id = r.target_id
+          AND e.tenant_id = r.tenant_id
+          AND e.approval_state = 'verified'
         WHERE r.tenant_id = $1
           AND r.source_id = $2
           AND r.relationship_type = 'caused_by'
+          AND r.approval_state = 'verified'
         ORDER BY r.confidence DESC NULLS LAST
         LIMIT 5`,
       [tenantId, faultEntityId],
@@ -405,6 +429,7 @@ export async function maintenanceContext(
       `SELECT * FROM kg_entities
          WHERE tenant_id = $1
            AND entity_type = 'equipment'
+           AND approval_state = 'verified'
            AND (id::text = $2 OR entity_id = $2)
          LIMIT 1`,
       [tenantId, equipmentEntityId],
@@ -420,6 +445,7 @@ export async function maintenanceContext(
                 e.created_at, e.updated_at, 0, ARRAY[e.id::text]
            FROM kg_entities e
            WHERE e.id = $1
+             AND e.approval_state = 'verified'
          UNION ALL
          SELECT e.id, e.tenant_id, e.entity_type, e.entity_id, e.name, e.properties,
                 e.created_at, e.updated_at, u.depth + 1, u.path || e.id::text
@@ -428,9 +454,11 @@ export async function maintenanceContext(
              ON r.target_id = u.id
             AND r.tenant_id = $2
             AND r.relationship_type = 'parent_of'
+            AND r.approval_state = 'verified'
            JOIN kg_entities e
              ON e.id = r.source_id
             AND e.tenant_id = $2
+            AND e.approval_state = 'verified'
           WHERE u.depth < 5 AND NOT (e.id::text = ANY(u.path))
        )
        SELECT * FROM up WHERE depth > 0 ORDER BY depth`,
@@ -448,8 +476,12 @@ export async function maintenanceContext(
       // Components
       client.query<EntityRow>(
         `SELECT e.* FROM kg_relationships r
-           JOIN kg_entities e ON e.id = r.target_id AND e.tenant_id = r.tenant_id
+           JOIN kg_entities e
+             ON e.id = r.target_id
+            AND e.tenant_id = r.tenant_id
+            AND e.approval_state = 'verified'
           WHERE r.tenant_id = $1 AND r.source_id = $2 AND r.relationship_type = 'has_component'
+            AND r.approval_state = 'verified'
           ORDER BY e.name LIMIT 20`,
         [tenantId, equipment.id],
       ),
@@ -458,10 +490,14 @@ export async function maintenanceContext(
         `SELECT e.entity_id AS code, COUNT(*)::text AS count,
                 MAX((r.properties->>'occurred_at')::timestamptz) AS last_seen
            FROM kg_relationships r
-           JOIN kg_entities e ON e.id = r.target_id AND e.tenant_id = r.tenant_id
+           JOIN kg_entities e
+             ON e.id = r.target_id
+            AND e.tenant_id = r.tenant_id
+            AND e.approval_state = 'verified'
           WHERE r.tenant_id = $1
             AND r.source_id = $2
             AND r.relationship_type = 'had_fault'
+            AND r.approval_state = 'verified'
             AND COALESCE((r.properties->>'occurred_at')::timestamptz, r.created_at)
                 > now() - ($3 || ' days')::interval
           GROUP BY e.entity_id
@@ -471,34 +507,50 @@ export async function maintenanceContext(
       // Work orders (most recent N)
       client.query<EntityRow>(
         `SELECT e.* FROM kg_relationships r
-           JOIN kg_entities e ON e.id = r.target_id AND e.tenant_id = r.tenant_id
+           JOIN kg_entities e
+             ON e.id = r.target_id
+            AND e.tenant_id = r.tenant_id
+            AND e.approval_state = 'verified'
           WHERE r.tenant_id = $1 AND r.source_id = $2 AND r.relationship_type = 'has_work_order'
+            AND r.approval_state = 'verified'
           ORDER BY e.created_at DESC LIMIT $3`,
         [tenantId, equipment.id, maxWO],
       ),
       // Parts
       client.query<EntityRow>(
         `SELECT e.* FROM kg_relationships r
-           JOIN kg_entities e ON e.id = r.target_id AND e.tenant_id = r.tenant_id
+           JOIN kg_entities e
+             ON e.id = r.target_id
+            AND e.tenant_id = r.tenant_id
+            AND e.approval_state = 'verified'
           WHERE r.tenant_id = $1 AND r.source_id = $2 AND r.relationship_type = 'requires_part'
+            AND r.approval_state = 'verified'
           ORDER BY e.name LIMIT 30`,
         [tenantId, equipment.id],
       ),
       // Manuals — both direct references and via references_drawing
       client.query<EntityRow>(
         `SELECT DISTINCT e.* FROM kg_relationships r
-           JOIN kg_entities e ON e.id = r.target_id AND e.tenant_id = r.tenant_id
+           JOIN kg_entities e
+             ON e.id = r.target_id
+            AND e.tenant_id = r.tenant_id
+            AND e.approval_state = 'verified'
           WHERE r.tenant_id = $1
             AND r.source_id = $2
             AND e.entity_type = 'manual'
+            AND r.approval_state = 'verified'
           LIMIT 10`,
         [tenantId, equipment.id],
       ),
       // PM tasks
       client.query<EntityRow>(
         `SELECT e.* FROM kg_relationships r
-           JOIN kg_entities e ON e.id = r.target_id AND e.tenant_id = r.tenant_id
+           JOIN kg_entities e
+             ON e.id = r.target_id
+            AND e.tenant_id = r.tenant_id
+            AND e.approval_state = 'verified'
           WHERE r.tenant_id = $1 AND r.source_id = $2 AND r.relationship_type = 'has_pm'
+            AND r.approval_state = 'verified'
           ORDER BY e.name LIMIT 10`,
         [tenantId, equipment.id],
       ),
@@ -506,8 +558,12 @@ export async function maintenanceContext(
       opts.includeSimilar
         ? client.query<EntityRow>(
             `SELECT e.* FROM kg_relationships r
-               JOIN kg_entities e ON e.id = r.target_id AND e.tenant_id = r.tenant_id
+               JOIN kg_entities e
+                 ON e.id = r.target_id
+                AND e.tenant_id = r.tenant_id
+                AND e.approval_state = 'verified'
               WHERE r.tenant_id = $1 AND r.source_id = $2 AND r.relationship_type = 'similar_to'
+                AND r.approval_state = 'verified'
               ORDER BY (r.properties->>'similarity_score')::float DESC NULLS LAST
               LIMIT 5`,
             [tenantId, equipment.id],

--- a/mira-hub/src/lib/signal-recorder.ts
+++ b/mira-hub/src/lib/signal-recorder.ts
@@ -274,6 +274,7 @@ export async function countTransitions(
     tenantId: string;
     plcTag?: string | null;
     componentId?: string | null;
+    sourceSystem?: string | null;
     windowSeconds: number;
   },
 ): Promise<{
@@ -293,6 +294,12 @@ export async function countTransitions(
   if (!topicFilter) {
     throw Object.assign(new Error("plcTag_or_componentId_required"), { status: 400 });
   }
+  const sourceFilterSql = opts.sourceSystem
+    ? "AND (CASE WHEN source IN ('demo_simulator', 'simulator') THEN 'simulator' ELSE source END) = $4"
+    : "";
+  const params = opts.sourceSystem
+    ? [tenantId, topicFilter.param, String(windowSeconds), opts.sourceSystem]
+    : [tenantId, topicFilter.param, String(windowSeconds)];
 
   const { rows } = await client.query<{
     transitions: string;
@@ -311,6 +318,7 @@ export async function countTransitions(
        FROM live_signal_events
        WHERE tenant_id = $1
          AND ${topicFilter.sql}
+         ${sourceFilterSql}
          AND created_at > now() - ($3::text || ' seconds')::interval
      )
      SELECT
@@ -322,7 +330,7 @@ export async function countTransitions(
        (now() - ($3::text || ' seconds')::interval)::text AS window_start,
        (now())::text AS window_end
        FROM window_events`,
-    [tenantId, topicFilter.param, String(windowSeconds)],
+    params,
   );
 
   const row = rows[0] ?? { transitions: "0", window_start: "", window_end: "" };


### PR DESCRIPTION
﻿## Summary
- Add a feature-flagged approved-context gate for `/api/mira/ask`, asset chat, and namespace node chat.
- Restrict answer-facing KG context to verified entities/relationships and remove unapproved triple-log facts from answer prompts.
- Filter live telemetry grounding through enabled `approved_tags`, including source-system provenance and ambiguous transition-source handling.
- Filter manual/node chunks to verified chunks under the Ask MIRA enforcement gate, and allow asset chat to proceed from a real verified KG relationship count.

## Safety
- No new database or graph store.
- No live write/control paths.
- Approval gates are preserved and tightened.
- Runtime behavior is behind `MIRA_ENFORCE_APPROVED_ASK` / existing approved retrieval gating.

## Verification
- `npm test -- src/lib/__tests__/approved-context.test.ts src/lib/__tests__/manual-rag.test.ts src/lib/knowledge-graph/__tests__/context-builder.test.ts src/lib/knowledge-graph/__tests__/traversal.test.ts src/app/api/mira/ask/__tests__/route.test.ts "src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts" "src/app/api/assets/[id]/chat/__tests__/route.test.ts"` — PASS, 7 files / 94 tests.
- `npx eslint src/lib/approved-context.ts src/lib/signal-recorder.ts src/lib/__tests__/approved-context.test.ts src/app/api/mira/ask/route.ts src/app/api/mira/ask/__tests__/route.test.ts "src/app/api/namespace/node/[id]/chat/route.ts" "src/app/api/namespace/node/[id]/chat/__tests__/route.test.ts" "src/app/api/assets/[id]/chat/route.ts" "src/app/api/assets/[id]/chat/__tests__/route.test.ts" src/lib/knowledge-graph/context-builder.ts src/lib/knowledge-graph/traversal.ts src/lib/knowledge-graph/__tests__/context-builder.test.ts src/lib/knowledge-graph/__tests__/traversal.test.ts` — PASS.
- `npm run build` — PASS, with existing Next middleware deprecation / Turbopack NFT trace / Google auth unset warnings.
- `npm run lint` — FAILS on pre-existing unrelated repo-wide Hub lint debt: 91 errors / 37 warnings, primarily hook/set-state rules in pages/components outside this PR.

## Stack
- Base: `codex/context-spine-readiness-checklist` / #2308.
- This is the next stacked draft PR in the context-spine sequence.
