### PR TITLE
docs: define spatial evidence mapper field trial

### DIFF
--- a/docs/guides/spatial-evidence-field-trial.md
+++ b/docs/guides/spatial-evidence-field-trial.md
@@ -1,16 +1,26 @@
 # Garage Conveyor Spatial-Evidence Field Trial
 
-Use this guide to collect a small, clean photo set today. It uses the existing
-MIRA Hub Visual Workspace. The background mapper is not live until its PR has
-merged and been deployed; today proves that the evidence set is useful and
-gives the mapper a safe backfill target.
+Use this guide to collect a small, clean photo set for the Garage Conveyor
+trial. The public product entry point is
+`https://app.factorylm.com/hub`.
+
+**Current product reality:** the mobile application does not currently expose
+a Visual Workspace or Field Capture tab. The internal `mira-hub` service has a
+`/visual` implementation, but it is not a supported public mobile workflow.
+Do not try to use an undocumented `/visual` URL to run this trial.
+
+The mapper PR adds the required supported Field Capture entry. Before that PR
+is merged and deployed, today's useful work is collecting authorized original
+photos on the phone in one local album; the app cannot yet create this field
+session from mobile.
 
 ## Before you start
 
 1. Confirm you are authorized to photograph and upload the Garage Conveyor
    area, facility maps, panels, labels, and components.
-2. Use only MIRA Hub. Do not move facility images into a personal cloud,
-   consumer AI tool, or shared chat.
+2. Keep the original images on the authorized phone until the public Field
+   Capture entry is available. Do not move facility images into a personal
+   cloud, consumer AI tool, or shared chat.
 3. Do not use this activity to decide whether equipment is safe, energized, or
    ready to operate. Follow your site procedures and work authorization.
 4. Leave phone location and camera metadata enabled if site policy permits it.
@@ -18,13 +28,15 @@ gives the mapper a safe backfill target.
 5. This first trial is still photos only. Do not upload body-camera video to
    the current Visual Workspace.
 
-## Create one session
+## Create one capture set today
 
-1. On your phone or desktop browser, sign in to the existing MIRA Hub.
-2. Open **Visual Workspace** at `/visual`.
-3. Select **New session**.
-4. Keep every Garage Conveyor image in this one session. The current interface
-   creates a generic title; that is expected for this field trial.
+1. On the authorized phone, create a local album named `Garage Conveyor Field
+   Trial` followed by today's date.
+2. Keep every permitted trial photo in this one album and retain the original
+   files with their camera metadata.
+3. Do not upload the album through an unsupported application route. The
+   supported Field Capture entry will create the corresponding MIRA session
+   after the mapper PR is deployed.
 
 ## Capture in this order
 
@@ -50,31 +62,32 @@ For each subject, take overlapping wide and close shots. Avoid motion blur,
 glare, and people’s faces, badges, or unrelated screens. If a label is not
 readable, take a second closer, straight-on photo instead of assuming the text.
 
-## Upload and mark evidence
+## Upload and mark evidence after Field Capture deploys
 
-1. In the Visual Session, use the upload control to add each original photo.
-   The current workspace accepts PNG, JPEG, and WebP images one at a time.
-2. Keep upload order aligned with capture order: facility map first, then entry
-   point, asset anchor, wide context, panels, and close-ups.
-3. Select an uploaded image and draw a point or box around a readable asset tag,
-   map label, panel label, or component identifier.
-4. Give each region a short factual label such as `Garage Conveyor asset tag`,
+1. On the phone, open `https://app.factorylm.com/hub` and select **Field
+   Capture**.
+2. Start one Garage Conveyor session and upload the original photos from the
+   local album in capture order: facility map first, then entry point, asset
+   anchor, wide context, panels, and close-ups.
+3. Add factual labels only where the public Field Capture interface presents a
+   label or region control. Use labels such as `Garage Conveyor asset tag`,
    `Panel A label`, or `Map: Garage Conveyor area`. Do not label a component
    with an identity you cannot read or verify.
