### PR TITLE
[TEST-DO-NOT-MERGE] CI Gate failure-mode verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,6 @@ jobs:
               - '!**/*.png'
               - '!**/*.jpg'
               - '!**/*.gif'
-      - name: INJECTED FAILURE (verification only — must be removed)
-        run: exit 1
 
   actionlint:
     name: actionlint
@@ -83,6 +81,8 @@ jobs:
     name: Migration Order Check
     runs-on: ubuntu-latest
     steps:
+      - name: INJECTED FAILURE (verification only — must be removed)
+        run: exit 1
       - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
               - '!**/*.png'
               - '!**/*.jpg'
               - '!**/*.gif'
+      - name: INJECTED FAILURE (verification only — must be removed)
+        run: exit 1
 
   actionlint:
     name: actionlint


### PR DESCRIPTION
Throwaway verification PR. Push 1 (evidence #5): the `changes` job is intentionally broken (`exit 1`) — CI Gate MUST go red (fail-closed: a failed changes job can never pass the gate). Push 2 will instead break a gated job (evidence #4). Injections removed before any real merge; branch deleted after.