### PR TITLE
fix(tests): two tools/ dirs both claimed the module name `runner`, breaking Eval Offline on main

### DIFF
--- a/tests/printsense/test_grader_gate.py
+++ b/tests/printsense/test_grader_gate.py
@@ -10,6 +10,7 @@ truth-set is enforced against regression.
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -19,9 +20,42 @@ from printsense import grader_gate
 
 _ROOT = Path(__file__).resolve().parents[2]
 # The PR4 runner lives under tools/ — put it on sys.path (as tools/internet_print_test/test_runner.py does).
+# This insert STAYS even though _load() below imports by explicit path: runner.py
+# bare-imports its own siblings (`import mailer`, `import safety`, `from submit import ...`),
+# and those resolve through sys.path.
 _RUNNER_DIR = _ROOT / "tools" / "internet_print_test"
 if str(_RUNNER_DIR) not in sys.path:
     sys.path.insert(0, str(_RUNNER_DIR))
+
+
+def _load_runner():
+    """Load `tools/internet_print_test/runner.py` under a UNIQUE top-level name.
+
+    `tools/internet_print_test/runner.py` and `tools/routing_gauntlet/runner.py`
+    both want the bare name `runner`, and only the first import of it wins
+    `sys.modules` for the whole process. Since #3074 the gauntlet's test imports
+    its runner at COLLECTION time while this file imported at RUN time, so this
+    file always lost and got a module with no `TESTS_ROOT` — which is what broke
+    the Eval Offline job on main.
+
+    Loading by explicit path under a distinct name means neither test owns the
+    ambiguous bare name. Enforced by Contract 10 in tests/test_architecture.py.
+
+    Only `runner` is ambiguous. `submit` / `mailer` / `safety` keep their bare
+    names on purpose: `runner.run_one` itself does `from submit import
+    submit_image_sync` at call time, so the test's handle MUST be the same
+    `sys.modules['submit']` object the runner will reach, or the monkeypatch
+    silently misses and the test hits the real submit path.
+    """
+    cached = sys.modules.get("print_test_runner")
+    if cached is not None:
+        return cached
+    spec = importlib.util.spec_from_file_location("print_test_runner", _RUNNER_DIR / "runner.py")
+    assert spec and spec.loader, f"cannot load runner.py from {_RUNNER_DIR}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["print_test_runner"] = module
+    spec.loader.exec_module(module)
+    return module
 
 _ATV340_GRAPH = _ROOT / "printsense" / "fixtures" / "atv340" / "graph.json"
 _ATV340_RUBRIC = _ROOT / "printsense" / "benchmarks" / "atv340_vfd" / "rubric.json"
@@ -46,8 +80,9 @@ def _verdict(tmp_path, graph: dict, rubric: dict | None = None) -> dict:
 
 def _run_runner(tmp_path, monkeypatch, graph: dict, test_id: str, *, judge=None, no_judge=False):
     """Drive the REAL runner with submit + judge mocked (hermetic). Returns (row, td)."""
-    import runner  # lazy: only the 3 runner tests need it (+ httpx via safety/mailer)
-    import submit as submitmod
+    # lazy: only the 3 runner tests need these (+ httpx via safety/mailer)
+    runner = _load_runner()
+    import submit as submitmod  # bare on purpose — see _load_runner's docstring
 
     fixture = tmp_path / "x.png"
     fixture.write_bytes(_PNG_1x1)
