### PR TITLE
PrintSense landing page + design style guide

### DIFF
--- a/docs/printsense/style-guide.html
+++ b/docs/printsense/style-guide.html
@@ -1,0 +1,426 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PrintSense / FactoryLM — Landing Page Design Style Guide</title>
+<style>
+  :root{
+    --ink:#0A0E14; --ink-2:#0F1621; --panel:#131C2A; --panel-2:#0c131e;
+    --line:#20304A; --line-2:#2b3e5c;
+    --paper:#E8EEF6; --muted:#8A9BB4; --white:#F4F8FF;
+    --cyan:#2DD4E8; --cyan-deep:#14A3B8;
+    --lime:#9BE861; --amber:#F5B33C; --red:#FF5C6C; --violet:#8B7CF6;
+    --navy:#1B365D; /* inherited FactoryLM brand */
+    --mono:"SF Mono",ui-monospace,"JetBrains Mono",Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:var(--ink);color:var(--paper);font-family:var(--sans);line-height:1.65;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 28px}
+  .mono{font-family:var(--mono)}
+  a{color:var(--cyan);text-decoration:none}
+
+  /* header */
+  header{border-bottom:1px solid var(--line);padding:64px 0 48px;background:
+    radial-gradient(ellipse 70% 80% at 50% 0%,rgba(45,212,232,.08),transparent 70%)}
+  .tag{display:inline-block;font-family:var(--mono);font-size:12px;letter-spacing:2px;text-transform:uppercase;
+    color:var(--cyan);border:1px solid var(--line);padding:6px 14px;border-radius:100px;background:rgba(45,212,232,.05)}
+  h1{font-size:clamp(34px,5.5vw,54px);font-weight:800;letter-spacing:-1.5px;line-height:1.05;margin:22px 0 14px}
+  header p{color:var(--muted);font-size:19px;max-width:640px}
+  .meta{margin-top:22px;font-family:var(--mono);font-size:12.5px;color:var(--muted)}
+  .meta b{color:var(--paper)}
+
+  /* section shell */
+  section{padding:70px 0;border-bottom:1px solid var(--line)}
+  .snum{font-family:var(--mono);font-size:12px;letter-spacing:2px;color:var(--cyan);text-transform:uppercase}
+  h2{font-size:clamp(24px,3.4vw,34px);font-weight:800;letter-spacing:-.8px;margin:12px 0 10px;line-height:1.12}
+  .intro{color:var(--muted);font-size:17px;max-width:680px;margin-bottom:34px}
+  h3{font-size:18px;font-weight:700;margin:28px 0 14px}
+  p{color:var(--paper)}
+  .sub-muted{color:var(--muted)}
+
+  /* principles */
+  .principles{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  @media(max-width:720px){.principles{grid-template-columns:1fr}}
+  .principle{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:22px;border-left:3px solid var(--cyan)}
+  .principle .k{font-family:var(--mono);font-size:12px;color:var(--cyan);letter-spacing:1px}
+  .principle h4{font-size:17px;font-weight:700;margin:6px 0 6px}
+  .principle p{color:var(--muted);font-size:14px}
+
+  /* reference table */
+  table{width:100%;border-collapse:collapse;font-size:13.5px;margin-top:8px}
+  th,td{text-align:left;padding:11px 12px;border-bottom:1px solid var(--line);vertical-align:top}
+  th{font-family:var(--mono);font-size:11px;letter-spacing:1px;text-transform:uppercase;color:var(--muted);position:sticky}
+  td:first-child{font-weight:600;color:var(--white);white-space:nowrap}
+  td:nth-child(2){color:var(--cyan);font-family:var(--mono);font-size:12px;white-space:nowrap}
+  td:last-child{color:var(--muted)}
+  .cat-row td{background:var(--panel-2);font-family:var(--mono);font-size:11px;letter-spacing:1.5px;text-transform:uppercase;color:var(--amber)}
+
+  /* color swatches */
+  .swatches{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}
+  @media(max-width:720px){.swatches{grid-template-columns:1fr 1fr}}
+  .sw{border:1px solid var(--line);border-radius:12px;overflow:hidden;background:var(--panel)}
+  .sw .chip{height:70px}
+  .sw .info{padding:12px 14px}
+  .sw .name{font-weight:700;font-size:14px}
+  .sw .hex{font-family:var(--mono);font-size:12px;color:var(--muted)}
+  .sw .use{font-size:12px;color:var(--muted);margin-top:4px}
+  .role{display:flex;gap:10px;flex-wrap:wrap;margin-top:18px}
+  .role span{font-family:var(--mono);font-size:12px;padding:6px 11px;border-radius:7px;border:1px solid var(--line)}
+
+  /* type scale */
+  .type-row{display:flex;align-items:baseline;gap:20px;border-bottom:1px solid var(--line);padding:16px 0;flex-wrap:wrap}
+  .type-row .lbl{font-family:var(--mono);font-size:12px;color:var(--muted);width:150px;flex-shrink:0}
+  .t-display{font-size:44px;font-weight:800;letter-spacing:-1.5px}
+  .t-h2{font-size:30px;font-weight:800;letter-spacing:-.8px}
+  .t-h3{font-size:20px;font-weight:700}
+  .t-body{font-size:17px;color:var(--paper)}
+  .t-small{font-size:14px;color:var(--muted)}
+  .t-mono{font-family:var(--mono);font-size:13px;color:var(--cyan)}
+
+  /* component demos */
+  .demo{background:var(--panel);border:1px solid var(--line);border-radius:14px;padding:26px;margin-top:16px}
+  .btn{display:inline-flex;align-items:center;gap:8px;font-weight:600;font-size:14px;padding:11px 20px;border-radius:10px;cursor:pointer;border:1px solid transparent}
+  .btn-primary{background:var(--cyan);color:var(--ink);box-shadow:0 0 24px rgba(45,212,232,.3)}
+  .btn-ghost{border-color:var(--line);color:var(--paper);background:transparent}
+  .btn-row{display:flex;gap:12px;flex-wrap:wrap;align-items:center}
+
+  /* THE cited answer card — centerpiece component */
+  .answer{background:linear-gradient(180deg,var(--panel),var(--ink-2));border:1px solid var(--line-2);
+    border-radius:16px;padding:0;overflow:hidden;box-shadow:0 24px 60px -24px rgba(0,0,0,.7)}
+  .answer .q{display:flex;gap:12px;align-items:flex-start;padding:20px 22px;border-bottom:1px solid var(--line);background:var(--panel-2)}
+  .answer .q .avatar{width:30px;height:30px;border-radius:8px;background:var(--line);display:grid;place-items:center;font-size:14px;flex-shrink:0}
+  .answer .q .qt{font-size:15.5px;font-weight:600;color:var(--white)}
+  .answer .q .qs{font-family:var(--mono);font-size:11px;color:var(--muted);margin-top:2px}
+  .answer .a{padding:22px}
+  .answer .a .mira{display:flex;align-items:center;gap:9px;margin-bottom:14px}
+  .answer .a .mira .b{width:26px;height:26px;border-radius:7px;background:linear-gradient(135deg,var(--cyan),var(--cyan-deep));
+    display:grid;place-items:center;color:var(--ink);font-weight:800;font-size:13px}
+  .answer .a .mira .n{font-weight:700;font-size:14px}
+  .answer .a .mira .n small{color:var(--muted);font-weight:500;font-family:var(--mono);font-size:11px;margin-left:6px}
+  .answer .a .body{font-size:15px;color:var(--paper);line-height:1.7}
+  .answer .a .body mark{background:rgba(45,212,232,.14);color:var(--cyan);padding:1px 4px;border-radius:4px;font-weight:600}
+  .cites{display:flex;gap:8px;flex-wrap:wrap;margin-top:16px}
+  .cite{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:11.5px;color:var(--paper);
+    background:var(--panel-2);border:1px solid var(--line);border-radius:8px;padding:7px 11px}
+  .cite .ico{color:var(--cyan)}
+  .cite:hover{border-color:var(--cyan)}
+  .answer .foot{display:flex;align-items:center;gap:10px;padding:13px 22px;border-top:1px solid var(--line);
+    background:var(--panel-2);font-family:var(--mono);font-size:11.5px;color:var(--muted)}
+  .badge{font-family:var(--mono);font-weight:700;font-size:11px;padding:4px 10px;border-radius:6px}
+  .badge.grounded{background:rgba(155,232,97,.15);color:var(--lime);border:1px solid rgba(155,232,97,.3)}
+  .badge.stop{background:rgba(255,92,108,.14);color:var(--red);border:1px solid rgba(255,92,108,.32)}
+
+  /* stat blocks / bento */
+  .bento{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}
+  @media(max-width:720px){.bento{grid-template-columns:1fr 1fr}}
+  .stat{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:18px}
+  .stat .big{font-size:30px;font-weight:800;letter-spacing:-1px}
+  .stat .big.ok{color:var(--lime)} .stat .big.cy{color:var(--cyan)}
+  .stat .lbl{font-family:var(--mono);font-size:11px;letter-spacing:.5px;text-transform:uppercase;color:var(--muted);margin-top:4px}
+
+  /* blueprint / section order */
+  .blueprint{display:flex;flex-direction:column;gap:10px;counter-reset:step}
+  .bp{display:flex;gap:16px;align-items:flex-start;background:var(--panel);border:1px solid var(--line);border-radius:11px;padding:16px 18px}
+  .bp .n{counter-increment:step;font-family:var(--mono);font-size:12px;color:var(--cyan);border:1px solid var(--line);
+    min-width:30px;height:30px;border-radius:8px;display:grid;place-items:center;flex-shrink:0}
+  .bp .n::before{content:counter(step,decimal-leading-zero)}
+  .bp h4{font-size:15.5px;font-weight:700}
+  .bp p{color:var(--muted);font-size:13.5px}
+
+  /* do/dont */
+  .dd{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+  @media(max-width:720px){.dd{grid-template-columns:1fr}}
+  .do,.dont{border-radius:12px;padding:20px;border:1px solid var(--line)}
+  .do{background:#0f1712;border-color:rgba(155,232,97,.25)}
+  .dont{background:#161016;border-color:rgba(255,92,108,.22)}
+  .do h4{color:var(--lime)} .dont h4{color:var(--red)}
+  .dd ul{list-style:none;margin-top:12px;display:flex;flex-direction:column;gap:9px}
+  .dd li{font-size:13.5px;color:var(--paper);display:flex;gap:9px}
+  .do li:before{content:"✓";color:var(--lime);font-weight:800}
+  .dont li:before{content:"✕";color:var(--red);font-weight:800}
+
+  .note{font-size:12.5px;color:var(--muted);font-family:var(--mono);margin-top:14px;border-left:2px solid var(--line);padding-left:12px}
+  .foot-final{padding:40px 0;color:var(--muted);font-size:13px;font-family:var(--mono)}
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap">
+    <span class="tag">PrintSense · FactoryLM — Design System</span>
+    <h1>Landing page style guide</h1>
+    <p>A convincing, credibility-first design system for the hook products — grounded in a teardown of 25 industry landing pages. The centerpiece is the one thing competitors can't fake: a real MIRA answer citing a real manual.</p>
+    <div class="meta">v1.0 · scope: <b>printsense</b> + <b>drivecommander</b> hooks, aligned to <b>factorylm.com</b> · July 2026</div>
+  </div>
+</header>
+
+<!-- 1. PRINCIPLES -->
+<section>
+  <div class="wrap">
+    <div class="snum">01 — Principles</div>
+    <h2>Five rules everything else obeys</h2>
+    <p class="intro">These come straight from what the best pages in your space actually do. When a design decision is unclear, the answer is whichever option serves these five.</p>
+    <div class="principles">
+      <div class="principle"><div class="k">01</div><h4>Show the output, don't describe it</h4><p>Linear and Vercel put the real product on screen above the fold. Your product's output is a <b style="color:var(--paper)">cited answer</b>. Lead with it — no stock illustrations, ever.</p></div>
+      <div class="principle"><div class="k">02</div><h4>Credibility beats cleverness</h4><p>Technical buyers punish hype. Evidence, real fault codes, real manual sections, and honest limits convert them. Keep FactoryLM's "no AI hype" voice.</p></div>
+      <div class="principle"><div class="k">03</div><h4>One page, one job</h4><p>The hook page has exactly one goal: claim 5 free reads. Every section either builds trust toward that or gets cut.</p></div>
+      <div class="principle"><div class="k">04</div><h4>Motion clarifies, never decorates</h4><p>Subtle scan-lines, scroll reveals, a citation that expands. Motion that explains "how it's grounded." Nothing that slows the page.</p></div>
+      <div class="principle"><div class="k">05</div><h4>Trust is a color</h4><p>Green = grounded/pass. Amber = held/verify. Red = stop/fault. Never decorative. The palette itself tells the safety story.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- 2. THE 25 -->
+<section>
+  <div class="wrap">
+    <div class="snum">02 — The teardown</div>
+    <h2>25 landing pages, one lesson each</h2>
+    <p class="intro">Studied across three buckets: your direct industrial-maintenance competitors, the "answers-from-documents" AI tools that are your closest structural analog, and the B2B benchmarks everyone copies. The right-hand column is the single move worth stealing.</p>
+    <table>
+      <thead><tr><th>Page</th><th>Category</th><th>The one move to steal</th></tr></thead>
+      <tbody>
+        <tr class="cat-row"><td colspan="3">Direct — industrial maintenance / IoT</td></tr>
+        <tr><td>Tractian</td><td>CMMS+IoT</td><td>Real-time asset data shown as live cards; "one unified system" clarity. Bold, simple, confident.</td></tr>
+        <tr><td>MaintainX</td><td>CMMS</td><td>Phone-native proof — screenshots of the actual mobile work order. Frontline, not boardroom.</td></tr>
+        <tr><td>Limble</td><td>CMMS</td><td>Counter-example: dense, dated, too many fields. Shows what to avoid — don't out-feature, out-clarify.</td></tr>
+        <tr><td>UpKeep</td><td>CMMS</td><td>Role-segmented hero ("for technicians / managers") — mirror your Tier-0/1/2 audiences.</td></tr>
+        <tr><td>Fiix</td><td>CMMS</td><td>Integration logos as trust wall; asset-health visual language.</td></tr>
+        <tr><td>Augury</td><td>Machine health AI</td><td>"Diagnosis with confidence" framing; downtime-cost stat above the fold.</td></tr>
+        <tr><td>Samsara</td><td>Ops platform</td><td>Enterprise credibility bar: named customers + hard ROI numbers early.</td></tr>
+        <tr><td>Uptake / Cognite</td><td>Industrial AI</td><td>Data-to-decision diagram; how messy inputs become trusted output.</td></tr>
+        <tr><td>Tulip</td><td>Frontline ops</td><td>"No-code for the floor" — value even if you never scroll.</td></tr>
+        <tr class="cat-row"><td colspan="3">Closest analog — answers from documents (RAG / cited AI)</td></tr>
+        <tr><td>Harvey (legal AI)</td><td>Cited answers</td><td>THE model. The cited answer IS the hero. Citation chips under every claim. Copy this pattern exactly.</td></tr>
+        <tr><td>Glean</td><td>Enterprise search</td><td>"Answers with sources from your systems" — grounding is the whole pitch. Source pills.</td></tr>
+        <tr><td>Hebbia</td><td>Doc intelligence</td><td>Shows the document + the extracted answer side by side. See-the-evidence layout.</td></tr>
+        <tr><td>Perplexity</td><td>Answer engine</td><td>Numbered inline citations as a visual signature. Makes "grounded" legible at a glance.</td></tr>
+        <tr><td>Anthropic / Claude</td><td>AI platform</td><td>Calm, honest, safety-forward tone for a technical audience. Restraint reads as trust.</td></tr>
+        <tr><td>Sana</td><td>AI knowledge</td><td>Ask-a-question interactive hero — let visitors type and see a grounded reply.</td></tr>
+        <tr><td>Ironclad / Robin AI</td><td>Contract AI</td><td>Before/after: raw document → structured, verified output. Your print → graph story.</td></tr>
+        <tr class="cat-row"><td colspan="3">Benchmarks — B2B SaaS everyone copies</td></tr>
+        <tr><td>Linear</td><td>Dev tool</td><td>Whole page is the real UI in dark mode. Trial = the demo. Friction-free CTA.</td></tr>
+        <tr><td>Vercel</td><td>Dev platform</td><td>Product is the proof; specs and speed over marketing fluff. Ship the CTA straight to action.</td></tr>
+        <tr><td>Stripe</td><td>Payments</td><td>Answers the buyer's questions before they ask (the structured table). Technical + polished.</td></tr>
+        <tr><td>Ramp</td><td>Fintech</td><td>Quantified outcome in the headline ("save X"). Hard number, not adjective.</td></tr>
+        <tr><td>Retool</td><td>Internal tools</td><td>Bento grid of capabilities; code + UI side by side.</td></tr>
+        <tr><td>Notion</td><td>Productivity</td><td>Story-driven hero; narrative headline + micro-animation showing transformation.</td></tr>
+        <tr><td>Scale AI</td><td>AI data</td><td>Logo wall of serious customers as instant enterprise credibility.</td></tr>
+        <tr><td>Cursor</td><td>AI IDE</td><td>Show-don't-tell demo loop of the product doing the work in seconds.</td></tr>
+        <tr><td>Framer</td><td>Web builder</td><td>Kinetic type + oversized headline; motion as brand identity.</td></tr>
+      </tbody>
+    </table>
+    <p class="note">Buckets weighted deliberately: your closest analog isn't a CMMS — it's the cited-answer AI tools (Harvey, Glean, Perplexity). That's where the winning pattern lives.</p>
+  </div>
+</section>
+
+<!-- 3. CENTERPIECE COMPONENT -->
+<section style="background:radial-gradient(ellipse 60% 60% at 50% 0%,rgba(45,212,232,.06),transparent 70%)">
+  <div class="wrap">
+    <div class="snum">03 — The centerpiece component</div>
+    <h2>The Cited Answer Card</h2>
+    <p class="intro">This is the whole guide in one object. A real technician question, MIRA's grounded answer, and the manual sections it's built on — shown, not claimed. It leads the hero and repeats as social proof. Everything else is scaffolding around this.</p>
+
+    <div class="answer">
+      <div class="q">
+        <div class="avatar">🔧</div>
+        <div>
+          <div class="qt">"PowerFlex 755 is tripping F5 at about 1,200 RPM overnight. What do I check?"</div>
+          <div class="qs">Asset POW-755-A12 · Line 3 · sent via Telegram 02:14</div>
+        </div>
+      </div>
+      <div class="a">
+        <div class="mira"><span class="b">M</span><span class="n">MIRA <small>grounded answer</small></span></div>
+        <div class="body">
+          F5 on this drive is a <mark>DC bus undervoltage</mark> fault. The last 7 days show <mark>4 trips in the same RPM band, all overnight</mark> — a pattern consistent with sagging bus voltage under load, not a random fault. The manual's fault-recovery section points to the <mark>DC bus capacitor bank</mark> as the first check, and your own PM history flags it: the 2024-12-14 inspection noted bulging on capacitor 3. Start there before touching drive parameters.
+        </div>
+        <div class="cites">
+          <span class="cite"><span class="ico">📄</span> PowerFlex 755 Manual · §6.2 Fault F5</span>
+          <span class="cite"><span class="ico">🗂️</span> Fault history · POW-755-A12 · 7 d</span>
+          <span class="cite"><span class="ico">🛠️</span> PM record · 2024-12-14</span>
+        </div>
+      </div>
+      <div class="foot">
+        <span class="badge grounded">◆ GROUNDED 5/5</span>
+        <span>3 sources · 0 unsupported claims · read-only</span>
+      </div>
+    </div>
+
+    <h3>Anatomy &amp; rules</h3>
+    <table>
+      <tbody>
+        <tr><td>Question header</td><td>required</td><td>Real technician phrasing (fault code + symptom + asset). Never a marketing question. Shows the channel it came in on.</td></tr>
+        <tr><td>Grounded claims</td><td>highlight</td><td>Every fact that traces to a source is <mark>cyan-highlighted</mark>. If it isn't highlighted, it isn't cited — and shouldn't be in the answer.</td></tr>
+        <tr><td>Citation chips</td><td>required</td><td>One chip per source: manual §, fault history, PM/work order, PLC tag. This is the Harvey/Glean/Perplexity move. Chips are the proof.</td></tr>
+        <tr><td>Grounding badge</td><td>required</td><td>The 1–5 groundedness score + source count + "read-only." Turns the trust claim into a number.</td></tr>
+        <tr><td>Safety variant</td><td>conditional</td><td>When a safety keyword fires, the card flips to a red <span class="badge stop">⚠ STOP</span> header ("MIRA escalates, it never acts"). Reinforces the honest-limits brand.</td></tr>
+      </tbody>
+    </table>
+    <p class="note">Examples are representative of MIRA's real output shape and grounded on OEM documentation of the type FactoryLM indexes; swap in verified §/page numbers from a specific manual before any answer is presented as a factual claim.</p>
+  </div>
+</section>
+
+<!-- 4. COLOR -->
+<section>
+  <div class="wrap">
+    <div class="snum">04 — Color</div>
+    <h2>Ink, blueprint, and the three states</h2>
+    <p class="intro">Dark by default (2026 is a dark-mode expectation, and it reads as "engineered"). A single cyan action color, plus a strict traffic-light state system that carries the safety story. Inherits FactoryLM navy as the bridge to the parent brand.</p>
+    <div class="swatches">
+      <div class="sw"><div class="chip" style="background:#0A0E14"></div><div class="info"><div class="name">Ink</div><div class="hex">#0A0E14</div><div class="use">Page base</div></div></div>
+      <div class="sw"><div class="chip" style="background:#131C2A"></div><div class="info"><div class="name">Panel</div><div class="hex">#131C2A</div><div class="use">Cards, surfaces</div></div></div>
+      <div class="sw"><div class="chip" style="background:#20304A"></div><div class="info"><div class="name">Line</div><div class="hex">#20304A</div><div class="use">Borders, grid</div></div></div>
+      <div class="sw"><div class="chip" style="background:#1B365D"></div><div class="info"><div class="name">Brand navy</div><div class="hex">#1B365D</div><div class="use">FactoryLM link</div></div></div>
+      <div class="sw"><div class="chip" style="background:#2DD4E8"></div><div class="info"><div class="name">Cyan / action</div><div class="hex">#2DD4E8</div><div class="use">CTAs, highlights, links</div></div></div>
+      <div class="sw"><div class="chip" style="background:#9BE861"></div><div class="info"><div class="name">Lime / PASS</div><div class="hex">#9BE861</div><div class="use">Grounded, ok, running</div></div></div>
+      <div class="sw"><div class="chip" style="background:#F5B33C"></div><div class="info"><div class="name">Amber / HELD</div><div class="hex">#F5B33C</div><div class="use">Verify, warning</div></div></div>
+      <div class="sw"><div class="chip" style="background:#FF5C6C"></div><div class="info"><div class="name">Red / STOP</div><div class="hex">#FF5C6C</div><div class="use">Fault, safety stop, fail</div></div></div>
+    </div>
+    <h3>The one hard rule</h3>
+    <div class="role">
+      <span style="color:var(--cyan);border-color:var(--cyan)">cyan = action &amp; grounded evidence</span>
+      <span style="color:var(--lime);border-color:rgba(155,232,97,.4)">green = pass / ok</span>
+      <span style="color:var(--amber);border-color:rgba(245,179,60,.4)">amber = held / verify</span>
+      <span style="color:var(--red);border-color:rgba(255,92,108,.4)">red = stop / fault</span>
+    </div>
+    <p class="note">State colors are NEVER decorative. A green thing is a passing thing. This mirrors the FactoryLM UI token doctrine (muted normal; color = state only) so the hook and the platform feel like one company.</p>
+  </div>
+</section>
+
+<!-- 5. TYPE -->
+<section>
+  <div class="wrap">
+    <div class="snum">05 — Typography</div>
+    <h2>Two families. Oversized display, mono for proof.</h2>
+    <p class="intro">A clean grotesk sans for everything human (Inter / system stack), and a monospace for anything that signals "machine truth" — fault codes, citations, tags, scores. The mono is a trust device: it makes evidence look like evidence.</p>
+    <div class="demo">
+      <div class="type-row"><span class="lbl">Display / H1 · 800 · -1.5</span><span class="t-display">Trust the graph</span></div>
+      <div class="type-row"><span class="lbl">H2 · 800 · -0.8</span><span class="t-h2">Read any print</span></div>
+      <div class="type-row"><span class="lbl">H3 · 700</span><span class="t-h3">How it works</span></div>
+      <div class="type-row"><span class="lbl">Body · 400/600 · 17px</span><span class="t-body">Send a photo of a drawing; get a typed, evidence-backed graph.</span></div>
+      <div class="type-row"><span class="lbl">Small / muted · 14px</span><span class="t-small">No card. 5 free interpretations, then paid.</span></div>
+      <div class="type-row"><span class="lbl">Mono / proof · 13px</span><span class="t-mono">F5 · DC_BUS_UNDERVOLTAGE · §6.2 · GROUNDED 5/5</span></div>
+    </div>
+    <p class="note">Max two families. Mono is reserved — if it isn't machine data, it isn't mono. Oversized headlines (2026 trend) but kept legible; kinetic/scroll type only on the hero.</p>
+  </div>
+</section>
+
+<!-- 6. COMPONENTS -->
+<section>
+  <div class="wrap">
+    <div class="snum">06 — Component kit</div>
+    <h2>The reusable pieces</h2>
+    <p class="intro">Beyond the Cited Answer Card, five components carry every page. Consistent radii (10–16px), 1px lines, one accent.</p>
+
+    <h3>Buttons</h3>
+    <div class="demo"><div class="btn-row">
+      <span class="btn btn-primary">Claim 5 free reads →</span>
+      <span class="btn btn-ghost">See how it works</span>
+    </div><p class="sub-muted" style="font-size:13px;margin-top:14px">Primary = cyan, glow, one per view. Ghost = outline. Never two primaries competing.</p></div>
+
+    <h3>Stat / proof bento</h3>
+    <div class="bento" style="margin-top:16px">
+      <div class="stat"><div class="big cy">68,000+</div><div class="lbl">OEM doc chunks</div></div>
+      <div class="stat"><div class="big ok">91.7/A</div><div class="lbl">live read quality</div></div>
+      <div class="stat"><div class="big ok">0</div><div class="lbl">confident misreads</div></div>
+      <div class="stat"><div class="big cy">&lt;60s</div><div class="lbl">photo → verdict</div></div>
+    </div>
+    <p class="note">Bento grids: used by 67% of top SaaS pages, correlated with higher dwell + CTR. Use for proof stats and capability tiles — not for body copy.</p>
+
+    <h3>Verdict badges</h3>
+    <div class="demo"><div class="btn-row">
+      <span class="badge grounded">◆ GROUNDED 5/5</span>
+      <span class="badge" style="background:rgba(155,232,97,.15);color:var(--lime);border:1px solid rgba(155,232,97,.3)">PASS · importable</span>
+      <span class="badge" style="background:rgba(245,179,60,.14);color:var(--amber);border:1px solid rgba(245,179,60,.32)">HELD · review</span>
+      <span class="badge stop">⚠ STOP · escalate</span>
+    </div></div>
+  </div>
+</section>
+
+<!-- 7. SECTION BLUEPRINT -->
+<section>
+  <div class="wrap">
+    <div class="snum">07 — Page blueprint</div>
+    <h2>The section order that converts</h2>
+    <p class="intro">Sequenced so the page delivers value even if the visitor never scrolls, then stacks proof before the ask. This is the recommended order for the PrintSense hook page.</p>
+    <div class="blueprint">
+      <div class="bp"><div class="n"></div><div><h4>Hero = a live Cited Answer Card + one-line promise + "5 free reads" CTA</h4><p>Show the output first. Headline states the outcome, not the feature. Interactive if possible (type a question).</p></div></div>
+      <div class="bp"><div class="n"></div><div><h4>Proof strip — 68k chunks, manufacturer logos, 0 misreads</h4><p>Instant credibility wall. Real numbers, real OEM names.</p></div></div>
+      <div class="bp"><div class="n"></div><div><h4>The thesis — good prose ≠ a trustworthy graph</h4><p>The ATV340 81/B-with-P0-errors story. Your differentiator, stated plainly.</p></div></div>
+      <div class="bp"><div class="n"></div><div><h4>Manual Q&amp;A gallery — 3–4 more Cited Answer Cards, different manufacturers</h4><p>The convincing core. Rotate AB / Siemens / Schneider so buyers see their own gear answered.</p></div></div>
+      <div class="bp"><div class="n"></div><div><h4>How it works — photo → read → gate → verdict (4 steps)</h4><p>Demystify. Reinforce read-only + deterministic gate.</p></div></div>
+      <div class="bp"><div class="n"></div><div><h4>Generic-AI vs PrintSense comparison</h4><p>The same question, two answers. Sharpens why grounding matters.</p></div></div>
+      <div class="bp"><div class="n"></div><div><h4>Pricing — Free (5) → Pro → Team</h4><p>Answer price before they ask (Stripe move). Team tier upsell = export to FactoryLM namespace.</p></div></div>
+      <div class="bp"><div class="n"></div><div><h4>Ecosystem ladder — PrintSense → MIRA → FactoryLM</h4><p>"You are here." Show the platform without competing for the free-tool conversion.</p></div></div>
+      <div class="bp"><div class="n"></div><div><h4>Final CTA — email capture to unlock 5 reads</h4><p>Single field. Restate: no card, read-only, nothing writes back.</p></div></div>
+    </div>
+  </div>
+</section>
+
+<!-- 8. MOTION + VOICE -->
+<section>
+  <div class="wrap">
+    <div class="snum">08 — Motion &amp; voice</div>
+    <h2>How it moves, how it talks</h2>
+    <div class="dd">
+      <div class="do">
+        <h4>Motion — do</h4>
+        <ul>
+          <li>Scroll-reveal sections (subtle fade + rise, ~600ms)</li>
+          <li>A scan-line sweeping the print in the hero</li>
+          <li>Citation chips that expand to show the source on hover</li>
+          <li>Counters that tick up on stats when in view</li>
+          <li>Respect prefers-reduced-motion</li>
+        </ul>
+      </div>
+      <div class="dont">
+        <h4>Motion — don't</h4>
+        <ul>
+          <li>Auto-playing carousels or parallax that fights scroll</li>
+          <li>Anything that delays the hero paint</li>
+          <li>Decorative floating blobs / particles</li>
+          <li>Motion on the safety STOP card — it must feel instant &amp; sober</li>
+        </ul>
+      </div>
+    </div>
+    <h3>Voice</h3>
+    <div class="dd">
+      <div class="do">
+        <h4>Say it like this</h4>
+        <ul>
+          <li>"Get a graph you can actually trust."</li>
+          <li>"An A-grade read, correctly held for review."</li>
+          <li>"MIRA escalates. It never acts."</li>
+          <li>"Nothing writes back to your systems — ever."</li>
+          <li>Plain, technician-first, quantified.</li>
+        </ul>
+      </div>
+      <div class="dont">
+        <h4>Never this</h4>
+        <ul>
+          <li>"Revolutionary AI-powered synergy platform."</li>
+          <li>Vague superlatives with no number behind them.</li>
+          <li>Over-promising autonomy or control.</li>
+          <li>Corporate hedging. Keep FactoryLM's "no AI hype" spine.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section style="border-bottom:none">
+  <div class="wrap">
+    <div class="snum">09 — In one line</div>
+    <h2>Show a real answer, cite a real manual, and let honesty do the selling.</h2>
+    <p class="intro">Everything in this guide serves that sentence. The Cited Answer Card is the product; the rest is a frame that gets a skeptical technician to trust it in under 60 seconds.</p>
+  </div>
+</section>
+
+<div class="wrap foot-final">
+  PrintSense / FactoryLM design system v1.0 · built from a 25-page industry teardown · aligned to factorylm.com brand &amp; UI token doctrine.
+</div>
+
+</body>
+</html>

--- a/mira-web/public/printsense.html
+++ b/mira-web/public/printsense.html
@@ -1,0 +1,458 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PrintSense — Cited answers from your industrial prints & manuals</title>
+<meta name="description" content="Ask a fault-code or wiring question. Get a grounded answer that cites the actual OEM manual, your fault history, and PM records — plus a deterministic verdict you can trust. 5 free reads.">
+<style>
+  :root{
+    --ink:#0A0E14;--ink-2:#0F1621;--panel:#131C2A;--panel-2:#0c131e;
+    --line:#20304A;--line-2:#2b3e5c;--paper:#E8EEF6;--muted:#8A9BB4;--white:#F4F8FF;
+    --cyan:#2DD4E8;--cyan-deep:#14A3B8;--lime:#9BE861;--amber:#F5B33C;--red:#FF5C6C;
+    --radius:14px;
+    --mono:"SF Mono",ui-monospace,"JetBrains Mono",Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html{scroll-behavior:smooth}
+  body{background:var(--ink);color:var(--paper);font-family:var(--sans);line-height:1.6;-webkit-font-smoothing:antialiased;overflow-x:hidden}
+  a{color:inherit;text-decoration:none}
+  .wrap{max-width:1120px;margin:0 auto;padding:0 24px}
+  .mono{font-family:var(--mono)}
+  .grid-bg{position:absolute;inset:0;background-image:linear-gradient(rgba(45,212,232,.05) 1px,transparent 1px),linear-gradient(90deg,rgba(45,212,232,.05) 1px,transparent 1px);background-size:44px 44px;mask-image:radial-gradient(ellipse 80% 60% at 50% 0%,#000 40%,transparent 100%);pointer-events:none}
+
+  /* nav */
+  nav{position:sticky;top:0;z-index:50;background:rgba(10,14,20,.8);backdrop-filter:blur(12px);border-bottom:1px solid var(--line)}
+  .nav-in{display:flex;align-items:center;justify-content:space-between;height:64px}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:700}
+  .logo{width:30px;height:30px;border-radius:8px;background:linear-gradient(135deg,var(--cyan),var(--cyan-deep));display:grid;place-items:center;color:var(--ink);font-weight:800;box-shadow:0 0 20px rgba(45,212,232,.4)}
+  .brand small{color:var(--muted);font-weight:500;font-size:11px;letter-spacing:1px;text-transform:uppercase}
+  .nav-links{display:flex;gap:26px;align-items:center;font-size:14px;color:var(--muted)}
+  .nav-links a:hover{color:var(--white)}
+  .btn{display:inline-flex;align-items:center;gap:8px;font-weight:600;font-size:14px;padding:11px 20px;border-radius:10px;cursor:pointer;border:1px solid transparent;transition:.15s}
+  .btn-primary{background:var(--cyan);color:var(--ink);box-shadow:0 0 24px rgba(45,212,232,.3)}
+  .btn-primary:hover{background:#4de3f4;transform:translateY(-1px)}
+  .btn-ghost{border-color:var(--line);color:var(--paper)}
+  .btn-ghost:hover{border-color:var(--cyan);color:var(--cyan)}
+  @media(max-width:800px){.nav-links{display:none}}
+
+  /* hero */
+  .hero{padding:76px 0 64px;overflow:hidden}
+  .hero-grid{display:grid;grid-template-columns:1fr 1.05fr;gap:44px;align-items:center}
+  @media(max-width:940px){.hero-grid{grid-template-columns:1fr;gap:38px}}
+  .eyebrow{display:inline-flex;align-items:center;gap:8px;font-family:var(--mono);font-size:12px;letter-spacing:1.5px;text-transform:uppercase;color:var(--cyan);border:1px solid var(--line);padding:6px 14px;border-radius:100px;background:rgba(45,212,232,.06)}
+  .dot{width:7px;height:7px;border-radius:50%;background:var(--lime);box-shadow:0 0 10px var(--lime)}
+  h1{font-size:clamp(36px,5.4vw,60px);line-height:1.05;font-weight:800;letter-spacing:-1.5px;margin:22px 0 18px}
+  h1 .stroke{color:var(--cyan)}
+  .lede{font-size:clamp(16px,2vw,20px);color:var(--muted);max-width:560px}
+  .lede b{color:var(--paper);font-weight:600}
+  .hero-cta{display:flex;gap:14px;flex-wrap:wrap;margin-top:30px;align-items:center}
+  .free-note{font-size:13px;color:var(--muted);font-family:var(--mono)}
+  .free-note b{color:var(--lime)}
+
+  /* CITED ANSWER CARD (centerpiece) */
+  .answer{background:linear-gradient(180deg,var(--panel),var(--ink-2));border:1px solid var(--line-2);border-radius:16px;overflow:hidden;box-shadow:0 30px 80px -24px rgba(0,0,0,.8)}
+  .answer .q{display:flex;gap:12px;align-items:flex-start;padding:18px 20px;border-bottom:1px solid var(--line);background:var(--panel-2)}
+  .answer .q .avatar{width:30px;height:30px;border-radius:8px;background:var(--line);display:grid;place-items:center;font-size:14px;flex-shrink:0}
+  .answer .q .qt{font-size:15px;font-weight:600;color:var(--white);line-height:1.4}
+  .answer .q .qs{font-family:var(--mono);font-size:10.5px;color:var(--muted);margin-top:3px}
+  .answer .a{padding:20px}
+  .answer .a .mira{display:flex;align-items:center;gap:9px;margin-bottom:12px}
+  .answer .a .mira .b{width:26px;height:26px;border-radius:7px;background:linear-gradient(135deg,var(--cyan),var(--cyan-deep));display:grid;place-items:center;color:var(--ink);font-weight:800;font-size:13px}
+  .answer .a .mira .n{font-weight:700;font-size:14px}
+  .answer .a .mira .n small{color:var(--muted);font-weight:500;font-family:var(--mono);font-size:10.5px;margin-left:6px}
+  .answer .a .body{font-size:14.5px;color:var(--paper);line-height:1.7}
+  .answer .a .body mark{background:rgba(45,212,232,.14);color:var(--cyan);padding:1px 4px;border-radius:4px;font-weight:600}
+  .cites{display:flex;gap:8px;flex-wrap:wrap;margin-top:15px}
+  .cite{display:inline-flex;align-items:center;gap:7px;font-family:var(--mono);font-size:11px;color:var(--paper);background:var(--panel-2);border:1px solid var(--line);border-radius:8px;padding:7px 11px;transition:.15s}
+  .cite .ico{color:var(--cyan)}
+  .cite:hover{border-color:var(--cyan);transform:translateY(-1px)}
+  .answer .foot{display:flex;align-items:center;gap:10px;padding:12px 20px;border-top:1px solid var(--line);background:var(--panel-2);font-family:var(--mono);font-size:11px;color:var(--muted)}
+  .badge{font-family:var(--mono);font-weight:700;font-size:11px;padding:4px 10px;border-radius:6px}
+  .badge.grounded{background:rgba(155,232,97,.15);color:var(--lime);border:1px solid rgba(155,232,97,.3)}
+  .badge.stop{background:rgba(255,92,108,.14);color:var(--red);border:1px solid rgba(255,92,108,.32)}
+  .badge.pass{background:rgba(155,232,97,.16);color:var(--lime);border:1px solid rgba(155,232,97,.35)}
+  .badge.held{background:rgba(245,179,60,.14);color:var(--amber);border:1px solid rgba(245,179,60,.32)}
+
+  /* strip */
+  .strip{border-top:1px solid var(--line);border-bottom:1px solid var(--line);padding:24px 0;background:var(--ink-2)}
+  .strip-in{display:flex;align-items:center;gap:26px;flex-wrap:wrap;justify-content:center;font-family:var(--mono);font-size:12.5px;color:var(--muted)}
+  .strip-in b{color:var(--paper)} .strip-in span.d{color:var(--line)}
+
+  /* section shell */
+  .sec{padding:82px 0}
+  .kicker{font-family:var(--mono);font-size:12px;letter-spacing:2px;text-transform:uppercase;color:var(--cyan);margin-bottom:14px}
+  h2{font-size:clamp(27px,3.8vw,40px);font-weight:800;letter-spacing:-1px;line-height:1.12}
+  .sub{color:var(--muted);font-size:17px;margin-top:14px;max-width:640px}
+
+  /* Q&A gallery */
+  .gallery{display:grid;grid-template-columns:1fr 1fr;gap:20px;margin-top:40px}
+  @media(max-width:820px){.gallery{grid-template-columns:1fr}}
+
+  /* thesis */
+  .thesis{background:var(--ink-2);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+  .thesis-box{border:1px solid var(--line);border-left:3px solid var(--amber);border-radius:12px;background:var(--panel);padding:26px 28px;margin-top:28px}
+  .thesis-box .big{font-size:clamp(19px,2.7vw,25px);font-weight:700;letter-spacing:-.5px}
+  .thesis-box .big em{color:var(--amber);font-style:normal}
+  .thesis-box p{color:var(--muted);margin-top:12px;font-size:15px}
+  .thesis-box p code{font-family:var(--mono);color:var(--cyan);font-size:13px}
+
+  /* steps */
+  .steps{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-top:42px}
+  @media(max-width:860px){.steps{grid-template-columns:1fr 1fr}}
+  @media(max-width:520px){.steps{grid-template-columns:1fr}}
+  .step{background:var(--panel);border:1px solid var(--line);border-radius:var(--radius);padding:22px}
+  .step .n{font-family:var(--mono);font-size:12px;color:var(--cyan);border:1px solid var(--line);width:30px;height:30px;border-radius:8px;display:grid;place-items:center;margin-bottom:14px}
+  .step .ic{font-size:22px;margin-bottom:8px;display:block}
+  .step h3{font-size:16px;font-weight:700;margin-bottom:6px}
+  .step p{font-size:13.5px;color:var(--muted)}
+
+  /* bento stats */
+  .bento{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-top:40px}
+  @media(max-width:720px){.bento{grid-template-columns:1fr 1fr}}
+  .stat{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:20px}
+  .stat .big{font-size:32px;font-weight:800;letter-spacing:-1px}
+  .stat .big.ok{color:var(--lime)} .stat .big.cy{color:var(--cyan)}
+  .stat .lbl{font-family:var(--mono);font-size:11px;letter-spacing:.5px;text-transform:uppercase;color:var(--muted);margin-top:4px}
+
+  /* comparison */
+  .cmp{display:grid;grid-template-columns:1fr 1fr;gap:20px;margin-top:40px}
+  @media(max-width:820px){.cmp{grid-template-columns:1fr}}
+  .card-bad,.card-good{border-radius:var(--radius);padding:24px;border:1px solid var(--line)}
+  .card-bad{background:#161016;border-color:rgba(255,92,108,.25)}
+  .card-good{background:#0f1712;border-color:rgba(155,232,97,.28)}
+  .card-bad .hd{color:var(--red)}.card-good .hd{color:var(--lime)}
+  .cmp .hd{font-family:var(--mono);font-size:12px;letter-spacing:1px;text-transform:uppercase;margin-bottom:14px;font-weight:700}
+  .cmp blockquote{font-size:14.5px;color:var(--paper);border-left:2px solid var(--line);padding-left:14px;font-style:italic}
+  .cmp .note{margin-top:14px;font-size:12.5px;color:var(--muted);font-family:var(--mono)}
+
+  /* pricing */
+  .price-wrap{background:var(--ink-2);border-top:1px solid var(--line);border-bottom:1px solid var(--line)}
+  .prices{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;margin-top:42px}
+  @media(max-width:860px){.prices{grid-template-columns:1fr;max-width:440px;margin:42px auto 0}}
+  .plan{background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:28px;display:flex;flex-direction:column}
+  .plan.feature{border-color:var(--cyan);box-shadow:0 0 0 1px var(--cyan),0 24px 60px -20px rgba(45,212,232,.25);position:relative}
+  .plan .flag{position:absolute;top:-12px;left:28px;background:var(--cyan);color:var(--ink);font-size:11px;font-weight:700;font-family:var(--mono);padding:4px 10px;border-radius:6px}
+  .plan .pname{font-family:var(--mono);font-size:12px;letter-spacing:1.5px;text-transform:uppercase;color:var(--muted)}
+  .plan .amt{font-size:40px;font-weight:800;letter-spacing:-1.5px;margin:12px 0 2px}
+  .plan .amt small{font-size:15px;color:var(--muted);font-weight:500}
+  .plan .pdesc{font-size:13.5px;color:var(--muted);min-height:38px}
+  .plan ul{list-style:none;margin:20px 0;display:flex;flex-direction:column;gap:11px;flex:1}
+  .plan li{font-size:14px;display:flex;gap:10px;align-items:flex-start}
+  .plan li:before{content:"✓";color:var(--lime);font-weight:800}
+  .plan li.off{color:var(--muted)}.plan li.off:before{content:"·";color:var(--muted)}
+  .plan .btn{width:100%;justify-content:center;margin-top:auto}
+
+  /* ladder */
+  .ladder{display:grid;grid-template-columns:repeat(3,1fr);gap:0;margin-top:42px;border:1px solid var(--line);border-radius:16px;overflow:hidden}
+  @media(max-width:820px){.ladder{grid-template-columns:1fr}}
+  .rung{padding:28px;border-right:1px solid var(--line);background:var(--panel)}
+  .rung:last-child{border-right:none}
+  @media(max-width:820px){.rung{border-right:none;border-bottom:1px solid var(--line)}}
+  .rung.here{background:linear-gradient(180deg,rgba(45,212,232,.08),var(--panel))}
+  .rung .lvl{font-family:var(--mono);font-size:11px;letter-spacing:1.5px;text-transform:uppercase;color:var(--muted)}
+  .rung h3{font-size:20px;font-weight:800;margin:8px 0 4px}
+  .rung .who{font-family:var(--mono);font-size:11px;color:var(--cyan);margin-bottom:12px}
+  .rung p{font-size:13.5px;color:var(--muted)}
+  .rung .badge-here{display:inline-block;margin-top:12px;font-size:11px;font-family:var(--mono);background:var(--cyan);color:var(--ink);padding:3px 9px;border-radius:6px;font-weight:700}
+  .arrow-note{text-align:center;color:var(--muted);font-family:var(--mono);font-size:12.5px;margin-top:20px}
+  .arrow-note b{color:var(--lime)}
+
+  /* final */
+  .final{padding:92px 0;text-align:center;position:relative}
+  .final h2{max-width:700px;margin:0 auto}
+  .capture{display:flex;gap:10px;max-width:480px;margin:30px auto 0;flex-wrap:wrap;justify-content:center}
+  .capture input{flex:1;min-width:220px;background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:13px 16px;color:var(--white);font-size:15px;font-family:var(--sans)}
+  .capture input:focus{outline:none;border-color:var(--cyan)}
+
+  footer{border-top:1px solid var(--line);padding:38px 0;color:var(--muted);font-size:13px}
+  .foot-in{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;align-items:center}
+  .foot-links{display:flex;gap:22px;flex-wrap:wrap}
+  .foot-links a:hover{color:var(--cyan)}
+
+  .reveal{opacity:0;transform:translateY(18px);transition:.7s cubic-bezier(.2,.7,.2,1)}
+  .reveal.in{opacity:1;transform:none}
+  @media(prefers-reduced-motion:reduce){.reveal{opacity:1;transform:none;transition:none}}
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="wrap nav-in">
+    <div class="brand"><div class="logo">P</div><div>PrintSense <small>by FactoryLM</small></div></div>
+    <div class="nav-links">
+      <a href="#answers">Real answers</a>
+      <a href="#trust">Why trust it</a>
+      <a href="#how">How it works</a>
+      <a href="#pricing">Pricing</a>
+    </div>
+    <a href="#start" class="btn btn-primary">Try 5 free reads →</a>
+  </div>
+</nav>
+
+<!-- HERO: cited answer is the centerpiece -->
+<section class="hero">
+  <div class="grid-bg"></div>
+  <div class="wrap hero-grid">
+    <div>
+      <span class="eyebrow"><span class="dot"></span> Cited print &amp; manual intelligence · read-only</span>
+      <h1>Ask about any fault. Get the answer <span class="stroke">and its source.</span></h1>
+      <p class="lede">Snap a photo of an electrical print or ask a fault-code question. PrintSense answers with a <b>grounded, cited response</b> — pulled from the actual OEM manual, your fault history, and PM records — plus a deterministic verdict on whether it's safe to trust. <b>Claude reads it; a code shell owns the trust.</b></p>
+      <div class="hero-cta">
+        <a href="#start" class="btn btn-primary">Start with 5 free reads →</a>
+        <a href="#answers" class="btn btn-ghost">See real answers</a>
+      </div>
+      <p class="free-note" style="margin-top:18px">No card. <b>5 free interpretations</b>, then paid · nothing writes back to your systems.</p>
+    </div>
+
+    <!-- THE cited answer card -->
+    <div class="answer reveal">
+      <div class="q">
+        <div class="avatar">🔧</div>
+        <div>
+          <div class="qt">"PowerFlex 755 keeps tripping F5 around 1,200 RPM overnight — what do I check first?"</div>
+          <div class="qs">Asset POW-755-A12 · Line 3 · via Telegram · 02:14</div>
+        </div>
+      </div>
+      <div class="a">
+        <div class="mira"><span class="b">M</span><span class="n">MIRA <small>grounded answer</small></span></div>
+        <div class="body">
+          F5 on this drive is a <mark>DC bus undervoltage</mark> fault. Your last 7 days show <mark>4 trips in the same RPM band, all overnight</mark> — a sagging-bus pattern, not a random fault. The manual's fault-recovery section sends you to the <mark>DC bus capacitor bank</mark> first, and your own history backs it up: the 2024-12-14 PM flagged bulging on capacitor 3. Check there before changing any drive parameters.
+        </div>
+        <div class="cites">
+          <span class="cite"><span class="ico">📄</span> PowerFlex 755 Manual · §6.2 Fault F5</span>
+          <span class="cite"><span class="ico">🗂️</span> Fault history · 7 d</span>
+          <span class="cite"><span class="ico">🛠️</span> PM · 2024-12-14</span>
+        </div>
+      </div>
+      <div class="foot"><span class="badge grounded">◆ GROUNDED 5/5</span><span>3 sources · 0 unsupported claims · read-only</span></div>
+    </div>
+  </div>
+</section>
+
+<!-- TRUST STRIP -->
+<div class="strip">
+  <div class="wrap strip-in">
+    <span><b>68,000+</b> OEM doc chunks indexed</span><span class="d">·</span>
+    <span>Allen-Bradley</span><span class="d">·</span><span>Siemens</span><span class="d">·</span>
+    <span>Schneider</span><span class="d">·</span><span>ABB</span><span class="d">·</span><span>Yaskawa</span><span class="d">·</span>
+    <span><b>0</b> confident misreads</span>
+  </div>
+</div>
+
+<!-- Q&A GALLERY -->
+<section class="sec" id="answers">
+  <div class="wrap">
+    <div class="kicker">Real answers, real sources</div>
+    <h2>Every answer points back to a manual.</h2>
+    <p class="sub">This is the whole product. Not a chatbot guessing — a grounded answer with the OEM page, the fault history, or the PM record it stands on. Here's the same rigor across the gear on your floor.</p>
+
+    <div class="gallery">
+      <!-- Siemens -->
+      <div class="answer reveal">
+        <div class="q"><div class="avatar">🔧</div><div>
+          <div class="qt">"Siemens G120 showing F30002 — is this a real overload or a false trip?"</div>
+          <div class="qs">Asset CNV-G120-04 · Packaging · via web</div>
+        </div></div>
+        <div class="a">
+          <div class="mira"><span class="b">M</span><span class="n">MIRA <small>grounded answer</small></span></div>
+          <div class="body">F30002 is a <mark>DC-link overvoltage</mark> trip — commonly a regenerative load during rapid deceleration, not a wiring fault. The manual's remedy list points to <mark>extending the ramp-down time or adding a braking resistor</mark>. No braking resistor is recorded on this asset, and your ramp-down is set aggressive — consistent with the trips clustering on stops.</div>
+          <div class="cites">
+            <span class="cite"><span class="ico">📄</span> SINAMICS G120 List Manual · F30002</span>
+            <span class="cite"><span class="ico">🏷️</span> Param backup · ramp-down 0.5s</span>
+          </div>
+        </div>
+        <div class="foot"><span class="badge grounded">◆ GROUNDED 5/5</span><span>2 sources · read-only</span></div>
+      </div>
+
+      <!-- Schneider — HELD / gate working -->
+      <div class="answer reveal">
+        <div class="q"><div class="avatar">🔧</div><div>
+          <div class="qt">"Read this Schneider ATV340 print and import the device list."</div>
+          <div class="qs">SCU2 · sheet-20 · photo upload</div>
+        </div></div>
+        <div class="a">
+          <div class="mira"><span class="b">M</span><span class="n">MIRA <small>read + verdict</small></span></div>
+          <div class="body">Read complete: <mark>14 devices, 22 wires typed</mark>, quality <mark>91.7 / A</mark>, 0 misreads. But import is <mark>HELD</mark> — tag <mark>-K1 appears twice</mark> on sheet-20 and must be variant-qualified before it's safe to bring in. A great read is still not an import until the duplicate is resolved.</div>
+          <div class="cites">
+            <span class="cite"><span class="ico">📐</span> Typed graph · SCU2 sheet-20</span>
+            <span class="cite"><span class="ico">🛡️</span> Gate G7 · duplicate_identifier</span>
+          </div>
+        </div>
+        <div class="foot"><span class="badge held">⏸ IMPORT HELD</span><span>gate caught it — not shipped</span></div>
+      </div>
+
+      <!-- Allen-Bradley safety STOP variant -->
+      <div class="answer reveal">
+        <div class="q"><div class="avatar">🔧</div><div>
+          <div class="qt">"Photo of the panel — can I energize this 240V branch?"</div>
+          <div class="qs">Panel PP-12 · photo upload · 02:14</div>
+        </div></div>
+        <div class="a">
+          <div class="mira"><span class="b">M</span><span class="n">MIRA <small>safety escalation</small></span></div>
+          <div class="body"><mark>STOP — do not energize.</mark> The photo shows a meter reading <mark>480 V on a branch labeled 240 V</mark>. That's outside safe range for the downstream devices on this print. Verify with a meter and confirm the source before any next step. MIRA won't clear this — a human has to.</div>
+          <div class="cites">
+            <span class="cite"><span class="ico">📄</span> Panel schedule · PP-12 branch 4</span>
+            <span class="cite"><span class="ico">⚠️</span> Safety rule · voltage-mismatch</span>
+          </div>
+        </div>
+        <div class="foot"><span class="badge stop">⚠ STOP · ESCALATE</span><span>MIRA escalates — it never acts</span></div>
+      </div>
+
+      <!-- ABB — evidence-first -->
+      <div class="answer reveal">
+        <div class="q"><div class="avatar">🔧</div><div>
+          <div class="qt">"ABB ACS880 fault 2310 — where do I even start?"</div>
+          <div class="qs">Asset MIX-880-A1 · via Telegram</div>
+        </div></div>
+        <div class="a">
+          <div class="mira"><span class="b">M</span><span class="n">MIRA <small>grounded answer</small></span></div>
+          <div class="body">Fault 2310 is an <mark>overcurrent</mark> event. The manual's checklist starts with <mark>motor cable and winding checks</mark> before the drive itself. This asset has <mark>no prior 2310 in its history</mark>, so treat it as new — meg the motor leads first; the drive is the last suspect, not the first.</div>
+          <div class="cites">
+            <span class="cite"><span class="ico">📄</span> ACS880 Firmware Manual · 2310</span>
+            <span class="cite"><span class="ico">🗂️</span> Fault history · none prior</span>
+          </div>
+        </div>
+        <div class="foot"><span class="badge grounded">◆ GROUNDED 4/5</span><span>2 sources · read-only</span></div>
+      </div>
+    </div>
+    <p class="free-note" style="margin-top:20px;text-align:center">Representative of MIRA's real grounded output. Every claim you see highlighted is tied to a source — nothing else gets said.</p>
+  </div>
+</section>
+
+<!-- THESIS -->
+<section class="sec thesis" id="trust">
+  <div class="wrap">
+    <div class="kicker">Why you can trust it</div>
+    <h2>Good prose ≠ a trustworthy graph.</h2>
+    <div class="thesis-box reveal">
+      <div class="big">A Schneider ATV340 read scored <em>81/B</em> from an AI judge — while the graph underneath carried <em>P0 electrical errors.</em></div>
+      <p>Fluent language fools a judge. It must never unlock an import. So PrintSense splits the job: the model <b style="color:var(--paper)">interprets</b> the drawing, and a <b style="color:var(--paper)">deterministic shell</b> owns validation, evidence, and the import gate. <code>Fluent language can never clear the gate.</code> Read-only. Train before deploy.</p>
+    </div>
+    <div class="bento reveal">
+      <div class="stat"><div class="big cy">68,000+</div><div class="lbl">OEM doc chunks</div></div>
+      <div class="stat"><div class="big ok">91.7/A</div><div class="lbl">live read quality</div></div>
+      <div class="stat"><div class="big ok">0</div><div class="lbl">confident misreads</div></div>
+      <div class="stat"><div class="big cy">&lt;60s</div><div class="lbl">photo → verdict</div></div>
+    </div>
+  </div>
+</section>
+
+<!-- HOW -->
+<section class="sec" id="how">
+  <div class="wrap">
+    <div class="kicker">How it works</div>
+    <h2>Photo in. Cited answer out.</h2>
+    <p class="sub">Four steps, seconds of your time, zero access to your network.</p>
+    <div class="steps">
+      <div class="step reveal"><span class="ic">📸</span><div class="n">01</div><h3>Send it</h3><p>Text a drawing or a fault question to the bot. Skewed, rotated, phone-lit — handled.</p></div>
+      <div class="step reveal"><span class="ic">🧠</span><div class="n">02</div><h3>Claude reads it</h3><p>Full-resolution, auto-uprighted, IEC-81346 grammar. Every device and wire typed into a graph.</p></div>
+      <div class="step reveal"><span class="ic">🔎</span><div class="n">03</div><h3>MIRA grounds it</h3><p>Cross-checked against 68k OEM chunks, your fault history, and PM records — every claim tied to a source.</p></div>
+      <div class="step reveal"><span class="ic">🛡️</span><div class="n">04</div><h3>The gate rules</h3><p>A deterministic grader + 14 import gates return a clear PASS or HELD. No LLM gets a vote here.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- COMPARISON -->
+<section class="sec" style="background:var(--ink-2);border-top:1px solid var(--line);border-bottom:1px solid var(--line)">
+  <div class="wrap">
+    <div class="kicker">The difference</div>
+    <h2>Same question. Two very different answers.</h2>
+    <div class="cmp">
+      <div class="card-bad reveal">
+        <div class="hd">✕ Generic AI</div>
+        <blockquote>"F5 is usually undervoltage. Check your incoming line voltage and confirm your PLC tag mapping. You should be good to proceed."</blockquote>
+        <div class="note">No manual. No history. No idea about your bulging capacitor. Confident — and useless on the floor.</div>
+      </div>
+      <div class="card-good reveal">
+        <div class="hd">✓ PrintSense</div>
+        <blockquote>"F5 = DC bus undervoltage. 4 overnight trips in the same RPM band. Manual §6.2 → check the bus capacitor bank; your 2024-12-14 PM already flagged cap 3."</blockquote>
+        <div class="note">Every claim cited. The actual root cause, surfaced from your own records.</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- PRICING -->
+<section class="sec price-wrap" id="pricing">
+  <div class="wrap">
+    <div class="kicker">Pricing</div>
+    <h2>Start free. Pay when it saves you a call-out.</h2>
+    <p class="sub">Your first 5 interpretations are on us — no card, no demo. Keep going when you see it work.</p>
+    <div class="prices">
+      <div class="plan reveal">
+        <div class="pname">Free</div><div class="amt">$0</div>
+        <div class="pdesc">See it answer a real question about your own gear.</div>
+        <ul><li><b>5 interpretations</b></li><li>Cited answers + sources</li><li>Typed graph + read quality</li><li>Import PASS / HELD verdict</li><li class="off">Batch &amp; history</li><li class="off">Namespace export</li></ul>
+        <a href="#start" class="btn btn-ghost">Claim 5 free reads</a>
+      </div>
+      <div class="plan feature reveal">
+        <div class="flag">MOST POPULAR</div>
+        <div class="pname">Pro</div><div class="amt">$49<small>/mo</small></div>
+        <div class="pdesc">For the tech or crew reading prints every week.</div>
+        <ul><li><b>150 interpretations / mo</b></li><li>Everything in Free</li><li>Batch upload &amp; saved history</li><li>Export to CSV / graph</li><li>Priority read queue</li><li>Email support</li></ul>
+        <a href="#start" class="btn btn-primary">Start Pro</a>
+      </div>
+      <div class="plan reveal">
+        <div class="pname">Shop / Team</div><div class="amt">Custom</div>
+        <div class="pdesc">For a plant standardizing on trustworthy reads.</div>
+        <ul><li><b>Unlimited</b> interpretations</li><li>Everything in Pro</li><li>Export straight into your FactoryLM namespace</li><li>Shared team library</li><li>Onboarding + priority support</li><li>Volume pricing</li></ul>
+        <a href="#start" class="btn btn-ghost">Talk to Mike</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ECOSYSTEM -->
+<section class="sec">
+  <div class="wrap">
+    <div class="kicker">Where PrintSense fits</div>
+    <h2>The free tool is the front door.</h2>
+    <p class="sub">Every print you read and every answer MIRA grounds becomes structured asset context — the exact foundation FactoryLM's namespace is built on. Start small; the value compounds.</p>
+    <div class="ladder reveal">
+      <div class="rung here"><div class="lvl">Tier 0 · The hook</div><h3>PrintSense</h3><div class="who">for the technician</div><p>Read one drawing or answer one fault, free. Read-only, zero infra, seconds to value.</p><span class="badge-here">You are here</span></div>
+      <div class="rung"><div class="lvl">Tier 1 · Activate</div><h3>MIRA</h3><div class="who">for the maintenance team</div><p>Grounded troubleshooting that cites its sources — Telegram, web, and the CMMS.</p></div>
+      <div class="rung"><div class="lvl">Tier 2 · Expand</div><h3>FactoryLM</h3><div class="who">for the plant</div><p>The Maintenance Intelligence Namespace: manuals, PLC tags, and fault history structured into AI-ready context.</p></div>
+    </div>
+    <div class="arrow-note">PrintSense → MIRA → FactoryLM &nbsp;·&nbsp; <b>lead with context, not a copilot.</b></div>
+  </div>
+</section>
+
+<!-- FINAL CTA -->
+<section class="final" id="start">
+  <div class="grid-bg"></div>
+  <div class="wrap">
+    <div class="kicker" style="text-align:center">Get started</div>
+    <h2>Get one cited answer in the next 60 seconds.</h2>
+    <p class="sub" style="margin:14px auto 0;text-align:center">Drop your email to unlock 5 free interpretations and get the link to send your first print or fault question.</p>
+    <form class="capture" onsubmit="event.preventDefault();this.innerHTML='<p style=&quot;color:var(--lime);font-family:var(--mono)&quot;>✓ You&rsquo;re in. Check your inbox for your PrintSense link.</p>'">
+      <input type="email" placeholder="you@plant.com" required>
+      <button class="btn btn-primary" type="submit">Unlock 5 free reads →</button>
+    </form>
+    <p class="free-note" style="margin-top:16px">No card · read-only · nothing writes back to your systems</p>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap foot-in">
+    <div class="brand"><div class="logo">P</div><div>PrintSense <small>by FactoryLM</small></div></div>
+    <div class="foot-links">
+      <a href="https://factorylm.com">FactoryLM</a>
+      <a href="#answers">Real answers</a>
+      <a href="#pricing">Pricing</a>
+      <a href="https://factorylm.com/security">Security</a>
+      <a href="mailto:mike@factorylm.com">Talk to Mike</a>
+    </div>
+    <div style="width:100%;color:var(--line);font-size:12px;font-family:var(--mono);border-top:1px solid var(--line);padding-top:18px">
+      PrintSense is read-only print &amp; manual intelligence. MIRA escalates, it never acts. © FactoryLM · Built for industrial maintenance.
+    </div>
+  </div>
+</footer>
+
+<script>
+  const io=new IntersectionObserver((es)=>{es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('in');io.unobserve(e.target)}})},{threshold:.12});
+  document.querySelectorAll('.reveal').forEach(el=>io.observe(el));
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What
First-pass **PrintSense** marketing landing page and its supporting design system / style guide.

- `mira-web/public/printsense.html` — landing page for the print-intelligence pitch (send an electrical print, get a grounded, evidence-backed answer + trust verdict).
- `docs/printsense/style-guide.html` — design system: governing principles, 25-page competitive teardown, color/type system, component kit, the Cited Answer Card spec.

## Status / honest flags
- **Answer examples are representative**, not yet pulled from the graded fixtures. Follow-up: swap the hero + gallery to real graded output (ATV340 81/B trust-gap case, SCU2 91.7/A) and add anonymized print snippets.
- **Pricing ($49 Pro) is a placeholder.**
- **Email form is a front-end mock** — needs wiring to capture/Stripe/Telegram.

## Not included
Leaves untouched the unrelated in-progress changes on main (contextualization review route + migration 067).

## Test
Static HTML — open both files in a browser.