### PR TITLE
feat(litmus): Micro820→Litmus DeviceHub bench proof + reverse-engineered write API

### DIFF
--- a/plc/litmus/DEVICEHUB_API.md
+++ b/plc/litmus/DEVICEHUB_API.md
@@ -44,22 +44,42 @@ have to rediscover it every 2-hour reset. BENCH-ONLY; read-only toward the PLC.
   `analogGap`, `discreteGap`, `requestTimeoutMs`).
 - **Update:** `PUT /devicehub/devices/{id}` with the full `{name,driverId,properties}` body → 204.
 
-### Tags are called **"registers"** — `/devicehub/registers`
+### Tags are called **"registers"** — `/devicehub/registers`  (VERIFIED)
 - `GET /devicehub/registers` → list (`[]` when empty).
-- **Create:** `POST /devicehub/registers`. Fields discovered from validation errors:
-  - `deviceId` (string, the device id)
-  - `name` (string) — **must be a value from the driver's register-name catalog**; arbitrary
-    labels or Modbus refs like `"40110"`/`"HR109"` are rejected `"Unknown register name"`.
-    **OPEN ITEM — exact accepted format TBD** (capture it from the DeviceHub UI's Add-Tag form).
-  - `TagName` (string) — the friendly tag name (e.g. `vfd_dc_bus`).
-  - `address` (**int**, NOT string — opposite of device properties) — the Modbus offset.
-  - The real validation lives in `core/registers_validation.go`; failures surface only in the
-    `loopedge-dh` log (`/var/log/loopedge-dh/current`), not the HTTP body (which returns `500 null`).
-    **Read that log to debug register creates.**
+- **Create:** `POST /devicehub/registers`, body:
+  ```json
+  { "deviceId": "<id>", "name": "H", "TagName": "vfd_dc_bus", "address": 109, "valueType": "word" }
+  ```
+  - `deviceId` (string).
+  - **`name` = the register CLASS code** from the driver catalog (the UI Add-Tag "Name" dropdown):
+    - **`H`** = Analog Output Holding Registers → **FC3** (`valueType` word/int16/int32/uint32/float32/…)
+    - **`I`** = Analog Input Registers → **FC4**
+    - **`C`** = Coils → **FC1** (`valueType` `bit`);  **`D`** = Discrete Input Contacts → FC2 (bit)
+    - Arbitrary labels / Modbus refs (`"40110"`, `"HR109"`) are rejected `"Unknown register name"`.
+  - `TagName` (string) — the friendly tag name; read back as `tagName`.
+  - `address` (**int**, NOT string — opposite of device properties). 0-based when the device
+    has `"Zero-Based Addressing":"1"`.
+  - `valueType` — `word` (unsigned 16-bit) for the VFD analogs, `bit` for coils.
+  - Real validation lives in `core/registers_validation.go`; failures surface only in the
+    `loopedge-dh` log (`/var/log/loopedge-dh/current`), not the HTTP body (`500 null`). **Read that log.**
+- **Delete:** `DELETE /devicehub/registers/{id}` → 204.
+- **GOTCHA — poller caches the register set + batches contiguous addresses.** After add/deletes the
+  driver keeps polling the OLD set; and it batches adjacent addresses into one Modbus read, so a
+  batch that spans a non-existent address on a SPARSE PLC map fails wholesale (`exception 2, illegal
+  data address`). Fixes: provision only addresses that actually exist (single-read scan first), and
+  **reload the driver**: `docker exec le /command/s6-svc -r /run/service/loopedge-dh`. Verified: with
+  the real 11 addresses + a reload, polling runs with **zero exceptions**.
 
-## Read API (external, `x-api-key`) — `loopedge-access`
-- `GET /api/tags/by-device/{deviceID}` (header `x-api-key`) → live tag values. This is the path
-  `mira_on_litmus.py --source litmus` reads through. Get the key from the UI: System → Access Control → API Keys.
+## Read API (external) — `loopedge-access`
+- Serves on **`127.0.0.1:8094` INSIDE the container** (env `LOOPEDGE_ACCESS_SOCKET_API`); this port is
+  **not published to the host** in the bench `docker run`, so the read path is container-internal.
+- `GET /api/tags/by-device/{deviceID}` → live tag values (the path `mira_on_litmus.py --source litmus`
+  reads through). `GET /api/devices`, `/api/version` also available.
+- **Auth: an API key** — create via `POST http://127.0.0.1:8081/auth/v2/apikeys` `{"name":"..."}`
+  (returns `{id, value}`), or UI System → Access Control → API Keys. **OPEN ITEM:** the exact header
+  name/format the reader accepts (`apiKey` header rejects the raw `value` as *"invalid apiKey format"*;
+  grab a working key + header from the UI Network tab). Swagger security nominally says the
+  `Authorization` header ("Shared secret").
 
 ## Persistence note
 - The 2-hour Developer reset wipes DeviceHub config → re-run provisioning after each reset.

--- a/plc/litmus/DEVICEHUB_API.md
+++ b/plc/litmus/DEVICEHUB_API.md
@@ -1,0 +1,67 @@
+# Litmus Edge DeviceHub write API — reverse-engineered (2026-07-01)
+
+The Litmus Edge DeviceHub write API is **undocumented publicly** and the
+`loopedge-dh` binary is UPX-compressed (no greppable route strings). This is what
+was learned by probing it live on the bench container `le` (v4.0.14), so we don't
+have to rediscover it every 2-hour reset. BENCH-ONLY; read-only toward the PLC.
+
+## Auth (two separate systems)
+
+- **central.litmus.io** = cloud portal, ONLY for Developer-Edition license activation.
+- **localhost:8443** = the node's OWN local account (`loopedge-auth` + boltdb). This is
+  the UI login and the API credential. Current bench login: `admin` / `Factory2026!`.
+- **Mint a bearer token** (no F12 needed) — POST to the internal login endpoint:
+  ```
+  POST http://127.0.0.1:8081/auth/v2/login   {"username":"admin","password":"..."}
+  → { "jwtAccess": "<JWT>" }        # 5-min access token; use as  Authorization: Bearer <JWT>
+  ```
+  After a fresh login (mustChangePassword cleared) + license reset, the token carries full
+  scopes incl. `dh:Modify`, `dh:ModifyDevices`, `dh:ModifyTags`.
+
+## DeviceHub write endpoints (`loopedge-dh`, internal :8085, host via nginx `https://localhost:8443/devicehub`)
+
+### Drivers
+- `GET /devicehub/drivers` → catalog of ~80 drivers (id + name). Key ids:
+  - **Modbus TCP** = `2AF1FA08-D638-11E9-BB65-2A2AE2DBCCE4` (the proven path — matches the
+    live Modbus reads in `mira_on_litmus.py --source plc`).
+  - CIP Ethernet = `60B722BA-4539-4D5D-9D2F-7C63F7FADBFB` (EtherNet/IP by-name alt).
+- `GET /devicehub/drivers/{id}` → driver detail (Modbus TCP required fields: Network address,
+  Network Port, Station ID, Zero-Based Addressing).
+
+### Devices — `/devicehub/devices`
+- `GET /devicehub/devices` → list.
+- **Create:** `POST /devicehub/devices` with body:
+  ```json
+  { "name": "conv-101",
+    "driverId": "2AF1FA08-D638-11E9-BB65-2A2AE2DBCCE4",
+    "properties": { "networkAddress": "192.168.1.100", "networkPort": "502",
+                    "stationId": "1", "Zero-Based Addressing": "1" } }
+  ```
+  **GOTCHA: every `properties` value must be a STRING** ("502", not 502) — the model is
+  `map[string]string`. Sending `{}` for properties succeeds and the server returns the full
+  DEFAULT property set (handy for discovering keys: `networkAddress`, `networkPort`,
+  `stationId`, `overrideStationID`, `Zero-Based Addressing`, `maxAnalog`, `maxDiscrete`,
+  `analogGap`, `discreteGap`, `requestTimeoutMs`).
+- **Update:** `PUT /devicehub/devices/{id}` with the full `{name,driverId,properties}` body → 204.
+
+### Tags are called **"registers"** — `/devicehub/registers`
+- `GET /devicehub/registers` → list (`[]` when empty).
+- **Create:** `POST /devicehub/registers`. Fields discovered from validation errors:
+  - `deviceId` (string, the device id)
+  - `name` (string) — **must be a value from the driver's register-name catalog**; arbitrary
+    labels or Modbus refs like `"40110"`/`"HR109"` are rejected `"Unknown register name"`.
+    **OPEN ITEM — exact accepted format TBD** (capture it from the DeviceHub UI's Add-Tag form).
+  - `TagName` (string) — the friendly tag name (e.g. `vfd_dc_bus`).
+  - `address` (**int**, NOT string — opposite of device properties) — the Modbus offset.
+  - The real validation lives in `core/registers_validation.go`; failures surface only in the
+    `loopedge-dh` log (`/var/log/loopedge-dh/current`), not the HTTP body (which returns `500 null`).
+    **Read that log to debug register creates.**
+
+## Read API (external, `x-api-key`) — `loopedge-access`
+- `GET /api/tags/by-device/{deviceID}` (header `x-api-key`) → live tag values. This is the path
+  `mira_on_litmus.py --source litmus` reads through. Get the key from the UI: System → Access Control → API Keys.
+
+## Persistence note
+- The 2-hour Developer reset wipes DeviceHub config → re-run provisioning after each reset.
+- `auth.db` (the login) lives in the container writable layer and SURVIVES `docker restart`
+  (only `docker rm` wipes it). See `../../` memory `reference_litmus_local_admin_password_reset`.

--- a/plc/litmus/README.md
+++ b/plc/litmus/README.md
@@ -1,0 +1,72 @@
+<!-- ============================================================ -->
+<!--  BENCH-ONLY. Not a customer-shipped surface. Read-only OT.   -->
+<!--  Not the mira-relay ingest path (no ingest_contract /        -->
+<!--  ingest_batch / tag_events). See .claude/rules/fieldbus-     -->
+<!--  readonly.md and .claude/rules/one-pipeline-ingest.md.       -->
+<!-- ============================================================ -->
+
+# MIRA on top of Litmus Edge (bench proof)
+
+**Thesis:** Litmus Edge is *an* industrial data platform — it collects and
+normalizes the Micro820 conveyor's tags. **MIRA sits on top of it and adds the
+intelligence Litmus does not:** it turns the raw tag wall into *equipment state
++ likely cause + the next check*, grounded in the Conv_Simple machine card
+(`plc/conv_simple_anomaly` A0–A12 rules). This is the first proof that FactoryLM
+is a context layer that rides on **any** platform, not just our own ingest path.
+
+```
+Micro820 + GS10  --Modbus/EtherNet-IP-->  Litmus Edge  --/api (x-api-key)-->  MIRA rules  -->  diagnosis
+   (the machine)                            (the platform)                      (the value-add)
+```
+
+## Files
+
+| File | Role |
+|---|---|
+| `mira_on_litmus.py` | **The proof.** Reads tags THROUGH Litmus (`--source litmus`) or direct (`--source plc`), runs the same MIRA rules, prints the contextualized diagnosis. Zero third-party deps. |
+| `provision.py` | Re-creates the DeviceHub device + 11 verified tags in one command (survives the 2‑hour Developer-Edition reset). |
+
+## One-time setup in the Litmus UI (per 2‑hour session)
+
+Litmus DeviceHub **writes** go through the browser (Keycloak/OIDC) session; the
+`x-api-key` external API is **read-only**. So:
+
+1. **Log in + activate** the Developer Edition license (`https://100.72.2.99:8443`).
+2. **Provision the device** — either:
+   - click it once in DeviceHub (AB Micro850 Gen1.3 · `192.168.1.100` · port 44818 · slot 0; add the 11 tags by name), **or**
+   - script it: grab the UI bearer token (F12 → Network → any `/devicehub/*` → `Authorization: Bearer …`), then
+     `LITMUS_TOKEN=… python plc/litmus/provision.py`
+3. **Create an API key** (Settings → API Keys) for the read path → `export LITMUS_API_KEY=…`
+
+## Run the proof
+
+```bash
+# through Litmus (the thesis):
+LITMUS_API_KEY=… python plc/litmus/mira_on_litmus.py --source litmus --device-id conv-101
+
+# baseline, no Litmus in the path (same brain, same verdict):
+python plc/litmus/mira_on_litmus.py --source plc
+```
+
+## Verified facts baked in (2026-06-30, read-only)
+
+- PLC self-IDs over EtherNet/IP as **`2080-LC20-20QBB`** (Micro820), Allen-Bradley, FW 14.11.
+- 11 readable global vars confirmed by CIP read-by-name; VFD analogs are **UINT**.
+- Scales (raw → engineering): `vfd_dc_bus ÷10` (322 V, matches baseline), `vfd_frequency ÷100`, `vfd_current ÷100`, `vfd_voltage ÷10`. Mirrors `plc/conv_simple_anomaly/live_check.py`.
+
+## Honest status
+
+- ✅ **Validated & runs:** `mira_on_litmus.py --source plc` on live hardware — MIRA
+  produces a grounded diagnosis (healthy *and* injected-fault paths).
+- ⏳ **Pending one live-token pass:** `provision.py` and `--source litmus` POST/GET
+  against the discovered `/devicehub` + `/api/tags/by-device` endpoints. The
+  device-create JSON shape is Litmus-build-specific; the script prints the server
+  response so a field mismatch is a 1-line fix. Validate against a real `LITMUS_TOKEN`
+  before relying on it.
+
+## What this is NOT
+
+Not a production ingest path. Sending Litmus data into MIRA's canonical pipeline
+(`mira-relay` → `ingest_batch`) is a separate, **gated** effort (HOLD until
+#2280/#2281) and must obey `.claude/rules/one-pipeline-ingest.md`. This proof
+reads Litmus and diagnoses; it never writes `tag_events` / `live_signal_cache`.

--- a/plc/litmus/mira_on_litmus.py
+++ b/plc/litmus/mira_on_litmus.py
@@ -1,0 +1,183 @@
+"""
+MIRA on top of Litmus Edge -- the value-add proof.
+=================================================================
+BENCH-ONLY developer tool. Not a customer-shipped surface, not the mira-relay
+ingest path (does NOT touch ingest_contract / ingest_batch / tag_events).
+Read-only toward the PLC and toward Litmus.
+
+Thesis: Litmus Edge is *an* industrial data platform (it collects + normalizes
+the conveyor's tags). MIRA sits ON TOP of it and adds the intelligence Litmus
+does not: it turns the raw tag wall into equipment state + likely cause + the
+next check to make, grounded in the Conv_Simple machine card (the A0-A12 rules).
+
+Two read sources, same MIRA brain (plc/conv_simple_anomaly rules):
+  --source litmus   read tag values THROUGH Litmus' external API
+                    (GET /api/tags/by-device/{id}, header x-api-key).  <-- the thesis
+  --source plc      read the PLC directly over Modbus TCP (no Litmus).  <-- control/baseline
+
+    python plc/litmus/mira_on_litmus.py --source plc
+    LITMUS_API_KEY=... python plc/litmus/mira_on_litmus.py --source litmus --device-id conv-101
+
+Zero third-party deps (stdlib socket + urllib) so it runs under any python3.
+"""
+import argparse, json, os, socket, ssl, struct, sys, time, urllib.request
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "conv_simple_anomaly"))
+import rules  # noqa: E402  -- the A0-A12 machine-card brain (evaluate, T_*, DEFAULT_CFG)
+
+PLC_HOST = os.getenv("PLC_HOST", "192.168.1.100")
+PLC_PORT = int(os.getenv("PLC_PORT", "502"))
+UNIT = 1
+
+# ---- Litmus provisioned tag name -> (rules topic, scale divisor) -------------
+# Names are the VERIFIED live global vars (CIP read-by-name, 2026-06-30); scales
+# mirror plc/conv_simple_anomaly/live_check.py HR_SPECS (raw register -> engineering).
+LITMUS_TAG_MAP = {
+    "motor_running":      (rules.T_RUN,    None),   # bool
+    "vfd_comm_ok":        (rules.T_COMM,   None),   # bool
+    "e_stop_active":      (rules.T_ESTOP,  None),   # bool
+    "estop_wiring_fault": (rules.T_WIRING, None),   # bool
+    "vfd_dc_bus":         (rules.T_DCBUS,  10.0),   # UINT -> V
+    "vfd_frequency":      (rules.T_FREQ,   100.0),  # UINT -> Hz
+    "vfd_current":        (rules.T_CUR,    100.0),  # UINT -> A
+    "vfd_voltage":        ("vfd/vfd101/voltage_v", 10.0),
+    "vfd_cmd_word":       (rules.T_CMD,    1.0),
+    "vfd_fault_code":     (rules.T_FAULT,  1.0),
+    "vfd_status_word":    ("vfd/vfd101/status_word", 1.0),
+}
+
+# ---- Modbus offsets (mirror of live_check.py) for the --source plc baseline --
+_COILS = {0: rules.T_RUN, 3: rules.T_COMM, 5: rules.T_ESTOP, 9: rules.T_WIRING}
+_HR = {106: (rules.T_FREQ, 100.0), 107: (rules.T_CUR, 100.0),
+       108: ("vfd/vfd101/voltage_v", 10.0), 109: (rules.T_DCBUS, 10.0),
+       114: (rules.T_CMD, 1.0), 118: (rules.T_FAULT, 1.0)}
+
+
+def _modbus(sock, fc, start, qty):
+    pdu = struct.pack(">BHH", fc, start, qty)
+    sock.sendall(struct.pack(">HHH", 1, 0, len(pdu) + 1) + bytes([UNIT]) + pdu)
+    r = sock.recv(512)
+    if r[7] & 0x80:
+        return None  # Modbus exception (addr not in live map) -> degrade to None
+    return r[9:9 + r[8]]
+
+
+def read_plc():
+    """Direct Modbus TCP snapshot (no Litmus). Raw sockets, no pymodbus dep."""
+    snap = {}
+    s = socket.socket(); s.settimeout(3); s.connect((PLC_HOST, PLC_PORT))
+    try:
+        for off, topic in _COILS.items():
+            d = _modbus(s, 1, off, 1)
+            if d is not None:
+                snap[topic] = bool(d[0] & 1)
+        for off, (topic, div) in _HR.items():
+            d = _modbus(s, 3, off, 1)
+            if d is not None:
+                v = struct.unpack(">H", d)[0]
+                snap[topic] = v / div if div != 1.0 else v
+    finally:
+        s.close()
+    return snap
+
+
+def read_litmus(base, api_key, device_id):
+    """Snapshot read THROUGH Litmus' external integration API (x-api-key)."""
+    url = base.rstrip("/") + "/api/tags/by-device/" + urllib.request.quote(device_id)
+    ctx = ssl.create_default_context(); ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE
+    req = urllib.request.Request(url, headers={"x-api-key": api_key, "Accept": "application/json"})
+    with urllib.request.urlopen(req, context=ctx, timeout=10) as r:
+        payload = json.load(r)
+    # Tolerant parse: accept {tags:[...]}, [...], or {name:value}. Each tag row is
+    # expected to expose a name + a current value under common key spellings.
+    rows = payload.get("tags", payload) if isinstance(payload, dict) else payload
+    litmus_vals = {}
+    if isinstance(rows, dict):
+        litmus_vals = rows
+    else:
+        for row in rows:
+            name = row.get("name") or row.get("tagName") or row.get("tag")
+            val = row.get("value", row.get("lastValue", row.get("v")))
+            if name is not None:
+                litmus_vals[name] = val
+    snap = {}
+    for tag, (topic, div) in LITMUS_TAG_MAP.items():
+        if tag not in litmus_vals or litmus_vals[tag] is None:
+            continue
+        raw = litmus_vals[tag]
+        if div is None:
+            snap[topic] = bool(raw) if not isinstance(raw, bool) else raw
+        else:
+            snap[topic] = float(raw) / div if div != 1.0 else raw
+    return snap, litmus_vals
+
+
+def diagnose(snap):
+    now = time.time()
+    cmd_run = snap.get(rules.T_CMD) in rules.DEFAULT_CFG["run_cmd_values"]
+    derived = {"now": now, "max_stale_s": 0.0, "freq_frozen_s": 0.0,
+               "cmd_run_for_s": (rules.DEFAULT_CFG["cmd_run_grace_s"] + 1) if cmd_run else 0.0}
+    return rules.evaluate(snap, derived)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--source", choices=["litmus", "plc"], default="plc")
+    ap.add_argument("--device-id", default=os.getenv("LITMUS_DEVICE_ID", "conv-101"))
+    ap.add_argument("--base", default=os.getenv("LITMUS_BASE", "https://localhost:8443"))
+    ap.add_argument("--raw-json", action="store_true", help="dump the raw Litmus payload")
+    args = ap.parse_args()
+
+    litmus_vals = None
+    if args.source == "litmus":
+        key = os.getenv("LITMUS_API_KEY")
+        if not key:
+            print("ERROR: set LITMUS_API_KEY (Litmus UI -> Settings -> API Keys).")
+            return 2
+        snap, litmus_vals = read_litmus(args.base, key, args.device_id)
+        origin = "Litmus Edge external API (/api/tags/by-device, x-api-key)"
+    else:
+        snap = read_plc()
+        origin = "PLC direct (Modbus TCP %s:%d) -- no Litmus in the path" % (PLC_HOST, PLC_PORT)
+
+    print("=" * 68)
+    print("MIRA on top of Litmus Edge -- contextualized diagnosis")
+    print("  read source : %s" % origin)
+    print("=" * 68)
+
+    if args.raw_json and litmus_vals is not None:
+        print("\n-- RAW Litmus tag values --\n" + json.dumps(litmus_vals, indent=2))
+
+    print("\n--- WHAT THE PLATFORM SHOWS (raw tags) ---")
+    for topic in sorted(snap):
+        print("  %-28s = %s" % (topic, snap[topic]))
+    if not snap:
+        print("  (no tags -- check the device id / provisioning)")
+        return 1
+
+    anomalies = diagnose(snap)
+    print("\n--- WHAT MIRA ADDS (state + likely cause + next check) ---")
+    if not anomalies:
+        dcb = snap.get(rules.T_DCBUS)
+        comm = snap.get(rules.T_COMM)
+        run = snap.get(rules.T_RUN)
+        print("  STATE: conveyor %s, GS10 comms %s, DC bus %s V -- within all"
+              % ("RUNNING" if run else "idle",
+                 "healthy" if comm else "DOWN",
+                 ("%.1f" % dcb) if dcb is not None else "?"))
+        print("  MIRA: no anomalies against the Conv_Simple machine card (A0-A12).")
+        print("        Litmus shows the numbers; MIRA confirms they are all nominal.")
+    else:
+        for a in anomalies:
+            print("  [%s] %s -- %s" % (a.severity, a.title, a.rule_id))
+            print("      %s" % a.message)
+            if a.evidence:
+                ev = ", ".join("%s=%s" % (e["topic"].split("/")[-1], e["value"]) for e in a.evidence)
+                print("      evidence: %s" % ev)
+            print("      confidence: %.2f" % a.confidence)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plc/litmus/provision.py
+++ b/plc/litmus/provision.py
@@ -6,47 +6,44 @@ READ registers only; never writes a PLC register). Re-run after each 2-hour
 Developer Edition reset instead of re-clicking tags in the UI.
 
 The DeviceHub write API is undocumented + the loopedge-dh binary is compressed;
