### PR TITLE
fix(ci): repair four red scheduled monitors

### DIFF
--- a/.github/workflows/ci-evals.yml
+++ b/.github/workflows/ci-evals.yml
@@ -37,7 +37,12 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install pytest pytest-asyncio pyyaml
+          # httpx is imported at pytest COLLECTION time by many test modules
+          # (tests/beta, tests/conversation_suite, tools.drift_monitor, ...). The
+          # `-m "not network"` deselect happens AFTER import, so without httpx
+          # collection dies with 69 "ModuleNotFoundError: No module named 'httpx'"
+          # errors before any test runs. Install it so the whole tree collects.
+          pip install pytest pytest-asyncio pyyaml httpx
 
       - name: Run offline eval tests
         run: |

--- a/.github/workflows/dogfood-judge-heartbeat.yml
+++ b/.github/workflows/dogfood-judge-heartbeat.yml
@@ -31,8 +31,13 @@ jobs:
         id: check
         run: |
           set -euo pipefail
+          # NOTE: with --paginate, `gh --jq` applies the filter to EACH page
+          # separately, so `max_by` emits one object per page → multiple
+          # created_at values downstream → `date -d` gets a multi-line string and
+          # fails "invalid date". Fetch raw pages and aggregate ONCE with `jq -s`
+          # (`add` flattens the array-of-page-arrays) so exactly one object comes out.
           latest="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${ISSUE}/comments" \
-            --jq 'map(select(.body | contains("<!-- dogfood-heartbeat -->"))) | max_by(.created_at) // {}')"
+            | jq -s 'add | map(select(.body | contains("<!-- dogfood-heartbeat -->"))) | max_by(.created_at) // {}')"
           created="$(printf '%s' "$latest" | jq -r '.created_at // ""')"
           body="$(printf '%s' "$latest" | jq -r '.body // ""')"
           if [ -z "$created" ]; then

--- a/.github/workflows/proposal-state-canary.yml
+++ b/.github/workflows/proposal-state-canary.yml
@@ -43,4 +43,15 @@ jobs:
       - name: Proposal-state drift canary (staging)
         env:
           NEON_DATABASE_URL: ${{ secrets.NEON_STG_DATABASE_URL }}
-        run: python3 tests/canary/run_proposal_canary.py
+        run: |
+          set -uo pipefail
+          # A canary that cannot reach its DB is UNCONFIGURED, not failing. When the
+          # staging DB secret isn't wired, skip with a loud warning instead of a hard
+          # red (run_proposal_canary.py exits 2 on a missing URL). This keeps the
+          # scheduled monitor green until NEON_STG_DATABASE_URL is configured, and the
+          # canary still fails loudly on REAL drift once the secret is present.
+          if [ -z "${NEON_DATABASE_URL:-}" ]; then
+            echo "::warning::NEON_STG_DATABASE_URL is not configured — skipping the proposal-state drift canary (unconfigured, not a drift failure). Wire the staging DB secret to activate it."
+            exit 0
+          fi
+          python3 tests/canary/run_proposal_canary.py

--- a/.github/workflows/web-review-canary.yml
+++ b/.github/workflows/web-review-canary.yml
@@ -22,7 +22,7 @@ jobs:
     name: Headless audit (Lighthouse + headers + edges)
     runs-on: ubuntu-latest
     permissions:
-      contents: write      # needed to commit the wiki report back to main
+      contents: read       # report is published as a build artifact, not pushed to main
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -140,30 +140,19 @@ jobs:
             --out "wiki/reviews/$(date -u +%F)-factorylm.com.md"
           echo "::notice::Report written to wiki/reviews/$(date -u +%F)-factorylm.com.md"
 
