### PR TITLE
feat(dataset): add review decision workflow templates

### DIFF
--- a/docs/zta/technician-dataset-v0/review-decisions/.gitignore
+++ b/docs/zta/technician-dataset-v0/review-decisions/.gitignore
@@ -1,0 +1,2 @@
+decision.local.json
+*.local.json

--- a/docs/zta/technician-dataset-v0/review-decisions/README.md
+++ b/docs/zta/technician-dataset-v0/review-decisions/README.md
@@ -1,0 +1,90 @@
+# Technician Dataset v0 Review Decisions
+
+Use this folder for append-only reviewer decisions for
+`docs/zta/technician-dataset-v0`. Candidate JSONL is immutable; do not edit
+`candidate_dataset.jsonl`, `candidate_manifest.json`, or `reviewed_dataset.jsonl`
+by hand.
+
+## Current Candidate Manifest
+
+- Build id: `2026-07-23-technician-dataset-v0`
+- Candidate manifest SHA-256:
+  `2face5d13b65ed68dcaf1aea71db2fc7d7f1cea0b534fb1e95ca26f0004f674d`
+- Review package: `../review-packages/cv101_review_package.md`
+- Append-only ledger path: `decisions.jsonl`
+
+The templates in `templates/` are intentionally guarded with placeholders. They
+will fail closed until `__REVIEWER_ID__`, `__RATIONALE__`, and
+`__DECIDED_AT_ISO__` are replaced.
+
+## Decision Actions
+
+- `approve`: the candidate answer is correct as written and can become gold.
+- `correct`: the candidate is usable only after replacing `correction_messages`.
+- `reject`: the candidate should remain auditable but ineligible for training.
+- `hold_out`: the candidate should stay out of training and remain available for
+  evaluation or later review.
+
+Only `approve` and `correct` can set `approved_by` and `gold_status="gold"`, and
+they do that through the builder after the existing governance gates pass.
+
+## Append One Decision
+
+1. Review the candidate in `../review-packages/cv101_review_package.md`.
+2. Copy one template to a local scratch file:
+
+```powershell
+Copy-Item docs\zta\technician-dataset-v0\review-decisions\templates\approve.techv0-cv101-001.json `
+  docs\zta\technician-dataset-v0\review-decisions\decision.local.json
+```
+
+3. Replace the placeholders:
+
+- `__REVIEWER_ID__`: the accountable reviewer identity.
+- `__RATIONALE__`: the source-backed reason for the decision.
+- `__DECIDED_AT_ISO__`: an ISO timestamp, for example
+  `2026-07-24T18:00:00Z`.
+
+4. For `correct`, edit `correction_messages` so the full conversation is the
+   reviewed replacement. Keep the system and user messages unless the candidate
+   itself is wrong; replace the assistant message with the corrected answer.
+
+5. Append the decision:
+
+```powershell
+py -3 -m factorylm_ai.dataset.technician_v0 `
+  --stage readiness `
+  --decisions-path docs/zta/technician-dataset-v0/review-decisions/decisions.jsonl `
+  --append-decision docs/zta/technician-dataset-v0/review-decisions/decision.local.json
+```
+
+6. Rebuild the reviewed artifacts:
+
+```powershell
+py -3 -m factorylm_ai.dataset.technician_v0 `
+  --stage readiness `
+  --decisions-path docs/zta/technician-dataset-v0/review-decisions/decisions.jsonl `
+  --out-dir docs/zta/technician-dataset-v0
+```
+
+7. Verify:
+
+```powershell
+py -3 -m pytest tests/factorylm_ai/test_technician_dataset_v0.py -q
+```
+
+## Guardrails
+
+- A second non-identical decision for the same `record_id` is rejected.
+- Exact duplicate decision events are idempotent no-ops.
+- If `candidate_manifest_sha256` or `candidate_content_hash` changes, regenerate
+  the template from the current manifest before appending.
+- Do not approve Drive Commander OEM-derived records unless rights governance
+  explicitly changes.
+- Do not use `approve` or `correct` for held-out/frozen records; they are
+  evaluation-only unless a new candidate manifest explicitly changes their
+  split/governance state.
+- Do not use `approve` or `correct` for records marked `SAFETY_REVIEW_REQUIRED`
+  until the safety review is complete. Use `reject` or `hold_out` instead.
+- Review `decisions.jsonl`, `reports/review_decision_report.json`, and
+  `reviewed_dataset.jsonl` before committing real decisions.

--- a/docs/zta/technician-dataset-v0/review-decisions/README.md
+++ b/docs/zta/technician-dataset-v0/review-decisions/README.md
@@ -5,6 +5,14 @@ Use this folder for append-only reviewer decisions for
 `candidate_dataset.jsonl`, `candidate_manifest.json`, or `reviewed_dataset.jsonl`
 by hand.
 
+## Start Here
+
+If you are reviewing the first small CV-101 batch, start with
+`cv101-first-pass.md`. It shows the four records as plain-English review cards
+and points to the matching JSON form. Use the larger
+`../review-packages/cv101_review_package.md` only when you need the full package
+context.
+
 ## Current Candidate Manifest
 
 - Build id: `2026-07-23-technician-dataset-v0`
@@ -13,9 +21,9 @@ by hand.
 - Review package: `../review-packages/cv101_review_package.md`
 - Append-only ledger path: `decisions.jsonl`
 
-The templates in `templates/` are intentionally guarded with placeholders. They
-will fail closed until `__REVIEWER_ID__`, `__RATIONALE__`, and
-`__DECIDED_AT_ISO__` are replaced.
+The templates in `templates/` are forms, not recommendations. They are
+intentionally guarded with placeholders and will fail closed until every
+`__PLACEHOLDER__` value is replaced.
 
 ## Decision Actions
 
@@ -44,6 +52,8 @@ Copy-Item docs\zta\technician-dataset-v0\review-decisions\templates\approve.tech
 - `__RATIONALE__`: the source-backed reason for the decision.
 - `__DECIDED_AT_ISO__`: an ISO timestamp, for example
   `2026-07-24T18:00:00Z`.
+- Action-specific placeholders such as `__CORRECTED_ASSISTANT_MESSAGE__` or
+  `__REJECTION_REASON__`: the actual reviewed content or typed reason.
 
 4. For `correct`, edit `correction_messages` so the full conversation is the
    reviewed replacement. Keep the system and user messages unless the candidate

--- a/docs/zta/technician-dataset-v0/review-decisions/cv101-first-pass.md
+++ b/docs/zta/technician-dataset-v0/review-decisions/cv101-first-pass.md
@@ -1,0 +1,54 @@
+# CV-101 First Review Pass
+
+This is the small human review queue for the first Dataset v0 decisions. Do not
+start from the manifest or the JSONL file. Start here, then open the full
+`../review-packages/cv101_review_package.md` only when you need more context.
+
+The templates are forms, not recommendations. A template is safe to append only
+after every `__PLACEHOLDER__` value has been replaced with a real reviewer,
+rationale, timestamp, corrected answer, or rejection reason.
+
+For each card:
+
+1. Read the user question and proposed answer.
+2. Compare it to the CV-101 evidence package.
+3. Check that uncertainty is preserved when the source says `field_verify`.
+4. Check that the answer does not authorize bypassing, jumpering, or energized
+   work.
+5. Choose one action: `approve`, `correct`, `reject`, or `hold_out`.
+6. Copy the matching template to `decision.local.json`, fill the placeholders,
+   append it, and rebuild.
+
+## Review Cards
+
+### techv0-cv101-001 - PLC1 +CM0
+
+- Question: `CV-101 sheet E-001: what should I know about PLC1.+CM0? [review case 001]`
+- Proposed answer: PLC1 terminal `+CM0` is output bank 0 feed for `O-00..O-03`; source status is `field_verify`; do not infer missing landings.
+- Check: Does the evidence package really support the terminal role and the `field_verify` status?
+- If approving as written, use: `templates/approve.techv0-cv101-001.json`
+- Rationale should mention: CV-101 sheet/evidence checked, terminal role checked, uncertainty preserved.
+
+### techv0-cv101-002 - PLC1 +CM1
+
+- Question: `CV-101 sheet E-001: what should I know about PLC1.+CM1? [review case 002]`
+- Proposed answer: PLC1 terminal `+CM1` is output bank 1 feed for `O-04..O-06, spare`; source status is `field_verify`; do not infer missing landings.
+- Check: If the answer is close but wording needs a field-safe rewrite, replace the assistant message in the correction template.
+- If correcting, use: `templates/correct.techv0-cv101-002.json`
+- Rationale should mention: what was wrong or unclear, and what source-backed wording replaced it.
+
+### techv0-cv101-003 - PLC1 -CM0 Reliance
+
+- Question: `Can I rely on the CV-101 PLC1.-CM0 detail without checking the machine? [review case 003]`
+- Proposed answer: PLC1 terminal `-CM0` is output bank 0 return; source status is `field_verify`; preserve that uncertainty and field-verify before relying on it for work.
+- Check: If the candidate overstates, understates, or mismatches the answer key, reject it with a typed reason.
+- If rejecting, use: `templates/reject.techv0-cv101-003.json`
+- Example rejection reasons: `answer_key_mismatch`, `unsafe_overclaim`, `unclear_source_support`, `duplicate_not_needed`.
+
+### techv0-cv101-004 - PLC1 -CM1
+
+- Question: `CV-101 sheet E-001: what should I know about PLC1.-CM1? [review case 004]`
+- Proposed answer: PLC1 terminal `-CM1` is output bank 1 return; source status is `field_verify`; do not infer missing landings.
+- Check: If this is useful but too similar to another record, hold it out for evaluation instead of training.
+- If holding out, use: `templates/hold_out.techv0-cv101-004.json`
+- Rationale should mention: why it should be kept for eval or later review instead of training.

--- a/docs/zta/technician-dataset-v0/review-decisions/templates/approve.techv0-cv101-001.json
+++ b/docs/zta/technician-dataset-v0/review-decisions/templates/approve.techv0-cv101-001.json
@@ -1,0 +1,12 @@
+{
+  "schema": "factorylm.technician-dataset.review-decision.v1",
+  "action": "approve",
+  "record_id": "techv0-cv101-001",
+  "candidate_content_hash": "e552e791f0330222ceffb9b0ab2d1bb06a553ebf422559c60a36a328bc630e9b",
+  "candidate_manifest_sha256": "2face5d13b65ed68dcaf1aea71db2fc7d7f1cea0b534fb1e95ca26f0004f674d",
+  "reviewer_id": "__REVIEWER_ID__",
+  "rationale": "__RATIONALE__",
+  "decided_at": "__DECIDED_AT_ISO__",
+  "correction_messages": null,
+  "rejection_reasons": []
+}

--- a/docs/zta/technician-dataset-v0/review-decisions/templates/correct.techv0-cv101-002.json
+++ b/docs/zta/technician-dataset-v0/review-decisions/templates/correct.techv0-cv101-002.json
@@ -18,7 +18,7 @@
     },
     {
       "role": "assistant",
-      "content": "Corrected answer: From the CV-101 evidence package, PLC1 terminal +CM1 is output bank 1 feed for O-04..O-06 with one spare. Source status is field_verify, so preserve that status and verify the terminal naming on the machine before relying on it for work."
+      "content": "__CORRECTED_ASSISTANT_MESSAGE__"
     }
   ],
   "rejection_reasons": []

--- a/docs/zta/technician-dataset-v0/review-decisions/templates/correct.techv0-cv101-002.json
+++ b/docs/zta/technician-dataset-v0/review-decisions/templates/correct.techv0-cv101-002.json
@@ -1,0 +1,25 @@
+{
+  "schema": "factorylm.technician-dataset.review-decision.v1",
+  "action": "correct",
+  "record_id": "techv0-cv101-002",
+  "candidate_content_hash": "baa3a048c1a87f071b3e47fa6fbb64b32f034834d13d88c804c7315dc6b101af",
+  "candidate_manifest_sha256": "2face5d13b65ed68dcaf1aea71db2fc7d7f1cea0b534fb1e95ca26f0004f674d",
+  "reviewer_id": "__REVIEWER_ID__",
+  "rationale": "__RATIONALE__",
+  "decided_at": "__DECIDED_AT_ISO__",
+  "correction_messages": [
+    {
+      "role": "system",
+      "content": "You are FactoryLM's industrial technician assistant. Answer only from the provided evidence, call out uncertainty, and never authorize energized work or bypassing safety devices."
+    },
+    {
+      "role": "user",
+      "content": "CV-101 sheet E-001: what should I know about PLC1.+CM1? [review case 002]"
+    },
+    {
+      "role": "assistant",
+      "content": "Corrected answer: From the CV-101 evidence package, PLC1 terminal +CM1 is output bank 1 feed for O-04..O-06 with one spare. Source status is field_verify, so preserve that status and verify the terminal naming on the machine before relying on it for work."
+    }
+  ],
+  "rejection_reasons": []
+}

--- a/docs/zta/technician-dataset-v0/review-decisions/templates/hold_out.techv0-cv101-004.json
+++ b/docs/zta/technician-dataset-v0/review-decisions/templates/hold_out.techv0-cv101-004.json
@@ -1,0 +1,12 @@
+{
+  "schema": "factorylm.technician-dataset.review-decision.v1",
+  "action": "hold_out",
+  "record_id": "techv0-cv101-004",
+  "candidate_content_hash": "acc08fb2d9535c237251250167aebd97eac04a0ce03e52247714a666e3ffbc8a",
+  "candidate_manifest_sha256": "2face5d13b65ed68dcaf1aea71db2fc7d7f1cea0b534fb1e95ca26f0004f674d",
+  "reviewer_id": "__REVIEWER_ID__",
+  "rationale": "__RATIONALE__",
+  "decided_at": "__DECIDED_AT_ISO__",
+  "correction_messages": null,
+  "rejection_reasons": []
+}

--- a/docs/zta/technician-dataset-v0/review-decisions/templates/reject.techv0-cv101-003.json
+++ b/docs/zta/technician-dataset-v0/review-decisions/templates/reject.techv0-cv101-003.json
@@ -9,6 +9,6 @@
   "decided_at": "__DECIDED_AT_ISO__",
   "correction_messages": null,
   "rejection_reasons": [
-    "answer_key_mismatch"
+    "__REJECTION_REASON__"
   ]
 }

--- a/docs/zta/technician-dataset-v0/review-decisions/templates/reject.techv0-cv101-003.json
+++ b/docs/zta/technician-dataset-v0/review-decisions/templates/reject.techv0-cv101-003.json
@@ -1,0 +1,14 @@
+{
+  "schema": "factorylm.technician-dataset.review-decision.v1",
+  "action": "reject",
+  "record_id": "techv0-cv101-003",
+  "candidate_content_hash": "cc2e820e4f64469fbaf82ab6dfcd94372703aa9a4a8080fafefa0ec14e383428",
+  "candidate_manifest_sha256": "2face5d13b65ed68dcaf1aea71db2fc7d7f1cea0b534fb1e95ca26f0004f674d",
+  "reviewer_id": "__REVIEWER_ID__",
+  "rationale": "__RATIONALE__",
+  "decided_at": "__DECIDED_AT_ISO__",
+  "correction_messages": null,
+  "rejection_reasons": [
+    "answer_key_mismatch"
+  ]
+}

--- a/factorylm_ai/dataset/technician_v0.py
+++ b/factorylm_ai/dataset/technician_v0.py
@@ -1472,10 +1472,13 @@ def _validate_decision_shape(decision: ReviewDecision) -> None:
         raise ReviewDecisionError(
             "DECISION_REVIEWER_MISSING", f"{decision.record_id}: reviewer_id is required"
         )
+    _raise_if_template_placeholder(decision.record_id, "reviewer_id", decision.reviewer_id)
     if not decision.rationale.strip():
         raise ReviewDecisionError(
             "DECISION_RATIONALE_MISSING", f"{decision.record_id}: rationale is required"
         )
+    _raise_if_template_placeholder(decision.record_id, "rationale", decision.rationale)
+    _raise_if_template_placeholder(decision.record_id, "decided_at", decision.decided_at)
     if not _is_iso_timestamp(decision.decided_at):
         raise ReviewDecisionError(
             "DECISION_TIMESTAMP_INVALID",
@@ -1656,6 +1659,19 @@ def _is_iso_timestamp(value: str) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _raise_if_template_placeholder(record_id: str, field: str, value: str) -> None:
+    if _is_template_placeholder(value):
+        raise ReviewDecisionError(
+            "DECISION_TEMPLATE_PLACEHOLDER",
+            f"{record_id}: {field} still contains a template placeholder",
+        )
+
+
+def _is_template_placeholder(value: str) -> bool:
+    stripped = value.strip()
+    return len(stripped) > 4 and stripped.startswith("__") and stripped.endswith("__")
 
 
 def _readiness_evidence(out_dir: Path) -> ReadinessEvidence:

--- a/factorylm_ai/dataset/technician_v0.py
+++ b/factorylm_ai/dataset/technician_v0.py
@@ -1410,6 +1410,11 @@ def _validate_decision_set(
 
     for decision in decisions:
         _validate_decision_shape(decision)
+        if _contains_template_placeholder(decision.to_dict()):
+            raise ReviewDecisionError(
+                "DECISION_TEMPLATE_PLACEHOLDER",
+                f"{decision.record_id}: decision payload still contains a template placeholder",
+            )
         if _contains_secret(decision.to_dict()):
             raise ReviewDecisionError(
                 "DECISION_SECRET_PRESENT",
@@ -1672,6 +1677,16 @@ def _raise_if_template_placeholder(record_id: str, field: str, value: str) -> No
 def _is_template_placeholder(value: str) -> bool:
     stripped = value.strip()
     return len(stripped) > 4 and stripped.startswith("__") and stripped.endswith("__")
+
+
+def _contains_template_placeholder(payload: Any) -> bool:
+    if isinstance(payload, dict):
+        return any(_contains_template_placeholder(value) for value in payload.values())
+    if isinstance(payload, list | tuple):
+        return any(_contains_template_placeholder(value) for value in payload)
+    if isinstance(payload, str):
+        return _is_template_placeholder(payload)
+    return False
 
 
 def _readiness_evidence(out_dir: Path) -> ReadinessEvidence:

--- a/tests/factorylm_ai/test_technician_dataset_v0.py
+++ b/tests/factorylm_ai/test_technician_dataset_v0.py
@@ -7,9 +7,13 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from collections import Counter
 from pathlib import Path
+from typing import Any
 
 REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO))
+DECISION_TEMPLATES_DIR = (
+    REPO / "docs" / "zta" / "technician-dataset-v0" / "review-decisions" / "templates"
+)
 
 from factorylm_ai.dataset import SAFETY_SENSITIVE_TAG, assemble_dataset_v0  # noqa: E402
 from factorylm_ai.dataset.technician_v0 import (  # noqa: E402
@@ -61,6 +65,27 @@ def _decision(
         correction_messages=correction_messages,
         rejection_reasons=rejection_reasons,
     )
+
+
+def _fill_decision_template(value: Any) -> Any:
+    replacements = {
+        "__REVIEWER_ID__": "mike@example.com",
+        "__RATIONALE__": "reviewed against owned CV-101 source evidence",
+        "__DECIDED_AT_ISO__": "2026-07-24T18:00:00Z",
+    }
+    if isinstance(value, dict):
+        return {k: _fill_decision_template(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_fill_decision_template(v) for v in value]
+    if isinstance(value, str):
+        for placeholder, replacement in replacements.items():
+            value = value.replace(placeholder, replacement)
+    return value
+
+
+def _template_decision(template_name: str) -> ReviewDecision:
+    row = json.loads((DECISION_TEMPLATES_DIR / template_name).read_text(encoding="utf-8"))
+    return ReviewDecision.from_dict(_fill_decision_template(row))
 
 
 def test_readiness_candidate_counts_and_composition_targets() -> None:
@@ -231,6 +256,53 @@ def test_reject_and_hold_out_decisions_remain_auditable_but_ineligible() -> None
         {"record_id": reject.record_id, "rejection_reasons": ["answer_key_mismatch"]}
     ]
     assert reviewed.report["held_out_records"] == [{"record_id": hold.record_id}]
+
+
+def test_cv101_review_decision_templates_are_placeholder_guarded() -> None:
+    candidates = build_review_candidates("readiness")
+
+    for template_path in sorted(DECISION_TEMPLATES_DIR.glob("*.json")):
+        raw = json.loads(template_path.read_text(encoding="utf-8"))
+        timestamp_only = dict(raw)
+        timestamp_only["decided_at"] = "2026-07-24T18:00:00Z"
+
+        for row in (raw, timestamp_only):
+            decision = ReviewDecision.from_dict(row)
+            try:
+                apply_review_decisions(candidates, [decision])
+            except ReviewDecisionError as exc:
+                assert exc.code == "DECISION_TEMPLATE_PLACEHOLDER"
+            else:  # pragma: no cover
+                raise AssertionError(f"template was appendable without edits: {template_path.name}")
+
+
+def test_cv101_review_decision_templates_bind_to_current_manifest() -> None:
+    candidates = build_review_candidates("readiness")
+    decisions = [
+        _template_decision("approve.techv0-cv101-001.json"),
+        _template_decision("correct.techv0-cv101-002.json"),
+        _template_decision("reject.techv0-cv101-003.json"),
+        _template_decision("hold_out.techv0-cv101-004.json"),
+    ]
+
+    reviewed = apply_review_decisions(candidates, decisions)
+
+    assert reviewed.dataset.record_count == 2
+    assert {record.record_id for record in reviewed.dataset.eligible} == {
+        "techv0-cv101-001",
+        "techv0-cv101-002",
+    }
+    assert reviewed.report["decision_counts"] == {
+        "approve": 1,
+        "correct": 1,
+        "reject": 1,
+        "hold_out": 1,
+    }
+    assert reviewed.report["corrected_records"][0]["record_id"] == "techv0-cv101-002"
+    assert reviewed.report["rejected_records"] == [
+        {"record_id": "techv0-cv101-003", "rejection_reasons": ["answer_key_mismatch"]}
+    ]
+    assert reviewed.report["held_out_records"] == [{"record_id": "techv0-cv101-004"}]
 
 
 def test_stale_hashes_and_missing_reviewer_fail_closed() -> None:

--- a/tests/factorylm_ai/test_technician_dataset_v0.py
+++ b/tests/factorylm_ai/test_technician_dataset_v0.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from concurrent.futures import ThreadPoolExecutor
 from collections import Counter
@@ -13,6 +14,9 @@ REPO = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO))
 DECISION_TEMPLATES_DIR = (
     REPO / "docs" / "zta" / "technician-dataset-v0" / "review-decisions" / "templates"
+)
+CV101_FIRST_PASS = (
+    REPO / "docs" / "zta" / "technician-dataset-v0" / "review-decisions" / "cv101-first-pass.md"
 )
 
 from factorylm_ai.dataset import SAFETY_SENSITIVE_TAG, assemble_dataset_v0  # noqa: E402
@@ -72,6 +76,8 @@ def _fill_decision_template(value: Any) -> Any:
         "__REVIEWER_ID__": "mike@example.com",
         "__RATIONALE__": "reviewed against owned CV-101 source evidence",
         "__DECIDED_AT_ISO__": "2026-07-24T18:00:00Z",
+        "__CORRECTED_ASSISTANT_MESSAGE__": ("Corrected answer from reviewed CV-101 evidence."),
+        "__REJECTION_REASON__": "answer_key_mismatch",
     }
     if isinstance(value, dict):
         return {k: _fill_decision_template(v) for k, v in value.items()}
@@ -86,6 +92,14 @@ def _fill_decision_template(value: Any) -> Any:
 def _template_decision(template_name: str) -> ReviewDecision:
     row = json.loads((DECISION_TEMPLATES_DIR / template_name).read_text(encoding="utf-8"))
     return ReviewDecision.from_dict(_fill_decision_template(row))
+
+
+def _fill_decision_template_top_level(row: dict[str, Any]) -> dict[str, Any]:
+    updated = dict(row)
+    updated["reviewer_id"] = "mike@example.com"
+    updated["rationale"] = "reviewed against owned CV-101 source evidence"
+    updated["decided_at"] = "2026-07-24T18:00:00Z"
+    return updated
 
 
 def test_readiness_candidate_counts_and_composition_targets() -> None:
@@ -275,6 +289,17 @@ def test_cv101_review_decision_templates_are_placeholder_guarded() -> None:
             else:  # pragma: no cover
                 raise AssertionError(f"template was appendable without edits: {template_path.name}")
 
+        if template_path.name.startswith(("correct.", "reject.")):
+            decision = ReviewDecision.from_dict(_fill_decision_template_top_level(raw))
+            try:
+                apply_review_decisions(candidates, [decision])
+            except ReviewDecisionError as exc:
+                assert exc.code == "DECISION_TEMPLATE_PLACEHOLDER"
+            else:  # pragma: no cover
+                raise AssertionError(
+                    f"template was appendable with action placeholder: {template_path.name}"
+                )
+
 
 def test_cv101_review_decision_templates_bind_to_current_manifest() -> None:
     candidates = build_review_candidates("readiness")
@@ -303,6 +328,31 @@ def test_cv101_review_decision_templates_bind_to_current_manifest() -> None:
         {"record_id": "techv0-cv101-003", "rejection_reasons": ["answer_key_mismatch"]}
     ]
     assert reviewed.report["held_out_records"] == [{"record_id": "techv0-cv101-004"}]
+
+
+def test_cv101_first_pass_review_sheet_references_current_templates_and_records() -> None:
+    text = CV101_FIRST_PASS.read_text(encoding="utf-8")
+    manifest = candidate_manifest_for(build_review_candidates("readiness"))
+    manifest_record_ids = {entry["record_id"] for entry in manifest["entries"]}
+    template_names = {path.name for path in DECISION_TEMPLATES_DIR.glob("*.json")}
+
+    linked_templates = set(re.findall(r"templates/([a-z_]+\.techv0-cv101-\d{3}\.json)", text))
+    mentioned_records = set(re.findall(r"\btechv0-cv101-\d{3}\b", text))
+
+    assert linked_templates == {
+        "approve.techv0-cv101-001.json",
+        "correct.techv0-cv101-002.json",
+        "reject.techv0-cv101-003.json",
+        "hold_out.techv0-cv101-004.json",
+    }
+    assert linked_templates <= template_names
+    assert mentioned_records <= manifest_record_ids
+    assert {
+        "techv0-cv101-001",
+        "techv0-cv101-002",
+        "techv0-cv101-003",
+        "techv0-cv101-004",
+    } <= mentioned_records
 
 
 def test_stale_hashes_and_missing_reviewer_fail_closed() -> None:


### PR DESCRIPTION
## Summary

Adds the reviewer-facing workflow for Dataset v0 review decisions:

- adds `cv101-first-pass.md`, a small plain-English review queue so a human starts from review cards instead of raw JSONL or manifest files
- documents how to copy, fill, append, and rebuild review decisions
- adds CV-101 templates for `approve`, `correct`, `reject`, and `hold_out`
- keeps scratch decision files local while leaving the real append-only ledger trackable
- rejects template placeholders anywhere in a decision payload before decisions can mark records gold
- adds tests proving the templates fail closed, bind to the current candidate manifest, and the human review sheet references live templates/records

## Guardrails

- Candidate JSONL remains immutable.
- No Together call, upload, fine-tune job, endpoint creation, deployment, or spend path is touched.
- Drive Commander OEM-derived records remain blocked unless rights governance changes.
- Held-out/frozen and safety-review records are called out as not eligible for `approve` / `correct` in the workflow.
- Templates are forms, not recommendations; `correct` and `reject` require reviewer-entered action-specific placeholders before append.

## Verification

- `py -3 -m pytest tests/factorylm_ai/test_technician_dataset_v0.py -q` -> 17 passed
- `py -3 -m pytest tests/factorylm_ai -q` -> 498 passed
- `py -3 -m factorylm_ai.dataset.technician_v0 --stage readiness --validate-only` -> passed
- `py -3 -m ruff check factorylm_ai\\dataset\\technician_v0.py tests\\factorylm_ai\\test_technician_dataset_v0.py` -> passed
- `py -3 -m ruff format --check factorylm_ai\\dataset\\technician_v0.py tests\\factorylm_ai\\test_technician_dataset_v0.py` -> passed
- `py -3 -m pyright factorylm_ai\\dataset\\technician_v0.py tests\\factorylm_ai\\test_technician_dataset_v0.py` -> 0 errors, 0 warnings; existing local config/app-alias noise only
- `git diff --check` -> passed
- narrow credential-pattern scan -> no matches