@@ -57,7 +92,9 @@ def _run_runner(tmp_path, monkeypatch, graph: dict, test_id: str, *, judge=None,
     monkeypatch.setattr(submitmod, "submit_image_sync", lambda image_bytes, caption, **kw: {
         "handled": True, "classification": "ELECTRICAL_PRINT", "final_text": "R", "map_text": "m",
         "graph": graph, "interpreter_used": True, "model": "x", "latency_s": 0.1})
-    monkeypatch.setattr("runner.run_judge",
+    # Object form, not the string form: `monkeypatch.setattr("runner.run_judge", …)`
+    # resolves through sys.modules['runner'], the ambiguous name this file no longer owns.
+    monkeypatch.setattr(runner, "run_judge",
                         judge or (lambda *a, **k: {"overall_score_provisional": 60, "hard_failure": False, "provisional": True}))
     args = runner.argparse.Namespace(page=0, dpi=200, caption="Explain this print.", no_judge=no_judge,
                                      send_email=False, recipient=None, regrade=False)
@@ -146,7 +183,7 @@ def test_9_malformed_graphs_fail_safely(tmp_path):
 
 # ── 10. Report AND email preserve identical verdicts + blockers ───────────────
 def test_10_report_and_email_preserve_verdict_and_blockers(tmp_path, monkeypatch):
-    import runner
+    runner = _load_runner()
 
     bad = {"package": {"sheet": "1/2"}, "devices": [{"tag": "M"}, {"tag": "M"}],
            "off_page_references": [{"tag": "2/2"}]}

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -711,12 +711,24 @@ def test_verified_promotion_checker_catches_violations():
 _AMBIGUITY_ROOTS = ("tools", "scripts")
 
 # A pathlib chain rooted at a tools/-family segment: "tools" / "routing_gauntlet".
-_PATH_CHAIN_RE = re.compile(r'"(?:tools|scripts)"(?:\s*/\s*"[^"/]+")*')
-# The same directory written as one literal: "tools/qa/security". Requires the
-# slash — a bare "tools" is a one-segment CHAIN and is matched above, so making
-# the slash optional here would emit a spurious `tools` alongside every
-# `"tools" / "sub"` chain.
-_PATH_LITERAL_RE = re.compile(r'"(?:tools|scripts)/[^"]*"')
+# Segments are [A-Za-z0-9_-] (same class as the literal form below) so a chain
+# that ends in a FILE — `REPO / "tools" / "hooks" / "rm_guard.py"` — degrades to
+# its containing directory (tools/hooks) instead of contributing a bogus
+# "tools/hooks/rm_guard.py" entry. A permissive [^"/]+ here was the actual leak:
+# it let ~15 file paths through even after the literal form was tightened.
+_PATH_CHAIN_RE = re.compile(r'"(?:tools|scripts)"(?:\s*/\s*"[A-Za-z0-9_-]+")*')
+# The same directory written as one literal: "tools/qa/security".
+#   - Requires the slash: a bare "tools" is a one-segment CHAIN matched above, so
+#     an optional slash would emit a spurious `tools` beside every chain.
+#   - Segments are [A-Za-z0-9_-] only, so this matches DIRECTORIES and not the
+#     many file paths and prose fragments that also start with "tools/" in this
+#     tree ("tools/seeds/*.sql", "tools/hooks/rm_guard.py", "tools/…​ not found").
+#     Those all carry a dot or a space. Without this, ~30 non-directories entered
+#     the provider map; they were filtered later by is_dir(), but a *directory*
+#     reached only through a file path (tools/lead-hunter via
+#     "tools/lead-hunter/hunt.py") did not, and could manufacture a false
+#     ambiguity against a dir no test ever puts on sys.path.
+_PATH_LITERAL_RE = re.compile(r'"(?:tools|scripts)(?:/[A-Za-z0-9_-]+)+"')
 _QUOTED_RE = re.compile(r'"([^"]+)"')
 
 
@@ -751,10 +763,17 @@ def referenced_tool_dirs(test_sources: list[tuple[str, str]]) -> set[str]:
 
 
 def ambiguous_module_names(dir_to_modules: dict[str, set[str]]) -> dict[str, set[str]]:
-    """{top-level module name -> providing dirs} for names provided by >1 dir."""
+    """{top-level module name -> providing dirs} for names provided by >1 dir.
+
+    Dunders are excluded: `__init__` / `__main__` exist in most of these dirs but
+    are never reachable as a bare top-level import, so counting them would put a
+    permanent false entry in the failure message with no violation behind it.
+    """
     providers: dict[str, set[str]] = {}
     for directory, names in dir_to_modules.items():
         for name in names:
+            if name.startswith("__"):
+                continue
             providers.setdefault(name, set()).add(directory)
     return {n: d for n, d in providers.items() if len(d) > 1}
 
@@ -835,9 +854,24 @@ def test_ambiguous_tool_import_checker_catches_violations():
     assert referenced_tool_dirs([("t.py", 'sys.path.insert(0, str(P / "tools" / "qa" / "security"))')]) == {
         "tools/qa/security"
     }
+    # The dir written as one literal (not a pathlib chain).
+    assert referenced_tool_dirs([("t.py", 'P = "tools/qa/security"')]) == {"tools/qa/security"}
+    # A dir hoisted into a variable is still found — binding discovery to the
+    # sys.path.insert call missed exactly this and un-guarded the real bug.
+    assert referenced_tool_dirs(
+        [("t.py", '_D = REPO / "tools" / "routing_gauntlet"\nsys.path.insert(0, str(_D))')]
+    ) == {"tools/routing_gauntlet"}
     # Non-tools dirs are out of scope; fully variable-built paths are skipped.
     assert referenced_tool_dirs([("t.py", 'sys.path.insert(0, "mira-bots")')]) == set()
     assert referenced_tool_dirs([("t.py", "sys.path.insert(0, str(SCRIPTS))")]) == set()
+    # File paths and prose that merely start with "tools/" are NOT directories.
+    assert referenced_tool_dirs([("t.py", 'X = "tools/hooks/rm_guard.py"')]) == set()
+    assert referenced_tool_dirs([("t.py", 'M = "tools/seeds/a.sql is stale — "')]) == set()
+    assert referenced_tool_dirs([("t.py", 'M = "tools/ path discovery failed"')]) == set()
+    # A CHAIN ending in a file degrades to its containing directory.
+    assert referenced_tool_dirs([("t.py", 'P = REPO / "tools" / "hooks" / "rm_guard.py"')]) == {
+        "tools/hooks"
+    }
 
     # The real collision: two dirs, one shared name.
     ambiguous = ambiguous_module_names(
@@ -847,6 +881,10 @@ def test_ambiguous_tool_import_checker_catches_violations():
         }
     )
     assert set(ambiguous) == {"runner"}, ambiguous
+    # Dunders are shared by most tool dirs but are never bare-importable.
+    assert ambiguous_module_names(
+        {"tools/a": {"__init__", "__main__"}, "tools/b": {"__init__", "__main__"}}
+    ) == {}
 
     bad_cases = {
         "module-level bare import (test_routing_gauntlet's old shape)":

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -661,3 +661,217 @@ def test_verified_promotion_checker_catches_violations():
     }
     for label, sql in good_cases.items():
         assert scan_verified_promotion("good.sql", sql) == [], f"false positive: {label}"
+
+
+# ---------------------------------------------------------------------------
+# Contract 10: no test bare-imports a top-level module name that two different
+# tools/ directories both provide
+# ---------------------------------------------------------------------------
+# Python caches modules by top-level NAME in sys.modules, not by path. When two
+# directories that tests push onto sys.path each contain a `runner.py`, the
+# FIRST import of the bare name `runner` wins for the whole process and every
+# later `import runner` silently gets the other file.
+#
+# That is not hypothetical — it broke `main`. #3074 added
+# tools/routing_gauntlet/runner.py alongside the pre-existing
+# tools/internet_print_test/runner.py. tests/test_routing_gauntlet.py imported
+# its runner at COLLECTION time; tests/printsense/test_grader_gate.py imported
+# at RUN time (inside a helper), and pytest finishes all collection before
+# running anything — so the gauntlet always won and the printsense tests got a
+# module with no TESTS_ROOT:
+#
+#   AttributeError: <module 'runner' from '.../tools/routing_gauntlet/runner.py'>
+#                   has no attribute 'TESTS_ROOT'
+#
+# Bisected: 2666656b green -> 412a3464 (#3074) red, and every `main` run after.
+# It was invisible to every BLOCKING check because `test-unit` runs
+# `pytest tests/printsense/ -v` in ISOLATION, where the collision cannot happen;
+# only the `test-eval-offline` sweep collects both files in one process, and
+# that job is deliberately not in ci-gate. Isolation is exactly what hid it,
+# so adding those suites to test-unit would NOT have caught this — a
+# cross-file contract is the only thing that can. Contract 10 lives in
+# architecture-check, which IS gated.
+#
+# Remedy when this fires: load the module by explicit path under a unique name
+# (importlib.util.spec_from_file_location) instead of bare-importing the
+# ambiguous one. Both call sites do this now. Keep the sys.path.insert — the
+# tool's own modules still bare-import their siblings through it.
+#
+# SCOPE — deliberately narrowed to the tools/ family, and this was measured,
+# not assumed. tests/** contains ~60 distinct sys.path.insert expressions, many
+# built from local variables (relay_dir, bots_path, p, lead) that no static
+# checker can resolve, covering mira-bots, mira-bots/shared, mira-mcp,
+# mira-sidecar, mira-pipeline, mira-crawler, the repo root, ignition/ and plc/.
+# A contract over all of that would be both unresolvable and noisy. Over the
+# tools/-family dirs tests actually insert, exactly ONE name out of 85 is
+# ambiguous — `runner`, i.e. the bug. So the narrow scope costs no real
+# coverage and needs no allowlist. If a future collision lands outside tools/,
+# widen this deliberately rather than by accident.
+
+_AMBIGUITY_ROOTS = ("tools", "scripts")
+
+# A pathlib chain rooted at a tools/-family segment: "tools" / "routing_gauntlet".
+_PATH_CHAIN_RE = re.compile(r'"(?:tools|scripts)"(?:\s*/\s*"[^"/]+")*')
+# The same directory written as one literal: "tools/qa/security". Requires the
+# slash — a bare "tools" is a one-segment CHAIN and is matched above, so making
+# the slash optional here would emit a spurious `tools` alongside every
+# `"tools" / "sub"` chain.
+_PATH_LITERAL_RE = re.compile(r'"(?:tools|scripts)/[^"]*"')
+_QUOTED_RE = re.compile(r'"([^"]+)"')
+
+
+def referenced_tool_dirs(test_sources: list[tuple[str, str]]) -> set[str]:
+    """Repo-relative tools/-family dirs that any test names as a path.
+
+    Scans the WHOLE file, not just `sys.path.insert(...)` calls. Binding the
+    scan to the insert call was refuted immediately: the fix for this very bug
+    hoists the directory into a variable --
+
+        _GAUNTLET_DIR = REPO / "tools" / "routing_gauntlet"
+        sys.path.insert(0, str(_GAUNTLET_DIR))
+
+    -- so the insert carries no literal and the dir vanished from discovery,
+    silently un-guarding the exact collision this contract exists for. Matching
+    the path literal wherever it appears is the fix.
+
+    Over-matching is the correct bias, same as Contract 8's `_job_runs_tests`:
+    a merely-mentioned dir only adds its module names to the provider map, and
+    a violation still requires a test to actually bare-import a colliding name.
+    A false negative silently un-guards a real collision.
+
+    Pure: takes [(path, text), ...] so the self-test can drive it with fixtures.
+    """
+    found: set[str] = set()
+    for _path, text in test_sources:
+        for chain in _PATH_CHAIN_RE.findall(text):
+            found.add("/".join(_QUOTED_RE.findall(chain)))
+        for literal in _PATH_LITERAL_RE.findall(text):
+            found.add(literal.strip('"').strip("/"))
+    return {d for d in found if d.split("/")[0] in _AMBIGUITY_ROOTS}
+
+
+def ambiguous_module_names(dir_to_modules: dict[str, set[str]]) -> dict[str, set[str]]:
+    """{top-level module name -> providing dirs} for names provided by >1 dir."""
+    providers: dict[str, set[str]] = {}
+    for directory, names in dir_to_modules.items():
+        for name in names:
+            providers.setdefault(name, set()).add(directory)
+    return {n: d for n, d in providers.items() if len(d) > 1}
+
+
+def scan_bare_ambiguous_imports(
+    path: str, text: str, ambiguous: set[str]
+) -> list[str]:
+    """Violations where `path` bare-imports one of the `ambiguous` names."""
+    if not ambiguous:
+        return []
+    offenders = []
+    for match in _IMPORT_RE.finditer(text):
+        imported = match.group(1)
+        # Only a bare top-level name collides; `tools.x.runner` resolves by path.
+        if "." in imported:
+            continue
+        if imported in ambiguous:
+            line = text[: match.start()].count("\n") + 1
+            offenders.append(f"{path}:{line}: bare `{imported}` import")
+    return offenders
+
+
+def _test_sources() -> list[tuple[str, str]]:
+    tests_dir = _ROOT / "tests"
+    out = []
+    for py_file in sorted(tests_dir.rglob("*.py")):
+        if "__pycache__" in str(py_file):
+            continue
+        out.append((str(py_file.relative_to(_ROOT)), py_file.read_text(errors="replace")))
+    return out
+
+
+def test_no_test_bare_imports_an_ambiguous_tool_module():
+    """Contract 10: a name two tools/ dirs both provide must not be bare-imported."""
+    sources = _test_sources()
+
+    # Vacuity guard — a broken regex must fail loudly, not pass over nothing.
+    assert len(sources) > 100, f"only found {len(sources)} test files; discovery is broken"
+    tool_dirs = referenced_tool_dirs(sources)
+    assert "tools/internet_print_test" in tool_dirs and "tools/routing_gauntlet" in tool_dirs, (
+        "tools/ path discovery failed to find the two known dirs; "
+        f"found: {sorted(tool_dirs)}"
+    )
+
+    dir_to_modules = {
+        d: {p.stem for p in (_ROOT / d).glob("*.py")}
+        for d in sorted(tool_dirs)
+        if (_ROOT / d).is_dir()
+    }
+    assert sum(len(v) for v in dir_to_modules.values()) > 20, "module discovery is broken"
+
+    ambiguous = ambiguous_module_names(dir_to_modules)
+    offenders = []
+    for path, text in sources:
+        offenders.extend(scan_bare_ambiguous_imports(path, text, set(ambiguous)))
+
+    assert not offenders, (
+        "A test bare-imports a module name that two tools/ directories both provide.\n"
+        "Python caches by NAME, so whichever file is imported first wins sys.modules\n"
+        "for the whole process and the other test silently gets the wrong module.\n"
+        "Fix: load it by explicit path under a unique name --\n"
+        "    spec = importlib.util.spec_from_file_location('my_unique_name', DIR / 'runner.py')\n"
+        "    mod = importlib.util.module_from_spec(spec); sys.modules['my_unique_name'] = mod\n"
+        "    spec.loader.exec_module(mod)\n"
+        "Keep the sys.path.insert -- the tool's own modules bare-import their siblings.\n\n"
+        "Ambiguous names: "
+        + "; ".join(f"{n} -> {sorted(d)}" for n, d in sorted(ambiguous.items()))
+        + "\n\nOffenders:\n" + "\n".join(offenders)
+    )
+
+
+def test_ambiguous_tool_import_checker_catches_violations():
+    """The Contract 10 guard must FAIL on the known bad shapes and pass on the good ones."""
+    # Discovery finds a tools/ dir from the shapes actually used in this repo.
+    assert referenced_tool_dirs([("t.py", 'sys.path.insert(0, str(REPO / "tools" / "routing_gauntlet"))')]) == {
+        "tools/routing_gauntlet"
+    }
+    assert referenced_tool_dirs([("t.py", 'sys.path.insert(0, str(P / "tools" / "qa" / "security"))')]) == {
+        "tools/qa/security"
+    }
+    # Non-tools dirs are out of scope; fully variable-built paths are skipped.
+    assert referenced_tool_dirs([("t.py", 'sys.path.insert(0, "mira-bots")')]) == set()
+    assert referenced_tool_dirs([("t.py", "sys.path.insert(0, str(SCRIPTS))")]) == set()
+
+    # The real collision: two dirs, one shared name.
+    ambiguous = ambiguous_module_names(
+        {
+            "tools/internet_print_test": {"runner", "submit", "mailer", "safety"},
+            "tools/routing_gauntlet": {"runner", "corpus"},
+        }
+    )
+    assert set(ambiguous) == {"runner"}, ambiguous
+
+    bad_cases = {
+        "module-level bare import (test_routing_gauntlet's old shape)":
+            "from runner import ADVERSARIAL_VOTES, apply_arbitration\n",
+        "indented lazy bare import (test_grader_gate's old shape)":
+            "def helper():\n    import runner\n",
+        "aliased bare import":
+            "import runner as r\n",
+    }
+    for label, src in bad_cases.items():
+        assert scan_bare_ambiguous_imports("bad.py", src, set(ambiguous)), (
+            f"checker missed a violation: {label}"
+        )
+
+    good_cases = {
+        "unambiguous sibling stays bare (runner.run_one reaches the same object)":
+            "import submit as submitmod\n",
+        "dotted package path resolves without the bare name":
+            "from tools.routing_gauntlet.runner import run_tier1\n",
+        "explicit path load under a unique name":
+            "spec = importlib.util.spec_from_file_location('print_test_runner', D / 'runner.py')\n",
+        "a name that merely CONTAINS an ambiguous one":
+            "import runner_utils\n",
+    }
+    for label, src in good_cases.items():
+        assert scan_bare_ambiguous_imports("good.py", src, set(ambiguous)) == [], (
+            f"false positive: {label}"
+        )

--- a/tests/test_routing_gauntlet.py
+++ b/tests/test_routing_gauntlet.py
@@ -15,15 +15,48 @@ Offline, deterministic, no LLM, no DB. Runs in seconds.
 
 from __future__ import annotations
 
+import importlib.util
 import sys
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(REPO / "tools" / "routing_gauntlet"))
+_GAUNTLET_DIR = REPO / "tools" / "routing_gauntlet"
+# The sys.path insert STAYS even though the imports below are path-based: the
+# gauntlet's own modules bare-import each other (runner.py does
+# `from corpus import RoutingCase, generate`), and those resolve through sys.path.
+sys.path.insert(0, str(_GAUNTLET_DIR))
 sys.path.insert(0, str(REPO / "mira-bots"))
 