-5. Repeat for the facility-map label and the asset identifier. These are the
-   strongest review anchors for the first mapper pass.
+4. If a label or region control is not present in the deployed interface, leave
+   the image unlabelled. The mapper must return `unknown` instead of relying on
+   a made-up annotation.
 
 ## What to expect today
 
-Today’s success is a complete VisualSession containing original photos and
-your careful region labels. The current upload route preserves original image
-bytes but does not yet display phone GPS or capture time in the workspace.
+Before deployment, success is a complete local album of authorized original
+photos in the specified capture order. The public mobile app cannot yet create
+or display a VisualSession for this workflow.
 
-After the mapper PR is merged and deployed, an authorized backfill run will
-process this same session. It will either create reviewable candidate links to
-known Garage Conveyor assets/components or leave evidence unassigned with an
-explicit `unknown` result. It will not create new assets and will not silently
-mark a link correct.
+After the mapper PR is merged and deployed, upload the album through Field
+Capture. It will either create reviewable candidate links to known Garage
+Conveyor assets/components or leave evidence unassigned with an explicit
+`unknown` result. It will not create new assets and will not silently mark a
+link correct.
 
 ## Review after deployment
 
@@ -90,7 +103,7 @@ mark a link correct.
 
 Stop and report the issue instead of working around it if:
 
-- the Hub session does not load or upload fails;
+- the public Field Capture session does not load or upload fails;
 - the facility map or image contains material you are not authorized to retain;
 - an image lacks a readable anchor and cannot be honestly labeled; or
 - a candidate later points at the wrong asset or component.

--- a/docs/guides/spatial-evidence-field-trial.md
+++ b/docs/guides/spatial-evidence-field-trial.md
@@ -1,0 +1,99 @@
+# Garage Conveyor Spatial-Evidence Field Trial
+
+Use this guide to collect a small, clean photo set today. It uses the existing
+MIRA Hub Visual Workspace. The background mapper is not live until its PR has
+merged and been deployed; today proves that the evidence set is useful and
+gives the mapper a safe backfill target.
+
+## Before you start
+
+1. Confirm you are authorized to photograph and upload the Garage Conveyor
+   area, facility maps, panels, labels, and components.
+2. Use only MIRA Hub. Do not move facility images into a personal cloud,
+   consumer AI tool, or shared chat.
+3. Do not use this activity to decide whether equipment is safe, energized, or
+   ready to operate. Follow your site procedures and work authorization.
+4. Leave phone location and camera metadata enabled if site policy permits it.
+   Do not use a “strip location” export; upload the original image files.
+5. This first trial is still photos only. Do not upload body-camera video to
+   the current Visual Workspace.
+
+## Create one session
+
+1. On your phone or desktop browser, sign in to the existing MIRA Hub.
+2. Open **Visual Workspace** at `/visual`.
+3. Select **New session**.
+4. Keep every Garage Conveyor image in this one session. The current interface
+   creates a generic title; that is expected for this field trial.
+
+## Capture in this order
+
+Move normally through the permitted area. Take clear, still photos; do not
+change any equipment position to improve a shot.
+
+1. **Facility-map reference.** Photograph the full permitted garage/facility
+   map. Take a second close photo of the relevant legend or Garage Conveyor
+   area if the full map text is too small to read.
+2. **Route start.** Photograph the entrance, room marker, or approved area
+   identifier that establishes where this session begins.
+3. **Asset anchor.** Photograph the Garage Conveyor’s asset tag, nameplate, or
+   other visible identifier before photographing details.
+4. **Wide context.** Take an overview photo that shows the conveyor and its
+   nearby fixed landmarks.
+5. **Panels and components.** Work from wide to close: panel exterior, panel
+   identifier, component group, then each readable nameplate or terminal area.
+6. **Reference prints.** Photograph any authorized print, panel label, or
+   drawing that relates to the conveyor. Keep its page or sheet identifier in
+   the frame when possible.
+
+For each subject, take overlapping wide and close shots. Avoid motion blur,
+glare, and people’s faces, badges, or unrelated screens. If a label is not
+readable, take a second closer, straight-on photo instead of assuming the text.
+
+## Upload and mark evidence
+
+1. In the Visual Session, use the upload control to add each original photo.
+   The current workspace accepts PNG, JPEG, and WebP images one at a time.
+2. Keep upload order aligned with capture order: facility map first, then entry
+   point, asset anchor, wide context, panels, and close-ups.
+3. Select an uploaded image and draw a point or box around a readable asset tag,
+   map label, panel label, or component identifier.
+4. Give each region a short factual label such as `Garage Conveyor asset tag`,
+   `Panel A label`, or `Map: Garage Conveyor area`. Do not label a component
+   with an identity you cannot read or verify.
+5. Repeat for the facility-map label and the asset identifier. These are the
+   strongest review anchors for the first mapper pass.
+
+## What to expect today
+
+Today’s success is a complete VisualSession containing original photos and
+your careful region labels. The current upload route preserves original image
+bytes but does not yet display phone GPS or capture time in the workspace.
+
+After the mapper PR is merged and deployed, an authorized backfill run will
+process this same session. It will either create reviewable candidate links to
+known Garage Conveyor assets/components or leave evidence unassigned with an
+explicit `unknown` result. It will not create new assets and will not silently
+mark a link correct.
+
+## Review after deployment
+
+1. Open the Hub **Proposals** queue.
+2. Open each `Visual location link` candidate and inspect its source image,
+   marked region, target asset/component, confidence, and matching reason.
+3. Choose **accept** only when the target is correct. Choose **reject** when it
+   is wrong. Choose **correct** when the correct existing target is available.
+4. Treat every early review decision as calibration data. The mapper remains
+   candidate-only while it learns how your facility is actually organized.
+
+## Stop conditions
+
+Stop and report the issue instead of working around it if:
+
+- the Hub session does not load or upload fails;
+- the facility map or image contains material you are not authorized to retain;
+- an image lacks a readable anchor and cannot be honestly labeled; or
+- a candidate later points at the wrong asset or component.
+
+The correct result for insufficient evidence is `unknown`, not a confident
+guess.

