### PR TITLE
docs(spec): OEM crawler to retrieval bridge (SP1 design)

### DIFF
--- a/docs/superpowers/plans/2026-07-28-oem-crawler-retrieval-bridge.md
+++ b/docs/superpowers/plans/2026-07-28-oem-crawler-retrieval-bridge.md
@@ -1,5 +1,17 @@
 # OEM Crawler → Retrieval Bridge (SP1) Implementation Plan
 
+> **STATUS (2026-07-29): SHIPPED, WITH ONE TASK DROPPED.** Implementation landed as
+> **PR #2999** (`fix/oem-crawler-retrieval-bridge-sp1`, green, awaiting merge). Tasks
+> 1–3 and 5 (the `verified` flag, per-crawler-class trust, the `apply-seeds.yml`
+> staging target, the version bump) shipped as written. **Task 4 (the one-time
+> backfill seed) and Task 6 (applying it) were built, reviewed, and deliberately
+> dropped** — the seed's selector describes an output *shape*, not a verifiable
+> *origin*, and nothing recorded which writer produced a given row. Full reasoning is
+> on Task 4 ("Why this was dropped") and Task 6 (status note), kept intact rather than
+> deleted. Task 7 (crawler deploy) still applies, independent of Task 6. In place of
+> the backfill, 4 OEM manuals were added to `sources.yaml` so the trusted crawler
+> re-acquires them properly (issue #3000 tracks a follow-up corpus-health check).
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make the OEM manual chunks the Bravo crawler ingests reachable by MIRA's grounded answering — route them to the shared OEM tenant pool, mark them trusted, and retro-fit the chunks already written to the wrong tenant.
@@ -30,7 +42,7 @@
 
 - **Spec Unit 2c is wrong about where the flag goes.** It puts `verified=True` + `oem_tenant_id` at `base_crawler.py:151` — inside `BaseCrawler.process()`, which `CurriculumCrawler` and `CSVCrawler` both inherit (`csv_crawler.py:151` calls `super().process(...)`). As written it would auto-trust and re-tenant curriculum and CSV crawls too, which is wider than the Unit 1 doctrine allows. **Task 2 fixes this** with a class-level `oem_trusted` flag that only `ManufacturerCrawler` sets.
 - **Spec Unit 3 assumes `apply-seeds.yml` can target staging. It cannot** — it hardcodes `--config prd` and `environment: production`. **Task 3 adds a `target` input**, mirroring `db-inspect.yml:14-20` and `apply-migrations.yml:23-29`, so the staging gate is real rather than aspirational.
-- **Rollout order should be flipped.** The spec deploys the write-path change first, then backfills. Running the crawler against the shared pool *before* the backfill creates shared-pool copies of URLs already stored under the garage tenant, which the backfill's `NOT EXISTS` guard then skips — inflating orphan count. **Backfill first (Task 6), then deploy the code (Task 7).** The two are independent, so the reorder is free.
+- **Rollout order should be flipped.** The spec deploys the write-path change first, then backfills. Running the crawler against the shared pool *before* the backfill creates shared-pool copies of URLs already stored under the garage tenant, which the backfill's `NOT EXISTS` guard then skips — inflating orphan count. **Backfill first (Task 6), then deploy the code (Task 7).** The two are independent, so the reorder is free. *(Moot as of 2026-07-29 — Task 6 was dropped along with Task 4; only Task 7 ran. See Task 4's "Why this was dropped" and Task 6's status note.)*
 - **No knowledge-graph blast radius.** `BaseCrawler.process()` calls `store_chunks(...)` without `model_number`, so the KG branch in `store_chunks` (`if kg_writer is not None and manufacturer and model_number`) never fires on this path. Changing the tenant does **not** move `kg_entities` rows. Do not add KG handling.
 
 ---
@@ -593,7 +605,15 @@ git commit -m "ci(seeds): let apply-seeds target staging, not prod only"
 
 ---
 
-### Task 4: The one-time backfill seed
+### Task 4: The one-time backfill seed — SUPERSEDED, NOT SHIPPED
+
+> **STATUS (2026-07-29): dropped.** This task was implemented following the steps
+> below, reviewed, and then the seed was removed before PR #2999 merged. Kept
+> verbatim — not deleted — because the collision-guard design and the ephemeral-DB
+> test recipe below are the evidence the rejection argument (see "Why this was
+> dropped" at the end of this task) responds to. The file
+> `tools/seeds/backfill_oem_crawler_chunks.sql` does **not** exist on `main`; its bad
+> fixture was recovered verbatim into `tests/test_architecture.py` Contract 7 instead.
 
 **Files:**
 - Create: `tools/seeds/backfill_oem_crawler_chunks.sql`
@@ -727,6 +747,32 @@ git add tools/seeds/backfill_oem_crawler_chunks.sql
 git commit -m "feat(seeds): backfill orphaned OEM crawler chunks into the shared pool"
 ```
 
+#### Why this was dropped (added 2026-07-29)
+
+The collision guard above keys on `metadata->>'source' = 'mira_crawler'`, and review
+generalized the question to the shape-based selector `source_type =
+'equipment_manual' AND manufacturer <> ''`. Both describe an output **shape**, not an
+**origin** — three writers can produce that shape: `ManufacturerCrawler` (trusted),
+`CSVCrawler` (heuristic PDF resolution, untrusted), and `tasks/ingest.py::ingest_url`
+(untrusted). **No column stored by `insert_chunk` records which one wrote a given
+row.** An audit found only 10 of 311 `CSVCrawler` rows were ever ingested, and all 10
+re-verified as live valid PDFs from legitimate sources (zero third-party
+aggregators) — so this was not a document-quality problem. It was an
+**auditability** problem: for portal-scraped rows the crawler never persists the
+resolved PDF URL, so a future reviewer cannot confirm after the fact which rows a
+one-time `verified=true` promotion actually touched. That is exactly the pattern the
+Contract 7 guard in `tests/test_architecture.py` (added instead of this seed) now
+exists to reject — its bad fixture is this file, recovered verbatim from git.
+
+What shipped instead: class-scoped trust assertions
+(`mira-crawler/tests/test_oem_trust.py`), the Contract 7 guard, a `sources.yaml`
+well-formedness guard, and **re-acquisition, not reclassification** — 4 OEM manuals
+(Interroll MultiControl, Demag, Magnetek Impulse G+ Mini, Allen-Bradley 100-C30)
+added to `mira-crawler/sources.yaml` so the trusted crawler fetches them properly,
+instead of retroactively blessing rows a heuristic crawler already wrote. See the
+design doc's "Unit 3 — superseded" section for the full writeup, including the 28
+excluded re-acquisition candidates and follow-up issue #3000.
+
 ---
 
 ### Task 5: Version bump, changelog, and PR
@@ -785,7 +831,14 @@ Expected: green. `Version Bump Check` must pass — if it fails, `VERSION` did n
 
 ---
 
-### Task 6: Apply the backfill (staging → prod) — operator, gated
+### Task 6: Apply the backfill (staging → prod) — operator, gated — SUPERSEDED, NOT EXECUTED
+
+> **STATUS (2026-07-29): not run.** This task assumed Task 4's seed would ship. It
+> didn't (see Task 4's "Why this was dropped"), so none of the steps below ran — no
+> staging apply, no prod apply, no orphaned rows moved. Kept verbatim as the intended
+> operator runbook in case a future, better-audited backfill is proposed; do not run
+> it against the current repo, since `tools/seeds/backfill_oem_crawler_chunks.sql` no
+> longer exists on `main`.
 
 Do this **before** Task 7, so the crawler does not create shared-pool copies the guard then skips. Requires a human with workflow-dispatch rights; the agent cannot mutate prod (`MIRA_ALLOW_PROD=1` is human-only).
 
@@ -842,6 +895,9 @@ Same two dispatches with `target=prod`. Re-run the count query via `db-inspect.y
 
 ### Task 7: Deploy the crawler change to Bravo — operator
 
+> Independent of Task 6, which did not run (see its status note above). This task
+> still applies — it deploys the Unit 2 code change (Task 2), not the backfill.
+
 - [ ] **Step 1: Update the live crawler checkout**
 
 The production crawler runs from `~/mira-crawler-prod` on Bravo (a detached-HEAD worktree, currently at `1d58c8c6d`). Fast-forward it to the merged `main`:
@@ -880,6 +936,10 @@ Update `wiki/hot.md` with the outcome and the recorded counts, and note in PR #2
 ## Deferred / explicitly out of scope
 
 - **SP2 — PrintSense manual grounding.** `print_worker.py` is OCR-only and never calls `recall_knowledge`. Needs its own spec once SP1 is verified end-to-end.
-- **Duplicate sweep.** A `DELETE` of collision-skipped garage rows, only if Task 6 Step 3 shows a meaningful count.
+- **Duplicate sweep.** ~~A `DELETE` of collision-skipped garage rows, only if Task 6 Step 3 shows a meaningful count.~~ Moot — Task 4/6 (the backfill) never shipped, so no rows were ever moved and there is nothing to sweep duplicates from.
 - **The `MIRA_TENANT_ID` naming problem.** The var still means "garage bench tenant" while its name suggests otherwise. Renaming it is a separate cleanup with its own blast radius.
 - **#2968 mis-pagination remediation.** Tracked separately; do not fold in.
+- **The already-orphaned chunks stay orphaned (added 2026-07-29).** Dropping Task 4/6 means the crawler rows already written under the garage tenant remain unreachable by retrieval. Nothing rescues them — the accepted cost of not shipping an unauditable promotion. See Task 4's "Why this was dropped."
+- **`tasks/ingest.py::ingest_url` still writes OEM manuals to the garage tenant unverified (added 2026-07-29).** The third untrusted writer named in Task 4's rejection reasoning; unchanged by SP1.
+- **Issue #2989 — unsanitized path input in the seed-applying workflows (added 2026-07-29).** Surfaced during this review, tracked separately, not fixed here.
+- **Issue #3000 — periodic corpus-health check (added 2026-07-29).** Filed as the follow-up to dropping the backfill; deliberately an opt-in script, never a required CI gate.

--- a/docs/superpowers/plans/2026-07-28-oem-crawler-retrieval-bridge.md
+++ b/docs/superpowers/plans/2026-07-28-oem-crawler-retrieval-bridge.md
@@ -1,0 +1,885 @@
+# OEM Crawler → Retrieval Bridge (SP1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the OEM manual chunks the Bravo crawler ingests reachable by MIRA's grounded answering — route them to the shared OEM tenant pool, mark them trusted, and retro-fit the chunks already written to the wrong tenant.
+
+**Architecture:** Three independent changes. (1) `mira-crawler/ingest/store.py` gains a `verified` parameter threaded through both write functions, defaulting to today's behavior. (2) Trust becomes a **per-crawler-class property** (`oem_trusted`) that `ManufacturerCrawler` opts into — `BaseCrawler.process()` branches on it to pick the tenant and the verified flag. (3) A one-time idempotent SQL seed moves the already-stored crawler rows from the garage tenant to the shared pool, applied staging-first through `apply-seeds.yml` (which needs a `target` input added — it is prod-only today).
+
+**Tech Stack:** Python 3.12, `uv`, `ruff`, `pytest`, SQLAlchemy + NullPool against NeonDB (Postgres 16), GitHub Actions + Doppler.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-07-28-oem-crawler-retrieval-bridge-design.md` (PR #2982). This plan supersedes the spec where the two disagree — see "Corrections to the spec" below.
+- **Python:** 3.12 target, `ruff check` + `ruff format --check` must pass (`.claude/rules/python-standards.md`).
+- **Commits:** Conventional Commits, scope `crawler` / `ingest` / `ci` (`fix(crawler):`, `feat(ingest):`).
+- **VERSION:** this PR touches shippable code → bump `/VERSION` and add a `docs/CHANGELOG.md` note. Base is `3.224.4`; feat → **`3.225.0`**. CI-enforced by `version-gate.yml`.
+- **Never** `psql` prod. Seeds go staging → prod via `apply-seeds.yml` (`dry-run` then `apply`). `docs/environments.md`.
+- **Never** `git add -A` — the shared checkout carries foreign WIP. Stage explicit paths (`.claude/rules/session-discipline.md` rule 3).
+- **Worktree:** implement in an isolated worktree off `main`, not the primary checkout (which sits on `codex/dogfood-useful-work` with uncommitted foreign work).
+- **No paid inference.** Nothing in this plan spends money.
+- **Scope is SP1 only.** Do not touch `print_worker.py` or any PrintSense path — that is SP2, a separate spec.
+
+## Decisions (the spec's three open questions, resolved against the code)
+
+1. **Collision sweep → move-only.** The seed's `NOT EXISTS` guard keys on `(tenant_id, source_url, (metadata->>'chunk_index')::int)`, which is exactly the real unique index used by `ON CONFLICT` at `mira-crawler/ingest/store.py:113`. Skipped rows stay inert under the garage tenant as `verified = false`. Measure skippage in the staging dry-run; only sweep duplicates later if the count is meaningful.
+2. **Trust scope → trust by crawler class, not by tier string.** `mira-crawler/crawler/manufacturer.py:71-78` *deliberately* searches every tier (including `5_reference`) when a specific manufacturer is named — that is the #2959 fix. Filtering trust to `3_manufacturer` would undo it. `ManufacturerCrawler` is the unit of trust; whatever it reaches through curated `sources.yaml` entries is OEM content.
+3. **Shared-pool-only → confirmed correct.** Retrieval ORs the shared tenant in: `WHERE (tenant_id = :tid OR tenant_id = :shared_tid)` (`mira-bots/shared/neon_recall.py:385`, and `shared_tid` is bound on every stream — lines 428/526/643/915/1123/1216). The house bot reaches the shared pool anyway, so it loses nothing. No dual-write.
+
+## Corrections to the spec (do NOT implement the spec verbatim)
+
+- **Spec Unit 2c is wrong about where the flag goes.** It puts `verified=True` + `oem_tenant_id` at `base_crawler.py:151` — inside `BaseCrawler.process()`, which `CurriculumCrawler` and `CSVCrawler` both inherit (`csv_crawler.py:151` calls `super().process(...)`). As written it would auto-trust and re-tenant curriculum and CSV crawls too, which is wider than the Unit 1 doctrine allows. **Task 2 fixes this** with a class-level `oem_trusted` flag that only `ManufacturerCrawler` sets.
+- **Spec Unit 3 assumes `apply-seeds.yml` can target staging. It cannot** — it hardcodes `--config prd` and `environment: production`. **Task 3 adds a `target` input**, mirroring `db-inspect.yml:14-20` and `apply-migrations.yml:23-29`, so the staging gate is real rather than aspirational.
+- **Rollout order should be flipped.** The spec deploys the write-path change first, then backfills. Running the crawler against the shared pool *before* the backfill creates shared-pool copies of URLs already stored under the garage tenant, which the backfill's `NOT EXISTS` guard then skips — inflating orphan count. **Backfill first (Task 6), then deploy the code (Task 7).** The two are independent, so the reorder is free.
+- **No knowledge-graph blast radius.** `BaseCrawler.process()` calls `store_chunks(...)` without `model_number`, so the KG branch in `store_chunks` (`if kg_writer is not None and manufacturer and model_number`) never fires on this path. Changing the tenant does **not** move `kg_entities` rows. Do not add KG handling.
+
+---
+
+### Task 1: Thread a `verified` flag through the store write path
+
+Pure, default-preserving plumbing. No behavior changes for any existing caller.
+
+**Files:**
+- Modify: `mira-crawler/ingest/store.py` (`insert_chunk` ~line 62, the INSERT SQL ~line 103-116, `store_chunks` ~line 138)
+- Test: `mira-crawler/tests/test_store_verified.py` (create)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `insert_chunk(..., verified: bool = False) -> str` and `store_chunks(chunks_with_embeddings, tenant_id, manufacturer="", model_number="", image_embedding=None, verified=False) -> int`. Task 2 calls `store_chunks` with `verified=`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mira-crawler/tests/test_store_verified.py`:
+
+```python
+"""The `verified` flag on the crawler write path (SP1 Unit 2b).
+
+Zero real DB calls — the SQLAlchemy engine is faked so we can assert on the
+exact bound parameters.
+"""
+
+from __future__ import annotations
+
+import pytest
+from ingest import store
+
+
+class _FakeConn:
+    def __init__(self, captured: dict) -> None:
+        self.captured = captured
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, _stmt, params):
+        self.captured.update(params)
+
+    def commit(self):
+        pass
+
+
+class _FakeEngine:
+    def __init__(self, captured: dict) -> None:
+        self.captured = captured
+
+    def connect(self):
+        return _FakeConn(self.captured)
+
+
+@pytest.fixture
+def captured(monkeypatch) -> dict:
+    box: dict = {}
+    monkeypatch.setattr(store, "_engine", lambda: _FakeEngine(box))
+    return box
+
+
+def test_insert_chunk_defaults_to_unverified(captured: dict) -> None:
+    """Every existing caller keeps writing verified=false."""
+    entry_id = store.insert_chunk(
+        tenant_id="t1",
+        content="x",
+        embedding=[0.1],
+        source_url="u",
+        chunk_index=0,
+    )
+    assert entry_id
+    assert captured["verified"] is False
+
+
+def test_insert_chunk_binds_verified_true_when_asked(captured: dict) -> None:
+    entry_id = store.insert_chunk(
+        tenant_id="t1",
+        content="x",
+        embedding=[0.1],
+        source_url="u",
+        chunk_index=0,
+        verified=True,
+    )
+    assert entry_id
+    assert captured["verified"] is True
+
+
+def test_store_chunks_passes_verified_through(monkeypatch) -> None:
+    seen: dict = {}
+
+    monkeypatch.setattr(store, "chunk_exists", lambda *a, **k: False)
+
+    def _fake_insert(**kwargs):
+        seen.update(kwargs)
+        return "entry-1"
+
+    monkeypatch.setattr(store, "insert_chunk", _fake_insert)
+
+    inserted = store.store_chunks(
+        [({"text": "hello", "source_url": "u", "chunk_index": 0}, [0.1])],
+        tenant_id="t1",
+        manufacturer="AutomationDirect",
+        verified=True,
+    )
+    assert inserted == 1
+    assert seen["verified"] is True
+
+
+def test_store_chunks_defaults_to_unverified(monkeypatch) -> None:
+    seen: dict = {}
+
+    monkeypatch.setattr(store, "chunk_exists", lambda *a, **k: False)
+
+    def _fake_insert(**kwargs):
+        seen.update(kwargs)
+        return "entry-1"
+
+    monkeypatch.setattr(store, "insert_chunk", _fake_insert)
+
+    store.store_chunks(
+        [({"text": "hello", "source_url": "u", "chunk_index": 0}, [0.1])],
+        tenant_id="t1",
+    )
+    assert seen["verified"] is False
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd mira-crawler && python -m pytest tests/test_store_verified.py -v`
+Expected: FAIL — `TypeError: insert_chunk() got an unexpected keyword argument 'verified'`, and `KeyError: 'verified'` on the default cases (the SQL binds a literal, not a param).
+
+- [ ] **Step 3: Add the parameter to `insert_chunk`**
+
+In `mira-crawler/ingest/store.py`, add `verified` as the last keyword parameter of `insert_chunk`:
+
+```python
+def insert_chunk(
+    tenant_id: str,
+    content: str,
+    embedding: list[float],
+    source_url: str = "",
+    source_type: str = "equipment_manual",
+    manufacturer: str = "",
+    model_number: str = "",
+    equipment_id: str = "",
+    page_num: int | None = None,
+    section: str = "",
+    chunk_index: int = 0,
+    chunk_type: str = "text",
+    image_embedding: list[float] | None = None,
+    verified: bool = False,
+) -> str:
+```
+
+- [ ] **Step 4: Bind `verified` in the INSERT instead of the hardcoded literal**
+
+In the same function, change the VALUES line (currently `cast(:metadata AS jsonb), false, false, :chunk_type,`) so only `is_private` stays a literal:
+
+```python
+                    VALUES
+                        (:id, :tenant_id, :source_type, :manufacturer, :model_number,
+                         :content, cast(:embedding AS vector), :source_url, :source_page,
+                         cast(:metadata AS jsonb), false, :verified, :chunk_type,
+                         cast(:image_embedding AS vector))
+```
+
+and add the parameter to the bound dict, next to `"chunk_type"`:
+
+```python
+                    "chunk_type": chunk_type,
+                    "verified": verified,
+```
+
+`is_private` stays hardcoded `false` — OEM content is public, and customer-upload privacy is governed by `.claude/rules/knowledge-entries-tenant-scoping.md`, which this change does not touch.
+
+- [ ] **Step 5: Thread it through `store_chunks`**
+
+Add the parameter to the signature:
+
+```python
+def store_chunks(
+    chunks_with_embeddings: list[tuple[dict, list[float]]],
+    tenant_id: str,
+    manufacturer: str = "",
+    model_number: str = "",
+    image_embedding: list[float] | None = None,
+    verified: bool = False,
+) -> int:
+```
+
+and pass it in the `insert_chunk(...)` call inside the loop, after `image_embedding=image_embedding,`:
+
+```python
+            image_embedding=image_embedding,
+            verified=verified,
+        )
+```
+
+Add one line to the docstring under the existing text:
+
+```
+    verified: when True the chunk is written as trusted (citable while
+    MIRA_ENFORCE_APPROVED_RETRIEVAL is on). Only OEM-trusted crawlers pass
+    True — see .claude/rules/oem-crawler-trusted.md.
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cd mira-crawler && python -m pytest tests/test_store_verified.py -v`
+Expected: 4 passed.
+
+- [ ] **Step 7: Run the neighbouring suites to prove nothing regressed**
+
+Run: `cd mira-crawler && python -m pytest tests/test_manufacturer_normalize.py tests/test_ingest.py tests/test_crawlers.py -q`
+Expected: all pass, same counts as on `main`. If any of these are red on `main` too, note it — that is pre-existing, not yours (`.claude/rules/session-discipline.md` rule 2).
+
+- [ ] **Step 8: Lint**
+
+Run: `ruff check mira-crawler/ingest/store.py mira-crawler/tests/test_store_verified.py && ruff format --check mira-crawler/ingest/store.py mira-crawler/tests/test_store_verified.py`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add mira-crawler/ingest/store.py mira-crawler/tests/test_store_verified.py
+git commit -m "feat(ingest): thread a verified flag through the crawler write path"
+```
+
+---
+
+### Task 2: OEM crawls write to the shared pool as trusted
+
+The behavior change, plus the doctrine rule it encodes. This is where the spec's defect gets fixed.
+
+**Files:**
+- Create: `.claude/rules/oem-crawler-trusted.md`
+- Modify: `mira-crawler/config.py` (add `oem_tenant_id` after `mira_tenant_id`, ~line 19)
+- Modify: `mira-crawler/crawler/base_crawler.py` (class attribute after line 28; the `store_chunks(...)` call at ~line 149)
+- Modify: `mira-crawler/crawler/manufacturer.py` (class attribute on `ManufacturerCrawler`, ~line 25)
+- Test: `mira-crawler/tests/test_oem_trust.py` (create)
+
+**Interfaces:**
+- Consumes: `store_chunks(..., verified=...)` from Task 1.
+- Produces: `CrawlerConfig.oem_tenant_id: str`; `BaseCrawler.oem_trusted: bool = False`; `ManufacturerCrawler.oem_trusted = True`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `mira-crawler/tests/test_oem_trust.py`:
+
+```python
+"""OEM crawls land in the shared pool as trusted; nothing else changes.
+
+SP1 Unit 2. The whole ingest pipeline is stubbed — no network, no DB, no Ollama.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from config import CrawlerConfig
+from crawler import base_crawler
+from crawler.curriculum import CurriculumCrawler
+from crawler.manufacturer import ManufacturerCrawler
+
+SHARED = "78917b56-f85f-43bb-9a08-1bb98a6cd6c3"
+GARAGE = "e88bd0e8-8a84-4e30-9803-c0dc6efb07fe"
+
+
+def _make_config(tmp_path: Path) -> CrawlerConfig:
+    sources_file = tmp_path / "sources.yaml"
+    sources_file.write_text(yaml.dump({"tiers": {}}))
+    config = CrawlerConfig()
+    config.cache_dir = tmp_path / "cache"
+    config.dedup_db_path = tmp_path / "dedup.db"
+    config.sources_file = sources_file
+    config.rate_limit_sec = 0.0
+    config.mira_tenant_id = GARAGE
+    config.oem_tenant_id = SHARED
+    return config
+
+
+@pytest.fixture
+def captured(monkeypatch) -> dict:
+    """Stub the convert → chunk → embed → store pipeline, capture the store call."""
+    box: dict = {}
+
+    monkeypatch.setattr(
+        base_crawler, "extract_from_html", lambda data, min_chars=0: [{"text": "block"}]
+    )
+    monkeypatch.setattr(
+        base_crawler, "extract_from_pdf", lambda data, min_chars=0: [{"text": "block"}]
+    )
+    monkeypatch.setattr(
+        base_crawler,
+        "chunk_blocks",
+        lambda blocks, **kwargs: [
+            {"text": "chunk", "source_url": kwargs.get("source_url", "u"), "chunk_index": 0}
+        ],
+    )
+    monkeypatch.setattr(
+        base_crawler, "embed_batch", lambda chunks, **kwargs: [(chunks[0], [0.1])]
+    )
+
+    def _fake_store(
+        valid,
+        tenant_id,
+        manufacturer="",
+        model_number="",
+        image_embedding=None,
+        verified=False,
+    ):
+        box.update({"tenant_id": tenant_id, "verified": verified})
+        return len(valid)
+
+    monkeypatch.setattr(base_crawler, "store_chunks", _fake_store)
+    return box
+
+
+def _entry() -> dict:
+    return {
+        "format": "pdf",
+        "source_type": "equipment_manual",
+        "manufacturer": "AutomationDirect",
+        "equipment_id": "",
+    }
+
+
+def test_manufacturer_crawl_writes_shared_pool_verified(tmp_path, captured) -> None:
+    crawler = ManufacturerCrawler(_make_config(tmp_path))
+    stored = crawler.process("https://example.com/gs20m.pdf", b"%PDF-1.4", _entry())
+
+    assert stored == 1
+    assert captured["tenant_id"] == SHARED
+    assert captured["verified"] is True
+
+
+def test_curriculum_crawl_is_unchanged(tmp_path, captured) -> None:
+    """The inherited process() must NOT auto-trust non-OEM crawlers."""
+    crawler = CurriculumCrawler(_make_config(tmp_path))
+    stored = crawler.process("https://example.com/book.pdf", b"%PDF-1.4", _entry())
+
+    assert stored == 1
+    assert captured["tenant_id"] == GARAGE
+    assert captured["verified"] is False
+
+
+def test_base_crawler_defaults_to_untrusted() -> None:
+    assert base_crawler.BaseCrawler.oem_trusted is False
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd mira-crawler && python -m pytest tests/test_oem_trust.py -v`
+Expected: FAIL — `AttributeError: 'CrawlerConfig' object has no attribute 'oem_tenant_id'` / `type object 'BaseCrawler' has no attribute 'oem_trusted'`.
+
+- [ ] **Step 3: Add `oem_tenant_id` to the config**
+
+In `mira-crawler/config.py`, immediately after the `mira_tenant_id` field:
+
+```python
+    # The shared OEM pool that retrieval actually reads
+    # (mira-bots/shared/neon_recall.py binds it as :shared_tid on every stream).
+    # Deliberately NOT mira_tenant_id: MIRA_TENANT_ID was repointed to the garage
+    # bench tenant during the CV-101 work, and OEM crawls must not follow it.
+    oem_tenant_id: str = field(
+        default_factory=lambda: os.getenv(
+            "MIRA_SHARED_TENANT_ID", "78917b56-f85f-43bb-9a08-1bb98a6cd6c3"
+        )
+    )
+```
+
+- [ ] **Step 4: Add the trust flag to `BaseCrawler` and branch in `process()`**
+
+In `mira-crawler/crawler/base_crawler.py`, add a class attribute directly under the `BaseCrawler` docstring:
+
+```python
+class BaseCrawler:
+    """Abstract base for all crawlers."""
+
+    #: OEM-trusted crawlers write to the shared OEM pool as verified content.
+    #: Default False — only ManufacturerCrawler opts in. Subclasses that
+    #: inherit process() (CurriculumCrawler, CSVCrawler) keep prior behavior.
+    #: See .claude/rules/oem-crawler-trusted.md.
+    oem_trusted: bool = False
+```
+
+Then replace the `# Store` block in `process()`:
+
+```python
+        # Store. OEM-trusted crawlers write to the shared pool as verified so the
+        # content is citable with MIRA_ENFORCE_APPROVED_RETRIEVAL on; every other
+        # crawler keeps its prior tenant and stays unverified.
+        stored = store_chunks(
+            valid,
+            tenant_id=(
+                self.config.oem_tenant_id
+                if self.oem_trusted
+                else self.config.mira_tenant_id
+            ),
+            manufacturer=manufacturer,
+            verified=self.oem_trusted,
+        )
+```
+
+- [ ] **Step 5: Opt `ManufacturerCrawler` in**
+
+In `mira-crawler/crawler/manufacturer.py`, add the attribute under the class docstring:
+
+```python
+class ManufacturerCrawler(BaseCrawler):
+    """Crawl manufacturer documentation portals."""
+
+    #: Curated OEM sources — trusted by construction. The human gate is
+    #: sources.yaml curation (#2961), not per-chunk review.
+    oem_trusted = True
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cd mira-crawler && python -m pytest tests/test_oem_trust.py -v`
+Expected: 3 passed.
+
+- [ ] **Step 7: Write the doctrine rule**
+
+Create `.claude/rules/oem-crawler-trusted.md`:
+
+```markdown
+# OEM Crawler Content Is Trusted By Source
+
+Content crawled from a **curated OEM source in `mira-crawler/sources.yaml`** is
+**trusted by default**: written to the shared OEM pool (`MIRA_SHARED_TENANT_ID`,
+`CrawlerConfig.oem_tenant_id`) with `verified = true`, so it is citable while
+`MIRA_ENFORCE_APPROVED_RETRIEVAL` is on.
+
+**The human gate is `sources.yaml` curation (#2961), not per-chunk review.**
+
+## What is trusted
+
+Trust is a property of the **crawler class**, not of a tier string:
+`ManufacturerCrawler.oem_trusted = True`. It reaches `3_manufacturer` on broad
+crawls and additionally `5_reference` when a specific manufacturer is named
+(`crawler/manufacturer.py`) — both are curated OEM content, and scoping trust to
+one tier would undo #2959.
+
+## What is NOT trusted
+
+`CurriculumCrawler`, `CSVCrawler`, blog / patent / YouTube tasks, and every
+customer upload. They keep `oem_trusted = False`, write under
+`CrawlerConfig.mira_tenant_id`, and stay `verified = false` until a human
+approves them in the Hub. That is what the approval gate is for.
+
+## Why the OEM tenant is a separate config field
+
+`MIRA_TENANT_ID` was repointed to the garage/bench tenant during the CV-101
+live-machine-memory work, and the crawler silently followed it — which is how
+OEM chunks became invisible to customers and `/quickstart`. `oem_tenant_id` is
+pinned to `MIRA_SHARED_TENANT_ID` so OEM writes can never drift with it again.
+
+## What a reviewer must catch
+
+- ❌ A new crawler setting `oem_trusted = True` without curated `sources.yaml` entries.
+- ❌ `verified=True` passed from any non-OEM write path.
+- ❌ OEM writes reverting to `config.mira_tenant_id`.
+- ❌ Trust re-scoped to a tier string instead of the crawler class.
+
+## Cross-references
+
+- `.claude/rules/knowledge-entries-tenant-scoping.md` — the `is_private` + shared-tenant hybrid
+- `tools/seeds/backfill_verified_corpus.sql` — the pre-existing trusted-by-default policy
+- `docs/superpowers/specs/2026-07-28-oem-crawler-retrieval-bridge-design.md` — the design
+```
+
+- [ ] **Step 8: Run the full crawler suite + lint**
+
+Run: `cd mira-crawler && python -m pytest tests/ -q`
+Expected: no new failures vs. `main`. Record any pre-existing reds explicitly.
+
+Run: `ruff check mira-crawler/ .claude/ && ruff format --check mira-crawler/config.py mira-crawler/crawler/base_crawler.py mira-crawler/crawler/manufacturer.py mira-crawler/tests/test_oem_trust.py`
+Expected: clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add .claude/rules/oem-crawler-trusted.md mira-crawler/config.py mira-crawler/crawler/base_crawler.py mira-crawler/crawler/manufacturer.py mira-crawler/tests/test_oem_trust.py
+git commit -m "fix(crawler): OEM crawls write to the shared pool as trusted content"
+```
+
+---
+
+### Task 3: Give `apply-seeds.yml` a staging target
+
+Without this the staging gate in Task 5 cannot run — the workflow is prod-only today.
+
+**Files:**
+- Modify: `.github/workflows/apply-seeds.yml` (`inputs:` block ~line 15; the `environment:` line ~line 46; the Doppler resolve step ~line 71)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a `target` workflow input with values `staging` | `prod`, default `staging`.
+
+- [ ] **Step 1: Add the `target` input**
+
+In `.github/workflows/apply-seeds.yml`, add as the **first** entry under `inputs:` (mirroring `db-inspect.yml:14-20`):
+
+```yaml
+      target:
+        description: 'NeonDB target. staging = factorylm/stg, prod = factorylm/prd. Default staging — promote to prod only after staging is verified.'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - prod
+```
+
+- [ ] **Step 2: Make the environment gate follow the target**
+
+Replace `environment: production` in the `apply` job with the `db-inspect.yml:30` pattern:
+
+```yaml
+    environment: ${{ inputs.target == 'prod' && 'production' || 'staging' }}
+```
+
+- [ ] **Step 3: Resolve the Doppler config from the target**
+
+In the "Authenticate Doppler + resolve DATABASE_URL" step, replace the hardcoded `--config prd` line with:
+
+```bash
+          DOPPLER_CFG=$([ "${{ inputs.target }}" = "prod" ] && echo "prd" || echo "stg")
+          echo "Doppler config: factorylm/${DOPPLER_CFG}"
+          DATABASE_URL="$(doppler secrets get NEON_DATABASE_URL --project factorylm --config "${DOPPLER_CFG}" --plain)"
+```
+
+- [ ] **Step 4: Update the workflow header comment**
+
+Change the second comment line from "against prod NeonDB" to:
+
+```
+# Manually-triggered workflow to apply tools/seeds/*.sql against staging or prod
+# NeonDB. Default target is staging — promote to prod only after verifying.
+```
+
+- [ ] **Step 5: Lint the workflow**
+
+Run: `actionlint .github/workflows/apply-seeds.yml`
+Expected: no findings. (`actionlint` runs in `.githooks/pre-commit` for workflow files — a failure here blocks the commit anyway.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/apply-seeds.yml
+git commit -m "ci(seeds): let apply-seeds target staging, not prod only"
+```
+
+---
+
+### Task 4: The one-time backfill seed
+
+**Files:**
+- Create: `tools/seeds/backfill_oem_crawler_chunks.sql`
+
+Do **not** add it to `tools/seeds/README.md` — that table lists tenant-scoped *demo* seeds only, and the sibling `backfill_verified_corpus.sql` is correctly absent from it too.
+
+**Interfaces:**
+- Consumes: the `target` input from Task 3 (for the staging apply in Task 5).
+- Produces: a seed applied by basename `backfill_oem_crawler_chunks` — `apply-seeds.yml` resolves any `tools/seeds/<basename>.sql` that exists, so no allowlist edit is needed.
+
+- [ ] **Step 1: Write the seed**
+
+Create `tools/seeds/backfill_oem_crawler_chunks.sql`:
+
+```sql
+-- Move already-stored OEM crawler chunks into the shared pool and mark them trusted.
+--
+-- WHY: mira-crawler wrote chunks under config.mira_tenant_id (MIRA_TENANT_ID), which
+-- was repointed to the garage/bench tenant during the CV-101 work. Retrieval reads the
+-- shared OEM pool (MIRA_SHARED_TENANT_ID, mira-bots/shared/neon_recall.py), so those
+-- chunks are invisible to customers and /quickstart. Separately they were written
+-- verified=false, which MIRA_ENFORCE_APPROVED_RETRIEVAL filters out.
+--
+-- POLICY: .claude/rules/oem-crawler-trusted.md — curated OEM sources are trusted by
+-- source; the human gate is sources.yaml curation (#2961), not per-chunk review.
+-- This mirrors tools/seeds/backfill_verified_corpus.sql.
+--
+-- SAFETY: metadata->>'source' = 'mira_crawler' (stamped by ingest/store.py) is the
+-- selector that keeps this off garage-native rows — CV-101 machine memory, live
+-- Ignition rows, and customer uploads are untouched.
+--
+-- Idempotent and safe to re-run. STAGING FIRST (apply-seeds.yml target=staging,
+-- mode=dry-run then apply), verify retrieval, then prod. Never psql prod.
+--
+-- Verify before/after:
+--   SELECT tenant_id, verified, count(*) FROM knowledge_entries
+--    WHERE metadata->>'source' = 'mira_crawler' GROUP BY 1,2 ORDER BY 3 DESC;
+
+BEGIN;
+
+UPDATE knowledge_entries ke
+   SET tenant_id = '78917b56-f85f-43bb-9a08-1bb98a6cd6c3'::uuid,   -- MIRA_SHARED_TENANT_ID
+       verified  = true
+ WHERE ke.tenant_id = 'e88bd0e8-8a84-4e30-9803-c0dc6efb07fe'::uuid  -- garage MIRA_TENANT_ID
+   AND ke.metadata->>'source' = 'mira_crawler'
+   -- Collision guard keyed on the real unique index used by ON CONFLICT in
+   -- mira-crawler/ingest/store.py: (tenant_id, source_url, (metadata->>'chunk_index')::int).
+   -- Rows that would collide stay under the garage tenant as inert verified=false
+   -- duplicates; measure the skipped count before deciding whether to sweep them.
+   AND NOT EXISTS (
+     SELECT 1 FROM knowledge_entries dup
+      WHERE dup.tenant_id = '78917b56-f85f-43bb-9a08-1bb98a6cd6c3'::uuid
+        AND dup.source_url = ke.source_url
+        AND (dup.metadata->>'chunk_index')::int = (ke.metadata->>'chunk_index')::int
+   );
+
+COMMIT;
+```
+
+- [ ] **Step 2: Stand up an ephemeral Postgres to test it**
+
+Run:
+
+```bash
+docker run --rm -d --name oem-seed-test -e POSTGRES_PASSWORD=test -p 55432:5432 postgres:16
+sleep 5
+```
+
+- [ ] **Step 3: Seed a deliberate mix and run the seed**
+
+Run:
+
+```bash
+PGPASSWORD=test psql -h localhost -p 55432 -U postgres -v ON_ERROR_STOP=1 <<'SQL'
+CREATE TABLE knowledge_entries (
+  id uuid PRIMARY KEY,
+  tenant_id uuid NOT NULL,
+  source_url text,
+  verified boolean NOT NULL DEFAULT false,
+  metadata jsonb
+);
+
+-- 1. a garage crawler row that should MOVE
+INSERT INTO knowledge_entries VALUES
+  (gen_random_uuid(), 'e88bd0e8-8a84-4e30-9803-c0dc6efb07fe', 'https://oem/a.pdf', false,
+   '{"source":"mira_crawler","chunk_index":0}');
+-- 2. a garage crawler row that COLLIDES with an existing shared row → must stay
+INSERT INTO knowledge_entries VALUES
+  (gen_random_uuid(), 'e88bd0e8-8a84-4e30-9803-c0dc6efb07fe', 'https://oem/b.pdf', false,
+   '{"source":"mira_crawler","chunk_index":0}');
+INSERT INTO knowledge_entries VALUES
+  (gen_random_uuid(), '78917b56-f85f-43bb-9a08-1bb98a6cd6c3', 'https://oem/b.pdf', true,
+   '{"source":"mira_crawler","chunk_index":0}');
+-- 3. a garage-NATIVE row (CV-101 machine memory) → must be untouched
+INSERT INTO knowledge_entries VALUES
+  (gen_random_uuid(), 'e88bd0e8-8a84-4e30-9803-c0dc6efb07fe', 'https://garage/cv101', false,
+   '{"source":"hub_upload","chunk_index":0}');
+SQL
+
+PGPASSWORD=test psql -h localhost -p 55432 -U postgres -v ON_ERROR_STOP=1 \
+  -f tools/seeds/backfill_oem_crawler_chunks.sql
+```
+
+- [ ] **Step 4: Assert the outcome**
+
+Run:
+
+```bash
+PGPASSWORD=test psql -h localhost -p 55432 -U postgres -c \
+  "SELECT source_url, tenant_id, verified, metadata->>'source' AS src FROM knowledge_entries ORDER BY source_url, tenant_id;"
+```
+
+Expected, exactly:
+- `https://oem/a.pdf` → tenant `78917b56…`, `verified = t` (moved)
+- `https://oem/b.pdf` → **two** rows: the original `78917b56…` `t`, and the garage `e88bd0e8…` `f` (collision skipped)
+- `https://garage/cv101` → tenant `e88bd0e8…`, `verified = f` (untouched)
+
+- [ ] **Step 5: Prove idempotency**
+
+Run the seed a second time, then re-run the assertion query from Step 4.
+Expected: byte-identical output — re-running changes nothing.
+
+- [ ] **Step 6: Tear down**
+
+Run: `docker rm -f oem-seed-test`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/seeds/backfill_oem_crawler_chunks.sql
+git commit -m "feat(seeds): backfill orphaned OEM crawler chunks into the shared pool"
+```
+
+---
+
+### Task 5: Version bump, changelog, and PR
+
+**Files:**
+- Modify: `VERSION`
+- Modify: `docs/CHANGELOG.md`
+
+- [ ] **Step 1: Bump the version**
+
+Set `VERSION` to `3.225.0` (feat → minor; base was `3.224.4`). Re-check `git show origin/main:VERSION` first — if `main` has moved past `3.224.4`, bump the minor from whatever is actually there.
+
+- [ ] **Step 2: Add the changelog entry**
+
+Add at the top of the current section of `docs/CHANGELOG.md`:
+
+```markdown
+### 3.225.0 — OEM crawler → retrieval bridge (SP1)
+
+- `fix(crawler)`: OEM crawls write to the shared OEM pool (`MIRA_SHARED_TENANT_ID`) as
+  `verified = true` instead of following the repointed `MIRA_TENANT_ID` (garage tenant)
+  as unverified. Trust is a per-crawler-class property (`oem_trusted`) — only
+  `ManufacturerCrawler` opts in; curriculum/CSV crawls are unchanged.
+- `feat(ingest)`: `insert_chunk`/`store_chunks` take a `verified` flag (default `False`,
+  every existing caller unchanged).
+- `feat(seeds)`: `backfill_oem_crawler_chunks.sql` moves already-stored crawler chunks
+  into the shared pool, with a collision guard on the real unique index.
+- `ci(seeds)`: `apply-seeds.yml` can target staging, not just prod.
+- Doctrine: `.claude/rules/oem-crawler-trusted.md`.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add VERSION docs/CHANGELOG.md
+git commit -m "chore(release): v3.225.0 — OEM crawler retrieval bridge"
+```
+
+- [ ] **Step 4: Push and open the PR**
+
+Branch the work off `main` as `fix/oem-crawler-retrieval-bridge-sp1`, write the body to a scratchpad file first (heredocs into `gh` hang this shell), then:
+
+```bash
+git push -u origin fix/oem-crawler-retrieval-bridge-sp1
+gh pr create --base main \
+  --title "fix(crawler): OEM crawler to retrieval bridge (SP1)" \
+  --body-file "$SCRATCH/oem_bridge_pr_body.md"
+```
+
+The PR body must state: the two gaps closed, the three resolved design decisions, the spec defect this plan corrects (`oem_trusted` per class, not in `process()` unconditionally), and that Task 6's seed has **not** been applied to prod yet.
+
+- [ ] **Step 5: Poll CI to green**
+
+Run: `gh pr checks <number> --watch`
+Expected: green. `Version Bump Check` must pass — if it fails, `VERSION` did not change relative to `main`.
+
+---
+
+### Task 6: Apply the backfill (staging → prod) — operator, gated
+
+Do this **before** Task 7, so the crawler does not create shared-pool copies the guard then skips. Requires a human with workflow-dispatch rights; the agent cannot mutate prod (`MIRA_ALLOW_PROD=1` is human-only).
+
+- [ ] **Step 1: Read-only pre-count on staging**
+
+Run `db-inspect.yml` with `target=staging` and the query:
+
+```sql
+SELECT tenant_id, verified, count(*) FROM knowledge_entries
+ WHERE metadata->>'source' = 'mira_crawler' GROUP BY 1,2 ORDER BY 3 DESC;
+```
+
+Record the numbers — they are the before-half of the evidence.
+
+- [ ] **Step 2: Staging dry-run**
+
+`gh workflow run apply-seeds.yml -f target=staging -f seeds=backfill_oem_crawler_chunks -f mode=dry-run -f tenant_id=78917b56-f85f-43bb-9a08-1bb98a6cd6c3`
+
+Read the pre-flight output in the step summary. Confirm the garage-tenant crawler row count matches Step 1.
+
+- [ ] **Step 3: Staging apply, then re-count**
+
+Same command with `mode=apply`. Re-run Step 1's query.
+Expected: garage-tenant `mira_crawler` rows drop to the collision-skipped remainder; shared-tenant `verified = true` rows rise by the moved count. **Record the skipped count** — that is the input to the "do we sweep duplicates?" follow-up.
+
+- [ ] **Step 4: Prove retrieval actually changed on staging**
+
+Against the **staging** Neon branch, with the gate on, query as a **non-garage** tenant. `recall_knowledge` accepts `embedding=None` and falls through to the BM25/ILIKE streams, so this needs no Ollama:
+
+```bash
+cd mira-bots && doppler run --project factorylm --config stg -- python -c "
+from shared.neon_recall import recall_knowledge
+import os
+os.environ['MIRA_ENFORCE_APPROVED_RETRIEVAL'] = 'true'
+hits = recall_knowledge(
+    embedding=None,
+    tenant_id='00000000-0000-0000-0000-0000000000d1',  # demo tenant, NOT the garage
+    limit=5,
+    query_text='Siemens G120 fault F30001 overcurrent',
+)
+for h in hits:
+    print(h.get('manufacturer'), '|', h.get('source_url'), '|', (h.get('content') or '')[:80])
+print('HITS:', len(hits))
+"
+```
+
+Expected: at least one hit whose `source_url` is a crawler-ingested OEM PDF. Run the identical command **before** Step 3's apply to capture the zero-hit baseline. This is the acceptance test for the whole sub-project — if it fails, stop and diagnose before touching prod.
+
+- [ ] **Step 5: Prod dry-run, then apply**
+
+Same two dispatches with `target=prod`. Re-run the count query via `db-inspect.yml target=prod`. Never `psql` prod directly.
+
+---
+
+### Task 7: Deploy the crawler change to Bravo — operator
+
+- [ ] **Step 1: Update the live crawler checkout**
+
+The production crawler runs from `~/mira-crawler-prod` on Bravo (a detached-HEAD worktree, currently at `1d58c8c6d`). Fast-forward it to the merged `main`:
+
+```bash
+ssh bravo-tailscale 'cd ~/mira-crawler-prod && git fetch origin --quiet && git status -s && git checkout --detach origin/main && git log --oneline -1'
+```
+
+`git status -s` must show only the known-untracked `mira-crawler/mira-crawler/` and `requirements-host.lock` — if anything else is dirty, stop and inspect before checking out.
+
+- [ ] **Step 2: Restart the daemon**
+
+The launch agent is `com.mira.crawler` (a watchdog, `com.mira.crawler-watchdog`, sits alongside it):
+
+```bash
+ssh bravo-tailscale 'launchctl unload ~/Library/LaunchAgents/com.mira.crawler.plist && sleep 2 && launchctl load ~/Library/LaunchAgents/com.mira.crawler.plist && launchctl list | grep com.mira.crawler'
+```
+
+Then confirm a fresh heartbeat (the `ts` must be newer than the restart):
+
+```bash
+ssh bravo-tailscale 'tail -3 ~/mira-crawler-prod/mira-crawler/data/job_heartbeat.jsonl'
+```
+
+- [ ] **Step 3: Verify the next crawl writes to the right place**
+
+After the next scheduled manufacturer crawl, run the Step 1 count query from Task 6 against staging/prod as appropriate.
+Expected: **new** rows appear under `78917b56…` with `verified = true`, and **zero** new `mira_crawler` rows appear under `e88bd0e8…`.
+
+- [ ] **Step 4: Close the loop**
+
+Update `wiki/hot.md` with the outcome and the recorded counts, and note in PR #2982 that SP1 shipped so SP2 (PrintSense manual grounding) can be specced.
+
+---
+
+## Deferred / explicitly out of scope
+
+- **SP2 — PrintSense manual grounding.** `print_worker.py` is OCR-only and never calls `recall_knowledge`. Needs its own spec once SP1 is verified end-to-end.
+- **Duplicate sweep.** A `DELETE` of collision-skipped garage rows, only if Task 6 Step 3 shows a meaningful count.
+- **The `MIRA_TENANT_ID` naming problem.** The var still means "garage bench tenant" while its name suggests otherwise. Renaming it is a separate cleanup with its own blast radius.
+- **#2968 mis-pagination remediation.** Tracked separately; do not fold in.

--- a/docs/superpowers/specs/2026-07-28-oem-crawler-retrieval-bridge-design.md
+++ b/docs/superpowers/specs/2026-07-28-oem-crawler-retrieval-bridge-design.md
@@ -1,11 +1,37 @@
 # OEM Crawler → Retrieval Bridge — Design
 
 **Date:** 2026-07-28
-**Status:** DRAFT (awaiting user review)
+**Status:** IMPLEMENTED (SP1), PARTIAL — PR #2999, `fix/oem-crawler-retrieval-bridge-sp1`, green, awaiting merge. Units 1–2 shipped (with one correction). Unit 3 (the one-time backfill) was built, reviewed, and deliberately dropped — see "Status update (2026-07-29)" below.
 **Author:** Claude Code session (Bravo)
 **Related:** #2968 (corpus mis-pagination remediation), #2961 (OEM source-URL curation),
 `tools/seeds/backfill_verified_corpus.sql` (the trusted-by-default OEM policy),
 [[project_crawler_runtime_hardening]], [[project_kb_ingest_topology]]
+
+---
+
+## Status update (2026-07-29)
+
+SP1 shipped as **PR #2999**. Units 1 and 2 below landed close to as designed, with
+one correction: trust is scoped to the crawler *class*
+(`BaseCrawler.oem_trusted: bool = False`, only `ManufacturerCrawler` sets it `True`),
+not applied unconditionally inside `BaseCrawler.process()` as Unit 2c originally
+specified — see the correction note on Unit 2c below.
+
+**Unit 3, the one-time SQL backfill, was evaluated and deliberately dropped — it does
+not ship.** The selector it relied on (`metadata->>'source' = 'mira_crawler'`, and the
+more general shape-based selector considered during review,
+`source_type = 'equipment_manual' AND manufacturer <> ''`) describes an output
+**shape**, not an **origin**: three different writers can produce that shape
+(`ManufacturerCrawler`, trusted; `CSVCrawler`, heuristic/untrusted;
+`tasks/ingest.py::ingest_url`, untrusted), and no column stored by `insert_chunk`
+records which one wrote a given row. That auditability gap — not document quality —
+is why the backfill was pulled. Full reasoning trail, kept intact, is under
+"Unit 3 — superseded" below.
+
+**Read the rest of this document with that correction in mind** — the "Design —
+three units" section, the data-flow diagram, the rollout sequence, and the open
+questions were all written as if Unit 3 would ship. Each is annotated inline below
+rather than rewritten, so the original design intent is not lost.
 
 ---
 
@@ -74,7 +100,9 @@ This design is **SP1 of two sub-projects**. SP1 is foundational and unblocks SP2
 - **SP1 (this spec): Close the ingest→retrieval gaps.** Make crawler OEM data
   citable by MIRA's grounded answering (the diagnose/chat path that already uses
   `recall_knowledge`). Route to the shared pool + auto-trust OEM + backfill the
-  already-stored chunks.
+  already-stored chunks. *(As shipped: the route-to-shared-pool and auto-trust
+  goals were met; the backfill goal was not — see "Status update (2026-07-29)"
+  above and "Unit 3 — superseded" below.)*
 - **SP2 (separate spec, depends on SP1): PrintSense manual grounding.** Wire the
   photo/print-reading vision path (`print_worker.py`) to consult + cite the (now
   reachable) manual corpus. Today that path is OCR-only by design and never calls
@@ -151,6 +179,14 @@ store_chunks(
 )
 ```
 
+> **Correction (2026-07-29):** as designed above, this puts `verified=True` +
+> `oem_tenant_id` directly in `BaseCrawler.process()`, which `CurriculumCrawler` and
+> `CSVCrawler` also inherit — as written it would have silently auto-trusted both.
+> What shipped in PR #2999 instead: a class-level `BaseCrawler.oem_trusted: bool =
+> False` flag, with `process()` branching on it, and only `ManufacturerCrawler`
+> setting it `True`. Same outcome for the manufacturer crawler; no blast radius on
+> the other crawlers.
+
 **What it does:** new OEM crawls land citable in the shared pool.
 **Interface:** `store_chunks(chunks, tenant_id, manufacturer, verified=False)`.
 **Depends on:** Unit 1 (the rule it encodes).
@@ -159,7 +195,14 @@ store_chunks(
 `insert_chunk`/`store_chunks` call is byte-identical to prior behavior
 (`verified = false`) so no other caller regresses.
 
-### Unit 3 — One-time backfill of already-stored crawler chunks
+### Unit 3 — One-time backfill of already-stored crawler chunks — SUPERSEDED, NOT SHIPPED
+
+> **This unit was designed, implemented, and reviewed, then deliberately removed
+> before PR #2999 merged.** It is preserved verbatim below — not deleted — because
+> the design reasoning here, and the "two design points" the original reviewer was
+> asked to weigh, are exactly what the rejection argument (added at the end of this
+> section, "Why it was removed") responds to. Do not re-propose this seed without
+> reading that argument first.
 
 New gated seed `tools/seeds/backfill_oem_crawler_chunks.sql`, applied
 dev → staging → prod via `apply-seeds.yml` (**never** psql prod). Idempotent.
@@ -212,6 +255,54 @@ the bleed, Unit 3 cleans up what already bled).
 a grounded-answer eval on a Siemens G120 / PowerFlex question returns a cited chunk
 that didn't retrieve before.
 
+#### Why it was removed (added 2026-07-29)
+
+Both safety selectors above — `metadata->>'source' = 'mira_crawler'` here, and the
+more general `source_type = 'equipment_manual' AND manufacturer <> ''` considered
+during implementation review — describe an output **shape**, not an **origin**.
+Three different writers can produce that shape: `ManufacturerCrawler` (trusted,
+Units 1–2), `CSVCrawler` (heuristic PDF resolution, untrusted), and
+`tasks/ingest.py::ingest_url` (untrusted). **No column stored by `insert_chunk`
+records which of the three wrote a given row** — `metadata->>'source'` reflects which
+code path ran, not whether the URL it resolved was actually a legitimate OEM manual,
+so a selector on it cannot tell "the manufacturer crawler found this" apart from "a
+heuristic guessed this looks like a manual."
+
+An audit found only 10 of 311 `CSVCrawler` rows were ever ingested, and all 10
+re-verified as live, valid PDFs from legitimate sources (zero third-party
+aggregators) — so this was not a document-quality problem. It was an
+**auditability** problem: for portal-scraped rows the crawler never persists the
+resolved PDF URL, so what was actually ingested cannot be confirmed after the fact,
+for any row a future promotion might touch. A one-time `UPDATE` that promotes rows
+to `verified = true` across a tenant boundary by selecting on shape, with no way to
+verify after the fact which rows came from a trusted writer, is exactly the pattern
+Contract 7 (`tests/test_architecture.py`) now exists to reject — its bad fixture is
+this seed's SQL, recovered verbatim from git.
+
+**What shipped instead of the backfill:**
+- Enforcement: class-scoped trust assertions (`mira-crawler/tests/test_oem_trust.py`)
+  and the Contract 7 guard described above.
+- A `sources.yaml` well-formedness guard.
+- **Re-acquisition, not reclassification.** 4 OEM manuals — Interroll MultiControl,
+  Demag, Magnetek Impulse G+ Mini, Allen-Bradley 100-C30 — added to
+  `mira-crawler/sources.yaml` so the *trusted* crawler fetches them properly, instead
+  of retroactively blessing rows a heuristic crawler already wrote. 28 of 33
+  URL-bearing candidates considered were excluded: distributor/reseller hosts, portal
+  roots, unreachable/bot-blocked hosts, and dynamic document-ID endpoints (Siemens,
+  Yaskawa — they resolve today but are not durable addresses).
+- Follow-up issue #3000: a periodic corpus-health check, deliberately an opt-in
+  script, never a required CI gate.
+
+**Still open — not fixed by SP1:**
+- The already-orphaned chunks under the garage tenant remain unreachable. Nothing
+  rescues them; this is the direct, accepted cost of not shipping an unauditable
+  promotion.
+- `tasks/ingest.py::ingest_url` still writes OEM manuals to the garage tenant
+  unverified — the third untrusted writer named above is unchanged by SP1.
+- Issue #2989 tracks the unsanitized path input in the seed-applying workflows,
+  surfaced during this same review; it is orthogonal to this design and tracked
+  separately.
+
 ---
 
 ## Data flow (after SP1)
@@ -236,22 +327,32 @@ recall_knowledge  WHERE (tenant_id = caller OR tenant_id = 78917b56)
 grounded answer with citation   ← customers + quickstart + house bot all reach it
 ```
 
-Unit 3 retro-fits the already-stored rows into the same terminal state.
+**Not shipped:** the diagram above is the terminal state for *newly crawled* chunks
+(Unit 2, live). The sentence that originally closed this section — "Unit 3
+retro-fits the already-stored rows into the same terminal state" — does not hold;
+Unit 3 was dropped (see "Unit 3 — superseded" above), and the already-orphaned rows
+stay orphaned. The re-acquisition sources added to `sources.yaml` produce genuinely
+new crawler rows that flow through this diagram normally — they are not retro-fits
+of old rows.
 
 ---
 
 ## Error handling / safety
 
-- **Idempotency:** Unit 3 re-runnable (the `NOT EXISTS` guard + `verified` already
-  true → no-op on re-apply). Unit 2 default args preserve every non-OEM caller.
+- **Idempotency:** ~~Unit 3 re-runnable (the `NOT EXISTS` guard + `verified` already
+  true → no-op on re-apply).~~ Moot — Unit 3 was not shipped. Unit 2 default args
+  preserve every non-OEM caller.
 - **Blast radius:** Unit 2 changes only the manufacturer crawl path; other
   `insert_chunk` callers (blog/patents/youtube/full_ingest_pipeline) keep
-  `verified = False` default. Unit 3 touches only `metadata->>'source' =
+  `verified = False` default. ~~Unit 3 touches only `metadata->>'source' =
   'mira_crawler'` rows under the garage tenant — never customer or garage-native
-  data.
-- **Env boundary:** Unit 3 goes dev → staging → prod via `apply-seeds.yml`. No psql
+  data.~~ Moot — Unit 3 was not shipped; no rows were touched.
+- **Env boundary:** ~~Unit 3 goes dev → staging → prod via `apply-seeds.yml`. No psql
   prod (`docs/environments.md`, prod-guard). Verify retrieval on staging with the
-  gate ON before prod.
+  gate ON before prod.~~ N/A — no seed shipped. The env-boundary discipline this
+  point describes was still honored: `apply-seeds.yml` gained a real staging target
+  (kept, see the plan's Task 3), even though nothing was applied through it for this
+  design.
 - **No secret in code:** tenant UUIDs are non-secret identifiers (already in docs +
   the existing backfill seed); the crawler reads `MIRA_SHARED_TENANT_ID` from
   Doppler with a documented default.
@@ -263,9 +364,12 @@ Unit 3 retro-fits the already-stored rows into the same terminal state.
 - **Unit 2:** hermetic pytest — manufacturer path writes `tenant_id =
   MIRA_SHARED_TENANT_ID` + `verified = true`; default `insert_chunk`/`store_chunks`
   unchanged (`verified = false`); non-OEM callers untouched.
-- **Unit 3:** apply on ephemeral `postgres:16` with a seeded mix (garage crawler
-  rows + a colliding shared-pool row + a garage-native non-crawler row) → assert
-  only crawler rows move, the collision is skipped, garage-native row untouched.
+- **Unit 3 (superseded — not shipped):** apply on ephemeral `postgres:16` with a
+  seeded mix (garage crawler rows + a colliding shared-pool row + a garage-native
+  non-crawler row) → assert only crawler rows move, the collision is skipped,
+  garage-native row untouched. This is the test plan that was written for the seed
+  before it was dropped; kept for the reasoning trail. See "Unit 3 — superseded"
+  above.
 - **End-to-end (staging):** with `MIRA_ENFORCE_APPROVED_RETRIEVAL = true`, a
   `recall_knowledge` query for a Siemens G120 / PowerFlex 525 topic returns a
   crawler-sourced chunk that returned zero before the change.
@@ -274,17 +378,47 @@ Unit 3 retro-fits the already-stored rows into the same terminal state.
 
 ## Rollout
 
+> **Actual rollout (2026-07-29):** steps 1, 2, and 4 shipped as designed. Step 3 (the
+> Unit 3 seed) did not run — Unit 3 was dropped, see "Unit 3 — superseded" above.
+> Step 4's "fresh manual" now comes from the re-acquisition sources added to
+> `sources.yaml`, not from a backfilled historical chunk.
+
 1. Unit 1 rule + Unit 2 code + Unit 2 tests → PR → CI green → merge (stops the bleed).
 2. Deploy the crawler change to the Bravo daemon (unload/load, per
    [[project_crawler_runtime_hardening]]); verify next nightly crawl writes to
    `78917b56` + `verified = true` via a read-only staging check.
-3. Unit 3 seed → apply staging → verify retrieval → apply prod via `apply-seeds.yml`.
-4. Spot-check a grounded answer cites a fresh manual. Then open SP2 (PrintSense
-   manual grounding).
+3. ~~Unit 3 seed → apply staging → verify retrieval → apply prod via `apply-seeds.yml`.~~
+   **Dropped — not executed.** See "Unit 3 — superseded" above.
+4. Spot-check a grounded answer cites a fresh manual (from the re-acquired
+   `sources.yaml` entries, not a backfill). Then open SP2 (PrintSense manual
+   grounding).
 
 ---
 
 ## Open questions for reviewer
+
+### Resolved (2026-07-29) — see PR #2999
+
+1. **Collision sweep:** moot. Unit 3, the backfill this question was about, did not
+   ship (see "Unit 3 — superseded" above). No rows were ever moved, so there is
+   nothing to sweep duplicates from.
+2. **Trust scope:** resolved as **trust by crawler class, not by tier string.**
+   `BaseCrawler.oem_trusted: bool = False`; only `ManufacturerCrawler` sets it
+   `True`. This also fixed a real defect in the original Unit 2c design (see the
+   correction note there): putting `verified=True` unconditionally in
+   `BaseCrawler.process()` would have silently auto-trusted `CurriculumCrawler` and
+   `CSVCrawler`, which both inherit `process()`. The class-level flag is correct
+   whether `ManufacturerCrawler` reaches `3_manufacturer` alone or additionally
+   `5_reference` when a specific manufacturer is named (#2959) — trust follows the
+   crawler, not the tier it happens to search, so scoping to one tier was never the
+   right axis.
+3. **Shared-pool-only:** confirmed correct. Retrieval ORs the shared tenant in on
+   every stream (`mira-bots/shared/neon_recall.py`,
+   `WHERE (tenant_id = :tid OR tenant_id = :shared_tid)`, `shared_tid` bound on all
+   four streams), so the house bot reaches `78917b56` regardless of the crawler's
+   write target and loses nothing. No dual-write was added.
+
+### Original questions (preserved for context)
 
 1. **Collision sweep:** move-only (leave skipped garage duplicates as inert
    `verified = false`) vs. move-then-delete-duplicates? (Recommend move-only first,

--- a/docs/superpowers/specs/2026-07-28-oem-crawler-retrieval-bridge-design.md
+++ b/docs/superpowers/specs/2026-07-28-oem-crawler-retrieval-bridge-design.md
@@ -1,0 +1,298 @@
+# OEM Crawler → Retrieval Bridge — Design
+
+**Date:** 2026-07-28
+**Status:** DRAFT (awaiting user review)
+**Author:** Claude Code session (Bravo)
+**Related:** #2968 (corpus mis-pagination remediation), #2961 (OEM source-URL curation),
+`tools/seeds/backfill_verified_corpus.sql` (the trusted-by-default OEM policy),
+[[project_crawler_runtime_hardening]], [[project_kb_ingest_topology]]
+
+---
+
+## Problem
+
+The manufacturer crawler on Bravo started producing OEM manual chunks again on
+2026-07-28 (the #2959/#2961 URL fixes broke a ~2-month `0 chunks/day` drought —
+**7,114 chunks** ingested from Siemens G120, Rockwell PowerFlex, AutomationDirect).
+But **none of that data is reachable by MIRA's retrieval**, for two independent
+reasons discovered while tracing the write path against the read path:
+
+### Gap 1 — Tenant misroute (the bigger one)
+
+The crawler writes chunks under `config.mira_tenant_id`, sourced from the
+`MIRA_TENANT_ID` env var. In prod today `MIRA_TENANT_ID = e88bd0e8-…`, which is
+the **garage/bench dev tenant** (the CV-101 live-machine-memory work —
+`docs/RESUME_2026-07-04_cv101-live-machine-memory.md`,
+`docs/command-center-ignition-display.md`). Historically `MIRA_TENANT_ID` *was*
+the shared OEM pool (`docs/AUDIT.md`, `docs/README.md` both show
+`MIRA_TENANT_ID = 78917b56-…`); it was repointed to the garage tenant for the
+live work, and the crawler silently followed.
+
+The shared OEM pool that customers and the `/quickstart` path actually read is
+**`MIRA_SHARED_TENANT_ID = 78917b56-…`**. Retrieval (`mira-bots/shared/neon_recall.py`)
+matches `WHERE (tenant_id = :caller OR tenant_id = :shared_tid)` with
+`shared_tid = 78917b56-…`. So:
+
+- The **house Telegram/Slack bot** is built with `tenant_id = MIRA_TENANT_ID = e88bd0e8`
+  (`mira-bots/telegram/bot.py:100`), so it *does* reach `e88bd0e8` — the tenant gap
+  does **not** bite the default bot.
+- **Customers and `/quickstart`** read `78917b56`, never `e88bd0e8` — so tonight's
+  crawler output is invisible to the surfaces the product cares about (beta =
+  "a stranger uploads a manual and gets a cited answer"; the OEM corpus must live
+  in the shared pool).
+
+The existing 83.5k OEM corpus is fine — it lives under `78917b56`. Only the *new*
+crawler output drifted to `e88bd0e8`.
+
+### Gap 2 — Approval gate
+
+Independently, `mira-crawler/ingest/store.py` hardcodes `verified = false` on every
+chunk, and prod has `MIRA_ENFORCE_APPROVED_RETRIEVAL = true`. When the gate is on,
+`neon_recall._approval_filter_sql()` appends `AND verified = true` to all four
+retrieval streams (vector/BM25/ILIKE/product). So even for the house-bot tenant,
+`verified = false` chunks are filtered out of retrieval.
+
+### Governing policy (already exists — this design makes it code)
+
+`tools/seeds/backfill_verified_corpus.sql` (2026-06-27) already states the policy:
+> The shared OEM knowledge library (the system tenant) is **trusted by default** —
+> it is curated, public, OEM-sourced manual content. Mark it `verified = true`.
+> Per-tenant **customer uploads** are NOT auto-approved; they stay `verified = false`
+> until a human approves them in the Hub.
+
+Curated OEM crawler output already passed a human gate: `sources.yaml` curation
+(#2961). So per-chunk human review of OEM content would fight this doctrine. The
+user's decision (2026-07-28): **trust by source — OEM-sourced crawler content is
+fine to auto-trust.**
+
+---
+
+## Scope
+
+This design is **SP1 of two sub-projects**. SP1 is foundational and unblocks SP2.
+
+- **SP1 (this spec): Close the ingest→retrieval gaps.** Make crawler OEM data
+  citable by MIRA's grounded answering (the diagnose/chat path that already uses
+  `recall_knowledge`). Route to the shared pool + auto-trust OEM + backfill the
+  already-stored chunks.
+- **SP2 (separate spec, depends on SP1): PrintSense manual grounding.** Wire the
+  photo/print-reading vision path (`print_worker.py`) to consult + cite the (now
+  reachable) manual corpus. Today that path is OCR-only by design and never calls
+  `recall_knowledge`. **Out of scope here** — gets its own spec once SP1 lands and
+  we've verified grounded answering cites the fresh manuals.
+
+**Non-goals for SP1:**
+- No change to the PrintSense vision worker (that's SP2).
+- No new Hub review UI for OEM content (the trust rule replaces per-chunk review).
+- No change to customer-upload approval (customer uploads correctly stay
+  `verified = false` → Hub approval; this design touches only OEM crawler output).
+- No rotation of the garage `MIRA_TENANT_ID` / no touching legit `e88bd0e8`
+  garage-tenant data (CV-101 machine memory).
+- Not folding in the #2968 mis-pagination remediation (separate, already tracked).
+
+---
+
+## Design — three units
+
+### Unit 1 — The trust rule (doctrine)
+
+New file `.claude/rules/oem-crawler-trusted.md`. States:
+
+> Content crawled from a **curated OEM source in `mira-crawler/sources.yaml`**
+> (manufacturer/reference tiers) is **trusted by default**: written to the shared
+> OEM pool (`MIRA_SHARED_TENANT_ID`) with `verified = true`. The human gate is
+> `sources.yaml` curation (#2961), not per-chunk review. Blog / patent / YouTube /
+> customer-upload content is **not** OEM-trusted and does not get this treatment.
+
+This is the single source of truth the code (Units 2–3) points at. It aligns with
+`backfill_verified_corpus.sql` and `.claude/rules/knowledge-entries-tenant-scoping.md`
+(the `is_private` + shared-tenant hybrid; OEM corpus is `is_private = false`,
+shared-tenant, and now also `verified = true`).
+
+**What it does:** define which crawler content is trusted.
+**Interface:** referenced by Units 2 and 3; enforced by their tests.
+**Depends on:** nothing.
+
+### Unit 2 — Fix the crawler write path (going forward)
+
+Files: `mira-crawler/config.py`, `mira-crawler/ingest/store.py`,
+`mira-crawler/crawler/base_crawler.py`.
+
+**2a. Decouple the OEM-write tenant from `MIRA_TENANT_ID`.**
+Add a config field:
+```python
+# config.py
+oem_tenant_id: str = field(
+    default_factory=lambda: os.getenv(
+        "MIRA_SHARED_TENANT_ID", "78917b56-f85f-43bb-9a08-1bb98a6cd6c3"
+    )
+)
+```
+The manufacturer crawler writes OEM chunks under `config.oem_tenant_id`, **not**
+`config.mira_tenant_id`. `mira_tenant_id` (the repurposed garage var) is no longer
+the OEM-write target. Non-OEM tasks (blog/patents/youtube) are unchanged — out of
+scope.
+
+**2b. Thread a `verified` flag through the write path.**
+`insert_chunk()` and `store_chunks()` gain `verified: bool = False` (default
+preserves current behavior for every other caller). The SQL at `store.py`
+(currently the hardcoded `… false, false, …` for `is_private, verified`) binds the
+param instead of a literal for `verified`. `is_private` stays `false` (OEM is
+public — unchanged).
+
+**2c. The manufacturer crawler opts in.**
+`base_crawler.py:151` (`store_chunks(valid, tenant_id=…, manufacturer=…)`) changes to:
+```python
+store_chunks(
+    valid,
+    tenant_id=self.config.oem_tenant_id,   # shared OEM pool, not garage
+    manufacturer=manufacturer,
+    verified=True,                          # OEM = trusted (Unit 1 rule)
+)
+```
+
+**What it does:** new OEM crawls land citable in the shared pool.
+**Interface:** `store_chunks(chunks, tenant_id, manufacturer, verified=False)`.
+**Depends on:** Unit 1 (the rule it encodes).
+**Verify:** a hermetic test asserting the manufacturer path writes
+`tenant_id = MIRA_SHARED_TENANT_ID` and `verified = true`; a test that the default
+`insert_chunk`/`store_chunks` call is byte-identical to prior behavior
+(`verified = false`) so no other caller regresses.
+
+### Unit 3 — One-time backfill of already-stored crawler chunks
+
+New gated seed `tools/seeds/backfill_oem_crawler_chunks.sql`, applied
+dev → staging → prod via `apply-seeds.yml` (**never** psql prod). Idempotent.
+
+Promote the crawler chunks currently orphaned under the garage tenant into the
+shared pool + verified:
+```sql
+BEGIN;
+UPDATE knowledge_entries ke
+   SET tenant_id = '78917b56-f85f-43bb-9a08-1bb98a6cd6c3'::uuid,   -- MIRA_SHARED_TENANT_ID
+       verified  = true
+ WHERE ke.tenant_id = 'e88bd0e8-8a84-4e30-9803-c0dc6efb07fe'::uuid  -- garage MIRA_TENANT_ID
+   AND ke.metadata->>'source' = 'mira_crawler'                      -- crawler rows ONLY
+   -- collision guard: don't move a row if the shared pool already has the
+   -- same (source_url, chunk_index) — the unique key is
+   -- (tenant_id, source_url, (metadata->>'chunk_index')::int).
+   AND NOT EXISTS (
+     SELECT 1 FROM knowledge_entries dup
+      WHERE dup.tenant_id = '78917b56-f85f-43bb-9a08-1bb98a6cd6c3'::uuid
+        AND dup.source_url = ke.source_url
+        AND (dup.metadata->>'chunk_index')::int = (ke.metadata->>'chunk_index')::int
+   );
+COMMIT;
+-- Verify after: SELECT tenant_id, verified, count(*) FROM knowledge_entries
+--   WHERE metadata->>'source' = 'mira_crawler' GROUP BY 1,2;
+```
+
+**Two design points the reviewer must weigh:**
+
+1. **Collision handling.** The `NOT EXISTS` guard skips any crawler row whose
+   `(source_url, chunk_index)` already exists in the shared pool (e.g. a manual
+   crawled under both tenants historically). Skipped rows remain orphaned under
+   `e88bd0e8` as `verified = false` — harmless duplicates. **Alternative:** a
+   follow-up `DELETE` of the skipped garage-tenant duplicates to keep the table
+   clean. Recommend: move first (this seed), sweep duplicates in a separate step
+   only if a count shows meaningful skippage.
+
+2. **`metadata->>'source' = 'mira_crawler'` is the safety selector.** `store.py:93`
+   stamps `"source": "mira_crawler"` on every crawler chunk. This is what keeps the
+   UPDATE from touching legit garage-tenant rows (CV-101 machine memory, live
+   Ignition rows). Confirm on staging with a read-only `SELECT count(*) … WHERE
+   tenant_id = e88bd0e8 AND metadata->>'source' = 'mira_crawler'` before apply.
+
+**What it does:** makes the already-ingested 7,114 chunks (and any other orphaned
+crawler rows) citable.
+**Interface:** a gated workflow-applied SQL seed.
+**Depends on:** nothing at code level; conceptually pairs with Unit 2 (Unit 2 stops
+the bleed, Unit 3 cleans up what already bled).
+**Verify:** staging apply → read-only `GROUP BY tenant_id, verified` before/after →
+a grounded-answer eval on a Siemens G120 / PowerFlex question returns a cited chunk
+that didn't retrieve before.
+
+---
+
+## Data flow (after SP1)
+
+```
+sources.yaml (curated OEM, human-gated #2961)
+   │
+   ▼
+ManufacturerCrawler.discover_urls → fetch → chunk → embed
+   │  (base_crawler.py)
+   ▼
+store_chunks(tenant_id = MIRA_SHARED_TENANT_ID, verified = True)   ← Unit 2
+   │
+   ▼
+knowledge_entries  (tenant_id = 78917b56, is_private = false, verified = true)
+   │
+   ▼
+recall_knowledge  WHERE (tenant_id = caller OR tenant_id = 78917b56)
+                    AND verified = true            ← gate satisfied
+   │
+   ▼
+grounded answer with citation   ← customers + quickstart + house bot all reach it
+```
+
+Unit 3 retro-fits the already-stored rows into the same terminal state.
+
+---
+
+## Error handling / safety
+
+- **Idempotency:** Unit 3 re-runnable (the `NOT EXISTS` guard + `verified` already
+  true → no-op on re-apply). Unit 2 default args preserve every non-OEM caller.
+- **Blast radius:** Unit 2 changes only the manufacturer crawl path; other
+  `insert_chunk` callers (blog/patents/youtube/full_ingest_pipeline) keep
+  `verified = False` default. Unit 3 touches only `metadata->>'source' =
+  'mira_crawler'` rows under the garage tenant — never customer or garage-native
+  data.
+- **Env boundary:** Unit 3 goes dev → staging → prod via `apply-seeds.yml`. No psql
+  prod (`docs/environments.md`, prod-guard). Verify retrieval on staging with the
+  gate ON before prod.
+- **No secret in code:** tenant UUIDs are non-secret identifiers (already in docs +
+  the existing backfill seed); the crawler reads `MIRA_SHARED_TENANT_ID` from
+  Doppler with a documented default.
+
+---
+
+## Testing
+
+- **Unit 2:** hermetic pytest — manufacturer path writes `tenant_id =
+  MIRA_SHARED_TENANT_ID` + `verified = true`; default `insert_chunk`/`store_chunks`
+  unchanged (`verified = false`); non-OEM callers untouched.
+- **Unit 3:** apply on ephemeral `postgres:16` with a seeded mix (garage crawler
+  rows + a colliding shared-pool row + a garage-native non-crawler row) → assert
+  only crawler rows move, the collision is skipped, garage-native row untouched.
+- **End-to-end (staging):** with `MIRA_ENFORCE_APPROVED_RETRIEVAL = true`, a
+  `recall_knowledge` query for a Siemens G120 / PowerFlex 525 topic returns a
+  crawler-sourced chunk that returned zero before the change.
+
+---
+
+## Rollout
+
+1. Unit 1 rule + Unit 2 code + Unit 2 tests → PR → CI green → merge (stops the bleed).
+2. Deploy the crawler change to the Bravo daemon (unload/load, per
+   [[project_crawler_runtime_hardening]]); verify next nightly crawl writes to
+   `78917b56` + `verified = true` via a read-only staging check.
+3. Unit 3 seed → apply staging → verify retrieval → apply prod via `apply-seeds.yml`.
+4. Spot-check a grounded answer cites a fresh manual. Then open SP2 (PrintSense
+   manual grounding).
+
+---
+
+## Open questions for reviewer
+
+1. **Collision sweep:** move-only (leave skipped garage duplicates as inert
+   `verified = false`) vs. move-then-delete-duplicates? (Recommend move-only first,
+   measure skippage.)
+2. **Trust scope:** manufacturer tier only, or manufacturer **and** reference tiers
+   in `sources.yaml`? (This spec assumes both OEM tiers via `base_crawler`; confirm
+   base_crawler is used by reference-tier crawls too, or scope to manufacturer.)
+3. **Should the crawler ALSO keep a copy under the garage tenant** for the house
+   bot's live-machine-memory context, or is shared-pool-only correct? (This spec
+   says shared-pool-only — the house bot reaches `78917b56` via `shared_tid`, so it
+   loses nothing.)


### PR DESCRIPTION
## What

Design spec (docs-only, no code) for **SP1: OEM crawler → retrieval bridge** — making the manual chunks the Bravo crawler ingests actually reachable by MIRA's grounded answering.

Authored on the Bravo node 2026-07-28. Opening as a PR so the design is reviewable inline before it becomes an implementation plan.

## Why

The manufacturer crawler started producing OEM chunks again on 2026-07-28 (after the #2959/#2961 source-URL fixes ended a ~2-month drought), but none of that output is reachable by retrieval, for two independent reasons:

1. **Tenant misroute** — `mira-crawler/crawler/base_crawler.py:151` writes under `config.mira_tenant_id` (`MIRA_TENANT_ID`), which was repointed to the garage/bench tenant during the CV-101 work. The shared OEM pool retrieval reads is `MIRA_SHARED_TENANT_ID` (`mira-bots/shared/neon_recall.py:114`). The house bot still reaches its own tenant; customers and `/quickstart` never do.
2. **Approval gate** — `mira-crawler/ingest/store.py:110` hardcodes `verified = false`, and prod runs `MIRA_ENFORCE_APPROVED_RETRIEVAL=true`, so `_approval_filter_sql()` (`neon_recall.py:139`) appends `AND verified = true` to all four retrieval streams.

## Scope

**SP1 only** — close the ingest→retrieval gaps. Three units: a trust-by-source doctrine rule, the crawler write-path fix, and a one-time gated backfill seed (`apply-seeds.yml`, never psql prod).

**SP2 (PrintSense manual grounding) is explicitly deferred to its own spec** — `print_worker.py` is OCR-only today and never calls `recall_knowledge`. SP1 is its prerequisite.

## Open questions for the reviewer

1. Backfill collisions — move-only, or move-then-delete the garage-tenant duplicates?
2. Trust scope — manufacturer tier only, or manufacturer **+** reference tiers?
3. Shared-pool-only, or also keep a garage-tenant copy? (Spec argues shared-pool-only.)

## Notes

- Docs-only — no `/VERSION` bump required per `docs/versioning.md`.
- No code, migration, seed, or deploy is authorized by this PR.
