### PR TITLE
docs: add Emre Kalem robot arm package

### DIFF
--- a/docs/instructions/README.md
+++ b/docs/instructions/README.md
@@ -1,0 +1,10 @@
+# Instruction Packages
+
+Fast index for bench guides and generated local instruction packages.
+
+## Robot Arms
+
+- `emre-kalem-robot-arm/` - Emre Kalem 6-axis robot arm package for Arduino Uno wiring, servo calibration, main controller programming, conveyor load/unload waypoint planning, and future teleop/training arm setup.
+  - Start with `emre-kalem-robot-arm/README.md`.
+  - Printable guide: `emre-kalem-robot-arm/emre-kalem-robot-arm-wiring-and-programming-guide.pdf`.
+  - Arduino sketches: `emre-kalem-robot-arm/arduino/`.

--- a/docs/instructions/emre-kalem-robot-arm/.gitattributes
+++ b/docs/instructions/emre-kalem-robot-arm/.gitattributes
@@ -1,0 +1,1 @@
+*.pdf binary

--- a/docs/instructions/emre-kalem-robot-arm/AGENTS.md
+++ b/docs/instructions/emre-kalem-robot-arm/AGENTS.md
@@ -1,0 +1,48 @@
+# Agent Quick Context - Emre Kalem Robot Arm
+
+This folder is the source-of-truth local package for the Emre Kalem 6-axis
+3D-printed robot arm using an Arduino Uno.
+
+## What To Open First
+
+1. `README.md` - morning wiring sequence and package map.
+2. `emre-kalem-robot-arm-wiring-and-programming-guide.pdf` - printable guide.
+3. `wiring-map.csv` - servo signal/power/ground table.
+4. `arduino/README.md` - upload and Serial Monitor command notes.
+5. `arduino/emre_kalem_arm_calibrate/emre_kalem_arm_calibrate.ino` - one-servo
+   calibration sketch.
+6. `arduino/emre_kalem_arm_uno_controller/emre_kalem_arm_uno_controller.ino` -
+   main manual-control and locked waypoint-playback sketch.
+
+## Hardware Assumptions
+
+- Arduino Uno.
+- 4x MG995/MG996R 180-degree servos.
+- 3x MG90S 180-degree servos.
+- 6 logical axes, 7 physical servos.
+- Shoulder / Arm A uses two opposed servos; the second is mirrored in code as
+  `180 - angle`.
+- External regulated 5V 10A servo supply.
+- KCD1 rocker switch used as servo-power enable.
+- Servo power ground and Arduino GND must be common.
+- Servo red wires must not be powered from the Arduino 5V pin.
+
+## Default Signal Map
+
+This package follows Emre's original Arduino pin map:
+
+- D3 - base.
+- D4 - Arm A left.
+- D5 - Arm A right, mirrored.
+- D6 - Arm B / elbow.
+- D9 - wrist A / pitch.
+- D10 - wrist B / roll.
+- D11 - gripper.
+
+## Safety Defaults
+
+- Automatic conveyor demo playback is locked in code:
+  `ALLOW_DEMO_PROGRAM = false`.
+- Do not unlock playback until physical limits and conveyor waypoints are
+  calibrated on the actual printed arm.
+- Treat the KCD1 rocker as a power enable, not a safety-rated emergency stop.

--- a/docs/instructions/emre-kalem-robot-arm/README.md
+++ b/docs/instructions/emre-kalem-robot-arm/README.md
@@ -1,0 +1,84 @@
+# Emre Kalem Robot Arm Wiring Package
+
+This package is for the 6-axis Emre Kalem "Robotic Arm with Servo & Arduino"
+build using an Arduino Uno, 4 MG995/MG996R 180-degree servos, 3 MG90S
+180-degree servos, and a separate 5V 10A servo power supply.
+
+## Start here when you wake up
+
+1. Print or open the PDF:
+   `docs/instructions/emre-kalem-robot-arm/emre-kalem-robot-arm-wiring-and-programming-guide.pdf`
+2. Put the arm at the mechanical home pose before applying servo power.
+3. Wire only the power bus first:
+   external 5V supply positive -> rocker switch/fuse -> servo red bus;
+   external 5V supply negative -> servo ground bus.
+4. Connect Arduino GND to the servo ground bus. Do not connect the external
+   5V servo rail to the Uno 5V pin while the Uno is on USB.
+5. Upload the calibration sketch and test one servo channel at a time.
+6. Upload the main controller sketch and use Serial Monitor at 115200 baud.
+7. Leave conveyor load/unload playback locked until each joint limit has been
+   calibrated on your physical print.
+
+## Files
+
+- `wiring-map.csv` - servo-by-servo wiring table.
+- `conveyor-waypoints-template.csv` - worksheet for the second arm's
+  conveyor pick/place cycle.
+- `arduino/emre_kalem_arm_calibrate/emre_kalem_arm_calibrate.ino` - one-servo
+  calibration and horn-centering sketch.
+- `arduino/emre_kalem_arm_uno_controller/emre_kalem_arm_uno_controller.ino` -
+  main manual-control and waypoint-playback sketch.
+- `arduino/README.md` - upload and serial-command notes.
+- `emre-kalem-robot-arm-wiring-and-programming-guide.pdf` - printable bench
+  guide tracked in the package for fast GitHub access.
+- `tools/emre-kalem-arm-guide-pdf.py` - generator for the printable PDF.
+
+## Default Uno signal map
+
+This package follows Emre's original Arduino pin map:
+
+- D3 - base
+- D4 - Arm A left
+- D5 - Arm A right, mirrored in code
+- D6 - Arm B
+- D9 - wrist A
+- D10 - wrist B
+- D11 - gripper
+
+If you prefer a contiguous D2-D8 signal strip, that also works electrically,
+but update `SERVO_PINS` in both sketches and mark the change on the wiring
+table before powering the arm.
+
+## Morning order of operations
+
+Do the job in this order. It prevents most of the usual servo drama.
+
+1. Mechanical check:
+   - Arm moves by hand with power off.
+   - No links bind.
+   - Servo horns are not tightened yet unless already centered.
+   - Wires can flex without pulling on servo sockets.
+
+2. Power check:
+   - 5V supply adjusted to 5.0V before connecting servos.
+   - Rocker switch interrupts only the servo positive rail.
+   - Servo ground and Arduino ground are common.
+   - No servo red wire is connected to the Uno 5V pin.
+
+3. Calibration:
+   - Upload `emre_kalem_arm_calibrate.ino`.
+   - Select one channel, attach it, center it at 90, then install/tighten the
+     horn in the closest mechanical home position.
+   - Repeat for all seven physical servos.
+
+4. Manual control:
+   - Upload `emre_kalem_arm_uno_controller.ino`.
+   - Open Serial Monitor at 115200 baud.
+   - Use `help`, `status`, `home`, and the small nudges (`b+`, `b-`, `a+`,
+     `a-`, `e+`, `e-`, `p+`, `p-`, `r+`, `r-`, `g+`, `g-`).
+
+5. Conveyor arm later:
+   - Fill `conveyor-waypoints-template.csv` after manual jogging proves the
+     pickup and drop poses.
+   - Copy those angles into the demo waypoint array.
+   - Only then change `ALLOW_DEMO_PROGRAM` from `false` to `true`.

--- a/docs/instructions/emre-kalem-robot-arm/arduino/README.md
+++ b/docs/instructions/emre-kalem-robot-arm/arduino/README.md
@@ -1,0 +1,47 @@
+# Arduino Sketches
+
+Use Arduino IDE 2.x or Arduino Cloud Editor with board set to **Arduino Uno**.
+The standard Arduino `Servo` library is bundled with the IDE.
+
+## Upload order
+
+1. Open `emre_kalem_arm_calibrate/emre_kalem_arm_calibrate.ino`.
+2. Upload it to the Uno.
+3. Open Serial Monitor at `115200` baud.
+4. Center and test each servo one at a time.
+5. Open `emre_kalem_arm_uno_controller/emre_kalem_arm_uno_controller.ino`.
+6. Upload it after mechanical centers and first-pass limits are known.
+
+## Main controller serial commands
+
+- `help` - show commands.
+- `status` - print current logical joint angles.
+- `home` - move all joints slowly to the configured home pose.
+- `detach` - stop sending servo pulses. The arm may sag under gravity.
+- `attach` - reattach servos and write current setpoints.
+- `b+` / `b-` - base nudge.
+- `a+` / `a-` - shoulder / Arm A nudge.
+- `e+` / `e-` - elbow / Arm B nudge.
+- `p+` / `p-` - wrist pitch nudge.
+- `r+` / `r-` - wrist roll nudge.
+- `g+` / `g-` - gripper nudge.
+- `set base 90` - set a named joint to an angle.
+- `speed 25` - set move delay in milliseconds per degree.
+- `step 2` - set serial nudge size in degrees.
+- `demo` - plays conveyor waypoints only after `ALLOW_DEMO_PROGRAM` is changed
+  to `true` in the sketch.
+
+## Pin map
+
+The main sketch follows Emre's original Arduino sketch pin map:
+
+- D3 - base
+- D4 - Arm A left
+- D5 - Arm A right, mirrored in code
+- D6 - Arm B
+- D9 - wrist A
+- D10 - wrist B
+- D11 - gripper
+
+It keeps D0 and D1 free for the USB serial connection. If you wire a different
+signal map, update `SERVO_PINS` in both sketches before uploading.

--- a/docs/instructions/emre-kalem-robot-arm/arduino/emre_kalem_arm_calibrate/emre_kalem_arm_calibrate.ino
+++ b/docs/instructions/emre-kalem-robot-arm/arduino/emre_kalem_arm_calibrate/emre_kalem_arm_calibrate.ino
@@ -1,0 +1,179 @@
+/*
+  Emre Kalem 6-axis robot arm - one-servo calibration sketch
+
+  Purpose:
+  - Attach only one servo channel at a time.
+  - Center the servo at 90 degrees before installing/tightening horns.
+  - Nudge each channel to learn safe physical limits on your print.
+
+  Wiring:
+  - Servo signal wires: D3, D4, D5, D6, D9, D10, D11.
+  - Servo red wires: external switched 5V supply.
+  - Servo brown/black wires: external supply ground.
+  - Arduino GND: tied to the servo ground bus.
+  - Do not power the servo red wires from the Arduino 5V pin.
+*/
+
+#include <Servo.h>
+
+const long SERIAL_BAUD = 115200;
+const byte SERVO_COUNT = 7;
+
+const byte SERVO_PINS[SERVO_COUNT] = {3, 4, 5, 6, 9, 10, 11};
+const char* SERVO_LABELS[SERVO_COUNT] = {
+  "0 base MG996R",
+  "1 arm_a_left MG996R",
+  "2 arm_a_right MG996R mirrored",
+  "3 arm_b MG996R",
+  "4 wrist_a MG90S",
+  "5 wrist_b MG90S",
+  "6 gripper MG90S"
+};
+
+Servo servos[SERVO_COUNT];
+bool isAttached[SERVO_COUNT] = {false, false, false, false, false, false, false};
+int servoAngle[SERVO_COUNT] = {90, 90, 90, 90, 90, 90, 90};
+byte selected = 0;
+
+int clampAngle(int value) {
+  if (value < 0) return 0;
+  if (value > 180) return 180;
+  return value;
+}
+
+void attachSelected() {
+  if (!isAttached[selected]) {
+    servos[selected].attach(SERVO_PINS[selected]);
+    isAttached[selected] = true;
+    delay(30);
+  }
+  servos[selected].write(servoAngle[selected]);
+  Serial.print(F("Attached "));
+  Serial.print(SERVO_LABELS[selected]);
+  Serial.print(F(" on D"));
+  Serial.print(SERVO_PINS[selected]);
+  Serial.print(F(" at "));
+  Serial.println(servoAngle[selected]);
+}
+
+void detachSelected() {
+  if (isAttached[selected]) {
+    servos[selected].detach();
+    isAttached[selected] = false;
+  }
+  Serial.print(F("Detached "));
+  Serial.println(SERVO_LABELS[selected]);
+}
+
+void writeSelected(int nextAngle) {
+  servoAngle[selected] = clampAngle(nextAngle);
+  if (isAttached[selected]) {
+    servos[selected].write(servoAngle[selected]);
+  }
+  Serial.print(SERVO_LABELS[selected]);
+  Serial.print(F(" -> "));
+  Serial.println(servoAngle[selected]);
+}
+
+void printStatus() {
+  Serial.println();
+  Serial.println(F("Servo calibration status"));
+  for (byte i = 0; i < SERVO_COUNT; i++) {
+    Serial.print(i);
+    Serial.print(F(": D"));
+    Serial.print(SERVO_PINS[i]);
+    Serial.print(F(" angle="));
+    Serial.print(servoAngle[i]);
+    Serial.print(F(" attached="));
+    Serial.print(isAttached[i] ? F("yes") : F("no"));
+    Serial.print(F("  "));
+    Serial.println(SERVO_LABELS[i]);
+  }
+  Serial.print(F("Selected: "));
+  Serial.println(SERVO_LABELS[selected]);
+  Serial.println();
+}
+
+void printHelp() {
+  Serial.println();
+  Serial.println(F("Emre Kalem arm calibration"));
+  Serial.println(F("Commands:"));
+  Serial.println(F("  0..6   select servo channel"));
+  Serial.println(F("  a      attach selected servo and write current angle"));
+  Serial.println(F("  d      detach selected servo"));
+  Serial.println(F("  c      center selected servo at 90 degrees"));
+  Serial.println(F("  + / -  nudge selected servo by 1 degree"));
+  Serial.println(F("  ] / [  nudge selected servo by 5 degrees"));
+  Serial.println(F("  p      print status"));
+  Serial.println(F("  h      help"));
+  Serial.println(F("Power reminder: servo red wires use external 5V. Arduino GND must share servo ground."));
+  Serial.println();
+  printStatus();
+}
+
+void setup() {
+  Serial.begin(SERIAL_BAUD);
+  while (!Serial) {
+    ; // Wait for serial on boards that need it. Uno continues immediately.
+  }
+  printHelp();
+}
+
+void loop() {
+  if (!Serial.available()) {
+    return;
+  }
+
+  char c = Serial.read();
+  if (c == '\r' || c == '\n' || c == ' ') {
+    return;
+  }
+
+  if (c >= '0' && c <= '6') {
+    selected = c - '0';
+    Serial.print(F("Selected "));
+    Serial.println(SERVO_LABELS[selected]);
+    return;
+  }
+
+  switch (c) {
+    case 'a':
+    case 'A':
+      attachSelected();
+      break;
+    case 'd':
+    case 'D':
+      detachSelected();
+      break;
+    case 'c':
+    case 'C':
+      writeSelected(90);
+      break;
+    case '+':
+      writeSelected(servoAngle[selected] + 1);
+      break;
+    case '-':
+      writeSelected(servoAngle[selected] - 1);
+      break;
+    case ']':
+      writeSelected(servoAngle[selected] + 5);
+      break;
+    case '[':
+      writeSelected(servoAngle[selected] - 5);
+      break;
+    case 'p':
+    case 'P':
+      printStatus();
+      break;
+    case 'h':
+    case 'H':
+    case '?':
+      printHelp();
+      break;
+    default:
+      Serial.print(F("Unknown command: "));
+      Serial.println(c);
+      Serial.println(F("Type h for help."));
+      break;
+  }
+}