--- a/docs/prd/2026-08-01-spatial-evidence-mapper.md
+++ b/docs/prd/2026-08-01-spatial-evidence-mapper.md
@@ -1,0 +1,207 @@
+# Spatial Evidence Mapper PRD
+
+**Status:** Draft for implementation review  
+**Date:** 2026-08-01  
+**Owner:** FactoryLM / MIRA  
+**First field trial:** Garage Conveyor visual session
+
+## 1. Purpose
+
+Turn newly captured visual evidence into reviewable, evidence-backed links to
+**existing** MIRA assets and components. The mapper helps a technician build a
+trusted spatial understanding of a facility over time without creating a
+second asset registry, mapping product, conversational agent, or evidence
+contract.
+
+The source of truth is the reviewed evidence ledger. A route display, facility
+map overlay, or future 3D walkthrough is a projection of that ledger; it is
+not a source of truth by itself.
+
+## 2. Problem
+
+Technicians collect photos of rooms, panels, nameplates, prints, facility
+maps, and components while moving through a site. Today MIRA can retain and
+interpret visual evidence, but it does not continuously propose the practical
+association that makes evidence useful later: which existing asset or
+component an image most likely depicts or locates.
+
+Without a reviewable mapping path, a photo can be useful in the moment yet be
+hard to retrieve as part of the machine context later.
+
+## 3. Product outcome
+
+After evidence is uploaded through the existing Hub VisualSession path, a
+background mapper creates a candidate relation only when it can name an
+existing tenant-scoped asset or component. The candidate appears in the
+existing Hub proposal queue with its source evidence, confidence, and reason.
+
+The technician accepts, rejects, or corrects the candidate. Only an accepted
+candidate becomes confirmed spatial evidence. Unknown items remain unassigned;
+the mapper never creates an asset or component record.
+
+## 4. Users and primary scenario
+
+The primary user is a maintenance technician collecting permitted photographs
+on a phone during an inspection, then reviewing the results in FactoryLM Hub
+on desktop or phone.
+
+The first validation scenario is the Garage Conveyor. The technician creates
+one VisualSession, uploads a facility-map reference plus a sequenced set of
+conveyor-area photos, and reviews any mapping candidates after the worker has
+run.
+
+## 5. Scope
+
+### In scope for the first implementation PR
+
+- Reuse `visual_session`, `evidence_item`, `region_of_interest`, and
+  `observation` as the visual evidence ledger.
+- Preserve server-extracted capture metadata from an original photo when it is
+  present, including capture time, latitude, longitude, and accuracy. Missing
+  data remains missing; the system never estimates it from a filename or prose.
+- Run an idempotent background mapper over new and previously unprocessed
+  VisualSession evidence.
+- Create candidate relation observations linking an evidence item to an
+  **existing** asset or component only.
+- Reuse the existing `ai_suggestions` proposal queue for technician review.
+- Allow an authorized reviewer to accept, reject, or correct a candidate while
+  preserving its source evidence and review history.
+- Ship a backfill mode so evidence captured before deployment, including the
+  Garage Conveyor field trial, can be evaluated from its preserved originals.
+- Add unit, integration, tenant-isolation, idempotency, and approval-path
+  tests.
+- Provide the field-capture and review guide in
+  `docs/guides/spatial-evidence-field-trial.md`.
+
+### Explicitly out of scope
+
+- A native Android app, background phone tracking, or a body-camera intake.
+- Google Maps, offline map tiles, route visualization, point clouds,
+  photogrammetry, AR, or a 3D walkthrough.
+- Creating new facilities, rooms, assets, components, graph entities, or
+  wiring connections from a mapper result.
+- Automatic verification, automatic asset creation, operational control,
+  safety-release, or return-to-service decisions.
+- Cross-tenant learning, external training, or use of customer imagery outside
+  its tenant-approved purpose.
+
+## 6. Non-negotiable rules
+
+1. **One technician brain.** This is an evidence producer under ADR-0033, not
+   a new spatial assistant or chatbot.
+2. **One evidence spine.** The mapper extends the existing VisualSession and
+   TechnicianContext contracts. It creates no parallel context schema, queue,
+   registry, or approval ladder.
+3. **Candidate first.** Mapper output is always an unreviewed candidate in the
+   first implementation. Model confidence never verifies a link by itself.
+4. **Existing targets only.** A candidate target must resolve to an existing
+   asset or component inside the current tenant. Otherwise the item is left
+   unassigned.
+5. **Evidence and provenance are mandatory.** Every candidate carries the
+   evidence-item identifier, original hash, session identifier, mapper version,
+   matching signals, and confidence. A missing audit anchor means no candidate.
+6. **GPS is contextual.** GPS and accuracy describe where the phone reported it
+   was. They do not prove an indoor cabinet location or override a reviewed
+   facility-map reference.
+7. **Read-only OT boundary.** The mapper can read evidence and create review
+   candidates only. It cannot issue control actions or make safety judgments.
+8. **Tenant privacy.** Original facility maps and photos remain tenant-private.
+   The feature is disabled until the customer has authorized capture and upload.
+
+## 7. Data flow
+
+```text
+Existing Hub VisualSession upload
+  -> original image and capture metadata retained in evidence_item
+  -> idempotent mapper finds an unprocessed item
+  -> deterministic candidate resolver searches existing tenant assets/components
+  -> candidate relation observation is appended to the visual ledger
+  -> matching ai_suggestions row enters the existing Hub review queue
+  -> technician accepts, rejects, or corrects
+  -> accepted relation is confirmed evidence available to TechnicianContext
+```
+
+Facility-map photos are ordinary visual evidence with the role `area`. They
+may supply labels, landmarks, and context for a reviewed mapping decision. A
+facility-map photo does not establish a coordinate system, a route, or an asset
+location automatically.
+
+## 8. Candidate behavior
+
+The mapper evaluates only evidence that has not already produced a mapper
+record for the same mapper version and source hash. It uses only auditable
+signals:
+
+- an existing session asset association;
+- a visible, extracted, or technician-labeled existing asset identifier;
+- an existing component/nameplate identity tied to a tenant asset;
+- a reviewer-provided region label; and
+- retained capture metadata as contextual support, never as sole identity.
+
+The candidate record includes a plain-language explanation of which signals
+matched and which expected evidence is missing. It must say `unknown` rather
+than force a target where no existing target is supported.
+
+Worker failure is fail-open for evidence capture: the original upload remains
+available, the failure is recorded for retry, and no candidate is fabricated.
+
+## 9. Review and confidence calibration
+
+The existing Hub proposal queue is the review surface. A reviewer sees the
+source image, session, target candidate, confidence, matching signals, and
+candidate state. The reviewer can accept, reject, or correct the target.
+
+The first implementation has no auto-selection path. Review outcomes form a
+tenant-local calibration record.
+
+Automatic selection is a later, separately approved release. It may be enabled
+for a tenant only when all of the following are true:
+
+- the tenant has at least 100 finalized mapper review decisions;
+- two separate 50-item held-out review sets each show at least 98% precision;
+- neither held-out set contains a wrong accepted target for a safety-critical
+  or high-risk candidate;
+- a qualified tenant administrator explicitly enables the feature; and
+- every automatic result remains auditable, reversible, and visible in the
+  review history.
+
+This gate prevents a model score from becoming an unearned claim of ground
+truth.
+
+## 10. Acceptance criteria
+
+1. A Hub upload retains its original bytes and parses supported capture metadata
+   without trusting client-supplied coordinates.
+2. A run over the same evidence twice creates no duplicate observation or
+   proposal.
+3. A candidate never targets a record outside the current tenant.
+4. A candidate without a source session, source evidence, source hash, or
+   target identifier is not created.
+5. An accepted candidate confirms the linked relation without creating a new
+   asset or component; a rejected candidate is excluded from active context.
+6. A worker outage cannot block photo upload or delete captured evidence.
+7. The Garage Conveyor backfill run produces either reviewable candidates or
+   explicit `unknown` results; it never silently claims a map is complete.
+8. The feature makes no operational-control, safety, or return-to-service
+   recommendation.
+
+## 11. Success measures
+
+- Every candidate has a source image and an explainable target match.
+- The initial field trial can be captured with the current phone-to-Hub path.
+- A reviewer can reach a correct accept/reject/correct outcome without database
+  access.
+- No duplicate candidate appears after retry or backfill.
+- The implementation adds no second asset store, mapping queue, or context
+  contract.
+
+## 12. Delivery sequence
+
+1. Land the mapper contract, capture-metadata parsing, candidate observation,
+   proposal-queue integration, and tests.
+2. Deploy to a non-production environment and run the Garage Conveyor backfill
+   against authorized trial evidence.
+3. Review every candidate manually and record results.
+4. Correct mapper defects before any broader customer trial.
+5. Treat route, map, and reconstruction views as separate follow-on projects
+   that consume reviewed spatial evidence rather than replace it.