-from corpus import generate  # noqa: E402
-from runner import ADVERSARIAL_VOTES, apply_arbitration, run_tier1  # noqa: E402
+
+def _load(name: str, filename: str):
+    """Load a gauntlet module under a UNIQUE top-level name.
+
+    `tools/routing_gauntlet/runner.py` and `tools/internet_print_test/runner.py`
+    both want the bare name `runner`. Whichever is imported first wins
+    `sys.modules['runner']` for the whole process — and this file's module-level
+    import ran at COLLECTION time, so it always won, handing
+    tests/printsense/test_grader_gate.py the wrong module at RUN time
+    (`AttributeError: ... has no attribute 'TESTS_ROOT'`). That broke the
+    Eval Offline job on main for every commit after #3074.
+
+    Loading by explicit path under a distinct name means neither test owns the
+    ambiguous bare name. Enforced by Contract 10 in tests/test_architecture.py.
+    """
+    spec = importlib.util.spec_from_file_location(name, _GAUNTLET_DIR / filename)
+    assert spec and spec.loader, f"cannot load {filename} from {_GAUNTLET_DIR}"
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_corpus = _load("routing_gauntlet_corpus", "corpus.py")
+_runner = _load("routing_gauntlet_runner", "runner.py")
+
+generate = _corpus.generate
+ADVERSARIAL_VOTES = _runner.ADVERSARIAL_VOTES
+apply_arbitration = _runner.apply_arbitration
+run_tier1 = _runner.run_tier1
 
 
 def test_corpus_is_deterministic_and_nontrivial():