--- a/docs/instructions/emre-kalem-robot-arm/arduino/emre_kalem_arm_uno_controller/emre_kalem_arm_uno_controller.ino
+++ b/docs/instructions/emre-kalem-robot-arm/arduino/emre_kalem_arm_uno_controller/emre_kalem_arm_uno_controller.ino
@@ -1,0 +1,389 @@
+/*
+  Emre Kalem 6-axis robot arm - Arduino Uno controller
+
+  This sketch gives you:
+  - Serial keyboard jogging for the built arm.
+  - Shared logical shoulder joint with two mirrored physical servos.
+  - Conservative per-joint software limits.
+  - Optional conveyor load/unload waypoint playback after calibration.
+
+  Wiring:
+  - Servo signal wires: D3, D4, D5, D6, D9, D10, D11.
+  - Servo red wires: external switched 5V supply.
+  - Servo brown/black wires: external supply ground.
+  - Arduino GND: tied to the servo ground bus.
+  - Do not power the servo red wires from the Arduino 5V pin.
+*/
+
+#include <Servo.h>
+
+const long SERIAL_BAUD = 115200;
+const byte JOINT_COUNT = 6;
+const byte SERVO_COUNT = 7;
+
+// Keep demo playback locked until you have calibrated physical limits and
+// replaced the placeholder waypoint angles with verified safe poses.
+const bool ALLOW_DEMO_PROGRAM = false;
+
+// Default motion settings. You can change these over serial with "speed N"
+// and "step N".
+int moveDelayMs = 20;
+int nudgeStepDeg = 2;
+
+enum JointId {
+  BASE = 0,
+  ARM_A = 1,
+  ARM_B = 2,
+  WRIST_A = 3,
+  WRIST_B = 4,
+  GRIPPER = 5
+};
+
+const char* JOINT_ID[JOINT_COUNT] = {
+  "base", "arm_a", "arm_b", "wrist_a", "wrist_b", "gripper"
+};
+
+const char* JOINT_LABEL[JOINT_COUNT] = {
+  "Base rotation",
+  "Shoulder / Arm A",
+  "Elbow / Arm B",
+  "Wrist pitch",
+  "Wrist roll",
+  "Gripper"
+};
+
+// First-pass logical limits. These are intentionally conservative. Tune these
+// for your printed parts before running automatic waypoints.
+int jointMin[JOINT_COUNT] = {10, 45, 30, 25, 10, 35};
+int jointHome[JOINT_COUNT] = {90, 90, 90, 90, 90, 70};
+int jointMax[JOINT_COUNT] = {170, 135, 150, 155, 170, 110};
+int jointCurrent[JOINT_COUNT] = {90, 90, 90, 90, 90, 70};
+
+Servo servos[SERVO_COUNT];
+
+const byte SERVO_PINS[SERVO_COUNT] = {3, 4, 5, 6, 9, 10, 11};
+const byte SERVO_TO_JOINT[SERVO_COUNT] = {
+  BASE, ARM_A, ARM_A, ARM_B, WRIST_A, WRIST_B, GRIPPER
+};
+
+// arm_a_right is mirrored because the shoulder uses two opposed servos.
+// If your physical build moves the wrong way, flip the matching true/false.
+const bool SERVO_MIRRORED[SERVO_COUNT] = {
+  false, false, true, false, false, false, false
+};
+
+// Fine mechanical trim after horns are installed. Positive values add degrees
+// to the physical servo command after mirroring.
+int servoTrim[SERVO_COUNT] = {0, 0, 0, 0, 0, 0, 0};
+
+const char* SERVO_LABEL[SERVO_COUNT] = {
+  "base MG996R",
+  "arm_a_left MG996R",
+  "arm_a_right MG996R mirrored",
+  "arm_b MG996R",
+  "wrist_a MG90S",
+  "wrist_b MG90S",
+  "gripper MG90S"
+};
+
+// Placeholder conveyor cycle. Replace these with angles from
+// conveyor-waypoints-template.csv before unlocking ALLOW_DEMO_PROGRAM.
+const byte WAYPOINT_COUNT = 9;
+const int WAYPOINTS[WAYPOINT_COUNT][JOINT_COUNT] = {
+  {90, 90, 90, 90, 90, 70},  // home
+  {75, 92, 105, 92, 90, 90}, // pre_pick
+  {75, 112, 125, 88, 90, 90},// pick
+  {75, 112, 125, 88, 90, 55},// grip
+  {75, 82, 105, 92, 90, 55}, // lift
+  {118, 82, 105, 92, 90, 55},// pre_drop
+  {118, 108, 128, 88, 90, 55},// drop
+  {118, 108, 128, 88, 90, 95},// release
+  {90, 90, 90, 90, 90, 70}   // retreat/home
+};
+
+const unsigned long WAYPOINT_MS[WAYPOINT_COUNT] = {
+  1500, 1500, 1500, 700, 1400, 1800, 1500, 800, 1800
+};
+
+int clampInt(int value, int low, int high) {
+  if (value < low) return low;
+  if (value > high) return high;
+  return value;
+}
+
+int physicalAngleForServo(byte servoIndex) {
+  byte joint = SERVO_TO_JOINT[servoIndex];
+  int logical = jointCurrent[joint];
+  int physical = SERVO_MIRRORED[servoIndex] ? 180 - logical : logical;
+  physical += servoTrim[servoIndex];
+  return clampInt(physical, 0, 180);
+}
+
+void writeAllServos() {
+  for (byte i = 0; i < SERVO_COUNT; i++) {
+    servos[i].write(physicalAngleForServo(i));
+  }
+}
+
+void writeJoint(byte joint, int angle) {
+  jointCurrent[joint] = clampInt(angle, jointMin[joint], jointMax[joint]);
+  writeAllServos();
+}
+
+void moveJointTo(byte joint, int target) {
+  target = clampInt(target, jointMin[joint], jointMax[joint]);
+  while (jointCurrent[joint] != target) {
+    int direction = target > jointCurrent[joint] ? 1 : -1;
+    jointCurrent[joint] += direction;
+    writeAllServos();
+    delay(moveDelayMs);
+  }
+}
+
+void moveAllTo(const int targetPose[JOINT_COUNT], unsigned long durationMs) {
+  int start[JOINT_COUNT];
+  int target[JOINT_COUNT];
+  for (byte j = 0; j < JOINT_COUNT; j++) {
+    start[j] = jointCurrent[j];
+    target[j] = clampInt(targetPose[j], jointMin[j], jointMax[j]);
+  }
+
+  int steps = durationMs / 20;
+  if (steps < 1) steps = 1;
+
+  for (int s = 1; s <= steps; s++) {
+    for (byte j = 0; j < JOINT_COUNT; j++) {
+      long delta = (long)(target[j] - start[j]) * s;
+      jointCurrent[j] = start[j] + (int)(delta / steps);
+    }
+    writeAllServos();
+    delay(20);
+  }
+
+  for (byte j = 0; j < JOINT_COUNT; j++) {
+    jointCurrent[j] = target[j];
+  }
+  writeAllServos();
+}
+
+void attachAllServos() {
+  for (byte i = 0; i < SERVO_COUNT; i++) {
+    if (!servos[i].attached()) {
+      servos[i].attach(SERVO_PINS[i]);
+      delay(30);
+    }
+  }
+  writeAllServos();
+}
+
+void detachAllServos() {
+  for (byte i = 0; i < SERVO_COUNT; i++) {
+    servos[i].detach();
+  }
+}
+
+void homeArm() {
+  int homePose[JOINT_COUNT];
+  for (byte j = 0; j < JOINT_COUNT; j++) {
+    homePose[j] = jointHome[j];
+  }
+  moveAllTo(homePose, 1800);
+}
+
+void printStatus() {
+  Serial.println();
+  Serial.println(F("Logical joints"));
+  for (byte j = 0; j < JOINT_COUNT; j++) {
+    Serial.print(F("  "));
+    Serial.print(JOINT_ID[j]);
+    Serial.print(F(" = "));
+    Serial.print(jointCurrent[j]);
+    Serial.print(F("  limits "));
+    Serial.print(jointMin[j]);
+    Serial.print(F("-"));
+    Serial.print(jointMax[j]);
+    Serial.print(F("  home "));
+    Serial.println(jointHome[j]);
+  }
+
+  Serial.println(F("Physical servos"));
+  for (byte i = 0; i < SERVO_COUNT; i++) {
+    Serial.print(F("  D"));
+    Serial.print(SERVO_PINS[i]);
+    Serial.print(F(" "));
+    Serial.print(SERVO_LABEL[i]);
+    Serial.print(F(" -> "));
+    Serial.print(physicalAngleForServo(i));
+    Serial.print(F(" attached="));
+    Serial.println(servos[i].attached() ? F("yes") : F("no"));
+  }
+  Serial.println();
+}
+
+byte jointFromToken(String token) {
+  token.trim();
+  token.toLowerCase();
+
+  if (token == "b" || token == "base") return BASE;
+  if (token == "a" || token == "arm" || token == "arm_a" || token == "shoulder") return ARM_A;
+  if (token == "e" || token == "elbow" || token == "arm_b") return ARM_B;
+  if (token == "p" || token == "pitch" || token == "wrist_a") return WRIST_A;
+  if (token == "r" || token == "roll" || token == "wrist_b") return WRIST_B;
+  if (token == "g" || token == "grip" || token == "gripper") return GRIPPER;
+
+  return 255;
+}
+
+void printHelp() {
+  Serial.println();
+  Serial.println(F("Emre Kalem arm Uno controller"));
+  Serial.println(F("Serial Monitor: 115200 baud. Newline or no-line-ending both work."));
+  Serial.println(F("Commands:"));
+  Serial.println(F("  help, status, home, attach, detach"));
+  Serial.println(F("  b+ b-   base"));
+  Serial.println(F("  a+ a-   shoulder / Arm A"));
+  Serial.println(F("  e+ e-   elbow / Arm B"));
+  Serial.println(F("  p+ p-   wrist pitch"));
+  Serial.println(F("  r+ r-   wrist roll"));
+  Serial.println(F("  g+ g-   gripper"));
+  Serial.println(F("  set base 90"));
+  Serial.println(F("  speed 25     milliseconds per degree for manual moves"));
+  Serial.println(F("  step 2       serial nudge size in degrees"));
+  Serial.println(F("  demo         locked until ALLOW_DEMO_PROGRAM is true"));
+  Serial.println(F("Power reminder: servo red wires are external 5V. Arduino GND shares servo ground."));
+  Serial.println();
+}
+
+void playDemo() {
+  if (!ALLOW_DEMO_PROGRAM) {
+    Serial.println(F("Demo is locked. Calibrate limits, replace waypoint angles, then set ALLOW_DEMO_PROGRAM=true."));
+    return;
+  }
+
+  Serial.println(F("Playing conveyor waypoint program."));
+  for (byte w = 0; w < WAYPOINT_COUNT; w++) {
+    Serial.print(F("Waypoint "));
+    Serial.println(w);
+    moveAllTo(WAYPOINTS[w], WAYPOINT_MS[w]);
+  }
+  Serial.println(F("Demo complete."));
+}
+
+void handleLine(String line) {
+  line.trim();
+  line.toLowerCase();
+  if (line.length() == 0) return;
+
+  if (line == "help" || line == "?") {
+    printHelp();
+    return;
+  }
+  if (line == "status" || line == "p") {
+    printStatus();
+    return;
+  }
+  if (line == "home" || line == "h") {
+    Serial.println(F("Moving home."));
+    homeArm();
+    printStatus();
+    return;
+  }
+  if (line == "attach") {
+    attachAllServos();
+    Serial.println(F("Attached all servos."));
+    return;
+  }
+  if (line == "detach") {
+    detachAllServos();
+    Serial.println(F("Detached all servos. Arm may sag under gravity."));
+    return;
+  }
+  if (line == "demo") {
+    playDemo();
+    return;
+  }
+
+  if (line.startsWith("speed ")) {
+    int value = line.substring(6).toInt();
+    moveDelayMs = clampInt(value, 5, 100);
+    Serial.print(F("moveDelayMs = "));
+    Serial.println(moveDelayMs);
+    return;
+  }
+
+  if (line.startsWith("step ")) {
+    int value = line.substring(5).toInt();
+    nudgeStepDeg = clampInt(value, 1, 10);
+    Serial.print(F("nudgeStepDeg = "));
+    Serial.println(nudgeStepDeg);
+    return;
+  }
+
+  if (line.startsWith("set ")) {
+    int firstSpace = line.indexOf(' ', 4);
+    if (firstSpace < 0) {
+      Serial.println(F("Use: set base 90"));
+      return;
+    }
+    String token = line.substring(4, firstSpace);
+    int value = line.substring(firstSpace + 1).toInt();
+    byte joint = jointFromToken(token);
+    if (joint == 255) {
+      Serial.println(F("Unknown joint."));
+      return;
+    }
+    moveJointTo(joint, value);
+    printStatus();
+    return;
+  }
+
+  char last = line.charAt(line.length() - 1);
+  if (last == '+' || last == '-') {
+    String token = line.substring(0, line.length() - 1);
+    byte joint = jointFromToken(token);
+    if (joint == 255) {
+      Serial.println(F("Unknown joint."));
+      return;
+    }
+    int delta = (last == '+') ? nudgeStepDeg : -nudgeStepDeg;
+    moveJointTo(joint, jointCurrent[joint] + delta);
+    Serial.print(JOINT_ID[joint]);
+    Serial.print(F(" = "));
+    Serial.println(jointCurrent[joint]);
+    return;
+  }
+
+  Serial.print(F("Unknown command: "));
+  Serial.println(line);
+  Serial.println(F("Type help for commands."));
+}
+
+void setup() {
+  Serial.begin(SERIAL_BAUD);
+  while (!Serial) {
+    ; // Uno continues immediately; native-USB boards may wait.
+  }
+
+  attachAllServos();
+  delay(300);
+  printHelp();
+  printStatus();
+}
+
+void loop() {
+  static String line;
+
+  while (Serial.available()) {
+    char c = Serial.read();
+    if (c == '\r' || c == '\n') {
+      handleLine(line);
+      line = "";
+    } else {
+      line += c;
+      if (line.length() > 40) {
+        handleLine(line);
+        line = "";
+      }
+    }
+  }
+}

