### PR TITLE
[TEST-DO-NOT-MERGE] CI Gate docs-only verification

### DIFF
--- a/docs/_ci_gate_docs_only_test.md
+++ b/docs/_ci_gate_docs_only_test.md
@@ -1,0 +1,3 @@
+# CI Gate docs-only verification
+
+Throwaway file to prove a docs-only PR skips heavy jobs but still produces a green CI Gate. Delete with the branch.


### PR DESCRIPTION
Throwaway verification PR (evidence #3): a docs-only change should SKIP the heavy jobs (test-unit et al.) and still produce a green **CI Gate**. Base is the temporary test/** trigger branch. Will be closed unmerged and its branches deleted.