-      - name: Commit + push wiki report
-        run: |
-          git config user.email "web-review-canary@factorylm.com"
-          git config user.name "web-review canary"
-          git add wiki/reviews/
-          if git diff --cached --quiet; then
-            echo "::notice::No wiki changes to commit (report unchanged)."
-            exit 0
-          fi
-          git commit -m "chore(web-review): daily canary $(date -u +%FT%H%MZ)"
-          # main moves under this scheduled canary (other pushes land while it
-          # runs), so a bare push hits `! [rejected] non-fast-forward`. Rebase
-          # onto latest main before pushing; retry a few times to absorb a
-          # concurrent push that lands mid-rebase. The report is an append-only
-          # new file, so the rebase never conflicts.
-          ok=0
-          for attempt in 1 2 3; do
-            if git pull --rebase origin main && git push origin HEAD:main; then
-              ok=1; break
-            fi
-            echo "::notice::push attempt $attempt raced a moving main; retrying"
-            sleep $((attempt * 3))
-          done
-          [ "$ok" = 1 ] || { echo "::error::web-review canary: push failed after 3 rebase attempts"; exit 1; }
+      - name: Publish report as artifact (never push to protected main)
+        # `main` is a protected branch — a scheduled job pushing straight to it is
+        # rejected (branch protection), which red-failed this canary every day.
+        # Publish the vault report as a downloadable build artifact instead; the
+        # findings summary is also surfaced in the run summary step below. No push,
+        # no PR spam, no protected-branch write.
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: web-review-report-${{ github.run_number }}
+          path: wiki/reviews/
+          if-no-files-found: warn
+          retention-days: 90
 
       - name: Surface P0/P1 in run summary
         if: always()


### PR DESCRIPTION
**Draft** — repairs the four currently-failing scheduled monitor workflows. Workflow/CI-config only; no application code.

## Failures fixed (with evidence)
| Workflow | Latest failing run | Root cause | Fix |
|---|---|---|---|
| **Dogfood Judge Heartbeat** | run 30039764798 | `gh api --paginate --jq 'max_by(.created_at)'` runs the jq filter **per page**, so `max_by` emits one object per page → `$created` is multi-line → `date -d` → "invalid date" | aggregate across pages once: `gh api --paginate ... \| jq -s 'add \| map(select(...)) \| max_by(.created_at)'` |
| **web-review canary** | run 30028469033 | `git push origin HEAD:main` — direct push to **protected `main`** is rejected → `exit 1` daily | publish the report as a **build artifact** (`upload-artifact`); drop the push; `contents: write`→`read` |
| **Proposal State Canary** | run 29994622917 | `run_proposal_canary.py` returns exit 2 when `NEON_STG_DATABASE_URL` is unwired → hard red | **skip gracefully** (warn + `exit 0`) when the secret is empty; still fails loudly on real drift once wired |
| **Evaluations** | run 29991274720 | `pytest tests/` dies at **collection** with 69 × `ModuleNotFoundError: No module named 'httpx'` (network-marked modules import httpx before `-m "not network"` deselects them) | install `httpx` so the tree collects |

## Verification
- YAML parses for all four (`yaml.safe_load`).
- `actionlint` runs in CI (not available locally).
- Per-workflow `workflow_dispatch` runs were kicked off on this branch to confirm the fixes actually go green — results linked in a comment.

## Notes / follow-ups
- **Evaluations:** `httpx` addresses the observed 69 collection errors; if a residual `ModuleNotFound` surfaces on the next dispatch, the follow-up is to install `-r mira-bots/telegram/requirements.txt` (the proven-collectible recipe in `ci.yml`) or narrow the collected suite. This workflow has **no `pull_request` trigger**, so it can only be validated via `workflow_dispatch`.
- **Proposal canary:** the fix assumes the failure is the unwired secret. If `NEON_STG_DATABASE_URL` actually IS configured, the canary would instead be reporting **real ADR-0017 status-triple drift** — check the next scheduled run's output before treating green as healthy.
- **web-review canary:** switching from a `main` commit to an artifact means the daily report is no longer in the `wiki/reviews/` git history; the run-summary step still surfaces P0/P1 inline. If diffable history is required, a dedicated non-protected `web-review-reports` branch is the alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)