--- a/docs/instructions/emre-kalem-robot-arm/conveyor-waypoints-template.csv
+++ b/docs/instructions/emre-kalem-robot-arm/conveyor-waypoints-template.csv
@@ -1,0 +1,10 @@
+waypoint,purpose,base_deg,arm_a_deg,arm_b_deg,wrist_a_deg,wrist_b_deg,gripper_deg,duration_ms,verified_notes
+home,Known safe starting pose,90,90,90,90,90,70,1500,"Arm clear of conveyor and fixture"
+pre_pick,Approach above pickup point,,,,,,,,"Jog manually; keep clear of belt and guides"
+pick,Lower to part pickup height,,,,,,,,"Use empty gripper first"
+grip,Close gripper on part,,,,,,,,"Record gripper angle that holds without crushing"
+lift,Lift part clear of conveyor,,,,,,,,"Confirm no collision through entire lift"
+pre_drop,Move above drop location,,,,,,,,"Slow sweep from lift to drop before carrying part"
+drop,Lower to unload position,,,,,,,,"Part should not rub side rails"
+release,Open gripper,,,,,,,,"Confirm part releases cleanly"
+retreat,Clear fixture and return toward home,,,,,,,,"Must be collision-free if part slips"

--- a/docs/instructions/emre-kalem-robot-arm/emre-kalem-robot-arm-wiring-and-programming-guide.pdf
+++ b/docs/instructions/emre-kalem-robot-arm/emre-kalem-robot-arm-wiring-and-programming-guide.pdf
@@ -1,0 +1,175 @@
+%PDF-1.4
+%“Œ‹ž ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 14 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 15 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 612 792 ] /Parent 13 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/PageMode /UseNone /Pages 13 0 R /Type /Catalog
+>>
+endobj
+12 0 obj
+<<
+/Author (Codex) /CreationDate (D:20260731170200-04'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260731170200-04'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (\(unspecified\)) /Title (Emre Kalem Robot Arm Wiring and Programming Guide) /Trapped /False
+>>
+endobj
+13 0 obj
+<<
+/Count 6 /Kids [ 4 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R ] /Type /Pages
+>>
+endobj
+14 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2831
+>>
+stream
+GauHN>Beg[&q9SYQq+Q"d0/q)6dN$4e@TS29k$20kmJb',&NKN5r+>srQYBg-/"Ru]BgTZjos\ei0t65^`X&%r*fHjU&_^7K8X(R0F.$3^c]em]AMTGh:Z.J>t[]tdI?"5"$;H(Yiq\u4"LB>U;!]Bm'rbN\fj%X$/ht:annC2pl4I2!%$g6!Nlc3B.>E5Y\LL4^_A94'#8sH]*GkCOn=#h$[Rr,DZp]X(j.G<HuC`pq*>FTj+O#M^iDf_pYmQTf\hngMdII2M$Dpl1^<(tbB5p`^.\09qkS)@<(1`EFK_aRl'YO;j:54]63_p,b;V=&i\oU+k%'`eZ,#aC\l;7jPnNNTf>)J<$_D!P`LBPekJ57D.OA/R(Bo@ln\la3\!.5g<5?/kEfKY#IU'tbX4Ufa/pVKbQ?4j`.&\5(**QYZ$AW3IZj9>MEZqKA7e*Q*7JMuKf:ismM+G"f\L87C[']m:Jn$mYe./C4gAk\&>Cl/_^b?$*6U)%l$A2dR`#`sHMM!<BJ+_+nA;MC]NYR0_7TKXjI?-9=Ilt'F1]t1;<WhXr<:8:FKC@c3*K+_uMGRC#-K[#u5'NIEqojW$F.&=V\WTZ3$coYPlk0!P^;f)rl?5-RN7[nW=)5H=R)u,A$j+2h<[H'(q0Z\g#ItTWGb.8Se5qLZ,X`_O_c!1roNa$u:9MLC<L[bGqOc0T9;pUFau@D.9QWEp6pI]n9$%i/2fEJF,kV#IrpS'M0c0bgq2De=#dSQW-!a#?,i@SnosJ@pjgoAqDX%XUN;s_s;^8gW(ahK&7:Nq1mB?<^J:L+\b@n3#2N%Y?1o:QbT<?KO_=a*J77S6oOMe2<Z%ps)hE-(n>MnD-"L"$hjGT'PKa9oO%DACCq!gWI_]c.8.FK5`])eAYZB"QH)Z:WaHd&]Of%a[LHqAScGA1*qAR2d!W"7>-R"sp67.P*3-Jig=?IRhe577'PWZ8po2AcZtrXHIMq;Nb9^DduO=>s^.cZ-0Jf5^.ad,3apYfNC_@\q#/9:F#r3OmSf^>8#TI1qCnhTZU&U+"<eFk/+lF.?84!^"71a%[+_ee/#hK3@q<J([Ph9$b4h)@a8r>Y)Ctf#V^Lb!k/6'LinE-nng/:`rXM,0\T4CG*b0PLa>T4g[Y3;G@dKBdW1kb6s^QNp/.Ck@h/sIM@SE\W!SS5aR^^m[/n9Dfp"cL8!MUFPY"R4oK%,K`r`a14RG^*-s5=HLa;AXDDjco<s3h^hnl:`^;iYd:oRro0fMb9\")r"Af0"[=;^eaVn0J%uo.o7*ZO8;Gu%NFMmU4%$J2PabT[G6&sltUplJQX'?X!?RIRped?g<ZfB.#@%5Af]'5CqF(poiAMIF%7,<M[m^8g8c,Z1ECZd1pV$e!"`CP$.[ZKs-ht>71@E/e30rj(@HX?_n;ZHR161']M``5299A\[6WQV8@<ZX38AWc)5CVhYuY(gPYabW_l&$)3`^Y96Ir&4N?WW"DS+(!&+GE8_`IG9\9a'Cj*igG/9X.p0RVF;.+m;kg0+X"3(CA/nBa&79=#Ib)fJb$<\6Q_*^3mDK14J&Kpp)U1ikn%#m*#?XnGE3!HbgZB'k+?VgGT&_PqqLeYa5;?Uh:2F0`UEE/>^,VM3puDje\5W6O/[==S8d_[b$6`ZrU62nDZ&Xen4`?gQ.6=U,@#X;GNkJeND&ZnUV7^Hi@I1Ob;#8BAqKm:2*i6@?7%A?<&2d\]5gT9hrW!8(!bH?3/oR]*StRplY+](>%JFdb`7$ij8aPDL#[ke`_Q;I]V'!d,3td9^>ur0fFsu/lu,<ljb`Klj!JQFemnDRIAt4KSZ_\Qp3U!2fsY&OTS:d2Ds3meHAOAilC7E5hh$2rB3Rg!LVC`OGDt)`I>dF[.+/WSMr$9#-A7#C.'PgN^:r8@)&8pGJZcWR?07k5e7.jSD(h3\>h^;X\c6ojat]B0Du+D*.epk&`UplrGH"\,jqpUL=$rK#1t@\*lPpf!"l7aT[pn-B2oSmnh+;5pLQ3SV4lNT3"LPm,:hof%=]]([R%gOr/[n9^,EaD@l:Q*-[,=)SUg:O+BJGV`;HI.hCf`&^"]]pp3V[`lpfESn!O?QMSs>-b@&\<5f/I`+?'Al[@+(q$'L?i[pdD+'n[bK_f7E88GS+0C.(3I[g/T(l?XJP2C0S+e"YnG?NB8=m0_R_TFZPCDHqjtCQMh]`@Yl$;Wa(kr,=+(a_Em]C\)88NY+X]U=[OE5Od/&49mo^-O\D%]1XXai;/V)^pAq\DOoqYgaQ1<!;V!u<CG5UhQ[.7/[KGMtpgJ3nApLZaO(%:cXa`+8dgk;c+kBS/fApRHl;Jl1=\2+1F>2&QcEc5KH!Z6][V\et:sT.*jMS,aqt&;9gS9Z?Uh3J7[_Qg7h`D&B+FK]8n]jsQpEYL']_0=jW*q$HPYFqhh+;u]p/706VS^.;?3D!bZ(]<4=Jo:c*'"IiB=77b\RG[8[o]K#`LU-#2k]i)6JDki#MT&I+-5].e*WQ==9#_eZ=t]odtsPX+6Y2p%<-!d6=>T\(r$g!M/=re%.uVY^2A1e?SpFcD+(ABVc&f0Y7QVVQW3]!!2e;.5.`CDKN?aE-4K]2/f@0EkXV;,99Gie!H+Rc[tj>.W!@Y%@ta2S#>h'>hDV`PU57/ViK"=s\J6S]#2dKWCSV0)1#K6QR.E4%n2;"J/FogYnNj<O6ELVV+t_P[FY_;%+PmT2GSDnXGne'n+>342Ytfou2.:3Z.SNq*3@qL!huA`;CVHe?3as\kA"<sTTT`c1KfLlQ(oHtg7ub1KW&B%>Q/\8H\Ae1ACQ7O]E6FTBfkC9-$2CDVIs/+(BE&&dVeLS~>endstream
+endobj
+15 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2382
+>>
+stream
+Gau0E?'j9d&Ug9Y;(jrMf`e'fU#_`61ELB$`eep,_4-e(1sgbhIGgDJ/H7oCe7p-D(ebG5GRS]'\uK]+Wk*m)ZLQs3s3<Epf2EU$Fi\Q:\g5>*I%(%mhG!CPh6f$N:Q2o*b7!]Nm$#D<^"@Ho;Cc)>Zl?V`A9hKL/m^l5B(Y@_VBihkWQ[mJZ_AY;1>4')a]GjLPD,eUD8]&0qcB58U$5?hk9E)C>DAgd;Aa[[!1,EX`NU:LAArHEa*;Tud#Zh?*:"j$MTLq!esM3:HWXYSFD!P%Bj[>CgWbT2m_$OX-3>9MBiC$4N5mPR%P3@=jnK=e*M(k1(V\k0UUMkpr7:64l9djOng%pUjA0et.$B'tUe3D1=!d6EF`?E&LMhcHq@FMl*&unm-S2H@j0d+olX;*_MQ4(#DEr$WNg?]dRZYn1AYR>iU0if2Ce(=$:IRj5Jo]Z$>2UO"=NYA;<2,N`g(\*r,t1R%.2Ocps%7u#-[Jc-l<>i[r![B3PslA"9e,m4!!]Dn:f]\5*BGi3U0:Kd=%R`%>uFR(beM#:;-,G@"fBg..:m-M'+=1Ri;eJDeKR_R#s0Y;=le-?`;b\O06^H-E:tJ7#fs;]!'R2Tn*U2BG#,9BV-!73V8m2fmY:+]0tY3E/9nUUhsQ!d`5a*#p]3lO)!OS953'\Lb;1`ja39)O':Rt[&2;E>_)%]TJjB:<'1HP#0_"qn?P=7G3D*&3'Uf<r+!qIq"0NA<-uil/m6Ig+#%T>uW>mb=&Vo_:R8b[J)a(6[c)HWgA)l6'W.,@:B)A'*o3TQK+u*GUZ8>@R!7@-4Y)>>H82VNXcAM">[ON`,!Ju1i/!Xp9E7uQCF?l13IbCl8IK1_3kB$k!JV"]s%g:$kIhSK(?$:<mWFD?_")pQ%r/0R>#/a'52ZqP0A/KTJ7@)%a![=JQ#!jOOoisD./;n)I'roMajTWGOR*YcL!:.).:"8-HTC[Yd5F<qF_&(3C!G:uikVjObiC(u=<n<a7g=?6LBV]^<f1I2t>D-jD)HTsuVSt$Q2d;Qh.Mo&o<rGF=od'T*c\ek1cs^)H>mQnt^E5`h5c-UFiB;hVf_5Rm"I72hHF9WM@.l%?eRi',Bj7O>".Goc/W3f[^Yd"Mph;]`79Q)E$Fjdn1WD'_88&3=.Q>IN=^#qI<$[C)^<MRpf5eD)d:o/Q:tToirM%3$h+.]!4=Xl*Q^?(ngc[\M.]s`dJO:1h67Ap)=Uh(&G]ehRjZ0HCd_#%q0nR-e6]RI"EJ'g#d=8Oo]3"TH;TX2a.s\rs+Re2=!'Z_hj1$mE)SRP!@N^/$/7aW"".q;Te8Pmm6D_iqDeImAKW-mgcG`VRFpL5L[CUHr6QmCSlF;5#<g`._=";Zq/&K(!Y1Uum<%*@5$RNM#(<CL9G'2#fhKfl=D4kU>HN-6ui:%if"+'9)+s._t:EE]BG9j!P%ot@L;N?o&9l`fE<UchO':rObYP%!8WTNNql[FS&SU"giH$Y=#O![#pZ[>nfA[@i7clm0(0m`S&_@LdsU.2Y`hYN1f)<sjYR\d*+qkd+QH*8!+JijFI#<nPqcG:042"=)"?o/0[PB\p(D#?>@06K2',X`pPi:$.*q=1jN$0YG_A/Q'TBAOiK_elh1TB/S<H,1F1>'K>OTfpD2@)n%c=&[Wt<rM9gkj>Q8<k\C@@stB[b4SH@,6c'F3-;^_Zf.TfJgn(3Y`5LArUimVs*s6o1JQ^.5XlF:Z3n-r+W!\l],S2&09mfcl3Ehf+/C<#NXI.3;/m+M)<+j'h,Nd6d6Z3lcZR=ub7"DW0'O,)W*Xh[P2(EoH95\O.DI.L9,N@-S4a:l)aQBG9b1Ci)`X/-.nKQn9+@;,ln.*^9BH8-4tiC@2jA&@>\7PcfeFqfWP_c<)a;r4Gtt07qM`@q)g:k2&Q6'`?WWno`'q]I^G/]JD-/`.JTJ,oo#nCbOk]t+f?,*^J<nkubL'<ugbA'!\Q<kq$f#:(n*Ze[3khH@LEb&A79I^&2<Y77->mJf!t&+TA?F$&I;jh>]AUu5F):Kt5+kXoH:q1Tr^9k/DU;r2M;`!)4bL'_?`V!_BE*,(1"9H03?:E]EX=NB#eH'tm@#)MgP]A?dNtLnD+/ur]JdBo8+&69r[*&5nUKf;DJAe68?!RSk+8Y6F()P"A]f<Zd<`?.$XH_t:l+<fRO`,"FQM3*C&(*=&^]oYoU?Kh8e,M^e!.TWl1&9,]u<W'j`oG=2Xh,lb75N<6Rgld^W=#2bRO8[NFtA[q2mHLGXE!K4_faS6iOc70DRquI)ctJ,IE!(ejk`!$aof)E,5lN.Bh!Ob6>Jdm'o<);jQ$`)scn+8bKZc:mq'([J=3Bgo)S<RLa]kf&kupql\9FlbVWX>rSUF!8[SaF+H3^~>endstream
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2612
+>>
+stream
+Gb!#^D/\/e&H88.ESonq2(e*!(pG0_e"YU.^,Tso$q!;7N3,Ma>tU!:J%m6$@bHU63oPTIFY)bk5'NpfNlRnC=SP8Vn&5LhiX.$9-r:kcDLf=:Kr[Gso'5T-=X=B=+De1oa1$ZI"etuXO\L7c.s3MI#.C(Q3)0H3IedrjJ^NRKEqk85Him9j71N"/?l.!G?,<OsQQ4#LALe89O)XbF>lCI;5+i,QOKM*$#]N$F<Q=?Xg=5^=+LW<#*X1O+[c^+POVGeYN.(18T7l-!5j4]0WmT>BTs>HD9#\n&)lTYt&1K\2*e>2qG@E\L+6s%(U@gZGYcXYgUP`q'ipTdaaGN:lI2(@sMp<W2V[c<6/[0("eT6?SIuhu2^XA<Bb6p\M]sa$6PQnORon0QWRWe:iC(3;T4Wnq8TtYO?el,2Rg&W@jC?Pq';D*4/^<bdB959Y\RIW_C!s2)2(MkT];#q;Oi;YFh2"-*mSjcnZGdDX[m]CmC(jX%,9`i$F4"`Vbm(asA;$1/u;5DB15f[r%CXg.d/;`PQjfq?"'feL1[e(+jg]<1_BHQ=`.R9%0R'Z,roU)jPnLb@`;d?J"*hof7jJaq'>j=gRDE9d<4M^j8Q]MTrG&b5uo7g3hn+.*ac0B9l`@d_*'=PD>I2XtDRd)R[Z6?fK<Tbr4m`7Z>GXBEN(fLcP[i@($dV*jFAUJP0q3lqF-nJJXi;r7(Y@^5OWAOm97hNrVD/^]5B%I@(kt\TcR$^:4X[S@'\V.)D2b`'=7Z'e,WB1qGmZT"qPAt&.Ms!TeaX?RYggQ#38(NcXPq"NH*"0XT?Imm!aed5^lS1HPK=!QDgX(B_9.;.TSr.=?Rm`lpK=ogds*)8+UO#%pqaT+].<)h]nT:0"%4ti[PgkIi8\A%Z6DIp['"CNc$K<#W8^TaU7/k="=Dr`6#=?<RhISGY]:iml#rqU5Jg'b^:3ce///VCIfqDeQRm/mi65"4r4G/>Ye`me5juX'bFe%gYTL]a4Q@.B+I8mun0m5=tnnU/!I<0X?'HV'*08B7?%WiTuZ/:J2hFK?AI\UX?S,EP`\lpGrNR/DZR\P?hmpI37bCT6AV</PQ-/"%d]h-/*mSY;nI?p&`-;g\j)Bug]^Pg(9;)Oq>Ga$J3:X1Z%1UY"uooHbD(ECVJZ0e[i*HS9AQ&N3,SpjmDn/FcC4b-X9q$&"?PR]GHH`6GKVs<-3pKqA*#-m:SA<DZV]lV5W!ggJKT'"/n@mp>;5Q@=;!-'"i84XsI*t\fB.gk7qlSGnpf@hn1<'(<G=TUB2Z^U42_):Q:^A<kF@h>P-Tojs@DLG$#<f]e"[0b='oN<D[p:@6`juPqcmj7h3QA'M*+FR-\4KkT75,fiSUSKUeBJf4,'t_Vsnu-CaFZgIN8m!)T80^b2KpJ$[D5ln-MQTQT*O_f))_)%@Bm$qPIX#s]aS&0\>`Tlt:MgL8Ts)0tf:d)q4bR5Ve[n3F\D/*>3p&eV5q)5-Eal^kn$dlmipB5WI9EU_AXm2"R_jerJ*YB7(7[@6iDXQ%>P5lk.WH0jfHM#N,jMU4%IP#dFn+MNa2^u/+)8IhL,"Ht&+rgXQ"mu2OR68UkAj_DWMj")qW;"im[.1A.>8__\Ltc`bq@MA'XNJ.H#9+KJT5Cea/_N@),0Gf1k\Qk'1%poH<74Q?qD\Q-fjY&9K5%g1q?[<p3TY%Z!FZ*lV?p8o&JnWfC.Vp2$50O_cp$+MgUNAMkjI`nn4pPc[$3na8T^5@qaTGZ(b$Ko0quRj)i\)ghQb^^GmRQhQh9<<"f1]`!O=.'`RjO>b<i8pp=&%8^2n=mSkR+93lu/)g"6i_eJ`k\(*XDa."p/=d!Ij67XekXR_VXY/3=Q-QBf-pNAHns)*c-kRn=h3\1G<Fk+=\VrWW3,>q&#E7/NLr+:9.?.>-o@FWc()eSg_<fd4P;=/.a>?5k#&#1"<p`bJD+d*8R)L(g(>R2[CqpX9go?SLO;>*i[.2>3FZ,3d\H(%[ChOX-G`]!Cp/#T>I[Lc?:j-T5k_H+a*^d]:+=RYK4\pZIpA".!#;Co+FN);*`Kut(^K]Dtc^/_ABN:j5&@jX,J<^("F][jr8eNmJ?$&3X283Fs#<AE6(pR'RuZ$L42*\1/>!U[FcSkS+F8E1]Q=-d@hkLl.)F&qq?nk,,%enZh_ag^[3&'EQGq7>6eqX%T)kX(84<YI+an*s6+7Q4;3)T<?:aEp$mpuGKM_j<&LMn@TSJQ]YW`?R0R6dl,nWHDrRl<\g?KQQt\Q&R-,WW]i6hN61a$iu8D92hGSDULMa[V5Mr2$\2ok7$\=9H/p@g<rl!_!GTjQ*"r\(H;Yq3F5u;][-Gi1Uiq.95'MS;uVRXqQ0;jF'Z+@T9UaS?K)(Jo"fCm+gPLt=1D"OF?*7Rm%"%f9rBI*_k\cS3p\a2p/eM(nRJogp\7gdeU9pA#2b:4#EA_pcY/MM>t01unu.OFDVJg,0pMEIK*Bc)X%lrfUb\LW=I%W]Q5=t-mG[J<=TpX1/q#Xjg2>el]\MAe>2;3nD0Oq1=jq)kr)Pn]4DQupq`[9TmfKG:pO76\>?s/;(u=rDS<ba%]*7C<F9$qOI*eMk[PeK-p(ipq!]^&f&G^6r~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2082
+>>
+stream
+Gb!#]hc&8h&:WfGfLN(L`q"%4g]MD-YBM[bOL[P1MQJ-*g[`HARG;/!.k,WMKt,o_DE:U'Gnkb>X&$@./HHZ;M#!O*!:T)ip5&e>@(laV3!%5ViF79.pX)_KCI-C`GPoOAP5lU$l_be\5d'`aZ<PuQA&n=RnF.ZSGmVM-V.B'C/Q`<W/;+'S9A"4*Wth^>Shi?[R][J1^VKagk3k.P%;O6A)+@:';=$@fWf6D;e4TnnfL_h`nm^h&W(;VLLcm,>+ASF0:<bT30Ade\Ai6Wj1"eE2HbI69*"'O_^Lja,)^Yl#&W_TBMOsnmnT1I2n5),%p?[tJWIF2755nj/l83"9@`I>hWO9g>(jbcf4*i,jg`[>!%P4pGC[>!OEJ)ae$-Y>Ir/Ia7W&92bC'95%%0Id$3Mgt2q$AmZ?l<hl50-66!`UV;XaquSWcH0G$*]/W$rRm^[ZZS,-[O;MGh"3G'RL*lF_83S!A2A"KP_F7+^<EQB=,Ib-%fAX>]EV$n7;pDM+S%QRl@9I_3HKHkN27;>#\g(1V1jX09K4sD@t@10'OGT\9VHh%9]F19rU"oKTp."_DTUH47NRT]1;lKJPS,Gd=Z.dr_GEC@J9L&*PU2_Xk[p@$jsL%'"<AX5'c<$Vf`Ze>9VY$s6L[`cc?`PqHQFn4W!!Kr2;h7*Jlm3%RL5W++%FXg(SObk9PWjB.)W$h.a-pl(@-l$Tajm9CpZ[4EfWiSIQ`0V5,LH,fs+:<g&apdf*7\>=DitXiHESNqWnHO3a/]U.?lMOAt[(d\SQ!c%0:K\pMedkRM+L?!E/tXOl(_Q#L-F@h7p.K:J7-dC_fGEMRAAX-OO!]C/$7Ee^AiYboLhSo]$?1U\&fXu-gA,MOF>C?prp=L8ES`caYS#L2X&A.L5H`>4NaP.$(]n;+/1^V%5YG5(OdlMBr7m/$>?r9Ca;/K4<qBa9dK-b_sZ8Em".)o+XHLAIU%P[5!\T'nulM=Ie*r56-c0R/<hON8C8dYU%X-)`f+S"_6U-U3D"h0g\TH:WYp!O!=EV=3X%B9"?OL-B)H2dGnnGKl"kbfVC)DV&?M]JSKa\D!n5.>=)a+eGopORYH4[McDo9#Rp#G821(Q,trY6B>ff.N"aY[(]jb)^@):"@T<U<kXk:H@OjEH"3"$Yk+7\`k4#PhA%AaBF;!n[O.W)C<9PZ`9>\3i</$b`+Z=jRRe6!@>n;Q.H7n?Bljqp[bF\f,It[KUW'55\^<*2CQ][u!(eM!M`LYH02..FX$geS3aIbLdap'_Q,Y.8?(@6`8MtU4ciHut>rZ$c$>6S&*V7+3ORFW!OB%dR%b!RsV@,dk>=h>eS.ZIpHu!JY1H<F'4oYP@]k"]^_mIC!eD_o#08]q12J_aX+#'%kdm]U,Rp1rB4!irHM9-]OY"R;B@oIk,=K*m;A!TlFB?eqKqRDf13*hbNBffC+G#!nh=n9/D"$:70(f+7u0a.q*&6!eke1"6h.70`&,uu+r0#NR"6;t4L06q01ZpR%He*-o=U7rQ439#H;+`Gcq,qlM%AlsiM%Hre\9bl-ZYZFQ3@[bT`_2<?GLsd\PK/Zts:'[`2@+Yqus+fj.p9(T@aPt<4R'T\L(crVdXKD3@J.:>g1)!'0[5^$<Mmh'9!*tt34Z._OrO`&.N6:o=3/MNH-28A;?2mKCb$OPKmZJTM2lMK&Sp..,1<8i\U3J?3kAE.18C;^r`/K#1:G@h$1,J3,`5a+RbKQoKOYe%[A4O<a*_>;,qoBfA@7S!^n-43k;(qNmJKB!abM6d0LDb6?AD\"np'nj*%$WGu:4i6:]aAAu8c3P#J/R]j*Q#i[H5bh\HFqD=I^bnm%S`S:$f!@QO[1X+G<>[3dEg?9s2:c%*=p'Is3jQ[9,!T&Y+,f[`*=:!cL>,t[V;l4::u.8;2OkG>+7%..!Y01a`aCf>mE]?g(c8Dhsi>0PQEMtqn@2S]]0HLXa?/0@E%d?0<2%a[u$)^`hOm(K%IW[2jT%6p@_thfCdtMQeC_OG4?.cC!iAu5L&Y$FJA3MpIIVk]_U"-dS(HrctPeIs4`>(Z&]Clfim@+^UkWF*5U%;0#U:=~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 3446
+>>
+stream
+GauHND0)1;')nJ0d3!d@2Wc$BHqIiq[C>J?CFd#><EF<s?mL^8$o`]Jh64T]*^Gl%8TBW(A_.\+RX+,kVqV^6ps7okB`[^@$C;hSE*SdU_=9*!VSC%Ao[SFuFXn%U9SWG1(Y[9T#E/TQ@b1oP0BcQ:gXu0CbOZosnQ-"F!m[qV/`=)`(BnJ0;[k"`J@3n4>em)!R=G[DP(eGE+#&+nkq@/(+,HTIdLWDj,2CO8aEZT_>UKeeYZs-X!s^A1EW\NQ+=18di$*ii$`s_[%cGb+?b5(Wh`b-]I"HV=_$)2o$,lJ-B+k[0X7B,(P_S'qP$NMcF8Q2[&c$:8P^>[1Jf7Bh/*N\\_.;QB!86l_-[IC$S"pc9,S%a<CkUeO*eTk5"k4_rA]Bn6Q`A:dR#-MJ+fQW9<)jl6F%5?bP"kH9\^\SZdGc-XD$.)[LYG958L%/)2eanQRmAAB7BS+kLXc:gSS:2eB6\?cCapaSVRGDT6&A2jkHAI'"Gr;i[=FMn"`KDs]cFi8SKqt^8M,XN7R<m$,GM3%\[g#(XBh>Pk(Q^dE5!`#]3)oieW<%%,^GD'gZ^!tKsD1<+q.<\!Qm+]'G9*i`($M]h:P55\)Mp%(n8>pKHAj*+&27fKbNE@@lVO%a.?c[AIX+;,7)Ylm$Ck+K4m>fS6-9g)^?!$J_Oa6Mh<ZE+i#=op/*.3_8G&Ae2P!;V1A5:4SL:o^Pi!U8^qf5pBOK;StG@On4o54P5XQsCgD6(I(o2WBC!sk%Y!#%oJn]#1s+iQ-]NXghoWi9OuE+?Ek*+<I`DA8f]60iUB8+u^YZa.Hgu_leElT16ci#f)$_%$EgUWB&H2]Cn"PT2,#I#a#9?C"Xp#p.;q%Je(+NT1f4F=/O0Ks`aWM<8RkfOdU2Drr<f(]r]1&Gq:s!h0<gT4TeKCObU!;1:'KN%<DN_;"E`+&a>fi'E@)_=iL(@]mc0*.>(.D_angsQO8.eE^g,lIInW*SkG7r$:OP;B+;4pGu@AWYWEV59GjZ:3`Ut$A;_?9Y(S4h#@jWYKu.g_F,0k1M4LrYF1^'46kJjD,-B#uK')Y)krgToX,*9-N-cJDJge&_SIUYr>bs181,l_iu1Mkn=,$r(uM!jLpIhpg2Dnp/QhN,D;<9`m80WicI>8E<18@cotQ/Dk_mHp.f_Yi(gV9r$g4I*J,NS/4\Z_a3aom0Z(<FR,bkOUUa^lb'f+'bumV<@$6U02T3'go\S\:+)L+XKfjJ!VMbCQr3_pL4C5eZ'<4L,4hQN2I8i^\&;_e$Q?NW?kFO3@:$cB*"U'D/AhNJaY"9aAC)>C0QB[/1cq'UX1$]e!=FfVOufKmn&<EATE;+J@=/6AKpldF/sB1ad@8>gc&'>hGcF0cM!S?mre^Y>]Wr`7iWW^aS2dl'pcC`%!-]MlTnq8]%%ufDJ@Wh]T%E>f^:ea:hKuDTip/`YD`G]H\*Nh"hp$.s@Lju:eZZsc%PYW\=!DRmO!"826%JL.^X!_p$F7nCnU+bGOKTS\r*f>jgrR,WrSHE2j'-';pYnL5EK!MNLhmYV[pi=L+8&khEiljL>5[&MXeFZ;7BCGOnF:9I,M9[_\7f6cG3?2lc8N89)d',nCi`G]rJ6S@eafY7,*!JZe0?N:nt0R,6-T.c./uH*@"*Vp\/'cHAe`>-"nJId#Z_XQrdD1nDVbIs0s"6_="QA=9^+q=-5QM?2\2QoT``Qn!lO[+?3WR1(m*qR3LFcYRsM%%@BC869AC!&@_T,\%2LUb6LU_V=/B(Fo?X\7W_o"7(a,IbcNLOui]'E9CU">!jMTgE[Qi/@+NL"`QTFehd(+!=oZk0PZ[E9H65QPJHKVQr/j1c]h>Ya7n_>k/*TVQQ;#GXYG.6H$BD8cB$`6Rr\V]ttVBQhVip\tIr)[>K4PnTY,5]>j'ZHZ]jrR<gcl^KF@;KJB6r@PeKaT)*=CGKK=g'6;b7`87r$Ff8Z@P?<bG=L+94jo7f\!H2j<W.91u-Kc^Y2l<f4\GdbtWA?G)jOaZgRo&/[9[Ho-\.afU0BPV5[W`\tj9sBlN7Cd]5CfgX>(n6fg^?0`oS&45DAY>)-%SO`96GW7D-fM+NG1(BA[>A,j4MN'TX![",K44&L*mJJrdFgV5"I`eU"GpIds:Pos9Ta`9L7:h="<#Y$2.k2dPanf24TkV09gS73@Y(&Rj!_[BHcD%.m]X>itsan&1\qig*jDa0,LHKQ3JjYbNV7eLbC;i0r0cV5XN,q5J5neZ,h]/1qhG#`7kH7?d(BqZ>h5>bV_p>\]e7&@?/H8lSA+i-546#C@Y][^SI.E5>_bUftH,V`c4\A#`Ngg+^U6C#1&CT2<s]'`Wq#g8e6VIBBX@6%<eI#kXhrC76iU#UG4%U33^P7(:l1gPXPJD(0*j.^VBO9ZsW&g^"''%6Ar8VppV%U(9g9M/j,29ula\n"9aoI:UQiKIM0QN`+Ie'1FOfpi[;MC88418/4<)f!pKcn^nZ290_ZQaWSLf_C:X_SeeVNBK`:iu`.BIar>Nh\6fk=@\6PlEH=qjGh#cPoA=D23[aT*5`5rffnQW+6:mp%2Sl.ei&<*2.]$)C=.-nPtTscMl+:49)Kp.0f1(k2>V[;<PP2K<4*Pl1N\%>'=IqsQhtunKHK$!JLfs,pl.ldlfE=_)\MWmZ%J&cB^W"e^.o58(thR+MSYo][oJ]3hEW<p/LCS2IKSh4UoWnqGZ8rU"(kf4m%BM[[L*4Ci%b#:npc`q6fa46;;t4N?jbSWb-3/.\u<^]:SKo)(_tjS`ACJX]t,Y*M?G4Q(Zi*)80aZ<d2`\WSKWrLD^kq]Q)p6aP93"p;8P88dD;B]W,$E3lGbSi[[&iSn.i3^SX"M6AlU<`D[[HLVWPqC@M4\\2nJ1_HZ/"ZgiBY>BZM(_'8:.'T.l!s1#5C&(&=>]E$i!?38"F8qrQ0p^mHf@jds7:Rhun&HZYsP0#BWV7`^/%Xj:FIb6m[@n,E7_T:93VmQTN6?O^+3Xb2p+`3C":]pKQOWM"tn^Z*meQ;_2mXa$E.-t3!3-"isr\AUV*qs];MmVnro?HjGc1QehV'2L(/H!>kpjSMdo.@uNf7hsCAaBGZ@H2)b3b=hFMGlh+_,*Q-f;s_h(dCW@7:u;a$W/&nBo%u<aq,6aT#gI(NE'e]B:1LHnb:<fgI9hpmPF%;^@q_2<O(AO[W(NS=iaW=M)`@n3>@RDp@<TqYr)/<6+Pq2OZW<Rhaf,D+?@)G"[<ba,,*sW_3Cnu2p,,XU:+10G1nRW"QRnT!3PmB([_s+*;;5i*p40_<WQ,VLOde8:5`sD8XRof(^5IX5"B(0&3NmDJD!0-cO=F0*bm\QG*lc%q`V3/FQuELU'>F='WQi_0?VPBl[@O9k)!hZ+bgeDXnTLd!hIL8nA+*-6llBV!B'GZWil>[jEJ+i7I/^AIAo?7^Fj-cNRV>^<X8`:krG=e~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2370
+>>
+stream
+Gau0D>BAOW(4Q"]3%m?f45pFVdlTWQ:)nJi]4ilug6^*0+;0hKP6;7i;Uf(2"7RYlO^obqAVmqei7uW`&9./,b\pM`]UXRp6\'D8SHB2b!2fdOf@,XB0=mQR:F*ifm72&a"CUPF5P7PMEhV*JNj.]e[dV8pi?Nqg#qoVOP/703_+Keu-5rP_KFO9\>/4UdEs<E0FMT*r&Z21.qNKe!4`\o5$pm%-(^UDf161,-,@Qggm<N[_'!V>e$\MD7;Lt*`'g_%RFoji.gj8ru7nnIS1@%9"=`eOD+JI1JWo\UoL^c;U@.8p%&")'^.uKFj0_'"`@k2]N`'qA8?5fJ'm53=PQ7[Ib=n3\k'4f<21&eVofu+>`"IJj\OarP'=0"'9CKU04e+=W539Z?*3CIMER+QC3F(,eW3CR8]e6:kFdX%%6igt;-O6Z7YY'CC(4HRr"E9FFZP<@\X(R];gV&Hne)D3N$0Q^+V?G!+Hgs\UaFB\FG8m9u;=s$\c3>oJ@E\4BGel'*,a%8X2"gdso&OIJ0a8iK_Dc9L[W\rN<Bl3(B(;+CHeZc>3B[>duL-7nLM%8#kl0`a=n(!T+#3J6=ZXf^GZC1$;o7MW]d+hc(q>n!#9H@#EOIkh&hlK^*o+eH^RCk>>G;st/-o@\&T1R`jkD3$RF@]$]XOL>-VT:ZoHe)`N6Yc56al`NhC0O]t%c*e?U*uBkVE:E?0::Wn?GX/E1\CFLan<d,N=a&2IA'7a;f8]uTA0&4L`4RYaE5N=]Xtn/"fiL:OcWq5s1e@-FCE5"QQLgMO>LtkI"ka%iPWtXkTcRf10SjT[-\TICZaD\gjLm=5$6F?GY5mILL#^j4MqNTlR<HJlXuS@]m_U-LC%ejUBk6s@\ts.dPtVWV*"('(M_0hH#-\0O7+/nbCH?AoYuF]mbl0miE!$j`o'qG0X]Mp>1Q5jE]f%(9]o)1$QJSFqjf[N%Q&(%K%Z"tR-^XtFgbA=mp!Ng1i&<b;or]_l2^^?,Oe9k.4BG_)[-rA_GIfDM.Jc*DG?$(;l5LiOX/H"Xl?iua=0!4j^nQ/_V%r.f1[YtkX\ba7<88MgjhjIn:rQ?(c6Q$%\kh47PF\n"SW&9[=5>EQ2'(dcaY&```ua03OmIXP>c6/k'jT`NVV0b]ZMsaQX!.)$Sf]>_*+!<3JneKOgF$[Q;(;Y9?6So\QN`iiKRej)I2<eqPB1#aW\S5;D2i:):)!2hXG.169hM$CYDVj$9MlLWY?sr`>7#A%H;D1dds]rCi&b"Ai2pm-4nU'/3X#>s6J3bIe0>r.fIP?IEZS8E^gJE_n+52j@j-Jf/hb8&6\W]eqmRf:CJH__[+((dil.M^1;_r\3q.3WPkG]\7uKg;j*6+ER59uK]EMI@B<gYTL4Q]Z_9?We*LD5@LHMuCFAM4d_P`IHgPIXebsbrJ(o$M,9FZgbp?Wl0VaM"i&X,#9"6(t%,7Y7c,__K@OiHEpg'W.i<mUZ\[3BjJ.PhU*G[#%ftH:^LrlYBEUeEp`XeLfoM7(QqrRdl$M9r1?JiKg4d^:n)A>\CIj%W((il[FM345a9`F/M`,u9/H-B)tAc.f-8m0i1AbVOAYX0m_eS,DXRQq9S0q3$r,REbGH:C2[IL"!=oE:'n8u&NF*[PU,@<-r68q_^]E?0:!-*0+:q$`f1X.cWaY^+Sh,WaI-nO2=(Og^/kpk[f<4rCf%dtX;Igf$T)H+V7WG*Y-]ChpZBR8-kIXaO-s+0?TJDuZ8:/P=[K90$'+r^Dr,%,$H"O."idTAd0bQ9&7Pa>$^7[+[1YgBi8?IArFi6IN/-gJ$O?>-\>)^#\"ee>RpgNXC?*d(b3pLTH?6SuY!IVDQm@@"=Ks_UZ8*S<f5@2G1QcgQ5X5?g>PVQm8ZOKOJM'X!P[2;MHaR:5'a+/F1ZOgL\*/nU\at[s/s*2--0IS["MOS01DK)#gmVBX[j!`?.<>?mBs7G+*>oL<79eB;ftje_T7`(kPlASXk'uo6.7e'<?/+G!R6WbpB)b=RsGZb#VE7Jt<YU!BDAKGk6!F7NZ"D3K;J1]%HNfNFA-o]$_qLN!2_4f<<^5?(hsWW4\VKb%W:g,BU\U*2;$)>CB_b(.EjP_!)TW4sQ\Z3E``P%]so6EJj9OdB,Rlh8"T[M]B@<`tXT/C`=fQNd7u]*6^bF.N:&8mcM0tpqa?%7K2+#de\a^hJ.*+'Qa1,]AW8fCQMX,DsCmp[.F]B\S%;Q42&Z%^QUCX5;AJ/M_U(]-*r$KSOIm_l]:jYn+`Hmm^gG_(?=1pBAnR)]ngS#e3#\Bh;._CqhKFj2T><C\KK_Ak:jSXNd/2)R9i)oKu4$Oqb]T7\H=RWm\[mGZ#+A>9P]lo^$1'*^B&^8aDC~>endstream
+endobj
+xref
+0 20
+0000000000 65535 f 
+0000000061 00000 n 
+0000000112 00000 n 
+0000000219 00000 n 
+0000000331 00000 n 
+0000000526 00000 n 
+0000000631 00000 n 
+0000000826 00000 n 
+0000001021 00000 n 
+0000001216 00000 n 
+0000001411 00000 n 
+0000001607 00000 n 
+0000001677 00000 n 
+0000001986 00000 n 
+0000002077 00000 n 
+0000005000 00000 n 
+0000007474 00000 n 
+0000010178 00000 n 
+0000012352 00000 n 
+0000015890 00000 n 
+trailer
+<<
+/ID 
+[<a5aca6fbd7b987e3ea08fa0492887f27><a5aca6fbd7b987e3ea08fa0492887f27>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 12 0 R
+/Root 11 0 R
+/Size 20
+>>
+startxref
+18352
+%%EOF

--- a/docs/instructions/emre-kalem-robot-arm/wiring-map.csv
+++ b/docs/instructions/emre-kalem-robot-arm/wiring-map.csv
@@ -1,0 +1,11 @@
+physical_servo,joint,servo_type,recommended_signal_pin,external_5v,common_ground,notes
+base,Base rotation,MG995 or MG996R 180-degree,D3,Servo red to switched 5V bus,Servo brown/black to ground bus,"Matches Emre original sketch. Base may draw high current when starting."
+arm_a_left,Shoulder / Arm A primary,MG995 or MG996R 180-degree,D4,Servo red to switched 5V bus,Servo brown/black to ground bus,"Moves from the logical Arm A angle."
+arm_a_right,Shoulder / Arm A mirrored,MG995 or MG996R 180-degree,D5,Servo red to switched 5V bus,Servo brown/black to ground bus,"Mirrored in code as 180 - Arm A. Reverse this flag if your linkage moves the wrong way."
+arm_b,Elbow / Arm B,MG995 or MG996R 180-degree,D6,Servo red to switched 5V bus,Servo brown/black to ground bus,"Use conservative limits until the printed elbow is calibrated."
+wrist_a,Wrist pitch,MG90S 180-degree,D9,Servo red to switched 5V bus,Servo brown/black to ground bus,"Micro servo. Watch for binding at wrist extremes."
+wrist_b,Wrist roll,MG90S 180-degree,D10,Servo red to switched 5V bus,Servo brown/black to ground bus,"Micro servo. Keep wire slack through wrist rotation."
+gripper,Gripper open/close,MG90S 180-degree,D11,Servo red to switched 5V bus,Servo brown/black to ground bus,"Calibrate open/closed angles with no object first."
+arduino_uno,Controller logic,Arduino Uno,USB serial,Do not power servos from Uno 5V,Arduino GND to servo ground bus,"Uno sends signal only. The external supply powers the servo red wires."
+kcd1_rocker_switch,Servo power enable,KCD1 rocker switch,not applicable,Inline on 5V positive feed before servo bus,not applicable,"Use as servo-power enable, not as an emergency stop for hazardous equipment."
+external_supply,Servo rail power,5V 10A regulated supply,not applicable,+5V to switch/fuse then servo red bus,0V to ground bus,"Adjust to about 5.0V before connecting servos. Keep mains terminals covered."

--- a/tools/emre-kalem-arm-guide-pdf.py
+++ b/tools/emre-kalem-arm-guide-pdf.py
@@ -1,0 +1,639 @@
+#!/usr/bin/env python3
+"""Generate the Emre Kalem robot arm wiring/programming PDF.
+
+Output:
+  output/pdf/emre-kalem-robot-arm-wiring-and-programming-guide.pdf
+
+Usage:
+  python tools/emre-kalem-arm-guide-pdf.py
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_CENTER
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    KeepTogether,
+    ListFlowable,
+    ListItem,
+    PageBreak,
+    Paragraph,
+    Preformatted,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+
+NAVY = colors.HexColor("#1f3a5f")
+INK = colors.HexColor("#1b1f24")
+MUTED = colors.HexColor("#5c6670")
+LINE = colors.HexColor("#c9d1d9")
+LIGHT = colors.HexColor("#f6f8fa")
+GREEN = colors.HexColor("#2f7d32")
+AMBER = colors.HexColor("#b76e00")
+RED = colors.HexColor("#b42318")
+BLUE_LIGHT = colors.HexColor("#eef4fb")
+AMBER_LIGHT = colors.HexColor("#fff7e6")
+RED_LIGHT = colors.HexColor("#fdecea")
+GREEN_LIGHT = colors.HexColor("#edf7ed")
+
+
+def build_styles():
+    base = getSampleStyleSheet()
+    styles = {
+        "title": ParagraphStyle(
+            "Title",
+            parent=base["Title"],
+            fontName="Helvetica-Bold",
+            fontSize=23,
+            leading=27,
+            textColor=NAVY,
+            alignment=TA_CENTER,
+            spaceAfter=8,
+        ),
+        "subtitle": ParagraphStyle(
+            "Subtitle",
+            parent=base["Normal"],
+            fontName="Helvetica",
+            fontSize=10.5,
+            leading=14,
+            textColor=MUTED,
+            alignment=TA_CENTER,
+            spaceAfter=14,
+        ),
+        "h1": ParagraphStyle(
+            "Heading1",
+            parent=base["Heading1"],
+            fontName="Helvetica-Bold",
+            fontSize=15,
+            leading=19,
+            textColor=colors.white,
+            backColor=NAVY,
+            borderPadding=(6, 8, 6, 8),
+            spaceBefore=12,
+            spaceAfter=8,
+            keepWithNext=True,
+        ),
+        "h2": ParagraphStyle(
+            "Heading2",
+            parent=base["Heading2"],
+            fontName="Helvetica-Bold",
+            fontSize=12,
+            leading=15,
+            textColor=NAVY,
+            spaceBefore=10,
+            spaceAfter=4,
+            keepWithNext=True,
+        ),
+        "body": ParagraphStyle(
+            "Body",
+            parent=base["BodyText"],
+            fontName="Helvetica",
+            fontSize=9.4,
+            leading=12.3,
+            textColor=INK,
+            spaceAfter=6,
+        ),
+        "small": ParagraphStyle(
+            "Small",
+            parent=base["BodyText"],
+            fontName="Helvetica",
+            fontSize=8.2,
+            leading=10.4,
+            textColor=MUTED,
+            spaceAfter=4,
+        ),
+        "table": ParagraphStyle(
+            "TableText",
+            parent=base["BodyText"],
+            fontName="Helvetica",
+            fontSize=8.1,
+            leading=9.8,
+            textColor=INK,
+        ),
+        "table_bold": ParagraphStyle(
+            "TableBold",
+            parent=base["BodyText"],
+            fontName="Helvetica-Bold",
+            fontSize=8.1,
+            leading=9.8,
+            textColor=INK,
+        ),
+        "callout_title": ParagraphStyle(
+            "CalloutTitle",
+            parent=base["BodyText"],
+            fontName="Helvetica-Bold",
+            fontSize=9.5,
+            leading=12,
+            textColor=INK,
+            spaceAfter=3,
+        ),
+        "code": ParagraphStyle(
+            "Code",
+            parent=base["Code"],
+            fontName="Courier",
+            fontSize=7.8,
+            leading=9.2,
+            textColor=INK,
+        ),
+    }
+    return styles
+
+
+STYLES = build_styles()
+
+
+def para(text: str, style: str = "body") -> Paragraph:
+    return Paragraph(escape(text).replace("\n", "<br/>"), STYLES[style])
+
+
+def h1(text: str) -> Paragraph:
+    return para(text, "h1")
+
+
+def h2(text: str) -> Paragraph:
+    return para(text, "h2")
+
+
+def bullets(items: list[str]) -> ListFlowable:
+    return ListFlowable(
+        [ListItem(para(item, "body"), leftIndent=8) for item in items],
+        bulletType="bullet",
+        leftIndent=18,
+        bulletFontName="Helvetica",
+        bulletFontSize=8,
+        spaceAfter=6,
+    )
+
+
+def numbered(items: list[str]) -> ListFlowable:
+    return ListFlowable(
+        [ListItem(para(item, "body"), leftIndent=10) for item in items],
+        bulletType="1",
+        leftIndent=20,
+        bulletFontName="Helvetica",
+        bulletFontSize=8,
+        spaceAfter=6,
+    )
+
+
+def code(text: str) -> Table:
+    block = Preformatted(text.rstrip(), STYLES["code"], maxLineLength=96)
+    tbl = Table([[block]], colWidths=[6.65 * inch])
+    tbl.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, -1), LIGHT),
+                ("BOX", (0, 0), (-1, -1), 0.5, LINE),
+                ("LEFTPADDING", (0, 0), (-1, -1), 6),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 6),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+            ]
+        )
+    )
+    return tbl
+
+
+def callout(title: str, body: str, kind: str = "note") -> KeepTogether:
+    palette = {
+        "note": (BLUE_LIGHT, NAVY),
+        "warn": (AMBER_LIGHT, AMBER),
+        "danger": (RED_LIGHT, RED),
+        "ok": (GREEN_LIGHT, GREEN),
+    }
+    bg, border = palette[kind]
+    tbl = Table(
+        [[para(title, "callout_title")], [para(body, "body")]],
+        colWidths=[6.65 * inch],
+    )
+    tbl.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, -1), bg),
+                ("BOX", (0, 0), (-1, -1), 0.5, border),
+                ("LINEBEFORE", (0, 0), (0, -1), 4, border),
+                ("LEFTPADDING", (0, 0), (-1, -1), 10),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 8),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+            ]
+        )
+    )
+    return KeepTogether([tbl, Spacer(1, 6)])
+
+
+def table(headers: list[str], rows: list[list[str]], widths: list[float] | None = None) -> Table:
+    if widths is None:
+        widths = [6.65 / len(headers)] * len(headers)
+    data = [[para(h, "table_bold") for h in headers]]
+    data.extend([[para(cell, "table") for cell in row] for row in rows])
+    tbl = Table(data, colWidths=[w * inch for w in widths], repeatRows=1)
+    tbl.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#e8edf3")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), INK),
+                ("BOX", (0, 0), (-1, -1), 0.5, LINE),
+                ("INNERGRID", (0, 0), (-1, -1), 0.35, LINE),
+                ("VALIGN", (0, 0), (-1, -1), "TOP"),
+                ("LEFTPADDING", (0, 0), (-1, -1), 5),
+                ("RIGHTPADDING", (0, 0), (-1, -1), 5),
+                ("TOPPADDING", (0, 0), (-1, -1), 4),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 4),
+            ]
+        )
+    )
+    return tbl
+
+
+def page_footer(canvas, doc):
+    canvas.saveState()
+    canvas.setFont("Helvetica", 7)
+    canvas.setFillColor(MUTED)
+    canvas.drawCentredString(
+        letter[0] / 2,
+        0.38 * inch,
+        f"Emre Kalem robot arm wiring guide - page {doc.page}",
+    )
+    canvas.restoreState()
+
+
+def build_story() -> list:
+    story: list = []
+
+    story.append(para("Emre Kalem Robot Arm", "title"))
+    story.append(
+        para(
+            "Arduino Uno wiring, calibration, and programming package for the built arm, the conveyor load/unload arm, and a future teleop/training arm. Generated for bench use on 2026-07-31.",
+            "subtitle",
+        )
+    )
+    story.append(
+        callout(
+            "Bottom line",
+            "Use the Uno for signal only. Power all servo red wires from the separate regulated 5V 10A supply, tie the servo ground bus to Arduino GND, and leave the automatic conveyor program locked until the physical limits are calibrated.",
+            "ok",
+        )
+    )
+
+    story.append(h1("1. What This Assumes"))
+    story.append(
+        para(
+            "This guide assumes the MakerWorld Emre Kalem 6-axis robot arm: 1 Arduino Uno or Mega, 4 MG995/MG996R 180-degree servos, 3 MG90S 180-degree servos, a KCD1 rocker switch, one 608 bearing, two 6203 bearings, a 5V 10A power supply, M3 hardware including common 6 mm / 10 mm / 14 mm lengths, and jumper wiring."
+        )
+    )
+    story.append(
+        para(
+            "The wiring and sketches target an Arduino Uno because that is what you asked for. The arm has 6 logical joints, but 7 physical servos because the shoulder/Arm A joint uses two opposed servos. The code mirrors the second shoulder servo as 180 - logical angle."
+        )
+    )
+    story.append(
+        table(
+            ["Logical joint", "Physical servo(s)", "Default signal pin(s)", "Starting limits"],
+            [
+                ["Base", "1x MG995/MG996R", "D3", "10 to 170, home 90"],
+                ["Shoulder / Arm A", "2x MG995/MG996R, one mirrored", "D4 and D5", "45 to 135, home 90"],
+                ["Elbow / Arm B", "1x MG995/MG996R", "D6", "30 to 150, home 90"],
+                ["Wrist pitch", "1x MG90S", "D9", "25 to 155, home 90"],
+                ["Wrist roll", "1x MG90S", "D10", "10 to 170, home 90"],
+                ["Gripper", "1x MG90S", "D11", "35 to 110, home 70"],
+            ],
+            [1.2, 1.8, 1.35, 2.3],
+        )
+    )
+
+    story.append(h1("2. The 4-Hour Wake-Up Checklist"))
+    story.append(
+        numbered(
+            [
+                "Inspect the printed arm with power off. Each joint must move through its expected travel without binding, rubbing, or twisting servo wires.",
+                "Set the 5V supply to about 5.0V before connecting the servo rail. Cover mains terminals and strain-relieve the output wires.",
+                "Build the servo power bus: power-supply +5V -> fuse or inline protection -> KCD1 rocker switch -> servo red bus. Power-supply 0V -> servo ground bus.",
+                "Connect Arduino GND to the servo ground bus. Do not connect the external 5V servo rail to the Uno 5V pin while the Uno is powered by USB.",
+                "Upload the calibration sketch. Attach only one servo at a time. Center at 90 degrees, install/tighten the horn at mechanical home, then detach before moving to the next channel.",
+                "Upload the main controller sketch. Open Serial Monitor at 115200 baud, type help, then jog with small nudges.",
+                "Only after the motion is proven, fill the conveyor waypoint worksheet and copy those angles into the waypoint array.",
+            ]
+        )
+    )
+
+    story.append(h1("3. Safety and Power Rules"))
+    story.append(
+        callout(
+            "No live conveyor experiments yet",
+            "Bench-test the arm away from the conveyor first. Hobby servos do not have safety-rated position feedback or torque limiting. Do not let the arm enter a moving conveyor path until the conveyor is locked out or otherwise made safe by a qualified person.",
+            "danger",
+        )
+    )
+    story.append(
+        bullets(
+            [
+                "Treat the KCD1 rocker as a servo power enable, not a safety-rated emergency stop.",
+                "Keep fingers clear of shoulder, elbow, wrist, and gripper pinch points when servo power is on.",
+                "If a servo growls, stalls, or heats up, remove servo power immediately and reduce the software limits.",
+                "The Uno 5V pin and digital I/O pins cannot supply servo motor current. They are for logic and signal, not motor power.",
+                "A 5V 10A supply is enough to start the bench work, but four MG996R-class servos can demand large current spikes. Avoid commanding all high-torque joints to slam at once.",
+            ]
+        )
+    )
+
+    story.append(h1("4. Wiring Architecture"))
+    story.append(para("Use this as the mental model before touching wires:"))
+    story.append(
+        code(
+            """
+AC mains -> covered 5V 10A DC supply
+          -> fuse/inline protection
+          -> KCD1 rocker switch
+          -> +5V servo bus
+          -> every servo red wire
+
+5V supply 0V/GND -> servo ground bus
+                  -> every servo brown/black wire
+                  -> Arduino GND
+
+Arduino Uno D3/D4/D5/D6/D9/D10/D11 -> servo signal wires only
+Arduino Uno USB   -> programming + serial commands
+"""
+        )
+    )
+    story.append(
+        callout(
+            "Common ground is mandatory",
+            "The servo signal is measured relative to ground. If the servo supply ground and Arduino ground are not tied together, the servo may jitter, ignore commands, or behave unpredictably.",
+            "warn",
+        )
+    )
+    story.append(
+        table(
+            ["Servo lead color", "Connects to", "Notes"],
+            [
+                ["Red", "External switched +5V servo bus", "Never to an Uno digital pin. Avoid Uno 5V for servo motor power."],
+                ["Brown or black", "Servo ground bus and Arduino GND", "This is the shared reference for the signal pulse."],
+                ["Orange, yellow, or white", "Uno signal pin D3/D4/D5/D6/D9/D10/D11", "Signal only; current is tiny compared with motor current."],
+            ],
+            [1.25, 2.2, 3.2],
+        )
+    )
+
+    story.append(PageBreak())
+    story.append(h1("5. Servo-by-Servo Wiring"))
+    story.append(
+        table(
+            ["Physical servo", "Joint", "Signal", "Power", "Ground", "Calibration note"],
+            [
+                ["base", "Base rotation", "D3", "Red to switched 5V", "Brown/black to ground bus", "Matches Emre original sketch; verify the base cannot hit wiring."],
+                ["arm_a_left", "Shoulder primary", "D4", "Red to switched 5V", "Brown/black to ground bus", "Moves with logical Arm A."],
+                ["arm_a_right", "Shoulder mirrored", "D5", "Red to switched 5V", "Brown/black to ground bus", "Code sends 180 - Arm A. Flip the mirror flag if wrong."],
+                ["arm_b", "Elbow", "D6", "Red to switched 5V", "Brown/black to ground bus", "Keep limits conservative while unloaded."],
+                ["wrist_a", "Wrist pitch", "D9", "Red to switched 5V", "Brown/black to ground bus", "Watch for printed wrist binding."],
+                ["wrist_b", "Wrist roll", "D10", "Red to switched 5V", "Brown/black to ground bus", "Leave a wire service loop."],
+                ["gripper", "Gripper", "D11", "Red to switched 5V", "Brown/black to ground bus", "Find open/closed values gently."],
+            ],
+            [0.92, 1.1, 0.62, 1.08, 1.12, 1.81],
+        )
+    )
+    story.append(
+        callout(
+            "Why this pin map?",
+            "D3, D4, D5, D6, D9, D10, and D11 match Emre's original Arduino sketch and keep D0/D1 free for USB serial. A contiguous D2-D8 signal strip can also work, but only if you update the SERVO_PINS array in both included sketches.",
+            "note",
+        )
+    )
+
+    story.append(h1("6. Arduino Upload and Calibration"))
+    story.append(h2("Install and upload"))
+    story.append(
+        numbered(
+            [
+                "Open Arduino IDE.",
+                "Select Tools -> Board -> Arduino AVR Boards -> Arduino Uno.",
+                "Select the correct COM port.",
+                "Open docs/instructions/emre-kalem-robot-arm/arduino/emre_kalem_arm_calibrate/emre_kalem_arm_calibrate.ino.",
+                "Upload. Open Serial Monitor at 115200 baud.",
+            ]
+        )
+    )
+    story.append(h2("Calibration serial commands"))
+    story.append(
+        table(
+            ["Command", "Action"],
+            [
+                ["0..6", "Select physical servo channel."],
+                ["a", "Attach selected servo and write its current angle."],
+                ["d", "Detach selected servo."],
+                ["c", "Center selected servo at 90 degrees."],
+                ["+ / -", "Nudge selected servo by 1 degree."],
+                ["] / [", "Nudge selected servo by 5 degrees."],
+                ["p", "Print all servo angles and attach status."],
+            ],
+            [1.0, 5.65],
+        )
+    )
+    story.append(
+        callout(
+            "Horn-centering method",
+            "With the horn loose or removed, select a servo, attach it, send c to center at 90 degrees, then install the horn in the closest mechanical home position. If the closest tooth is a little off, use the servoTrim array in the main sketch for small corrections.",
+            "ok",
+        )
+    )
+
+    story.append(h1("7. Main Controller Programming"))
+    story.append(
+        para(
+            "After calibration, upload emre_kalem_arm_uno_controller.ino. The main sketch starts in serial manual-control mode. It has a placeholder conveyor program, but playback is locked by default with ALLOW_DEMO_PROGRAM=false."
+        )
+    )
+    story.append(
+        table(
+            ["Command", "Meaning"],
+            [
+                ["help", "Show command list."],
+                ["status", "Print logical joint angles and physical servo outputs."],
+                ["home", "Move slowly to configured home pose."],
+                ["attach", "Attach all servos and write current setpoints."],
+                ["detach", "Stop sending servo pulses. The arm may sag."],
+                ["b+ / b-", "Base nudge."],
+                ["a+ / a-", "Shoulder / Arm A nudge."],
+                ["e+ / e-", "Elbow / Arm B nudge."],
+                ["p+ / p-", "Wrist pitch nudge."],
+                ["r+ / r-", "Wrist roll nudge."],
+                ["g+ / g-", "Gripper nudge."],
+                ["set base 90", "Move a named joint to a specific angle."],
+                ["speed 25", "Set milliseconds per degree for manual motion."],
+                ["step 2", "Set nudge size in degrees."],
+                ["demo", "Run conveyor waypoints only after unlocking in code."],
+            ],
+            [1.35, 5.3],
+        )
+    )
+    story.append(
+        callout(
+            "First manual motion",
+            "Start with step 1 and speed 30 if the arm is near anything solid. Move one joint at a time. If the mirrored shoulder fights itself, cut servo power and flip the matching SERVO_MIRRORED value or adjust horn orientation.",
+            "warn",
+        )
+    )
+
+    story.append(PageBreak())
+    story.append(h1("8. Conveyor Load/Unload Arm Plan"))
+    story.append(
+        para(
+            "The second arm should begin as a copy of Arm 1 wiring and firmware, but its automatic cycle should be developed as recorded waypoints. Do not begin with inverse kinematics. A waypoint cycle is easier to prove, safer to debug, and good enough for a small conveyor demo."
+        )
+    )
+    story.append(
+        table(
+            ["Phase", "Goal", "Done when"],
+            [
+                ["1. Bench copy", "Build and calibrate the second arm exactly like Arm 1.", "Every joint jogs without binding away from the conveyor."],
+                ["2. Fixture mock", "Place a dead/static part and mark pickup/drop zones.", "Manual jog can pick and place with conveyor off."],
+                ["3. Waypoint capture", "Fill conveyor-waypoints-template.csv.", "Each row has verified angles and notes."],
+                ["4. Slow playback", "Copy angles into WAYPOINTS and unlock demo.", "Cycle runs at slow speed with no part."],
+                ["5. Part trial", "Run with part while conveyor is stopped or made safe.", "Part transfers cleanly without contacting rails."],
+                ["6. Conveyor integration", "Add read-only conveyor state/interlock inputs later.", "Arm only moves when the cell is safe and expected."],
+            ],
+            [1.15, 2.6, 2.9],
+        )
+    )
+    story.append(
+        callout(
+            "Do not trust hobby-servo position",
+            "The Servo library remembers the last commanded angle, not the actual physical position. If the arm is bumped, stalls, or starts from the wrong pose, the sketch does not know. Always home physically before servo power and before automatic playback.",
+            "danger",
+        )
+    )
+
+    story.append(h1("9. Third Arm: Teleop and Training"))
+    story.append(
+        para(
+            "The third arm can become a low-risk trainer. Keep it mechanically identical to the conveyor arm, but use it to teach poses, test gripper strategy, and practice operator workflows without tying up the real conveyor cell."
+        )
+    )
+    story.append(
+        bullets(
+            [
+                "Short term: use the same Uno serial controller and manually record angles from status output.",
+                "Training workflow: jog to pose, type status, copy the six logical angles into a waypoint worksheet.",
+                "Teleop upgrade: add joystick/pot inputs or move to an ESP32 controller later for wireless control.",
+                "Do not let the teleop arm become the safety reference for the conveyor arm. The conveyor arm still needs its own clearance and limit verification.",
+            ]
+        )
+    )
+
+    story.append(h1("10. Troubleshooting"))
+    story.append(
+        table(
+            ["Symptom", "Most likely cause", "Fix"],
+            [
+                ["Uno resets when servos move", "Servo current is being pulled through USB/Uno or ground is poor.", "Power servo red wires from external 5V supply; tie grounds; check supply voltage under load."],
+                ["Servo jitters but does not move correctly", "No common ground or weak signal connection.", "Tie Arduino GND to servo ground bus; reseat signal wire; keep signal wires away from noisy power wiring."],
+                ["Shoulder servos fight each other", "Mirrored servo direction or horn position is wrong.", "Cut servo power, remove load, flip SERVO_MIRRORED for that channel or re-center horns."],
+                ["Servo growls at an endpoint", "Software limit exceeds mechanical travel.", "Reduce jointMin/jointMax immediately; do not hold a stalled servo."],
+                ["Upload fails", "D0/D1 are connected or serial monitor is open.", "Keep D0/D1 unused; close Serial Monitor during upload."],
+                ["Gripper crushes or drops part", "Open/closed angles not tuned for the object.", "Record separate gripper angles for empty, grip, and release in the waypoint sheet."],
+            ],
+            [1.35, 2.3, 3.0],
+        )
+    )
+
+    story.append(h1("11. File Map"))
+    story.append(
+        table(
+            ["File", "Use"],
+            [
+                ["docs/instructions/emre-kalem-robot-arm/wiring-map.csv", "Servo-by-servo wiring table."],
+                ["docs/instructions/emre-kalem-robot-arm/conveyor-waypoints-template.csv", "Worksheet for the second arm's load/unload poses."],
+                ["docs/instructions/emre-kalem-robot-arm/arduino/emre_kalem_arm_calibrate/", "Calibration sketch."],
+                ["docs/instructions/emre-kalem-robot-arm/arduino/emre_kalem_arm_uno_controller/", "Main controller sketch."],
+                ["tools/emre-kalem-arm-guide-pdf.py", "This PDF generator."],
+            ],
+            [3.55, 3.1],
+        )
+    )
+
+    story.append(h1("12. Source Notes"))
+    story.append(
+        para(
+            "The guide was built from these source facts. Treat the exact joint limits and waypoints as calibration values for your physical print, not universal constants."
+        )
+    )
+    story.append(
+        table(
+            ["Source", "Used for"],
+            [
+                [
+                    "3DFinder mirror of MakerWorld model: https://3dfinder.io/model/makerworld/1134925-robotic-arm-with-servo-arduino and Emre Kalem assembly video: https://www.youtube.com/watch?v=CHV36hu9z3E",
+                    "Emre Kalem model description, 6-axis project statement, and required parts list.",
+                ],
+                [
+                    "Emre original Arduino/software package linked from the assembly video.",
+                    "Original pin map: D3 base, D4 Arm A1, D5 Arm A2, D6 Arm B, D9 Wrist A, D10 Wrist B, D11 gripper; Arm A2 mirrors as 180 - Arm A.",
+                ],
+                [
+                    "Related ESP32 firmware repo: https://github.com/peterz0310/robot-arm",
+                    "Cross-check: 6 logical joints, 7 hobby servos, mirrored Arm A servo, external servo power, home-position/no-feedback warning.",
+                ],
+                [
+                    "Arduino Uno R3 docs/datasheet: https://docs.arduino.cc/hardware/uno-rev3 and https://docs.arduino.cc/resources/datasheets/A000066-datasheet.pdf",
+                    "Uno has 14 digital I/O, USB programming, ATmega328P, and standard board resources.",
+                ],
+                [
+                    "Arduino Servo library API/source: https://raw.githubusercontent.com/arduino-libraries/Servo/master/docs/api.md and https://raw.githubusercontent.com/arduino-libraries/Servo/master/src/Servo.h",
+                    "attach(), write(), writeMicroseconds(), no physical feedback from read(), and endpoint overdrive high-current warning.",
+                ],
+                [
+                    "MG996R datasheet example: https://www.handsontec.com/dataspecs/motor_fan/MG996R.pdf",
+                    "MG996R operating voltage/current expectations and high stall current.",
+                ],
+                [
+                    "MG90S datasheet example: https://www.tinytronics.nl/product_files/000263_Data%20Sheet%20of%20MG90S%20Analog%20Servo%20Motor.pdf",
+                    "MG90S operating voltage and stall-current expectations.",
+                ],
+            ],
+            [3.2, 3.45],
+        )
+    )
+
+    return story
+
+
+def build_pdf(output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    doc = SimpleDocTemplate(
+        str(output),
+        pagesize=letter,
+        rightMargin=0.55 * inch,
+        leftMargin=0.55 * inch,
+        topMargin=0.55 * inch,
+        bottomMargin=0.65 * inch,
+        title="Emre Kalem Robot Arm Wiring and Programming Guide",
+        author="Codex",
+    )
+    doc.build(build_story(), onFirstPage=page_footer, onLaterPages=page_footer)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("output/pdf/emre-kalem-robot-arm-wiring-and-programming-guide.pdf"),
+    )
+    args = parser.parse_args()
+    build_pdf(args.output)
+    sys.stdout.write(f"wrote {args.output}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a fast local docs index for instruction packages
- Add the Emre Kalem robot arm package with printable PDF, wiring CSV, waypoint worksheet, and Arduino Uno sketches
- Add an agent-facing AGENTS.md quick context file and PDF generator

## Verification
- PDF metadata: 6 pages, US Letter, non-encrypted
- Rendered tracked PDF to PNG pages with Poppler for layout inspection
- Confirmed controller/calibration sketches use Emre original pin map: D3, D4, D5, D6, D9, D10, D11
- Confirmed conveyor demo remains locked with ALLOW_DEMO_PROGRAM=false
- Pre-commit checks passed with zero warnings