### PR DESCRIPTION
## The bug

`Eval Offline` has failed on **every `main` commit** since #3074. It is not an eval result — it's three printsense grader tests:

```
FAILED tests/printsense/test_grader_gate.py::test_7_judge_approval_cannot_clear_deterministic_fail
FAILED tests/printsense/test_grader_gate.py::test_8_missing_judge_still_grades
FAILED tests/printsense/test_grader_gate.py::test_10_report_and_email_preserve_verdict_and_blockers
  AttributeError: <module 'runner' from '.../tools/routing_gauntlet/runner.py'>
                  has no attribute 'TESTS_ROOT'
```

**Bisected to one commit:**

| commit | PR | `Eval Offline` |
|---|---|---|
| `69b1bc20` | #3069 | success |
| `2666656b` | #3072 | success |
| `412a3464` | **#3074** | **failure** — and every run since |

`git log --diff-filter=A -- tools/routing_gauntlet/runner.py` → `412a3464`.

## Mechanism

Python caches modules by top-level **name**, not by path. Two files want the bare name `runner`, and tests push both dirs onto `sys.path`:

| file | inserted by | how it imports | when |
|---|---|---|---|
| `tools/routing_gauntlet/runner.py` | `tests/test_routing_gauntlet.py` | `from runner import …` (module level) | **collection** |
| `tools/internet_print_test/runner.py` | `tests/printsense/test_grader_gate.py` | `import runner` (inside a helper) | **run** |

