### PR TITLE
docs(eval): Run-A frozen evidence baseline for G+ Mini fault-code schema (Refs #2691)

### DIFF
--- a/docs/eval/drive-pack-faultcode-runA/BASELINE_REPORT.md
+++ b/docs/eval/drive-pack-faultcode-runA/BASELINE_REPORT.md
@@ -1,0 +1,105 @@
+# Run A — Frozen G+ Mini fault-code baseline
+
+**Status:** FROZEN, immutable. Do not edit, overwrite, or re-run in place. A new
+observation goes in a new dated directory, never here.
+**Subject:** IMPULSE G+ Mini — a Magnetek/Columbus-McKinnon crane/hoist VFD whose
+fault codes are **mnemonic alphanumerics** (`oC`, `oV`, `GF`, `BE2`, `LL1`, …),
+not integer enums.
+**Constraint honored:** the schema was **not** repaired, **no** fallback was
+added, extraction was **not** improved before this capture (per the freeze
+order). Read-only execution; the harness writes only into this directory.
+**Commit / env:** see `env.json`. **Metrics:** see `metrics.json`. **Hashes:**
+see `MANIFEST.json` / `MANIFEST.md`. **Execution log:** see `run.log`.
+
+---
+
+## Headline
+
+Under the current production schema and loader, the G+ Mini fault-code pack is
+**empty — 0% coverage — and that is the correct, honest result.** It is empty for
+**two independent reasons**, which this baseline deliberately keeps separate:
+
+1. **Data-availability floor.** There is **no G+ Mini source material** anywhere
+   in the repo or on the build host (no manual, candidate, gold set, or registry
+   entry; Magnetek is not even a recognized vendor). Nothing to extract. Full
+   evidence table: `raw_inputs/NO_SOURCE_MATERIAL.md`.
+2. **Schema-representation floor.** Even *with* source, the schema field
+   `live_decode.fault_codes: dict[int, str]` (`schema.py:56`) plus the loader
+   gate `loader.py::_int_keyed` (`loader.py:73-88`, invoked at `loader.py:275`)
+   **cannot represent a mnemonic identifier and hard-rejects it** with a
+   deterministic `ValueError`. A source-preserving G+ Mini pack does not load
+   *near-empty* — it **fails to load entirely**.
+
+Both were exercised against the **real production modules** (imported, not
+reconstructed) by `run_a_freeze.py`.
+
+## What the harness observed (three scenarios)
+
+| Scenario | What it exercised | Result |
+|---|---|---|
+| **S1** data-availability | `loader.resolve_pack()` for three G+ Mini identity strings, over the shipped packs `['durapulse_gs10','powerflex_40','powerflex_525']` | `None` for all three — G+ Mini matches no pack |
+| **S2** schema gate (field) | real `loader._int_keyed()` on the probe's mnemonic `fault_codes` | `ValueError: … non-numeric key 'oC' in live_decode.fault_codes — wire enum tables must be int-keyed` |
+| **S3** schema gate (whole pack) | real `loader._parse_pack()` on the full probe pack | same `ValueError` — the pack fails to load **entirely** (fault_codes is validated at load time) |
+
+## The abstraction leak (documented, per the freeze order)
+
+The int-keyed schema is **already leaky for a drive it "supports."** The shipped
+GS10 pack stores mnemonic identity **inside the description string, under an
+integer key**:
+
+```
+"21": "oL overload"          # mnemonic 'oL' embedded in the value
+"58": "CE10 modbus timeout"  # mnemonic 'CE10' embedded in the value
+"4":  "GFF ground fault"
+"12": "Lvd undervoltage"
+```
+
+So even today, the mnemonic identity has **no first-class field** — it is free
+text smuggled into the human-readable string. `dict[int, str]` cannot key on it,
+cannot index it, cannot cite it as an identifier. For GS10 this is survivable
+because GS10 *also* exposes an integer fault register; for a purely-mnemonic
+drive like G+ Mini it is fatal. This is the strongest single piece of evidence
+for the eventual Run-C direction (a source-preserved string identifier), and it
+is why the empty G+ Mini pack is the **honest deterministic result, not a bug to
+paper over**.
+
+## Compatibility-sensitive readers (any future schema change must preserve these)
+
+Five locations consume `live_decode.fault_codes` (or the numeric fault-code
+assumption) and gate any schema evolution:
+
+1. `mira-bots/shared/live_snapshot.py:48` — `_FAULT_CODES: dict[int,str] = _GS10_PACK.live_decode.fault_codes` (encodes the int-register assumption hardest).
+2. `mira-bots/shared/drive_packs/loader.py:275` — `_int_keyed` gate; **this is the code that produces this floor**.
+3. `mira-bots/shared/drive_packs/cards.py:89` — provenance read for `live_decode.fault_codes`.
+4. `mira-bots/shared/drive_packs/cards.py:93` — `for code, name in pack.live_decode.fault_codes.items()` (int iteration).
+5. `mira-bots/shared/drive_packs/template_reader.py` — numeric fault-code keying; **mirrors `docs/migrations/002_fault_codes.sql`** (sleeper: a string identifier needs a DB-migration story there too — verify the Neon column type before Run C).
+
+## Honest Run-A floor (do not massage)
+
+| Metric | Value |
+|---|---|
+| G+ Mini source material present | **False** |
+| G+ Mini resolves to a pack | **False** |
+| Deterministic resolution | **0.0%** |
+| Fallback | **0.0%** (no fallback exists in Run A) |
+| Unresolved | **100.0%** (12/12 probe tokens) |
+| Raw mnemonic tokens captured by schema | **0** |
+| G+ Mini pack coverage | **0.0%** |
+| Hard failures (unsafe guesses) | **0** — Run A emits no answer, so it is never confidently wrong |
+| Citation accuracy | N/A (no answers emitted) |
+| Latency / token cost | N/A / 0 (no model calls) |
+
+**Safety note:** Run A's "0 hard failures" is the safety bar Run B must clear.
+Run A resolves nothing and therefore never guesses a crane/hoist fault meaning.
+Any Run B that introduces a fallback must be **provably no-less-safe**: it must
+never turn an honest refusal into a confidently-wrong crane fault decode.
+
+## Provenance / integrity
+
+- The only test input, `raw_inputs/gplus_mini_faultcodes_synthetic_probe.json`,
+  is a **clearly-labeled synthetic probe** exercising the loader's key-type
+  contract. No real manual content was fabricated (there was none to begin with,
+  and inventing one would defeat the purpose of this baseline).
+- Nothing here was promoted to `gold/`, added as a candidate, merged, deployed,
+  or wired into any runtime path. WO-evidence behavior is untouched; no
+  production flag was changed.

--- a/docs/eval/drive-pack-faultcode-runA/MANIFEST.json
+++ b/docs/eval/drive-pack-faultcode-runA/MANIFEST.json
@@ -1,0 +1,81 @@
+{
+  "run": "A",
+  "subject": "IMPULSE G+ Mini fault-code baseline (frozen)",
+  "immutable": true,
+  "execution_timestamp_utc": "2026-07-14T04:18:21Z",
+  "commit_sha": "db1177c90adc37c86e00d41dd79ac275754a1b84",
+  "commit_branch_at_capture": "HEAD",
+  "python_version": "3.12.13",
+  "platform": "macOS-26.3-arm64-arm-64bit",
+  "schema_fault_codes_annotation": "dict[int, str]",
+  "loader_supported_schema_versions": [
+    1,
+    2
+  ],
+  "pack_versions": {
+    "durapulse_gs10": "2",
+    "powerflex_525": "2",
+    "powerflex_40": "2"
+  },
+  "extractor_dir": "tools/drive-pack-extract",
+  "extractor_version_note": "tools/drive-pack-extract has no version string; identity is the commit SHA above. GS10 is registered automatable=false (no generator+gold), and G+ Mini is absent from the registry entirely.",
+  "hash_algorithm": "sha256",
+  "self_excluded_from_hashing": [
+    "MANIFEST.json",
+    "MANIFEST.md",
+    "make_manifest.py"
+  ],
+  "artifact_count": 10,
+  "artifacts": [
+    {
+      "path": "BASELINE_REPORT.md",
+      "bytes": 5939,
+      "sha256": "1301f28cffd408ea63f458cc91d8ce3ef25ef082271cdf7ca7ae5fb25387572e"
+    },
+    {
+      "path": "RUN_B_DESIGN.md",
+      "bytes": 8238,
+      "sha256": "e8fa018617f534744f8e252a7aee4a86009d22e310693cda11af0105c1d70dcc"
+    },
+    {
+      "path": "env.json",
+      "bytes": 620,
+      "sha256": "1987b3b2ea950914a6d8843c75abfc715e071a118f32d31586c3059c83fb60e0"
+    },
+    {
+      "path": "extractor_output/gplus_mini_pack_result.json",
+      "bytes": 287,
+      "sha256": "5eada1a4145f8bfd72559c79cd8bab78135b92d33e97e20b75232b2337b2ac19"
+    },
+    {
+      "path": "extractor_output/loader_rejection.txt",
+      "bytes": 281,
+      "sha256": "ba045d20c845d9639b8eb596a78c02656f754b787f9833018c1239d87e7c283c"
+    },
+    {
+      "path": "metrics.json",
+      "bytes": 2039,
+      "sha256": "f098d45399331253a7c04200a8ea841993b1071215c75431ef08012503ef6dc2"
+    },
+    {
+      "path": "raw_inputs/NO_SOURCE_MATERIAL.md",
+      "bytes": 3117,
+      "sha256": "cfd62f2e47d03c7df5dc583c1c12f45427e8973b2f633bf5eeb8b15c74cf803b"
+    },
+    {
+      "path": "raw_inputs/gplus_mini_faultcodes_synthetic_probe.json",
+      "bytes": 1875,
+      "sha256": "63f41efb43677d336315e3ab524f708e77f2f1c01b077e0a7ac5185e5901d7c6"
+    },
+    {
+      "path": "run.log",
+      "bytes": 2024,
+      "sha256": "274771b2c8412460b53b5a96df3c926d4a098bdeb5bac1f32d7e0be59a7c5131"
+    },
+    {
+      "path": "run_a_freeze.py",
+      "bytes": 10433,
+      "sha256": "f9ca5e5a8145f3584ff85b8e3871f10ab0f72778158319c9c48ff8f73e4aafe4"
+    }
+  ]
+}

--- a/docs/eval/drive-pack-faultcode-runA/MANIFEST.md
+++ b/docs/eval/drive-pack-faultcode-runA/MANIFEST.md
@@ -1,0 +1,27 @@
+# Run A baseline — hash manifest
+
+- **Run:** A (frozen, immutable)
+- **Subject:** IMPULSE G+ Mini fault-code baseline
+- **Execution timestamp (UTC):** 2026-07-14T04:18:21Z
+- **Commit SHA:** `db1177c90adc37c86e00d41dd79ac275754a1b84`
+- **Branch at capture:** `HEAD`
+- **Python:** 3.12.13  ·  **Platform:** macOS-26.3-arm64-arm-64bit
+- **schema fault_codes annotation:** `dict[int, str]`
+- **Pack versions:** GS10 v2, PF525 v2, PF40 v2
+- **Hash algorithm:** sha256  ·  **Artifacts:** 10
+- **Self-excluded (chicken-and-egg):** MANIFEST.json, MANIFEST.md, make_manifest.py
+
+| Artifact | Bytes | sha256 |
+|---|---|---|
+| `BASELINE_REPORT.md` | 5939 | `1301f28cffd408ea63f458cc91d8ce3ef25ef082271cdf7ca7ae5fb25387572e` |
+| `RUN_B_DESIGN.md` | 8238 | `e8fa018617f534744f8e252a7aee4a86009d22e310693cda11af0105c1d70dcc` |
+| `env.json` | 620 | `1987b3b2ea950914a6d8843c75abfc715e071a118f32d31586c3059c83fb60e0` |
+| `extractor_output/gplus_mini_pack_result.json` | 287 | `5eada1a4145f8bfd72559c79cd8bab78135b92d33e97e20b75232b2337b2ac19` |
+| `extractor_output/loader_rejection.txt` | 281 | `ba045d20c845d9639b8eb596a78c02656f754b787f9833018c1239d87e7c283c` |
+| `metrics.json` | 2039 | `f098d45399331253a7c04200a8ea841993b1071215c75431ef08012503ef6dc2` |
+| `raw_inputs/NO_SOURCE_MATERIAL.md` | 3117 | `cfd62f2e47d03c7df5dc583c1c12f45427e8973b2f633bf5eeb8b15c74cf803b` |
+| `raw_inputs/gplus_mini_faultcodes_synthetic_probe.json` | 1875 | `63f41efb43677d336315e3ab524f708e77f2f1c01b077e0a7ac5185e5901d7c6` |
+| `run.log` | 2024 | `274771b2c8412460b53b5a96df3c926d4a098bdeb5bac1f32d7e0be59a7c5131` |
+| `run_a_freeze.py` | 10433 | `f9ca5e5a8145f3584ff85b8e3871f10ab0f72778158319c9c48ff8f73e4aafe4` |
+
+Verify: `cd docs/eval/drive-pack-faultcode-runA && shasum -a 256 <artifact>` and compare, or re-run `make_manifest.py` and diff MANIFEST.json (byte-identical on an unchanged tree).

--- a/docs/eval/drive-pack-faultcode-runA/RUN_B_DESIGN.md
+++ b/docs/eval/drive-pack-faultcode-runA/RUN_B_DESIGN.md
@@ -1,0 +1,142 @@
+# Run B — design proposal (NOT implemented)
+
+Run B is the **hybrid wrapper**: after the Run-A baseline is frozen (it is —
+see `MANIFEST.json`), let Claude resolve the manual-backed information the
+deterministic extractor *cannot represent*, while the deterministic path stays
+exactly as Run A froze it. This document is design only. **No Run-B code is
+written here.** It is scoped to the five locked constraints and nothing else.
+
+> Scientific frame: Run A = current deterministic system (frozen). Run B =
+> deterministic **+ explicit, labeled Claude fallback**. Run C = an improved
+> deterministic system *learned from* Run B's approved records. The end-state is
+> **not** "Claude fills the pack forever" — it is "code can't resolve → Claude
+> resolves with evidence → human approves → system learns → future runs resolve
+> deterministically."
+
+## The five locked constraints (the only contract Run B is designed against)
+
+### C1 — Preserve the exact raw fault token verbatim
+Every Run-B record MUST carry the source token exactly as written: `oC`, not
+`oc`/`OC`/`0xoC`/`212`. This is captured **before** any normalization so Run C
+can derive aliases later; a record that loses the raw form is unreconstructable.
+
+- **Record field:** `raw_token: str` (verbatim, case-preserved, whitespace-trimmed only).
+- **No coercion:** no numeric alias, hash, synthetic id, or casefold at capture time.
+- **Rationale grounded in Run A:** the GS10 leak (`'21' → 'oL overload'`) proves
+  mnemonic identity has no home today; C1 gives it one *in the Run-B record*,
+  without touching the frozen schema.
+
+### C2 — Fallback resolves identity / description / severity ONLY with a manual citation
+Claude may fill exactly three semantic fields, and only when it can cite a
+manual page/excerpt for them:
+
+- `identity` (what the code *is* — e.g. "Overcurrent"),
+- `description` (human-readable meaning),
+- `severity` (advisory band).
+
+Each MUST carry `citation = {doc, page, excerpt}` (mirrors the existing
+`schema.Citation` shape at `schema.py:115`). **No citation ⇒ the field stays
+`unresolved`.** A Run-B record with a filled semantic field and an empty citation
+is invalid and fails validation.
+
+### C3 — Fallback may NOT invent codes, claim wire/register values, or give operational guidance
+Hard prohibitions, enforced by the record validator, not by prompt alone:
+
+- **No invented codes.** Claude may only resolve a `raw_token` that appears in
+  the provided source excerpt set; a token with no supporting excerpt ⇒
+  `unresolved`, never a guessed meaning.
+- **No unverified wire/register values.** Claude MUST NOT assert a Modbus/EtherNet-IP
+  register address or an integer enum value for a mnemonic code. Those are
+  `bench_verified` facts; absent bench data the field is `null`, never a guess.
+  (This keeps Run B from silently re-introducing the very int-key the schema
+  demands — which would be laundering a guess through the fallback.)
+- **No operational guidance.** No reset, clear, override, fault-acknowledge,
+  jog, or any action step. Read-only-in-beta + `.claude/rules/fieldbus-readonly.md`
+  + `train-before-deploy`. Resolving what a code *means* (cited) is allowed;
+  telling anyone what to *do* is not.
+
+### C4 — Safety-relevant unresolved crane/hoist faults stay unresolved and HARD-FAIL
+G+ Mini is a lifting drive. A hallucinated crane fault meaning is a lifting-safety
+issue. So:
+
+- A configurable **safety-relevant token set** (brake `BE*`, overload `oL*`,
+  overspeed, load-check `LL*`, encoder/feedback loss, phase loss) that Claude
+  cannot resolve **with a citation** ⇒ status `unresolved` **and a hard fail** of
+  that record — never a low-confidence guess, never a "best effort" meaning.
+- **Invariant (the Run-A bar):** Run B must be **provably no-less-safe than Run
+  A's refusal.** Run A resolves nothing and guesses nothing (0 hard failures =
+  0 unsafe outputs). Run B's `hard_failures` metric counts any case where a
+  safety-relevant code was emitted with a meaning; the target is **0**, identical
+  to Run A. A Run B that turns an honest refusal into a confident-but-wrong
+  crane decode has regressed safety even if coverage went up.
+
+### C5 — An approved fallback result must be convertible to determinism
+The win condition. For every Run-B record a human/reviewer marks **approved**,
+there must be a mechanical path to all three of:
+
+1. a **deterministic parser/pack entry** (the resolved code now lives in data the
+   Run-C schema can key on, no LLM needed),
+2. a **`fixtures/` case** (input → expected deterministic output),
+3. a **regression test** asserting the code resolves **without** invoking Claude.
+
+If an approved record cannot produce all three, the fallback wasn't really
+"learnable" and the approval is incomplete. Run C's success metric is exactly
+this: the codes Claude resolved in Run B now resolve deterministically, and
+`pct_fallback` for G+ Mini trends to ~0.
+
+## Proposed Run-B record shape (design only — captures C1–C4, feeds C5)
+
+```jsonc
+{
+  "drive_family": "impulse_gplus_mini",
+  "raw_token": "BE2",                    // C1 — verbatim, case-preserved
+  "resolution_label": "llm_fallback",    // one of: deterministic | llm_fallback | unresolved
+  "identity":    "Brake answerback fault",   // C2 — null unless cited
+  "description": "Drive commanded the brake but did not…",  // C2 — null unless cited
+  "severity":    "safety_relevant",      // C2/C4 advisory band
+  "citation":    {"doc": "IMPULSE G+ Mini UM", "page": "7-4", "excerpt": "BE2 …"},  // C2 — required to fill semantics
+  "wire_value":  null,                   // C3 — never guessed; bench_verified only
+  "operational_guidance": null,          // C3 — always null in beta
+  "deterministic_failure_reason": "loader._int_keyed rejects non-numeric key 'BE2' (loader.py:275)",
+  "model": "<model id>",                 // provenance
+  "prompt_version": "<hash/tag>",        // provenance
+  "confidence": "low|medium|high",
+  "validation_status": "valid|invalid",  // record validator verdict
+  "review_state": "pending|approved|rejected",  // C5 gate — human action
+  "safety_hard_fail": false              // C4 — true iff safety-relevant & uncited
+}
+```
+
+Every field is labeled `deterministic` / `llm_fallback` / `unresolved`, and every
+semantic field is traceable to a citation, a deterministic failure reason, a
+model+prompt version, a validation status, and a review state — as required.
+
+## Run-B metrics to report (same axes as Run A, for the A/B/C comparison)
+
+`coverage`, `score`, `hard_failures`, `citation_accuracy`, `latency_ms`,
+`token_cost`, `pct_deterministic`, `pct_fallback`, `pct_unresolved`. Run A's
+frozen floor for each is in `metrics.json` (0 / 0 / 0 / N-A / N-A / 0 / 0 / 0 /
+100). Run B is judged against that floor **with C4 as a veto**: a coverage gain
+that raises `hard_failures` above Run A's 0 is a failure, not progress.
+
+## Explicitly deferred to Run C (do NOT decide or build in Run B)
+Per the freeze discipline, these are ratified from Run-B evidence, not
+pre-committed: string-keyed map vs structured record (#1), version-bump vs
+adapter (#2), exact/display/normalized/alias semantics (#3), case-sensitivity
+policy (#4 — but C1 already forbids casefold at capture, protecting the option),
+runtime/API compat across the five reader sites (#5), fault→parameter linking
+(#6), existing-pack migration (#7). Build none speculatively (Karpathy). The one
+open **input** Run B should gather for Run C: whether any two G+ Mini mnemonic
+codes differ only by case (drives the #4 decision), and whether G+ Mini exposes
+any integer fault register at all (drives whether `wire_value` can ever be
+non-null).
+
+## Guardrails on Run B itself
+- Read/label only. Run B does **not** modify `schema.py`, `loader.py`, any pack,
+  `gold/`, or any runtime path. It produces **records**, reviewed offline.
+- Needs the actual G+ Mini manual as cited source (absent today — see
+  `raw_inputs/NO_SOURCE_MATERIAL.md`); acquiring/curating it is a Run-B
+  prerequisite, tracked separately, and its PDF is never committed (registry +
+  `.gitignore` discipline).
+- No merge, deploy, promote-to-`gold/`, or baseline overwrite without explicit
+  approval.

--- a/docs/eval/drive-pack-faultcode-runA/env.json
+++ b/docs/eval/drive-pack-faultcode-runA/env.json
@@ -1,0 +1,18 @@
+{
+  "executed_utc": "2026-07-14T04:18:21Z",
+  "repo_commit": "db1177c90adc37c86e00d41dd79ac275754a1b84",
+  "repo_branch": "HEAD",
+  "python_version": "3.12.13",
+  "platform": "macOS-26.3-arm64-arm-64bit",
+  "loader_path": "/Users/bravonode/Mira/mira-bots/shared/drive_packs/loader.py",
+  "schema_path": "/Users/bravonode/Mira/mira-bots/shared/drive_packs/schema.py",
+  "fault_codes_annotation": "dict[int, str]",
+  "loader_supported_schema_versions": [
+    1,
+    2
+  ],
+  "gs10_pack_version": "2",
+  "powerflex_525_pack_version": "2",
+  "powerflex_40_pack_version": "2",
+  "extractor_dir": "tools/drive-pack-extract"
+}

--- a/docs/eval/drive-pack-faultcode-runA/extractor_output/gplus_mini_pack_result.json
+++ b/docs/eval/drive-pack-faultcode-runA/extractor_output/gplus_mini_pack_result.json
@@ -1,0 +1,6 @@
+{
+  "pack_id": "impulse_gplus_mini",
+  "loaded": false,
+  "reason": "load_pack would raise FileNotFoundError (no shipped pack); a source-preserving mnemonic-keyed pack raises ValueError at loader.py:275 (_int_keyed). Either way: zero usable fault decode.",
+  "fault_codes_decoded": {}
+}

--- a/docs/eval/drive-pack-faultcode-runA/extractor_output/loader_rejection.txt
+++ b/docs/eval/drive-pack-faultcode-runA/extractor_output/loader_rejection.txt
@@ -1,0 +1,5 @@
+Field-level (_int_keyed):
+pack 'impulse_gplus_mini': non-numeric key 'oC' in live_decode.fault_codes — wire enum tables must be int-keyed
+
+Pack-level (_parse_pack):
+pack 'impulse_gplus_mini': non-numeric key 'oC' in live_decode.fault_codes — wire enum tables must be int-keyed

--- a/docs/eval/drive-pack-faultcode-runA/make_manifest.py
+++ b/docs/eval/drive-pack-faultcode-runA/make_manifest.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3.12
+"""Hash every Run-A baseline artifact and emit MANIFEST.json + MANIFEST.md.
+
+Deterministic: sha256 of each file in this directory (except the manifests and
+this script), sorted by path. Records commit SHA, pack/extractor versions, and
+execution timestamp read from env.json (single source of truth for the stamp).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[2]
+SELF_EXCLUDE = {"MANIFEST.json", "MANIFEST.md", "make_manifest.py"}
+
+
+def sha256(p: Path) -> str:
+    h = hashlib.sha256()
+    h.update(p.read_bytes())
+    return h.hexdigest()
+
+
+def git(*a: str) -> str:
+    try:
+        return subprocess.check_output(["git", "-C", str(REPO), *a], text=True).strip()
+    except Exception as exc:
+        return f"<git error: {exc}>"
+
+
+env = json.loads((HERE / "env.json").read_text())
+
+files = sorted(
+    p for p in HERE.rglob("*")
+    if p.is_file() and p.name not in SELF_EXCLUDE and "__pycache__" not in p.parts
+)
+entries = [
+    {"path": str(p.relative_to(HERE)), "bytes": p.stat().st_size, "sha256": sha256(p)}
+    for p in files
+]
+
+manifest = {
+    "run": "A",
+    "subject": "IMPULSE G+ Mini fault-code baseline (frozen)",
+    "immutable": True,
+    "execution_timestamp_utc": env["executed_utc"],
+    "commit_sha": env["repo_commit"],
+    "commit_branch_at_capture": env["repo_branch"],
+    "python_version": env["python_version"],
+    "platform": env["platform"],
+    "schema_fault_codes_annotation": env["fault_codes_annotation"],
+    "loader_supported_schema_versions": env["loader_supported_schema_versions"],
+    "pack_versions": {
+        "durapulse_gs10": env["gs10_pack_version"],
+        "powerflex_525": env["powerflex_525_pack_version"],
+        "powerflex_40": env["powerflex_40_pack_version"],
+    },
+    "extractor_dir": env["extractor_dir"],
+    "extractor_version_note": (
+        "tools/drive-pack-extract has no version string; identity is the commit "
+        "SHA above. GS10 is registered automatable=false (no generator+gold), and "
+        "G+ Mini is absent from the registry entirely."
+    ),
+    "hash_algorithm": "sha256",
+    "self_excluded_from_hashing": sorted(SELF_EXCLUDE),
+    "artifact_count": len(entries),
+    "artifacts": entries,
+}
+
+(HERE / "MANIFEST.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+lines = [
+    "# Run A baseline — hash manifest",
+    "",
+    "- **Run:** A (frozen, immutable)",
+    "- **Subject:** IMPULSE G+ Mini fault-code baseline",
+    f"- **Execution timestamp (UTC):** {manifest['execution_timestamp_utc']}",
+    f"- **Commit SHA:** `{manifest['commit_sha']}`",
+    f"- **Branch at capture:** `{manifest['commit_branch_at_capture']}`",
+    f"- **Python:** {manifest['python_version']}  ·  **Platform:** {manifest['platform']}",
+    f"- **schema fault_codes annotation:** `{manifest['schema_fault_codes_annotation']}`",
+    f"- **Pack versions:** GS10 v{manifest['pack_versions']['durapulse_gs10']}, "
+    f"PF525 v{manifest['pack_versions']['powerflex_525']}, "
+    f"PF40 v{manifest['pack_versions']['powerflex_40']}",
+    f"- **Hash algorithm:** sha256  ·  **Artifacts:** {manifest['artifact_count']}",
+    f"- **Self-excluded (chicken-and-egg):** {', '.join(manifest['self_excluded_from_hashing'])}",
+    "",
+    "| Artifact | Bytes | sha256 |",
+    "|---|---|---|",
+]
+for e in entries:
+    lines.append(f"| `{e['path']}` | {e['bytes']} | `{e['sha256']}` |")
+lines.append("")
+lines.append("Verify: `cd docs/eval/drive-pack-faultcode-runA && "
+             "shasum -a 256 <artifact>` and compare, or re-run `make_manifest.py` "
+             "and diff MANIFEST.json (byte-identical on an unchanged tree).")
+lines.append("")
+(HERE / "MANIFEST.md").write_text("\n".join(lines))
+
+print(f"wrote MANIFEST.json + MANIFEST.md ({len(entries)} artifacts hashed)")
+for e in entries:
+    print(f"  {e['sha256'][:16]}…  {e['path']}")

--- a/docs/eval/drive-pack-faultcode-runA/metrics.json
+++ b/docs/eval/drive-pack-faultcode-runA/metrics.json
@@ -1,0 +1,41 @@
+{
+  "run": "A",
+  "subject": "IMPULSE G+ Mini (crane/hoist VFD, mnemonic fault codes)",
+  "executed_utc": "2026-07-14T04:18:21Z",
+  "repo_commit": "db1177c90adc37c86e00d41dd79ac275754a1b84",
+  "python": "3.12.13",
+  "schema_repaired": false,
+  "fallback_enabled": false,
+  "extraction_improved": false,
+  "gplus_mini_source_material_present": false,
+  "gplus_mini_resolves_to_pack": false,
+  "shipped_packs": [
+    "durapulse_gs10",
+    "powerflex_40",
+    "powerflex_525"
+  ],
+  "probe_mnemonic_tokens_total": 12,
+  "raw_tokens_captured_by_schema": 0,
+  "fault_codes_deterministically_resolved": 0,
+  "fault_codes_via_fallback": 0,
+  "fault_codes_unresolved": 12,
+  "pct_deterministic": 0.0,
+  "pct_fallback": 0.0,
+  "pct_unresolved": 100.0,
+  "gplus_mini_pack_coverage_pct": 0.0,
+  "field_level_gate_error": "pack 'impulse_gplus_mini': non-numeric key 'oC' in live_decode.fault_codes \u2014 wire enum tables must be int-keyed",
+  "pack_level_gate_error": "pack 'impulse_gplus_mini': non-numeric key 'oC' in live_decode.fault_codes \u2014 wire enum tables must be int-keyed",
+  "pack_loads_at_all": false,
+  "hard_failures": 0,
+  "citation_accuracy": null,
+  "latency_ms": null,
+  "token_cost": 0,
+  "compat_sensitive_readers": [
+    "mira-bots/shared/live_snapshot.py:48  (_FAULT_CODES: dict[int,str] = _GS10_PACK.live_decode.fault_codes)",
+    "mira-bots/shared/drive_packs/loader.py:275  (_int_keyed gate \u2014 produces this floor)",
+    "mira-bots/shared/drive_packs/cards.py:89  (provenance read)",
+    "mira-bots/shared/drive_packs/cards.py:93  (for code, name in pack.live_decode.fault_codes.items())",
+    "mira-bots/shared/drive_packs/template_reader.py  (numeric fault_code keying; mirrors docs/migrations/002_fault_codes.sql)"
+  ],
+  "abstraction_leak": "GS10 already smuggles mnemonic identity into the VALUE string under an INT key (e.g. '21' -> 'oL overload', '58' -> 'CE10 modbus timeout'); mnemonic identity has no first-class field today, so dict[int,str] is already a leaky abstraction even for a 'supported' drive."
+}

--- a/docs/eval/drive-pack-faultcode-runA/raw_inputs/NO_SOURCE_MATERIAL.md
+++ b/docs/eval/drive-pack-faultcode-runA/raw_inputs/NO_SOURCE_MATERIAL.md
@@ -1,0 +1,51 @@
+# Run A raw inputs — data-availability floor (READ THIS FIRST)
+
+**Finding: there is NO IMPULSE "G+ Mini" source material in this repository or on
+the build host.** This is a real, verifiable Run-A result, captured before any
+schema repair (per the freeze constraint). It means the empty G+ Mini pack has
+**two independent causes**, which must not be conflated:
+
+1. **Data-availability floor (this file).** No G+ Mini manual, candidate, gold
+   set, or registry entry exists. There is literally nothing to extract.
+2. **Schema-representation floor (`gplus_mini_faultcodes_synthetic_probe.json`).**
+   Even *given* source material, the current production schema
+   (`live_decode.fault_codes: dict[int, str]`) + loader
+   (`loader.py::_int_keyed`) cannot represent mnemonic fault identifiers such as
+   `oC` / `BE2` / `LL1`; it hard-rejects them.
+
+## Evidence for cause #1 (data availability)
+
+Gathered read-only on the frozen commit (see `../env.json` for the SHA):
+
+| Check | Command | Result |
+|---|---|---|
+| Repo-wide G+ Mini / IMPULSE / Magnetek / crane / hoist refs (source dirs) | `grep -rilE "g\+ ?mini\|impulse\|magnetek\|columbus.?mckinnon" mira-bots tools docs` | only `test_cross_vendor_canonical.py`, YouTube corpus tags, eval logs, competitor notes — **no manual, no pack, no candidate** |
+| Extractor manual registry | `tools/drive-pack-extract/registry/sources.json` | 3 manuals: PowerFlex 525, DURApulse GS10, PowerFlex 40. **No IMPULSE / G+ Mini.** |
+| Gitignored manuals dir | `ls tools/drive-pack-extract/manuals/` | empty |
+| Extractor candidates | `ls tools/drive-pack-extract/candidates/` | `powerflex_40`, `powerflex_525` only |
+| Filesystem-wide (home, Downloads, MiraDrop) | `find ~ -iregex '.*(impulse\|g.?plus.?mini\|magnetek).*\.(pdf\|json\|txt\|md)'` | **0 hits** |
+| Vendor recognition | `mira-bots/tests/test_cross_vendor_canonical.py:56` | asserts `canonical_vendor("Magnetek") is None` — the OEM of the IMPULSE G+ Mini is **not even a recognized vendor** |
+
+**Conclusion for cause #1:** the extractor cannot be run against a real G+ Mini
+manual because none is present. No real manual content was fabricated to fill
+this gap — doing so would violate the evidence-integrity rule this baseline
+exists to protect.
+
+## What the synthetic probe is (and is NOT)
+
+`gplus_mini_faultcodes_synthetic_probe.json` is a **synthetic, clearly-labeled
+probe** used *only* to exercise the real production loader gate against
+mnemonic-style keys. Its purpose is to isolate cause #2 (schema representation)
+from cause #1 (data availability). It is NOT:
+
+- extracted from any manual,
+- authoritative or complete,
+- a candidate or a proposed pack,
+- input to any promotion / `gold/` path.
+
+The mnemonic tokens it uses (`oC`, `BE2`, `LL1`, …) are drawn from the publicly
+documented IMPULSE-series fault-code *naming convention* (mnemonic alphanumeric
+codes, not integer enums). They stand in for "any source-preserved mnemonic
+identifier" — the point being tested is the loader's key-type contract, not the
+specific semantics of any one code. See the file's own header for its provenance
+label.

--- a/docs/eval/drive-pack-faultcode-runA/raw_inputs/gplus_mini_faultcodes_synthetic_probe.json
+++ b/docs/eval/drive-pack-faultcode-runA/raw_inputs/gplus_mini_faultcodes_synthetic_probe.json
@@ -1,0 +1,37 @@
+{
+  "_provenance": "SYNTHETIC PROBE — NOT extracted manual content. Clearly-labeled test input whose ONLY purpose is to exercise the real production loader gate (mira-bots/shared/drive_packs/loader.py::_int_keyed) against source-preserved mnemonic fault identifiers. Not authoritative, not complete, not a candidate, never promoted. See raw_inputs/NO_SOURCE_MATERIAL.md.",
+  "_mnemonic_source": "Public IMPULSE-series fault-code NAMING CONVENTION (mnemonic alphanumeric codes, e.g. oC/oV/GF/BE). Codes stand in for 'any source-preserved mnemonic identifier'; the test is the loader's key-type contract, not per-code semantics.",
+  "_note_case_sensitivity": "Includes lowercase-leading tokens (oC, oV, oH) deliberately — the current int-keyed schema cannot represent them at all, and any future normalization MUST NOT casefold them away (oC vs OC is a real manufacturer distinction). Recorded for the Run-C case-sensitivity decision.",
+  "pack_id": "impulse_gplus_mini",
+  "schema_version": 1,
+  "family": {
+    "manufacturer": "Magnetek",
+    "series": "IMPULSE G+ Mini",
+    "aliases": ["IMPULSE G+ Mini", "G+ Mini", "IMPULSE Series 4"]
+  },
+  "nameplate": { "match_keywords": ["IMPULSE", "G+ Mini", "Magnetek"] },
+  "live_decode": {
+    "status_bits": {},
+    "cmd_word": {},
+    "fault_codes": {
+      "oC": "Overcurrent",
+      "oV": "DC bus overvoltage",
+      "Uv1": "DC bus undervoltage",
+      "oH": "Heatsink overheat",
+      "oL1": "Motor overload",
+      "oL2": "Drive overload",
+      "GF": "Ground fault",
+      "LL1": "Load check / light-load fault",
+      "BE2": "Brake answerback fault",
+      "SE1": "Sequence / travel-limit fault",
+      "CE": "Modbus communication error",
+      "EF": "External fault"
+    }
+  },
+  "envelope": {},
+  "knowledge": {},
+  "provenance": {
+    "items": { "live_decode.fault_codes": "manual_cited" },
+    "sources": []
+  }
+}

--- a/docs/eval/drive-pack-faultcode-runA/run_a_freeze.py
+++ b/docs/eval/drive-pack-faultcode-runA/run_a_freeze.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3.12
+"""Run A — freeze the unchanged G+ Mini fault-code baseline.
+
+READ-ONLY. This harness imports the REAL production drive-pack loader/schema
+(mira-bots/shared/drive_packs) and exercises it against the G+ Mini case. It
+does NOT modify the schema, add fallback, or improve extraction. It writes only
+into this baseline directory (extractor_output/, metrics.json, run.log, env.json)
+— never into production code, never into packs/, gold/, or candidates/.
+
+Three scenarios establish the honest Run-A floor:
+
+  S1  Data-availability floor: resolve_pack() against G+ Mini identity text ->
+      None (no pack matches; there is no source material — see
+      raw_inputs/NO_SOURCE_MATERIAL.md).
+
+  S2  Schema-gate floor (field level): feed the mnemonic-keyed fault_codes from
+      the synthetic probe to the REAL loader._int_keyed() -> deterministic
+      ValueError on the first non-numeric key.
+
+  S3  Schema-gate floor (whole pack): feed the full synthetic probe pack to the
+      REAL loader._parse_pack() -> the pack fails to load ENTIRELY (not
+      near-empty) because fault_codes is validated by _int_keyed at load time.
+
+Usage:  python3.12 run_a_freeze.py
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[2]  # docs/eval/drive-pack-faultcode-runA -> repo root
+SHARED = REPO / "mira-bots" / "shared"
+sys.path.insert(0, str(SHARED))
+
+from drive_packs import loader, schema  # noqa: E402  (real production modules)
+
+
+def _git(*args: str) -> str:
+    try:
+        return subprocess.check_output(["git", "-C", str(REPO), *args], text=True).strip()
+    except Exception as exc:  # pragma: no cover - env metadata is best-effort
+        return f"<git error: {exc}>"
+
+
+def _pack_version(pack_id: str) -> str:
+    """schema_version currently shipped for a live pack, read-only."""
+    p = SHARED / "drive_packs" / "packs" / pack_id / "pack.json"
+    if not p.is_file():
+        return "<no shipped pack>"
+    try:
+        return str(json.loads(p.read_text())["schema_version"])
+    except Exception as exc:
+        return f"<read error: {exc}>"
+
+
+def main() -> int:
+    log: list[str] = []
+
+    def emit(line: str = "") -> None:
+        print(line)
+        log.append(line)
+
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    probe_path = HERE / "raw_inputs" / "gplus_mini_faultcodes_synthetic_probe.json"
+    probe = json.loads(probe_path.read_text())
+
+    emit("=" * 72)
+    emit("RUN A — FROZEN G+ MINI FAULT-CODE BASELINE (read-only)")
+    emit(f"executed_utc={ts}")
+    emit(f"repo_commit={_git('rev-parse', 'HEAD')}")
+    emit(f"python={platform.python_version()}  platform={platform.platform()}")
+    emit(f"loader={loader.__file__}")
+    emit(f"schema.LiveDecode.fault_codes annotation = "
+         f"{schema.LiveDecode.__annotations__['fault_codes']!r}")
+    emit(f"loader supported schema_versions = {sorted(loader._SUPPORTED_SCHEMA_VERSIONS)}")
+    emit("=" * 72)
+
+    metrics: dict[str, object] = {
+        "run": "A",
+        "subject": "IMPULSE G+ Mini (crane/hoist VFD, mnemonic fault codes)",
+        "executed_utc": ts,
+        "repo_commit": _git("rev-parse", "HEAD"),
+        "python": platform.python_version(),
+        "schema_repaired": False,
+        "fallback_enabled": False,
+        "extraction_improved": False,
+    }
+
+    # ── S1: data-availability floor ──────────────────────────────────────────
+    emit("\n[S1] Data-availability floor — resolve_pack() over shipped packs")
+    shipped = loader.list_packs()
+    emit(f"     shipped packs = {shipped}")
+    for text in ("IMPULSE G+ Mini crane VFD", "Magnetek G+ Mini", "G+ Mini hoist drive"):
+        hit = loader.resolve_pack(text)
+        emit(f"     resolve_pack({text!r:40}) -> {hit.pack_id if hit else None}")
+    s1_matches = any(loader.resolve_pack(t) for t in
+                     ("IMPULSE G+ Mini crane VFD", "Magnetek G+ Mini", "G+ Mini hoist drive"))
+    emit(f"     RESULT: G+ Mini resolves to a pack? {s1_matches}  (expected: False — no source)")
+
+    # ── S2: schema-gate floor (field level) ──────────────────────────────────
+    emit("\n[S2] Schema-gate floor — real loader._int_keyed() on mnemonic fault_codes")
+    raw_fc = probe["live_decode"]["fault_codes"]
+    emit(f"     probe fault_codes keys = {list(raw_fc)}")
+    s2_error = None
+    try:
+        loader._int_keyed(raw_fc, pack_id=probe["pack_id"], field_name="fault_codes")
+        emit("     UNEXPECTED: _int_keyed accepted mnemonic keys")
+    except ValueError as exc:
+        s2_error = str(exc)
+        emit(f"     ValueError (deterministic, fail-closed): {s2_error}")
+
+    # ── S3: schema-gate floor (whole pack) ───────────────────────────────────
+    emit("\n[S3] Schema-gate floor — real loader._parse_pack() on the full probe")
+    s3_error = None
+    try:
+        loader._parse_pack(probe, probe["pack_id"], str(probe_path))
+        emit("     UNEXPECTED: pack parsed")
+    except ValueError as exc:
+        s3_error = str(exc)
+        emit(f"     ValueError (pack fails to load ENTIRELY, not near-empty): {s3_error}")
+
+    # ── Honest floor metrics ─────────────────────────────────────────────────
+    total_source_tokens = len(raw_fc)
+    metrics.update({
+        "gplus_mini_source_material_present": False,
+        "gplus_mini_resolves_to_pack": bool(s1_matches),
+        "shipped_packs": shipped,
+        "probe_mnemonic_tokens_total": total_source_tokens,
+        "raw_tokens_captured_by_schema": 0,
+        "fault_codes_deterministically_resolved": 0,
+        "fault_codes_via_fallback": 0,
+        "fault_codes_unresolved": total_source_tokens,
+        "pct_deterministic": 0.0,
+        "pct_fallback": 0.0,
+        "pct_unresolved": 100.0,
+        "gplus_mini_pack_coverage_pct": 0.0,
+        "field_level_gate_error": s2_error,
+        "pack_level_gate_error": s3_error,
+        "pack_loads_at_all": s3_error is None,
+        "hard_failures": 0,  # Run A neither guesses nor emits any answer -> zero unsafe outputs
+        "citation_accuracy": None,  # N/A: no answers emitted
+        "latency_ms": None,         # N/A: no model calls
+        "token_cost": 0,            # N/A: no model calls
+        "compat_sensitive_readers": [
+            "mira-bots/shared/live_snapshot.py:48  (_FAULT_CODES: dict[int,str] = _GS10_PACK.live_decode.fault_codes)",
+            "mira-bots/shared/drive_packs/loader.py:275  (_int_keyed gate — produces this floor)",
+            "mira-bots/shared/drive_packs/cards.py:89  (provenance read)",
+            "mira-bots/shared/drive_packs/cards.py:93  (for code, name in pack.live_decode.fault_codes.items())",
+            "mira-bots/shared/drive_packs/template_reader.py  (numeric fault_code keying; mirrors docs/migrations/002_fault_codes.sql)",
+        ],
+        "abstraction_leak": (
+            "GS10 already smuggles mnemonic identity into the VALUE string under an "
+            "INT key (e.g. '21' -> 'oL overload', '58' -> 'CE10 modbus timeout'); "
+            "mnemonic identity has no first-class field today, so dict[int,str] is "
+            "already a leaky abstraction even for a 'supported' drive."
+        ),
+    })
+
+    emit("\n" + "=" * 72)
+    emit("HONEST RUN-A FLOOR")
+    emit(f"     source material present ............ {metrics['gplus_mini_source_material_present']}")
+    emit(f"     deterministic resolution ........... {metrics['pct_deterministic']}%")
+    emit(f"     fallback ........................... {metrics['pct_fallback']}%")
+    emit(f"     unresolved ......................... {metrics['pct_unresolved']}%")
+    emit(f"     raw tokens captured by schema ...... {metrics['raw_tokens_captured_by_schema']}")
+    emit(f"     G+ Mini pack coverage .............. {metrics['gplus_mini_pack_coverage_pct']}%")
+    emit(f"     hard failures (unsafe guesses) ..... {metrics['hard_failures']}")
+    emit("=" * 72)
+
+    # ── write outputs (this dir only) ────────────────────────────────────────
+    out_dir = HERE / "extractor_output"
+    (out_dir / "loader_rejection.txt").write_text(
+        "Field-level (_int_keyed):\n" + (s2_error or "<none>") + "\n\n"
+        "Pack-level (_parse_pack):\n" + (s3_error or "<none>") + "\n"
+    )
+    # The "extracted pack" the current production path yields for G+ Mini:
+    (out_dir / "gplus_mini_pack_result.json").write_text(json.dumps({
+        "pack_id": "impulse_gplus_mini",
+        "loaded": False,
+        "reason": "load_pack would raise FileNotFoundError (no shipped pack); a "
+                  "source-preserving mnemonic-keyed pack raises ValueError at "
+                  "loader.py:275 (_int_keyed). Either way: zero usable fault decode.",
+        "fault_codes_decoded": {},
+    }, indent=2) + "\n")
+
+    (HERE / "metrics.json").write_text(json.dumps(metrics, indent=2) + "\n")
+
+    env = {
+        "executed_utc": ts,
+        "repo_commit": _git("rev-parse", "HEAD"),
+        "repo_branch": _git("rev-parse", "--abbrev-ref", "HEAD"),
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "loader_path": loader.__file__,
+        "schema_path": schema.__file__,
+        "fault_codes_annotation": str(schema.LiveDecode.__annotations__["fault_codes"]),
+        "loader_supported_schema_versions": sorted(loader._SUPPORTED_SCHEMA_VERSIONS),
+        "gs10_pack_version": _pack_version("durapulse_gs10"),
+        "powerflex_525_pack_version": _pack_version("powerflex_525"),
+        "powerflex_40_pack_version": _pack_version("powerflex_40"),
+        "extractor_dir": "tools/drive-pack-extract",
+    }
+    (HERE / "env.json").write_text(json.dumps(env, indent=2) + "\n")
+    (HERE / "run.log").write_text("\n".join(log) + "\n")
+
+    emit("\nwrote: extractor_output/loader_rejection.txt, "
+         "extractor_output/gplus_mini_pack_result.json, metrics.json, env.json, run.log")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What this is (and is NOT)

The **immutable Run-A evidence baseline** for the drive-pack fault-code schema investigation on the
IMPULSE **G+ Mini** (crane/hoist VFD, mnemonic fault codes `oC`/`BE2`/`LL1`).

- ✅ It **is** a frozen, hashed, independently-verified measurement of *current production behavior*.
- ❌ It is **NOT** the extractor fix / dialect, and makes **no** runtime schema decision.

**Refs #2691** (does **not** close it). #2691 — *"add a Magnetek/IMPULSE extractor dialect (0/0 on
G+ Mini …)"* — is the eventual fix; **this PR is the frozen floor that fix will be measured against.**

## Provenance / commits (why this replaces #2692)

The artifacts were originally frozen as **`3afcb50d`** (baseline) + **`a54c58fc`** (ruff-F541
lint-only) on branch `chore/drive-pack-faultcode-runA-baseline`. That branch was mistakenly cut
from an **unmerged feature commit** (`db1177c9`), so a PR from it dragged in foreign ops-agent files
and a VERSION downgrade (closed as #2692). This branch is a **byte-identical re-parent onto main**
(carrier commit `77d15d27`) with a **docs/eval-only diff**. The original `3afcb50d`/`a54c58fc`
remain intact on the old branch as the immutable record.

## Headline — the honest floor (not massaged)

| Metric | Value |
|---|---|
| Deterministic resolution | **0%** |
| Fallback | **0%** |
| Unresolved | **100%** |
| Hard failures (unsafe guesses) | **0** |

Under `fault_codes: dict[int, str]` (`schema.py:56`) + the `_int_keyed` gate (`loader.py:275`), a
source-preserving mnemonic-keyed G+ Mini pack **fails to load entirely** — not near-empty. The empty
pack is the **correct, honest result**, from two independent causes kept separate: (1) **no G+ Mini
source material exists** anywhere (Magnetek isn't even a recognized vendor), and (2) the int-keyed
schema cannot represent a mnemonic identifier. Exercised against the **real production loader**. GS10
abstraction leak documented (mnemonic smuggled into the int-keyed *value* string, e.g.
`'21' → 'oL overload'`).

## Evidence integrity

- All **10 artifact SHA-256** recorded in `MANIFEST.json`; `make_manifest.py` is **self-excluded**;
  re-verified byte-identical after the re-parent (capture provenance `db1177c9` preserved).
- Raw input is a **clearly-labeled synthetic probe** — no manual content fabricated.
- **Three read-only Sonnet verifiers all PASS** (hash recompute, factual claims, safety invariants).

## Run B — the five locked constraints (design only; `docs/eval/drive-pack-faultcode-runA/RUN_B_DESIGN.md`)

1. **C1** — preserve the exact raw fault token verbatim (no casefold at capture).
2. **C2** — fallback may resolve identity/description/severity **only** with a manual citation.
3. **C3** — fallback may **not** invent codes, claim unverified wire/register values, or give
   reset/override/clearing/operational guidance.
4. **C4** — safety-relevant unresolved crane/hoist faults stay **unresolved and hard-fail** (never
   guessed); Run B must be **provably no-less-safe than Run A's 0 hard failures**.
5. **C5** — an approved fallback record must convert to a deterministic parser/pack entry + a
   `fixtures/` case + a regression test proving Claude is no longer needed.

## Scope guarantees (explicit)

**No** runtime schema decision · **No** `gold/` promotion · **No** deployment · **No** flags · **No**
WO-evidence changes · **No** production effects.

## For Run B

Run B must use **this PR's frozen artifacts as its comparison floor** — do **not** regenerate
Run A. Floor lives at `docs/eval/drive-pack-faultcode-runA/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)