### PR TITLE
fix(printsense): add mem_limit to production bot services (#3073)

### DIFF
--- a/docker-compose.printsense-production.yml
+++ b/docker-compose.printsense-production.yml
@@ -18,9 +18,18 @@ x-printsense-production-env: &printsense-production-env
 
 services:
   mira-bot-telegram:
+    # Match the base service limits in docker-compose.saas.yml (this overlay is
+    # applied after it). Compose v2 merges service keys across -f files, but the
+    # mem-lint linter checks each file standalone, so the limits must be
+    # restated here. Not deploy.resources.limits.memory — that is Swarm syntax
+    # compose v2 silently ignores (the May 2026 mira-docling OOM lesson).
+    mem_limit: 512m
+    memswap_limit: 512m
     environment:
       <<: *printsense-production-env
 
   mira-bot-slack:
+    mem_limit: 512m
+    memswap_limit: 512m
     environment:
       <<: *printsense-production-env


### PR DESCRIPTION
## Problem
`compose-mem-lint (advisory)` has failed on every `main` run and PR since #2903, which added `mira-bot-telegram` + `mira-bot-slack` to the printsense-production overlay without memory limits:

```
✗ docker-compose.printsense-production.yml::mira-bot-telegram — no `mem_limit` set.
✗ docker-compose.printsense-production.yml::mira-bot-slack    — no `mem_limit` set.
```

A permanently-red advisory check stops being read — every PR now carries a failure authors learn to scroll past, which is how a real one (the May 2026 `mira-docling` OOM class) gets missed.

## Fix
Add `mem_limit: 512m` + `memswap_limit: 512m` to both services, matching the base definitions in `docker-compose.saas.yml`. This overlay is applied *after* saas.yml (compose merges the keys), but the linter checks each file standalone, so the limits must be restated here. Service-level keys, **not** `deploy.resources.limits.memory` (Swarm syntax compose v2 silently ignores — the mistake that made the May 2026 limits ineffective).

## Verification
```
$ python3 scripts/check_compose_mem_limits.py
  [OK] docker-compose.printsense-production.yml (2 services)
  ...
All services have `mem_limit` set.
exit=0
```

Closes #3073.

🤖 Generated with [Claude Code](https://claude.com/claude-code)