pytest finishes all collection before running anything, so the gauntlet **always** won `sys.modules['runner']` and the printsense tests got a module with no `TESTS_ROOT`. Deterministic, not flaky. `sys.path` order is irrelevant — the `sys.modules` cache decides.

## The fix

Both tests load their runner by explicit path under a unique name. Three details are load-bearing:

- **The `sys.path.insert` lines stay.** Each runner bare-imports its own siblings (`import mailer` / `import safety`, `from corpus import …`), which still resolve through `sys.path`. Deleting them as "now redundant" breaks the module being loaded.
- **`submit` stays a bare import** in the printsense test on purpose: `runner.run_one` itself does `from submit import submit_image_sync` **at call time**, so the test's handle must be the same `sys.modules['submit']` object — otherwise the monkeypatch silently misses and the test hits the real submit path.
- **`monkeypatch.setattr("runner.run_judge", …)` → object form.** The string form resolves through the ambiguous name this file no longer owns.

## Contract 10 (prevention)

`tests/test_architecture.py`: no test may bare-import a top-level name that two `tools/` dirs both provide. Lives in `architecture-check`, which **is** in `ci-gate`.

Scope was **measured, not assumed**. `tests/**` holds ~60 distinct `sys.path.insert` expressions, many built from local variables no static checker can resolve, spanning `mira-bots`, `mira-mcp`, `mira-sidecar`, the repo root, `ignition/`, `plc/`. Narrowed to the `tools/` family: **14 dirs, 107 module names, exactly 1 ambiguous — `runner`.** No allowlist needed.

