### PR TITLE
docs: add Release/PR Workflow, Git Workflow, Sub-agents/Worktrees, Safety, Security sections to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -177,6 +177,8 @@ Full rules: `.claude/rules/codegraph-usage.md`. Reference: `wiki/references/code
 - **FactoryLM UI style** — every front end (mira-contextualizer, mira-plc-parser `gui/`, mira-hub, mira-web, Ignition Perspective) uses the shared design tokens (`docs/design/factorylm-tokens.css`): flat/modern, muted-normal + color-for-state, never hardcode a hex. See `.claude/rules/ui-style.md` + skill `factorylm-ui-style` + runbook `docs/design/factorylm-style.md`.
 - **Debugging & verification** — perf problems are multi-cause (re-measure after each fix); verify exact table/column names + API auth paths from the codebase before guessing. See `.claude/rules/debugging-conventions.md`.
 - **Session discipline** — verify stated premises against the codebase + `git log` before building; re-run the full suite before reporting eval gains; stage only files your change touched (never `git add -A` over foreign WIP); validate migration/seed prerequisites + schema constraints; checkpoint long tasks to `.planning/STATE.md` early. See `.claude/rules/session-discipline.md`.
+- **Sub-agent worktree isolation** — any parallel-dispatched sub-agent that Edits/Writes files runs in its own git worktree (or has confirmed there's no foreign WIP in the shared checkout it could clobber). See `.claude/rules/subagent-worktree-isolation.md`.
+- **Dangerous commands** — before `rm -rf`, `git reset --hard`, or any other irreversible command, print the resolved absolute path/target and confirm it matches intent before executing. See `.claude/rules/dangerous-commands-safety.md`.
 - **Don't break the UNS confirmation gate.** Run `mira-run-hallucination-audit` after engine/bot edits.
 
 ## Testing expectations
@@ -220,6 +222,8 @@ Full rules: `.claude/rules/codegraph-usage.md`. Reference: `wiki/references/code
 - `.claude/rules/karpathy-principles.md` — coding behavior
 - `.claude/rules/debugging-conventions.md` — multi-cause perf debugging + verify schema/API paths before guessing
 - `.claude/rules/session-discipline.md` — premise-verify, regression-recheck, scoped-commits, migration-safety, long-task checkpointing
+- `.claude/rules/subagent-worktree-isolation.md` — parallel-dispatched sub-agents isolate via git worktree before touching files
+- `.claude/rules/dangerous-commands-safety.md` — print + confirm the resolved path before `rm -rf`/`git reset --hard`/etc.
 - `.claude/rules/codegraph-usage.md` — when to use CodeGraph vs grep/Read + trust model + preflight + blind spots
 - `.claude/rules/graphify-excluded.md` — Graphify excluded from code navigation (CodeGraph is the single code-nav graph)
 - `docs/specs/uns-kg-unification-spec.md` — UNS authority (data architecture)