--- a/docs/prd/2026-08-01-spatial-evidence-mapper.md
+++ b/docs/prd/2026-08-01-spatial-evidence-mapper.md
@@ -45,10 +45,11 @@ The primary user is a maintenance technician collecting permitted photographs
 on a phone during an inspection, then reviewing the results in FactoryLM Hub
 on desktop or phone.
 
-The first validation scenario is the Garage Conveyor. The technician creates
-one VisualSession, uploads a facility-map reference plus a sequenced set of
-conveyor-area photos, and reviews any mapping candidates after the worker has
-run.
+The first validation scenario is the Garage Conveyor. The technician opens the
+supported public application at `https://app.factorylm.com/hub`, starts a
+Field Capture session on a phone, uploads a facility-map reference plus a
+sequenced set of conveyor-area photos, and reviews any mapping candidates after
+the worker has run.
 
 ## 5. Scope
 
@@ -59,6 +60,10 @@ run.
 - Preserve server-extracted capture metadata from an original photo when it is
   present, including capture time, latitude, longitude, and accuracy. Missing
   data remains missing; the system never estimates it from a filename or prose.
+- Add a thin, supported **Field Capture** entry in the public
+  `app.factorylm.com/hub` experience. It creates or resumes one VisualSession,
+  uploads original raster photos, and clearly identifies the session as
+  candidate-only evidence. It is not a native Android app or a route viewer.
 - Run an idempotent background mapper over new and previously unprocessed
   VisualSession evidence.
 - Create candidate relation observations linking an evidence item to an
