### PR TITLE
docs(wiki): eval-fixer run 2026-07-19 (47/57, no-patch)

### DIFF
--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -1138,3 +1138,10 @@ and P0/P1/P2 failures become redacted, fingerprint-deduped GitHub issues. P3 noi
 - Scorecard: 47/57 passing (82%) — from 2026-06-27T2229 run
 - Action: issue-filed (commented on #1876)
 - Multi-file cluster hard stop: failures span engine.py (8 fixtures, FSM state mismatches) + guardrails.py/prompts (1 fixture, gs3_ground_fault keyword miss). Autopatch skipped; next steps in issue comment.
+
+## eval-fixer run — 2026-07-19
+- Scorecard: 47/57 passing (82%) — from 2026-07-19T0322 run; in the normal 44–51 band, **0 regressions flagged.**
+- Action: issue-filed (comment on rolling tracker #1876). **This wiki entry was committed to a fresh `origin/main`-based branch** (`docs/eval-fixer-2026-07-19`) because the working checkout was **334 commits behind main** — main's `hot.md` ends at 2026-06-27, so every eval-fixer entry 06-28 → 07-18 is **stranded** on the stale grab-bag branch and never reached main. This is the #2759 stranding bug, worse than realized (~3 weeks of reports lost to main).
+- No patch: same #2759 structurally-unsatisfiable gate — 10 failures / 10 patchable but the watchdog emits **3 file_clusters** (engine.py, guardrails.py, active.yaml; each `cp_keyword_match` statically maps to guardrails.py+active.yaml), tripping the multi-cluster hard stop.
+- Honest decomposition of the 10: **3 provider-timeout flakes** (`gs10_overcurrent_01`, `pf520_hw_overcurrent_17`, `vfd_abb_01_acs580_fault_2310` — all ended on the "taking longer than usual" placeholder, inflating the count, NOT content bugs); **5 engine.py FSM over-qualify-by-one-state** (`pf525_f004_02` Q2→DIAGNOSIS, `vague_opener_05` & `asset_change_08` & `abbreviation_10` Q1→Q2, `self_critique_34` IDLE→Q1); **2 KB/keyword misses** (`gs3_ground_fault_14` KB-miss honesty fallback, `vfd_siemens_04_v20_startup` generic+KB-gap).
+- Highest-leverage human fix remains the engine.py FSM pacing cluster; the #2759 watchdog-gate fix and the wiki-stranding fix both still outstanding.


### PR DESCRIPTION
Nightly eval-fixer wiki update for the 2026-07-19 offline scorecard (47/57, in-band, 0 regressions).

**Why a PR (not a direct branch commit):** the eval-fixer's working checkout was 334 commits behind main and its `wiki/hot.md` entries since 2026-06-28 are stranded on a stale grab-bag branch — main's `hot.md` still ends at 2026-06-27. This branch is cut fresh off `origin/main` so tonight's entry actually reaches main. Tracks the #2759 stranding problem.

Full scorecard decomposition is on rolling tracker #1876. No code patch (multi-cluster hard stop + in-band noise).

🤖 Generated by eval-fixer agent