--- a/.claude/rules/dangerous-commands-safety.md
+++ b/.claude/rules/dangerous-commands-safety.md
@@ -1,0 +1,68 @@
+# Dangerous Commands Safety
+
+Before running any command that **irreversibly discards data or history** —
+`rm -rf`, `git reset --hard`, `git clean -f`/`-fd`, `git checkout -- .`,
+`git restore .`, dropping a database/table, or force-overwriting a file —
+print the exact **resolved absolute path** (or target) first, and confirm it
+matches the intended target, before executing.
+
+## Rule
+
+1. **Resolve before you run.** Don't execute a destructive command against a
+   relative or ambiguous path. Run `pwd` / `realpath <path>` (or the
+   equivalent for the resource in question — e.g. the full DB connection
+   string's host, not just "prod") and state the resolved target in the same
+   turn, before the destructive command.
+2. **State the target explicitly, then act.** "This will delete
+   `/Users/charlienode/MIRA/.worktrees/stale-branch` (not the main checkout)"
+   — said out loud, in the response — before the `rm -rf` runs. Silent
+   execution of a destructive command is the failure mode this rule exists
+   to prevent.
+3. **When in doubt about scope, narrow the command or ask.** A destructive
+   command that could plausibly hit more than the intended target (a glob, a
+   missing trailing slash, a `..` in the path) gets rewritten to be
+   unambiguous, or the user is asked to confirm, before it runs.
+4. **This is doctrine, not a hook.** A `PreToolUse` hook can pattern-match
+   the command text but cannot verify "was the resolved path printed and
+   confirmed first" — that requires the response text preceding the tool
+   call. Enforcement is self-audit + human review of the transcript, the
+   same posture as `.claude/rules/train-before-deploy.md`.
+
+## Relationship to existing guards
+
+This rule is the general case; two narrower guards already exist and are
+unaffected:
+
+- **`tools/hooks/prod-guard.sh`** hard-blocks a specific class (prod-service
+  mutations: container restart/compose, `nginx -s`, `systemctl`, direct
+  writes to the VPS). It is a deterministic backstop for *production*
+  specifically — this rule covers the wider set of destructive **local**
+  commands prod-guard doesn't pattern-match (an errant `rm -rf` in the local
+  checkout, a `git reset --hard` that discards uncommitted work).
+- **The Git Safety Protocol** in the system prompt already requires
+  `git status` before any command that could discard uncommitted work
+  (`git checkout`/`restore`/`reset`/`clean` in a git repo) — this rule
+  extends the same discipline to non-git destructive commands (`rm -rf`
+  outside a repo, dropping a table) and adds the explicit
+  "print-the-resolved-path-first" step.
+
+## When this applies
+
+- Any `rm -rf`, `git reset --hard`, `git clean -f[d]`,
+  `git checkout -- .`/`git restore .`, `DROP TABLE`/`DROP DATABASE`, or
+  force-overwrite of a file that cannot be recovered from `git`.
+
+## When this does NOT apply
+
+- Reversible operations (a plain `git checkout <branch>`, a soft `git reset`,
+  deleting a file that's tracked and recoverable via `git checkout -- <file>`).
+- Deleting scratch files you created yourself this session in a scratchpad
+  directory — see the top-level "Executing actions with care" guidance.
+
+## Cross-references
+
+- `tools/hooks/prod-guard.sh` — the deterministic prod-mutation backstop
+- `.claude/rules/subagent-worktree-isolation.md` — the parallel-dispatch
+  analog (isolate instead of risking a shared checkout)
+- `.claude/rules/session-discipline.md` — `git status -s` before commits,
+  scoped commits

--- a/.claude/rules/subagent-worktree-isolation.md
+++ b/.claude/rules/subagent-worktree-isolation.md
@@ -1,0 +1,58 @@
+# Sub-agent Worktree Isolation
+
+Any sub-agent dispatched for parallel work that will `Edit`/`Write` files MUST
+operate in an isolated git worktree, or have explicit confirmation that there
+is no uncommitted work in the shared checkout it could clobber. Verify
+isolation **before** running any file/git commands — not after.
+
+## Why
+
+(Added 2026-07-06, from a Claude Code usage-insights report.) Two separate
+incidents where a dispatched sub-agent mutated the shared checkout instead of
+an isolated one, nearly destroying uncommitted work. The shared `~/MIRA`
+checkout routinely carries in-flight WIP from other sessions (see
+`project_concurrent_writers` — background sessions can revert edits or move
+`HEAD` out from under you). A sub-agent that edits files in that same
+checkout inherits that risk with none of the visibility a human has.
+
+## Rule
+
+1. **Default to `isolation: "worktree"`** on the `Agent` tool call for any
+   dispatch that will write code — especially when running >1 agent in
+   parallel. This is cheap insurance; the worktree is auto-removed if the
+   agent makes no changes.
+2. **Never assume a sub-agent "must" be isolated by default — verify it.**
+   Don't reason "it's just a small edit" as an excuse to skip isolation.
+   Check `git status -s` in the target checkout immediately before dispatch;
+   if it shows uncommitted changes that aren't yours, isolation is mandatory,
+   not optional.
+3. **Read-only sub-agents (research, search, review) are exempt.** Isolation
+   is for agents that call `Edit`/`Write`/`git commit` — a read-only agent
+   cannot clobber anything.
+4. **When isolation is skipped**, the dispatch prompt must say explicitly why
+   (e.g. "confirmed clean tree, single agent, no parallel dispatch") — don't
+   skip it silently.
+
+## When this applies
+
+- Any `Agent` tool call (or manual `git worktree add`) that dispatches a
+  sub-agent expected to mutate files, especially when dispatching multiple
+  agents in parallel against the same repo.
+
+## When this does NOT apply
+
+- Read-only sub-agents (`Explore`, research forks, review-only dispatches).
+- A single foreground session doing its own edits (not a dispatched
+  sub-agent) — ordinary `git status` hygiene before destructive git ops
+  applies instead; see `.claude/rules/dangerous-commands-safety.md` and
+  `.claude/rules/session-discipline.md` rule 3 (scoped commits).
+
+## Cross-references
+
+- Global `~/.claude/CLAUDE.md` § "Subagent Worktree Isolation" — the
+  cluster-wide version of this rule (applies to every project, not just
+  MIRA); this file is the MIRA-local pointer + rationale.
+- `.claude/rules/session-discipline.md` — scoped commits, premise
+  verification (the shared-checkout WIP problem this rule guards against).
+- `project_concurrent_writers` (session memory) — the incident record for
+  shared-checkout collisions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,26 @@ Installed 2026-04-20. Triggers on every PR to `main`/`develop`/`dev`.
 
 ---
 
+## Release / PR Workflow
+
+Any PR that touches shippable code must bump `/VERSION` (semver: feat→minor, fix→patch, breaking→major) and add a `docs/CHANGELOG.md` note. **CI-enforced** — `.github/workflows/version-gate.yml` (`Version Bump Check`) is a required status check on `main` and fails a code-touching PR that leaves `/VERSION` unchanged. Docs/wiki/markdown-only PRs are exempt (no bump required). See `docs/versioning.md` for semver conventions and the auto-tag-on-merge behavior.
+
+## Git Workflow
+
+`tools/hooks/git-state-guard.sh` (a `PreToolUse(Bash)` hook) blocks git mutators while the repo is mid-rebase or on a detached `HEAD` — **except** `git rebase --continue`/`--abort`/`--skip`/`--quit`, which are always allowed even mid-rebase, since they're the only way to resolve the wedge from inside a single Bash call. If a rebase gets wedged for a reason `--continue`/`--abort` can't resolve, **stop and ask the user** — don't retry with `MIRA_ALLOW_GIT_WEDGE=1`, `git reset --hard`, or by hand-deleting `.git/rebase-merge`. Those are destructive workarounds for a state a human should look at.
+
+## Sub-agents / Worktrees
+
+Any sub-agent dispatched for parallel work that will Edit/Write files MUST operate in its own isolated git worktree (`Agent` tool `isolation: "worktree"`) or have explicit confirmation there's no uncommitted foreign work in the shared checkout it could clobber — verified **before** running file/git commands, not after. See `.claude/rules/subagent-worktree-isolation.md`.
+
+## Safety / Dangerous Commands
+
+Before running `rm -rf`, `git reset --hard`, `git clean -f[d]`, or any other command that irreversibly discards data, print the exact resolved absolute path/target first and confirm it matches the intended target before executing. See `.claude/rules/dangerous-commands-safety.md`.
+
+## Security
+
+Credentials and passwords come from environment variables (Doppler-managed, `factorylm/{dev,stg,prd}`) — never hardcoded in scripts, including one-off `tools/`/`plc/` ops scripts and seed/migration scripts. Enforced by `.ast-grep-rules/hardcoded-secret.yml` (every PR, `code-review.yml`) and `gitleaks protect --staged` (pre-commit). See `.claude/rules/security-boundaries.md`.
+
 ## CLAUDE.md Maintenance
 
 This file targets **~120 lines** (map, not encyclopedia). Agent compliance drops past ~150.


### PR DESCRIPTION
## Summary

Closes #2568, #2569, #2570, #2571, #2572 — the 5-item CLAUDE.md doc goal.

- **Release / PR Workflow** (#2568): documents the existing `version-gate.yml` required check (VERSION bump + CHANGELOG note on any code-touching PR). No code change — gate already exists and is required.
- **Git Workflow** (#2571): documents the `git-state-guard.sh` `--continue`/`--abort`/`--skip` exemption. **Correction during work**: the underlying bug (hook blocking the exact recovery commands mid-rebase) was already fixed 2026-07-06 by `6845f5de` / PR #2508 — this PR only adds the missing doc pointer + the "stop and ask, don't force past a wedge" rule.
- **Sub-agents / Worktrees** (#2569): new `.claude/rules/subagent-worktree-isolation.md` + project CLAUDE.md cross-reference. The global `~/.claude/CLAUDE.md` already had this rule (2026-07-06); project-level doctrine was missing.
- **Safety / Dangerous Commands** (#2570): new `.claude/rules/dangerous-commands-safety.md` — print + confirm the resolved absolute path before `rm -rf`/`git reset --hard`/etc. Doctrine-level (a hook can't verify "was the path printed first").
- **Security** (#2572): documents env-var-only credentials, pointing at the existing `.ast-grep-rules/hardcoded-secret.yml` + gitleaks pre-commit enforcement (both already active — no gap found in a repo-wide grep for hardcoded password literals outside test fixtures).

All 5 sections are doc-only additions; the real enforcement mechanisms (version-gate.yml, git-state-guard.sh's existing exemption, ast-grep + gitleaks) already exist. Docs/markdown-only diff — `version-gate.yml` does not require a `/VERSION` bump for this PR.

## Test plan

- [x] `wc -l CLAUDE.md` — 286 lines (was ~260), reviewed for drift from the ~120-line target note (already over before this PR; not addressed here, out of scope).
- [x] Verified `git-state-guard.sh`'s `--continue`/`--abort`/`--skip` exemption is live on `origin/main` (`6845f5de`, PR #2508) before writing the doc section, per session-discipline rule 1 (premise verification).
- [x] Repo-wide grep for hardcoded `password = "..."` literals outside `.audit-worktrees/` scratch and test fixtures — clean.
- [ ] `version-gate.yml` — should pass without a bump (docs-only diff); confirm in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdK3bjKxvX931Q25rAhNDs