@@ -188,7 +193,8 @@ truth.
 ## 11. Success measures
 
 - Every candidate has a source image and an explainable target match.
-- The initial field trial can be captured with the current phone-to-Hub path.
+- The initial field trial can be captured from the supported public Field
+  Capture entry on a phone after deployment.
 - A reviewer can reach a correct accept/reject/correct outcome without database
   access.
 - No duplicate candidate appears after retry or backfill.

--- a/docs/superpowers/specs/2026-08-01-spatial-evidence-mapper-design.md
+++ b/docs/superpowers/specs/2026-08-01-spatial-evidence-mapper-design.md
@@ -1,0 +1,123 @@
+# Spatial Evidence Mapper Design
+
+**Status:** Approved product direction; awaiting written-spec review before implementation  
+**Date:** 2026-08-01
+
+## Decision
+
+Build a tenant-scoped, idempotent background mapper that consumes the existing
+VisualSession evidence ledger and writes only reviewable candidate links to
+existing MIRA assets and components. Reuse the existing Hub proposal queue and
+approval controls. Do not create a map service, an asset store, a spatial
+chatbot, or a second background queue.
+
+## Existing seams reused
+
+- `mira-hub` VisualSession upload retains original evidence in `evidence_item`.
+- `mira-bots/shared/visual` provides the append-only visual observation ledger.
+- `ai_suggestions` is the existing Hub-facing review queue.
+- `materialized_evidence/context_contract.py` adapts reviewed visual
+  observations into the single TechnicianContext spine.
+
+## Architecture
+
+### Capture metadata
+
+The Hub upload route parses capture metadata from the original image on the
+server. It retains values only when the image contains them:
+
+- `captured_at` in ISO-8601 form;
+- `latitude` and `longitude` as decimal degrees;
+- `horizontal_accuracy_m` when available; and
+- existing image dimensions and EXIF orientation.
+
+The route does not accept coordinates supplied by a browser form as trusted
+data. It stores no inferred location. Metadata parsing failure leaves only the
+original evidence and does not reject the upload.
+
+### Mapper worker
+
+The mapper is a small worker under the existing visual-evidence domain. It can
+run once for a controlled backfill or repeatedly on a bounded schedule. A run:
+
+1. reads tenant-scoped evidence that has no mapping result for the current
+   mapper version and source hash;
+2. obtains only existing tenant asset/component candidates;
+3. evaluates auditable identity signals and produces zero or one target
+   candidate per evidence item;
+4. appends an unreviewed `relation` observation when a candidate is supported;
+5. inserts one idempotent `ai_suggestions` review item linked to that
+   observation; and
+6. records a retryable failure without altering or blocking the original
+   evidence.
+
+The worker has no control-system dependency and no write path outside the
+visual ledger and existing review queue.
+
+### Candidate representation
+
+The append-only observation is the evidence record. It uses:
+
+- `obs_kind = relation`;
+- `evidence_state = LIKELY`;
+- `review_state = unreviewed`;
+- a source `evidence_id` and `session_id`; and
+- metadata containing mapper version, source hash, existing target id, target
+  type, confidence, and matching signals.
+
+The proposal queue row is the review task. It points back to the observation
+and source evidence and has a dedicated `visual_location_link` suggestion
+type. Accepting it transitions the suggestion through the existing transition
+helper and confirms the linked observation. Rejecting it rejects the linked
+observation. Neither action materializes a new asset, component, graph entity,
+or wiring connection.
+
+### Facility-map reference images
+
+The user can upload a facility map in the same VisualSession as field photos.
+The system stores it as normal evidence with the `area` role. In the first
+release it may contribute visible labels and reviewed context but cannot
+auto-georeference photos, fabricate a floor plan, or place an indoor asset from
+GPS alone.
+
+### Idempotency and retries
+
+The natural candidate key is tenant id + mapper version + source evidence hash
++ target id. A unique database constraint or equivalent atomic insert makes a
+retry safe. The worker must re-read state inside its transaction before writing
+so concurrent runs cannot create duplicate candidates.
+
+An evidence item with no supported target is recorded as processed with an
+explicit `unknown` result. It can be reconsidered only by a new mapper version
+or new human/visual evidence, never by an unbounded retry loop.
+
+## Error handling
+
+- Missing original bytes, malformed metadata, or no existing target: preserve
+  evidence and make no claim.
+- Candidate resolver failure: preserve evidence, journal the failure, and make
+  it eligible for a bounded retry.
+- Database or proposal-write failure: roll back the candidate transaction;
+  never leave an accepted-looking observation without a review task.
+- Unauthorized or cross-tenant target: treat as no target and emit no candidate.
+
+## Testing
+
+Tests must prove:
+
+1. server-side EXIF metadata parsing retains valid values and omits malformed
+   values;
+2. source evidence without an existing target produces `unknown`, not a new
+   asset;
+3. candidate observations include complete provenance;
+4. repeated mapper runs are idempotent;
+5. a tenant cannot map evidence to another tenant's target;
+6. accept/reject updates the correct linked observation only; and
+7. a mapper failure does not make evidence upload fail.
+
+## Deliberate deferrals
+
+This design does not add the Android companion, continuous phone tracking,
+offline map tiles, video ingestion, Google Maps, a floor-plan editor, a 3D
+viewer, point-cloud generation, or auto-selection. Each needs a separate
+design once the reviewed evidence set proves the mapper is useful.

