### PR TITLE
docs(runbook): CV-200 live proof + FactoryLM Ignition Connector v0 packaging plan

### DIFF
--- a/docs/runbooks/2026-06-29-cv200-connector-v0.md
+++ b/docs/runbooks/2026-06-29-cv200-connector-v0.md
@@ -1,0 +1,158 @@
+# CV-200 live runtime proof + FactoryLM Ignition Connector v0
+
+> **Date:** 2026-06-29 · **Status:** staging cloud-state verified; physical live proof pending the
+> PLC-laptop gateway. **Docs only** — no code, no secrets (placeholder names throughout).
+>
+> The merged stack this documents: **#2365** (Hub remote-commissioning panel) · **#2362**
+> (Northwind/CV-200 foundation) · **#2370** (CV-200 Perspective + cloud wiring). main `/VERSION` 3.53.0.
+>
+> **CV-200 is the reference connector implementation.** Connector v0 is a **project-import + scripts
+> bundle** built on the existing `ignition/` + `mira-web` + `mira-relay` + `mira-hub` path — it is
+> **not** a finished `.modl` Ignition module, and it does no Phase-2 UDT work.
+
+---
+
+## Part 1 — Live runtime proof (status)
+
+**Hard boundary:** the cloud half is verifiable from the KB-host (CHARLIE); the physical tag-stream
+requires the **PLC-laptop Ignition gateway**, a separate node. The on-site half was not simulated.
+
+| # | Goal item | Status | Evidence |
+|---|---|---|---|
+| 1 | Seeds apply cleanly | ✅ PROVEN live (staging) | Applied all 3 on `factorylm/stg`; exit 0, idempotent `ON CONFLICT` |
+| 2 | CV-200 entities exist | ✅ PROVEN live | `kg_entities=21`, `cmms_equipment=7`, CV-200 entity present |
+| 3 | Approved tags loaded | ✅ PROVEN live | `approved_tags=69` (incl. 23 `MIRA_IOCheck`); fail-closed allowlist populated |
+| 4 | Display registration exists | ✅ PROVEN live | `display_endpoints=1`, path `…/NorthwindBottling`, dev/staging 8890 proxy |
+| 5 | Garage untouched | ✅ PROVEN live | 0 garage-tenant rows affected; only the Northwind tenant written |
+| 6 | Approved accepted / unknown rejected (fail-closed) | 🟨 CI-proven; staging HTTP smoke pending | `mira-relay/tests/test_tag_ingest.py` 19/19; live smoke needs the staging relay URL |
+| 7 | `live_signal_cache` filling | ⛔ Blocked on on-site gateway | `live_signal_cache=0` — no producer yet; needs the gateway timer streaming |
+| 8 | Hub panel shows CV-200 **live** | ⛔ Blocked on #7 | Panel logic CI-proven (`mira-hub/src/lib/commissioning.test.ts` 12/12) |
+| — | Ask-MIRA vs CV-200 UNS | 🟨 CI-proven; live needs gateway/relay | `mira-pipeline/tests/test_ignition_chat_direct_connection.py` 9/9 (direct_connection + `422 uns_required`) |
+
+**Net:** the cloud reference path is **live-verified on staging through the seed/allowlist/display
+layer**, and **contract-verified by CI** for ingest, panel, and Ask-MIRA. The remaining three items
+require the **on-site gateway** (and, for the HTTP smoke, the **staging relay being up**).
+
+> **Lesson learned (recorded):** the first staging seed apply pulled the **stale `#2362` versions**
+> from a working tree still checked out on the old `feat/discharge-conveyor-cv200` branch (58 tags,
+> `ConvSimpleLive`). It was corrected by re-applying the merged **`#2370`** versions from
+> `origin/main` (69 tags, `NorthwindBottling`). **Always seed from `origin/main` content, never a
+> stale working tree.**
+
+### Staging verification queries (read-only; run on `factorylm/stg`, never `prd`)
+```bash
+# placeholders: $PSQL = libpq psql, $TENANT = the Northwind demo tenant UUID
+doppler run -p factorylm -c stg -- bash -c "$PSQL \"\$NEON_DATABASE_URL\" -tA -F' | ' -c \"
+  SELECT 'kg_entities',    count(*) FROM kg_entities      WHERE tenant_id='\$TENANT'
+  UNION ALL SELECT 'cmms_equipment', count(*) FROM cmms_equipment WHERE tenant_id='\$TENANT'
+  UNION ALL SELECT 'approved_tags',  count(*) FROM approved_tags  WHERE tenant_id='\$TENANT' AND enabled
+  UNION ALL SELECT 'display_rows',   count(*) FROM display_endpoints WHERE tenant_id='\$TENANT' AND enabled;\""
+```
+Expected: `21 · 7 · 69 · 1`.
+
+---
+
+## Part 2 — FactoryLM Ignition Connector v0 (packaging plan)
+
+**Principle:** v0 is a documented bundle of the existing path — **no new connector system, no `.modl`,
+no UDTs, read-only OT, fail-closed allowlist, garage untouched.**
+
+### Package inventory (all files already on `main`)
+
+**Edge (ships to the customer gateway):**
+- `ignition/gateway-scripts/tag-stream.py` — read-only Gateway Timer (browse + read + HMAC POST).
+- `ignition/webdev/FactoryLM/api/connect/doPost.py` — activation (`code → TENANT_ID + RELAY_URL`).
+- `ignition/webdev/FactoryLM/api/tags/{collector.py,allowlist.py}` + `api/chat/signing.py` — batch
+  build + client-side allowlist + HMAC signing.
+- `plc/ignition-project/NorthwindBottling/` — reference Perspective project (rename per customer):
+  views `ConvSimpleLive` / `MiraAsk` / `AnomalyCard` / `MaintenancePanel` / `Conveyor`; scripts
+  `mira_chat`, `mira_diagnose` (+ `mira_diagnose_core`), `mira_setup` (tag→role mapping UI),
+  `mira_tag_map`, `mira_signal_roles`, `mira_asset_config`.
+- `docs/integrations/ignition-tag-collector.md` — the collector contract.
+
+**Cloud (already deployed — customer does not install):**
+- Claim: `mira-web /api/connect/{generate-code,activate,status}` + `plg_activation_codes`.
+- Ingest: `mira-relay /api/v1/tags/ingest` + `auth.py` (HMAC) + `tag_ingest.py` (fail-closed allowlist).
+- Hub: `/api/command-center/{commissioning,gateways,tree,display}`.
+
+**Per-customer data (the only thing ops authors per site — CV-200 is the template):**
+- `tools/seeds/<customer>-hub.sql` (entities/equipment),
+- `tools/seeds/approved_tags_<customer>.sql` (allowlist),
+- `mira-hub/db/seeds/command_center_<customer>.sql` (display registration).
+
+### Required config (`factorylm.properties` on the gateway — placeholder names only)
+`INGEST_URL` · `TENANT_ID` (UUID) · `MIRA_HMAC_KEY` (must equal the relay's `MIRA_IGNITION_HMAC_KEY`)
+· `STREAM_TAG_FOLDER` (e.g. `[default]MIRA_IOCheck`) · `STREAM_SOURCE_CONNECTION_ID` · `STREAM_MAX_RETRIES`.
+> The gateway property is `MIRA_HMAC_KEY`; the relay env is `MIRA_IGNITION_HMAC_KEY` — **same value,
+> different name**. Pull from `factorylm/stg` (or `prd`); never commit or print the value.
+
+### Stranger-install guide (outline)
+1. **Hub:** create customer/site/equipment → build the UNS node.
+2. **Hub:** *Generate connect code* (`/api/connect/generate-code` → `MIRA-XXXX-XXXX-XXXX`).
+3. **Gateway:** import the FactoryLM project folder; open ConnectSetup; paste the code →
+   `/api/connect/activate` writes `TENANT_ID` + `RELAY_URL` to `factorylm.properties`.
+4. **Gateway:** add `MIRA_HMAC_KEY`, set `STREAM_TAG_FOLDER` to the customer's tag root; map tags→roles
+   with `mira_setup`.
+5. **Ops:** author + apply `approved_tags_<customer>.sql` (staging → prod). Ingest is fail-closed —
+   nothing flows until approved.
+6. **Gateway:** enable the tag-stream timer.
+7. **Verify from anywhere:** Command Center → **Remote Commissioning** panel turns green
+   (claimed → online → bound → approved → live → Ask-MIRA), or shows the exact next action.
+8. **Register the live display** — dev/staging: 8890 origin-root proxy; **production: dedicated
+   FactoryLM origin (ADR-0024), e.g. `https://<customer-gateway>.factorylm-gateways.com`** — never the
+   raw gateway, never the 8890 proxy.
+
+### Validation checklist (per install)
+- [ ] Code activated (row in `plg_activation_codes`)
+- [ ] Gateway online (Hub gateways probe)
+- [ ] `approved_tags > 0` for the tenant
+- [ ] `live_signal_cache` fresh under the asset UNS subtree
+- [ ] Unknown tag returns `rejected:[{reason:not_allowlisted}]`
+- [ ] Remote Commissioning panel green
+- [ ] Ask-MIRA returns a grounded answer; `422 {"error":"uns_required"}` when no asset id
+
+### Troubleshooting checklist
+- Panel "not configured" → `TENANT_ID` / `MIRA_HMAC_KEY` missing in `factorylm.properties`.
+- All tags rejected → allowlist not seeded / wrong `STREAM_TAG_FOLDER` (e.g. garage default) /
+  normalizer mismatch.
+- `401 auth_failed` → HMAC key mismatch or clock skew (±300 s).
+- Cache empty but timer running → folder has no leaf tags, or tags not allowlisted.
+- Display blank → framed via raw gateway or 8890 in production (must be the dedicated origin).
+
+### What still requires a human
+Importing the project; setting `factorylm.properties` (incl. the HMAC value); tag→role mapping;
+enabling the timer; authoring + approving the per-customer allowlist; provisioning the production
+display origin.
+
+### What later becomes a real `.modl`
+`tag-stream.py` + the WebDev `connect`/`tags`/`chat` endpoints + a bundled settings/config UI → a
+signed Ignition module with one-click install. **Explicitly out of v0** — v0 is the project-import +
+scripts bundle.
+
+---
+
+## Part 3 — Remaining gaps before the first guided beta
+1. **On-site live proof** (the only true e2e gap): import project + start the timer on the gateway →
+   `live_signal_cache` fills → panel green. *Owner: on-site.*
+2. **Production display origin** (ADR-0024 dedicated per-gateway origin) — DNS + nginx + allowlist.
+   *Owner: infra.*
+3. **Staging ingest HTTP smoke** — confirm the staging relay is up and run a signed accepted/rejected
+   POST to `/api/v1/tags/ingest`.
+4. **Per-customer seed templating** — CV-200 seeds are hand-authored; a guided beta wants a generator
+   for `<customer>-hub.sql` / `approved_tags_<customer>.sql` / `command_center_<customer>.sql`.
+5. **Per-connector HMAC keys** — today a shared `MIRA_IGNITION_HMAC_KEY`; per-connector keys are a
+   hardening follow-up (not v0-blocking).
+
+---
+
+## Invariants honored
+Read-only OT (no PLC writes) · fail-closed `approved_tags` · garage conveyor untouched · tenant /
+UNS path / HMAC / ADR-0024 production-origin policy preserved · reuse of the existing
+`ignition/` + `mira-web` + `mira-relay` + `mira-hub` path (no parallel connector system).
+
+## References
+- `docs/handoffs/2026-06-28-plc-laptop-northwind-cv200-perspective.md` — the build handoff.
+- `docs/handoffs/2026-06-28-remote-commissioning-discovery.md` — the reuse discovery.
+- `docs/adr/0024-dedicated-factorylm-origin-per-ignition-gateway.md` — production framing decision.
+- `.claude/rules/{fieldbus-readonly,one-pipeline-ingest,direct-connection-uns-certified}.md`.
+</content>


### PR DESCRIPTION
## What

Saves the CV-200 runtime proof + **FactoryLM Ignition Connector v0** packaging plan as a runbook. **Docs only** — one new file, no code, no secrets (placeholder names throughout).

`docs/runbooks/2026-06-29-cv200-connector-v0.md`

## Contents
- **Part 1 — Live runtime proof:** what's verified live on `factorylm/stg` (seeds applied; `kg_entities=21`, `cmms_equipment=7`, `approved_tags=69`, `display=1 → NorthwindBottling`; garage untouched), what's CI-proven (ingest fail-closed, panel, Ask-MIRA), and what's **still blocked on the PLC-laptop gateway** (`live_signal_cache` filling, panel showing live). Includes the **lesson learned: seed from `origin/main`, not a stale working tree.**
- **Part 2 — Connector v0 packaging plan:** exact package inventory (existing `ignition/` + `mira-web` + `mira-relay` + `mira-hub` files), required `factorylm.properties` config (placeholder names), stranger-install guide outline, validation + troubleshooting checklists, what requires a human, and what later becomes a real `.modl`.
- **Part 3 — Remaining gaps before the first guided beta.**

## Explicit framing
- Staging **cloud-state is verified**; the **physical live proof still requires the PLC-laptop gateway timer**.
- Connector v0 is a **project-import + scripts bundle, not a finished `.modl`** module. No Phase-2 UDT work; no parallel connector system.
- Invariants honored: read-only OT, fail-closed `approved_tags`, garage untouched, ADR-0024 production-origin policy.

Docs-only → no `/VERSION` bump required (version-gate exempts docs-only PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)