### PR TITLE
fix(deploy): staging bakes the tag-derived version like prod already does

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -102,6 +102,19 @@ jobs:
             docker rm -f "stg-${svc}" 2>/dev/null || true
           done
 
+          # Deploy identity — `/VERSION` was retired 2026-08-02 (#3064); the
+          # version is derived from the latest v* tag and baked into the image
+          # as MIRA_APP_VERSION (compose build arg -> Dockerfile ARG). Prod does
+          # this in deploy-vps.yml; staging was never wired, so every staging
+          # image reported "unknown" and the journey-swarm receipt recorded an
+          # unusable target revision (PRD §8.2 "the target revision is known").
+          # Fetch first: a shallow checkout has no tags, and a missing tag must
+          # degrade to "unknown", never fail the deploy.
+          git fetch --tags --quiet 2>/dev/null || true
+          export MIRA_APP_VERSION="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null | sed 's/^v//' | tr -d '[:space:]')"
+          export MIRA_APP_VERSION="${MIRA_APP_VERSION:-unknown}"
+          echo "Staging deploy identity: version=${MIRA_APP_VERSION}"
+
           echo "=== Build staging images ==="
           DOCKER_BUILDKIT=1 doppler run --project factorylm --config stg -- \
             docker compose -f docker-compose.staging-vps.yml build $TARGETS

--- a/docker-compose.staging-vps.yml
+++ b/docker-compose.staging-vps.yml
@@ -215,6 +215,10 @@ services:
     build:
       context: .
       dockerfile: mira-pipeline/Dockerfile
+      args:
+        # Deploy identity — `/VERSION` retired 2026-08-02 (#3064); the version
+        # is derived from the git tag and exported by deploy-staging.yml.
+        MIRA_APP_VERSION: ${MIRA_APP_VERSION:-unknown}
     container_name: stg-mira-pipeline
     ports:
       - "0.0.0.0:4099:9099"
@@ -402,6 +406,10 @@ services:
     build:
       context: .
       dockerfile: mira-bots/telegram/Dockerfile
+      args:
+        # Deploy identity — `/VERSION` retired 2026-08-02 (#3064); the version
+        # is derived from the git tag and exported by deploy-staging.yml.
+        MIRA_APP_VERSION: ${MIRA_APP_VERSION:-unknown}
     container_name: stg-mira-bot-telegram
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Follow-up to the tagging-model switch (#3064/#3071). **The model itself is correct and prod is fully wired** — `deploy-vps.yml` exports `MIRA_APP_VERSION` from `git describe --tags`, `docker-compose.saas.yml` passes it as a build arg, the Dockerfile bakes it, and prod correctly reports `3.248.0` today.

**Staging was simply never wired.** Neither `docker-compose.staging-vps.yml` nor `deploy-staging.yml` mentioned `MIRA_APP_VERSION` (those two files were not in #3071's change set), so every staging image built with the Dockerfile default:

```
prod:    docker exec mira-pipeline-saas printenv MIRA_APP_VERSION  -> 3.248.0
staging: docker exec stg-mira-pipeline   printenv MIRA_APP_VERSION -> unknown
```

## Why this isn't cosmetic

The journey swarm depends on it:

- `executor.assert_service_identity()` **refuses to run** unless the target reports a version — "the run revision cannot be recorded" (PRD §8.2: *stop before executing if its environment, tenant, or service identity does not match*).
- Every run receipt records `target_version` as the deployed revision (PRD G5: *code revision* in the evidence set).

With staging permanently `unknown`, each receipt recorded an unusable revision — the swarm's own audit trail could not say which build it validated. Today's GREEN 12/12 run reads `target: … vunknown`.

## The change

Mirrors the prod pattern **exactly** — same `git describe --tags --abbrev=0 --match 'v*'` expression, same fail-soft to `unknown` so a missing tag can never fail a deploy, same placement inside the SSH heredoc so the fetch runs in the VPS checkout:

- `docker-compose.staging-vps.yml`: `build.args.MIRA_APP_VERSION` on the two staging services whose images report a version (`mira-pipeline` serves `/health`, `mira-bot-telegram` logs it at boot).
- `deploy-staging.yml`: export the tag-derived version before `compose build`.

No new mechanism, no reintroduction of `/VERSION` — this makes staging use the tagging model that already works in prod.

## Verification

YAML parses for both files. Post-merge I'll redeploy staging and confirm `/health` reports the real version, then re-run the journey swarm so its receipt carries a usable revision.