--- a/docs/superpowers/specs/2026-08-01-spatial-evidence-mapper-design.md
+++ b/docs/superpowers/specs/2026-08-01-spatial-evidence-mapper-design.md
@@ -21,6 +21,25 @@ chatbot, or a second background queue.
 
 ## Architecture
 
+### Public Field Capture entry
+
+`mira-hub` is an internal service name, not the name or URL a technician uses.
+The public entry point is `https://app.factorylm.com/hub`. The current mobile
+experience does not expose the internal `/visual` workspace as a supported tab,
+so the mapper cannot rely on a technician finding that route.
+
+The first implementation adds one mobile-accessible **Field Capture** entry to
+the public Hub. It is a thin client over the existing VisualSession APIs:
+
+1. create or resume a session;
+2. upload an original PNG, JPEG, or WebP image;
+3. show that the item is captured evidence awaiting review; and
+4. link to the existing review queue when candidates are available.
+
+It does not show a route, Google map, point cloud, 3D walkthrough, or control
+surface. It is deliberately the smallest public door required to test the
+background mapper on a phone.
+
 ### Capture metadata
 
 The Hub upload route parses capture metadata from the original image on the


### PR DESCRIPTION
## What changed

- Adds the Spatial Evidence Mapper PRD and implementation design.
- Adds a Garage Conveyor phone-to-Hub field-trial guide.
- Defines a background candidate-mapping path that reuses VisualSession, the existing proposal queue, and the shared TechnicianContext evidence spine.

## Why

Technicians need visual evidence to remain retrievable as part of an existing machine context. The design makes only candidate links to existing tenant assets/components, with technician review before confirmation.

## Validation

- `git diff --check`
- Documentation self-review: no placeholders, no parallel context schema/queue/asset store, read-only OT boundary preserved.

## Follow-up

This draft is documentation-only. Implementation starts after review of `docs/superpowers/specs/2026-08-01-spatial-evidence-mapper-design.md`; the Garage Conveyor guide supports a baseline evidence capture today.