### PR TITLE
fix(security): the knowledge_entries allowlist could attach a review to the wrong query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -667,6 +667,16 @@ jobs:
         # the explicit allowlist with documented reasons (deferred fixes, test code).
         run: python3 tools/qa/security/check_knowledge_entries_filters.py
 
+      - name: knowledge_entries checker unit tests
+        # The step above runs the CHECKER; this runs the checker's own tests.
+        # Without it the checker's test file is collected by nothing — `ci.yml`
+        # enumerates test paths individually, and neither root `tests/` nor
+        # `mira-crawler/tests/` is collected wholesale. That gap is exactly how
+        # a durable secret leak and a lost-update race reached review with a
+        # full green board on #3023. A guard whose own tests never run is a
+        # guard nobody is checking.
+        run: pytest tests/test_knowledge_entries_security_check.py -q
+
   simlab-gate:
     name: SimLab Grader Gate
     runs-on: ubuntu-latest

--- a/tests/test_knowledge_entries_security_check.py
+++ b/tests/test_knowledge_entries_security_check.py
@@ -11,7 +11,7 @@ from pathlib import Path
 # Add parent to path
 sys.path.insert(0, str(Path(__file__).parent.parent / "tools" / "qa" / "security"))
 
-from check_knowledge_entries_filters import _classify_read
+from check_knowledge_entries_filters import _classify_read, _snippet_matches, check_reads
 
 
 def test_hybrid_pattern_is_private_false_or_tenant():
@@ -183,6 +183,84 @@ def test_library_tenant_only_known_gap():
     assert classification == "TENANT-ONLY", f"Expected TENANT-ONLY, got {classification}: {reason}"
 
 
+# ── allowlist key integrity ───────────────────────────────────────────────────
+#
+# The allowlist key is `file:line`, which is NOT stable under edits. Inserting or
+# deleting lines above a read slides it onto a NEIGHBOUR's approved line; when the
+# classifications match, nothing else in the checker notices and the read runs
+# under a review written for a different query. `query_snippet` was already being
+# written into the allowlist and never read back — comparing it is what turns it
+# from decoration into the content key the line number cannot be.
+
+
+def _read(line_num, sql, classification="TENANT-ONLY"):
+    return {
+        "file": "svc.py",
+        "line_num": line_num,
+        "query": sql,
+        "classification": classification,
+        "reason": "test",
+    }
+
+
+def _entry(sql, classification="TENANT-ONLY"):
+    return {
+        "approved_classification": classification,
+        "reason": "reviewed",
+        "query_snippet": sql,
+    }
+
+
+SQL_A = 'cur.execute("SELECT title FROM knowledge_entries WHERE tenant_id = %s")'
+SQL_B = 'cur.execute("SELECT source_url FROM knowledge_entries WHERE tenant_id = %s")'
+
+
+def test_matching_snippet_is_clean():
+    errors, code = check_reads([_read(4, SQL_A)], {"approved": {"svc.py:4": _entry(SQL_A)}})
+    assert code == 0, errors
+    assert errors == [], errors
+
+
+def test_a_shifted_read_cannot_inherit_a_neighbours_approval():
+    """The defect: read B slides onto read A's approved line. Same classification,
+    so the pre-existing checks stay silent — this must now be loud."""
+    errors, code = check_reads([_read(4, SQL_B)], {"approved": {"svc.py:4": _entry(SQL_A)}})
+    assert code == 1, "a misattributed approval must fail the build"
+    assert any("DIFFERENT query" in e for e in errors), errors
+
+
+def test_yaml_block_indentation_is_not_a_difference():
+    """The snippet round-trips through a YAML `|` block, so it carries the
+    template's indentation. That must not read as a changed query."""
+    assert _snippet_matches("      " + SQL_A + "\n", SQL_A)
+
+
+def test_trailing_context_does_not_match_a_neighbour():
+    """`_extract_query_context` captures the read line PLUS trailing context, so a
+    read's context routinely contains the NEXT read's line. A containment
+    comparison would silently accept the neighbour; anchoring on the first line
+    does not."""
+    context_of_a = SQL_A + "\ndef b(cur, t):\n    " + SQL_B
+    assert _snippet_matches(SQL_A, context_of_a)
+    assert not _snippet_matches(SQL_B, context_of_a)
+
+
+def test_an_entry_without_a_snippet_is_still_accepted():
+    """A ratchet, not a flag day: entries predating this check cannot be verified,
+    and must not fail the ~135 live entries already in the allowlist."""
+    entry = {"approved_classification": "TENANT-ONLY", "reason": "reviewed"}
+    errors, code = check_reads([_read(4, SQL_A)], {"approved": {"svc.py:4": entry}})
+    assert code == 0, errors
+
+
+def test_classification_mismatch_still_wins():
+    """The stronger, pre-existing signal must not be masked by the new one."""
+    errors, _ = check_reads(
+        [_read(4, SQL_B, "UNFILTERED")], {"approved": {"svc.py:4": _entry(SQL_A)}}
+    )
+    assert any("Classification mismatch" in e for e in errors), errors
+
+
 if __name__ == "__main__":
     tests = [
         test_hybrid_pattern_is_private_false_or_tenant,
@@ -200,6 +278,12 @@ if __name__ == "__main__":
         test_multiline_hybrid_with_additional_filters,
         test_asset_chat_rag_hybrid,
         test_library_tenant_only_known_gap,
+        test_matching_snippet_is_clean,
+        test_a_shifted_read_cannot_inherit_a_neighbours_approval,
+        test_yaml_block_indentation_is_not_a_difference,
+        test_trailing_context_does_not_match_a_neighbour,
+        test_an_entry_without_a_snippet_is_still_accepted,
+        test_classification_mismatch_still_wins,
     ]
 
     passed = 0