-the schema below was reverse-engineered live -- see DEVICEHUB_API.md in this dir.
+the schema below was reverse-engineered + VERIFIED live -- see DEVICEHUB_API.md.
 
 Auth: DeviceHub writes need an Authorization: Bearer <JWT>. Two ways to get one:
   1. Mint it directly (no UI):  export LITMUS_PASSWORD=... (default 'Factory2026!')
      -- the script logs in to loopedge-auth and mints a token itself.
-  2. Or paste a token from the logged-in UI (F12 -> Network -> any /devicehub/*
-     request -> copy the 'Bearer <token>' value):   export LITMUS_TOKEN=<token>
+  2. Or paste a UI Bearer token (F12 -> Network -> any /devicehub/*):  export LITMUS_TOKEN=...
 
     python plc/litmus/provision.py               # mints its own token from LITMUS_PASSWORD
-    LITMUS_TOKEN=... python plc/litmus/provision.py
 
-Status: device creation is VERIFIED end-to-end. Register (tag) creation is
-scaffolded but the register `name` must be a value from the Modbus driver's
-register-name catalog -- the exact accepted format is the one OPEN item
-(confirm from the DeviceHub UI Add-Tag form, then set NAME_FN below). Until then
-the script fully provisions the DEVICE and reports each register attempt.
+VERIFIED end-to-end (2026-07-01): device + all 11 registers create, and Litmus
+polls the PLC with ZERO modbus exceptions (DC bus, freq, current, voltage, cmd,
+status, fault via FC3 holding; motor/comm/estop/wiring via FC1 coils).
+
+NOTE: the loopedge-dh poller caches its register set -- after add/deletes it may
+keep polling stale registers. Restart the driver to reload:
+    docker exec le /command/s6-svc -r /run/service/loopedge-dh
 """
 import argparse, json, os, ssl, urllib.request
 
 BASE = os.getenv("LITMUS_BASE", "https://localhost:8443")
-# loopedge-auth login via the nginx-fronted path; if minting fails, pass LITMUS_TOKEN.
 AUTH_LOGIN = os.getenv("LITMUS_AUTH_LOGIN", BASE.rstrip("/") + "/auth/v2/login")
 MODBUS_TCP_DRIVER = "2AF1FA08-D638-11E9-BB65-2A2AE2DBCCE4"  # GET /devicehub/drivers
 _CTX = ssl.create_default_context(); _CTX.check_hostname = False; _CTX.verify_mode = ssl.CERT_NONE
 
-# Proven Modbus map (0-based; mirror of mira_on_litmus.py read path). address is an INT.
-#   ("area", offset)  where area is "hr" (holding reg, FC3) or "coil" (FC1).
-REGISTERS = [
-    ("vfd_dc_bus",         "hr",   109), ("vfd_frequency",   "hr",   106),
-    ("vfd_current",        "hr",   107), ("vfd_voltage",     "hr",   108),
-    ("vfd_cmd_word",       "hr",   114), ("vfd_status_word", "hr",   117),
-    ("vfd_fault_code",     "hr",   118), ("motor_running",   "coil", 0),
-    ("vfd_comm_ok",        "coil", 3),   ("e_stop_active",   "coil", 5),
-    ("estop_wiring_fault", "coil", 9),
+# VERIFIED live map. Litmus register class code -> Modbus function:
+#   name="H" -> FC3 Holding registers   (valueType "word" = unsigned 16-bit)
+#   name="C" -> FC1 Coils               (valueType "bit")
+# addresses are 0-based (device property "Zero-Based Addressing"="1") and are all
+# confirmed to EXIST on the sparse Micro820 map (single-read scan, no exception 2).
+HOLDING = [  # (TagName, address)  read as name="H", valueType="word"
+    ("vfd_dc_bus", 109), ("vfd_frequency", 106), ("vfd_current", 107),
+    ("vfd_voltage", 108), ("vfd_cmd_word", 114), ("vfd_status_word", 117),
+    ("vfd_fault_code", 118),
 ]
-
-# OPEN ITEM: the accepted register `name` (driver catalog value). Confirm from the
-# UI Add-Tag form, then implement. Best current guess left for quick iteration.
-def NAME_FN(area, offset):
-    # e.g. Modbus 4xxxx/0xxxx reference -- TBD against the driver catalog.
-    return ("4%04d" % (offset + 1)) if area == "hr" else ("0%04d" % (offset + 1))
+COILS = [  # (TagName, address)  read as name="C", valueType="bit"
+    ("motor_running", 0), ("vfd_comm_ok", 3), ("e_stop_active", 5),
+    ("estop_wiring_fault", 9),
+]
 
 
 def _call(method, path, token, body=None):
@@ -63,8 +60,8 @@ def _call(method, path, token, body=None):
 
 
 def mint_token():
-    pw = os.getenv("LITMUS_PASSWORD", "Factory2026!")
-    body = json.dumps({"username": os.getenv("LITMUS_USER", "admin"), "password": pw}).encode()
+    body = json.dumps({"username": os.getenv("LITMUS_USER", "admin"),
+                       "password": os.getenv("LITMUS_PASSWORD", "Factory2026!")}).encode()
     req = urllib.request.Request(AUTH_LOGIN, data=body, method="POST",
                                  headers={"Content-Type": "application/json"})
     with urllib.request.urlopen(req, context=_CTX, timeout=15) as r:
@@ -78,9 +75,10 @@ def device_body(name, host, port, unit):
                            "stationId": str(unit), "Zero-Based Addressing": "1"}}
 
 
-def register_body(device_id, tag, area, offset):
-    return {"deviceId": device_id, "name": NAME_FN(area, offset),
-            "TagName": tag, "address": int(offset)}
+def register_body(device_id, cls, tag, address, value_type):
+    # NOTE: address is an INT here (register bodies are typed; device props are strings).
+    return {"deviceId": device_id, "name": cls, "TagName": tag,
+            "address": int(address), "valueType": value_type}
 
 
 def main():
@@ -89,15 +87,12 @@ def main():
     ap.add_argument("--host", default=os.getenv("PLC_HOST", "192.168.1.100"))
     ap.add_argument("--port", type=int, default=502)
     ap.add_argument("--unit", type=int, default=1)
-    ap.add_argument("--skip-registers", action="store_true",
-                    help="provision the device only (registers need NAME_FN confirmed)")
     args = ap.parse_args()
 
     token = os.getenv("LITMUS_TOKEN")
     if not token:
         try:
-            token = mint_token()
-            print("Minted a token from LITMUS_PASSWORD.")
+            token = mint_token(); print("Minted a token from LITMUS_PASSWORD.")
         except Exception as e:  # noqa: BLE001
             print("ERROR: no LITMUS_TOKEN and mint failed (%s). Paste a UI Bearer token." % e)
             return 2
@@ -112,23 +107,21 @@ def main():
     device_id = resp.get("id") or args.name
     print("  device id: %s  (ip=%s)" % (device_id, resp.get("properties", {}).get("networkAddress")))
 
-    if args.skip_registers:
-        print("Device provisioned; --skip-registers set. Confirm NAME_FN then re-run for tags.")
-        return 0
-
     ok = 0
-    for tag, area, offset in REGISTERS:
-        st, resp = _call("POST", "/devicehub/registers", token, register_body(device_id, tag, area, offset))
-        print("  register %-20s (%s %d) -> HTTP %s" % (tag, area, offset, st))
-        if st in (200, 201):
-            ok += 1
-        elif resp:
-            print("       response: %s" % resp)
-    print("\nDone: %d/%d registers. (If 0, NAME_FN needs the real driver register-name format --"
-          " see /var/log/loopedge-dh/current + DEVICEHUB_API.md.)" % (ok, len(REGISTERS)))
+    for tag, addr in HOLDING:
+        st, resp = _call("POST", "/devicehub/registers", token, register_body(device_id, "H", tag, addr, "word"))
+        ok += st in (200, 201); print("  H  %-20s @%-3d -> HTTP %s" % (tag, addr, st))
+    for tag, addr in COILS:
+        st, resp = _call("POST", "/devicehub/registers", token, register_body(device_id, "C", tag, addr, "bit"))
+        ok += st in (200, 201); print("  C  %-20s @%-3d -> HTTP %s" % (tag, addr, st))
+
+    n = len(HOLDING) + len(COILS)
+    print("\nDone: %d/%d registers provisioned." % (ok, n))
+    print("Reload the poller so it drops any stale registers:\n"
+          "  docker exec le /command/s6-svc -r /run/service/loopedge-dh")
     print("Then read through Litmus:\n"
           "  LITMUS_API_KEY=... python plc/litmus/mira_on_litmus.py --source litmus --device-id %s" % device_id)
-    return 0
+    return 0 if ok == n else 1
 
 
 if __name__ == "__main__":

--- a/plc/litmus/provision.py
+++ b/plc/litmus/provision.py
@@ -1,0 +1,135 @@
+"""
+Provision the Micro820 conveyor into Litmus Edge DeviceHub -- in one command.
+=================================================================
+BENCH-ONLY developer tool. Read-only toward the PLC (creates a READ device +
+READ registers only; never writes a PLC register). Re-run after each 2-hour
+Developer Edition reset instead of re-clicking tags in the UI.
+
+The DeviceHub write API is undocumented + the loopedge-dh binary is compressed;
+the schema below was reverse-engineered live -- see DEVICEHUB_API.md in this dir.
+
+Auth: DeviceHub writes need an Authorization: Bearer <JWT>. Two ways to get one:
+  1. Mint it directly (no UI):  export LITMUS_PASSWORD=... (default 'Factory2026!')
+     -- the script logs in to loopedge-auth and mints a token itself.
+  2. Or paste a token from the logged-in UI (F12 -> Network -> any /devicehub/*
+     request -> copy the 'Bearer <token>' value):   export LITMUS_TOKEN=<token>
+
+    python plc/litmus/provision.py               # mints its own token from LITMUS_PASSWORD
+    LITMUS_TOKEN=... python plc/litmus/provision.py
+
+Status: device creation is VERIFIED end-to-end. Register (tag) creation is
+scaffolded but the register `name` must be a value from the Modbus driver's
+register-name catalog -- the exact accepted format is the one OPEN item
+(confirm from the DeviceHub UI Add-Tag form, then set NAME_FN below). Until then
+the script fully provisions the DEVICE and reports each register attempt.
+"""
+import argparse, json, os, ssl, urllib.request
+
+BASE = os.getenv("LITMUS_BASE", "https://localhost:8443")
+# loopedge-auth login via the nginx-fronted path; if minting fails, pass LITMUS_TOKEN.
+AUTH_LOGIN = os.getenv("LITMUS_AUTH_LOGIN", BASE.rstrip("/") + "/auth/v2/login")
+MODBUS_TCP_DRIVER = "2AF1FA08-D638-11E9-BB65-2A2AE2DBCCE4"  # GET /devicehub/drivers
+_CTX = ssl.create_default_context(); _CTX.check_hostname = False; _CTX.verify_mode = ssl.CERT_NONE
+
+# Proven Modbus map (0-based; mirror of mira_on_litmus.py read path). address is an INT.
+#   ("area", offset)  where area is "hr" (holding reg, FC3) or "coil" (FC1).
+REGISTERS = [
+    ("vfd_dc_bus",         "hr",   109), ("vfd_frequency",   "hr",   106),
+    ("vfd_current",        "hr",   107), ("vfd_voltage",     "hr",   108),
+    ("vfd_cmd_word",       "hr",   114), ("vfd_status_word", "hr",   117),
+    ("vfd_fault_code",     "hr",   118), ("motor_running",   "coil", 0),
+    ("vfd_comm_ok",        "coil", 3),   ("e_stop_active",   "coil", 5),
+    ("estop_wiring_fault", "coil", 9),
+]
+
+# OPEN ITEM: the accepted register `name` (driver catalog value). Confirm from the
+# UI Add-Tag form, then implement. Best current guess left for quick iteration.
+def NAME_FN(area, offset):
+    # e.g. Modbus 4xxxx/0xxxx reference -- TBD against the driver catalog.
+    return ("4%04d" % (offset + 1)) if area == "hr" else ("0%04d" % (offset + 1))
+
+
+def _call(method, path, token, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE.rstrip("/") + path, data=data, method=method,
+                                 headers={"Authorization": "Bearer " + token,
+                                          "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, context=_CTX, timeout=15) as r:
+            txt = r.read().decode()
+            return r.status, (json.loads(txt) if txt else {})
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()[:400]
+
+
+def mint_token():
+    pw = os.getenv("LITMUS_PASSWORD", "Factory2026!")
+    body = json.dumps({"username": os.getenv("LITMUS_USER", "admin"), "password": pw}).encode()
+    req = urllib.request.Request(AUTH_LOGIN, data=body, method="POST",
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, context=_CTX, timeout=15) as r:
+        return json.load(r)["jwtAccess"]
+
+
+def device_body(name, host, port, unit):
+    # every properties value MUST be a string (map[string]string).
+    return {"name": name, "driverId": MODBUS_TCP_DRIVER,
+            "properties": {"networkAddress": host, "networkPort": str(port),
+                           "stationId": str(unit), "Zero-Based Addressing": "1"}}
+
+
+def register_body(device_id, tag, area, offset):
+    return {"deviceId": device_id, "name": NAME_FN(area, offset),
+            "TagName": tag, "address": int(offset)}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--name", default="conv-101")
+    ap.add_argument("--host", default=os.getenv("PLC_HOST", "192.168.1.100"))
+    ap.add_argument("--port", type=int, default=502)
+    ap.add_argument("--unit", type=int, default=1)
+    ap.add_argument("--skip-registers", action="store_true",
+                    help="provision the device only (registers need NAME_FN confirmed)")
+    args = ap.parse_args()
+
+    token = os.getenv("LITMUS_TOKEN")
+    if not token:
+        try:
+            token = mint_token()
+            print("Minted a token from LITMUS_PASSWORD.")
+        except Exception as e:  # noqa: BLE001
+            print("ERROR: no LITMUS_TOKEN and mint failed (%s). Paste a UI Bearer token." % e)
+            return 2
+
+    print("Provisioning '%s' (Modbus TCP %s:%d unit %d) on %s ..."
+          % (args.name, args.host, args.port, args.unit, BASE))
+    st, resp = _call("POST", "/devicehub/devices", token, device_body(args.name, args.host, args.port, args.unit))
+    print("  POST /devicehub/devices -> HTTP %s" % st)
+    if st not in (200, 201):
+        print("  response: %s" % resp)
+        return 1
+    device_id = resp.get("id") or args.name
+    print("  device id: %s  (ip=%s)" % (device_id, resp.get("properties", {}).get("networkAddress")))
+
+    if args.skip_registers:
+        print("Device provisioned; --skip-registers set. Confirm NAME_FN then re-run for tags.")
+        return 0
+
+    ok = 0
+    for tag, area, offset in REGISTERS:
+        st, resp = _call("POST", "/devicehub/registers", token, register_body(device_id, tag, area, offset))
+        print("  register %-20s (%s %d) -> HTTP %s" % (tag, area, offset, st))
+        if st in (200, 201):
+            ok += 1
+        elif resp:
+            print("       response: %s" % resp)
+    print("\nDone: %d/%d registers. (If 0, NAME_FN needs the real driver register-name format --"
+          " see /var/log/loopedge-dh/current + DEVICEHUB_API.md.)" % (ok, len(REGISTERS)))
+    print("Then read through Litmus:\n"
+          "  LITMUS_API_KEY=... python plc/litmus/mira_on_litmus.py --source litmus --device-id %s" % device_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Bench-only, read-only proof that **MIRA reads the Micro820/GS10 conveyor _through_ Litmus Edge** — FactoryLM/MIRA as the context layer on top of any industrial data platform. Focused PR off `main` (the bundled difference-engine / proof-packet / golden-path work on `feat/litmus-bench-proof` will get its own PRs).

Depends only on `plc/conv_simple_anomaly/rules.py`, already on `main`.

## Contents (`plc/litmus/`)

- **`mira_on_litmus.py`** — reads conveyor tags via Litmus (`--source litmus`, `/api/tags/by-device` + `x-api-key`) OR direct Modbus TCP (`--source plc`), maps to the `conv_simple_anomaly` A0–A12 rules, prints *"what the platform shows"* vs *"what MIRA adds"*.
- **`provision.py`** — one-command DeviceHub provisioning (re-run after each 2-hour Developer reset). Mints its own token or takes `LITMUS_TOKEN`.
- **`DEVICEHUB_API.md`** — the reverse-engineered, otherwise-undocumented DeviceHub write API (device/register schema, string-typed properties, `/devicehub/registers`, token minting), so it isn't rediscovered every reset.
- **`README.md`** — the bench setup + collect/visualize runbook.

## Status / evidence

- ✅ **Direct-PLC read + rules VERIFIED live** on the bench: DC bus 320.5 V, GS10 comms healthy, idle → no anomalies against the machine card.
- ✅ **DeviceHub device creation VERIFIED** (Modbus TCP driver, `192.168.1.100:502`, `conv-101`).
- ⏳ **Open item:** register (tag) creation — the register `name` must be a value from the Modbus driver's register-name catalog; the exact accepted format is being confirmed from the DeviceHub UI, then `NAME_FN` in `provision.py` gets the one-line fix and a follow-up commit lands here.

## Guardrails

- **Read-only toward the PLC** throughout; no PLC writes.
- **NOT** the `mira-relay` ingest path — the one-pipeline law is untouched. Litmus stays a self-contained bench/eval tool (also sidesteps the 2-hour-reset problem of making it a real ingest source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)