Two things the first draft got wrong, both caught by printing the real discovered set rather than trusting the regex:

1. Binding discovery to the `sys.path.insert` call was refuted **by this PR's own fix** — hoisting the dir into `_GAUNTLET_DIR` leaves no literal in the call, silently un-guarding the exact collision the contract exists for. It scans the whole file now.
2. A permissive segment class let ~15 **file paths** (`tools/hooks/rm_guard.py`, `tools/seeds/*.sql`) into the provider map. A directory reached only via a file path could have manufactured a false ambiguity. Both regex forms now take `[A-Za-z0-9_-]` segments, so a chain ending in a file degrades to its containing directory. Dunders excluded — `__init__` showed up immediately as a permanent false entry.

Checker is a pure function with bad/good fixtures and a vacuity guard, per the Contract 5/6/7 precedent.

## Why no gate caught it

- `test-unit` runs `pytest tests/printsense/ -v` **in isolation**, where the collision cannot occur — stays green.
- Only the `test-eval-offline` sweep collects both files in one process, and that job is deliberately outside `ci-gate` (#3021 codifies the exemption).
- **Adding those suites to `test-unit` would NOT have caught this** — isolation is precisely what hid it. A cross-file contract is the only thing that can, which is why Contract 10 lives in the gated `architecture-check`.

## Verification

| | result |
|---|---|
| Repro before fix (`test_grader_gate.py` + `test_routing_gauntlet.py`) | **3 failed**, 15 passed — identical to CI |
| After fix, three collection orders (incl. `tests/printsense/` first) | **18 / 18 / 713 passed** |
| Contract 10 against the **reverted** import | **RED** — `tests/test_routing_gauntlet.py:54: bare \`runner\` import` |
| Contract 10 with the fix restored | green |
| Full CI-equivalent sweep on `origin/main` | **3 failed, 3685 passed** |
| Full CI-equivalent sweep on this branch | **3690 passed, 0 failed** |

Net **+5**: 3 fixed, 2 new contract tests, **zero regressions**. Run under `-n auto` (xdist), matching CI's invocation exactly. Python 3.12 — CHARLIE's system 3.9.6 can't even import the checker.

## Notes for review

- ⚠️ **Conflicts with open PR #3021**, which adds Contracts 8+9 to the same region of `tests/test_architecture.py` and is itself currently CONFLICTING. Whoever lands second keeps **both** contract blocks — they're independent.
- `ruff format` is deliberately **not** run on these files: both were already non-conforming on `main` (verified), CI's format check doesn't cover `tests/`, and reformatting would bury a ~30-line fix in hundreds of lines of unrelated churn.
- No production code changes. No `ci.yml` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfKtEHcrfRjYhANJjpBerM