### PR TITLE
fix(deploy): deploy identity was clobbered by a second rebuild path — telegram/slack reported "unknown"

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -279,12 +279,13 @@ jobs:
           # so /api/version + /api/health report which code is live. Exported here
           # so docker-compose build.args pick them up; default "unknown" otherwise.
           export MIRA_GIT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"
-          # `/VERSION` was retired 2026-08-02 (#3064) — the version is DERIVED
-          # from the latest v* tag (version-tag.yml creates it on push to main).
-          # Fetch first: a shallow/stale checkout has no tags, and a missing tag
-          # must degrade to "unknown", never fail the deploy.
-          git fetch --tags --quiet 2>/dev/null || true
-          export MIRA_APP_VERSION="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null | sed 's/^v//' | tr -d '[:space:]')"
+          # `/VERSION` was retired 2026-08-02 (#3064) — the version is DERIVED from
+          # the release tag. Reuse RELEASE_TAG (computed above, and the ref actually
+          # checked out) rather than re-deriving with `git describe`: in the no-tag
+          # fallback branch the checkout is origin/main, and `git describe` would
+          # name the PREVIOUS tag — reporting a version that is not the running
+          # code. Empty ⇒ "unknown", which is the honest answer there.
+          export MIRA_APP_VERSION="${RELEASE_TAG#v}"
           export MIRA_APP_VERSION="${MIRA_APP_VERSION:-unknown}"
           export MIRA_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           echo "Deploy identity: sha=${MIRA_GIT_SHA} version=${MIRA_APP_VERSION} built=${MIRA_BUILD_TIME}"

--- a/.github/workflows/printsense-production-activation.yml
+++ b/.github/workflows/printsense-production-activation.yml
@@ -111,6 +111,26 @@ jobs:
           git reset --hard origin/main
           test -f docker-compose.printsense-production.yml
 
+          # Deploy identity must be exported HERE too, not only in deploy-vps.yml.
+          # This workflow runs AFTER a deploy and rebuilds the two bot images, so
+          # whatever it bakes in is what actually runs. Before #3064 the bots read
+          # a COPY'd /VERSION file and this path inherited the right answer for
+          # free; now the version arrives as a BUILD ARG, so a rebuild without
+          # these exports resolves `${MIRA_APP_VERSION:-unknown}` to "unknown" and
+          # silently overwrites the identity the deploy just baked. Observed live
+          # on 2026-08-03: mira-pipeline reported 3.248.0 while mira-bot-telegram
+          # reported "unknown" — same commit, same minute, different build path.
+          #
+          # Derived from the tag at origin/main HEAD (this step resets to
+          # origin/main, so that IS the deployed code). No tag ⇒ "unknown", which
+          # is the honest answer rather than a plausible wrong one.
+          PS_RELEASE_TAG="$(git tag --points-at origin/main --list 'v[0-9]*' | sort -V | tail -1)"
+          export MIRA_APP_VERSION="${PS_RELEASE_TAG#v}"
+          export MIRA_APP_VERSION="${MIRA_APP_VERSION:-unknown}"
+          export MIRA_GIT_SHA="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+          export MIRA_BUILD_TIME="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "Deploy identity: sha=${MIRA_GIT_SHA} version=${MIRA_APP_VERSION} built=${MIRA_BUILD_TIME}"
+
           COMPOSE="docker compose -f docker-compose.saas.yml -f docker-compose.printsense-production.yml"
 
           echo "=== Validate production overlay ==="
@@ -139,6 +159,15 @@ jobs:
             HEALTH=$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container")
             echo "$container health=$HEALTH"
             test "$HEALTH" = "healthy"
+
+            # The rebuild above must carry the SAME identity the deploy baked —
+            # not "unknown", and not a stale earlier version. Compared against the
+            # value exported for this build rather than merely asserting non-empty,
+            # so a future path that rebuilds without the exports fails HERE instead
+            # of shipping a container that lies about which code it is running.
+            GOT_VER=$(docker exec "$container" sh -c 'printf %s "$MIRA_APP_VERSION"')
+            echo "$container MIRA_APP_VERSION=$GOT_VER (expected $MIRA_APP_VERSION)"
+            test "$GOT_VER" = "$MIRA_APP_VERSION"
           done
 
           echo "=== Run network-free readiness in both containers ==="


### PR DESCRIPTION
Follow-up to #3071, found by verifying that deploy end-to-end rather than trusting the green run.

## What was wrong

After #3071 deployed as `v3.248.0`:

| surface | reported |
|---|---|
| `mira-hub` `/api/version` | `3.248.0` ✅ |
| `mira-pipeline` `/health` | `3.248.0` ✅ |
| `mira-bot-telegram` startup log | **`unknown`** ❌ |

Same commit, same minute. `docker inspect` on the images confirmed it was baked, not a read bug — pipeline had `MIRA_APP_VERSION=3.248.0`, telegram had `unknown`.

## Cause — a second deploy path, not the Dockerfiles

The two Dockerfiles are identical in the relevant respect, and both compose services carry the same `args:` block. The difference is **who built the image last**.

`printsense-production-activation.yml` triggers *after* `deploy-vps.yml` and rebuilds `mira-bot-telegram` + `mira-bot-slack` with an overlay compose — in a shell that never exports `MIRA_APP_VERSION`. So `${MIRA_APP_VERSION:-unknown}` resolved to `unknown`, and it overwrote the identity the deploy had baked ~30 seconds earlier. Timeline from the run logs: deploy finishes → PrintSense activation `03:29:11 → 03:29:58` → telegram image created `03:29:28`, bot starts `03:29:41`.

## Why this belongs with #3064, not in a backlog

**#3064 caused it.** Before that change the bots read a `COPY`'d `/VERSION` file, so *any* build path produced the correct version for free. Moving to a build `ARG` made the version a property of the **build environment** — and this path's environment didn't have it. That is the real cost of the ARG approach, and every rebuild path has to pay it. Shipping the regression and filing a ticket would be leaving my own breakage in place.

## The fix

1. Export the same deploy identity in `printsense-production-activation.yml` before the rebuild, derived from the tag at `origin/main` HEAD (that step does `git reset --hard origin/main`, so that *is* the deployed code). No tag ⇒ `unknown`, which is honest rather than plausibly wrong.
2. **Assert it.** The existing per-container config loop now compares the container's `MIRA_APP_VERSION` to the value exported for that build — compared, not merely checked non-empty, so a *future* rebuild path that forgets the exports fails there instead of silently shipping a container that misreports its own code. This assertion would have caught the bug on the run that introduced it.

## Also in this PR

`deploy-vps.yml` derived `MIRA_APP_VERSION` with a second `git describe --tags --abbrev=0`, when the step already computes `RELEASE_TAG` and checks it out. Redundant on the happy path and **wrong in the fallback**: with no tag at HEAD the checkout is `origin/main`, but `git describe` returns the *previous* tag — reporting a version that is not the running code. Same defect class as the tag skew #3064 existed to remove. Now `${RELEASE_TAG#v}`, which is exactly what was checked out.

## Verification

`actionlint` clean on both workflows. The real proof is the next PrintSense activation run: its own assertion must pass, and `docker logs mira-bot-telegram | grep 'bot starting'` must show the release version instead of `unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKYdhFE6hvQYAAJ9iVPfPM