--- a/tools/qa/security/check_knowledge_entries_filters.py
+++ b/tools/qa/security/check_knowledge_entries_filters.py
@@ -220,6 +220,50 @@ def load_allowlist(allowlist_path: Path) -> dict:
         return {}
 
 
+def _norm_snippet(text) -> str:
+    """The read's OWN line, whitespace-normalized.
+
+    Two reasons this takes only the first line rather than the whole snippet:
+
+    1. YAML block-scalar indentation is not a difference — normalizing whitespace
+       removes it.
+    2. `_extract_query_context` captures the read line plus TRAILING context, and
+       that tail keeps growing until a statement terminator. So a read's context
+       routinely CONTAINS the next read's line, and a whole-snippet containment
+       comparison silently matches a neighbour. The first line is the one the
+       `file:line` key actually points at, and the one that identifies the read.
+    """
+    for line in str(text or "").splitlines():
+        if line.strip():
+            return " ".join(line.split())
+    return ""
+
+
+def _snippet_matches(approved, found: str) -> bool:
+    """Is the approval attached to the query actually sitting at that line?
+
+    The allowlist key is `file:line`, which is not stable under edits: inserting or
+    deleting lines above a read slides it onto a NEIGHBOUR's approved line. When
+    both carry the same classification, nothing else in this checker notices — the
+    read then runs under a review written for a different query, and a human fixing
+    the accompanying loud complaints sees green and never re-reads it.
+
+    `query_snippet` was already being WRITTEN into the allowlist by
+    `generate_allowlist_template` and never read back. Comparing it is what turns
+    it from decoration into the content key the line number cannot be.
+
+    An entry with NO snippet (hand-added, or written before this check existed)
+    cannot be verified, so it is accepted — this must not fail the 148 existing
+    entries. It is a ratchet: every entry the template generates carries one.
+    """
+    if approved is None:
+        return True
+    a, f = _norm_snippet(approved), _norm_snippet(found)
+    if not a:
+        return True
+    return a == f
+
+
 def check_reads(reads: list[ReadSite], allowlist: dict) -> tuple[list[str], int]:
     """
     Check reads against the law and allowlist.
@@ -251,6 +295,17 @@ def check_reads(reads: list[ReadSite], allowlist: dict) -> tuple[list[str], int]
                         f"   Expected: {entry.get('approved_classification')}\n"
                         f"   Found: {classification}\n"
                         f"   Note: The read pattern may have changed"
+                    )
+                elif not _snippet_matches(entry.get("query_snippet"), read["query"]):
+                    errors.append(
+                        f"⚠️  {key} - Approval is attached to a DIFFERENT query\n"
+                        f"   Approved:  {_norm_snippet(entry.get('query_snippet'))[:120]}\n"
+                        f"   Found:     {_norm_snippet(read['query'])[:120]}\n"
+                        f"   Note: keys are file:line, so inserting or deleting lines above a\n"
+                        f"         read slides it onto a NEIGHBOUR's approved line. The\n"
+                        f"         classification still matches, so without this check the read\n"
+                        f"         runs under a review written for someone else's query.\n"
+                        f"   Action: re-key the entry and RE-READ the query before approving it"
                     )
                 elif "TODO" in str(entry.get("reason", "")):
                     # enumerated debt, not approval — non-fatal but counted


### PR DESCRIPTION
## The defect

`tools/qa/security/knowledge_entries_read_allowlist.yml` keys each approved read on **`file:line`** — a key that is not stable under edits. Inserting or deleting lines above a read slides it onto a **neighbour's** approved line, and when both carry the same classification, nothing in the checker notices. The read then runs under a review written for a **different query**.

**It is not a silent bypass** — and I want to be precise about that, because overstating it would be its own problem. The same shift also produces loud complaints (the first read lands on no key; the last key lands on no read), so CI fails and someone looks.

The hazard is what survives the **fix-up**. Reproduced on a 3-read fixture, deleting 2 lines above them:

```
exit=1, 2 complaints
  ❌ svc.py:2 - TENANT-ONLY                    <- loud, gets re-keyed
  ⚠️  svc.py:8 - Allowlist entry not found     <- loud, gets re-keyed

what each read is now running under:
  line 2  reads title        -> UNAPPROVED (loud)
  line 4  reads source_url   -> *** MISATTRIBUTED: REVIEWED FOR: title ***
  line 6  reads embedding    -> *** MISATTRIBUTED: REVIEWED FOR: source_url ***
```

A human fixes the two loud complaints, sees green, and never learns that the two reads in between are now approved by someone else's review.

## The fix

`query_snippet` was **already being written** into every entry by `generate_allowlist_template` and **never read back** — pure decoration. Comparing it is what turns it into the content key the line number cannot be.

After the fix, the same scenario reports 4 complaints instead of 2, naming exactly the misattributed reads.

**One non-obvious detail, found by the repro rather than by reasoning.** My first version compared whole snippets by containment and *did not catch the case*. `_extract_query_context` captures the read line **plus trailing context**, so a read's snippet routinely *contains* the next read's line — the neighbour matched anyway. The comparison now anchors on the read's own first line, which is what the `file:line` key actually points at. There is a test for exactly this.

## A ratchet, not a flag day

An entry with **no** `query_snippet` cannot be verified and is accepted. That keeps the existing corpus green while every entry the template generates carries one.

Verified **non-vacuous** — the check is live, not passing by absence:

| | |
|---|---|
| allowlist entries | 135 |
| with a `query_snippet` | **135** |
| live + snippet (actually compared) | **135** |
| of those, snippet matched | **135** |
| checker against the real repo | ✅ exit 0, 156 read sites classified |

## Tests

6 added (21 total in `tests/test_knowledge_entries_security_check.py`): matching snippet clean · shifted read cannot inherit a neighbour's approval · YAML block indentation is not a difference · trailing context does not match a neighbour · missing snippet still accepted · classification mismatch still wins (the stronger pre-existing signal must not be masked).

`test_a_shifted_read_cannot_inherit_a_neighbours_approval` confirmed **RED** with the new branch neutered (`elif False:`) — 1 failed, 20 passed — and green with it.

## Provenance

This fragility was hit **twice** while shipping #3023 — the key shifted 747 → 782 as lines were added above it — and flagged there as a known-but-unfixed hazard rather than fixed. This is that fix. Unrelated to #3023's evidence work; deliberately a separate branch off `main`.

## Not in scope

- **Re-keying to something stable** (a content hash instead of `file:line`) would be the deeper fix. It rewrites all 135 keys and loses the file/line locator that makes a complaint actionable. This change makes the existing key *safe* without that churn.
- The 120 entries still carrying `TODO: justify this read pattern` — pre-existing enumerated debt, non-fatal, untouched.